### PR TITLE
[#7375] Add request immediately of collector

### DIFF
--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/server/StreamExecutorServerInterceptor.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/server/StreamExecutorServerInterceptor.java
@@ -52,8 +52,6 @@ public class StreamExecutorServerInterceptor implements ServerInterceptor {
         this.initNumMessages = initNumMessages;
         Assert.requireNonNull(scheduledExecutorService, "scheduledExecutorService");
         Assert.isTrue(periodMillis > 0, "periodMillis must be positive");
-
-        Assert.isTrue(recoveryMessagesCount > 0, "recoveryMessagesCount must be positive");
         this.scheduler = new StreamExecutorRejectedExecutionRequestScheduler(scheduledExecutorService, periodMillis, recoveryMessagesCount);
     }
 


### PR DESCRIPTION
#7375 

Call.request(1) is immediately executed for the RejectedExecution request.

pinpoint-collector-grpc.properties
~~~
collector.receiver.grpc.stat.stream.scheduler.recovery.message.count=-1
~~~