### PR TITLE
update sampler to support sampling rate range from 1% to 100%

### DIFF
--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -56,8 +56,8 @@ profiler.jvm.stat.collect.detailed.metrics=true
 # Allow sampling.
 profiler.sampling.enable=true
 
-# 1 out of n transactions will be sampled where n is the rate. (1: 100%, 20: 5%)
-profiler.sampling.rate=1
+# n out of 100 transactions will be sampled. (1: 1%, 20: 20%, 100:100%)
+profiler.sampling.rate=100
 
 # Permits per second, if throughput is 0, it is unlimited.
 # "New" is a transaction that is newly traced.

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -56,8 +56,8 @@ profiler.jvm.stat.collect.detailed.metrics=false
 # Allow sampling.
 profiler.sampling.enable=true
 
-# 1 out of n transactions will be sampled where n is the rate. (1: 100%, 20: 5%)
-profiler.sampling.rate=20
+# n out of 100 transactions will be sampled. (1: 1%, 20: 20%)
+profiler.sampling.rate=5
 
 # Permits per second, if throughput is 0, it is unlimited.
 # "New" is a transaction that is newly traced.

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
@@ -462,7 +462,7 @@ public class DefaultProfilerConfig implements ProfilerConfig {
 
 
         this.samplingEnable = readBoolean("profiler.sampling.enable", true);
-        this.samplingRate = readInt("profiler.sampling.rate", 1);
+        this.samplingRate = readInt("profiler.sampling.rate", 100);
         // Throughput sampling
         this.samplingNewThroughput = readInt("profiler.sampling.new.throughput", 0);
         this.samplingContinueThroughput = readInt("profiler.sampling.continue.throughput", 0);

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -27,8 +27,8 @@ You can change the log level by modifying the agent's *log4j.xml* located in *PI
 
 ### Why is only the first/some of the requests traced?
 There is a sampling rate option in the agent's pinpoint.config file (profiler.sampling.rate).
-Pinpoint agent samples 1 trace every N transactions if this value was set as N.
-Changing this value to 1 will allow you to trace every transaction.
+Pinpoint agent samples N traces every 100 transactions if this value was set as N.
+Changing this value to 100 will allow you to trace every transaction.
 
 ### Request count in the Scatter Chart is different from the ones in Response Summary chart. Why is this?
 The Scatter Chart data have a second granularity, so the requests counted here can be differentiated by a second interval.

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/sampler/SamplerFactory.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/sampler/SamplerFactory.java
@@ -26,7 +26,7 @@ public class SamplerFactory {
         if (!sampling || samplingRate <= 0) {
             return new FalseSampler();
         }
-        if (samplingRate == 1) {
+        if (samplingRate == 100) {
             return new TrueSampler();
         }
         return new SamplingRateSampler(samplingRate);

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/sampler/SamplingRateSampler.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/sampler/SamplingRateSampler.java
@@ -28,21 +28,29 @@ public class SamplingRateSampler implements Sampler {
 
     private final AtomicInteger counter = new AtomicInteger(0);
     private final int samplingRate;
+    private final int samplingMaxSeqNum;
+    private final int samplingOutOfNum;
 
     public SamplingRateSampler(int samplingRate) {
-        if (samplingRate <= 0) {
+        if (samplingRate <= 0 || samplingRate > 100) {
             throw new IllegalArgumentException("Invalid samplingRate " + samplingRate);
         }
         this.samplingRate = samplingRate;
+        boolean percentSampling = (samplingRate % 10) != 0;
+        if (percentSampling) { //ex. 1% 15%
+            this.samplingOutOfNum = 100;
+            this.samplingMaxSeqNum = samplingRate;
+        } else { // 10% 20% 30% ...
+            this.samplingOutOfNum = 10;
+            this.samplingMaxSeqNum = samplingRate / 10;
+        }
     }
-
-
 
     @Override
     public boolean isSampling() {
         int samplingCount = MathUtils.fastAbs(counter.getAndIncrement());
-        int isSampling = samplingCount % samplingRate;
-        return isSampling == 0;
+        int mod = samplingCount % samplingOutOfNum;
+        return mod < samplingMaxSeqNum;
     }
 
     @Override

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/sampler/SimpleSamplerTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/sampler/SimpleSamplerTest.java
@@ -16,9 +16,6 @@
 
 package com.navercorp.pinpoint.profiler.sampler;
 
-
-import com.navercorp.pinpoint.profiler.sampler.SamplingRateSampler;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -32,18 +29,36 @@ public class SimpleSamplerTest {
 
 
     @Test
-    public void test() {
-        SamplingRateSampler simpleSampler = new SamplingRateSampler(1);
-        assertChoice(simpleSampler);
-        assertChoice(simpleSampler);
-        assertChoice(simpleSampler);
-        assertChoice(simpleSampler);
+    public void testSamplingAll() {
+        SamplingRateSampler simpleSampler = new SamplingRateSampler(100);
+        for (int i = 0; i < 100; i++) {
+            assertChoice(simpleSampler);
+        }
+    }
 
-         SamplingRateSampler simpleSampler2 = new SamplingRateSampler(2);
-        assertChoice(simpleSampler2);
-        assertDrop(simpleSampler2);
-        assertChoice(simpleSampler2);
-        assertDrop(simpleSampler2);
+    @Test
+    public void testSamplingBy10() {
+        SamplingRateSampler simpleSampler2 = new SamplingRateSampler(30);
+        for (int i = 0; i < 10; i++) {
+            if (i >= 3) {
+                assertDrop(simpleSampler2);
+            } else {
+                assertChoice(simpleSampler2);
+            }
+        }
+    }
+
+    @Test
+    public void testSamplingPercent() {
+        int rate = 75;
+        SamplingRateSampler simpleSampler2 = new SamplingRateSampler(rate);
+        for (int i = 0; i < 100; i++) {
+            if (i < rate) {
+                assertChoice(simpleSampler2);
+            } else {
+                assertDrop(simpleSampler2);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
1. The sampling rate now is n%, where n is an integer and ranges from 1 to 100.
2. If the sampling rate is 10%, 20% or some other rates which have no mod divided by 10, the requests would be checked every 10 requests(This would be very useful for testing). Otherwise they would be checked by every 100 requests.

Update Guide:
**Need to update agent config profiler.sampling.rate to use the new way.**