### PR TITLE
[#7362] Add kafka client plugin IT

### DIFF
--- a/plugins-it/kafka-it/pom.xml
+++ b/plugins-it/kafka-it/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint-plugins-it</artifactId>
+        <version>2.1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pinpoint-kafka-plugin-it</artifactId>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <jdk.version>1.8</jdk.version>
+        <jdk.home>${env.JAVA_8_HOME}</jdk.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-kafka-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-plugin-it-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.12</artifactId>
+            <version>2.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClientITBase.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClientITBase.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedAnnotation;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import test.pinpoint.plugin.kafka.*;
+
+import java.lang.reflect.Method;
+
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
+import static test.pinpoint.plugin.kafka.KafkaITConstants.*;
+
+/**
+ * @author Younsung Hwang
+ */
+public abstract class KafkaClientITBase {
+
+    private static final KafkaUnitServer KAFKA_UNIT_SERVER = new KafkaUnitServer(2189, 9092);
+    private static final OffsetStore OFFSET_STORE = new OffsetStore();
+    private static final TestConsumer TEST_CONSUMER = new TestConsumer(OFFSET_STORE);
+    protected final TestProducer producer = new TestProducer();
+
+    @BeforeClass
+    public static void beforeClass() {
+        KAFKA_UNIT_SERVER.startup();
+        TEST_CONSUMER.start();
+    }
+
+    @AfterClass
+    public static void afterClass() throws InterruptedException {
+        TEST_CONSUMER.shutdown();
+        KAFKA_UNIT_SERVER.shutdown();
+    }
+
+    protected void verifyProducerSend(int messageCount) throws NoSuchMethodException {
+
+        int consumerInvocationCount = messageCount * 2;
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.awaitTraceCount(messageCount + consumerInvocationCount, 100, MAX_TRACE_WAIT_TIME);
+        verifier.printCache();
+
+        Method sendMethod = KafkaProducer.class.getDeclaredMethod("send", ProducerRecord.class, Callback.class);
+        ExpectedTrace.Builder eventBuilder = ExpectedTrace.createEventBuilder(KAFKA_CLIENT_SERVICE_TYPE);
+        eventBuilder.setMethod(sendMethod);
+        eventBuilder.setEndPoint(BROKER_URL);
+        eventBuilder.setDestinationId(BROKER_URL);
+        eventBuilder.setAnnotations(annotation("kafka.topic", TOPIC));
+        ExpectedTrace producerSendExpected = eventBuilder.build();
+
+        for (int i = 0; i < messageCount; i++) {
+            verifier.verifyDiscreteTrace(producerSendExpected);
+        }
+
+        verifier.verifyTraceCount(consumerInvocationCount);
+    }
+
+    protected void verifySingleConsumerEntryPoint() throws NoSuchMethodException {
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.awaitTraceCount(3, 100, MAX_TRACE_WAIT_TIME);
+
+        String expectedRpc = "kafka://topic=" + TOPIC + "?partition=" + PARTITION + "&offset=" + OFFSET_STORE.getOffset();
+        verifyConsumerEntryPoint(verifier, TOPIC, expectedRpc, ConsumerRecord.class,
+                annotation("kafka.topic", TOPIC),
+                annotation("kafka.partition", PARTITION),
+                annotation("kafka.offset", OFFSET_STORE.getOffset())
+        );
+    }
+
+    protected void verifyMultiConsumerEntryPoint() throws NoSuchMethodException {
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.awaitTraceCount(3, 100, MAX_TRACE_WAIT_TIME);
+
+        String expectedRpc = "kafka://topic=" + TOPIC + "?batch=1";
+        verifyConsumerEntryPoint(verifier, TOPIC, expectedRpc, ConsumerRecords.class,
+                annotation("kafka.topic", TOPIC),
+                annotation("kafka.batch", 1)
+        );
+    }
+
+    private void verifyConsumerEntryPoint(PluginTestVerifier verifier, String topic, String expectedRpc, Class paramType, ExpectedAnnotation... expectedAnnotations)
+            throws NoSuchMethodException {
+
+        Method sendMethod = KafkaProducer.class.getDeclaredMethod("send", ProducerRecord.class, Callback.class);
+        ExpectedTrace.Builder eventBuilder = ExpectedTrace.createEventBuilder(KAFKA_CLIENT_SERVICE_TYPE);
+        eventBuilder.setMethod(sendMethod);
+        eventBuilder.setEndPoint(BROKER_URL);
+        eventBuilder.setDestinationId(BROKER_URL);
+        eventBuilder.setAnnotations(annotation("kafka.topic", topic));
+        ExpectedTrace producerSendExpected = eventBuilder.build();
+
+        ExpectedTrace.Builder rootBuilder = ExpectedTrace.createRootBuilder(KAFKA_CLIENT_SERVICE_TYPE);
+        rootBuilder.setMethodSignature("Kafka Consumer Invocation");
+        rootBuilder.setRpc(expectedRpc);
+        rootBuilder.setRemoteAddr(BROKER_URL);
+        rootBuilder.setAnnotations(expectedAnnotations);
+        ExpectedTrace consumerEntryPointInvocationExpected = rootBuilder.build();
+
+        Method consumeRecordsMethod = TestConsumerRecordEntryPoint.class.getDeclaredMethod("consumeRecord", paramType);
+        ExpectedTrace messageArrivedExpected = event(KAFKA_CLIENT_INTERNAL_SERVICE_TYPE, consumeRecordsMethod);
+
+        verifier.printCache();
+        verifier.verifyDiscreteTrace(producerSendExpected, consumerEntryPointInvocationExpected, messageArrivedExpected);
+    }
+}

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_0_11_x_IT.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_0_11_x_IT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_MULTI_RECORDS;
+
+/**
+ * @author Younsung Hwang
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-kafka-client.config")
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
+@Dependency({
+        "org.apache.kafka:kafka_2.12:[0.11.0.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
+        "org.apache.kafka:kafka-clients:[0.11.0.0,0.11.max]",
+})
+@JvmVersion(8)
+public class KafkaClient_0_11_x_IT extends KafkaClientITBase {
+
+    @Test
+    public void producerSendTest() throws NoSuchMethodException {
+        int messageCount = new Random().nextInt(5) + 1;
+        producer.sendMessage(messageCount);
+        verifyProducerSend(messageCount);
+    }
+
+    @Test
+    public void recordEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1);
+        verifySingleConsumerEntryPoint();
+    }
+
+    @Test
+    public void recordMultiEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_MULTI_RECORDS);
+        verifyMultiConsumerEntryPoint();
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_1_0_x_IT.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_1_0_x_IT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_MULTI_RECORDS;
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
+
+
+/**
+ * @author Younsung Hwang
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-kafka-client.config")
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
+@Dependency({
+        "org.apache.kafka:kafka_2.12:[1.0.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
+        "org.apache.kafka:kafka-clients:[1.0.0,1.0.max]"
+})
+@JvmVersion(8)
+public class KafkaClient_1_0_x_IT extends KafkaClientITBase {
+
+    @Test
+    public void producerSendTest() throws NoSuchMethodException {
+        int messageCount = new Random().nextInt(5) + 1;
+        producer.sendMessage(messageCount);
+        verifyProducerSend(messageCount);
+    }
+
+    @Test
+    public void recordEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_RECORD);
+        verifySingleConsumerEntryPoint();
+    }
+
+    @Test
+    public void recordMultiEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_MULTI_RECORDS);
+        verifyMultiConsumerEntryPoint();
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_1_1_x_IT.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_1_1_x_IT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_MULTI_RECORDS;
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
+
+
+/**
+ * @author Younsung Hwang
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-kafka-client.config")
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
+@Dependency({
+        "org.apache.kafka:kafka_2.12:[1.1.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
+        "org.apache.kafka:kafka-clients:[1.1.0,1.1.max]"
+})
+@JvmVersion(8)
+public class KafkaClient_1_1_x_IT extends KafkaClientITBase {
+
+    @Test
+    public void producerSendTest() throws NoSuchMethodException {
+        int messageCount = new Random().nextInt(5) + 1;
+        producer.sendMessage(messageCount);
+        verifyProducerSend(messageCount);
+    }
+
+    @Test
+    public void recordEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_RECORD);
+        verifySingleConsumerEntryPoint();
+    }
+
+    @Test
+    public void recordMultiEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_MULTI_RECORDS);
+        verifyMultiConsumerEntryPoint();
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_0_x_IT.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_0_x_IT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_MULTI_RECORDS;
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
+
+
+/**
+ * @author Younsung Hwang
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-kafka-client.config")
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
+@Dependency({
+        "org.apache.kafka:kafka_2.12:[2.0.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
+        "org.apache.kafka:kafka-clients:[2.0.0,2.0.max]",
+})
+@JvmVersion(8)
+public class KafkaClient_2_0_x_IT extends KafkaClientITBase {
+
+    @Test
+    public void producerSendTest() throws NoSuchMethodException {
+        int messageCount = new Random().nextInt(5) + 1;
+        producer.sendMessage(messageCount);
+        verifyProducerSend(messageCount);
+    }
+
+    @Test
+    public void recordEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_RECORD);
+        verifySingleConsumerEntryPoint();
+    }
+
+    @Test
+    public void recordMultiEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_MULTI_RECORDS);
+        verifyMultiConsumerEntryPoint();
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_2_x_IT.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_2_x_IT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_MULTI_RECORDS;
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
+
+
+/**
+ * @author Younsung Hwang
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-kafka-client.config")
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
+@Dependency({
+        "org.apache.kafka:kafka_2.12:[2.2.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
+        "org.apache.kafka:kafka-clients:[2.2.0,2.2.max]",
+})
+@JvmVersion(8)
+public class KafkaClient_2_2_x_IT extends KafkaClientITBase {
+
+    @Test
+    public void producerSendTest() throws NoSuchMethodException {
+        int messageCount = new Random().nextInt(5) + 1;
+        producer.sendMessage(messageCount);
+        verifyProducerSend(messageCount);
+    }
+
+    @Test
+    public void recordEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_RECORD);
+        verifySingleConsumerEntryPoint();
+    }
+
+    @Test
+    public void recordMultiEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_MULTI_RECORDS);
+        verifyMultiConsumerEntryPoint();
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_3_0_IT.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_3_0_IT.java
@@ -1,0 +1,47 @@
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_MULTI_RECORDS;
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
+
+
+/**
+ * @author Younsung Hwang
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-kafka-client.config")
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
+@Dependency({
+        "org.apache.kafka:kafka_2.12:[2.3.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
+        "org.apache.kafka:kafka-clients:[2.3.0]",
+})
+@JvmVersion(8)
+public class KafkaClient_2_3_0_IT extends KafkaClientITBase {
+
+    @Test
+    public void producerSendTest() throws NoSuchMethodException {
+        int messageCount = new Random().nextInt(5) + 1;
+        producer.sendMessage(messageCount);
+        verifyProducerSend(messageCount);
+    }
+
+    @Test
+    public void recordEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_RECORD);
+        verifySingleConsumerEntryPoint();
+    }
+
+    @Test
+    public void recordMultiEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_MULTI_RECORDS);
+        verifyMultiConsumerEntryPoint();
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_3_1_to_max_IT.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_3_1_to_max_IT.java
@@ -1,0 +1,47 @@
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_MULTI_RECORDS;
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
+
+
+/**
+ * @author Younsung Hwang
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-kafka-client.config")
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
+@Dependency({
+        "org.apache.kafka:kafka_2.12:[2.3.1]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
+        "org.apache.kafka:kafka-clients:[2.3.1,2.3.max]",
+})
+@JvmVersion(8)
+public class KafkaClient_2_3_1_to_max_IT extends KafkaClientITBase {
+
+    @Test
+    public void producerSendTest() throws NoSuchMethodException {
+        int messageCount = new Random().nextInt(5) + 1;
+        producer.sendMessage(messageCount);
+        verifyProducerSend(messageCount);
+    }
+
+    @Test
+    public void recordEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_RECORD);
+        verifySingleConsumerEntryPoint();
+    }
+
+    @Test
+    public void recordMultiEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_MULTI_RECORDS);
+        verifyMultiConsumerEntryPoint();
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_4_x_IT.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_4_x_IT.java
@@ -1,0 +1,47 @@
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_MULTI_RECORDS;
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
+
+
+/**
+ * @author Younsung Hwang
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-kafka-client.config")
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
+@Dependency({
+        "org.apache.kafka:kafka_2.12:[2.4.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
+        "org.apache.kafka:kafka-clients:[2.4.0,2.4.max]"
+})
+@JvmVersion(8)
+public class KafkaClient_2_4_x_IT extends KafkaClientITBase {
+
+    @Test
+    public void producerSendTest() throws NoSuchMethodException {
+        int messageCount = new Random().nextInt(5) + 1;
+        producer.sendMessage(messageCount);
+        verifyProducerSend(messageCount);
+    }
+
+    @Test
+    public void recordEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_RECORD);
+        verifySingleConsumerEntryPoint();
+    }
+
+    @Test
+    public void recordMultiEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_MULTI_RECORDS);
+        verifyMultiConsumerEntryPoint();
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_5_x_IT.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_5_x_IT.java
@@ -1,0 +1,47 @@
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_MULTI_RECORDS;
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
+
+
+/**
+ * @author Younsung Hwang
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-kafka-client.config")
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
+@Dependency({
+        "org.apache.kafka:kafka_2.12:[2.5.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
+        "org.apache.kafka:kafka-clients:[2.5.0,2.5.max]"
+})
+@JvmVersion(8)
+public class KafkaClient_2_5_x_IT extends KafkaClientITBase {
+
+    @Test
+    public void producerSendTest() throws NoSuchMethodException {
+        int messageCount = new Random().nextInt(5) + 1;
+        producer.sendMessage(messageCount);
+        verifyProducerSend(messageCount);
+    }
+
+    @Test
+    public void recordEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_RECORD);
+        verifySingleConsumerEntryPoint();
+    }
+
+    @Test
+    public void recordMultiEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_MULTI_RECORDS);
+        verifyMultiConsumerEntryPoint();
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_6_x_IT.java
+++ b/plugins-it/kafka-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_6_x_IT.java
@@ -1,0 +1,47 @@
+package com.navercorp.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_MULTI_RECORDS;
+import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
+
+
+/**
+ * @author Younsung Hwang
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-kafka-client.config")
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
+@Dependency({
+        "org.apache.kafka:kafka_2.12:[2.6.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
+        "org.apache.kafka:kafka-clients:[2.6.0,)"
+})
+@JvmVersion(8)
+public class KafkaClient_2_6_x_IT extends KafkaClientITBase {
+
+    @Test
+    public void producerSendTest() throws NoSuchMethodException {
+        int messageCount = new Random().nextInt(5) + 1;
+        producer.sendMessage(messageCount);
+        verifyProducerSend(messageCount);
+    }
+
+    @Test
+    public void recordEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_RECORD);
+        verifySingleConsumerEntryPoint();
+    }
+
+    @Test
+    public void recordMultiEntryPointTest() throws NoSuchMethodException {
+        producer.sendMessage(1, TRACE_TYPE_MULTI_RECORDS);
+        verifyMultiConsumerEntryPoint();
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/KafkaITConstants.java
+++ b/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/KafkaITConstants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.pinpoint.plugin.kafka;
+
+import java.util.UUID;
+
+/**
+ * @author Younsung Hwang
+ */
+public class KafkaITConstants {
+    public static final String BROKER_URL = "localhost:9092";
+    public static final String TOPIC = "kafka-it-topic";
+    public static final String MESSAGE = "message-" + UUID.randomUUID().toString();
+    public static final String GROUP_ID = "kafka-it-group";
+    public static final String KAFKA_CLIENT_SERVICE_TYPE = "KAFKA_CLIENT";
+    public static final String KAFKA_CLIENT_INTERNAL_SERVICE_TYPE = "KAFKA_CLIENT_INTERNAL";
+    public static final int PARTITION = 0;
+    public static final String TRACE_TYPE_RECORD = "RECORD";
+    public static final String TRACE_TYPE_MULTI_RECORDS = "MULTI_RECORDS";
+    public static final long MAX_TRACE_WAIT_TIME = 10000;
+}

--- a/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/KafkaUnitServer.java
+++ b/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/KafkaUnitServer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.pinpoint.plugin.kafka;
+
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServerStartable;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Properties;
+
+/**
+ * Copy of https://github.com/chbatey/kafka-unit/blob/master/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+ * Some codes have been modified for testing from the copied code.
+ */
+public class KafkaUnitServer {
+
+    private static final Logger logger = LoggerFactory.getLogger(KafkaUnitServer.class);
+    private String zookeeperString;
+    private String brokerString;
+    private int zkPort;
+    private int brokerPort;
+    private Properties kafkaBrokerConfig;
+    private int zkMaxConnections;
+    private KafkaServerStartable broker;
+    private ZookeeperUnitServer zookeeper;
+    private File logDir;
+
+    public KafkaUnitServer(int zkPort, int brokerPort) {
+        this(zkPort, brokerPort, 16);
+    }
+
+    public KafkaUnitServer(int zkPort, int brokerPort, int zkMaxConnections) {
+        this.kafkaBrokerConfig = new Properties();
+        this.zkPort = zkPort;
+        this.brokerPort = brokerPort;
+        this.zookeeperString = "localhost:" + zkPort;
+        this.brokerString = "localhost:" + brokerPort;
+        this.zkMaxConnections = zkMaxConnections;
+    }
+
+    public void startup() {
+        zookeeper = new ZookeeperUnitServer(zkPort, zkMaxConnections);
+        zookeeper.startup();
+
+        try {
+            logDir = Files.createTempDirectory("kafka").toFile();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to start Kafka", e);
+        }
+        logDir.deleteOnExit();
+        Runtime.getRuntime().addShutdownHook(new Thread(getDeleteLogDirectoryAction()));
+
+        kafkaBrokerConfig.setProperty("zookeeper.connect", zookeeperString);
+        kafkaBrokerConfig.setProperty("broker.id", "1");
+        kafkaBrokerConfig.setProperty("host.name", "localhost");
+        kafkaBrokerConfig.setProperty("port", Integer.toString(brokerPort));
+        kafkaBrokerConfig.setProperty("log.dir", logDir.getAbsolutePath());
+        kafkaBrokerConfig.setProperty("log.flush.interval.messages", String.valueOf(1));
+        kafkaBrokerConfig.setProperty("delete.topic.enable", String.valueOf(true));
+        kafkaBrokerConfig.setProperty("offsets.topic.replication.factor", String.valueOf(1));
+        kafkaBrokerConfig.setProperty("auto.create.topics.enable", String.valueOf(true));
+        broker = new KafkaServerStartable(new KafkaConfig(kafkaBrokerConfig));
+        broker.startup();
+    }
+
+    public void shutdown() {
+        if (broker != null) {
+            broker.shutdown();
+            broker.awaitShutdown();
+        }
+        if (zookeeper != null) {
+            zookeeper.shutdown();
+        }
+    }
+    private Runnable getDeleteLogDirectoryAction() {
+        return new Runnable() {
+            @Override
+            public void run() {
+                if (logDir != null) {
+                    try {
+                        FileUtils.deleteDirectory(logDir);
+                    } catch (IOException e) {
+                        logger.warn("Problems deleting temporary directory " + logDir.getAbsolutePath(), e);
+                    }
+                }
+            }
+        };
+    }
+}

--- a/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/OffsetStore.java
+++ b/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/OffsetStore.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.pinpoint.plugin.kafka;
+
+/**
+ * @author Younsung Hwang
+ */
+public class OffsetStore {
+    private long offset = 0L;
+    public long getOffset() {
+        return offset;
+    }
+    public void setOffset(long offset) {
+        this.offset = offset;
+    }
+}

--- a/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/TestConsumer.java
+++ b/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/TestConsumer.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.pinpoint.plugin.kafka;
+
+import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.test.plugin.shared.SharedPluginTestConstants;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Properties;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.*;
+
+/**
+ * @author Younsung Hwang
+ */
+public class TestConsumer {
+
+    private static final Logger logger = LoggerFactory.getLogger(KafkaUnitServer.class);
+    private final Thread consumerThread;
+    private final Poller poller;
+
+    public TestConsumer(OffsetStore offsetStore) {
+        String testClassName = System.getProperty(SharedPluginTestConstants.TEST_CLAZZ_NAME);
+        String testSimpleClassName = StringUtils.hasLength(testClassName) ? testClassName.substring(testClassName.lastIndexOf(".") + 1) : "UNKNOWN";
+        String threadName = testSimpleClassName + "-test-poller";
+        poller = new Poller(offsetStore);
+        consumerThread = new Thread(poller, threadName);
+        consumerThread.setDaemon(true);
+    }
+
+    public void shutdown() throws InterruptedException {
+        poller.shutdown();
+        consumerThread.join(100L);
+    }
+
+    public void start() {
+        consumerThread.start();
+    }
+
+    private static class Poller implements Runnable {
+
+        private final KafkaConsumer<String, String> consumer;
+        private final OffsetStore offsetStore;
+
+        private Poller(OffsetStore offsetStore) {
+            Properties props = new Properties();
+            props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BROKER_URL);
+            props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "10000");
+            props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+            props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+            props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, String.valueOf(true));
+            props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+            consumer = new KafkaConsumer<>(props);
+            this.offsetStore = offsetStore;
+        }
+
+        private void shutdown() {
+            consumer.wakeup();
+        }
+
+        @Override
+        public void run() {
+            consumer.subscribe(Collections.singleton(TOPIC));
+            consumer.poll(0);
+            consumer.seekToBeginning(Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
+            TestConsumerRecordEntryPoint entryPoint = new TestConsumerRecordEntryPoint();
+
+            try {
+                while (true) {
+                    ConsumerRecords<String, String> records = consumer.poll(1000L);
+                    if(records != null && records.count() > 0) {
+                        Iterator<ConsumerRecord<String, String>> iterator = records.iterator();
+                        if (!iterator.hasNext()) {
+                            continue;
+                        }
+                        ConsumerRecord<String, String> firstRecord = iterator.next();
+                        String traceType = firstRecord.key();
+                        if (traceType.equals(TRACE_TYPE_MULTI_RECORDS)) {
+                            entryPoint.consumeRecord(records);
+                        } else if (traceType.equals(TRACE_TYPE_RECORD)) {
+                            offsetStore.setOffset(firstRecord.offset());
+                            records.forEach(record -> entryPoint.consumeRecord(record));
+                        }
+                    }
+                }
+            } catch (WakeupException e) {
+                logger.info("shutdown polling...");
+            }
+        }
+    }
+
+
+}

--- a/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/TestConsumerRecordEntryPoint.java
+++ b/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/TestConsumerRecordEntryPoint.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.pinpoint.plugin.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+/**
+ * @author Younsung Hwang
+ */
+public class TestConsumerRecordEntryPoint {
+
+    public void consumeRecord(ConsumerRecord<String, String> record) {
+        // cosume record ...
+        // This method is called for kafka consumer invocatino. This method does nothing.
+    }
+
+    public void consumeRecord(ConsumerRecords<String, String> records) {
+        // cosume records ...
+        // This method is called for kafka consumer invocatino. This method does nothing.
+    }
+
+}

--- a/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/TestProducer.java
+++ b/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/TestProducer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.pinpoint.plugin.kafka;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.util.Properties;
+
+import static test.pinpoint.plugin.kafka.KafkaITConstants.*;
+
+/**
+ * @author Younsung Hwang
+ */
+public class TestProducer {
+
+    public void sendMessage(int messageCount) {
+        sendMessage(messageCount, TRACE_TYPE_RECORD);
+    }
+
+    public void sendMessage(int messageCount, String traceType) {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BROKER_URL);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        KafkaProducer<String, String> producer = new KafkaProducer<>(props);
+        for (int i = 0; i < messageCount; i++) {
+            ProducerRecord<String, String> record = new ProducerRecord<>(TOPIC, traceType, MESSAGE);
+            producer.send(record);
+        }
+        producer.flush();
+        producer.close();
+    }
+
+
+
+}

--- a/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/ZookeeperUnitServer.java
+++ b/plugins-it/kafka-it/src/test/java/test/pinpoint/plugin/kafka/ZookeeperUnitServer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.pinpoint.plugin.kafka;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.zookeeper.server.NIOServerCnxnFactory;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+
+/**
+ * Copy of https://github.com/chbatey/kafka-unit/blob/master/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+ * Some codes have been modified for testing from the copied code.
+ */
+public class ZookeeperUnitServer {
+    private int port;
+    private int maxConnections;
+    private ServerCnxnFactory factory;
+
+    public ZookeeperUnitServer(int port) {
+        this.port = port;
+        this.maxConnections = 16;
+    }
+
+    public ZookeeperUnitServer(int port, int maxConnections) {
+        this.port = port;
+        this.maxConnections = maxConnections;
+    }
+
+    public void startup() {
+        final File snapshotDir;
+        final File logDir;
+        try {
+            snapshotDir = Files.createTempDirectory("zookeeper-snapshot").toFile();
+            logDir = Files.createTempDirectory("zookeeper-logs").toFile();
+        } catch (IOException ioe) {
+            throw new RuntimeException("Unable to start Kafka", ioe);
+        }
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                FileUtils.deleteDirectory(snapshotDir);
+                FileUtils.deleteDirectory(logDir);
+            } catch (IOException ioe) {}
+        }));
+
+        try {
+            int tickTime = 500;
+            ZooKeeperServer zkServer = new ZooKeeperServer(snapshotDir, logDir, tickTime);
+            factory = NIOServerCnxnFactory.createFactory();
+            factory.configure(new InetSocketAddress("localhost", port), maxConnections);
+            factory.startup(zkServer);
+        } catch (InterruptedException var5) {
+            Thread.currentThread().interrupt();
+        } catch (IOException var6) {
+            throw new RuntimeException("Unable to start ZooKeeper", var6);
+        }
+
+    }
+
+    public void shutdown() {
+        factory.shutdown();
+    }
+}

--- a/plugins-it/kafka-it/src/test/resources/pinpoint-kafka-client.config
+++ b/plugins-it/kafka-it/src/test/resources/pinpoint-kafka-client.config
@@ -1,0 +1,4 @@
+profiler.kafka.producer.enable=true
+profiler.kafka.consumer.enable=true
+profiler.springkafka.consumer.enable=true
+profiler.kafka.consumer.entryPoint=test.pinpoint.plugin.kafka.TestConsumerRecordEntryPoint.consumeRecord

--- a/plugins-it/pom.xml
+++ b/plugins-it/pom.xml
@@ -76,6 +76,7 @@
         <module>postgresql-jdbc-it</module>
         <module>process-it</module>
         <module>paho-mqtt-it</module>
+        <module>kafka-it</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
issue : #7362 

This PR is kafka client plugin IT module.

KafkaUnitServer.java and ZookeeperUnitServer.java are the copy of https://github.com/chbatey/kafka-unit.
These enables Kafka broker, ZooKeeper to run in unit test.
KafkaUnitServer.java and ZookeeperUnitServer.java have been modified to suit the test environment.