### PR TITLE
fix pinpoint headers added multiple times in Netty HttpClient

### DIFF
--- a/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpClientRequestHeaderAdaptor.java
+++ b/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpClientRequestHeaderAdaptor.java
@@ -31,7 +31,11 @@ public class HttpClientRequestHeaderAdaptor implements ClientHeaderAdaptor<HttpC
     @Override
     public void setHeader(final HttpClientRequest request, final String name, final String value) {
         if (request != null) {
-            request.addHeader(name, value);
+            try {
+                request.header(name, value);
+            } catch (IllegalStateException|UnsupportedOperationException e) {
+                logger.warn("Set header {}={} failed, because {}", name, value, e.getMessage());
+            }
             if (isDebug) {
                 logger.debug("Set header {}={}", name, value);
             }


### PR DESCRIPTION
fix #7748 

https://projectreactor.io/docs/netty/release/api/reactor/netty/http/client/HttpClientRequest.html

> addHeader(java.lang.CharSequence name, java.lang.CharSequence value)
>     Add an outbound http header, appending the value if the header is already set.

> header(java.lang.CharSequence name, java.lang.CharSequence value)
>     Set an outbound header, replacing any pre-existing value.



