### PR TITLE
[#7559] Removes possibility of duplicate puts.

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate2.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate2.java
@@ -349,9 +349,11 @@ public class HbaseTemplate2 extends HbaseAccessor implements HbaseOperations2, I
         Put put = new Put(rowName);
         put.addColumn(familyName, qualifier, valBytes);
         //check for existence and put for the first time
-        checkAndPut(tableName, rowName, familyName, qualifier, CompareFilter.CompareOp.EQUAL, null, put);
-        //check for max and put for update
-        checkAndPut(tableName, rowName, familyName, qualifier, CompareFilter.CompareOp.GREATER_OR_EQUAL, valBytes, put);
+        boolean success = checkAndPut(tableName, rowName, familyName, qualifier, CompareFilter.CompareOp.EQUAL, null, put);
+        if (!success) {
+            //check for max and put for update
+            checkAndPut(tableName, rowName, familyName, qualifier, CompareFilter.CompareOp.GREATER, valBytes, put);
+        }
     }
 
     @Override


### PR DESCRIPTION
Collector is doing checkAndPut twice in maxColumnValue.
The first is just in case it doesn't exist.
For above reason, if first operation is success, then second operation do not need.

In the second operation, if the values are the same, it will be changed the operation do not perform.