### PR TITLE
[#7868] disable environment/property support

### DIFF
--- a/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointBootStrap.java
+++ b/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointBootStrap.java
@@ -39,6 +39,14 @@ public class PinpointBootStrap {
     private static final LoadState STATE = new LoadState();
 
     public static void premain(String agentArgs, Instrumentation instrumentation) {
+
+        if (disabled()) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("PinPoint is disabled via Env/Property.");
+            }
+            return;
+        }
+
         final boolean success = STATE.start();
         if (!success) {
             logger.warn("pinpoint-bootstrap already started. skipping agent loading.");
@@ -82,6 +90,12 @@ public class PinpointBootStrap {
             logPinpointAgentLoadFail();
         }
 
+    }
+
+    private static boolean disabled() {
+        final String env = System.getenv("PINPOINT_DISABLE");
+        final String prop = System.getProperty("pinpoint.disable");
+        return env != null || prop != null;
     }
 
     private static ModuleBootLoader loadModuleBootLoader(Instrumentation instrumentation, ClassLoader parentClassLoader) {


### PR DESCRIPTION
# feature
To disable the pinpoint agent, even the agent is set via javaagent.

# when to use
When the javaagent jvm parameter is set as global to all applications/pods, especially for k8s environments, or set by JAVA_OPTS. Some jvm applications may need to disable the agent for now/ever/emergency.
# how to use
### 1. by environment variable
 env PINPOINT_DISABLE=true java -jar /path/to/jar
### 2. by property
java -Dpinpoint.disable=true -jar /path/to/jar