### PR TITLE
[#noissue] Change the log location of channelConnected method

### DIFF
--- a/rpc/src/main/java/com/navercorp/pinpoint/rpc/server/PinpointServerAcceptor.java
+++ b/rpc/src/main/java/com/navercorp/pinpoint/rpc/server/PinpointServerAcceptor.java
@@ -309,7 +309,6 @@ public class PinpointServerAcceptor implements PinpointServerConfig {
         @Override
         public void channelConnected(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception {
             final Channel channel = e.getChannel();
-            logger.info("channelConnected started. channel:{}", channel);
 
             if (released) {
                 logger.warn("already released. channel:{}", channel);
@@ -327,6 +326,8 @@ public class PinpointServerAcceptor implements PinpointServerConfig {
                 logger.debug("channelConnected() channel discard. {}", channel);
                 return;
             }
+
+            logger.info("channelConnected started. channel:{}", channel);
 
             DefaultPinpointServer pinpointServer = createPinpointServer(channel);
             


### PR DESCRIPTION
The log is recorded when an event occurs, so even if you set it in `collector.l4.ip', the log is being recorded and its location will be changed.