### PR TITLE
[#7803] Add agent statistics table cell link

### DIFF
--- a/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list-container.component.ts
+++ b/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list-container.component.ts
@@ -62,7 +62,7 @@ export class AgentStatisticListContainerComponent implements OnInit, OnDestroy {
     private makeRow(agent: IAgent, index: number, hasChild: boolean, isChild: boolean): any {
         const oRow: IGridData = {
             index: index,
-            application: isChild ? '' : agent.applicationName,
+            application: agent.applicationName,
             serviceType: agent.serviceType,
             agent: agent.agentId,
             agentVersion: agent.agentVersion,

--- a/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list-container.component.ts
+++ b/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list-container.component.ts
@@ -3,6 +3,7 @@ import { Subject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { UrlPath } from 'app/shared/models';
+import { EndTime } from 'app/core/models/end-time';
 import { StoreHelperService, UrlRouteManagerService, AnalyticsService, TRACKED_EVENT_LIST } from 'app/shared/services';
 import { IGridData } from './agent-statistic-list.component';
 
@@ -66,6 +67,7 @@ export class AgentStatisticListContainerComponent implements OnInit, OnDestroy {
             serviceType: agent.serviceType,
             agent: agent.agentId,
             agentVersion: agent.agentVersion,
+            startTimestamp: agent.startTimestamp,
             jvmVersion: agent.jvmInfo ? agent.jvmInfo.jvmVersion : ''
         };
         if (hasChild) {
@@ -78,12 +80,28 @@ export class AgentStatisticListContainerComponent implements OnInit, OnDestroy {
     }
 
     onCellClick(params: any): void {
-        this.urlRouteManagerService.openPage({
-            path: [
-                UrlPath.MAIN,
-                `${params.application}@${params.serviceType}`
-            ]
-        });
-        this.analyticsService.trackEvent(TRACKED_EVENT_LIST.CLICK_APPLICATION_IN_STATISTIC_LIST);
+        if (params.colDef.field === 'application') {
+            this.urlRouteManagerService.openPage({
+                path: [
+                    UrlPath.MAIN,
+                    `${params.data.application}@${params.data.serviceType}`
+                ]
+            });
+            this.analyticsService.trackEvent(TRACKED_EVENT_LIST.CLICK_APPLICATION_IN_STATISTIC_LIST);
+        } else {
+            const diffMinute = 5;
+            const startTime = EndTime.newByNumber(params.data.startTimestamp);
+            this.urlRouteManagerService.openPage({
+                path: [
+                    UrlPath.INSPECTOR,
+                    `${params.data.application}@${params.data.serviceType}`,
+                    `${diffMinute}m`,
+                    startTime.calcuNextTime(diffMinute).getEndTime(),
+                    params.data.agent
+                ]
+            });
+            this.analyticsService.trackEvent(TRACKED_EVENT_LIST.CLICK_AGENT_IN_STATISTIC_LIST);
+        }
+
     }
 }

--- a/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list.component.ts
+++ b/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list.component.ts
@@ -7,6 +7,7 @@ export interface IGridData {
     serviceType: string;
     agent: string;
     agentVersion: string;
+    startTimestamp: number;
     jvmVersion: string;
     folder?: boolean;
     open?: boolean;
@@ -78,7 +79,8 @@ export class AgentStatisticListComponent implements OnInit  {
                 },
                 cellStyle: {
                     color: 'rgb(54, 162, 235)',
-                    'font-weight': 600
+                    'font-weight': 600,
+                    'cursor': 'pointer'
                 },
                 filter: 'agTextColumnFilter',
                 tooltipField: 'application'
@@ -88,7 +90,10 @@ export class AgentStatisticListComponent implements OnInit  {
                 field: 'agent',
                 width: 300,
                 filter: 'agTextColumnFilter',
-                tooltipField: 'agent'
+                tooltipField: 'agent',
+                cellStyle: {
+                    'cursor': 'pointer'
+                }
             },
             {
                 headerName: 'Agent Version',
@@ -108,14 +113,7 @@ export class AgentStatisticListComponent implements OnInit  {
     }
 
     onCellClick(params: any): void {
-        if (params.colDef.field !== 'application') {
-            return;
-        }
-
-        this.outCellClick.next({
-            application: params.data.application,
-            serviceType: params.data.serviceType
-        });
+        this.outCellClick.next(params);
     }
 
     onRendered(): void {

--- a/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list.component.ts
+++ b/web/src/main/angular/src/app/core/components/agent-statistic-list/agent-statistic-list.component.ts
@@ -92,6 +92,8 @@ export class AgentStatisticListComponent implements OnInit  {
                 filter: 'agTextColumnFilter',
                 tooltipField: 'agent',
                 cellStyle: {
+                    color: 'rgb(54, 162, 235)',
+                    'font-weight': 600,
                     'cursor': 'pointer'
                 }
             },

--- a/web/src/main/angular/src/app/shared/services/analytics.service.ts
+++ b/web/src/main/angular/src/app/shared/services/analytics.service.ts
@@ -117,6 +117,7 @@ export enum TRACKED_EVENT_LIST {
     FETCH_AGENT_STATISTIC_DATA = 'Fetch Agent Statistic Data',
     RELOAD_AGENT_STATISTIC_DATA = 'Reload Agent Statistic Data',
     CLICK_APPLICATION_IN_STATISTIC_LIST = 'Click Application in Statistic List',
+    CLICK_AGENT_IN_STATISTIC_LIST = 'Click Agent in Statistic List',
     SHOW_ONE_AGENT_REMOVE_CONFIRM_VIEW = 'Show One Agent Remove Confirm View',
     SHOW_ALL_INACTIVE_AGENTS_REMOVE_CONFIRM_VIEW = 'Show All Inactive Agents Remove Confirm View',
     REMOVE_ONE_AGENT = 'Remove One Agent',


### PR DESCRIPTION
Changes:
1. always show application name in children rows and link to /main/{app_name}@{service_type}

before:

![image](https://user-images.githubusercontent.com/1879641/114837717-9747f580-9e06-11eb-9d02-7adc74ecb5c8.png)

after:

![image](https://user-images.githubusercontent.com/1879641/114853533-75ef0580-9e16-11eb-98d2-2d1c7331675d.png)

2. the other cells except application cells link to /inspector/ {app_name}@{service_type} /5m/ {start_time + 5m} / {agent_id}