### PR TITLE
Support latest version of Openwhisk

### DIFF
--- a/agent/src/main/resources-local/pinpoint.config
+++ b/agent/src/main/resources-local/pinpoint.config
@@ -939,9 +939,10 @@ profiler.grpc.server.streaming.onmessage.enable=false
 # Openwhisk (Reliability and stability can not be guaranteed)
 # Note: To use Openwhisk plugin, please enable Akka HTTP Plugin and
 # change transform target config as follows
-# - profiler.akka.http.transform.targetname=akka.http.scaladsl.server.directives.ExecutionDirectives$$anonfun$handleExceptions$1$$anonfun$apply$1.apply
-# - profiler.akka.http.transform.targetparameter=akka.http.scaladsl.server.RequestContext
+# - profiler.akka.http.transform.targetname=akka.http.scaladsl.server.directives.ExecutionDirectives.$anonfun$handleExceptions$2
+# - profiler.akka.http.transform.targetparameter=akka.http.scaladsl.server.ExceptionHandler,scala.Function1,akka.http.scaladsl.server.RequestContext
 ###########################################################
 profiler.openwhisk.enable=true
 profiler.openwhisk.logging.message=true
-profiler.openwhisk.transform.targetname=whisk.http.BasicHttpService$$anonfun$assignId$1$$anonfun$apply$13
+profiler.openwhisk.transform.targetname=org.apache.openwhisk.http.BasicHttpService.$anonfun$assignId$2
+profiler.openwhisk.transform.targetparameter=org.apache.openwhisk.http.BasicHttpService,boolean,akka.http.scaladsl.server.RequestContext

--- a/agent/src/main/resources-release/pinpoint.config
+++ b/agent/src/main/resources-release/pinpoint.config
@@ -919,9 +919,10 @@ profiler.grpc.server.streaming.onmessage.enable=false
 # Openwhisk (Reliability and stability can not be guaranteed)
 # Note: To use Openwhisk plugin, please enable Akka HTTP Plugin and
 # change transform target config as follows
-# - profiler.akka.http.transform.targetname=akka.http.scaladsl.server.directives.ExecutionDirectives$$anonfun$handleExceptions$1$$anonfun$apply$1.apply
-# - profiler.akka.http.transform.targetparameter=akka.http.scaladsl.server.RequestContext
+# - profiler.akka.http.transform.targetname=akka.http.scaladsl.server.directives.ExecutionDirectives.$anonfun$handleExceptions$2
+# - profiler.akka.http.transform.targetparameter=akka.http.scaladsl.server.ExceptionHandler,scala.Function1,akka.http.scaladsl.server.RequestContext
 ###########################################################
 profiler.openwhisk.enable=false
 profiler.openwhisk.logging.message=false
-profiler.openwhisk.transform.targetname=whisk.http.BasicHttpService$$anonfun$assignId$1$$anonfun$apply$13
+profiler.openwhisk.transform.targetname=org.apache.openwhisk.http.BasicHttpService.$anonfun$assignId$2
+profiler.openwhisk.transform.targetparameter=org.apache.openwhisk.http.BasicHttpService,boolean,akka.http.scaladsl.server.RequestContext

--- a/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/OpenwhiskConfig.java
+++ b/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/OpenwhiskConfig.java
@@ -17,6 +17,8 @@ package com.navercorp.pinpoint.plugin.openwhisk;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 
+import java.util.List;
+
 /**
  * @author Seonghyun Oh
  */
@@ -27,10 +29,12 @@ public class OpenwhiskConfig {
     private final boolean loggingMessage;
 
     private final String transformTargetName;
+    private final List<String> transformParameters;
 
     static final String KEY_TRANSFORM_TARGET_NAME = "profiler.openwhisk.transform.targetname";
-    private static final String DEFAULT_TRANSFORM_TARGET_NAME = "whisk.http.BasicHttpService$$anonfun$assignId$1$$anonfun$apply$13";
+    static final String KEY_TRANSFORM_PARAMETERS = "profiler.openwhisk.transform.targetparameter";
 
+    private static final String DEFAULT_TRANSFORM_TARGET_NAME = "org.apache.openwhisk.http.BasicHttpService.$anonfun$assignId$2";
 
     public OpenwhiskConfig(ProfilerConfig config) {
         /*
@@ -40,11 +44,14 @@ public class OpenwhiskConfig {
         this.loggingMessage = config.readBoolean("profiler.openwhisk.logging.message", false);
 
         this.transformTargetName = config.readString(KEY_TRANSFORM_TARGET_NAME, DEFAULT_TRANSFORM_TARGET_NAME);
+        this.transformParameters = config.readList(KEY_TRANSFORM_PARAMETERS);
     }
 
     public String getTransformTargetName() {
         return transformTargetName;
     }
+
+    public List<String> getTransformTargetParameters() { return transformParameters; }
 
     public boolean isEnable() {
         return enable;

--- a/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/OpenwhiskDetector.java
+++ b/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/OpenwhiskDetector.java
@@ -23,9 +23,9 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
  */
 public class OpenwhiskDetector {
 
-    private static final String CONTROLLER_REQUIRED_CLASS = "whisk.core.controller.Controller";
+    private static final String CONTROLLER_REQUIRED_CLASS = "org.apache.openwhisk.core.controller.Controller";
 
-    private static final String INVOKER_REQUIRED_CLASS = "whisk.core.invoker.Invoker";
+    private static final String INVOKER_REQUIRED_CLASS = "org.apache.openwhisk.core.invoker.Invoker";
 
     public ServiceType detectApplicationType() {
         boolean controllerClassPresent = ClassResourceCondition.INSTANCE.check(CONTROLLER_REQUIRED_CLASS);

--- a/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/descriptor/LogMarkerMethodDescriptor.java
+++ b/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/descriptor/LogMarkerMethodDescriptor.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.plugin.openwhisk.descriptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.common.trace.MethodType;
-import whisk.common.LogMarkerToken;
+import org.apache.openwhisk.common.LogMarkerToken;
 
 public class LogMarkerMethodDescriptor implements MethodDescriptor {
     private int apiId = 0;

--- a/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/KafkaProducerSendInterceptor.java
+++ b/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/KafkaProducerSendInterceptor.java
@@ -23,7 +23,8 @@ import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.plugin.openwhisk.OpenwhiskConstants;
 import com.navercorp.pinpoint.plugin.openwhisk.setter.TraceContextSetter;
 import scala.collection.immutable.Map;
-import whisk.core.connector.ActivationMessage;
+import org.apache.openwhisk.core.connector.ActivationMessage;
+
 
 /**
  * @author Seonghyun Oh

--- a/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/TransactionIdCreateInterceptor.java
+++ b/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/TransactionIdCreateInterceptor.java
@@ -15,6 +15,7 @@
  */
 package com.navercorp.pinpoint.plugin.openwhisk.interceptor;
 
+import akka.http.scaladsl.server.RequestContextImpl;
 import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
 import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
 import com.navercorp.pinpoint.bootstrap.context.*;
@@ -42,14 +43,24 @@ public class TransactionIdCreateInterceptor implements AroundInterceptor {
 
     @Override
     public void after(Object target, Object[] args, Object result, Throwable throwable) {
-        if (args[0] instanceof AsyncContextAccessor) {
 
-            AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args[0]);
-            if (asyncContext == null) {
-                return;
-            }
-            ((AsyncContextAccessor) (result))._$PINPOINT$_setAsyncContext(asyncContext);
+        int requestContextIndex = getArgsIndexOfRequestContext(args);
+        if (requestContextIndex == -1) {
+            return;
         }
+        AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args[requestContextIndex]);
+        if (asyncContext == null) {
+            return;
+        }
+        ((AsyncContextAccessor) (result))._$PINPOINT$_setAsyncContext(asyncContext);
     }
+
+    private int getArgsIndexOfRequestContext(Object[] args) {
+        for (int i = 0; i < args.length; i++) {
+            if (args[i] instanceof RequestContextImpl) return i;
+        }
+        return -1;
+    }
+
 }
 

--- a/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/TransactionIdFailedInterceptor.java
+++ b/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/TransactionIdFailedInterceptor.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.plugin.openwhisk.accessor.PinpointTraceAccessor;
-import scala.runtime.AbstractFunction0;
+import scala.Function0;
 
 /**
  * @author Seonghyun Oh
@@ -49,7 +49,7 @@ public class TransactionIdFailedInterceptor implements AroundInterceptor {
         }
 
         // set error message
-        String message = ((AbstractFunction0) args[3]).apply().toString();
+        String message = ((Function0) args[3]).apply().toString();
         SpanEventRecorder recorder = trace.currentSpanEventRecorder();
 
         recorder.recordException(new Throwable(message));

--- a/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/TransactionIdMarkInterceptor.java
+++ b/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/TransactionIdMarkInterceptor.java
@@ -24,7 +24,7 @@ import com.navercorp.pinpoint.plugin.openwhisk.OpenwhiskConfig;
 import com.navercorp.pinpoint.plugin.openwhisk.OpenwhiskConstants;
 import com.navercorp.pinpoint.plugin.openwhisk.descriptor.LogMarkerMethodDescriptor;
 import scala.runtime.AbstractFunction0;
-import whisk.common.LogMarkerToken;
+import org.apache.openwhisk.common.LogMarkerToken;
 
 /**
  * @author Seonghyun Oh

--- a/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/TransactionIdMarkInterceptor.java
+++ b/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/TransactionIdMarkInterceptor.java
@@ -23,7 +23,7 @@ import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.plugin.openwhisk.OpenwhiskConfig;
 import com.navercorp.pinpoint.plugin.openwhisk.OpenwhiskConstants;
 import com.navercorp.pinpoint.plugin.openwhisk.descriptor.LogMarkerMethodDescriptor;
-import scala.runtime.AbstractFunction0;
+import scala.Function0;
 import org.apache.openwhisk.common.LogMarkerToken;
 
 /**
@@ -75,7 +75,7 @@ public class TransactionIdMarkInterceptor implements AroundInterceptor {
 
         try {
             LogMarkerToken logMarkerToken = (LogMarkerToken) args[2];
-            String message = ((AbstractFunction0) args[3]).apply().toString();
+            String message = ((Function0) args[3]).apply().toString();
             recorder.recordApi(new LogMarkerMethodDescriptor(logMarkerToken));
 
             if (isLoggingMessage && message.length() > 0) {

--- a/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/TransactionIdStartedInterceptor.java
+++ b/plugins/openwhisk/src/main/java/com/navercorp/pinpoint/plugin/openwhisk/interceptor/TransactionIdStartedInterceptor.java
@@ -25,8 +25,8 @@ import com.navercorp.pinpoint.plugin.openwhisk.OpenwhiskConfig;
 import com.navercorp.pinpoint.plugin.openwhisk.OpenwhiskConstants;
 import com.navercorp.pinpoint.plugin.openwhisk.accessor.PinpointTraceAccessor;
 import com.navercorp.pinpoint.plugin.openwhisk.descriptor.LogMarkerMethodDescriptor;
-import scala.runtime.AbstractFunction0;
-import whisk.common.LogMarkerToken;
+import scala.Function0;
+import org.apache.openwhisk.common.LogMarkerToken;
 
 /**
  * @author Seonghyun Oh
@@ -110,7 +110,7 @@ public class TransactionIdStartedInterceptor implements AroundInterceptor {
             final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
 
             LogMarkerToken logMarkerToken = (LogMarkerToken) args[2];
-            String message = ((AbstractFunction0) args[3]).apply().toString();
+            String message = ((Function0) args[3]).apply().toString();
             recorder.recordApi(new LogMarkerMethodDescriptor(logMarkerToken));
 
             if (logMarkerToken.component().equals("database")) {


### PR DESCRIPTION
## Note

Currently, Openwhisk plugin does not work with the openwhisk's latest version.
because there have been following major changes in the code recently. 

- scala version is updated from 2.11 to 2.12
- package name is changed from `whisk` to `org.apache.openwhisk`

This plugin has been modified and tested to work with the latest version.

## Changes
- Scala version is updated from 2.11 to 2.12
  - need to use `scala.Function0` to get a log message instead of `scala.runtime.AbstractFunction0`
- a package name is changed from `whisk` to `org.apache.openwhisk`
- Added parameter config `profiler.openwhisk.transform.targetparameter` to accommodate upstream changes more flexible.
