### PR TITLE
[#7962] record configured response header

### DIFF
--- a/agent/src/main/resources/pinpoint-root.config
+++ b/agent/src/main/resources/pinpoint-root.config
@@ -314,6 +314,11 @@ profiler.http.status.code.errors=5xx
 # e.g. profiler.http.record.request.cookies=userid,device-id,uuid
 #profiler.http.record.request.cookies=
 
+# record HTTP response headers case-sensitive
+# set to HEADERS-ALL to record all of the headers.
+# e.g. profiler.http.record.response.headers=Set-Cookie
+#profiler.http.record.response.headers=
+
 ###########################################################
 # Application Type                                        #
 ###########################################################

--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -211,6 +211,11 @@ profiler.http.record.request.headers=
 # e.g. profiler.http.record.request.cookies=userid,device-id,uuid
 profiler.http.record.request.cookies=
 
+# record HTTP response headers case-sensitive
+# set to HEADERS-ALL to record all of the headers.
+# e.g. profiler.http.record.response.headers=Set-Cookie
+profiler.http.record.response.headers=Connection
+
 ###########################################################
 # application type                                        # 
 ###########################################################

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -211,6 +211,11 @@ profiler.http.status.code.errors=5xx
 # e.g. profiler.http.record.request.cookies=userid,device-id,uuid
 #profiler.http.record.request.cookies=
 
+# record HTTP response headers case-sensitive
+# set to HEADERS-ALL to record all of the headers.
+# e.g. profiler.http.record.response.headers=Set-Cookie
+#profiler.http.record.response.headers=
+
 ###########################################################
 # application type                                        # 
 ###########################################################

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/AttributeRecorder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/AttributeRecorder.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.context;
+
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+
+/**
+ * @author yjqg6666
+ */
+public interface AttributeRecorder {
+
+    void recordAttribute(AnnotationKey key, String value);
+
+    void recordAttribute(AnnotationKey key, int value);
+
+    void recordAttribute(AnnotationKey key, Object value);
+
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/SpanEventRecorder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/SpanEventRecorder.java
@@ -20,7 +20,7 @@ import com.navercorp.pinpoint.common.annotations.InterfaceStability;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
-public interface SpanEventRecorder extends FrameAttachment {
+public interface SpanEventRecorder extends AttributeRecorder, FrameAttachment {
 
     void recordTime(boolean time);
 
@@ -45,12 +45,6 @@ public interface SpanEventRecorder extends FrameAttachment {
     void recordSqlParsingResult(ParsingResult parsingResult);
 
     void recordSqlParsingResult(ParsingResult parsingResult, String bindValue);
-
-    void recordAttribute(AnnotationKey key, String value);
-
-    void recordAttribute(AnnotationKey key, int value);
-
-    void recordAttribute(AnnotationKey key, Object value);
 
     void recordServiceType(ServiceType serviceType);
 

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/SpanEventRecorder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/SpanEventRecorder.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.bootstrap.context;
 
 import com.navercorp.pinpoint.common.annotations.InterfaceStability;
-import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public interface SpanEventRecorder extends AttributeRecorder, FrameAttachment {

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/SpanRecorder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/SpanRecorder.java
@@ -1,10 +1,9 @@
 package com.navercorp.pinpoint.bootstrap.context;
 
-import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.LoggingInfo;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
-public interface SpanRecorder extends FrameAttachment {
+public interface SpanRecorder extends FrameAttachment, AttributeRecorder {
 
     boolean canSampled();
 
@@ -31,12 +30,6 @@ public interface SpanRecorder extends FrameAttachment {
     void recordApi(MethodDescriptor methodDescriptor, Object[] args, int start, int end);
 
     void recordApiCachedString(MethodDescriptor methodDescriptor, String args, int index);
-
-    void recordAttribute(AnnotationKey key, String value);
-
-    void recordAttribute(AnnotationKey key, int value);
-
-    void recordAttribute(AnnotationKey key, Object value);
 
     void recordServiceType(ServiceType serviceType);
 

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServletRequestListener.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServletRequestListener.java
@@ -135,7 +135,17 @@ public class ServletRequestListener<REQ> {
         return trace;
     }
 
+    /**
+     * kept for bc, since response listener for weblogic & websphere has not been implemented yet.
+     * @param request request
+     * @param throwable error
+     * @param statusCode status code
+     */
     public void destroyed(REQ request, final Throwable throwable, final int statusCode) {
+        destroyed(request, throwable, statusCode, true);
+    }
+
+    public void destroyed(REQ request, final Throwable throwable, final int statusCode, final boolean recordStatusCode) {
         if (isDebug) {
             logger.debug("Destroyed requestEvent. request={}, throwable={}, statusCode={}", request, throwable, statusCode);
         }
@@ -159,7 +169,9 @@ public class ServletRequestListener<REQ> {
         try {
             final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
             recorder.recordException(throwable);
-            this.httpStatusCodeRecorder.record(trace.getSpanRecorder(), statusCode);
+            if (recordStatusCode) {
+                this.httpStatusCodeRecorder.record(trace.getSpanRecorder(), statusCode);
+            }
             // Must be executed in destroyed()
             this.parameterRecorder.record(recorder, request, throwable);
         } finally {

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServletRequestListenerBuilder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServletRequestListenerBuilder.java
@@ -57,6 +57,7 @@ public class ServletRequestListenerBuilder<REQ> {
     private List<String> recordRequestHeaders;
     private List<String> recordRequestCookies;
     private UriStatRecorder<REQ> uriStatRecorder = DisabledUriStatRecorder.create();
+    private boolean recordStatusCode = true;
 
     public ServletRequestListenerBuilder(final ServiceType serviceType,
                                          final TraceContext traceContext,
@@ -104,6 +105,10 @@ public class ServletRequestListenerBuilder<REQ> {
         this.uriStatRecorder = reqUriStatRecorder;
     }
 
+    public void setRecordStatusCode(boolean recordStatusCode) {
+        this.recordStatusCode = recordStatusCode;
+    }
+
     private <T> Filter<T> newExcludeUrlFilter(Filter<T> excludeUrlFilter) {
         if (excludeUrlFilter == null) {
             return new SkipFilter<>();
@@ -144,7 +149,8 @@ public class ServletRequestListenerBuilder<REQ> {
 
 
         return new ServletRequestListener<>(serviceType, traceContext, requestAdaptor, requestTraceReader,
-                excludeUrlFilter, parameterRecorder, proxyRequestRecorder, serverRequestRecorder, httpStatusCodeRecorder, uriStatRecorder);
+                excludeUrlFilter, parameterRecorder, proxyRequestRecorder, serverRequestRecorder, httpStatusCodeRecorder,
+                uriStatRecorder, recordStatusCode);
     }
 
 

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/BypassServerResponseHeaderRecorder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/BypassServerResponseHeaderRecorder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.response;
+
+import com.navercorp.pinpoint.bootstrap.context.AttributeRecorder;
+
+/**
+ * @author yjqg6666
+ */
+public class BypassServerResponseHeaderRecorder<T> implements ServerResponseHeaderRecorder<T> {
+
+    @Override
+    public void recordHeader(AttributeRecorder recorder, T response) {
+        // empty
+    }
+
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/DefaultServerResponseHeaderRecorder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/DefaultServerResponseHeaderRecorder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.response;
+
+import com.navercorp.pinpoint.bootstrap.context.AttributeRecorder;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import com.navercorp.pinpoint.common.util.StringStringValue;
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author yjqg6666
+ */
+public class DefaultServerResponseHeaderRecorder<RESP> implements ServerResponseHeaderRecorder<RESP> {
+
+    private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+
+    private final ResponseAdaptor<RESP> responseAdaptor;
+    private final Collection<String> recordHeaders;
+    private final boolean recordAllHeaders;
+
+    public DefaultServerResponseHeaderRecorder(ResponseAdaptor<RESP> responseAdaptor, List<String> recordHeaders) {
+        this.responseAdaptor = Objects.requireNonNull(responseAdaptor, "responseAdaptor");
+        Objects.requireNonNull(recordHeaders, "recordHeaders");
+        this.recordAllHeaders = recordHeaders.size() == 1 && "HEADERS-ALL".contentEquals(recordHeaders.get(0));
+        this.recordHeaders = recordHeaders;
+    }
+
+    @Override
+    public void recordHeader(final AttributeRecorder recorder, final RESP response) {
+        Collection<String> headerNames = recordAllHeaders ? getHeaderNames(response) : this.recordHeaders;
+        for (String headerName : headerNames) {
+            if (!StringUtils.hasText(headerName)) {
+                continue;
+            }
+            final Collection<String> headers = getHeaders(response, headerName);
+            if (headers == null || headers.isEmpty()) {
+                continue;
+            }
+            StringStringValue header = new StringStringValue(headerName, formatHeaderValues(headers));
+            recorder.recordAttribute(AnnotationKey.HTTP_RESPONSE_HEADER, header);
+        }
+    }
+
+    private Set<String> getHeaderNames(final RESP response) {
+        try {
+            final Collection<String> headerNames = responseAdaptor.getHeaderNames(response);
+            if (headerNames == null || headerNames.isEmpty()) {
+                return Collections.emptySet();
+            }
+            //deduplicate
+            Set<String> names = new HashSet<>(headerNames.size());
+            names.addAll(headerNames);
+            return names;
+        } catch (IOException e) {
+            logger.warn("Extract all of the response header names from response {} failed, caused by:", response, e);
+            return Collections.emptySet();
+        }
+    }
+
+    private Collection<String> getHeaders(final RESP response, String headerName) {
+        try {
+            return responseAdaptor.getHeaders(response, headerName);
+        } catch (IOException e) {
+            logger.warn("Extract response header {} from response {} failed, caused by:", headerName, response, e);
+            return Collections.emptyList();
+        }
+    }
+
+    private String formatHeaderValues(Collection<String> headers) {
+        final String val;
+        if (headers.size() == 1) {
+            final String[] stringArray = headers.toArray(new String[0]);
+            val = stringArray[0];
+        } else {
+            val = headers.toString();
+        }
+        return val;
+    }
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseAdaptor.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseAdaptor.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.response;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * @author yjqg6666
+ */
+public interface ResponseAdaptor<RESP> {
+
+    /**
+     * Returns a boolean indicating whether the named response header
+     * has already been set.
+     *
+     * @param    response    response
+     * @param    name    the header name
+     * @return        <code>true</code> if the named response header
+     * has already been set;
+     * <code>false</code> otherwise
+     */
+
+    boolean containsHeader(RESP response, String name);
+
+    /**
+     * Sets a response header with the given name and value.
+     * If the header had already been set, the new value overwrites the
+     * previous one.  The <code>containsHeader</code> method can be
+     * used to test for the presence of a header before setting its
+     * value.
+     *
+     * @param    response    response
+     * @param    name    the name of the header
+     * @param    value    the header value  If it contains octet string,
+     * it should be encoded according to RFC 2047
+     * (http://www.ietf.org/rfc/rfc2047.txt)
+     * @see #containsHeader
+     */
+
+    void setHeader(RESP response, String name, String value);
+
+    /**
+     * Adds a response header with the given name and value.
+     * This method allows response headers to have multiple values.
+     *
+     * @param    response  response
+     * @param    name    the name of the header
+     * @param    value    the additional header value   If it contains
+     * octet string, it should be encoded
+     * according to RFC 2047
+     * (http://www.ietf.org/rfc/rfc2047.txt)
+     * @see #setHeader
+     */
+
+    void addHeader(RESP response, String name, String value);
+
+    /**
+     * Gets the value of the response header with the given name.
+     *
+     * <p>If a response header with the given name exists and contains
+     * multiple values, the value that was added first will be returned.
+     *
+     * @param response response
+     * @param name the name of the response header whose value to return
+     * @return the value of the response header with the given name,
+     * or <tt>null</tt> if no header with the given name has been set
+     * on this response
+     */
+    String getHeader(RESP response, String name);
+
+
+    /**
+     * Gets the values of the response header with the given name.
+     *
+     * @param name the name of the response header whose values to return
+     * @return a (possibly empty) <code>Collection</code> of the values
+     * of the response header with the given name
+     */
+    Collection<String> getHeaders(RESP response, String name) throws IOException;
+
+    /**
+     * Gets all of the response header names
+     *
+     * @param response response
+     * @return a (possibly empty) <code>Collection</code> of response header names
+     */
+    Collection<String> getHeaderNames(RESP response) throws IOException;
+
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseAdaptor.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseAdaptor.java
@@ -34,7 +34,6 @@ public interface ResponseAdaptor<RESP> {
      * has already been set;
      * <code>false</code> otherwise
      */
-
     boolean containsHeader(RESP response, String name);
 
     /**
@@ -51,7 +50,6 @@ public interface ResponseAdaptor<RESP> {
      * (http://www.ietf.org/rfc/rfc2047.txt)
      * @see #containsHeader
      */
-
     void setHeader(RESP response, String name, String value);
 
     /**
@@ -66,7 +64,6 @@ public interface ResponseAdaptor<RESP> {
      * (http://www.ietf.org/rfc/rfc2047.txt)
      * @see #setHeader
      */
-
     void addHeader(RESP response, String name, String value);
 
     /**

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseHeaderRecorderFactory.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseHeaderRecorderFactory.java
@@ -29,9 +29,9 @@ public class ResponseHeaderRecorderFactory {
     public static <RESP> ServerResponseHeaderRecorder<RESP> newResponseHeaderRecorder(ProfilerConfig profilerConfig, ResponseAdaptor<RESP> adaptor) {
         final List<String> recordResponseHeaders = profilerConfig.readList(ServerResponseHeaderRecorder.CONFIG_KEY_RECORD_RESP_HEADERS);
         if (CollectionUtils.isEmpty(recordResponseHeaders)) {
-            return new BypassServerResponseHeaderRecorder<RESP>();
+            return new BypassServerResponseHeaderRecorder<>();
         }
-        return new DefaultServerResponseHeaderRecorder<RESP>(adaptor, recordResponseHeaders);
+        return new DefaultServerResponseHeaderRecorder<>(adaptor, recordResponseHeaders);
     }
 
 }

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseHeaderRecorderFactory.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseHeaderRecorderFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.response;
+
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
+
+import java.util.List;
+
+/**
+ * @author yjqg6666
+ */
+public class ResponseHeaderRecorderFactory {
+
+    public static <RESP> ServerResponseHeaderRecorder<RESP> newResponseHeaderRecorder(ProfilerConfig profilerConfig, ResponseAdaptor<RESP> adaptor) {
+        final List<String> recordResponseHeaders = profilerConfig.readList(ServerResponseHeaderRecorder.CONFIG_KEY_RECORD_RESP_HEADERS);
+        if (CollectionUtils.isEmpty(recordResponseHeaders)) {
+            return new BypassServerResponseHeaderRecorder<RESP>();
+        }
+        return new DefaultServerResponseHeaderRecorder<RESP>(adaptor, recordResponseHeaders);
+    }
+
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ServerResponseHeaderRecorder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ServerResponseHeaderRecorder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.response;
+
+import com.navercorp.pinpoint.bootstrap.context.AttributeRecorder;
+
+public interface ServerResponseHeaderRecorder<RESP> {
+
+    String CONFIG_KEY_RECORD_RESP_HEADERS = "profiler.http.record.response.headers";
+
+    void recordHeader(AttributeRecorder recorder, RESP response);
+
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ServletResponseListener.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ServletResponseListener.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.response;
+
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.http.HttpStatusCodeRecorder;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+
+import java.util.Objects;
+
+/**
+ * @author yjqg6666
+ */
+public class ServletResponseListener<RESP> {
+
+    private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final ServerResponseHeaderRecorder<RESP> serverResponseHeaderRecorder;
+    private final HttpStatusCodeRecorder httpStatusCodeRecorder;
+
+    public ServletResponseListener(final TraceContext traceContext,
+                                   final ServerResponseHeaderRecorder<RESP> serverResponseHeaderRecorder,
+                                  final HttpStatusCodeRecorder httpStatusCodeRecorder) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.serverResponseHeaderRecorder = Objects.requireNonNull(serverResponseHeaderRecorder, "serverResponseHeaderRecorder");
+        this.httpStatusCodeRecorder = Objects.requireNonNull(httpStatusCodeRecorder, "statusCodeRecorder");
+    }
+
+
+    public void initialized(RESP response, final ServiceType serviceType, final MethodDescriptor methodDescriptor) {
+        Objects.requireNonNull(response, "response");
+        Objects.requireNonNull(serviceType, "serviceType");
+        Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+
+        if (isDebug) {
+            logger.debug("Initialized responseEvent. response={}, serviceType={}, methodDescriptor={}", response, serviceType, methodDescriptor);
+        }
+    }
+
+    public void destroyed(RESP response, final Throwable throwable, final int statusCode) {
+        Objects.requireNonNull(response, "response");
+
+        if (isDebug) {
+            logger.debug("Destroyed responseEvent. response={}, throwable={}, statusCode={}", response, throwable, statusCode);
+        }
+
+        final Trace trace = this.traceContext.currentRawTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        if (trace.canSampled()) {
+            final SpanRecorder spanRecorder = trace.getSpanRecorder();
+            this.httpStatusCodeRecorder.record(spanRecorder, statusCode);
+            this.serverResponseHeaderRecorder.recordHeader(spanRecorder, response);
+        }
+    }
+
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ServletResponseListenerBuilder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ServletResponseListenerBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.response;
+
+import com.navercorp.pinpoint.bootstrap.config.HttpStatusCodeErrors;
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.plugin.http.HttpStatusCodeRecorder;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author yjqg6666
+ */
+public class ServletResponseListenerBuilder<RESP> {
+    private final TraceContext traceContext;
+    private final ResponseAdaptor<RESP> responseAdaptor;
+
+    private List<String> recordResponseHeaders;
+
+    private HttpStatusCodeErrors httpStatusCodeErrors;
+
+    public ServletResponseListenerBuilder(final TraceContext traceContext,
+                                          final ResponseAdaptor<RESP> responseAdaptor) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.responseAdaptor = Objects.requireNonNull(responseAdaptor, "responseAdaptor");
+
+        final ProfilerConfig profilerConfig = traceContext.getProfilerConfig();
+        final List<String> recordResponseHeaders = profilerConfig.readList(ServerResponseHeaderRecorder.CONFIG_KEY_RECORD_RESP_HEADERS);
+        setRecordResponseHeaders(recordResponseHeaders);
+        setHttpStatusCodeRecorder(profilerConfig.getHttpStatusCodeErrors());
+    }
+
+    public void setRecordResponseHeaders(List<String> recordResponseHeaders) {
+        this.recordResponseHeaders = recordResponseHeaders;
+    }
+
+    public void setHttpStatusCodeRecorder(final HttpStatusCodeErrors httpStatusCodeErrors) {
+        this.httpStatusCodeErrors = httpStatusCodeErrors;
+    }
+
+    public ServletResponseListener<RESP> build() {
+        HttpStatusCodeRecorder httpStatusCodeRecorder;
+        if (httpStatusCodeErrors == null) {
+            HttpStatusCodeErrors httpStatusCodeErrors = new HttpStatusCodeErrors(Collections.<String>emptyList());
+            httpStatusCodeRecorder = new HttpStatusCodeRecorder(httpStatusCodeErrors);
+        } else {
+            httpStatusCodeRecorder = new HttpStatusCodeRecorder(httpStatusCodeErrors);
+        }
+        return new ServletResponseListener<RESP>(traceContext, newServerResponseHeaderRecorder(), httpStatusCodeRecorder);
+    }
+
+    private ServerResponseHeaderRecorder<RESP> newServerResponseHeaderRecorder() {
+        if (CollectionUtils.isEmpty(recordResponseHeaders)) {
+            return new BypassServerResponseHeaderRecorder<RESP>();
+        }
+        return new DefaultServerResponseHeaderRecorder<RESP>(responseAdaptor, recordResponseHeaders);
+    }
+
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ServletResponseListenerBuilder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ServletResponseListenerBuilder.java
@@ -64,14 +64,14 @@ public class ServletResponseListenerBuilder<RESP> {
         } else {
             httpStatusCodeRecorder = new HttpStatusCodeRecorder(httpStatusCodeErrors);
         }
-        return new ServletResponseListener<RESP>(traceContext, newServerResponseHeaderRecorder(), httpStatusCodeRecorder);
+        return new ServletResponseListener<>(traceContext, newServerResponseHeaderRecorder(), httpStatusCodeRecorder);
     }
 
     private ServerResponseHeaderRecorder<RESP> newServerResponseHeaderRecorder() {
         if (CollectionUtils.isEmpty(recordResponseHeaders)) {
-            return new BypassServerResponseHeaderRecorder<RESP>();
+            return new BypassServerResponseHeaderRecorder<>();
         }
-        return new DefaultServerResponseHeaderRecorder<RESP>(responseAdaptor, recordResponseHeaders);
+        return new DefaultServerResponseHeaderRecorder<>(responseAdaptor, recordResponseHeaders);
     }
 
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/AnnotationKey.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/AnnotationKey.java
@@ -70,6 +70,8 @@ import static com.navercorp.pinpoint.common.trace.AnnotationKeyProperty.VIEW_IN_
  * <tr><td>48</td><td>http.internal.display</td></tr>
  * <tr><td>49</td><td>http.io</td></tr>
  * <tr><td>50</td><td>arcus.command</td></tr>
+ * <tr><td>55</td><td>http.resp.header</td></tr>
+ *
  * <tr><td>60</td><td><i>RESERVED</i></td></tr>
  * <tr><td>61</td><td><i>RESERVED</i></td></tr>
  * <tr><td>62</td><td><i>RESERVED</i></td></tr>
@@ -82,6 +84,9 @@ import static com.navercorp.pinpoint.common.trace.AnnotationKeyProperty.VIEW_IN_
  * <tr><td>82</td><td>thrift.result</td></tr>
  * <tr><td>90</td><td>dubbo.args</td></tr>
  * <tr><td>91</td><td>dubbo.result</td></tr>
+ *
+ * <tr><td>100</td><td>message.queue.url</td></tr>
+ *
  * <tr><td>110</td><td></td>hystrix.command</tr>
  * <tr><td>111</td><td></td>hystrix.command.execution</tr>
  * <tr><td>112</td><td></td>hystrix.command.fallback.cause</tr>
@@ -201,7 +206,7 @@ public interface AnnotationKey {
     AnnotationKey HTTP_REQUEST_HEADER = AnnotationKeyFactory.of(47, "http.req.header", VIEW_IN_RECORD_SET);
     AnnotationKey HTTP_INTERNAL_DISPLAY = AnnotationKeyFactory.of(48, "http.internal.display");
     AnnotationKey HTTP_IO = AnnotationKeyFactory.of(49, "http.io", VIEW_IN_RECORD_SET);
-    AnnotationKey HTTP_RESPONSE_HEADER = AnnotationKeyFactory.of(50, "http.resp.header", VIEW_IN_RECORD_SET);
+    AnnotationKey HTTP_RESPONSE_HEADER = AnnotationKeyFactory.of(55, "http.resp.header", VIEW_IN_RECORD_SET);
     // post method parameter of httpclient
 
     AnnotationKey MESSAGE_QUEUE_URI = AnnotationKeyFactory.of(100, "message.queue.url");

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/AnnotationKey.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/AnnotationKey.java
@@ -201,6 +201,7 @@ public interface AnnotationKey {
     AnnotationKey HTTP_REQUEST_HEADER = AnnotationKeyFactory.of(47, "http.req.header", VIEW_IN_RECORD_SET);
     AnnotationKey HTTP_INTERNAL_DISPLAY = AnnotationKeyFactory.of(48, "http.internal.display");
     AnnotationKey HTTP_IO = AnnotationKeyFactory.of(49, "http.io", VIEW_IN_RECORD_SET);
+    AnnotationKey HTTP_RESPONSE_HEADER = AnnotationKeyFactory.of(50, "http.resp.header", VIEW_IN_RECORD_SET);
     // post method parameter of httpclient
 
     AnnotationKey MESSAGE_QUEUE_URI = AnnotationKeyFactory.of(100, "message.queue.url");

--- a/plugins-it/httpclient4-it/src/test/java/com/navercorp/pinpoint/plugin/httpclient4/HttpClientIT.java
+++ b/plugins-it/httpclient4-it/src/test/java/com/navercorp/pinpoint/plugin/httpclient4/HttpClientIT.java
@@ -98,7 +98,7 @@ public class HttpClientIT {
         verifier.verifyTrace(event("HTTP_CLIENT_4_INTERNAL", AbstractHttpClient.class.getMethod("execute", HttpUriRequest.class, ResponseHandler.class)));
         final String hostname = webServer.getHostAndPort();
         verifier.verifyTrace(event("HTTP_CLIENT_4_INTERNAL", connectorClass.getMethod("open", HttpRoute.class, HttpContext.class, HttpParams.class), annotation("http.internal.display", hostname)));
-        verifier.verifyTrace(event("HTTP_CLIENT_4", HttpRequestExecutor.class.getMethod("execute", HttpRequest.class, HttpClientConnection.class, HttpContext.class), null, null, hostname, annotation("http.url", "/"), annotation("http.status.code", 200), annotation("http.io", anyAnnotationValue())));
+        verifier.verifyTrace(event("HTTP_CLIENT_4", HttpRequestExecutor.class.getMethod("execute", HttpRequest.class, HttpClientConnection.class, HttpContext.class), null, null, hostname, annotation("http.url", "/"),  annotation("http.status.code", 200), annotation("http.resp.header", anyAnnotationValue()), annotation("http.io", anyAnnotationValue())));
         verifier.verifyTraceCount(0);
     }
 }

--- a/plugins-it/jdk-http-it/src/test/java/com/navercorp/pinpoint/plugin/jdk/http/HttpURLConnectionIT.java
+++ b/plugins-it/jdk-http-it/src/test/java/com/navercorp/pinpoint/plugin/jdk/http/HttpURLConnectionIT.java
@@ -76,9 +76,11 @@ public class HttpURLConnectionIT {
         String destinationId = webServer.getHostAndPort();
         String httpUrl = webServer.getCallHttpUrl();
         verifier.verifyTraceCount(2);
-        verifier.verifyTrace(event("JDK_HTTPURLCONNECTOR", getInputStream, null, null, destinationId, annotation("http.url", httpUrl)));
+        verifier.verifyTrace(event("JDK_HTTPURLCONNECTOR", getInputStream, null, null, destinationId,
+                annotation("http.url", httpUrl),
+                annotation("http.resp.header", anyAnnotationValue())));
     }
-
+    
     @Test
     public void testConnectTwice() throws Exception {
         URL url = new URL(webServer.getCallHttpUrl());
@@ -96,9 +98,11 @@ public class HttpURLConnectionIT {
         String destinationId = webServer.getHostAndPort();
         String httpUrl = webServer.getCallHttpUrl();
         verifier.verifyTraceCount(2);
-        verifier.verifyTrace(event("JDK_HTTPURLCONNECTOR", connect, null, null, destinationId, annotation("http.url", httpUrl)));
+        verifier.verifyTrace(event("JDK_HTTPURLCONNECTOR", connect, null, null, destinationId,
+                annotation("http.url", httpUrl),
+                annotation("http.resp.header", anyAnnotationValue())));
     }
-
+    
     @Test
     public void testConnecting() throws Exception {
 

--- a/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_2_x_IT.java
+++ b/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_2_x_IT.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.plugin.okhttp;
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
 import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
-import com.navercorp.pinpoint.plugin.okhttp.EndPointUtils;
 import com.navercorp.pinpoint.pluginit.utils.AgentPath;
 import com.navercorp.pinpoint.pluginit.utils.PluginITConstants;
 import com.navercorp.pinpoint.pluginit.utils.WebServer;
@@ -42,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.anyAnnotationValue;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 import static com.navercorp.pinpoint.common.trace.ServiceType.ASYNC;
 import static com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants.OK_HTTP_CLIENT;
@@ -96,7 +96,8 @@ public class OkHttpClient_2_x_IT {
 
         Method readResponseMethod = HttpEngine.class.getDeclaredMethod("readResponse");
         verifier.verifyTrace(event(OK_HTTP_CLIENT_INTERNAL.getName(), readResponseMethod,
-                annotation("http.status.code", response.code())));
+                annotation("http.status.code", response.code()),
+                annotation("http.resp.header", anyAnnotationValue())));
 
         verifier.verifyTraceCount(0);
     }
@@ -152,7 +153,8 @@ public class OkHttpClient_2_x_IT {
         Assert.assertNotNull("response is null", response);
         Method readResponseMethod = HttpEngine.class.getDeclaredMethod("readResponse");
         verifier.verifyTrace(event(OK_HTTP_CLIENT_INTERNAL.getName(), readResponseMethod,
-                annotation("http.status.code", response.code())));
+                annotation("http.status.code", response.code()),
+                annotation("http.resp.header", anyAnnotationValue())));
 
         verifier.verifyTraceCount(0);
     }

--- a/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_3_0_0_to_3_3_x_IT.java
+++ b/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_3_0_0_to_3_3_x_IT.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.anyAnnotationValue;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 import static com.navercorp.pinpoint.common.trace.ServiceType.ASYNC;
 import static com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants.OK_HTTP_CLIENT;
@@ -94,7 +95,9 @@ public class OkHttpClient_3_0_0_to_3_3_x_IT {
 
         Method readResponseMethod = Class.forName("okhttp3.internal.http.HttpEngine").getDeclaredMethod("readResponse");
         verifier.verifyTrace(event(OK_HTTP_CLIENT_INTERNAL.getName(), readResponseMethod,
-                annotation("http.status.code", response.code())));
+                annotation("http.status.code", response.code()),
+                annotation("http.resp.header", anyAnnotationValue())
+        ));
 
         verifier.verifyTraceCount(0);
     }
@@ -147,7 +150,8 @@ public class OkHttpClient_3_0_0_to_3_3_x_IT {
         Response response = responseRef.get();
         Method readResponseMethod = Class.forName("okhttp3.internal.http.HttpEngine").getDeclaredMethod("readResponse");
         verifier.verifyTrace(event(OK_HTTP_CLIENT_INTERNAL.getName(), readResponseMethod,
-                annotation("http.status.code", response.code())));
+                annotation("http.status.code", response.code()),
+                annotation("http.resp.header", anyAnnotationValue())));
 
         verifier.verifyTraceCount(0);
     }

--- a/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_3_4_0_to_3_x_IT.java
+++ b/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_3_4_0_to_3_x_IT.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.anyAnnotationValue;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 import static com.navercorp.pinpoint.common.trace.ServiceType.ASYNC;
 import static com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants.OK_HTTP_CLIENT;
@@ -87,7 +88,8 @@ public class OkHttpClient_3_4_0_to_3_x_IT {
         verifier.verifyTrace(event(OK_HTTP_CLIENT.getName(), interceptMethod,
                 null, null, webServer.getHostAndPort(),
                 annotation("http.url", request.url().toString()),
-                annotation("http.status.code", response.code())));
+                annotation("http.status.code", response.code()),
+                annotation("http.resp.header", anyAnnotationValue())));
 
         String hostAndPort = HostAndPort.toHostAndPortString(request.url().host(), request.url().port());
         Method connectMethod = getConnectMethod(Class.forName("okhttp3.internal.connection.RealConnection"));
@@ -137,7 +139,8 @@ public class OkHttpClient_3_4_0_to_3_x_IT {
         verifier.verifyTrace(event(OK_HTTP_CLIENT.getName(), interceptMethod,
                 null, null, webServer.getHostAndPort(),
                 annotation("http.url", request.url().toString()),
-                annotation("http.status.code", response.code())));
+                annotation("http.status.code", response.code()),
+                annotation("http.resp.header", anyAnnotationValue())));
 
         String hostAndPort = HostAndPort.toHostAndPortString(request.url().host(), request.url().port());
         Method connectMethod = getConnectMethod(Class.forName("okhttp3.internal.connection.RealConnection"));

--- a/plugins/common-servlet/src/main/java/com/navercorp/pinpoint/plugin/common/servlet/util/HttpServletResponseAdaptor.java
+++ b/plugins/common-servlet/src/main/java/com/navercorp/pinpoint/plugin/common/servlet/util/HttpServletResponseAdaptor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.common.servlet.util;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collection;
+
+/**
+ * @author yjqg6666
+ */
+public class HttpServletResponseAdaptor implements ResponseAdaptor<HttpServletResponse> {
+
+    public HttpServletResponseAdaptor() {
+    }
+
+    @Override
+    public boolean containsHeader(HttpServletResponse response, String name) {
+        return response.containsHeader(name);
+    }
+
+    @Override
+    public void setHeader(HttpServletResponse response, String name, String value) {
+        response.setHeader(name, value);
+    }
+
+    @Override
+    public void addHeader(HttpServletResponse response, String name, String value) {
+        response.addHeader(name, value);
+    }
+
+    @Override
+    public String getHeader(HttpServletResponse response, String name) {
+        return response.getHeader(name);
+    }
+
+    @Override
+    public Collection<String> getHeaders(HttpServletResponse response, String name) {
+        return response.getHeaders(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpServletResponse response) {
+        return response.getHeaderNames();
+    }
+
+}

--- a/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/HttpClient3ResponseHeaderAdaptor.java
+++ b/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/HttpClient3ResponseHeaderAdaptor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.httpclient3;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.HttpMethod;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author yjqg6666
+ */
+public class HttpClient3ResponseHeaderAdaptor implements ResponseAdaptor<HttpMethod> {
+
+    @Override
+    public boolean containsHeader(HttpMethod response, String name) {
+        return response.getResponseHeader(name) != null;
+    }
+
+    @Override
+    public void setHeader(HttpMethod response, String name, String value) {
+        throw new UnsupportedOperationException("not supported for http client3");
+    }
+
+    @Override
+    public void addHeader(HttpMethod response, String name, String value) {
+        throw new UnsupportedOperationException("not supported for http client3");
+    }
+
+    @Override
+    public String getHeader(HttpMethod response, String name) {
+        final Header header = response.getResponseHeader(name);
+        return header != null ? header.getValue() : null;
+    }
+
+    @Override
+    public Collection<String> getHeaders(HttpMethod response, String name) {
+        final Header[] headers = response.getResponseHeaders(name);
+        if (headers == null || headers.length == 0) {
+            return Collections.emptyList();
+        }
+        List<String> values = new ArrayList<>(headers.length);
+        for (Header header : headers) {
+            values.add(header.getValue());
+        }
+        return values;
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpMethod response) {
+        final Header[] headers = response.getResponseHeaders();
+        if (headers == null || headers.length == 0) {
+            return Collections.emptyList();
+        }
+        Set<String> values = new HashSet<>(headers.length);
+        for (Header header : headers) {
+            values.add(header.getName());
+        }
+        return values;
+    }
+}

--- a/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/HttpClient3ResponseHeaderAdaptor.java
+++ b/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/HttpClient3ResponseHeaderAdaptor.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.plugin.httpclient3;
 
 import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.navercorp.pinpoint.common.util.ArrayUtils;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpMethod;
 
@@ -69,7 +70,7 @@ public class HttpClient3ResponseHeaderAdaptor implements ResponseAdaptor<HttpMet
     @Override
     public Collection<String> getHeaderNames(HttpMethod response) {
         final Header[] headers = response.getResponseHeaders();
-        if (headers == null || headers.length == 0) {
+        if (ArrayUtils.isEmpty(headers)) {
             return Collections.emptyList();
         }
         Set<String> values = new HashSet<>(headers.length);

--- a/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/interceptor/HttpMethodBaseExecuteMethodInterceptor.java
+++ b/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/interceptor/HttpMethodBaseExecuteMethodInterceptor.java
@@ -30,10 +30,13 @@ import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieRecorderFactor
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.EntityExtractor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.EntityRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.EntityRecorderFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseHeaderRecorderFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ServerResponseHeaderRecorder;
 import com.navercorp.pinpoint.common.util.ArrayUtils;
 import com.navercorp.pinpoint.common.util.IntBooleanIntBooleanValue;
 import com.navercorp.pinpoint.plugin.httpclient3.HttpClient3EntityExtractor;
 import com.navercorp.pinpoint.plugin.httpclient3.HttpClient3RequestWrapper;
+import com.navercorp.pinpoint.plugin.httpclient3.HttpClient3ResponseHeaderAdaptor;
 import com.navercorp.pinpoint.plugin.httpclient3.HttpMethodClientHeaderAdaptor;
 import com.navercorp.pinpoint.plugin.httpclient3.HttpClient3CookieExtractor;
 import org.apache.commons.httpclient.HttpConnection;
@@ -75,6 +78,7 @@ public class HttpMethodBaseExecuteMethodInterceptor implements AroundInterceptor
     private final boolean io;
     private final CookieRecorder<HttpMethod> cookieRecorder;
     private final EntityRecorder<HttpMethod> entityRecorder;
+    private final ServerResponseHeaderRecorder<HttpMethod> responseHeaderRecorder;
 
     public HttpMethodBaseExecuteMethodInterceptor(TraceContext traceContext, MethodDescriptor descriptor, InterceptorScope interceptorScope) {
         this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
@@ -93,6 +97,8 @@ public class HttpMethodBaseExecuteMethodInterceptor implements AroundInterceptor
 
         EntityExtractor<HttpMethod> entityExtractor = HttpClient3EntityExtractor.INSTANCE;
         this.entityRecorder = EntityRecorderFactory.newEntityRecorder(httpDumpConfig, entityExtractor);
+
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<HttpMethod>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new HttpClient3ResponseHeaderAdaptor());
 
         ClientHeaderAdaptor<HttpMethod> clientHeaderAdaptor = new HttpMethodClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
@@ -186,6 +192,7 @@ public class HttpMethodBaseExecuteMethodInterceptor implements AroundInterceptor
                 this.clientRequestRecorder.record(recorder, requestWrapper, throwable);
                 this.cookieRecorder.record(recorder, httpMethod, throwable);
                 this.entityRecorder.record(recorder, httpMethod, throwable);
+                this.responseHeaderRecorder.recordHeader(recorder, httpMethod);
             }
 
             if (result != null) {

--- a/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/interceptor/HttpMethodBaseExecuteMethodInterceptor.java
+++ b/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/interceptor/HttpMethodBaseExecuteMethodInterceptor.java
@@ -98,7 +98,7 @@ public class HttpMethodBaseExecuteMethodInterceptor implements AroundInterceptor
         EntityExtractor<HttpMethod> entityExtractor = HttpClient3EntityExtractor.INSTANCE;
         this.entityRecorder = EntityRecorderFactory.newEntityRecorder(httpDumpConfig, entityExtractor);
 
-        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<HttpMethod>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new HttpClient3ResponseHeaderAdaptor());
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.newResponseHeaderRecorder(traceContext.getProfilerConfig(), new HttpClient3ResponseHeaderAdaptor());
 
         ClientHeaderAdaptor<HttpMethod> clientHeaderAdaptor = new HttpMethodClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);

--- a/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/HttpResponse4ClientHeaderAdaptor.java
+++ b/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/HttpResponse4ClientHeaderAdaptor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.httpclient4;
+
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author yjqg6666
+ */
+public class HttpResponse4ClientHeaderAdaptor implements ResponseAdaptor<HttpResponse> {
+
+    private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    @Override
+    public boolean containsHeader(HttpResponse response, String name) {
+        return response.containsHeader(name);
+    }
+
+    @Override
+    public void setHeader(HttpResponse response, String name, String value) {
+        if (isDebug) {
+            logger.debug("Set header {}={}", name, value);
+        }
+        response.setHeader(name, value);
+    }
+
+    @Override
+    public void addHeader(HttpResponse response, String name, String value) {
+        if (isDebug) {
+            logger.debug("Add header {}={}", name, value);
+        }
+        response.addHeader(name, value);
+    }
+
+    @Override
+    public String getHeader(HttpResponse response, String name) {
+        final Header header = response.getFirstHeader(name);
+        return header != null ? header.getValue() : null;
+    }
+
+    @Override
+    public Collection<String> getHeaders(HttpResponse response, String name) {
+        final Header[] headers = response.getHeaders(name);
+        if (headers == null || headers.length == 0) {
+            return Collections.emptyList();
+        }
+        List<String> values = new ArrayList<>(headers.length);
+        for (Header header : headers) {
+            values.add(header.getValue());
+        }
+        return values;
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpResponse response) {
+        final Header[] headers = response.getAllHeaders();
+        if (headers == null || headers.length == 0) {
+            return Collections.emptyList();
+        }
+        Set<String> values = new HashSet<>(headers.length);
+        for (Header header : headers) {
+            values.add(header.getName());
+        }
+        return values;
+    }
+
+}

--- a/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/HttpRequestExecutorExecuteMethodInterceptor.java
+++ b/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/HttpRequestExecutorExecuteMethodInterceptor.java
@@ -92,9 +92,9 @@ public class HttpRequestExecutorExecuteMethodInterceptor implements AroundInterc
         this.statusCode = profilerConfig.isStatusCode();
         this.io = profilerConfig.isIo();
         ClientHeaderAdaptor<HttpRequest> clientHeaderAdaptor = new HttpRequest4ClientHeaderAdaptor();
-        this.requestTraceWriter = new DefaultRequestTraceWriter<HttpRequest>(clientHeaderAdaptor, traceContext);
+        this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
 
-        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<HttpResponse>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new HttpResponse4ClientHeaderAdaptor());
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.newResponseHeaderRecorder(traceContext.getProfilerConfig(), new HttpResponse4ClientHeaderAdaptor());
     }
 
     @Override

--- a/plugins/jboss/src/main/java/com/navercorp/pinpoint/plugin/jboss/interceptor/StandardHostValveInvokeInterceptor.java
+++ b/plugins/jboss/src/main/java/com/navercorp/pinpoint/plugin/jboss/interceptor/StandardHostValveInvokeInterceptor.java
@@ -77,19 +77,21 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
         RequestAdaptor<HttpServletRequest> requestAdaptor = new HttpServletRequestAdaptor();
         ParameterRecorder<HttpServletRequest> parameterRecorder = ParameterRecorderFactory.newParameterRecorderFactory(config.getExcludeProfileMethodFilter(), config.isTraceRequestParam());
 
-        ServletRequestListenerBuilder<HttpServletRequest> builder = new ServletRequestListenerBuilder<>(JbossConstants.JBOSS, traceContext, requestAdaptor);
-        builder.setExcludeURLFilter(config.getExcludeUrlFilter());
-        builder.setParameterRecorder(parameterRecorder);
-        builder.setRequestRecorderFactory(requestRecorderFactory);
+        ServletRequestListenerBuilder<HttpServletRequest> reqBuilder = new ServletRequestListenerBuilder<>(JbossConstants.JBOSS, traceContext, requestAdaptor);
+        reqBuilder.setExcludeURLFilter(config.getExcludeUrlFilter());
+        reqBuilder.setParameterRecorder(parameterRecorder);
+        reqBuilder.setRequestRecorderFactory(requestRecorderFactory);
 
         final ProfilerConfig profilerConfig = traceContext.getProfilerConfig();
-        builder.setRealIpSupport(config.getRealIpHeader(), config.getRealIpEmptyValue());
-        builder.setHttpStatusCodeRecorder(profilerConfig.getHttpStatusCodeErrors());
-        builder.setServerHeaderRecorder(profilerConfig.readList(ServerHeaderRecorder.CONFIG_KEY_RECORD_REQ_HEADERS));
-        builder.setServerCookieRecorder(profilerConfig.readList(ServerCookieRecorder.CONFIG_KEY_RECORD_REQ_COOKIES));
-        this.servletRequestListener = builder.build();
+        reqBuilder.setRealIpSupport(config.getRealIpHeader(), config.getRealIpEmptyValue());
+        reqBuilder.setHttpStatusCodeRecorder(profilerConfig.getHttpStatusCodeErrors());
+        reqBuilder.setServerHeaderRecorder(profilerConfig.readList(ServerHeaderRecorder.CONFIG_KEY_RECORD_REQ_HEADERS));
+        reqBuilder.setServerCookieRecorder(profilerConfig.readList(ServerCookieRecorder.CONFIG_KEY_RECORD_REQ_COOKIES));
+        reqBuilder.setRecordStatusCode(false);
 
-        this.servletResponseListener = new ServletResponseListenerBuilder<HttpServletResponse>(traceContext, new HttpServletResponseAdaptor()).build();
+        this.servletRequestListener = reqBuilder.build();
+
+        this.servletResponseListener = new ServletResponseListenerBuilder(traceContext, new HttpServletResponseAdaptor()).build();
 
         this.servletApiHelper = newServletApi();
     }
@@ -153,7 +155,7 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
             }
             final int statusCode = servletApiHelper.getStatus(response);
             this.servletResponseListener.destroyed(response, throwable, statusCode); //must before request listener due to trace block ending
-            this.servletRequestListener.destroyed(request, throwable, statusCode, false);
+            this.servletRequestListener.destroyed(request, throwable, statusCode);
         } catch (Throwable t) {
             if (isInfo) {
                 logger.info("Failed to servlet request event handle.", t);

--- a/plugins/jboss/src/main/java/com/navercorp/pinpoint/plugin/jboss/interceptor/StandardHostValveInvokeInterceptor.java
+++ b/plugins/jboss/src/main/java/com/navercorp/pinpoint/plugin/jboss/interceptor/StandardHostValveInvokeInterceptor.java
@@ -29,8 +29,11 @@ import com.navercorp.pinpoint.bootstrap.plugin.request.ServerHeaderRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ServletRequestListener;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ServletRequestListenerBuilder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.ParameterRecorder;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ServletResponseListener;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ServletResponseListenerBuilder;
 import com.navercorp.pinpoint.plugin.common.servlet.util.ArgumentValidator;
 import com.navercorp.pinpoint.plugin.common.servlet.util.HttpServletRequestAdaptor;
+import com.navercorp.pinpoint.plugin.common.servlet.util.HttpServletResponseAdaptor;
 import com.navercorp.pinpoint.plugin.common.servlet.util.ParameterRecorderFactory;
 import com.navercorp.pinpoint.plugin.common.servlet.util.ServletArgumentValidator;
 import com.navercorp.pinpoint.plugin.jboss.JbossConfig;
@@ -58,6 +61,7 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
     private final MethodDescriptor methodDescriptor;
     private final ArgumentValidator argumentValidator;
     private final ServletRequestListener<HttpServletRequest> servletRequestListener;
+    private final ServletResponseListener<HttpServletResponse> servletResponseListener;
     private final ServletApiHelper servletApiHelper;
 
     /**
@@ -84,6 +88,8 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
         builder.setServerHeaderRecorder(profilerConfig.readList(ServerHeaderRecorder.CONFIG_KEY_RECORD_REQ_HEADERS));
         builder.setServerCookieRecorder(profilerConfig.readList(ServerCookieRecorder.CONFIG_KEY_RECORD_REQ_COOKIES));
         this.servletRequestListener = builder.build();
+
+        this.servletResponseListener = new ServletResponseListenerBuilder<HttpServletResponse>(traceContext, new HttpServletResponseAdaptor()).build();
 
         this.servletApiHelper = newServletApi();
     }
@@ -116,6 +122,8 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
                 return;
             }
             this.servletRequestListener.initialized(request, JbossConstants.JBOSS_METHOD, this.methodDescriptor);
+            final HttpServletResponse response = (HttpServletResponse) args[1];
+            this.servletResponseListener.initialized(response, JbossConstants.JBOSS_METHOD, this.methodDescriptor); //must after request listener due to trace block begin
         } catch (Throwable t) {
             if (isInfo) {
                 logger.info("Failed to servlet request event handle.", t);
@@ -144,7 +152,8 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
                 return;
             }
             final int statusCode = servletApiHelper.getStatus(response);
-            this.servletRequestListener.destroyed(request, throwable, statusCode);
+            this.servletResponseListener.destroyed(response, throwable, statusCode); //must before request listener due to trace block ending
+            this.servletRequestListener.destroyed(request, throwable, statusCode, false);
         } catch (Throwable t) {
             if (isInfo) {
                 logger.info("Failed to servlet request event handle.", t);

--- a/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/JdkHttpClientResponseAdaptor.java
+++ b/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/JdkHttpClientResponseAdaptor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.jdk.http;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+
+import java.net.HttpURLConnection;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author yjqg6666
+ */
+public class JdkHttpClientResponseAdaptor implements ResponseAdaptor<HttpURLConnection> {
+    @Override
+    public boolean containsHeader(HttpURLConnection response, String name) {
+        return response.getHeaderField(name) != null;
+    }
+
+    @Override
+    public void setHeader(HttpURLConnection response, String name, String value) {
+        throw new UnsupportedOperationException("not supported to set header for jdk http client");
+    }
+
+    @Override
+    public void addHeader(HttpURLConnection response, String name, String value) {
+        throw new UnsupportedOperationException("not supported to add header for jdk http client");
+    }
+
+    @Override
+    public String getHeader(HttpURLConnection response, String name) {
+        return response.getHeaderField(name);
+    }
+
+    /**
+     * return the last header value if set
+     */
+    @Override
+    public Collection<String> getHeaders(HttpURLConnection response, String name) {
+        final String val = response.getHeaderField(name);
+        return val != null ? Collections.singletonList(val) : Collections.<String>emptyList();
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpURLConnection response) {
+        final Map<String, List<String>> headerFields = response.getHeaderFields();
+        return headerFields == null ? Collections.<String>emptySet() : headerFields.keySet();
+    }
+}

--- a/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/JdkHttpPlugin.java
+++ b/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/JdkHttpPlugin.java
@@ -46,7 +46,6 @@ public class JdkHttpPlugin implements ProfilerPlugin, TransformTemplateAware {
 
     public static final String INTERCEPT_HTTPS_CLASS_NAME = "sun.net.www.protocol.https.HttpsURLConnectionImpl";
 
-
     @Override
     public void setup(ProfilerPluginSetupContext context) {
         JdkHttpPluginConfig config = new JdkHttpPluginConfig(context.getConfig());

--- a/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/interceptor/HttpURLConnectionInterceptor.java
+++ b/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/interceptor/HttpURLConnectionInterceptor.java
@@ -17,12 +17,15 @@
 package com.navercorp.pinpoint.plugin.jdk.http.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.*;
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
 import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScopeInvocation;
 import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.request.*;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseHeaderRecorderFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ServerResponseHeaderRecorder;
 import com.navercorp.pinpoint.plugin.jdk.http.*;
 
 import java.net.HttpURLConnection;
@@ -35,6 +38,7 @@ import java.net.URL;
  */
 public class HttpURLConnectionInterceptor implements AroundInterceptor {
     private static final Object TRACE_BLOCK_BEGIN_MARKER = new Object();
+    private static final String TRACE_SCOPE_NAME_RESPONSE = "_JdkHttpInputStreamRespRecording";
     private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
     private final boolean isDebug = logger.isDebugEnabled();
 
@@ -42,8 +46,11 @@ public class HttpURLConnectionInterceptor implements AroundInterceptor {
     private final MethodDescriptor descriptor;
     private final InterceptorScope scope;
     private final ClientRequestRecorder<HttpURLConnection> clientRequestRecorder;
+    private final ServerResponseHeaderRecorder<HttpURLConnection> responseHeaderRecorder;
 
     private final RequestTraceWriter<HttpURLConnection> requestTraceWriter;
+
+    private static final String CONNECTION_INPUT_STREAM_CLASS_NAME = "HttpURLConnection$HttpInputStream";
 
     public HttpURLConnectionInterceptor(TraceContext traceContext, MethodDescriptor descriptor, InterceptorScope scope) {
         this.traceContext = traceContext;
@@ -53,10 +60,11 @@ public class HttpURLConnectionInterceptor implements AroundInterceptor {
         final JdkHttpPluginConfig config = new JdkHttpPluginConfig(traceContext.getProfilerConfig());
 
         ClientRequestAdaptor<HttpURLConnection> clientRequestAdaptor = new JdkHttpClientRequestAdaptor();
-        this.clientRequestRecorder = new ClientRequestRecorder<>(config.isParam(), clientRequestAdaptor);
+        this.clientRequestRecorder = new ClientRequestRecorder<HttpURLConnection>(config.isParam(), clientRequestAdaptor);
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<HttpURLConnection>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new JdkHttpClientResponseAdaptor());
 
         ClientHeaderAdaptor<HttpURLConnection> clientHeaderAdaptor = new HttpURLConnectionClientHeaderAdaptor();
-        this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.requestTraceWriter = new DefaultRequestTraceWriter<HttpURLConnection>(clientHeaderAdaptor, traceContext);
     }
 
     @Override
@@ -72,6 +80,16 @@ public class HttpURLConnectionInterceptor implements AroundInterceptor {
         Trace trace = traceContext.currentRawTraceObject();
         if (trace == null) {
             return;
+        }
+
+        final boolean interceptingGetInputStream = isInterceptingGetInputStream();
+        final boolean recordingResponse = isRecordingResponse(trace);
+        if (recordingResponse) {
+            if (interceptingGetInputStream) {
+                return;
+            } else {
+                clearRecordingResponseStatus(trace);
+            }
         }
 
         boolean connected = false;
@@ -127,16 +145,33 @@ public class HttpURLConnectionInterceptor implements AroundInterceptor {
             return;
         }
 
+        final boolean interceptingGetInputStream = isInterceptingGetInputStream();
+        if (interceptingGetInputStream && isRecordingResponse(trace)) {
+            return;
+        }
+
         try {
             final HttpURLConnection request = (HttpURLConnection) target;
             final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
             recorder.recordApi(descriptor);
             recorder.recordException(throwable);
             this.clientRequestRecorder.record(recorder, request, throwable);
+            if (interceptingGetInputStream) {
+                if (startRecordingResponse(trace)) {
+                    this.responseHeaderRecorder.recordHeader(recorder, request);
+                }
+            }
+            if (isInterceptingGetInputStream(result)) {
+                this.responseHeaderRecorder.recordHeader(recorder, request);
+            }
         } finally {
             currentInvocation.removeAttachment();
             trace.traceBlockEnd();
         }
+    }
+
+    private boolean isInterceptingGetInputStream(Object result) {
+        return result != null && result.getClass().getName().endsWith(CONNECTION_INPUT_STREAM_CLASS_NAME);
     }
 
     private String getHost(HttpURLConnection httpURLConnection) {
@@ -151,12 +186,50 @@ public class HttpURLConnectionInterceptor implements AroundInterceptor {
         return null;
     }
 
+    private boolean isInterceptingGetInputStream() {
+        return "getInputStream".contentEquals(this.descriptor.getMethodName());
+    }
+
     private boolean isInterceptingConnect() {
         return "connect".contentEquals(this.descriptor.getMethodName());
     }
 
     private boolean isInterceptingHttps() {
         return JdkHttpPlugin.INTERCEPT_HTTPS_CLASS_NAME.contentEquals(this.descriptor.getClassName());
+    }
+
+    private boolean isRecordingResponse(Trace trace) {
+        final TraceScope scope = trace.getScope(TRACE_SCOPE_NAME_RESPONSE);
+        return scope != null && scope.isActive();
+    }
+
+    private boolean startRecordingResponse(Trace trace) {
+        TraceScope scope = trace.getScope(TRACE_SCOPE_NAME_RESPONSE);
+        if (scope == null) {
+            trace.addScope(TRACE_SCOPE_NAME_RESPONSE);
+            scope = trace.getScope(TRACE_SCOPE_NAME_RESPONSE);
+        }
+        if (scope != null) {
+            final boolean ok = scope.tryEnter();
+            if (!ok) {
+                logger.warn("Try to startRecording response failed, tryEnter scope failed");
+            }
+            return ok;
+        } else {
+            logger.warn("Try to startRecording response failed, getOrAdd scope failed");
+            return false;
+        }
+    }
+
+    private void clearRecordingResponseStatus(Trace trace) {
+        final TraceScope scope = trace.getScope(TRACE_SCOPE_NAME_RESPONSE);
+        if (scope != null) {
+            if (scope.canLeave()) {
+                scope.leave();
+            } else {
+                logger.warn("Try to  learRecordingResponseStatus failed, canLeave scope returned false");
+            }
+        }
     }
 
 }

--- a/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/interceptor/HttpURLConnectionInterceptor.java
+++ b/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/interceptor/HttpURLConnectionInterceptor.java
@@ -60,11 +60,11 @@ public class HttpURLConnectionInterceptor implements AroundInterceptor {
         final JdkHttpPluginConfig config = new JdkHttpPluginConfig(traceContext.getProfilerConfig());
 
         ClientRequestAdaptor<HttpURLConnection> clientRequestAdaptor = new JdkHttpClientRequestAdaptor();
-        this.clientRequestRecorder = new ClientRequestRecorder<HttpURLConnection>(config.isParam(), clientRequestAdaptor);
-        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<HttpURLConnection>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new JdkHttpClientResponseAdaptor());
+        this.clientRequestRecorder = new ClientRequestRecorder<>(config.isParam(), clientRequestAdaptor);
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.newResponseHeaderRecorder(traceContext.getProfilerConfig(), new JdkHttpClientResponseAdaptor());
 
         ClientHeaderAdaptor<HttpURLConnection> clientHeaderAdaptor = new HttpURLConnectionClientHeaderAdaptor();
-        this.requestTraceWriter = new DefaultRequestTraceWriter<HttpURLConnection>(clientHeaderAdaptor, traceContext);
+        this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
     }
 
     @Override

--- a/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v2/OkHttpResponseAdaptor.java
+++ b/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v2/OkHttpResponseAdaptor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.okhttp.v2;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.Response;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * @author yjqg6666
+ */
+public class OkHttpResponseAdaptor implements ResponseAdaptor<Response> {
+
+    @Override
+    public boolean containsHeader(Response response, String name) {
+        return response.header(name) != null;
+    }
+
+    @Override
+    public void setHeader(Response response, String name, String value) {
+        throw new UnsupportedOperationException("set header not supported in okhttp");
+    }
+
+    @Override
+    public void addHeader(Response response, String name, String value) {
+        throw new UnsupportedOperationException("add header not supported in okhttp");
+    }
+
+    @Override
+    public String getHeader(Response response, String name) {
+        return response.header(name);
+    }
+
+    @Override
+    public Collection<String> getHeaders(Response response, String name) {
+        return response.headers(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(Response response) {
+        final Headers headers = response.headers();
+        return headers == null ? Collections.<String>emptySet(): headers.names();
+    }
+}

--- a/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v2/interceptor/HttpEngineReadResponseMethodInterceptor.java
+++ b/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v2/interceptor/HttpEngineReadResponseMethodInterceptor.java
@@ -45,7 +45,7 @@ public class HttpEngineReadResponseMethodInterceptor implements AroundIntercepto
         this.traceContext = traceContext;
         this.methodDescriptor = methodDescriptor;
         this.statusCode = statusCode;
-        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<Response>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new OkHttpResponseAdaptor());
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.newResponseHeaderRecorder(traceContext.getProfilerConfig(), new OkHttpResponseAdaptor());
     }
 
     @Override

--- a/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/OkHttpResponseAdaptor.java
+++ b/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/OkHttpResponseAdaptor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.okhttp.v3;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import okhttp3.Headers;
+import okhttp3.Response;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * @author yjqg6666
+ */
+public class OkHttpResponseAdaptor implements ResponseAdaptor<Response> {
+    @Override
+    public boolean containsHeader(Response response, String name) {
+        return response.header(name) != null;
+    }
+
+    @Override
+    public void setHeader(Response response, String name, String value) {
+        throw new UnsupportedOperationException("set header not supported in okhttp3");
+    }
+
+    @Override
+    public void addHeader(Response response, String name, String value) {
+        throw new UnsupportedOperationException("set header not supported in okhttp3");
+    }
+
+    @Override
+    public String getHeader(Response response, String name) {
+        return response.header(name);
+    }
+
+    @Override
+    public Collection<String> getHeaders(Response response, String name) {
+        return response.headers(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(Response response) {
+        final Headers headers = response.headers();
+        return headers == null ? Collections.<String>emptySet(): headers.names();
+    }
+
+}

--- a/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/interceptor/BridgeInterceptorInterceptMethodInterceptor.java
+++ b/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/interceptor/BridgeInterceptorInterceptMethodInterceptor.java
@@ -32,12 +32,15 @@ import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieRecorderFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseHeaderRecorderFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ServerResponseHeaderRecorder;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.util.ArrayUtils;
 import com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants;
 import com.navercorp.pinpoint.plugin.okhttp.OkHttpPluginConfig;
 import com.navercorp.pinpoint.plugin.okhttp.v3.OkHttpClientCookieExtractor;
 import com.navercorp.pinpoint.plugin.okhttp.v3.OkHttpClientRequestAdaptor;
+import com.navercorp.pinpoint.plugin.okhttp.v3.OkHttpResponseAdaptor;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -55,6 +58,7 @@ public class BridgeInterceptorInterceptMethodInterceptor implements AroundInterc
 
     private final ClientRequestRecorder<Request> clientRequestRecorder;
     private final CookieRecorder<Request> cookieRecorder;
+    private final ServerResponseHeaderRecorder<Response> responseHeaderRecorder;
 
     public BridgeInterceptorInterceptMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, InterceptorScope interceptorScope) {
         this.traceContext = traceContext;
@@ -68,6 +72,7 @@ public class BridgeInterceptorInterceptMethodInterceptor implements AroundInterc
 
         CookieExtractor<Request> cookieExtractor = new OkHttpClientCookieExtractor();
         this.cookieRecorder = CookieRecorderFactory.newCookieRecorder(config.getHttpDumpConfig(), cookieExtractor);
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<Response>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new OkHttpResponseAdaptor());
     }
 
     @Override
@@ -142,6 +147,7 @@ public class BridgeInterceptorInterceptMethodInterceptor implements AroundInterc
             if (result instanceof Response) {
                 Response response = (Response) result;
                 recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, response.code());
+                this.responseHeaderRecorder.recordHeader(recorder, response);
             }
         } finally {
             trace.traceBlockEnd();

--- a/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/interceptor/BridgeInterceptorInterceptMethodInterceptor.java
+++ b/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/interceptor/BridgeInterceptorInterceptMethodInterceptor.java
@@ -72,7 +72,7 @@ public class BridgeInterceptorInterceptMethodInterceptor implements AroundInterc
 
         CookieExtractor<Request> cookieExtractor = new OkHttpClientCookieExtractor();
         this.cookieRecorder = CookieRecorderFactory.newCookieRecorder(config.getHttpDumpConfig(), cookieExtractor);
-        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<Response>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new OkHttpResponseAdaptor());
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.newResponseHeaderRecorder(traceContext.getProfilerConfig(), new OkHttpResponseAdaptor());
     }
 
     @Override

--- a/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/interceptor/HttpEngineReadResponseMethodInterceptor.java
+++ b/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/interceptor/HttpEngineReadResponseMethodInterceptor.java
@@ -48,7 +48,7 @@ public class HttpEngineReadResponseMethodInterceptor implements AroundIntercepto
         this.traceContext = traceContext;
         this.methodDescriptor = methodDescriptor;
         this.statusCode = statusCode;
-        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<Response>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new OkHttpResponseAdaptor());
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.newResponseHeaderRecorder(traceContext.getProfilerConfig(), new OkHttpResponseAdaptor());
     }
 
     @Override

--- a/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/interceptor/HttpEngineReadResponseMethodInterceptor.java
+++ b/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/interceptor/HttpEngineReadResponseMethodInterceptor.java
@@ -23,8 +23,11 @@ import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseHeaderRecorderFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ServerResponseHeaderRecorder;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants;
+import com.navercorp.pinpoint.plugin.okhttp.v3.OkHttpResponseAdaptor;
 import com.navercorp.pinpoint.plugin.okhttp.v3.UserRequestGetter;
 import com.navercorp.pinpoint.plugin.okhttp.v3.UserResponseGetter;
 import okhttp3.Response;
@@ -39,11 +42,13 @@ public class HttpEngineReadResponseMethodInterceptor implements AroundIntercepto
     private final TraceContext traceContext;
     private final MethodDescriptor methodDescriptor;
     private final boolean statusCode;
+    private final ServerResponseHeaderRecorder<Response> responseHeaderRecorder;
 
     public HttpEngineReadResponseMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, boolean statusCode) {
         this.traceContext = traceContext;
         this.methodDescriptor = methodDescriptor;
         this.statusCode = statusCode;
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<Response>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new OkHttpResponseAdaptor());
     }
 
     @Override
@@ -108,6 +113,7 @@ public class HttpEngineReadResponseMethodInterceptor implements AroundIntercepto
                 final Response response = ((UserResponseGetter) target)._$PINPOINT$_getUserResponse();
                 if (response != null) {
                     recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, response.code());
+                    this.responseHeaderRecorder.recordHeader(recorder, response);
                 }
             }
         } finally {

--- a/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/ReactorNettyResponseHeaderAdaptor.java
+++ b/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/ReactorNettyResponseHeaderAdaptor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactor.netty;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import io.netty.handler.codec.http.HttpResponse;
+
+import java.util.Collection;
+
+/**
+ * @author yjqg6666
+ */
+public class ReactorNettyResponseHeaderAdaptor implements ResponseAdaptor<HttpResponse> {
+
+    @Override
+    public boolean containsHeader(HttpResponse response, String name) {
+        return response.headers().contains(name);
+    }
+
+    @Override
+    public void setHeader(HttpResponse response, String name, String value) {
+        response.headers().set(name, value);
+    }
+
+    @Override
+    public void addHeader(HttpResponse response, String name, String value) {
+        response.headers().add(name, value);
+    }
+
+    @Override
+    public String getHeader(HttpResponse response, String name) {
+        return response.headers().getAsString(name);
+    }
+
+    @Override
+    public Collection<String> getHeaders(HttpResponse response, String name) {
+        return response.headers().getAllAsString(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpResponse response) {
+        return response.headers().names();
+    }
+
+}

--- a/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpClientOperationsOnInboundNextInterceptor.java
+++ b/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpClientOperationsOnInboundNextInterceptor.java
@@ -40,7 +40,7 @@ public class HttpClientOperationsOnInboundNextInterceptor extends AsyncContextSp
 
     public HttpClientOperationsOnInboundNextInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
         super(traceContext, methodDescriptor);
-        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<HttpResponse>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new ReactorNettyResponseHeaderAdaptor());
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.newResponseHeaderRecorder(traceContext.getProfilerConfig(), new ReactorNettyResponseHeaderAdaptor());
     }
 
     // BEFORE

--- a/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpResponseAdaptor.java
+++ b/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpResponseAdaptor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.reactor.netty.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import reactor.netty.http.server.HttpServerResponse;
+
+import java.util.Collection;
+
+/**
+ * @author yjqg6666
+ */
+public class HttpResponseAdaptor implements ResponseAdaptor<HttpServerResponse> {
+
+    @Override
+    public boolean containsHeader(HttpServerResponse response, String name) {
+        return response.responseHeaders().contains(name);
+    }
+
+    @Override
+    public void setHeader(HttpServerResponse response, String name, String value) {
+        response.header(name, value);
+    }
+
+    @Override
+    public void addHeader(HttpServerResponse response, String name, String value) {
+        response.addHeader(name, value);
+    }
+
+    @Override
+    public String getHeader(HttpServerResponse response, String name) {
+        return response.responseHeaders().getAsString(name);
+    }
+
+    @Override
+    public Collection<String> getHeaders(HttpServerResponse response, String name) {
+        return response.responseHeaders().getAllAsString(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpServerResponse response) {
+        return response.responseHeaders().names();
+    }
+}

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/RestTemplateResponseHeaderAdaptor.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/RestTemplateResponseHeaderAdaptor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.resttemplate;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.util.Collection;
+
+/**
+ * @author yjqg6666
+ */
+public class RestTemplateResponseHeaderAdaptor implements ResponseAdaptor<ClientHttpResponse> {
+
+    @Override
+    public boolean containsHeader(ClientHttpResponse response, String name) {
+        return response.getHeaders().containsKey(name);
+    }
+
+    @Override
+    public void setHeader(ClientHttpResponse response, String name, String value) {
+        response.getHeaders().set(name, value);
+    }
+
+    @Override
+    public void addHeader(ClientHttpResponse response, String name, String value) {
+        response.getHeaders().add(name, value);
+    }
+
+    @Override
+    public String getHeader(ClientHttpResponse response, String name) {
+        return response.getHeaders().getFirst(name);
+    }
+
+    @Override
+    public Collection<String> getHeaders(ClientHttpResponse response, String name) {
+        return response.getHeaders().get(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(ClientHttpResponse response) {
+        return response.getHeaders().keySet();
+    }
+}

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/ClientHttpResponseInterceptor.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/ClientHttpResponseInterceptor.java
@@ -38,7 +38,7 @@ public class ClientHttpResponseInterceptor extends SpanEventSimpleAroundIntercep
 
     public ClientHttpResponseInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
-        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<ClientHttpResponse>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new RestTemplateResponseHeaderAdaptor());
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.newResponseHeaderRecorder(traceContext.getProfilerConfig(), new RestTemplateResponseHeaderAdaptor());
     }
 
     @Override

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/ListenableFutureInterceptor.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/ListenableFutureInterceptor.java
@@ -42,7 +42,7 @@ public class ListenableFutureInterceptor extends AsyncContextSpanEventSimpleArou
 
     public ListenableFutureInterceptor(MethodDescriptor methodDescriptor, TraceContext traceContext) {
         super(traceContext, methodDescriptor);
-        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<ClientHttpResponse>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new RestTemplateResponseHeaderAdaptor());
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.newResponseHeaderRecorder(traceContext.getProfilerConfig(), new RestTemplateResponseHeaderAdaptor());
     }
 
     @Override

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringWebFluxResponseHeaderAdaptor.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringWebFluxResponseHeaderAdaptor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.spring.webflux;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+
+import java.util.Collection;
+
+/**
+ * @author yjqg6666
+ */
+public class SpringWebFluxResponseHeaderAdaptor implements ResponseAdaptor<ClientHttpResponse> {
+
+    @Override
+    public boolean containsHeader(ClientHttpResponse response, String name) {
+        return response.getHeaders().containsKey(name);
+    }
+
+    @Override
+    public void setHeader(ClientHttpResponse response, String name, String value) {
+        response.getHeaders().set(name, value);
+    }
+
+    @Override
+    public void addHeader(ClientHttpResponse response, String name, String value) {
+        response.getHeaders().add(name, value);
+    }
+
+    @Override
+    public String getHeader(ClientHttpResponse response, String name) {
+        return response.getHeaders().getFirst(name);
+    }
+
+    @Override
+    public Collection<String> getHeaders(ClientHttpResponse response, String name) {
+        return response.getHeaders().get(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(ClientHttpResponse response) {
+        return response.getHeaders().keySet();
+    }
+}

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/ClientResponseFunctionInterceptor.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/ClientResponseFunctionInterceptor.java
@@ -37,7 +37,7 @@ public class ClientResponseFunctionInterceptor extends SpanEventSimpleAroundInte
 
     public ClientResponseFunctionInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
         super(traceContext, descriptor);
-        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.<ClientHttpResponse>newResponseHeaderRecorder(traceContext.getProfilerConfig(), new SpringWebFluxResponseHeaderAdaptor());
+        this.responseHeaderRecorder = ResponseHeaderRecorderFactory.newResponseHeaderRecorder(traceContext.getProfilerConfig(), new SpringWebFluxResponseHeaderAdaptor());
     }
 
     @Override

--- a/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/interceptor/StandardHostValveInvokeInterceptor.java
+++ b/plugins/tomcat/src/main/java/com/navercorp/pinpoint/plugin/tomcat/interceptor/StandardHostValveInvokeInterceptor.java
@@ -73,23 +73,24 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
         RequestAdaptor<HttpServletRequest> requestAdaptor = new HttpServletRequestAdaptor();
         ParameterRecorder<HttpServletRequest> parameterRecorder = ParameterRecorderFactory.newParameterRecorderFactory(config.getExcludeProfileMethodFilter(), config.isTraceRequestParam());
 
-        ServletRequestListenerBuilder<HttpServletRequest> builder = new ServletRequestListenerBuilder<>(TomcatConstants.TOMCAT, traceContext, requestAdaptor);
-        builder.setExcludeURLFilter(config.getExcludeUrlFilter());
-        builder.setParameterRecorder(parameterRecorder);
-        builder.setRequestRecorderFactory(requestRecorderFactory);
+        ServletRequestListenerBuilder<HttpServletRequest> reqBuilder = new ServletRequestListenerBuilder<>(TomcatConstants.TOMCAT, traceContext, requestAdaptor);
+        reqBuilder.setExcludeURLFilter(config.getExcludeUrlFilter());
+        reqBuilder.setParameterRecorder(parameterRecorder);
+        reqBuilder.setRequestRecorderFactory(requestRecorderFactory);
 
         final ProfilerConfig profilerConfig = traceContext.getProfilerConfig();
-        builder.setRealIpSupport(config.getRealIpHeader(), config.getRealIpEmptyValue());
-        builder.setHttpStatusCodeRecorder(profilerConfig.getHttpStatusCodeErrors());
-        builder.setServerHeaderRecorder(profilerConfig.readList(ServerHeaderRecorder.CONFIG_KEY_RECORD_REQ_HEADERS));
-        builder.setServerCookieRecorder(profilerConfig.readList(ServerCookieRecorder.CONFIG_KEY_RECORD_REQ_COOKIES));
+        reqBuilder.setRealIpSupport(config.getRealIpHeader(), config.getRealIpEmptyValue());
+        reqBuilder.setHttpStatusCodeRecorder(profilerConfig.getHttpStatusCodeErrors());
+        reqBuilder.setServerHeaderRecorder(profilerConfig.readList(ServerHeaderRecorder.CONFIG_KEY_RECORD_REQ_HEADERS));
+        reqBuilder.setServerCookieRecorder(profilerConfig.readList(ServerCookieRecorder.CONFIG_KEY_RECORD_REQ_COOKIES));
 
         UriStatRecorder<HttpServletRequest> httpServletRequestUriStatRecorder = uriStatRecorderFactory.create(new ServletRequestUriExtractorService());
-        builder.setReqUriStatRecorder(httpServletRequestUriStatRecorder);
+        reqBuilder.setReqUriStatRecorder(httpServletRequestUriStatRecorder);
+        reqBuilder.setRecordStatusCode(false);
 
-        this.servletRequestListener = builder.build();
+        this.servletRequestListener = reqBuilder.build();
 
-        this.servletResponseListener = new ServletResponseListenerBuilder<HttpServletResponse>(traceContext, new HttpServletResponseAdaptor()).build();
+        this.servletResponseListener = new ServletResponseListenerBuilder<>(traceContext, new HttpServletResponseAdaptor()).build();
     }
 
     @Override
@@ -149,7 +150,7 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
                 }
             }
             this.servletResponseListener.destroyed(response, throwable, statusCode); //must before request listener due to trace block ending
-            this.servletRequestListener.destroyed(request, throwable, statusCode, false);
+            this.servletRequestListener.destroyed(request, throwable, statusCode);
         } catch (Throwable t) {
             if (isInfo) {
                 logger.info("Failed to servlet request event handle.", t);

--- a/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/interceptor/HttpServerExchangeResponseAdaptor.java
+++ b/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/interceptor/HttpServerExchangeResponseAdaptor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.undertow.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderValues;
+import io.undertow.util.HttpString;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author yjqg6666
+ */
+public class HttpServerExchangeResponseAdaptor implements ResponseAdaptor<HttpServerExchange> {
+
+    @Override
+    public boolean containsHeader(HttpServerExchange response, String name) {
+        return response.getResponseHeaders().contains(name);
+    }
+
+    @Override
+    public void setHeader(HttpServerExchange response, String name, String value) {
+        response.getResponseHeaders().put(new HttpString(name), value);
+    }
+
+    @Override
+    public void addHeader(HttpServerExchange response, String name, String value) {
+        response.getResponseHeaders().add(new HttpString(name), value);
+    }
+
+    @Override
+    public String getHeader(HttpServerExchange response, String name) {
+        return response.getResponseHeaders().getFirst(name);
+    }
+
+    @Override
+    public Collection<String> getHeaders(HttpServerExchange response, String name) {
+        final HeaderValues values = response.getResponseHeaders().get(name);
+        if (values == null) {
+            return Collections.emptyList();
+        }
+        return values;
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpServerExchange response) {
+        final Collection<HttpString> headerNames = response.getResponseHeaders().getHeaderNames();
+        if (headerNames == null) {
+            return Collections.emptyList();
+        }
+        Set<String> values = new HashSet<>(headerNames.size());
+        for (HttpString headerName : headerNames) {
+            values.add(headerName.toString());
+        }
+        return values;
+    }
+}


### PR DESCRIPTION
## Feature
Record response header on server/client side.

## Configuration
profiler.http.record.response.headers=Connection,Location,ExternalTraceid,Set-Cookie

Set the config value to _**HEADERS-ALL**_  to record all of the response headers from server/client side.

## Status

### Server Side
**Plugin        Implemented         Tested**  
Jetty                 Yes                    Yes  
Tomcat             Yes                    Yes  
Reactor-netty    Yes                    Yes
Undertow           Yes                    Yes   
Jboss                 Yes                    No  
Resin                 Yes                    No
Weblogic            No                      No
Websphere         No                      No

Note: _If the feature for Weblogic & Websphere plugins had been implemented_, the status code recorder can be removed from the ServletRequestListener completely and currently is kept for compatibility.

### Client Side
**Plugin        Implemented         Tested**
httpclient4         Yes                       Yes
httpclient3          Yes                       Yes
okhttp                  Yes                      Yes
okhttp3                 Yes                      Yes
jdk http                Yes                        Yes
resttemplate        Yes                      Yes
webflux                Yes                      Yes
reactor-netty        Yes                       Yes


## Demo

Configured header occurred once:

![image](https://user-images.githubusercontent.com/1879641/122891993-95a32c80-d377-11eb-82e9-595e8ba7c673.png)

Configured header occurred multiple times:
![image](https://user-images.githubusercontent.com/1879641/122892414-f29ee280-d377-11eb-9d61-b826bbb2d800.png)

Configured header applied on client side:
![image](https://user-images.githubusercontent.com/1879641/123203166-7ed01780-d4e8-11eb-8181-c30756f74c95.png)

Async request:
![image](https://user-images.githubusercontent.com/1879641/125581257-6ecb4049-6ce3-4479-94a2-030661ccd2cc.png)




## Additional changes
1. Move response status recorder to ServletResponseListener.
2. ~~Extract the common interface methods of SpanRecorder and SpanEventRecorder to SpanCommonRecorder~~. Extract the recordAttribute interface methods of SpanRecorder and SpanEventRecorder to AttributeRecorder.
