### PR TITLE
[#7375] Add DiscardLimiter

### DIFF
--- a/agent/src/main/resources/pinpoint-root.config
+++ b/agent/src/main/resources/pinpoint-root.config
@@ -82,6 +82,8 @@ profiler.transport.grpc.span.sender.write.buffer.highwatermark=32M
 profiler.transport.grpc.span.sender.write.buffer.lowwatermark=16M
 profiler.transport.grpc.span.sender.discardpolicy.logger.discard.ratelimit=1
 profiler.transport.grpc.span.sender.discardpolicy.maxpendingthreshold=1024
+profiler.transport.grpc.span.sender.discardpolicy.discard-count-for-reconnect=1000
+profiler.transport.grpc.span.sender.discardpolicy.not-ready-timeout-millis=300000
 
 # This configuration enable some function of netty
 # Functions are available without the this configuration when using jdk8 and below,

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/SpanClientMock.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/SpanClientMock.java
@@ -25,6 +25,10 @@ import com.navercorp.pinpoint.grpc.client.ClientOption;
 import com.navercorp.pinpoint.grpc.client.DefaultChannelFactoryBuilder;
 import com.navercorp.pinpoint.grpc.client.ForwardClientCall;
 import com.navercorp.pinpoint.grpc.client.HeaderFactory;
+import com.navercorp.pinpoint.grpc.client.UnaryCallDeadlineInterceptor;
+import com.navercorp.pinpoint.grpc.client.interceptor.DiscardClientInterceptor;
+import com.navercorp.pinpoint.grpc.client.interceptor.DiscardEventListener;
+import com.navercorp.pinpoint.grpc.client.interceptor.LoggingDiscardEventListener;
 import com.navercorp.pinpoint.grpc.trace.PAnnotation;
 import com.navercorp.pinpoint.grpc.trace.PAnnotationValue;
 import com.navercorp.pinpoint.grpc.trace.PSpan;
@@ -32,6 +36,11 @@ import com.navercorp.pinpoint.grpc.trace.PSpanChunk;
 import com.navercorp.pinpoint.grpc.trace.PSpanEvent;
 import com.navercorp.pinpoint.grpc.trace.PSpanMessage;
 import com.navercorp.pinpoint.grpc.trace.SpanGrpc;
+import com.navercorp.pinpoint.profiler.sender.grpc.ReconnectExecutor;
+import com.navercorp.pinpoint.profiler.sender.grpc.Reconnector;
+import com.navercorp.pinpoint.profiler.sender.grpc.ResponseStreamObserver;
+import com.navercorp.pinpoint.profiler.sender.grpc.SpanGrpcDataSender;
+import com.navercorp.pinpoint.profiler.sender.grpc.StreamId;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -44,54 +53,116 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class SpanClientMock {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    private final ReconnectExecutor reconnectExecutor = new ReconnectExecutor(scheduledExecutorService);
+
+
 
     private final ManagedChannel channel;
     private final SpanGrpc.SpanStub spanStub;
     private final ChannelFactory channelFactory;
     private final AtomicLong total = new AtomicLong(0);
+    private volatile StreamObserver<PSpanMessage> spanStream;
+    private final Reconnector spanStreamReconnector;
 
     public SpanClientMock(final String host, final int port) throws Exception {
         channelFactory = newChannelFactory();
         this.channel = channelFactory.build("SpanClientMock", host, port);
-        this.spanStub = SpanGrpc.newStub(channel).withInterceptors(new ClientInterceptor() {
-            @Override
-            public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
-                return new ForwardClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
-                    AtomicLong counter = new AtomicLong(0);
-                    @Override
-                    public void sendMessage(ReqT message) {
-                        if (isReady()) {
-                            super.sendMessage(message);
-                        } else {
-                            logger.info("Drop span message, stream not ready.");
-                            System.out.println(counter.incrementAndGet());
-                        }
-                    }
 
-                    @Override
-                    public void cancel(String message, Throwable cause) {
-                        logger.info("Cancel message. message={}, cause={}", message, cause.getMessage(), cause);
-                        super.cancel(message, cause);
-                    }
-                };
+        final AtomicBoolean onReadyFlag = new AtomicBoolean();
+        this.spanStub = SpanGrpc.newStub(channel);
+//        this.spanStub = SpanGrpc.newStub(channel).withInterceptors(new ClientInterceptor() {
+//            @Override
+//            public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+//                return new ForwardClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+//                    AtomicLong counter = new AtomicLong(0);
+//                    @Override
+//                    public void sendMessage(ReqT message) {
+//                        try {
+//                            super.sendMessage(message);
+//                        } catch(Exception e) {
+//                            System.out.println("Exception " + e.getMessage());
+//                        }
+//
+//                        if (Boolean.FALSE == isReady()) {
+//                            if(onReadyFlag.compareAndSet(Boolean.TRUE, Boolean.FALSE)) {
+//                                System.out.println("");
+//                            }
+//                            System.out.print("D");
+////                            logger.info("Drop span message, stream not ready. " + counter.incrementAndGet());
+//                        } else {
+//                            if(onReadyFlag.compareAndSet(Boolean.FALSE, Boolean.TRUE)) {
+//                                System.out.println("");
+//                            }
+//                            System.out.print("S");
+//                        }
+//                    }
+//
+//                    @Override
+//                    public void cancel(String message, Throwable cause) {
+//                        logger.info("Cancel message. message={}, cause={}", message, cause.getMessage(), cause);
+//                        super.cancel(message, cause);
+//                    }
+//
+//
+//
+//                };
+//            }
+//        });
+        final Runnable spanStreamReconnectJob = new Runnable() {
+            @Override
+            public void run() {
+                spanStream = newSpanStream();
             }
-        });
+        };
+        this.spanStreamReconnector = reconnectExecutor.newReconnector(spanStreamReconnectJob);
+        spanStreamReconnectJob.run();
+
+
+
         logger.info("CallOptions={}, channel={}", spanStub.getCallOptions(), spanStub.getChannel());
     }
+
+    private StreamObserver<PSpanMessage> newSpanStream() {
+        System.out.println("### ");
+        System.out.println("NEW SpanStream");
+        System.out.println("###");
+        StreamId spanId = StreamId.newStreamId("SpanStream");
+        ResponseStreamObserver<PSpanMessage, Empty> responseStreamObserver = new ResponseStreamObserver<PSpanMessage, Empty>(spanId, spanStreamReconnector);
+        return spanStub.sendSpan(responseStreamObserver);
+    }
+
 
     private ChannelFactory newChannelFactory() {
         HeaderFactory headerFactory = new AgentHeaderFactory("mockAgentId", "mockApplicationName", System.currentTimeMillis());
 
         ChannelFactoryBuilder channelFactoryBuilder = new DefaultChannelFactoryBuilder("SpanClientMock");
+        final ClientInterceptor unaryCallDeadlineInterceptor = new UnaryCallDeadlineInterceptor(1000);
+        channelFactoryBuilder.addClientInterceptor(unaryCallDeadlineInterceptor);
+
+        final ClientInterceptor discardClientInterceptor = newDiscardClientInterceptor();
+        channelFactoryBuilder.addClientInterceptor(discardClientInterceptor);
+
         channelFactoryBuilder.setHeaderFactory(headerFactory);
         channelFactoryBuilder.setClientOption(new ClientOption.Builder().build());
 
         return channelFactoryBuilder.build();
+    }
+
+    private ClientInterceptor newDiscardClientInterceptor() {
+        final int spanDiscardLogRateLimit = 1000;
+        final long spanDiscardMaxPendingThreshold = 1000;
+        final long spanDiscardCountForReconnect = 5 * 60 * 100;
+        final long spanNotReadyTimeoutMillis = 5 * 60 * 1000;
+        final DiscardEventListener<?> discardEventListener = new LoggingDiscardEventListener(SpanGrpcDataSender.class.getName(), spanDiscardLogRateLimit);
+        return new DiscardClientInterceptor(discardEventListener, spanDiscardMaxPendingThreshold, 1000, 1000);
     }
 
     public void stop() throws InterruptedException {
@@ -109,7 +180,7 @@ public class SpanClientMock {
     ExecutorService service = Executors.newFixedThreadPool(1);
 
     public void span(int count) {
-        final int size = 10;
+        final int size = 1000;
         final byte[] bytes = new byte[size];
         for(int i = 0; i < size; i++) {
             bytes[i] = (byte) i;
@@ -119,27 +190,30 @@ public class SpanClientMock {
         PAnnotation annotation = PAnnotation.newBuilder().setValue(value).build();
         PSpanEvent spanEvent = PSpanEvent.newBuilder().addAnnotation(annotation).build();
 
+        AtomicLong counter = new AtomicLong();
         service.execute(new Runnable() {
             @Override
             public void run() {
-                StreamObserver<Empty> responseObserver = getResponseObserver();
-                StreamObserver<PSpanMessage> requestObserver = spanStub.sendSpan(responseObserver);
+//                StreamObserver<Empty> responseObserver = getResponseObserver();
+//                StreamObserver<PSpanMessage> requestObserver = spanStub.sendSpan(responseObserver);
                 try {
                     TimeUnit.SECONDS.sleep(3);
                 } catch (InterruptedException e) {
                 }
 
                 for (int i = 0; i < count; i++) {
-                    final PSpan span = PSpan.newBuilder().addSpanEvent(spanEvent).build();
+                    final PSpan span = PSpan.newBuilder().setSpanId(i).addSpanEvent(spanEvent).build();
                     final PSpanMessage spanMessage = PSpanMessage.newBuilder().setSpan(span).build();
-                    requestObserver.onNext(spanMessage);
+                    spanStream.onNext(spanMessage);
+//                    requestObserver.onNext(spanMessage);
                     try {
                         TimeUnit.MILLISECONDS.sleep(10);
                     } catch (InterruptedException e) {
                     }
-
+//                    System.out.print("S");
                 }
-                requestObserver.onCompleted();
+                spanStream.onCompleted();
+//                requestObserver.onCompleted();
             }
         });
     }
@@ -153,41 +227,42 @@ public class SpanClientMock {
             @Override
             public void run() {
 
-                StreamObserver<Empty> responseObserver = getResponseObserver();
-
-                StreamObserver<PSpanMessage> requestObserver = spanStub.sendSpan(responseObserver);
+//                StreamObserver<Empty> responseObserver = getResponseObserver();
+//                StreamObserver<PSpanMessage> requestObserver = spanStub.sendSpan(responseObserver);
                 for (int i = 0; i < count; i++) {
                     final PSpanChunk spanChunk = PSpanChunk.newBuilder().build();
                     final PSpanMessage spanMessage = PSpanMessage.newBuilder().setSpanChunk(spanChunk).build();
-                    requestObserver.onNext(spanMessage);
+                    spanStream.onNext(spanMessage);
+//                    requestObserver.onNext(spanMessage);
                     try {
                         TimeUnit.SECONDS.sleep(1);
                     } catch (InterruptedException e) {
                     }
                 }
-                requestObserver.onCompleted();
+                spanStream.onCompleted();
+//                requestObserver.onCompleted();
             }
         });
 
     }
 
-    private StreamObserver<Empty> getResponseObserver() {
-        StreamObserver<Empty> responseObserver = new StreamObserver<Empty>() {
-            @Override
-            public void onNext(Empty pResult) {
-                logger.info("Response {}", pResult);
-            }
-
-            @Override
-            public void onError(Throwable throwable) {
-                logger.info("Error ", throwable);
-            }
-
-            @Override
-            public void onCompleted() {
-                logger.info("Completed");
-            }
-        };
-        return responseObserver;
-    }
+//    private StreamObserver<Empty> getResponseObserver() {
+//        StreamObserver<Empty> responseObserver = new StreamObserver<Empty>() {
+//            @Override
+//            public void onNext(Empty pResult) {
+//                logger.info("Response {}", pResult);
+//            }
+//
+//            @Override
+//            public void onError(Throwable throwable) {
+//                logger.info("Error ", throwable);
+//            }
+//
+//            @Override
+//            public void onCompleted() {
+//                logger.info("Completed");
+//            }
+//        };
+//        return responseObserver;
+//    }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/SpanClientTestMain.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/SpanClientTestMain.java
@@ -17,18 +17,27 @@
 package com.navercorp.pinpoint.collector.receiver.grpc;
 
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class SpanClientTestMain {
-    private static final int MAX = 100000;
+    public static final Logger logger = Logger.getLogger(SpanClientTestMain.class.getName());
+    static {
+        logger.setLevel(Level.FINE);
+    }
+    private static final int MAX = Integer.MAX_VALUE;
 
     public static void main(String[] args) throws Exception {
-        SpanClientMock clientMock = new SpanClientMock("localhost", 9998);
-        TimeUnit.SECONDS.sleep(5);
+        logger.info("START");
+
+        SpanClientMock clientMock = new SpanClientMock("localhost", 9993);
+        TimeUnit.SECONDS.sleep(3);
 
         long startTime = System.currentTimeMillis();
-        clientMock.span(1000);
+        clientMock.span(MAX);
 
-        TimeUnit.SECONDS.sleep(60);
-        clientMock.stop();
+        TimeUnit.SECONDS.sleep(999999999);
+
+//        clientMock.stop();
     }
 }

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/client/interceptor/DiscardClientCall.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/client/interceptor/DiscardClientCall.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.grpc.client.interceptor;
 
 import com.navercorp.pinpoint.common.util.Assert;
@@ -9,17 +25,25 @@ import io.grpc.Metadata;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * @author Woonduk Kang(emeroad)
+ * @author jaehong.kim
+ */
 class DiscardClientCall<ReqT, RespT> extends ForwardClientCall<ReqT, RespT> {
-    private static final State OK = new State(true, "OK");
+    private static final State OK = new State(false, "OK");
+    private static final State NOT_READY = new State(false, "stream not ready");
+
     private final AtomicBoolean onReadyState = new AtomicBoolean(false);
     private final AtomicLong pendingCounter = new AtomicLong();
     private final long maxPendingThreshold;
     private final DiscardEventListener listener;
+    private final DiscardLimiter discardLimiter;
 
-    public DiscardClientCall(ClientCall<ReqT, RespT> delegate, DiscardEventListener listener, long maxPendingThreshold) {
+    public DiscardClientCall(ClientCall<ReqT, RespT> delegate, DiscardEventListener listener, long maxPendingThreshold, long discardCountForReconnect, long notReadyTimeoutMillis) {
         super(delegate);
         this.listener = Assert.requireNonNull(listener, "listener");
         this.maxPendingThreshold = maxPendingThreshold;
+        this.discardLimiter = new DiscardLimiter(discardCountForReconnect, notReadyTimeoutMillis);
     }
 
     @Override
@@ -37,6 +61,7 @@ class DiscardClientCall<ReqT, RespT> extends ForwardClientCall<ReqT, RespT> {
     private void reset() {
         this.onReadyState.compareAndSet(false, true);
         this.pendingCounter.set(0);
+        this.discardLimiter.reset();
     }
 
     @Override
@@ -44,24 +69,33 @@ class DiscardClientCall<ReqT, RespT> extends ForwardClientCall<ReqT, RespT> {
         final State state = readyState();
         if (OK == state) {
             super.sendMessage(message);
+        } else if (Boolean.FALSE == state.isCancel()) {
+            discardMessage(message, state.getMessage());
         } else {
-            discardMessage(message, state.getCause());
+            cancel(state.getMessage(), state.getCause());
         }
     }
 
     private State readyState() {
-        // skip pending queue state : DelayedStream
-        if (this.onReadyState.get() == false) {
+        // skip pending queue cancel : DelayedStream
+        if (Boolean.FALSE == this.onReadyState.get()) {
             final long pendingCount = this.pendingCounter.incrementAndGet();
             if (pendingCount > this.maxPendingThreshold) {
-                final String cause = "maximum pending requests " + pendingCount + "/" + this.maxPendingThreshold;
-                return new State(false, cause);
+                final String message = "maximum pending requests " + pendingCount + "/" + this.maxPendingThreshold;
+                return new State(false, message);
             }
             return OK;
         }
 
-        if (isReady() == false) {
-            return new State(false, "stream not ready");
+        final boolean ready = isReady();
+        try {
+            this.discardLimiter.discard(ready);
+        } catch (DiscardLimiter.DiscardLimiterException e) {
+            return new State(true, e.getMessage(), e);
+        }
+
+        if (Boolean.FALSE == ready) {
+            return NOT_READY;
         }
         return OK;
     }
@@ -80,23 +114,35 @@ class DiscardClientCall<ReqT, RespT> extends ForwardClientCall<ReqT, RespT> {
         return onReadyState.get();
     }
 
-
     public long getPendingCount() {
         return pendingCounter.get();
     }
 
     private static class State {
-        private final boolean state;
-        private final String cause;
+        private final boolean cancel;
+        private final String message;
+        private final Throwable cause;
 
-        public State(boolean state, String cause) {
-            this.state = state;
+        public State(boolean cancel, String message) {
+            this(cancel, message, null);
+        }
+
+        public State(boolean cancel, String message, Throwable cause) {
+            this.cancel = cancel;
+            this.message = message;
             this.cause = cause;
         }
 
-        public String getCause() {
+        public boolean isCancel() {
+            return cancel;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public Throwable getCause() {
             return cause;
         }
     }
-
 }

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/client/interceptor/DiscardClientInterceptor.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/client/interceptor/DiscardClientInterceptor.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * @author Woonduk Kang(emeroad)
+ * @author jaehong.kim
  */
 public class DiscardClientInterceptor implements ClientInterceptor {
 
@@ -34,10 +35,14 @@ public class DiscardClientInterceptor implements ClientInterceptor {
 
     private final DiscardEventListener listener;
     private final long maxPendingThreshold;
+    private final long discardCountForReconnect;
+    private final long notReadyTimeoutMillis;
 
-    public DiscardClientInterceptor(DiscardEventListener listener, long maxPendingThreshold) {
+    public DiscardClientInterceptor(DiscardEventListener listener, long maxPendingThreshold, long discardCountForReconnect, long notReadyTimeoutMillis) {
         this.listener = Assert.requireNonNull(listener, "listener");
         this.maxPendingThreshold = maxPendingThreshold;
+        this.discardCountForReconnect = discardCountForReconnect;
+        this.notReadyTimeoutMillis = notReadyTimeoutMillis;
     }
 
     @Override
@@ -47,7 +52,7 @@ public class DiscardClientInterceptor implements ClientInterceptor {
                 logger.debug("interceptCall {}", method.getFullMethodName());
             }
             final ClientCall<ReqT, RespT> newCall = next.newCall(method, callOptions);
-            return new DiscardClientCall<ReqT, RespT>(newCall, this.listener, maxPendingThreshold);
+            return new DiscardClientCall<ReqT, RespT>(newCall, this.listener, maxPendingThreshold, discardCountForReconnect, notReadyTimeoutMillis);
         } else {
             return next.newCall(method, callOptions);
         }

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/client/interceptor/DiscardLimiter.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/client/interceptor/DiscardLimiter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.grpc.client.interceptor;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author jaehong.kim
+ */
+public class DiscardLimiter {
+    private final AtomicBoolean isDone = new AtomicBoolean(Boolean.FALSE);
+    private final AtomicBoolean isReadyState = new AtomicBoolean(Boolean.TRUE);
+    private final AtomicLong discardCounter = new AtomicLong();
+    private final AtomicBoolean reachDiscardCountForReconnect = new AtomicBoolean(Boolean.FALSE);
+    private final AtomicBoolean reachNotReadyTimeout = new AtomicBoolean(Boolean.FALSE);
+    private final long discardCountForReconnect;
+    private final long notReadyTimeoutMillis;
+
+    private final AtomicLong notReadyStartTimeMillis = new AtomicLong();
+
+    public DiscardLimiter(long discardCountForReconnect, long notReadyTimeoutMillis) {
+        this.discardCountForReconnect = discardCountForReconnect;
+        this.notReadyTimeoutMillis = notReadyTimeoutMillis;
+    }
+
+    public void reset() {
+        this.isDone.set(Boolean.FALSE);
+        this.isReadyState.set(Boolean.TRUE);
+        this.discardCounter.set(0);
+        this.reachDiscardCountForReconnect.set(Boolean.FALSE);
+        this.reachNotReadyTimeout.set(Boolean.FALSE);
+        this.notReadyStartTimeMillis.set(System.currentTimeMillis());
+    }
+
+    public void discard(final boolean ready) throws DiscardLimiterException {
+        if (ready) {
+            if (this.isReadyState.compareAndSet(Boolean.FALSE, Boolean.TRUE)) {
+                reset();
+            }
+            return;
+        }
+
+        if (this.isDone.get()) {
+            // Done
+            return;
+        }
+
+        if (this.isReadyState.compareAndSet(Boolean.TRUE, Boolean.FALSE)) {
+            this.notReadyStartTimeMillis.set(System.currentTimeMillis());
+        }
+
+        if (checkDiscardCountForReconnect() && checkNotReadyTimeout()) {
+            this.isDone.set(Boolean.TRUE);
+            final long durationTimeMillis = System.currentTimeMillis() - this.notReadyStartTimeMillis.get();
+            throw new DiscardLimiterException(this.discardCounter.get(), this.discardCountForReconnect, durationTimeMillis, this.notReadyTimeoutMillis);
+        }
+    }
+
+    boolean checkDiscardCountForReconnect() {
+        final long discardCount = this.discardCounter.incrementAndGet();
+        if (this.reachDiscardCountForReconnect.get()) {
+            // Reach the limit
+            return true;
+        }
+
+        if (discardCount > this.discardCountForReconnect) {
+            this.reachDiscardCountForReconnect.set(Boolean.TRUE);
+            return true;
+        }
+        return false;
+    }
+
+    boolean checkNotReadyTimeout() {
+        if (this.reachNotReadyTimeout.get()) {
+            // Reach the limit
+            return true;
+        }
+
+        final long notReadyDurationTimeMillis = System.currentTimeMillis() - this.notReadyStartTimeMillis.get();
+        if (notReadyDurationTimeMillis > this.notReadyTimeoutMillis) {
+            this.reachNotReadyTimeout.set(Boolean.TRUE);
+            return true;
+        }
+        return false;
+    }
+
+    static class DiscardLimiterException extends Exception {
+        public DiscardLimiterException(long discardCount, long discardCountForReconnect, long durationTimeMillis, long timeoutMillis) {
+            super("reach the limit, discard=" + discardCount + "/" + discardCountForReconnect + ", duration=" + durationTimeMillis + "ms, timeout=" + timeoutMillis + "ms");
+        }
+    }
+}

--- a/grpc/src/test/java/com/navercorp/pinpoint/grpc/client/interceptor/DiscardClientInterceptorTest.java
+++ b/grpc/src/test/java/com/navercorp/pinpoint/grpc/client/interceptor/DiscardClientInterceptorTest.java
@@ -80,7 +80,7 @@ public class DiscardClientInterceptorTest {
         when(channel.newCall(descriptor, callOptions)).thenReturn(clientCall);
 
         discardEventListener = spy(new LoggingDiscardEventListener<String>(DiscardClientInterceptorTest.class.getName(), 1));
-        this.interceptor = new DiscardClientInterceptor(discardEventListener, 1);
+        this.interceptor = new DiscardClientInterceptor(discardEventListener, 1, 100, 1000);
 
         this.call = (DiscardClientCall<String, Integer>) interceptor.interceptCall(descriptor, callOptions, channel);
     }

--- a/grpc/src/test/java/com/navercorp/pinpoint/grpc/client/interceptor/DiscardLimiterTest.java
+++ b/grpc/src/test/java/com/navercorp/pinpoint/grpc/client/interceptor/DiscardLimiterTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.grpc.client.interceptor;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author jaehong.kim
+ */
+public class DiscardLimiterTest {
+
+    @Test
+    public void discardCase1() throws Exception {
+        DiscardLimiter discardLimiter = new DiscardLimiter(100, 100);
+        discardLimiter.reset();
+
+        // Ready
+        for (int i = 0; i < 1000; i++) {
+            try {
+                discardLimiter.discard(true);
+            } catch (DiscardLimiter.DiscardLimiterException e) {
+                fail("unexpected condition");
+            }
+        }
+    }
+
+    @Test
+    public void discardCase2() throws Exception {
+        DiscardLimiter discardLimiter = new DiscardLimiter(100, 100);
+        discardLimiter.reset();
+
+        // Not ready
+        for (int i = 0; i < 100; i++) {
+            try {
+                discardLimiter.discard(false);
+            } catch (DiscardLimiter.DiscardLimiterException e) {
+                fail("unexpected condition");
+            }
+        }
+
+        TimeUnit.MILLISECONDS.sleep(200);
+        boolean onException = false;
+        try {
+            discardLimiter.discard(false);
+        } catch (DiscardLimiter.DiscardLimiterException e) {
+            onException = true;
+        }
+        assertTrue(onException);
+    }
+
+    @Test
+    public void discardCase3() throws Exception {
+        DiscardLimiter discardLimiter = new DiscardLimiter(100, 100);
+        discardLimiter.reset();
+
+        // Not ready
+        try {
+            discardLimiter.discard(false);
+        } catch (DiscardLimiter.DiscardLimiterException e) {
+            fail("unexpected condition");
+        }
+        // Reach not ready timeout
+        TimeUnit.MILLISECONDS.sleep(200);
+
+        for (int i = 0; i < 99; i++) {
+            try {
+                discardLimiter.discard(false);
+            } catch (DiscardLimiter.DiscardLimiterException e) {
+                fail("unexpected condition");
+            }
+        }
+
+        boolean onException = false;
+        try {
+            discardLimiter.discard(false);
+        } catch (DiscardLimiter.DiscardLimiterException e) {
+            onException = true;
+        }
+        assertTrue(onException);
+    }
+
+    @Test
+    public void checkDiscardCountForReconnect() throws Exception {
+        DiscardLimiter discardLimiter = new DiscardLimiter(100, 100);
+        discardLimiter.reset();
+
+        for (int i = 0; i < 100; i++) {
+            assertFalse(discardLimiter.checkDiscardCountForReconnect());
+        }
+        // Reach the discard count for reconnect
+        assertTrue(discardLimiter.checkDiscardCountForReconnect());
+
+        // Ready
+        discardLimiter.reset();
+
+        for (int i = 0; i < 100; i++) {
+            assertFalse(discardLimiter.checkDiscardCountForReconnect());
+        }
+        // Reach the discard count for reconnect
+        assertTrue(discardLimiter.checkDiscardCountForReconnect());
+    }
+
+    @Test
+    public void checkNotReadyTimeout() throws Exception {
+        DiscardLimiter discardLimiter = new DiscardLimiter(100, 100);
+        discardLimiter.reset();
+
+        for (int i = 0; i < 99; i++) {
+            assertFalse(discardLimiter.checkNotReadyTimeout());
+        }
+
+        TimeUnit.MILLISECONDS.sleep(200);
+        // Reach the discard count for reconnect
+        assertTrue(discardLimiter.checkNotReadyTimeout());
+
+        // Ready
+        discardLimiter.reset();
+
+        for (int i = 0; i < 99; i++) {
+            assertFalse(discardLimiter.checkNotReadyTimeout());
+        }
+
+        TimeUnit.MILLISECONDS.sleep(200);
+        // Reach the discard count for reconnect
+        assertTrue(discardLimiter.checkNotReadyTimeout());
+    }
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/GrpcTransportConfig.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/GrpcTransportConfig.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.grpc.client.ClientOption;
 
 /**
  * @author Woonduk Kang(emeroad)
+ * @author jaehong.kim
  */
 public class GrpcTransportConfig {
 
@@ -48,6 +49,8 @@ public class GrpcTransportConfig {
 
     private static final int DEFAULT_DISCARD_LOG_RATE_LIMIT = 100;
     private static final long DEFAULT_DISCARD_MAX_PENDING_THRESHOLD = 1024;
+    private static final long DEFAULT_DISCARD_COUNT_FOR_RECONNECT = 1000;
+    private static final long DEFAULT_NOT_READY_TIMEOUT_MILLIS = 5 * 60 * 1000;
 
     private static final int DEFAULT_METADATA_RETRY_MAX_COUNT = 3;
     private static final int DEFAULT_METADATA_RETRY_DELAY_MILLIS = 1000;
@@ -92,6 +95,8 @@ public class GrpcTransportConfig {
 
     private int spanDiscardLogRateLimit = DEFAULT_DISCARD_LOG_RATE_LIMIT;
     private long spanDiscardMaxPendingThreshold = DEFAULT_DISCARD_MAX_PENDING_THRESHOLD;
+    private long spanDiscardCountForReconnect = DEFAULT_DISCARD_COUNT_FOR_RECONNECT;
+    private long spanNotReadyTimeoutMillis = DEFAULT_NOT_READY_TIMEOUT_MILLIS;
 
     public void read(ProfilerConfig profilerConfig) {
         final ProfilerConfig.ValueResolver placeHolderResolver = new DefaultProfilerConfig.PlaceHolderResolver();
@@ -130,6 +135,8 @@ public class GrpcTransportConfig {
         this.spanChannelExecutorQueueSize = profilerConfig.readInt("profiler.transport.grpc.span.sender.channel.executor.queue.size", DEFAULT_SPAN_CHANNEL_EXECUTOR_QUEUE_SIZE);
         this.spanDiscardLogRateLimit = profilerConfig.readInt("profiler.transport.grpc.span.sender.discardpolicy.logger.discard.ratelimit", DEFAULT_DISCARD_LOG_RATE_LIMIT);
         this.spanDiscardMaxPendingThreshold = profilerConfig.readLong("profiler.transport.grpc.span.sender.discardpolicy.maxpendingthreshold", DEFAULT_DISCARD_MAX_PENDING_THRESHOLD);
+        this.spanDiscardCountForReconnect = profilerConfig.readLong("profiler.transport.grpc.span.sender.discardpolicy.discard-count-for-reconnect", DEFAULT_DISCARD_COUNT_FOR_RECONNECT);
+        this.spanNotReadyTimeoutMillis = profilerConfig.readLong("profiler.transport.grpc.span.sender.discardpolicy.not-ready-timeout-millis", DEFAULT_NOT_READY_TIMEOUT_MILLIS);
 
         // Netty
         this.nettySystemPropertyTryReflectiveSetAccessible = profilerConfig.readBoolean(KEY_PROFILER_CONFIG_NETTY_TRY_REFLECTION_SET_ACCESSIBLE, DEFAULT_NETTY_SYSTEM_PROPERTY_TRY_REFLECTIVE_SET_ACCESSIBLE);
@@ -223,6 +230,14 @@ public class GrpcTransportConfig {
 
     public long getSpanDiscardMaxPendingThreshold() {
         return spanDiscardMaxPendingThreshold;
+    }
+
+    public long getSpanDiscardCountForReconnect() {
+        return spanDiscardCountForReconnect;
+    }
+
+    public long getSpanNotReadyTimeoutMillis() {
+        return spanNotReadyTimeoutMillis;
     }
 
     public long getAgentRequestTimeout() {

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/grpc/SpanGrpcDataSenderProvider.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/grpc/SpanGrpcDataSenderProvider.java
@@ -98,8 +98,10 @@ public class SpanGrpcDataSenderProvider implements Provider<DataSender<Object>> 
     private ClientInterceptor newDiscardClientInterceptor() {
         final int spanDiscardLogRateLimit = grpcTransportConfig.getSpanDiscardLogRateLimit();
         final long spanDiscardMaxPendingThreshold = grpcTransportConfig.getSpanDiscardMaxPendingThreshold();
+        final long spanDiscardCountForReconnect = grpcTransportConfig.getSpanDiscardCountForReconnect();
+        final long spanNotReadyTimeoutMillis = grpcTransportConfig.getSpanNotReadyTimeoutMillis();
         final DiscardEventListener<?> discardEventListener = new LoggingDiscardEventListener(SpanGrpcDataSender.class.getName(), spanDiscardLogRateLimit);
-        return new DiscardClientInterceptor(discardEventListener, spanDiscardMaxPendingThreshold);
+        return new DiscardClientInterceptor(discardEventListener, spanDiscardMaxPendingThreshold, spanDiscardCountForReconnect, spanNotReadyTimeoutMillis);
     }
 
 }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/sender/grpc/ResponseStreamObserver.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/sender/grpc/ResponseStreamObserver.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Woonduk Kang(emeroad)
+ * @author jaehong.kim
  */
 public class ResponseStreamObserver<ReqT, RespT> implements ClientResponseObserver<ReqT, RespT> {
 
@@ -39,11 +40,10 @@ public class ResponseStreamObserver<ReqT, RespT> implements ClientResponseObserv
     public ResponseStreamObserver(StreamId name, Reconnector reconnector) {
         this.name = Assert.requireNonNull(name, "name");
         this.reconnector = Assert.requireNonNull(reconnector, "reconnector");
-
     }
 
     @Override
-    public void beforeStart(ClientCallStreamObserver<ReqT> requestStream) {
+    public void beforeStart(final ClientCallStreamObserver<ReqT> requestStream) {
         logger.info("beforeStart:{}", name);
         requestStream.setOnReadyHandler(new Runnable() {
             private final AtomicInteger counter = new AtomicInteger();
@@ -75,7 +75,8 @@ public class ResponseStreamObserver<ReqT, RespT> implements ClientResponseObserv
 
     @Override
     public void onCompleted() {
-        logger.debug("{} onCompleted", name);
+        logger.warn("{} onCompleted", name);
+        reconnector.reconnect();
     }
 
     @Override


### PR DESCRIPTION
#7375

* Reconnect when the number of discards exceeds the config.
* Reconnect when "not ready" state times out.

~~~
profiler.transport.grpc.span.sender.discardpolicy.discard-count-for-reconnect=1000
profiler.transport.grpc.span.sender.discardpolicy.not-ready-timeout-millis=300000
~~~