### PR TITLE
[#7471] add ability to disconnect rabbit producer and consumer

### DIFF
--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -1068,6 +1068,8 @@ profiler.netty.channel.close=true
 profiler.rabbitmq.client.enable=true
 profiler.rabbitmq.client.producer.enable=true
 profiler.rabbitmq.client.consumer.enable=true
+# If you decided to break the producer - consumer chained tracing, set this to true.
+profiler.rabbitmq.client.consumer.disconnect.enable=false
 # Custom consumer classes to be traced (comma separated list of fully qualified class names)
 # If a consumer class is an inner class, specify the outer class
 profiler.rabbitmq.client.consumer.classes=

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -1070,6 +1070,8 @@ profiler.netty.channel.close=true
 profiler.rabbitmq.client.enable=true
 profiler.rabbitmq.client.producer.enable=true
 profiler.rabbitmq.client.consumer.enable=true
+# If you decided to break the producer - consumer chained tracing, set this to true.
+profiler.rabbitmq.client.consumer.disconnect.enable=false
 # Custom consumer classes to be traced (comma separated list of fully qualified class names)
 # If a consumer class is an inner class, specify the outer class
 profiler.rabbitmq.client.consumer.classes=

--- a/plugins/rabbitmq/src/main/java/com/navercorp/pinpoint/plugin/rabbitmq/client/RabbitMQClientPluginConfig.java
+++ b/plugins/rabbitmq/src/main/java/com/navercorp/pinpoint/plugin/rabbitmq/client/RabbitMQClientPluginConfig.java
@@ -31,6 +31,7 @@ public class RabbitMQClientPluginConfig {
     private final boolean traceRabbitMQClient;
     private final boolean traceRabbitMQClientProducer;
     private final boolean traceRabbitMQClientConsumer;
+    private final boolean traceRabbitMqClientConsumerDisconnect;
     private final List<String> consumerClasses;
     private final Filter<String> excludeExchangeFilter;
 
@@ -38,6 +39,7 @@ public class RabbitMQClientPluginConfig {
         this.traceRabbitMQClient = config.readBoolean("profiler.rabbitmq.client.enable", true);
         this.traceRabbitMQClientProducer = config.readBoolean("profiler.rabbitmq.client.producer.enable", true);
         this.traceRabbitMQClientConsumer = config.readBoolean("profiler.rabbitmq.client.consumer.enable", true);
+        this.traceRabbitMqClientConsumerDisconnect = config.readBoolean("profiler.rabbitmq.client.consumer.disconnect.enable", false);
         this.consumerClasses = config.readList("profiler.rabbitmq.client.consumer.classes");
 
         String excludeExchange = config.readString("profiler.rabbitmq.client.exchange.exclude", "");
@@ -58,6 +60,10 @@ public class RabbitMQClientPluginConfig {
 
     public boolean isTraceRabbitMQClientConsumer() {
         return this.traceRabbitMQClientConsumer;
+    }
+
+    public boolean isTraceRabbitMqClientConsumerDisconnect() {
+        return traceRabbitMqClientConsumerDisconnect;
     }
 
     public List<String> getConsumerClasses() {

--- a/plugins/rabbitmq/src/main/java/com/navercorp/pinpoint/plugin/rabbitmq/client/interceptor/RabbitMQConsumerDispatchInterceptor.java
+++ b/plugins/rabbitmq/src/main/java/com/navercorp/pinpoint/plugin/rabbitmq/client/interceptor/RabbitMQConsumerDispatchInterceptor.java
@@ -65,12 +65,14 @@ public class RabbitMQConsumerDispatchInterceptor implements AroundInterceptor {
 
     private final TraceContext traceContext;
     private final MethodDescriptor methodDescriptor;
+    private final RabbitMQClientPluginConfig config;
     private final Filter<String> excludeExchangeFilter;
 
     public RabbitMQConsumerDispatchInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, Filter<String> excludeExchangeFilter) {
         this.traceContext = traceContext;
         this.methodDescriptor = methodDescriptor;
         this.excludeExchangeFilter = excludeExchangeFilter;
+        this.config = new RabbitMQClientPluginConfig(traceContext.getProfilerConfig());
         this.traceContext.cacheApi(CONSUMER_ENTRY_METHOD_DESCRIPTOR);
     }
 
@@ -193,6 +195,12 @@ public class RabbitMQConsumerDispatchInterceptor implements AroundInterceptor {
         if (transactionId == null) {
             return null;
         }
+
+        // If disconnect is true, dont continue the span
+        if(config.isTraceRabbitMqClientConsumerDisconnect()) {
+            return null;
+        }
+
         long parentSpanId = NumberUtils.parseLong(headers.get(RabbitMQClientConstants.META_PARENT_SPAN_ID).toString(), SpanId.NULL);
         long spanId = NumberUtils.parseLong(headers.get(RabbitMQClientConstants.META_SPAN_ID).toString(), SpanId.NULL);
         short flags = NumberUtils.parseShort(headers.get(RabbitMQClientConstants.META_FLAGS).toString(), (short) 0);


### PR DESCRIPTION
The new property
`profiler.rabbitmq.client.consumer.disconnect.enable`
which will determine if we need to continue the transaction at the consumer side.

So if app1 -> rabbitq1 -> app2 -> rabbit2 -> app3

When profiler.rabbitmq.client.consumer.disconnect.enable is true
we break them and create

tran1 : app1-> rabbitq1
tran2 : rabbitq1-> app2 -> rabbit2
tran3 : rabbit2 -> app3