### PR TITLE
#82 Allow multiple channel state change event listeners to be attached

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/cluster/zookeeper/ZookeeperClusterService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/cluster/zookeeper/ZookeeperClusterService.java
@@ -39,7 +39,7 @@ import com.navercorp.pinpoint.collector.cluster.WorkerStateContext;
 import com.navercorp.pinpoint.collector.config.CollectorConfiguration;
 import com.navercorp.pinpoint.collector.util.CollectorUtils;
 import com.navercorp.pinpoint.rpc.server.ChannelContext;
-import com.navercorp.pinpoint.rpc.server.SocketChannelStateChangeEventListener;
+import com.navercorp.pinpoint.rpc.server.handler.ChannelStateChangeEventHandler;
 
 /**
  * @author koo.taejin
@@ -164,7 +164,7 @@ public class ZookeeperClusterService extends AbstractClusterService {
         return config.isClusterEnable();
     }
 
-    public SocketChannelStateChangeEventListener getChannelStateChangeEventListener() {
+    public ChannelStateChangeEventHandler getChannelStateChangeEventHandler() {
         return profilerClusterManager;
     }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/cluster/zookeeper/ZookeeperProfilerClusterManager.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/cluster/zookeeper/ZookeeperProfilerClusterManager.java
@@ -35,13 +35,13 @@ import com.navercorp.pinpoint.collector.cluster.zookeeper.job.UpdateJob;
 import com.navercorp.pinpoint.collector.receiver.tcp.AgentHandshakePropertyType;
 import com.navercorp.pinpoint.rpc.server.ChannelContext;
 import com.navercorp.pinpoint.rpc.server.PinpointServerSocketStateCode;
-import com.navercorp.pinpoint.rpc.server.SocketChannelStateChangeEventListener;
+import com.navercorp.pinpoint.rpc.server.handler.ChannelStateChangeEventHandler;
 import com.navercorp.pinpoint.rpc.util.MapUtils;
 
 /**
  * @author koo.taejin
  */
-public class ZookeeperProfilerClusterManager implements SocketChannelStateChangeEventListener  {
+public class ZookeeperProfilerClusterManager implements ChannelStateChangeEventHandler  {
 
     private static final Charset charset = Charset.forName("UTF-8");
 
@@ -141,7 +141,14 @@ public class ZookeeperProfilerClusterManager implements SocketChannelStateChange
             return;
         }
     }
-
+    
+    @Override
+    public void exceptionCaught(ChannelContext channelContext, PinpointServerSocketStateCode stateCode, Throwable e) {
+        if (logger.isWarnEnabled()) {
+            logger.warn(this.getClass().getSimpleName() + " exception occured. Error: " + e.getMessage() + "."  , e);
+        }
+    }
+    
     public List<String> getClusterData() {
         byte[] contents = worker.getClusterData();
         if (contents == null) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/tcp/TCPReceiver.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/tcp/TCPReceiver.java
@@ -104,7 +104,7 @@ public class TCPReceiver {
         if (service == null || !service.isEnable()) {
             this.pinpointServerSocket = new PinpointServerSocket();
         } else {
-            this.pinpointServerSocket = new PinpointServerSocket(service.getChannelStateChangeEventListener());
+            this.pinpointServerSocket = new PinpointServerSocket(service.getChannelStateChangeEventHandler());
         }
         
         this.dispatchHandler = dispatchHandler;

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/server/handler/ChannelStateChangeEventHandler.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/server/handler/ChannelStateChangeEventHandler.java
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
-package com.navercorp.pinpoint.rpc.server;
+package com.navercorp.pinpoint.rpc.server.handler;
 
-public interface SocketChannelStateChangeEventListener {
+import com.navercorp.pinpoint.rpc.server.ChannelContext;
+import com.navercorp.pinpoint.rpc.server.PinpointServerSocketStateCode;
 
-    void eventPerformed(ChannelContext channelContext, PinpointServerSocketStateCode stateCode);
+/**
+ * @author koo.taejin
+ */
+public interface ChannelStateChangeEventHandler {
+
+    void eventPerformed(ChannelContext channelContext, PinpointServerSocketStateCode stateCode) throws Exception;
+    
+    void exceptionCaught(ChannelContext channelContext, PinpointServerSocketStateCode stateCode, Throwable e);
 
 }

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/server/handler/DoNothingChannelStateEventHandler.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/server/handler/DoNothingChannelStateEventHandler.java
@@ -14,20 +14,33 @@
  * limitations under the License.
  */
 
-package com.navercorp.pinpoint.rpc.server;
+package com.navercorp.pinpoint.rpc.server.handler;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DoNothingChannelStateEventListener implements SocketChannelStateChangeEventListener {
+import com.navercorp.pinpoint.rpc.server.ChannelContext;
+import com.navercorp.pinpoint.rpc.server.PinpointServerSocketStateCode;
+
+/**
+ * @author koo.taejin
+ */
+public class DoNothingChannelStateEventHandler implements ChannelStateChangeEventHandler {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    public static final SocketChannelStateChangeEventListener INSTANCE = new DoNothingChannelStateEventListener();
+    public static final ChannelStateChangeEventHandler INSTANCE = new DoNothingChannelStateEventHandler();
 
     @Override
     public void eventPerformed(ChannelContext channelContext, PinpointServerSocketStateCode stateCode) {
-        logger.info("eventPerformed {}:", channelContext);
+        logger.info("{} eventPerformed {}:{}", this.getClass().getSimpleName(), channelContext, stateCode);
+    }
+    
+    @Override
+    public void exceptionCaught(ChannelContext channelContext, PinpointServerSocketStateCode stateCode, Throwable e) {
+        if (logger.isWarnEnabled()) {
+            logger.warn(this.getClass().getSimpleName() + " exception occured. Error: " + e.getMessage() + "."  , e);
+        }
     }
 
 }

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/server/handler/ExecutionChannelStateChangeEventHandler.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/server/handler/ExecutionChannelStateChangeEventHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.rpc.server.handler;
+
+import java.util.concurrent.Executor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.navercorp.pinpoint.rpc.server.ChannelContext;
+import com.navercorp.pinpoint.rpc.server.PinpointServerSocketStateCode;
+
+/**
+ * @author koo.taejin
+ */
+public abstract class ExecutionChannelStateChangeEventHandler implements ChannelStateChangeEventHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    
+    private final ChannelStateChangeEventHandler handler;
+    private final Executor executor;
+    
+    public ExecutionChannelStateChangeEventHandler(ChannelStateChangeEventHandler handler, Executor executor) {
+        this.handler = handler;
+        this.executor = executor;
+    }
+    
+    @Override
+    public void eventPerformed(ChannelContext channelContext, PinpointServerSocketStateCode stateCode) {
+        logger.info("{} eventPerformed {}:{}", this.getClass().getSimpleName(), channelContext, stateCode);
+
+        Execution execution = new Execution(channelContext, stateCode);
+        this.executor.execute(execution);
+    }
+    
+    private class Execution implements Runnable {
+        private final ChannelContext channelContext;
+        private final PinpointServerSocketStateCode stateCode;
+
+        public Execution(ChannelContext channelContext, PinpointServerSocketStateCode stateCode) {
+            this.channelContext = channelContext;
+            this.stateCode = stateCode;
+        }
+        
+        @Override
+        public void run() {
+            try {
+                handler.eventPerformed(channelContext, stateCode);
+            } catch (Exception e) {
+                handler.exceptionCaught(channelContext, stateCode, e);
+            }
+        }
+    }
+
+}

--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/util/ListUtils.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/util/ListUtils.java
@@ -1,0 +1,46 @@
+package com.navercorp.pinpoint.rpc.util;
+
+import java.util.List;
+
+public final class ListUtils {
+
+    private ListUtils() {
+    }
+
+    public static <V> boolean addIfValueNotNull(List<V> list, V value) {
+        if (value == null) {
+            return false;
+        }
+
+        return list.add(value);
+    }
+    
+    public static <V> boolean addAllIfAllValuesNotNull(List<V> list, V[] values) {
+        if (values == null) {
+            return false;
+        }
+        
+        for (V value : values) {
+            if (value == null) {
+                return false;
+            }
+        }
+        
+        for (V value : values) {
+            list.add(value);
+        }
+        
+        return true;
+    }
+    
+    public static <V> void addAllExceptNullValue(List<V> list, V[] values) {
+        if (values == null) {
+            return;
+        }
+        
+        for (V value : values) {
+            addIfValueNotNull(list, value);
+        }
+    }
+    
+}

--- a/rpc/src/test/java/com/navercorp/pinpoint/rpc/util/ListUtilsTest.java
+++ b/rpc/src/test/java/com/navercorp/pinpoint/rpc/util/ListUtilsTest.java
@@ -1,0 +1,44 @@
+package com.navercorp.pinpoint.rpc.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+public class ListUtilsTest {
+
+    @Test
+    public void addIfValueNotNullTest() {
+        List<String> list = new ArrayList<String>();
+        
+        ListUtils.addIfValueNotNull(list, "firstString");
+        ListUtils.addIfValueNotNull(list, null);
+        
+        Assert.assertEquals(1, list.size());
+    }
+    
+    @Test
+    public void addAllIfAllValuesNotNullTest() {
+        List<String> list = new ArrayList<String>();
+
+        String[] values = {"firstString", null, "secondString"};
+        
+        ListUtils.addAllIfAllValuesNotNull(list, values);
+        
+        Assert.assertEquals(0, list.size());
+    }
+    
+    @Test
+    public void addAllExceptNullValueTest() {
+        List<String> list = new ArrayList<String>();
+
+        String[] values = {"firstString", null, "secondString"};
+        
+        ListUtils.addAllExceptNullValue(list, values);
+        
+        Assert.assertEquals(2, list.size());
+    }
+    
+}


### PR DESCRIPTION
to PinpointServerSocket 
1. Allow multiple channel state change event listeners to be attached to
   PinpointServerSocket
2. Changed class name (SocketChannelStateChangeEventListener ->
   ChannelStateChangeEventListener)
3. Added exceptionCaught method in ChannelStateChangeEventHandler class.
