### PR TITLE
[#7907] Fixes plugin integration tests failing to recognize local maven repositories

### DIFF
--- a/test/src/main/java/com/navercorp/pinpoint/test/plugin/AbstractPinpointPluginTestSuite.java
+++ b/test/src/main/java/com/navercorp/pinpoint/test/plugin/AbstractPinpointPluginTestSuite.java
@@ -50,9 +50,11 @@ public abstract class AbstractPinpointPluginTestSuite extends Suite {
     private final TaggedLogger logger = TestLogger.getLogger();
 
     private static final int NO_JVM_VERSION = -1;
+    private static final List<String> EMPTY_REPOSITORY_URLS = new ArrayList<String>();
 
     private final List<String> requiredLibraries;
     private final List<String> mavenDependencyLibraries;
+    private final List<String> repositoryUrls;
     private final String testClassLocation;
 
     private final String agentJar;
@@ -85,6 +87,9 @@ public abstract class AbstractPinpointPluginTestSuite extends Suite {
 
         ImportPlugin importPlugin = testClass.getAnnotation(ImportPlugin.class);
         this.importPluginIds = getImportPlugin(importPlugin);
+
+        Repository repository = testClass.getAnnotation(Repository.class);
+        this.repositoryUrls = getRepository(repository);
 
         List<ClassLoaderLib> classLoaderLibs = collectLib(getClass().getClassLoader());
         if (logger.isDebugEnabled()) {
@@ -121,6 +126,13 @@ public abstract class AbstractPinpointPluginTestSuite extends Suite {
             return null;
         }
         return Arrays.asList(ids);
+    }
+
+    private List<String> getRepository(Repository repository) {
+        if (repository == null) {
+            return EMPTY_REPOSITORY_URLS;
+        }
+        return Arrays.asList(repository.value());
     }
 
     private String[] getJvmArguments(JvmArgument jvmArgument) {
@@ -348,7 +360,7 @@ public abstract class AbstractPinpointPluginTestSuite extends Suite {
                 }
 
                 PluginTestContext context = new PluginTestContext(agentJar, profile,
-                        configFile, requiredLibraries, mavenDependencyLibraries,
+                        configFile, requiredLibraries, mavenDependencyLibraries, repositoryUrls,
                         getTestClass().getJavaClass(), testClassLocation,
                         jvmArguments, debug, ver, javaExe, importPluginIds);
 

--- a/test/src/main/java/com/navercorp/pinpoint/test/plugin/DependencyResolver.java
+++ b/test/src/main/java/com/navercorp/pinpoint/test/plugin/DependencyResolver.java
@@ -198,8 +198,9 @@ public class DependencyResolver {
         RemoteRepository mavenCentralRepository = newMavenCentralRepository();
         repositories.add(mavenCentralRepository);
 
+        int localRepositoriesCount = 0;
         for (String url : urls) {
-            RemoteRepository remoteRepository = new RemoteRepository.Builder(null, "default", url).build();
+            RemoteRepository remoteRepository = new RemoteRepository.Builder("local" + localRepositoriesCount, "default", url).build();
             repositories.add(remoteRepository);
         }
 

--- a/test/src/main/java/com/navercorp/pinpoint/test/plugin/PluginTestContext.java
+++ b/test/src/main/java/com/navercorp/pinpoint/test/plugin/PluginTestContext.java
@@ -28,6 +28,7 @@ public class PluginTestContext {
 
     private final List<String> requiredLibraries;
     private final List<String> mavenDependencyLibraries;
+    private final List<String> repositoryUrls;
     private final Class<?> testClass;
     private final String testClassLocation;
 
@@ -40,7 +41,7 @@ public class PluginTestContext {
     private final List<String> importPluginIds;
 
     public PluginTestContext(String agentJar, String profile, String configFile,
-                             List<String> requiredLibraries, List<String> mavenDependencyLibraries,
+                             List<String> requiredLibraries, List<String> mavenDependencyLibraries, List<String> repositoryUrls,
                              Class<?> testClass, String testClassLocation, String[] jvmArguments,
                              boolean debug, int jvmVersion,
                              String javaExecutable, List<String> importPluginIds) {
@@ -49,6 +50,7 @@ public class PluginTestContext {
         this.configFile = configFile;
         this.requiredLibraries = requiredLibraries;
         this.mavenDependencyLibraries = mavenDependencyLibraries;
+        this.repositoryUrls = repositoryUrls;
         this.testClass = testClass;
         this.testClassLocation = testClassLocation;
         this.jvmArguments = jvmArguments;
@@ -65,6 +67,8 @@ public class PluginTestContext {
     public List<String> getMavenDependencyLibraries() {
         return mavenDependencyLibraries;
     }
+
+    public List<String> getRepositoryUrls() { return repositoryUrls; }
 
     public String getTestClassLocation() {
         return testClassLocation;
@@ -114,6 +118,7 @@ public class PluginTestContext {
                 ", configFile='" + configFile + '\'' +
                 ", requiredLibraries=" + requiredLibraries +
                 ", mavenDependencyLibraries=" + mavenDependencyLibraries +
+                ", repositoryUrls=" + repositoryUrls +
                 ", testClass=" + testClass +
                 ", testClassLocation='" + testClassLocation + '\'' +
                 ", jvmArguments=" + Arrays.toString(jvmArguments) +

--- a/test/src/main/java/com/navercorp/pinpoint/test/plugin/shared/ReflectionDependencyResolver.java
+++ b/test/src/main/java/com/navercorp/pinpoint/test/plugin/shared/ReflectionDependencyResolver.java
@@ -32,11 +32,13 @@ import java.util.concurrent.Callable;
 public class ReflectionDependencyResolver {
 
     private final ClassLoader classLoader;
+    private final String[] repositoryUrls;
     private Object dependencyResolverObject;
     private Method resolveArtifactsAndDependenciesMethod;
 
-    public ReflectionDependencyResolver(ClassLoader classLoader) {
+    public ReflectionDependencyResolver(ClassLoader classLoader, String[] repositoryUrls) {
         this.classLoader = Objects.requireNonNull(classLoader, "classLoader");
+        this.repositoryUrls = Objects.requireNonNull(repositoryUrls, "repositoryUrls");
     }
 
     public List<File> lookup(final List<String> classpathList) throws Exception {
@@ -74,7 +76,7 @@ public class ReflectionDependencyResolver {
         Object factoryObject = factory.newInstance();
         Method resolverGet = factory.getMethod("get", String[].class);
 
-        dependencyResolverObject = resolverGet.invoke(factoryObject, (Object) new String[]{});
+        dependencyResolverObject = resolverGet.invoke(factoryObject, (Object)repositoryUrls);
 
         Class<?> dependencyResolverClazz = dependencyResolverObject.getClass();
         resolveArtifactsAndDependenciesMethod = dependencyResolverClazz.getMethod("resolveArtifactsAndDependencies", String.class);

--- a/test/src/main/java/com/navercorp/pinpoint/test/plugin/shared/SharedPinpointPluginTest.java
+++ b/test/src/main/java/com/navercorp/pinpoint/test/plugin/shared/SharedPinpointPluginTest.java
@@ -60,6 +60,13 @@ public class SharedPinpointPluginTest {
             return;
         }
 
+        final String repositoryUrlString = System.getProperty(SharedPluginTestConstants.TEST_REPOSITORY_URLS);
+        if (repositoryUrlString == null) {
+            logger.error("repositoryUrls must not be empty");
+            return;
+        }
+        logger.debug("-D{}={}", SharedPluginTestConstants.TEST_REPOSITORY_URLS, repositoryUrlString);
+
         final String testLocation = System.getProperty(SharedPluginTestConstants.TEST_LOCATION);
         if (testLocation == null) {
             logger.error("testLocation must not be empty");
@@ -91,10 +98,11 @@ public class SharedPinpointPluginTest {
         }
 
         String[] mavenDependencyResolverClassPathArray = mavenDependencyResolverClassPaths.split(File.pathSeparator);
+        String[] repositoryUrls = repositoryUrlString.split(",");
         TestParameterParser parser = new TestParameterParser();
         List<TestParameter> testParameters = parser.parse(args);
         SharedPinpointPluginTest pluginTest = new SharedPinpointPluginTest(testClazzName, testLocation, testLogger,
-                mavenDependencyResolverClassPathArray, testParameters, System.out);
+                mavenDependencyResolverClassPathArray, repositoryUrls, testParameters, System.out);
         pluginTest.execute();
 
     }
@@ -103,22 +111,25 @@ public class SharedPinpointPluginTest {
     private final String testLocation;
     private final boolean testLogger;
     private final String[] mavenDependencyResolverClassPaths;
+    private final String[] repositoryUrls;
     private final List<TestParameter> testParameters;
     private final PrintStream out;
 
     public SharedPinpointPluginTest(String testClazzName, String testLocation, boolean testLogger,
-                                    String[] mavenDependencyResolverClassPaths, List<TestParameter> testParameters, PrintStream out) {
+                                    String[] mavenDependencyResolverClassPaths, String[] repositoryUrls,
+                                    List<TestParameter> testParameters, PrintStream out) {
         this.testClazzName = testClazzName;
         this.testLocation = testLocation;
         this.testLogger = testLogger;
         this.mavenDependencyResolverClassPaths = mavenDependencyResolverClassPaths;
+        this.repositoryUrls = repositoryUrls;
         this.testParameters = testParameters;
         this.out = out;
 
     }
 
-    private List<TestInfo> newTestCaseInfo(List<TestParameter> testParameters, File testClazzLocation, ClassLoader dependencyClassLoader) throws Exception {
-        ReflectionDependencyResolver dependencyResolver = new ReflectionDependencyResolver(dependencyClassLoader);
+    private List<TestInfo> newTestCaseInfo(List<TestParameter> testParameters, File testClazzLocation, String[] repositoryUrls, ClassLoader dependencyClassLoader) throws Exception {
+        ReflectionDependencyResolver dependencyResolver = new ReflectionDependencyResolver(dependencyClassLoader, repositoryUrls);
         List<File> loggerDependencies = getLoggerDependencies(dependencyResolver, dependencyClassLoader);
         logger.debug("loggerDependency:{}", loggerDependencies);
 
@@ -132,7 +143,7 @@ public class SharedPinpointPluginTest {
             List<File> testParameterDependency = getTestParameterDependency(dependencyClassLoader, dependencyResolver, testParameter);
             testDependency.addAll(testParameterDependency);
 
-            final TestInfo testInfo = new TestInfo(testParameter.getTestId(), testDependency);
+            final TestInfo testInfo = new TestInfo(testParameter.getTestId(), testDependency, Arrays.asList(repositoryUrls));
             testInfos.add(testInfo);
         }
         return testInfos;
@@ -158,7 +169,7 @@ public class SharedPinpointPluginTest {
             return Collections.emptyList();
         }
         List<String> dependencyLib = PluginClassLoading.LOGGER_DEPENDENCY;
-        List<File> libFiles = lookup(dependencyResolver, dependencyLib, mavenDependencyResolverClassLoader);
+        List<File> libFiles = lookup(dependencyResolver, dependencyLib,  mavenDependencyResolverClassLoader);
         if (logger.isDebugEnabled()) {
             logger.debug("LoggerDependency {}", dependencyLib);
             for (File libFile : libFiles) {
@@ -188,6 +199,9 @@ public class SharedPinpointPluginTest {
             for (TestParameter testParameter : testParameters) {
                 logger.debug("{} {}", testClazzName, testParameter);
             }
+            for (String repositoryUrl : repositoryUrls) {
+                logger.debug("{}: {}", SharedPluginTestConstants.TEST_REPOSITORY_URLS, repositoryUrl);
+            }
         }
     }
 
@@ -195,7 +209,7 @@ public class SharedPinpointPluginTest {
         logTestInformation();
         ClassLoader mavenDependencyResolverClassLoader = new ChildFirstClassLoader(URLUtils.fileToUrls(mavenDependencyResolverClassPaths));
         File testClazzLocation = new File(testLocation);
-        List<TestInfo> testInfos = newTestCaseInfo(testParameters, testClazzLocation, mavenDependencyResolverClassLoader);
+        List<TestInfo> testInfos = newTestCaseInfo(testParameters, testClazzLocation, repositoryUrls, mavenDependencyResolverClassLoader);
         for (TestInfo testInfo : testInfos) {
             execute(testInfo);
         }

--- a/test/src/main/java/com/navercorp/pinpoint/test/plugin/shared/SharedPluginTestConstants.java
+++ b/test/src/main/java/com/navercorp/pinpoint/test/plugin/shared/SharedPluginTestConstants.java
@@ -29,4 +29,6 @@ public class SharedPluginTestConstants {
 
     public static final String MAVEN_DEPENDENCY_RESOLVER_CLASS_PATHS = "mavenDependencyResolverClassPaths";
 
+    public static final String TEST_REPOSITORY_URLS = "repositoryUrls";
+
 }

--- a/test/src/main/java/com/navercorp/pinpoint/test/plugin/shared/SharedProcessManager.java
+++ b/test/src/main/java/com/navercorp/pinpoint/test/plugin/shared/SharedProcessManager.java
@@ -163,6 +163,8 @@ public class SharedProcessManager implements ProcessManager {
 
         final String mavenDependencyResolverClassPaths = join(context.getMavenDependencyLibraries());
         list.add(format(SharedPluginTestConstants.MAVEN_DEPENDENCY_RESOLVER_CLASS_PATHS, mavenDependencyResolverClassPaths));
+        final String repositoryUrlString = join(context.getRepositoryUrls());
+        list.add(format(SharedPluginTestConstants.TEST_REPOSITORY_URLS, repositoryUrlString));
         list.add(format(SharedPluginTestConstants.TEST_LOCATION,  context.getTestClassLocation()));
         list.add(format(SharedPluginTestConstants.TEST_CLAZZ_NAME, context.getTestClass().getName()));
 

--- a/test/src/main/java/com/navercorp/pinpoint/test/plugin/shared/TestInfo.java
+++ b/test/src/main/java/com/navercorp/pinpoint/test/plugin/shared/TestInfo.java
@@ -25,10 +25,12 @@ import java.util.List;
 public class TestInfo {
     private final String testId;
     private final List<File> dependencyFileList;
+    private final List<String> repositoryUrls;
 
-    public TestInfo(String testId, List<File> dependencyFileList) {
+    public TestInfo(String testId, List<File> dependencyFileList, List<String> repositoryUrls) {
         this.testId = testId;
         this.dependencyFileList = dependencyFileList;
+        this.repositoryUrls = repositoryUrls;
     }
 
     public String getTestId() {
@@ -37,5 +39,9 @@ public class TestInfo {
 
     public List<File> getDependencyFileList() {
         return dependencyFileList;
+    }
+
+    public List<String> getRepositoryUrls() {
+        return repositoryUrls;
     }
 }

--- a/test/src/test/java/com/navercorp/pinpoint/test/plugin/shared/ReflectionDependencyResolverTest.java
+++ b/test/src/test/java/com/navercorp/pinpoint/test/plugin/shared/ReflectionDependencyResolverTest.java
@@ -34,7 +34,7 @@ public class ReflectionDependencyResolverTest {
 
     @Test
     public void get() throws Exception {
-        ReflectionDependencyResolver dependencyResolver = new ReflectionDependencyResolver(Thread.currentThread().getContextClassLoader());
+        ReflectionDependencyResolver dependencyResolver = new ReflectionDependencyResolver(Thread.currentThread().getContextClassLoader(), new String[]{});
         List<File> files = dependencyResolver.lookup(Arrays.asList("org.slf4j:slf4j-api:1.7.21"));
         Assert.assertEquals(files.size(), 1);
     }


### PR DESCRIPTION
- Uses dummy repository id in DependencyResolver for maven-resolver plugin to properly scan for required artifacts
- Passes repository urls specified by @Repository in plugin integration tests to SharedPinpointPluginTest