### PR TITLE
Always record request having Pinpoint-Force-Sample request header

### DIFF
--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/Header.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/Header.java
@@ -28,6 +28,7 @@ public enum Header {
     HTTP_SPAN_ID("Pinpoint-SpanID"),
     HTTP_PARENT_SPAN_ID("Pinpoint-pSpanID"),
     HTTP_SAMPLED("Pinpoint-Sampled"),
+    HTTP_FORCE_SAMPLE("Pinpoint-Force-Sample"),
     HTTP_FLAGS("Pinpoint-Flags"),
     HTTP_PARENT_APPLICATION_NAME("Pinpoint-pAppName"),
     HTTP_PARENT_APPLICATION_TYPE("Pinpoint-pAppType"),

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/RequestTraceReader.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/RequestTraceReader.java
@@ -37,6 +37,7 @@ public class RequestTraceReader<T> {
     private final TraceContext traceContext;
     private final RequestAdaptor<T> requestAdaptor;
     private final boolean async;
+    private final boolean forceSamplingHeaderEnabled;
 
     private final TraceHeaderReader<T> traceHeaderReader;
     private final NameSpaceChecker<T> nameSpaceChecker;
@@ -52,6 +53,7 @@ public class RequestTraceReader<T> {
         this.async = async;
         String applicationNamespace = traceContext.getProfilerConfig().getApplicationNamespace();
         this.nameSpaceChecker = NameSpaceCheckFactory.newNamespace(requestAdaptor, applicationNamespace);
+        this.forceSamplingHeaderEnabled = traceContext.getProfilerConfig().readBoolean("profiler.sampling.force.header", false);
     }
 
     // Read the transaction information from the request.
@@ -85,7 +87,7 @@ public class RequestTraceReader<T> {
     }
 
     private Trace newTrace(T request) {
-        if (requestAdaptor.getHeader(request, Header.HTTP_FORCE_SAMPLE.toString()) != null) {
+        if (forceSamplingHeaderEnabled && requestAdaptor.getHeader(request, Header.HTTP_FORCE_SAMPLE.toString()) != null) {
             SamplingHint.forceSampling();
         }
         final Trace trace = newTrace();

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/RequestTraceReader.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/RequestTraceReader.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.bootstrap.plugin.request;
 
+import com.navercorp.pinpoint.bootstrap.context.Header;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.context.TraceId;
@@ -23,6 +24,7 @@ import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.NameSpaceCheckFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.NameSpaceChecker;
+import com.navercorp.pinpoint.bootstrap.sampler.SamplingHint;
 import com.navercorp.pinpoint.common.util.Assert;
 
 /**
@@ -83,6 +85,9 @@ public class RequestTraceReader<T> {
     }
 
     private Trace newTrace(T request) {
+        if (requestAdaptor.getHeader(request, Header.HTTP_FORCE_SAMPLE.toString()) != null) {
+            SamplingHint.forceSampling();
+        }
         final Trace trace = newTrace();
         if (trace.canSampled()) {
             if (isDebug) {

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/sampler/SamplingHint.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/sampler/SamplingHint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2020 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,26 @@
  * limitations under the License.
  */
 
-package com.navercorp.pinpoint.profiler.sampler;
-
-import com.navercorp.pinpoint.bootstrap.sampler.Sampler;
+package com.navercorp.pinpoint.bootstrap.sampler;
 
 /**
- * @author emeroad
+ * @author yjqg6666
  */
-public class SamplerFactory {
-    public Sampler createSampler(boolean sampling, int samplingRate) {
-        if (!sampling || samplingRate <= 0) {
-            return new FalseSampler();
-        }
-        if (samplingRate == 1) {
-            return new TrueSampler();
-        }
-        return new HintSamplingRateSampler(samplingRate);
+public class SamplingHint {
+
+    private static final ThreadLocal<Boolean> HINT = new ThreadLocal<Boolean>();
+
+    private SamplingHint() {
     }
+
+    public static boolean getAndReset() {
+        boolean hint = HINT.get() != null;
+        HINT.remove();
+        return hint;
+    }
+
+    public static void forceSampling() {
+        HINT.set(Boolean.TRUE);
+    }
+
 }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/sampler/HintSamplingRateSampler.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/sampler/HintSamplingRateSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2020 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,27 @@
 
 package com.navercorp.pinpoint.profiler.sampler;
 
-import com.navercorp.pinpoint.bootstrap.sampler.Sampler;
+import com.navercorp.pinpoint.bootstrap.sampler.SamplingHint;
 
 /**
- * @author emeroad
+ * @author yjqg6666
  */
-public class SamplerFactory {
-    public Sampler createSampler(boolean sampling, int samplingRate) {
-        if (!sampling || samplingRate <= 0) {
-            return new FalseSampler();
-        }
-        if (samplingRate == 1) {
-            return new TrueSampler();
-        }
-        return new HintSamplingRateSampler(samplingRate);
+public class HintSamplingRateSampler extends SamplingRateSampler {
+
+    public HintSamplingRateSampler(int samplingRate) {
+        super(samplingRate);
     }
+
+    @Override
+    public boolean isSampling() {
+        boolean sampling = super.isSampling();
+        boolean hint = SamplingHint.getAndReset();
+        return sampling || hint;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+
 }

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/sampler/HintSamplingRateSamplerTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/sampler/HintSamplingRateSamplerTest.java
@@ -16,19 +16,17 @@
 
 package com.navercorp.pinpoint.profiler.sampler;
 
-import com.navercorp.pinpoint.bootstrap.sampler.Sampler;
+import com.navercorp.pinpoint.bootstrap.sampler.SamplingHint;
+import org.junit.Assert;
+import org.junit.Test;
 
-/**
- * @author emeroad
- */
-public class SamplerFactory {
-    public Sampler createSampler(boolean sampling, int samplingRate) {
-        if (!sampling || samplingRate <= 0) {
-            return new FalseSampler();
-        }
-        if (samplingRate == 1) {
-            return new TrueSampler();
-        }
-        return new HintSamplingRateSampler(samplingRate);
+public class HintSamplingRateSamplerTest {
+
+    @Test
+    public void testHint() {
+        SamplingHint.forceSampling();
+        HintSamplingRateSampler sampler = new HintSamplingRateSampler(100000);
+        Assert.assertTrue("force sampling failed", sampler.isSampling());
+        Assert.assertFalse("force sampling reset failed", sampler.isSampling());
     }
 }


### PR DESCRIPTION
- If the http request have Pinpoint-Force-Sample request header and the request path is not excluded, always record the request regardless of sampling rate.
- This feature is off by default for the security reason & backward compatibility, can be enabled by profiler.sampling.force.header=true.  We could turn this feature on in development environment(dev profile) and off in production environment(release profile).