### PR TITLE
[#noissue] Fix PreparedStatement#setBytes interceptor problem and improve BytesConverter

### DIFF
--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/PreparedStatementBindingMethodFilter.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/PreparedStatementBindingMethodFilter.java
@@ -48,7 +48,14 @@ public class PreparedStatementBindingMethodFilter implements MethodFilter {
             String[] paramTypeNames = new String[len];
             
             for (int i = 0; i < len; i++) {
-                paramTypeNames[i] = paramTypes[i].getName();
+                Class<?> paramType = paramTypes[i];
+                String paramTypeName;
+                if(paramType.isArray()) {
+                    paramTypeName = paramType.getComponentType().getName() + "[]";
+                }else {
+                    paramTypeName = paramType.getName();
+                }
+                paramTypeNames[i] = paramTypeName;
             }
             
             list.add(paramTypeNames);

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/BytesConverter.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/BytesConverter.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.bootstrap.plugin.jdbc.bindvalue;
 
-import com.navercorp.pinpoint.common.util.ArrayUtils;
+import java.util.Arrays;
 
 /**
  * @author emeroad
@@ -32,9 +32,35 @@ public class BytesConverter implements Converter {
             if (bytes == null) {
                 return "null";
             } else {
-                return ArrayUtils.abbreviate(bytes);
+                return toHexString(bytes, MAX_BYTES_SIZE);
             }
         }
         return "error";
     }
+
+    // for uuid
+    private static final int MAX_BYTES_SIZE = 16;
+
+    private static final char[] HEX_CHARS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',
+        'F' };
+
+    private static String toHexString(byte[] bytes) {
+        char[] result = new char[bytes.length * 2];
+        int idx = 0;
+        for (byte b : bytes) {
+            int temp = (int) b & 0xFF;
+            result[idx++] = HEX_CHARS[temp / 16];
+            result[idx++] = HEX_CHARS[temp % 16];
+        }
+        return new String(result);
+    }
+
+    private static String toHexString(byte[] bytes, int maxSize) {
+        if(bytes.length > 16) {
+            return toHexString(Arrays.copyOf(bytes, maxSize)) + "...";
+        }else {
+            return toHexString(bytes);
+        }
+    }
+
 }

--- a/bootstraps/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/BindValueConverterTest.java
+++ b/bootstraps/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/plugin/jdbc/bindvalue/BindValueConverterTest.java
@@ -23,8 +23,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.UUID;
 
 public class BindValueConverterTest {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -50,5 +52,18 @@ public class BindValueConverterTest {
         // Should not throw even if given arguments are not supported value
         String setBoolean = BindValueConverter.convert("setXxxx", new Object[]{null, "XXX"});
         Assert.assertEquals(setBoolean, "");
+    }
+
+    @Test
+    public void testBindValueBytes() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+        byte[] bytes = bb.array();
+
+        String uuidHex = uuid.toString().toUpperCase().replaceAll("-", "");
+        String setBytes = BindValueConverter.convert("setBytes", new Object[]{null, bytes});
+        Assert.assertEquals(setBytes, uuidHex);
     }
 }


### PR DESCRIPTION
PreparedStatementBindingMethodFilter has a problem when generating the parameter type name, so bytes type jdbc parameter output is not being processed.

Also, improved to output bytes output in limited length Hex.