### PR TITLE
[#noissue] Fix pom.xml pluginRepository maven url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <pluginRepository>
             <id>central</id>
             <name>Maven central plugin repository</name>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
point I got a clone of current master Branch and tried to build it,

https://github.com/naver/pinpoint/issues/6432 The same thing happened to the person who posted this issue.

So I tried to find the problem,

Successfully changed pluginRepository maven url in pom.xml from http to https and tried to build again.

So I send a pull request for that modification.