### PR TITLE
#7527 fix exception info lost when intercepting method `org.apache.http.concurrent.BasicFuture#failed`

### DIFF
--- a/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/HttpClient4Plugin.java
+++ b/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/HttpClient4Plugin.java
@@ -30,6 +30,7 @@ import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
+import com.navercorp.pinpoint.plugin.httpclient4.interceptor.BasicFutureFailedMethodInterceptor;
 import com.navercorp.pinpoint.plugin.httpclient4.interceptor.BasicFutureMethodInterceptor;
 import com.navercorp.pinpoint.plugin.httpclient4.interceptor.DefaultClientExchangeHandlerImplStartMethodInterceptor;
 import com.navercorp.pinpoint.plugin.httpclient4.interceptor.DefaultHttpRequestRetryHandlerRetryRequestMethodInterceptor;
@@ -340,7 +341,7 @@ public class HttpClient4Plugin implements ProfilerPlugin, TransformTemplateAware
 
             InstrumentMethod failed = target.getDeclaredMethod("failed", "java.lang.Exception");
             if (failed != null) {
-                failed.addInterceptor(BasicFutureMethodInterceptor.class);
+                failed.addInterceptor(BasicFutureFailedMethodInterceptor.class);
 
             }
 

--- a/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/BasicFutureFailedMethodInterceptor.java
+++ b/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/BasicFutureFailedMethodInterceptor.java
@@ -29,9 +29,9 @@ import com.navercorp.pinpoint.plugin.httpclient4.HttpClient4Constants;
  * @author jaehong.kim
  * 
  */
-public class BasicFutureMethodInterceptor extends AsyncContextSpanEventSimpleAroundInterceptor {
+public class BasicFutureFailedMethodInterceptor extends AsyncContextSpanEventSimpleAroundInterceptor {
 
-    public BasicFutureMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+    public BasicFutureFailedMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
         super(traceContext, methodDescriptor);
     }
 
@@ -43,10 +43,10 @@ public class BasicFutureMethodInterceptor extends AsyncContextSpanEventSimpleAro
     @Override
     protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
         recorder.recordApi(methodDescriptor);
-        if ("failed".equals(methodDescriptor.getMethodName()) && args.length == 1 && args[0] instanceof Exception) {
-            recorder.recordException((Exception) args[0]);
-        } else {
+        if (throwable!= null) {
             recorder.recordException(throwable);
+        } else if (args.length == 1 && args[0] instanceof Exception) {
+            recorder.recordException((Exception) args[0]);
         }
     }
 }


### PR DESCRIPTION
`org.apache.http.concurrent.BasicFuture#failed` doesn't throw exception but contains exception as its method argument.