### PR TITLE
support lite mode sampling

### DIFF
--- a/agent/src/main/resources/pinpoint-root.config
+++ b/agent/src/main/resources/pinpoint-root.config
@@ -139,6 +139,12 @@ profiler.sampling.enable=true
 # 1 out of n transactions will be sampled where n is the rate. (1: 100%, 20: 5%)
 profiler.sampling.rate=1
 
+# n percent of the traced requests(decided by profiler.sampling.rate) would be in lite mode(only server type#, client type and queue type are traced and recorded, no db/spring bean tracing), disabled by default.
+# e.g. 0: 0%, all in full trace mode as before
+# e.g. 80: 80%, 80% in lite trace mode and 20% in full trace mode
+# e.g. 100: 100%, all the traced requests are in lite mode
+#profiler.sampling.lite.rate=0
+
 # Permits per second, if throughput is 0, it is unlimited.
 # "New" is a transaction that is newly traced.
 profiler.sampling.new.throughput=0

--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -59,6 +59,12 @@ profiler.sampling.enable=true
 # 1 out of n transactions will be sampled where n is the rate. (1: 100%, 20: 5%)
 profiler.sampling.rate=1
 
+# n percent of the traced requests(decided by profiler.sampling.rate) would be in lite mode(only server type#, client type and queue type are traced and recorded, no db/spring bean tracing), disabled by default.
+# e.g. 0: 0%, all in full trace mode as before
+# e.g. 80: 80%, 80% in lite trace mode and 20% in full trace mode
+# e.g. 100: 100%, all the traced requests are in lite mode
+#profiler.sampling.lite.rate=0
+
 # Permits per second, if throughput is 0, it is unlimited.
 # "New" is a transaction that is newly traced.
 profiler.sampling.new.throughput=0

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -59,6 +59,12 @@ profiler.sampling.enable=true
 # 1 out of n transactions will be sampled where n is the rate. (1: 100%, 20: 5%)
 profiler.sampling.rate=20
 
+# n percent of the traced requests(decided by profiler.sampling.rate) would be in lite mode(only server type#, client type and queue type are traced and recorded, no db/spring bean tracing), disabled by default.
+# e.g. 0: 0%, all in full trace mode as before
+# e.g. 80: 80%, 80% in lite trace mode and 20% in full trace mode
+# e.g. 100: 100%, all the traced requests are in lite mode
+#profiler.sampling.lite.rate=0
+
 # Permits per second, if throughput is 0, it is unlimited.
 # "New" is a transaction that is newly traced.
 profiler.sampling.new.throughput=0

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
@@ -132,6 +132,7 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     // Sampling
     private boolean samplingEnable = true;
     private int samplingRate = 1;
+    private int samplingLiteRate = 0;
     private int samplingNewThroughput = 0;
     private int samplingContinueThroughput = 0;
 
@@ -268,6 +269,11 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     @Override
     public int getSamplingRate() {
         return samplingRate;
+    }
+
+    @Override
+    public int getSamplingLiteRate() {
+        return samplingLiteRate;
     }
 
     @Override
@@ -463,6 +469,7 @@ public class DefaultProfilerConfig implements ProfilerConfig {
 
         this.samplingEnable = readBoolean("profiler.sampling.enable", true);
         this.samplingRate = readInt("profiler.sampling.rate", 1);
+        this.samplingLiteRate = readInt("profiler.sampling.lite.rate", 0);
         // Throughput sampling
         this.samplingNewThroughput = readInt("profiler.sampling.new.throughput", 0);
         this.samplingContinueThroughput = readInt("profiler.sampling.continue.throughput", 0);
@@ -647,6 +654,7 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         sb.append(", maxSqlBindValueSize=").append(maxSqlBindValueSize);
         sb.append(", samplingEnable=").append(samplingEnable);
         sb.append(", samplingRate=").append(samplingRate);
+        sb.append(", samplingLiteRate=").append(samplingLiteRate);
         sb.append(", samplingNewThroughput=").append(samplingNewThroughput);
         sb.append(", samplingContinueThroughput=").append(samplingContinueThroughput);
         sb.append(", ioBufferingEnable=").append(ioBufferingEnable);

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
@@ -63,6 +63,8 @@ public interface ProfilerConfig {
 
     int getSamplingRate();
 
+    int getSamplingLiteRate();
+
     int getSamplingNewThroughput();
 
     int getSamplingContinueThroughput();

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/Trace.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/Trace.java
@@ -43,6 +43,8 @@ public interface Trace extends StackOperation {
 
     boolean isRoot();
 
+    boolean isLiteModeTrace();
+
     boolean isAsync();
     
     SpanRecorder getSpanRecorder();

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/TraceId.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/TraceId.java
@@ -37,5 +37,9 @@ public interface TraceId {
 
     short getFlags();
 
+    boolean isLiteModeTrace();
+
+    boolean isFullModeTrace();
+
     boolean isRoot();
 }

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/SpanEventSimpleAroundInterceptorForPlugin.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/SpanEventSimpleAroundInterceptorForPlugin.java
@@ -54,7 +54,7 @@ public abstract class SpanEventSimpleAroundInterceptorForPlugin implements Aroun
         prepareBeforeTrace(target, args);
 
         final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || !canTrace(trace)) {
             return;
         }
         
@@ -76,6 +76,14 @@ public abstract class SpanEventSimpleAroundInterceptorForPlugin implements Aroun
 
     }
 
+    protected boolean canTrace(Trace trace) {
+        return true;
+    }
+
+    protected boolean notInLiteMode(Trace trace) {
+        return trace != null && !trace.isLiteModeTrace();
+    }
+
     protected abstract void doInBeforeTrace(final SpanEventRecorder recorder, final Object target, final Object[] args) throws Exception;
 
     @Override
@@ -87,7 +95,7 @@ public abstract class SpanEventSimpleAroundInterceptorForPlugin implements Aroun
         prepareAfterTrace(target, args, result, throwable);
 
         final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || !canTrace(trace)) {
             return;
         }
         try {

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/PreparedStatementBindVariableInterceptor.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/PreparedStatementBindVariableInterceptor.java
@@ -58,7 +58,7 @@ public class PreparedStatementBindVariableInterceptor implements StaticAroundInt
         }
 
         final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || trace.isLiteModeTrace()) {
             return;
         }
 

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/PreparedStatementCreateInterceptor.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/PreparedStatementCreateInterceptor.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.ParsingResult;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor;
@@ -47,6 +48,11 @@ public class PreparedStatementCreateInterceptor extends SpanEventSimpleAroundInt
 
     public PreparedStatementCreateInterceptor(TraceContext context, MethodDescriptor descriptor) {
         super(context, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/PreparedStatementExecuteQueryInterceptor.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/PreparedStatementExecuteQueryInterceptor.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.ParsingResult;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.BindValueAccessor;
@@ -55,6 +56,11 @@ public class PreparedStatementExecuteQueryInterceptor extends SpanEventSimpleAro
     public PreparedStatementExecuteQueryInterceptor(TraceContext traceContext, MethodDescriptor descriptor, int maxSqlBindValueLength) {
         super(traceContext, descriptor);
         this.maxSqlBindValueLength = maxSqlBindValueLength;
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/StatementCreateInterceptor.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/StatementCreateInterceptor.java
@@ -75,7 +75,7 @@ public class StatementCreateInterceptor implements AroundInterceptor {
             return;
         }
         Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || trace.isLiteModeTrace()) {
             return;
         }
         if (CONNECTION_CLASS.isInstance(target)) {

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/StatementExecuteQueryInterceptor.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/StatementExecuteQueryInterceptor.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor;
 import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor;
@@ -37,6 +38,10 @@ public class StatementExecuteQueryInterceptor extends SpanEventSimpleAroundInter
         super(traceContext, descriptor);
     }
 
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
+    }
 
     @Override
     public void doInBeforeTrace(SpanEventRecorder recorder, final Object target, Object[] args) {

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/StatementExecuteUpdateInterceptor.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/StatementExecuteUpdateInterceptor.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor;
 import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor;
@@ -43,6 +44,11 @@ public class StatementExecuteUpdateInterceptor extends SpanEventSimpleAroundInte
     
     public StatementExecuteUpdateInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/TransactionCommitInterceptor.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/TransactionCommitInterceptor.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor;
 import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor;
@@ -34,6 +35,11 @@ public class TransactionCommitInterceptor extends SpanEventSimpleAroundIntercept
 
     public TransactionCommitInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/TransactionRollbackInterceptor.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/TransactionRollbackInterceptor.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor;
 import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor;
@@ -34,6 +35,11 @@ public class TransactionRollbackInterceptor extends SpanEventSimpleAroundInterce
 
     public TransactionRollbackInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/TransactionSetAutoCommitInterceptor.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/interceptor/TransactionSetAutoCommitInterceptor.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.bootstrap.plugin.jdbc.interceptor;
 import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor;
@@ -34,6 +35,11 @@ public class TransactionSetAutoCommitInterceptor extends SpanEventSimpleAroundIn
 
     public TransactionSetAutoCommitInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServletRequestListener.java
+++ b/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServletRequestListener.java
@@ -28,6 +28,7 @@ import com.navercorp.pinpoint.bootstrap.plugin.http.HttpStatusCodeRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.proxy.ProxyRequestRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.method.ServletSyncMethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.ParameterRecorder;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.Assert;
 
@@ -126,6 +127,9 @@ public class ServletRequestListener<REQ> {
             this.serverRequestRecorder.record(recorder, request);
             // record proxy HTTP header.
             this.proxyRequestRecorder.record(recorder, request);
+            if (trace.isRoot()) {
+                recorder.recordAttribute(AnnotationKey.TRACE_MODE, trace.isLiteModeTrace() ? "Lite" : "Full");
+            }
         }
         return trace;
     }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/AnnotationKey.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/AnnotationKey.java
@@ -56,6 +56,7 @@ import static com.navercorp.pinpoint.common.trace.AnnotationKeyProperty.VIEW_IN_
  * <tr><td>15</td><td><i>RESERVED</i></td></tr>
  * <tr><td>16</td><td><i>RESERVED</i></td></tr>
  * <tr><td>17</td><td><i>RESERVED</i></td></tr>
+ * <tr><td>18</td><td><i>TRACE-MODE</i></td></tr>
  * <tr><td>20</td><td>SQL-ID</td></tr>
  * <tr><td>21</td><td>SQL</td></tr>
  * <tr><td>22</td><td>SQL-METADATA</td></tr>
@@ -181,6 +182,8 @@ public interface AnnotationKey {
 
     // it's not clear to handle a error code.  so ApiMetaDataError with searching ERROR_API_META_DATA has been used.
     // automatically generated id
+
+    AnnotationKey TRACE_MODE = AnnotationKeyFactory.of(18, "Trace-Mode", VIEW_IN_RECORD_SET);
 
     AnnotationKey SQL_ID = AnnotationKeyFactory.of(20, "SQL-ID");
     AnnotationKey SQL = AnnotationKeyFactory.of(21, "SQL", VIEW_IN_RECORD_SET);

--- a/plugins/dbcp/src/main/java/com/navercorp/pinpoint/plugin/commons/dbcp/interceptor/DataSourceCloseConnectionInterceptor.java
+++ b/plugins/dbcp/src/main/java/com/navercorp/pinpoint/plugin/commons/dbcp/interceptor/DataSourceCloseConnectionInterceptor.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.commons.dbcp.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.commons.dbcp.CommonsDbcpConstants;
@@ -30,6 +31,11 @@ public class DataSourceCloseConnectionInterceptor extends SpanEventSimpleAroundI
 
     public DataSourceCloseConnectionInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/dbcp/src/main/java/com/navercorp/pinpoint/plugin/commons/dbcp/interceptor/DataSourceGetConnectionInterceptor.java
+++ b/plugins/dbcp/src/main/java/com/navercorp/pinpoint/plugin/commons/dbcp/interceptor/DataSourceGetConnectionInterceptor.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.commons.dbcp.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.commons.dbcp.CommonsDbcpConstants;
@@ -30,6 +31,11 @@ public class DataSourceGetConnectionInterceptor extends SpanEventSimpleAroundInt
 
     public DataSourceGetConnectionInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/dbcp2/src/main/java/com/navercorp/pinpoint/plugin/commons/dbcp2/interceptor/DataSourceCloseConnectionInterceptor.java
+++ b/plugins/dbcp2/src/main/java/com/navercorp/pinpoint/plugin/commons/dbcp2/interceptor/DataSourceCloseConnectionInterceptor.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.commons.dbcp2.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.commons.dbcp2.CommonsDbcp2Constants;
@@ -26,6 +27,11 @@ public class DataSourceCloseConnectionInterceptor extends SpanEventSimpleAroundI
 
     public DataSourceCloseConnectionInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/dbcp2/src/main/java/com/navercorp/pinpoint/plugin/commons/dbcp2/interceptor/DataSourceGetConnectionInterceptor.java
+++ b/plugins/dbcp2/src/main/java/com/navercorp/pinpoint/plugin/commons/dbcp2/interceptor/DataSourceGetConnectionInterceptor.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.commons.dbcp2.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.commons.dbcp2.CommonsDbcp2Constants;
@@ -29,6 +30,11 @@ public class DataSourceGetConnectionInterceptor extends SpanEventSimpleAroundInt
 
     public DataSourceGetConnectionInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/druid/src/main/java/com/navercorp/pinpoint/plugin/druid/interceptor/DataSourceCloseConnectionInterceptor.java
+++ b/plugins/druid/src/main/java/com/navercorp/pinpoint/plugin/druid/interceptor/DataSourceCloseConnectionInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.druid.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.druid.DruidConstants;
@@ -37,6 +38,11 @@ public class DataSourceCloseConnectionInterceptor extends SpanEventSimpleAroundI
      */
     public DataSourceCloseConnectionInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/druid/src/main/java/com/navercorp/pinpoint/plugin/druid/interceptor/DataSourceGetConnectionInterceptor.java
+++ b/plugins/druid/src/main/java/com/navercorp/pinpoint/plugin/druid/interceptor/DataSourceGetConnectionInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.druid.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.druid.DruidConstants;
@@ -37,6 +38,11 @@ public class DataSourceGetConnectionInterceptor extends SpanEventSimpleAroundInt
      */
     public DataSourceGetConnectionInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ParseArrayInterceptor.java
+++ b/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ParseArrayInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.fastjson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.fastjson.FastjsonConstants;
@@ -37,6 +38,11 @@ public class ParseArrayInterceptor extends SpanEventSimpleAroundInterceptorForPl
      */
     public ParseArrayInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ParseInterceptor.java
+++ b/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ParseInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.fastjson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.fastjson.FastjsonConstants;
@@ -37,6 +38,11 @@ public class ParseInterceptor extends SpanEventSimpleAroundInterceptorForPlugin 
      */
     public ParseInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ParseObjectInterceptor.java
+++ b/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ParseObjectInterceptor.java
@@ -77,7 +77,7 @@ public class ParseObjectInterceptor implements AroundInterceptor {
 
         final Trace trace = traceContext.currentTraceObject();
 
-        if (trace == null) {
+        if (trace == null || trace.isLiteModeTrace()) {
             return;
         }
 

--- a/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ToJavaObjectInterceptor.java
+++ b/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ToJavaObjectInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.fastjson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.fastjson.FastjsonConstants;
@@ -37,6 +38,11 @@ public class ToJavaObjectInterceptor extends SpanEventSimpleAroundInterceptorFor
      */
     public ToJavaObjectInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ToJsonBytesInterceptor.java
+++ b/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ToJsonBytesInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.fastjson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.fastjson.FastjsonConstants;
@@ -37,6 +38,11 @@ public class ToJsonBytesInterceptor extends SpanEventSimpleAroundInterceptorForP
      */
     public ToJsonBytesInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ToJsonInterceptor.java
+++ b/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ToJsonInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.fastjson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.fastjson.FastjsonConstants;
@@ -37,6 +38,11 @@ public class ToJsonInterceptor extends SpanEventSimpleAroundInterceptorForPlugin
      */
     public ToJsonInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ToJsonStringInterceptor.java
+++ b/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/ToJsonStringInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.fastjson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.fastjson.FastjsonConstants;
@@ -37,6 +38,11 @@ public class ToJsonStringInterceptor extends SpanEventSimpleAroundInterceptorFor
      */
     public ToJsonStringInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/WriteJsonStringInterceptor.java
+++ b/plugins/fastjson/src/main/java/com/navercorp/pinpoint/plugin/fastjson/interceptor/WriteJsonStringInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.fastjson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.fastjson.FastjsonConstants;
@@ -37,6 +38,11 @@ public class WriteJsonStringInterceptor extends SpanEventSimpleAroundInterceptor
      */
     public WriteJsonStringInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/ibatis/src/main/java/com/navercorp/pinpoint/plugin/ibatis/interceptor/SqlMapOperationInterceptor.java
+++ b/plugins/ibatis/src/main/java/com/navercorp/pinpoint/plugin/ibatis/interceptor/SqlMapOperationInterceptor.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.ibatis.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -33,6 +34,11 @@ public class SqlMapOperationInterceptor extends SpanEventSimpleAroundInterceptor
     public SqlMapOperationInterceptor(TraceContext context, MethodDescriptor descriptor, ServiceType serviceType) {
         super(context, descriptor);
         this.serviceType = serviceType;
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/jackson/src/main/java/com/navercorp/pinpoint/plugin/jackson/interceptor/ReadValueInterceptor.java
+++ b/plugins/jackson/src/main/java/com/navercorp/pinpoint/plugin/jackson/interceptor/ReadValueInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.jackson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.jackson.JacksonConstants;
@@ -35,6 +36,11 @@ public class ReadValueInterceptor extends SpanEventSimpleAroundInterceptorForPlu
     @Override
     protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
         recorder.recordServiceType(JacksonConstants.SERVICE_TYPE);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/jackson/src/main/java/com/navercorp/pinpoint/plugin/jackson/interceptor/WriteValueAsBytesInterceptor.java
+++ b/plugins/jackson/src/main/java/com/navercorp/pinpoint/plugin/jackson/interceptor/WriteValueAsBytesInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.jackson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.jackson.JacksonConstants;
@@ -29,6 +30,11 @@ public class WriteValueAsBytesInterceptor extends SpanEventSimpleAroundIntercept
 
     public WriteValueAsBytesInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/jackson/src/main/java/com/navercorp/pinpoint/plugin/jackson/interceptor/WriteValueAsStringInterceptor.java
+++ b/plugins/jackson/src/main/java/com/navercorp/pinpoint/plugin/jackson/interceptor/WriteValueAsStringInterceptor.java
@@ -16,6 +16,7 @@ package com.navercorp.pinpoint.plugin.jackson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.jackson.JacksonConstants;
@@ -29,6 +30,11 @@ public class WriteValueAsStringInterceptor extends SpanEventSimpleAroundIntercep
 
     public WriteValueAsStringInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/json-lib/src/main/java/com/navercorp/pinpoint/plugin/json_lib/interceptor/ParsingInterceptor.java
+++ b/plugins/json-lib/src/main/java/com/navercorp/pinpoint/plugin/json_lib/interceptor/ParsingInterceptor.java
@@ -17,6 +17,7 @@ package com.navercorp.pinpoint.plugin.json_lib.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.common.util.ArrayUtils;
@@ -31,6 +32,11 @@ public class ParsingInterceptor extends SpanEventSimpleAroundInterceptorForPlugi
 
     public ParsingInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/json-lib/src/main/java/com/navercorp/pinpoint/plugin/json_lib/interceptor/ToStringInterceptor.java
+++ b/plugins/json-lib/src/main/java/com/navercorp/pinpoint/plugin/json_lib/interceptor/ToStringInterceptor.java
@@ -17,6 +17,7 @@ package com.navercorp.pinpoint.plugin.json_lib.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.json_lib.JsonLibConstants;
@@ -30,6 +31,11 @@ public class ToStringInterceptor extends SpanEventSimpleAroundInterceptorForPlug
 
     public ToStringInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/mongodb/src/main/java/com/navercorp/pinpoint/plugin/mongo/interceptor/MongoCUDSessionInterceptor.java
+++ b/plugins/mongodb/src/main/java/com/navercorp/pinpoint/plugin/mongo/interceptor/MongoCUDSessionInterceptor.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.MongoDatabaseInfo;
@@ -41,6 +42,11 @@ public class MongoCUDSessionInterceptor extends SpanEventSimpleAroundInterceptor
         super(traceContext, descriptor);
         this.collectJson = collectJson;
         this.traceBsonBindValue = traceBsonBindValue;
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/mongodb/src/main/java/com/navercorp/pinpoint/plugin/mongo/interceptor/MongoRSessionInterceptor.java
+++ b/plugins/mongodb/src/main/java/com/navercorp/pinpoint/plugin/mongo/interceptor/MongoRSessionInterceptor.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.MongoDatabaseInfo;
@@ -43,6 +44,10 @@ public class MongoRSessionInterceptor extends SpanEventSimpleAroundInterceptorFo
         this.traceBsonBindValue = traceBsonBindValue;
     }
 
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
+    }
 
     @Override
     protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {

--- a/plugins/mybatis/src/main/java/com/navercorp/pinpoint/plugin/mybatis/interceptor/SqlSessionOperationInterceptor.java
+++ b/plugins/mybatis/src/main/java/com/navercorp/pinpoint/plugin/mybatis/interceptor/SqlSessionOperationInterceptor.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.mybatis.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.common.util.ArrayUtils;
@@ -31,6 +32,11 @@ public class SqlSessionOperationInterceptor extends SpanEventSimpleAroundInterce
 
     public SqlSessionOperationInterceptor(TraceContext context, MethodDescriptor descriptor) {
         super(context, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/mysql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mysql/interceptor/MySQLConnectionCreateInterceptor.java
+++ b/plugins/mysql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mysql/interceptor/MySQLConnectionCreateInterceptor.java
@@ -74,7 +74,7 @@ public class MySQLConnectionCreateInterceptor implements AroundInterceptor {
         }
 
         final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || trace.isLiteModeTrace()) {
             return;
         }
 

--- a/plugins/mysql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mysql/interceptor/MySQL_6_X_ConnectionCreateInterceptor.java
+++ b/plugins/mysql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mysql/interceptor/MySQL_6_X_ConnectionCreateInterceptor.java
@@ -74,7 +74,7 @@ public class MySQL_6_X_ConnectionCreateInterceptor implements AroundInterceptor 
         }
 
         final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || trace.isLiteModeTrace()) {
             return;
         }
 

--- a/plugins/postgresql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/postgresql/interceptor/PostgreSQLConnectionCreateInterceptor.java
+++ b/plugins/postgresql-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/postgresql/interceptor/PostgreSQLConnectionCreateInterceptor.java
@@ -81,7 +81,7 @@ public class PostgreSQLConnectionCreateInterceptor implements AroundInterceptor 
         }
 
         final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || trace.isLiteModeTrace()) {
             return;
         }
 

--- a/plugins/redis-lettuce/src/main/java/com/navercorp/pinpoint/plugin/redis/lettuce/interceptor/LettuceMethodInterceptor.java
+++ b/plugins/redis-lettuce/src/main/java/com/navercorp/pinpoint/plugin/redis/lettuce/interceptor/LettuceMethodInterceptor.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.redis.lettuce.EndPointAccessor;
@@ -34,6 +35,11 @@ public class LettuceMethodInterceptor extends SpanEventSimpleAroundInterceptorFo
 
     public LettuceMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
         super(traceContext, methodDescriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/CommandAsyncServiceMethodInterceptor.java
+++ b/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/CommandAsyncServiceMethodInterceptor.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
@@ -46,6 +47,11 @@ public class CommandAsyncServiceMethodInterceptor extends SpanEventSimpleAroundI
 
         final RedissonPluginConfig config = new RedissonPluginConfig(traceContext.getProfilerConfig());
         this.keyTrace = config.isKeyTrace();
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/ReactiveMethodInterceptor.java
+++ b/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/ReactiveMethodInterceptor.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
@@ -40,6 +41,11 @@ public class ReactiveMethodInterceptor extends SpanEventSimpleAroundInterceptorF
         super(traceContext, descriptor);
         final RedissonPluginConfig config = new RedissonPluginConfig(traceContext.getProfilerConfig());
         this.keyTrace = config.isKeyTrace();
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/RedissonMethodInterceptor.java
+++ b/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/RedissonMethodInterceptor.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.redis.redisson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.redis.redisson.RedissonConstants;
@@ -28,6 +29,11 @@ import com.navercorp.pinpoint.plugin.redis.redisson.RedissonConstants;
 public class RedissonMethodInterceptor extends SpanEventSimpleAroundInterceptorForPlugin {
     public RedissonMethodInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/redis/src/main/java/com/navercorp/pinpoint/plugin/redis/jedis/interceptor/JedisMethodInterceptor.java
+++ b/plugins/redis/src/main/java/com/navercorp/pinpoint/plugin/redis/jedis/interceptor/JedisMethodInterceptor.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.redis.jedis.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope;
@@ -44,6 +45,11 @@ public class JedisMethodInterceptor extends SpanEventSimpleAroundInterceptorForP
 
         this.interceptorScope = interceptorScope;
         this.io = io;
+    }
+
+    @Override
+    protected boolean canTrace(Trace trace) {
+        return super.notInLiteMode(trace);
     }
 
     @Override

--- a/plugins/redis/src/main/java/com/navercorp/pinpoint/plugin/redis/jedis/interceptor/ProtocolSendCommandAndReadMethodInterceptor.java
+++ b/plugins/redis/src/main/java/com/navercorp/pinpoint/plugin/redis/jedis/interceptor/ProtocolSendCommandAndReadMethodInterceptor.java
@@ -53,7 +53,7 @@ public class ProtocolSendCommandAndReadMethodInterceptor implements AroundInterc
         }
 
         final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || trace.isLiteModeTrace()) {
             return;
         }
 
@@ -83,7 +83,7 @@ public class ProtocolSendCommandAndReadMethodInterceptor implements AroundInterc
         }
 
         final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || trace.isLiteModeTrace()) {
             return;
         }
 

--- a/plugins/spring/src/main/java/com/navercorp/pinpoint/plugin/spring/beans/interceptor/BeanMethodInterceptor.java
+++ b/plugins/spring/src/main/java/com/navercorp/pinpoint/plugin/spring/beans/interceptor/BeanMethodInterceptor.java
@@ -49,7 +49,7 @@ public class BeanMethodInterceptor implements ApiIdAwareAroundInterceptor {
         }
 
         final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || trace.isLiteModeTrace()) {
             return;
         }
 
@@ -64,7 +64,7 @@ public class BeanMethodInterceptor implements ApiIdAwareAroundInterceptor {
         }
 
         final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+        if (trace == null || trace.isLiteModeTrace()) {
             return;
         }
 

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AsyncChildTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AsyncChildTrace.java
@@ -209,6 +209,11 @@ public class AsyncChildTrace implements Trace {
         return this.getTraceId().isRoot();
     }
 
+    @Override
+    public boolean isLiteModeTrace() {
+        return this.getTraceId().isLiteModeTrace();
+    }
+
     private void logSpan(SpanEvent spanEvent) {
         this.storage.store(spanEvent);
     }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AsyncTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/AsyncTrace.java
@@ -66,6 +66,11 @@ public class AsyncTrace implements Trace {
     }
 
     @Override
+    public boolean isLiteModeTrace() {
+        return this.traceRoot.getTraceId().isLiteModeTrace();
+    }
+
+    @Override
     public SpanEventRecorder traceBlockBegin() {
         return trace.traceBlockBegin();
     }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultTrace.java
@@ -233,6 +233,10 @@ public final class DefaultTrace implements Trace {
         return this.getTraceId().isRoot();
     }
 
+    public boolean isLiteModeTrace() {
+        return this.getTraceId().isLiteModeTrace();
+    }
+
     private void logSpan(SpanEvent spanEvent) {
         this.storage.store(spanEvent);
     }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DisableTrace.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DisableTrace.java
@@ -92,6 +92,11 @@ public class DisableTrace implements Trace {
     }
 
     @Override
+    public boolean isLiteModeTrace() {
+        return false;
+    }
+
+    @Override
     public boolean isAsync() {
         return false;
     }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/id/DefaultTraceId.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/id/DefaultTraceId.java
@@ -34,11 +34,11 @@ public class DefaultTraceId implements TraceId {
     private final short flags;
 
     public DefaultTraceId(String agentId, long agentStartTime, long transactionId) {
-        this(agentId, agentStartTime, transactionId, SpanId.NULL, SpanId.newSpanId(), (short) 0);
+        this(agentId, agentStartTime, transactionId, (short) 0);
     }
 
-    public TraceId getNextTraceId() {
-        return new DefaultTraceId(this.agentId, this.agentStartTime, transactionSequence, spanId, SpanId.nextSpanID(spanId, parentSpanId), flags);
+    public DefaultTraceId(String agentId, long agentStartTime, long transactionId, short flags) {
+        this(agentId, agentStartTime, transactionId, SpanId.NULL, SpanId.newSpanId(), flags);
     }
 
     public DefaultTraceId(String agentId, long agentStartTime, long transactionId, long parentSpanId, long spanId, short flags) {
@@ -52,6 +52,10 @@ public class DefaultTraceId implements TraceId {
         this.parentSpanId = parentSpanId;
         this.spanId = spanId;
         this.flags = flags;
+    }
+
+    public TraceId getNextTraceId() {
+        return new DefaultTraceId(this.agentId, this.agentStartTime, transactionSequence, spanId, SpanId.nextSpanID(spanId, parentSpanId), flags);
     }
 
     public String getTransactionId() {
@@ -82,6 +86,14 @@ public class DefaultTraceId implements TraceId {
 
     public short getFlags() {
         return flags;
+    }
+
+    public boolean isLiteModeTrace() {
+        return (flags & 1) == 1;
+    }
+
+    public boolean isFullModeTrace() {
+        return (flags & 1) == 0;
     }
 
     public boolean isRoot() {

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/id/DefaultTraceIdFactory.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/id/DefaultTraceIdFactory.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.profiler.util.TransactionIdUtils;
 import com.navercorp.pinpoint.common.util.Assert;
 import com.navercorp.pinpoint.profiler.context.module.AgentId;
 import com.navercorp.pinpoint.profiler.context.module.AgentStartTime;
+import com.navercorp.pinpoint.profiler.context.module.config.ProfilerSamplingLiteRate;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -31,18 +32,43 @@ public class DefaultTraceIdFactory implements TraceIdFactory {
 
     private final String agentId;
     private final long agentStartTime;
+    private final int samplingFullModeRate;
+    private final int samplingLiteMinSeqNum;
+    private final int samplingLiteOutOfNum;
 
     @Inject
-    public DefaultTraceIdFactory(@AgentId String agentId, @AgentStartTime long agentStartTime) {
+    public DefaultTraceIdFactory(@AgentId String agentId, @AgentStartTime long agentStartTime, @ProfilerSamplingLiteRate int samplingLiteRate) {
         this.agentId = Assert.requireNonNull(agentId, "agentId");
         this.agentStartTime = agentStartTime;
-
+        this.samplingFullModeRate = 100 - samplingLiteRate;
+        boolean isPercent = (this.samplingFullModeRate % 10) != 0;
+        if (isPercent) {
+            this.samplingLiteOutOfNum = 100;
+            this.samplingLiteMinSeqNum = this.samplingFullModeRate;
+        } else {
+            this.samplingLiteOutOfNum = 10;
+            this.samplingLiteMinSeqNum = this.samplingFullModeRate / 10;
+        }
     }
 
     @Override
     public TraceId newTraceId(long localTransactionId) {
-        final TraceId traceId = new DefaultTraceId(agentId, agentStartTime, localTransactionId);
-        return traceId;
+        return new DefaultTraceId(agentId, agentStartTime, localTransactionId, getNewTraceFlags(localTransactionId));
+    }
+
+    private short getNewTraceFlags(long localTransactionId) {
+        return isLiteTrace(localTransactionId) ? (short) 1 : 0;
+    }
+
+    private boolean isLiteTrace(long localTransactionId) {
+        if (samplingFullModeRate == 100) {
+            return false;
+        }
+        if (samplingFullModeRate == 0) {
+            return true;
+        }
+        final long mod = localTransactionId % this.samplingLiteOutOfNum;
+        return mod >= this.samplingLiteMinSeqNum;
     }
 
     public TraceId continueTraceId(String transactionId, long parentSpanId, long spanId, short flags) {

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/config/ConfigModule.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/config/ConfigModule.java
@@ -109,6 +109,8 @@ public class ConfigModule extends AbstractModule {
         Named callstackMaxDepth = Names.named("profiler.callstack.max.depth");
         bindConstant().annotatedWith(callstackMaxDepth).to(profilerConfig.getCallStackMaxDepth());
 
+        bindConstant().annotatedWith(ProfilerSamplingLiteRate.class).to(profilerConfig.getSamplingLiteRate());
+
         bindConstant().annotatedWith(TraceAgentActiveThread.class).to(profilerConfig.isTraceAgentActiveThread());
 
         bindConstant().annotatedWith(DeadlockMonitorEnable.class).to(profilerConfig.isDeadlockMonitorEnable());

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/config/ProfilerSamplingLiteRate.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/config/ProfilerSamplingLiteRate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.context.module.config;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author yjqg6666
+ */
+@BindingAnnotation
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface ProfilerSamplingLiteRate {
+}

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/id/DefaultTraceIdTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/id/DefaultTraceIdTest.java
@@ -1,0 +1,21 @@
+package com.navercorp.pinpoint.profiler.context.id;
+
+import com.navercorp.pinpoint.bootstrap.context.TraceId;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DefaultTraceIdTest {
+    @Test
+    public void testMode() {
+        TraceId traceId = new DefaultTraceId("agentId", 1600686110110L, 1);
+        assertTrue("not full profiling mode", traceId.isFullModeTrace());
+        assertFalse("should not be lite mode profiling", traceId.isLiteModeTrace());
+        short liteMode = 1;
+        TraceId liteTraceId = new DefaultTraceId("agentId", 1600686110110L, 2, liteMode);
+        assertTrue("should be lite mode profiling", liteTraceId.isLiteModeTrace());
+        assertFalse("should not be full profiling mode", liteTraceId.isFullModeTrace());
+
+    }
+}


### PR DESCRIPTION
related to #7257 The final implementation have some changes.

Feature:
In a lite trace only the span events of server/client/queue type are recorded. A new config profiler.sampling.lite.rate is added. If profiler.sampling.lite.rate is not set or is set to 0, it would behave as it used to.  If the rate is set to 100, then all traces are lite.

Let's say that the configs in a profile are profiler.sampling.rate=1 (100%) profiler.sampling.lite.rate=80 and we have 100 requests. Then in the PR version 80 requests would be traced in lite mode and the left 20 request would be traced in full mode. 

This feature is disabled by default.

![image](https://user-images.githubusercontent.com/1879641/94134216-4edde000-fe94-11ea-92bc-21daeb997d9a.png)



