### PR TITLE
Support collect detailed exception stacktrace by config

### DIFF
--- a/agent/src/main/resources/pinpoint-root.config
+++ b/agent/src/main/resources/pinpoint-root.config
@@ -253,6 +253,11 @@ profiler.callstack.max.depth=64
 # weather or not to propagate exceptions occurred at interceptor
 profiler.interceptor.exception.propagate=false
 
+## Trace Exception StackTrace
+# Set line, default is enable and trace 20 line, if -1 is unlimited.
+profiler.exception.stacktrace.enable=true
+profiler.exception.stacktrace.line=20
+
 # Allow bytecode framework (ASM only)
 profiler.instrument.engine=ASM
 

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
@@ -198,6 +198,11 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     @Value("${profiler.uri.stat.completed.data.limit.size}")
     private int completedUriStatDataLimitSize = 3;
 
+    @Value("${profiler.exception.stacktrace.enable}")
+    private boolean exceptionStackTraceEnable = true;
+    @Value("${profiler.exception.stacktrace.line}")
+    private int exceptionStackTraceLine = 20;
+
     public DefaultProfilerConfig() {
         this.properties = new Properties();
     }
@@ -435,6 +440,16 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     }
 
     @Override
+    public boolean getExceptionStackTraceEnable () {
+        return exceptionStackTraceEnable;
+    }
+
+    @Override
+    public int getExceptionStackTraceLine() {
+        return exceptionStackTraceLine;
+    }
+
+    @Override
     public boolean isPropagateInterceptorException() {
         return propagateInterceptorException;
     }
@@ -647,6 +662,8 @@ public class DefaultProfilerConfig implements ProfilerConfig {
         sb.append(", pluginLoadOrder=").append(pluginLoadOrder);
         sb.append(", disabledPlugins=").append(disabledPlugins);
         sb.append(", propagateInterceptorException=").append(propagateInterceptorException);
+        sb.append(", exceptionStackTraceEnable=").append(exceptionStackTraceEnable);
+        sb.append(", exceptionStackTraceLine=").append(exceptionStackTraceLine);
         sb.append(", supportLambdaExpressions=").append(supportLambdaExpressions);
         sb.append(", proxyHttpHeaderEnable=").append(proxyHttpHeaderEnable);
         sb.append(", httpStatusCodeErrors=").append(httpStatusCodeErrors);

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
@@ -143,4 +143,7 @@ public interface ProfilerConfig {
 
     int getLogDirMaxBackupSize();
 
+    boolean getExceptionStackTraceEnable();
+
+    int getExceptionStackTraceLine();
 }

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/ApplicationContextModule.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/ApplicationContextModule.java
@@ -34,7 +34,9 @@ import com.navercorp.pinpoint.profiler.context.provider.BindVariableServiceProvi
 import com.navercorp.pinpoint.profiler.context.provider.UriExtractorProviderLocatorProvider;
 import com.navercorp.pinpoint.profiler.context.provider.UriStatRecorderFactoryProvider;
 import com.navercorp.pinpoint.profiler.context.provider.UriStatStorageProvider;
+import com.navercorp.pinpoint.profiler.context.provider.metadata.ExceptionRecordingServiceProvider;
 import com.navercorp.pinpoint.profiler.context.storage.UriStatStorage;
+import com.navercorp.pinpoint.profiler.metadata.ExceptionRecordingService;
 import com.navercorp.pinpoint.profiler.transformer.DefaultDynamicTransformerRegistry;
 import com.navercorp.pinpoint.profiler.transformer.DynamicTransformerRegistry;
 import com.navercorp.pinpoint.profiler.JvmInformation;
@@ -244,6 +246,7 @@ public class ApplicationContextModule extends AbstractModule {
         bind(StringMetaDataService.class).toProvider(StringMetadataServiceProvider.class).in(Scopes.SINGLETON);
         bind(ApiMetaDataService.class).toProvider(ApiMetaDataServiceProvider.class).in(Scopes.SINGLETON);
         bind(SqlMetaDataService.class).toProvider(SqlMetadataServiceProvider.class).in(Scopes.SINGLETON);
+        bind(ExceptionRecordingService.class).toProvider(ExceptionRecordingServiceProvider.class).in(Scopes.SINGLETON);
         bind(PredefinedMethodDescriptorRegistry.class).to(DefaultPredefinedMethodDescriptorRegistry.class).in(Scopes.SINGLETON);
     }
 

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/metadata/ExceptionRecordingServiceProvider.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/metadata/ExceptionRecordingServiceProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.context.provider.metadata;
+
+import com.google.inject.Inject;
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.common.util.Assert;
+import com.navercorp.pinpoint.profiler.metadata.DefaultExceptionRecordingService;
+import com.navercorp.pinpoint.profiler.metadata.ExceptionRecordingService;
+import javax.inject.Provider;
+
+/**
+ * @author Ilucky Si
+ */
+public class ExceptionRecordingServiceProvider implements Provider<ExceptionRecordingService> {
+
+    private final ProfilerConfig profilerConfig;
+
+    @Inject
+    public ExceptionRecordingServiceProvider(ProfilerConfig profilerConfig) {
+        this.profilerConfig = Assert.requireNonNull(profilerConfig, "profilerConfig");
+    }
+
+    @Override
+    public ExceptionRecordingService get() {
+        return new DefaultExceptionRecordingService(profilerConfig);
+    }
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/AbstractRecorder.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/AbstractRecorder.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.profiler.context.recorder;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.util.AnnotationKeyUtils;
+import com.navercorp.pinpoint.profiler.metadata.ExceptionRecordingService;
 import java.util.Objects;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.profiler.context.Annotation;
@@ -30,11 +31,13 @@ import com.navercorp.pinpoint.profiler.metadata.StringMetaDataService;
  */
 public abstract class AbstractRecorder {
 
+    protected final ExceptionRecordingService exceptionRecordingService;
     protected final StringMetaDataService stringMetaDataService;
     protected final SqlMetaDataService sqlMetaDataService;
     protected final IgnoreErrorHandler ignoreErrorHandler;
 
-    public AbstractRecorder(final StringMetaDataService stringMetaDataService, SqlMetaDataService sqlMetaDataService, IgnoreErrorHandler ignoreErrorHandler) {
+    public AbstractRecorder(final ExceptionRecordingService exceptionRecordingService, final StringMetaDataService stringMetaDataService, SqlMetaDataService sqlMetaDataService, IgnoreErrorHandler ignoreErrorHandler) {
+        this.exceptionRecordingService = Objects.requireNonNull(exceptionRecordingService, "exceptionRecordingService");
         this.stringMetaDataService = Objects.requireNonNull(stringMetaDataService, "stringMetaDataService");
         this.sqlMetaDataService = Objects.requireNonNull(sqlMetaDataService, "sqlMetaDataService");
         this.ignoreErrorHandler = Objects.requireNonNull(ignoreErrorHandler, "ignoreErrorHandler");
@@ -52,7 +55,13 @@ public abstract class AbstractRecorder {
         if (throwable == null) {
             return;
         }
-        final String drop = StringUtils.abbreviate(throwable.getMessage(), 256);
+
+        String drop = StringUtils.abbreviate(throwable.getMessage(), 256);
+        String exceptionStack = exceptionRecordingService.recordException(throwable);
+        if (exceptionStack != null && exceptionStack.length() > 0) {
+            drop += exceptionStack;
+        }
+
         // An exception that is an instance of a proxy class could make something wrong because the class name will vary.
         final int exceptionId = stringMetaDataService.cacheString(throwable.getClass().getName());
         setExceptionInfo(exceptionId, drop);

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultSpanRecorder.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultSpanRecorder.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.profiler.context.DefaultTrace;
 import com.navercorp.pinpoint.profiler.context.Span;
 import com.navercorp.pinpoint.profiler.context.errorhandler.IgnoreErrorHandler;
 import com.navercorp.pinpoint.profiler.context.id.TraceRoot;
+import com.navercorp.pinpoint.profiler.metadata.ExceptionRecordingService;
 import com.navercorp.pinpoint.profiler.metadata.SqlMetaDataService;
 import com.navercorp.pinpoint.profiler.metadata.StringMetaDataService;
 import org.slf4j.Logger;
@@ -41,10 +42,10 @@ public class DefaultSpanRecorder extends AbstractRecorder implements SpanRecorde
     private final boolean isRoot;
     private final boolean sampling;
     
-    public DefaultSpanRecorder(final Span span, final boolean isRoot, final boolean sampling,
+    public DefaultSpanRecorder(final Span span, final boolean isRoot, final boolean sampling, ExceptionRecordingService exceptionRecordingService,
                                final StringMetaDataService stringMetaDataService, SqlMetaDataService sqlMetaDataService,
                                final IgnoreErrorHandler errorHandler) {
-        super(stringMetaDataService, sqlMetaDataService, errorHandler);
+        super(exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
         this.span = span;
         this.isRoot = isRoot;
         this.sampling = sampling;

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/WrappedAsyncSpanEventRecorder.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/WrappedAsyncSpanEventRecorder.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.profiler.context.recorder;
 
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.AsyncState;
+import com.navercorp.pinpoint.profiler.metadata.ExceptionRecordingService;
 import java.util.Objects;
 import com.navercorp.pinpoint.profiler.context.AsyncContextFactory;
 import com.navercorp.pinpoint.profiler.context.AsyncId;
@@ -33,12 +34,12 @@ public class WrappedAsyncSpanEventRecorder extends WrappedSpanEventRecorder {
 
     private final AsyncState asyncState;
 
-    public WrappedAsyncSpanEventRecorder(TraceRoot traceRoot, AsyncContextFactory asyncContextFactory,
+    public WrappedAsyncSpanEventRecorder(TraceRoot traceRoot, AsyncContextFactory asyncContextFactory, ExceptionRecordingService exceptionRecordingService,
                                          StringMetaDataService stringMetaDataService, SqlMetaDataService sqlMetaCacheService,
                                          IgnoreErrorHandler errorHandler,
                                          AsyncState asyncState) {
 
-        super(traceRoot, asyncContextFactory, stringMetaDataService, sqlMetaCacheService, errorHandler);
+        super(traceRoot, asyncContextFactory, exceptionRecordingService, stringMetaDataService, sqlMetaCacheService, errorHandler);
         this.asyncState = Objects.requireNonNull(asyncState, "asyncState");
     }
 

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/WrappedSpanEventRecorder.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/WrappedSpanEventRecorder.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.bootstrap.context.ParsingResult;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.profiler.metadata.ExceptionRecordingService;
 import java.util.Objects;
 import com.navercorp.pinpoint.common.util.IntStringStringValue;
 import com.navercorp.pinpoint.common.util.StringUtils;
@@ -50,10 +51,10 @@ public class WrappedSpanEventRecorder extends AbstractRecorder implements SpanEv
 
     private SpanEvent spanEvent;
 
-    public WrappedSpanEventRecorder(TraceRoot traceRoot, AsyncContextFactory asyncContextFactory,
+    public WrappedSpanEventRecorder(TraceRoot traceRoot, AsyncContextFactory asyncContextFactory, ExceptionRecordingService exceptionRecordingService,
                                     final StringMetaDataService stringMetaDataService, final SqlMetaDataService sqlMetaCacheService,
                                     final IgnoreErrorHandler errorHandler) {
-        super(stringMetaDataService, sqlMetaCacheService, errorHandler);
+        super(exceptionRecordingService, stringMetaDataService, sqlMetaCacheService, errorHandler);
         this.traceRoot = Objects.requireNonNull(traceRoot, "traceRoot");
 
         this.asyncContextFactory = Objects.requireNonNull(asyncContextFactory, "asyncContextFactory");

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/metadata/DefaultExceptionRecordingService.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/metadata/DefaultExceptionRecordingService.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.metadata;
+
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.common.util.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Ilucky Si
+ */
+public class DefaultExceptionRecordingService implements ExceptionRecordingService {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final ProfilerConfig profilerConfig;
+
+    public DefaultExceptionRecordingService(ProfilerConfig profilerConfig) {
+        this.profilerConfig = Assert.requireNonNull(profilerConfig, "profilerConfig");;
+    }
+
+    @Override public String recordException(Throwable throwable) {
+        StringBuffer sb = new StringBuffer();
+        boolean exceptionStackTraceEnable = profilerConfig.getExceptionStackTraceEnable();
+        if (isDebug) {
+            logger.debug("exceptionStackTraceEnable:{}", exceptionStackTraceEnable);
+        }
+
+        if (exceptionStackTraceEnable) {
+            int exceptionStackTraceLine = profilerConfig.getExceptionStackTraceLine();
+            if (isDebug) {
+                logger.debug("exceptionStackTraceLine:{}", exceptionStackTraceLine);
+            }
+
+            StackTraceElement[] stackTraceElementArray = throwable.getStackTrace();
+            if (stackTraceElementArray == null || stackTraceElementArray.length == 0) {
+                return "";
+            }
+
+            int length = stackTraceElementArray.length;
+            if (exceptionStackTraceLine != -1) {
+                length = exceptionStackTraceLine < length ? exceptionStackTraceLine : length;
+            }
+            if (isDebug) {
+                logger.debug("length:{}", length);
+            }
+
+            for (int i = 0; i < length; i++) {
+                StackTraceElement stackTraceElement = stackTraceElementArray[i];
+                if (stackTraceElement != null) {
+                    sb.append("\n" + stackTraceElement.toString());
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+}

--- a/profiler/src/main/java/com/navercorp/pinpoint/profiler/metadata/ExceptionRecordingService.java
+++ b/profiler/src/main/java/com/navercorp/pinpoint/profiler/metadata/ExceptionRecordingService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.metadata;
+
+/**
+ * @author Ilucky Si
+ */
+public interface ExceptionRecordingService {
+    String recordException(Throwable th);
+}

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/DefaultTraceTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/DefaultTraceTest.java
@@ -30,6 +30,7 @@ import com.navercorp.pinpoint.profiler.context.recorder.DefaultSpanRecorder;
 import com.navercorp.pinpoint.profiler.context.recorder.WrappedSpanEventRecorder;
 import com.navercorp.pinpoint.profiler.context.storage.Storage;
 import com.navercorp.pinpoint.profiler.logging.Slf4jLoggerBinderInitializer;
+import com.navercorp.pinpoint.profiler.metadata.ExceptionRecordingService;
 import com.navercorp.pinpoint.profiler.metadata.SqlMetaDataService;
 import com.navercorp.pinpoint.profiler.metadata.StringMetaDataService;
 
@@ -53,6 +54,8 @@ public class DefaultTraceTest {
     private TraceRoot traceRoot;
     @Mock
     private Shared shared;
+    @Mock
+    private ExceptionRecordingService exceptionRecordingService;
     @Mock
     private StringMetaDataService stringMetaDataService;
     @Mock
@@ -160,8 +163,8 @@ public class DefaultTraceTest {
 
         final Span span = spanFactory.newSpan(traceRoot);
         final boolean root = span.getTraceRoot().getTraceId().isRoot();
-        final SpanRecorder spanRecorder = new DefaultSpanRecorder(span, root, true, stringMetaDataService, sqlMetaDataService, errorHandler);
-        final WrappedSpanEventRecorder wrappedSpanEventRecorder = new WrappedSpanEventRecorder(traceRoot, asyncContextFactory, stringMetaDataService, sqlMetaDataService, errorHandler);
+        final SpanRecorder spanRecorder = new DefaultSpanRecorder(span, root, true, exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
+        final WrappedSpanEventRecorder wrappedSpanEventRecorder = new WrappedSpanEventRecorder(traceRoot, asyncContextFactory, exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
 
         return new DefaultTrace(span, callStack, storage, true, spanRecorder, wrappedSpanEventRecorder, ActiveTraceHandle.EMPTY_HANDLE);
     }

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/TraceTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/TraceTest.java
@@ -28,6 +28,7 @@ import com.navercorp.pinpoint.profiler.context.id.TraceRoot;
 import com.navercorp.pinpoint.profiler.context.recorder.DefaultSpanRecorder;
 import com.navercorp.pinpoint.profiler.context.recorder.WrappedSpanEventRecorder;
 import com.navercorp.pinpoint.profiler.context.storage.Storage;
+import com.navercorp.pinpoint.profiler.metadata.ExceptionRecordingService;
 import com.navercorp.pinpoint.profiler.metadata.SqlMetaDataService;
 import com.navercorp.pinpoint.profiler.metadata.StringMetaDataService;
 import org.junit.Test;
@@ -55,6 +56,8 @@ public class TraceTest {
     @Mock
     private AsyncContextFactory asyncContextFactory = mock(AsyncContextFactory.class);
     @Mock
+    private ExceptionRecordingService exceptionRecordingService;
+    @Mock
     private StringMetaDataService stringMetaDataService;
     @Mock
     private SqlMetaDataService sqlMetaDataService;
@@ -71,8 +74,8 @@ public class TraceTest {
         final Span span = newSpan(traceRoot);
 
         boolean root = span.getTraceRoot().getTraceId().isRoot();
-        SpanRecorder spanRecorder = new DefaultSpanRecorder(span, root, true, stringMetaDataService, sqlMetaDataService, errorHandler);
-        WrappedSpanEventRecorder wrappedSpanEventRecorder = new WrappedSpanEventRecorder(traceRoot, asyncContextFactory, stringMetaDataService, sqlMetaDataService, errorHandler);
+        SpanRecorder spanRecorder = new DefaultSpanRecorder(span, root, true, exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
+        WrappedSpanEventRecorder wrappedSpanEventRecorder = new WrappedSpanEventRecorder(traceRoot, asyncContextFactory, exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
 
         AsyncContextFactory asyncContextFactory = mock(AsyncContextFactory.class);
 
@@ -104,8 +107,8 @@ public class TraceTest {
         final Span span = newSpan(traceRoot);
 
         final boolean root = span.getTraceRoot().getTraceId().isRoot();
-        SpanRecorder spanRecorder = new DefaultSpanRecorder(span, root, true, stringMetaDataService, sqlMetaDataService, errorHandler);
-        WrappedSpanEventRecorder wrappedSpanEventRecorder = new WrappedSpanEventRecorder(traceRoot, asyncContextFactory, stringMetaDataService, sqlMetaDataService, errorHandler);
+        SpanRecorder spanRecorder = new DefaultSpanRecorder(span, root, true, exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
+        WrappedSpanEventRecorder wrappedSpanEventRecorder = new WrappedSpanEventRecorder(traceRoot, asyncContextFactory, exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
 
 
         AsyncContextFactory asyncContextFactory = mock(AsyncContextFactory.class);

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultSpanRecorderTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultSpanRecorderTest.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.profiler.context.errorhandler.BypassErrorHandler;
 import com.navercorp.pinpoint.profiler.context.errorhandler.IgnoreErrorHandler;
 import com.navercorp.pinpoint.profiler.context.id.Shared;
 import com.navercorp.pinpoint.profiler.context.id.TraceRoot;
+import com.navercorp.pinpoint.profiler.metadata.ExceptionRecordingService;
 import com.navercorp.pinpoint.profiler.metadata.SqlMetaDataService;
 import com.navercorp.pinpoint.profiler.metadata.StringMetaDataService;
 import org.junit.Assert;
@@ -46,6 +47,8 @@ public class DefaultSpanRecorderTest {
     @Mock
     private TraceId traceId;
     @Mock
+    private ExceptionRecordingService exceptionRecordingService;
+    @Mock
     private StringMetaDataService stringMetaDataService;
     @Mock
     private SqlMetaDataService sqlMetaDataService;
@@ -56,7 +59,7 @@ public class DefaultSpanRecorderTest {
     public void testRecordApiId() throws Exception {
         Span span = new Span(traceRoot);
 
-        SpanRecorder recorder = new DefaultSpanRecorder(span, true, true, stringMetaDataService, sqlMetaDataService, errorHandler);
+        SpanRecorder recorder = new DefaultSpanRecorder(span, true, true, exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
 
         final int API_ID = 1000;
         recorder.recordApiId(API_ID);
@@ -71,7 +74,7 @@ public class DefaultSpanRecorderTest {
 
         Span span = new Span(traceRoot);
 
-        SpanRecorder recorder = new DefaultSpanRecorder(span, true, true, stringMetaDataService, sqlMetaDataService, errorHandler);
+        SpanRecorder recorder = new DefaultSpanRecorder(span, true, true, exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
 
         final String endPoint = "endPoint";
         recorder.recordEndPoint(endPoint);

--- a/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/recorder/WrappedSpanEventRecorderTest.java
+++ b/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/recorder/WrappedSpanEventRecorderTest.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.profiler.context.errorhandler.BypassErrorHandler;
 import com.navercorp.pinpoint.profiler.context.errorhandler.IgnoreErrorHandler;
 import com.navercorp.pinpoint.profiler.context.id.Shared;
 import com.navercorp.pinpoint.profiler.context.id.TraceRoot;
+import com.navercorp.pinpoint.profiler.metadata.ExceptionRecordingService;
 import com.navercorp.pinpoint.profiler.metadata.SqlMetaDataService;
 import com.navercorp.pinpoint.profiler.metadata.StringMetaDataService;
 import org.junit.Assert;
@@ -45,6 +46,9 @@ public class WrappedSpanEventRecorderTest {
     private Shared shared;
 
     @Mock
+    private ExceptionRecordingService exceptionRecordingService;
+
+    @Mock
     private AsyncContextFactory asyncContextFactory;
 
     @Mock
@@ -60,7 +64,7 @@ public class WrappedSpanEventRecorderTest {
         when(traceRoot.getShared()).thenReturn(shared);
 
         SpanEvent spanEvent = new SpanEvent();
-        WrappedSpanEventRecorder recorder = new WrappedSpanEventRecorder(traceRoot, asyncContextFactory, stringMetaDataService, sqlMetaDataService, errorHandler);
+        WrappedSpanEventRecorder recorder = new WrappedSpanEventRecorder(traceRoot, asyncContextFactory, exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
         recorder.setWrapped(spanEvent);
 
         final String exceptionMessage1 = "exceptionMessage1";
@@ -82,7 +86,7 @@ public class WrappedSpanEventRecorderTest {
     @Test
     public void testRecordAPIId() throws Exception {
         SpanEvent spanEvent = new SpanEvent();
-        WrappedSpanEventRecorder recorder = new WrappedSpanEventRecorder(traceRoot, asyncContextFactory, stringMetaDataService, sqlMetaDataService, errorHandler);
+        WrappedSpanEventRecorder recorder = new WrappedSpanEventRecorder(traceRoot, asyncContextFactory, exceptionRecordingService, stringMetaDataService, sqlMetaDataService, errorHandler);
         recorder.setWrapped(spanEvent);
 
 

--- a/web/src/main/angular/src/app/core/components/message-popup/message-popup.component.css
+++ b/web/src/main/angular/src/app/core/components/message-popup/message-popup.component.css
@@ -69,6 +69,7 @@
     word-break: break-all;
     overflow-y: auto;
     line-height: 2em;
+    white-space: pre;
 }
 .l-list a {
     color: #4a8fd2;


### PR DESCRIPTION
I pulled a request that supports the collection of exception stack details, but for some reason, it didn't merge to the master (I guess the reason may be that I forked the pinpoint to an Organization, but I don't know how to set the allow edits from maintainers permission). Recently, I took the time to sort out this logic and put it directly under my user~

https://github.com/pinpoint-apm/pinpoint/pull/7255

![image](https://user-images.githubusercontent.com/11611061/111125304-6fb60100-85ac-11eb-8be2-2f10bd6d5806.png)
