### PR TITLE
[#7895] Fix jedis plugin for java compatibility

### DIFF
--- a/plugins/bom/pom.xml
+++ b/plugins/bom/pom.xml
@@ -30,7 +30,7 @@
     <name>pinpoint-plugin-bom</name>
 
     <properties>
-        <jedis.version>3.4.0</jedis.version>
+        <jedis.version>2.4.2</jedis.version>
         <lettuce.version>5.1.2.RELEASE</lettuce.version>
         <cassandra.driver.version>2.1.7.1</cassandra.driver.version>
         <dubbo.version>2.5.3</dubbo.version>

--- a/plugins/redis/src/main/java/com/navercorp/pinpoint/plugin/redis/jedis/interceptor/SetEndPointInterceptor.java
+++ b/plugins/redis/src/main/java/com/navercorp/pinpoint/plugin/redis/jedis/interceptor/SetEndPointInterceptor.java
@@ -29,7 +29,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.plugin.redis.jedis.EndPointAccessor;
-import redis.clients.jedis.JedisSocketFactory;
+//import redis.clients.jedis.JedisSocketFactory; // For compatibility with Java 1.7
 
 /**
  * Jedis (redis client) constructor interceptor
@@ -76,9 +76,10 @@ public class SetEndPointInterceptor implements AroundInterceptor {
         } else if (argZero instanceof JedisShardInfo) {
             final JedisShardInfo info = (JedisShardInfo) argZero;
             return HostAndPort.toHostAndPortString(info.getHost(), info.getPort());
-        } else if (argZero instanceof JedisSocketFactory) {
-            final JedisSocketFactory factory = (JedisSocketFactory) argZero;
-            return HostAndPort.toHostAndPortString(factory.getHost(), factory.getPort());
+        // TODO The JedisSocketFactory class is supported from jedis version 3.6, and java 1.8 is required.
+        // } else if (argZero instanceof JedisSocketFactory) {
+        //    final JedisSocketFactory factory = (JedisSocketFactory) argZero;
+        //    return HostAndPort.toHostAndPortString(factory.getHost(), factory.getPort());
         }
         return "Unknown";
     }


### PR DESCRIPTION
#7895 
The JedisSocketFactory class is supported from jedis version 3.6, and java 1.8 is required.
