### PR TITLE
[#7788] show agent name in agent statistics & management administration pages

### DIFF
--- a/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list-container.component.ts
+++ b/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list-container.component.ts
@@ -65,6 +65,7 @@ export class AgentStatisticListContainerComponent implements OnInit, OnDestroy {
             application: isChild ? '' : agent.applicationName,
             serviceType: agent.serviceType,
             agent: agent.agentId,
+            agentName: agent.agentName ? agent.agentName : 'N/A',
             agentVersion: agent.agentVersion,
             jvmVersion: agent.jvmInfo ? agent.jvmInfo.jvmVersion : ''
         };

--- a/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list.component.ts
+++ b/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list.component.ts
@@ -6,6 +6,7 @@ export interface IGridData {
     application: string;
     serviceType: string;
     agent: string;
+    agentName?: string;
     agentVersion: string;
     jvmVersion: string;
     folder?: boolean;
@@ -84,11 +85,18 @@ export class AgentStatisticListComponent implements OnInit  {
                 tooltipField: 'application'
             },
             {
-                headerName: `Agent`,
+                headerName: `Agent Id`,
                 field: 'agent',
                 width: 300,
                 filter: 'agTextColumnFilter',
                 tooltipField: 'agent'
+            },
+            {
+                headerName: `Agent Name`,
+                field: 'agentName',
+                width: 300,
+                filter: 'agTextColumnFilter',
+                tooltipField: 'agentName'
             },
             {
                 headerName: 'Agent Version',

--- a/web/src/main/angular/src/app/core/components/removable-agent-list/removable-agent-list-container.component.ts
+++ b/web/src/main/angular/src/app/core/components/removable-agent-list/removable-agent-list-container.component.ts
@@ -76,9 +76,9 @@ export class RemovableAgentListContainerComponent implements OnInit, OnDestroy {
                 map((data: IAgentList) => {
                     return Object.entries(data).reduce((acc: {[key: string]: any}[], [key, value]: [string, IAgent[]]) => {
                         return [...acc, ...value.map((agent: IAgent) => {
-                            const {applicationName, hostName, agentId, agentVersion, startTimestamp, ip} = agent;
-
-                            return {applicationName, hostName, agentId, agentVersion, startTimestamp, ip};
+                            const {applicationName, hostName, agentId, agentName, agentVersion, startTimestamp, ip} = agent;
+                            const agentNameText = agentName ? agentName : "N/A";
+                            return {applicationName, hostName, agentId, agentNameText, agentVersion, startTimestamp, ip};
                         })];
                     }, []);
                 }),

--- a/web/src/main/angular/src/app/core/components/removable-agent-list/removable-agent-list-container.component.ts
+++ b/web/src/main/angular/src/app/core/components/removable-agent-list/removable-agent-list-container.component.ts
@@ -77,7 +77,8 @@ export class RemovableAgentListContainerComponent implements OnInit, OnDestroy {
                     return Object.entries(data).reduce((acc: {[key: string]: any}[], [key, value]: [string, IAgent[]]) => {
                         return [...acc, ...value.map((agent: IAgent) => {
                             const {applicationName, hostName, agentId, agentName, agentVersion, startTimestamp, ip} = agent;
-                            const agentNameText = agentName ? agentName : "N/A";
+                            const agentNameText = agentName ? agentName : 'N/A';
+                            
                             return {applicationName, hostName, agentId, agentNameText, agentVersion, startTimestamp, ip};
                         })];
                     }, []);

--- a/web/src/main/angular/src/app/core/components/removable-agent-list/removable-agent-list.component.ts
+++ b/web/src/main/angular/src/app/core/components/removable-agent-list/removable-agent-list.component.ts
@@ -62,6 +62,12 @@ export class RemovableAgentListComponent implements OnInit {
                         cellStyle: this.alignCenterCellStyle
                     },
                     {
+                        headerName: 'Agent Name',
+                        field: 'agentNameText',
+                        width: 250,
+                        cellStyle: this.alignCenterCellStyle
+                    },
+                    {
                         headerName: 'Agent Version',
                         field: 'agentVersion',
                         width: 160,

--- a/web/src/main/angular/src/globals.d.ts
+++ b/web/src/main/angular/src/globals.d.ts
@@ -60,6 +60,7 @@ interface IAgentList {
 // @store
 interface IAgent {
     agentId: string;
+    agentName?: string;
     agentVersion: string;
     applicationName: string;
     hostName: string;


### PR DESCRIPTION
For #7788 and related to #7787 

The updated UI pages are:

1. agent management page:

![image](https://user-images.githubusercontent.com/1879641/114827282-10415000-9dfb-11eb-91c3-8a249e18c307.png)


2. agent statistics page:
![image](https://user-images.githubusercontent.com/1879641/114828650-c0638880-9dfc-11eb-9708-7352b2640114.png)


