### PR TITLE
add configuration to disable kafka header

### DIFF
--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -1113,6 +1113,8 @@ profiler.springkafka.consumer.enable=false
 # you must set target that handles ConsumerRecord or ConsumerRecords(Remote Trace feature is not enabled.) as a argument for remote trace
 # ex) profiler.kafka.consumer.entryPoint=clazzName.methodName
 profiler.kafka.consumer.entryPoint=
+# you should disable kafka header(set the following config to false) if your kafka broker version is 0.11+ but the log.message.format.version is overridden by a lower version than 0.11 (e.g. 0.10) which can not be automatically detected.
+#profiler.kafka.header.enable=true
 
 ###########################################################
 # Hbase (Reliability and stability can not be guaranteed)

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -1112,6 +1112,8 @@ profiler.springkafka.consumer.enable=false
 # you must set target that handles ConsumerRecord or ConsumerRecords(Remote Trace feature is not enabled.) as a argument for remote trace
 # ex) profiler.kafka.consumer.entryPoint=clazzName.methodName
 profiler.kafka.consumer.entryPoint=
+# you should disable kafka header(set the following config to false) if your kafka broker version is 0.11+ but the log.message.format.version is overridden by a lower version than 0.11 (e.g. 0.10) which can not be automatically detected.
+#profiler.kafka.header.enable=true
 
 ###########################################################
 # Hbase (Reliability and stability can not be guaranteed)

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfig.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfig.java
@@ -20,6 +20,8 @@ import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 
 public class KafkaConfig {
 
+    public static final String HEADER_ENABLE = "profiler.kafka.header.enable";
+
     static final String PRODUCER_ENABLE = "profiler.kafka.producer.enable";
 
     static final String CONSUMER_ENABLE = "profiler.kafka.consumer.enable";

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ProducerAddHeaderInterceptor.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ProducerAddHeaderInterceptor.java
@@ -26,6 +26,7 @@ import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.bootstrap.sampler.SamplingFlagUtils;
 import com.navercorp.pinpoint.common.util.Assert;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConfig;
 import com.navercorp.pinpoint.plugin.kafka.KafkaConstants;
 import com.navercorp.pinpoint.plugin.kafka.field.getter.ApiVersionsGetter;
 
@@ -40,14 +41,21 @@ public class ProducerAddHeaderInterceptor implements AroundInterceptor {
 
     private final TraceContext traceContext;
 
+    private final boolean headerEnable;
+
     public ProducerAddHeaderInterceptor(TraceContext traceContext) {
         this.traceContext = traceContext;
+        this.headerEnable = traceContext.getProfilerConfig().readBoolean(KafkaConfig.HEADER_ENABLE, true);
     }
 
     @Override
     public void before(Object target, Object[] args) {
         if (logger.isDebugEnabled()) {
             logger.beforeInterceptor(target, args);
+        }
+
+        if (!headerEnable) {
+            return;
         }
 
         Trace trace = traceContext.currentRawTraceObject();


### PR DESCRIPTION
# when to use
If your kafka broker version is 0.11+ but the log.message.format.version is overridden by a lower version than 0.11 (e.g. 0.10) which can not be automatically detected.
> kafaka-2.4.1 $ ./bin/kafka-server-start.sh config/server.properties --override log.message.format.version=0.10.2

The Kafka Pinpoint headers will cause the messages delivered to the broker(s) can not be saved and get error:

> [2021-01-19 13:47:36,188] ERROR [ReplicaManager broker=0] Error processing append operation on partition pinpoint-kafka-plugin-check-dev-0 (kafka.server.ReplicaManager)
> java.lang.IllegalArgumentException: Magic v1 does not support record headers
>         at org.apache.kafka.common.record.MemoryRecordsBuilder.appendWithOffset(MemoryRecordsBuilder.java:410)
>         at org.apache.kafka.common.record.MemoryRecordsBuilder.appendWithOffset(MemoryRecordsBuilder.java:449)
>         at org.apache.kafka.common.record.MemoryRecordsBuilder.appendWithOffset(MemoryRecordsBuilder.java:602)
>         at kafka.log.LogValidator$$anonfun$convertAndAssignOffsetsNonCompressed$1$$anonfun$apply$1.apply(LogValidator.scala:151)
>         at kafka.log.LogValidator$$anonfun$convertAndAssignOffsetsNonCompressed$1$$anonfun$apply$1.apply(LogValidator.scala:149)
>         at scala.collection.Iterator$class.foreach(Iterator.scala:891)
>         at scala.collection.AbstractIterator.foreach(Iterator.scala:1334)
>         at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
>         at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
>         at kafka.log.LogValidator$$anonfun$convertAndAssignOffsetsNonCompressed$1.apply(LogValidator.scala:149)

Detailed explanation: https://stuckintheloop.com/posts/a_kafka_magic_error/

# how to use
Set the config profiler.kafka.header.enable=false, default to true. It will treat the kafka as a terminal service type.
