### PR TITLE
[#6783] Fix some agent config properties is not works

### DIFF
--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
@@ -423,7 +423,7 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     }
 
     @Value("${profiler.plugin.disable}")
-    void getDisabledPlugins(String disabledPlugins) {
+    void setDisabledPlugins(String disabledPlugins) {
         this.disabledPlugins = StringUtils.tokenizeToStringList(disabledPlugins, ",");
     }
 
@@ -481,7 +481,7 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     }
 
     @Value("${profiler.http.status.code.errors}")
-    void getHttpStatusCodeErrors(String httpStatusCodeErrors) {
+    void setHttpStatusCodeErrors(String httpStatusCodeErrors) {
         List<String> httpStatusCodeErrorList = StringUtils.tokenizeToStringList(httpStatusCodeErrors, ",");
         this.httpStatusCodeErrors = new HttpStatusCodeErrors(httpStatusCodeErrorList);
     }


### PR DESCRIPTION
`@Value` annotation is not worked at getter methods.
fix to setter method.

* profiler.http.status.code.errors
* profiler.plugin.disable

fix #6783