### PR TITLE
[#8042] record all of the request headers received on the server side

### DIFF
--- a/agent-testweb/jdk-http-plugin-testweb/src/main/java/com/pinpointest/plugin/controller/HttpHeaderController.java
+++ b/agent-testweb/jdk-http-plugin-testweb/src/main/java/com/pinpointest/plugin/controller/HttpHeaderController.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pinpointest.plugin.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+@RestController
+public class HttpHeaderController {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @GetMapping(value = "/reqHeader")
+    public String reqHeader(HttpServletRequest request) {
+        Collection<String> headerNames = Collections.list(request.getHeaderNames());
+
+        Function<String, Collection<String>> getHeaders = (name) -> Collections.list(request.getHeaders(name));
+
+        List<Pair<String, Collection<String>>> allHeader = getAllHeader(getHeaders, headerNames);
+
+        for (Pair<String, Collection<String>> pair : allHeader) {
+            logger.info("req {}:{}", pair.getKey(), pair.getValue());
+        }
+
+        return format(allHeader);
+    }
+
+    private <K, V> List<Pair<K, V>> getAllHeader(Function<K, V> headerFunction, Collection<K> headerNames) {
+        List<Pair<K, V>> result = new ArrayList<>();
+
+        for (K headerName : headerNames) {
+            V headers = headerFunction.apply(headerName);
+            result.add(new Pair<>(headerName, headers));
+        }
+
+        return result;
+    }
+
+    @GetMapping(value = "/resHeader")
+    public String resHeader(HttpServletResponse response) {
+        response.addHeader("TEST_HEADER", "1");
+        response.addHeader("TEST_HEADER", "2");
+        response.addHeader("TEST_HEADER", "3");
+        response.addHeader("TEST_HEADER", "a, b, c");
+
+        Collection<String> headerNames = response.getHeaderNames();
+        for (String headerName : headerNames) {
+            String header = response.getHeader(headerName);
+            logger.info("res getHeader: {}:{}",headerName, header);
+        }
+
+
+        Function<String, Collection<String>> getHeaders = response::getHeaders;
+
+        List<Pair<String, Collection<String>>> allHeader = getAllHeader(getHeaders, headerNames);
+
+        logger.info("response header dump : API");
+        for (Pair<String, Collection<String>> pair : allHeader) {
+            logger.info("res {}:{}", pair.getKey(), pair.getValue());
+        }
+
+        return format(allHeader);
+    }
+
+    private String format(List<Pair<String, Collection<String>>> allHeader) {
+        StringBuilder sb = new StringBuilder();
+        for (Pair<String, Collection<String>> pair : allHeader) {
+            sb.append(pair.getKey());
+            sb.append(":");
+
+            sb.append(pair.getValue());
+            sb.append("\n");
+        }
+
+        return sb.toString();
+    }
+}

--- a/agent-testweb/jdk-http-plugin-testweb/src/main/java/com/pinpointest/plugin/controller/Pair.java
+++ b/agent-testweb/jdk-http-plugin-testweb/src/main/java/com/pinpointest/plugin/controller/Pair.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pinpointest.plugin.controller;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class Pair<K, V> {
+    private final K key;
+    private final V value;
+
+    public Pair(K key, V value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public V getValue() {
+        return value;
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return key + ":" + value;
+    }
+}

--- a/agent-testweb/jdk-http-plugin-testweb/src/test/http/.http
+++ b/agent-testweb/jdk-http-plugin-testweb/src/test/http/.http
@@ -1,0 +1,13 @@
+### Request Header duplicate test
+GET http://{{host}}/reqHeader
+TEST_HEADER: 1
+TEST_HEADER: 2
+TEST_HEADER: 3
+
+### Response Header duplicate test
+GET http://{{host}}/resHeader
+
+
+###
+
+

--- a/agent-testweb/jdk-http-plugin-testweb/src/test/http/http-client.env.json
+++ b/agent-testweb/jdk-http-plugin-testweb/src/test/http/http-client.env.json
@@ -1,0 +1,5 @@
+{
+  "dev": {
+    "host": "localhost:18080"
+  }
+}

--- a/agent/src/main/resources/pinpoint-root.config
+++ b/agent/src/main/resources/pinpoint-root.config
@@ -307,6 +307,7 @@ profiler.proxy.http.header.enable=true
 profiler.http.status.code.errors=5xx
 
 # record HTTP request headers case-sensitive
+# set to HEADERS-ALL to record all of the request headers including cookie.
 # e.g. profiler.http.record.request.headers=X-AccessKey,X-Device-UUID
 #profiler.http.record.request.headers=
 

--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -207,6 +207,7 @@ profiler.proxy.http.headers=
 profiler.http.status.code.errors=5xx
 
 # record HTTP request headers case-sensitive
+# set to HEADERS-ALL to record all of the request headers including cookie.
 # e.g. profiler.http.record.request.headers=X-AccessKey,X-Device-UUID
 profiler.http.record.request.headers=
 

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -207,6 +207,7 @@ profiler.proxy.http.headers=
 profiler.http.status.code.errors=5xx
 
 # record HTTP request headers case-sensitive
+# set to HEADERS-ALL to record all of the request headers including cookie.
 # e.g. profiler.http.record.request.headers=X-AccessKey,X-Device-UUID
 #profiler.http.record.request.headers=
 

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/AllServerHeaderRecorder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/AllServerHeaderRecorder.java
@@ -8,16 +8,23 @@ import com.navercorp.pinpoint.common.util.StringStringValue;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 public class AllServerHeaderRecorder<REQ> implements ServerHeaderRecorder<REQ> {
 
     private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
 
+    public static final String HEADERS_ALL = "HEADERS-ALL";
+
     private final RequestAdaptor<REQ> requestAdaptor;
 
     public AllServerHeaderRecorder(RequestAdaptor<REQ> requestAdaptor) {
         this.requestAdaptor = Objects.requireNonNull(requestAdaptor, "requestAdaptor");
+    }
+
+    public static boolean isRecordAllHeaders(List<String> recordHeaders) {
+        return recordHeaders.contains(HEADERS_ALL);
     }
 
     @Override

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/AllServerHeaderRecorder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/AllServerHeaderRecorder.java
@@ -1,0 +1,47 @@
+package com.navercorp.pinpoint.bootstrap.plugin.request;
+
+import com.navercorp.pinpoint.bootstrap.context.SpanRecorder;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import com.navercorp.pinpoint.common.util.StringStringValue;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+public class AllServerHeaderRecorder<REQ> implements ServerHeaderRecorder<REQ> {
+
+    private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+
+    private final RequestAdaptor<REQ> requestAdaptor;
+
+    public AllServerHeaderRecorder(RequestAdaptor<REQ> requestAdaptor) {
+        this.requestAdaptor = Objects.requireNonNull(requestAdaptor, "requestAdaptor");
+    }
+
+    @Override
+    public void recordHeader(final SpanRecorder recorder, final REQ request) {
+        final Collection<String> headerNames = getHeaderNames(request);
+
+        for (String headerName : headerNames) {
+            final String value = requestAdaptor.getHeader(request, headerName);
+            if (value == null) {
+                continue;
+            }
+            StringStringValue header = new StringStringValue(headerName, value);
+            recorder.recordAttribute(AnnotationKey.HTTP_REQUEST_HEADER, header);
+        }
+    }
+
+    private Collection<String> getHeaderNames(final REQ request) {
+        try {
+            // It's good that APM dumps duplicate headers.
+            return requestAdaptor.getHeaderNames(request);
+        } catch (Exception e) {
+            logger.warn("Extract all of the request header names from request {} failed, caused by:", request, e);
+            return Collections.emptyList();
+        }
+    }
+
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/RequestAdaptor.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/RequestAdaptor.java
@@ -16,6 +16,9 @@
 
 package com.navercorp.pinpoint.bootstrap.plugin.request;
 
+import java.io.IOException;
+import java.util.Collection;
+
 /**
  * @author Woonduk Kang(emeroad)
  */
@@ -23,6 +26,12 @@ public interface RequestAdaptor<REQ> {
 
     String getHeader(REQ request, String name);
 
+    /**
+     * get a list of request header names
+     * @param request request
+     * @return list of request header names (may duplicated)
+     */
+    Collection<String> getHeaderNames(REQ request) throws IOException;
 
     /**
      * Procedure name(optional)

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/RequestAdaptor.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/RequestAdaptor.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.bootstrap.plugin.request;
 
-import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -31,7 +30,7 @@ public interface RequestAdaptor<REQ> {
      * @param request request
      * @return list of request header names (may duplicated)
      */
-    Collection<String> getHeaderNames(REQ request) throws IOException;
+    Collection<String> getHeaderNames(REQ request);
 
     /**
      * Procedure name(optional)

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServerRequestWrapperAdaptor.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServerRequestWrapperAdaptor.java
@@ -16,6 +16,9 @@
 
 package com.navercorp.pinpoint.bootstrap.plugin.request;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * @author Woonduk Kang(emeroad)
  */
@@ -24,6 +27,11 @@ public class ServerRequestWrapperAdaptor implements RequestAdaptor<ServerRequest
     @Override
     public String getHeader(ServerRequestWrapper request, String name) {
         return request.getHeader(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(ServerRequestWrapper request) {
+        return Collections.emptyList();
     }
 
     @Override

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServletRequestListenerBuilder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServletRequestListenerBuilder.java
@@ -40,6 +40,9 @@ import java.util.Objects;
  * @author Woonduk Kang(emeroad)
  */
 public class ServletRequestListenerBuilder<REQ> {
+
+    public static final String HEADERS_ALL = "HEADERS-ALL";
+
     private final ServiceType serviceType;
     private final TraceContext traceContext;
     private final RequestAdaptor<REQ> requestAdaptor;
@@ -164,6 +167,11 @@ public class ServletRequestListenerBuilder<REQ> {
         if (CollectionUtils.isEmpty(recordRequestHeaders)) {
             return new BypassServerHeaderRecorder<>();
         }
+
+        if (recordRequestHeaders.contains("HEADERS-ALL")) {
+            return new AllServerHeaderRecorder<>(requestAdaptor);
+        }
+
         return new DefaultServerHeaderRecorder<>(requestAdaptor, recordRequestHeaders);
     }
 

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServletRequestListenerBuilder.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ServletRequestListenerBuilder.java
@@ -40,9 +40,6 @@ import java.util.Objects;
  * @author Woonduk Kang(emeroad)
  */
 public class ServletRequestListenerBuilder<REQ> {
-
-    public static final String HEADERS_ALL = "HEADERS-ALL";
-
     private final ServiceType serviceType;
     private final TraceContext traceContext;
     private final RequestAdaptor<REQ> requestAdaptor;
@@ -168,7 +165,7 @@ public class ServletRequestListenerBuilder<REQ> {
             return new BypassServerHeaderRecorder<>();
         }
 
-        if (recordRequestHeaders.contains("HEADERS-ALL")) {
+        if (AllServerHeaderRecorder.isRecordAllHeaders(recordRequestHeaders)) {
             return new AllServerHeaderRecorder<>(requestAdaptor);
         }
 

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/util/HeaderResolveRequestAdaptor.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/util/HeaderResolveRequestAdaptor.java
@@ -20,6 +20,7 @@ package com.navercorp.pinpoint.bootstrap.plugin.request.util;
 import com.navercorp.pinpoint.bootstrap.context.RemoteAddressResolver;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestAdaptor;
 
+import java.util.Collection;
 import java.util.Objects;
 
 /**
@@ -38,6 +39,11 @@ public class HeaderResolveRequestAdaptor<T> implements RequestAdaptor<T> {
     @Override
     public String getHeader(T request, String name) {
         return delegate.getHeader(request, name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(T request) {
+        return delegate.getHeaderNames(request);
     }
 
     @Override

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseAdaptor.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseAdaptor.java
@@ -88,7 +88,7 @@ public interface ResponseAdaptor<RESP> {
      * @return a (possibly empty) <code>Collection</code> of the values
      * of the response header with the given name
      */
-    Collection<String> getHeaders(RESP response, String name) throws IOException;
+    Collection<String> getHeaders(RESP response, String name);
 
     /**
      * Gets all of the response header names
@@ -96,6 +96,6 @@ public interface ResponseAdaptor<RESP> {
      * @param response response
      * @return a (possibly empty) <code>Collection</code> of response header names
      */
-    Collection<String> getHeaderNames(RESP response) throws IOException;
+    Collection<String> getHeaderNames(RESP response);
 
 }

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseHeaderRecorderFactory.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/response/ResponseHeaderRecorderFactory.java
@@ -31,6 +31,9 @@ public class ResponseHeaderRecorderFactory {
         if (CollectionUtils.isEmpty(recordResponseHeaders)) {
             return new BypassServerResponseHeaderRecorder<>();
         }
+        if (AllServerResponseHeaderRecorder.isRecordAllHeaders(recordResponseHeaders)) {
+            return new AllServerResponseHeaderRecorder(adaptor);
+        }
         return new DefaultServerResponseHeaderRecorder<>(adaptor, recordResponseHeaders);
     }
 

--- a/grpc/src/test/java/com/navercorp/pinpoint/grpc/MetadataTest.java
+++ b/grpc/src/test/java/com/navercorp/pinpoint/grpc/MetadataTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.grpc;
+
+import com.navercorp.pinpoint.common.util.BytesUtils;
+import io.grpc.InternalMetadata;
+import io.grpc.Metadata;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MetadataTest {
+    private static final Logger logger = LoggerFactory.getLogger(ChannelFactoryTest.class);
+
+    @Test
+    public void metadataTest() throws Exception {
+        Metadata.Key<String> dd = Metadata.Key.of("key", Metadata.ASCII_STRING_MARSHALLER);
+        Metadata metadata = InternalMetadata.newMetadata(BytesUtils.toBytes("key"), BytesUtils.toBytes("value"));
+
+        Iterable<String> remove1 = metadata.removeAll(dd);
+        logger.debug("{}", remove1);
+
+        Iterable<String> remove2 = metadata.removeAll(dd);
+        logger.debug("{}", remove2);
+    }
+}

--- a/plugins/akka-http/src/main/java/com/navercorp/pinpoint/plugin/akka/http/HttpRequestAdaptor.java
+++ b/plugins/akka-http/src/main/java/com/navercorp/pinpoint/plugin/akka/http/HttpRequestAdaptor.java
@@ -25,6 +25,10 @@ import com.navercorp.pinpoint.bootstrap.plugin.request.RequestAdaptor;
 import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
 import com.navercorp.pinpoint.common.util.StringUtils;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -56,6 +60,22 @@ public class HttpRequestAdaptor implements RequestAdaptor<HttpRequest> {
     @Override
     public String getHeader(HttpRequest request, String name) {
         return getHeader(request, name, null);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpRequest request) {
+        if (request == null) {
+            return Collections.emptyList();
+        }
+        final Iterable<HttpHeader> headers = request.getHeaders();
+        if (headers == null) {
+            return Collections.emptyList();
+        }
+        List<String> names = new ArrayList<>();
+        for (HttpHeader header : headers) {
+            names.add(header.name());
+        }
+        return names;
     }
 
     private String getHeader(HttpRequest request, String name, String defaultValue) {

--- a/plugins/common-servlet/src/main/java/com/navercorp/pinpoint/plugin/common/servlet/util/HttpServletRequestAdaptor.java
+++ b/plugins/common-servlet/src/main/java/com/navercorp/pinpoint/plugin/common/servlet/util/HttpServletRequestAdaptor.java
@@ -25,6 +25,10 @@ import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 
 /**
@@ -50,6 +54,19 @@ public class HttpServletRequestAdaptor implements RequestAdaptor<HttpServletRequ
     @Override
     public String getHeader(HttpServletRequest request, String name) {
         return request.getHeader(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpServletRequest request) {
+        final Enumeration<String> headerNames = request.getHeaderNames();
+        if (headerNames == null) {
+            return Collections.emptySet();
+        }
+        List<String> names = new ArrayList<>();
+        while (headerNames.hasMoreElements()) {
+            names.add(headerNames.nextElement());
+        }
+        return names;
     }
 
     @Override

--- a/plugins/common-servlet/src/main/java/com/navercorp/pinpoint/plugin/common/servlet/util/HttpServletRequestAdaptor.java
+++ b/plugins/common-servlet/src/main/java/com/navercorp/pinpoint/plugin/common/servlet/util/HttpServletRequestAdaptor.java
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -62,11 +61,7 @@ public class HttpServletRequestAdaptor implements RequestAdaptor<HttpServletRequ
         if (headerNames == null) {
             return Collections.emptySet();
         }
-        List<String> names = new ArrayList<>();
-        while (headerNames.hasMoreElements()) {
-            names.add(headerNames.nextElement());
-        }
-        return names;
+        return Collections.list(headerNames);
     }
 
     @Override

--- a/plugins/grpc/src/main/java/com/navercorp/pinpoint/plugin/grpc/interceptor/server/GrpcServerStreamRequestAdaptor.java
+++ b/plugins/grpc/src/main/java/com/navercorp/pinpoint/plugin/grpc/interceptor/server/GrpcServerStreamRequestAdaptor.java
@@ -19,6 +19,9 @@ package com.navercorp.pinpoint.plugin.grpc.interceptor.server;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestAdaptor;
 import com.navercorp.pinpoint.common.util.StringUtils;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * @author Taejin Koo
  */
@@ -27,6 +30,14 @@ public class GrpcServerStreamRequestAdaptor implements RequestAdaptor<GrpcServer
     @Override
     public String getHeader(GrpcServerStreamRequest request, String name) {
         return request.getHeader(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(GrpcServerStreamRequest request) {
+        //todo to be replaced with GrpcServerStreamRequest request
+        //throw new UnsupportedOperationException("not implemented yet!");
+        //inside the impl. of getHeader, why metadata.removeAll(key) get called?
+        return Collections.emptyList();
     }
 
     @Override

--- a/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/HttpClient3ResponseHeaderAdaptor.java
+++ b/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/HttpClient3ResponseHeaderAdaptor.java
@@ -40,12 +40,12 @@ public class HttpClient3ResponseHeaderAdaptor implements ResponseAdaptor<HttpMet
 
     @Override
     public void setHeader(HttpMethod response, String name, String value) {
-        throw new UnsupportedOperationException("not supported for http client3");
+
     }
 
     @Override
     public void addHeader(HttpMethod response, String name, String value) {
-        throw new UnsupportedOperationException("not supported for http client3");
+
     }
 
     @Override
@@ -57,10 +57,13 @@ public class HttpClient3ResponseHeaderAdaptor implements ResponseAdaptor<HttpMet
     @Override
     public Collection<String> getHeaders(HttpMethod response, String name) {
         final Header[] headers = response.getResponseHeaders(name);
-        if (headers == null || headers.length == 0) {
+        if (ArrayUtils.isEmpty(headers)) {
             return Collections.emptyList();
         }
-        List<String> values = new ArrayList<>(headers.length);
+        if (headers.length == 1) {
+            return Collections.singletonList(headers[0].getValue());
+        }
+        Set<String> values = new HashSet<>(headers.length);
         for (Header header : headers) {
             values.add(header.getValue());
         }
@@ -72,6 +75,9 @@ public class HttpClient3ResponseHeaderAdaptor implements ResponseAdaptor<HttpMet
         final Header[] headers = response.getResponseHeaders();
         if (ArrayUtils.isEmpty(headers)) {
             return Collections.emptyList();
+        }
+        if (headers.length == 1) {
+            return Collections.singletonList(headers[0].getName());
         }
         Set<String> values = new HashSet<>(headers.length);
         for (Header header : headers) {

--- a/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/HttpResponse4ClientHeaderAdaptor.java
+++ b/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/HttpResponse4ClientHeaderAdaptor.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.plugin.httpclient4;
 import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.navercorp.pinpoint.common.util.ArrayUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 
@@ -67,10 +68,13 @@ public class HttpResponse4ClientHeaderAdaptor implements ResponseAdaptor<HttpRes
     @Override
     public Collection<String> getHeaders(HttpResponse response, String name) {
         final Header[] headers = response.getHeaders(name);
-        if (headers == null || headers.length == 0) {
+        if (ArrayUtils.isEmpty(headers)) {
             return Collections.emptyList();
         }
-        List<String> values = new ArrayList<>(headers.length);
+        if (headers.length == 1) {
+            return Collections.singletonList(headers[0].getValue());
+        }
+        Set<String> values = new HashSet<>(headers.length);
         for (Header header : headers) {
             values.add(header.getValue());
         }
@@ -80,8 +84,11 @@ public class HttpResponse4ClientHeaderAdaptor implements ResponseAdaptor<HttpRes
     @Override
     public Collection<String> getHeaderNames(HttpResponse response) {
         final Header[] headers = response.getAllHeaders();
-        if (headers == null || headers.length == 0) {
+        if (ArrayUtils.isEmpty(headers)) {
             return Collections.emptyList();
+        }
+        if (headers.length == 1) {
+            return Collections.singletonList(headers[0].getName());
         }
         Set<String> values = new HashSet<>(headers.length);
         for (Header header : headers) {

--- a/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/JdkHttpClientResponseAdaptor.java
+++ b/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/JdkHttpClientResponseAdaptor.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.plugin.jdk.http;
 
 import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.navercorp.pinpoint.common.util.MapUtils;
 
 import java.net.HttpURLConnection;
 import java.util.Collection;
@@ -35,12 +36,12 @@ public class JdkHttpClientResponseAdaptor implements ResponseAdaptor<HttpURLConn
 
     @Override
     public void setHeader(HttpURLConnection response, String name, String value) {
-        throw new UnsupportedOperationException("not supported to set header for jdk http client");
+
     }
 
     @Override
     public void addHeader(HttpURLConnection response, String name, String value) {
-        throw new UnsupportedOperationException("not supported to add header for jdk http client");
+
     }
 
     @Override
@@ -53,13 +54,19 @@ public class JdkHttpClientResponseAdaptor implements ResponseAdaptor<HttpURLConn
      */
     @Override
     public Collection<String> getHeaders(HttpURLConnection response, String name) {
-        final String val = response.getHeaderField(name);
-        return val != null ? Collections.singletonList(val) : Collections.<String>emptyList();
+        final Map<String, List<String>> headerFields = response.getHeaderFields();
+        if (MapUtils.isEmpty(headerFields)) {
+            return Collections.emptyList();
+        }
+        return headerFields.get(name);
     }
 
     @Override
     public Collection<String> getHeaderNames(HttpURLConnection response) {
         final Map<String, List<String>> headerFields = response.getHeaderFields();
-        return headerFields == null ? Collections.<String>emptySet() : headerFields.keySet();
+        if (MapUtils.isEmpty(headerFields)) {
+            return Collections.emptyList();
+        }
+        return headerFields.keySet();
     }
 }

--- a/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v2/OkHttpResponseAdaptor.java
+++ b/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v2/OkHttpResponseAdaptor.java
@@ -35,12 +35,12 @@ public class OkHttpResponseAdaptor implements ResponseAdaptor<Response> {
 
     @Override
     public void setHeader(Response response, String name, String value) {
-        throw new UnsupportedOperationException("set header not supported in okhttp");
+
     }
 
     @Override
     public void addHeader(Response response, String name, String value) {
-        throw new UnsupportedOperationException("add header not supported in okhttp");
+
     }
 
     @Override

--- a/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/OkHttpResponseAdaptor.java
+++ b/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v3/OkHttpResponseAdaptor.java
@@ -34,12 +34,12 @@ public class OkHttpResponseAdaptor implements ResponseAdaptor<Response> {
 
     @Override
     public void setHeader(Response response, String name, String value) {
-        throw new UnsupportedOperationException("set header not supported in okhttp3");
+
     }
 
     @Override
     public void addHeader(Response response, String name, String value) {
-        throw new UnsupportedOperationException("set header not supported in okhttp3");
+
     }
 
     @Override

--- a/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/ReactorNettyResponseHeaderAdaptor.java
+++ b/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/ReactorNettyResponseHeaderAdaptor.java
@@ -16,6 +16,7 @@
 package com.navercorp.pinpoint.plugin.reactor.netty;
 
 import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponse;
 
 import java.util.Collection;
@@ -47,7 +48,7 @@ public class ReactorNettyResponseHeaderAdaptor implements ResponseAdaptor<HttpRe
 
     @Override
     public Collection<String> getHeaders(HttpResponse response, String name) {
-        return response.headers().getAllAsString(name);
+        return response.headers().getAll(name);
     }
 
     @Override

--- a/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpRequestAdaptor.java
+++ b/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpRequestAdaptor.java
@@ -24,6 +24,8 @@ import reactor.netty.http.server.HttpServerRequest;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * @author jaehong.kim
@@ -40,6 +42,12 @@ public class HttpRequestAdaptor implements RequestAdaptor<HttpServerRequest> {
         } catch (Exception ignored) {
         }
         return null;
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpServerRequest request) {
+        final HttpHeaders entries = request.requestHeaders();
+        return entries == null ? Collections.emptyList() : entries.names();
     }
 
     @Override

--- a/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpResponseAdaptor.java
+++ b/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpResponseAdaptor.java
@@ -48,7 +48,7 @@ public class HttpResponseAdaptor implements ResponseAdaptor<HttpServerResponse> 
 
     @Override
     public Collection<String> getHeaders(HttpServerResponse response, String name) {
-        return response.responseHeaders().getAllAsString(name);
+        return response.responseHeaders().getAll(name);
     }
 
     @Override

--- a/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/interceptor/HttpServerExchangeAdaptor.java
+++ b/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/interceptor/HttpServerExchangeAdaptor.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.bootstrap.plugin.request.RequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.util.SocketAddressUtils;
 import com.navercorp.pinpoint.bootstrap.util.NetworkUtils;
 import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HeaderValues;
@@ -56,7 +57,7 @@ public class HttpServerExchangeAdaptor implements RequestAdaptor<HttpServerExcha
             return Collections.emptyList();
         }
         final Collection<HttpString> headerNames = requestHeaders.getHeaderNames();
-        if (headerNames == null) {
+        if (CollectionUtils.isEmpty(headerNames)) {
             return Collections.emptyList();
         }
         Set<String> values = new HashSet<>(headerNames.size());

--- a/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/interceptor/HttpServerExchangeAdaptor.java
+++ b/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/interceptor/HttpServerExchangeAdaptor.java
@@ -21,9 +21,15 @@ import com.navercorp.pinpoint.bootstrap.plugin.util.SocketAddressUtils;
 import com.navercorp.pinpoint.bootstrap.util.NetworkUtils;
 import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
 import io.undertow.util.HeaderValues;
+import io.undertow.util.HttpString;
 
 import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author jaehong.kim
@@ -32,11 +38,32 @@ public class HttpServerExchangeAdaptor implements RequestAdaptor<HttpServerExcha
 
     @Override
     public String getHeader(HttpServerExchange request, String name) {
-        final HeaderValues values = request.getRequestHeaders().get(name);
+        final HeaderMap requestHeaders = request.getRequestHeaders();
+        if (requestHeaders == null) {
+            return null;
+        }
+        final HeaderValues values = requestHeaders.get(name);
         if (values != null) {
             return values.peekFirst();
         }
         return null;
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpServerExchange request) {
+        final HeaderMap requestHeaders = request.getRequestHeaders();
+        if (requestHeaders == null) {
+            return Collections.emptyList();
+        }
+        final Collection<HttpString> headerNames = requestHeaders.getHeaderNames();
+        if (headerNames == null) {
+            return Collections.emptyList();
+        }
+        Set<String> values = new HashSet<>(headerNames.size());
+        for (HttpString headerName : headerNames) {
+            values.add(headerName.toString());
+        }
+        return values;
     }
 
     @Override

--- a/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/interceptor/HttpServerExchangeResponseAdaptor.java
+++ b/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/interceptor/HttpServerExchangeResponseAdaptor.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.plugin.undertow.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.HttpString;
@@ -63,7 +64,7 @@ public class HttpServerExchangeResponseAdaptor implements ResponseAdaptor<HttpSe
     @Override
     public Collection<String> getHeaderNames(HttpServerExchange response) {
         final Collection<HttpString> headerNames = response.getResponseHeaders().getHeaderNames();
-        if (headerNames == null) {
+        if (CollectionUtils.isEmpty(headerNames)) {
             return Collections.emptyList();
         }
         Set<String> values = new HashSet<>(headerNames.size());

--- a/plugins/vertx/src/main/java/com/navercorp/pinpoint/plugin/vertx/interceptor/HttpServerRequestAdaptor.java
+++ b/plugins/vertx/src/main/java/com/navercorp/pinpoint/plugin/vertx/interceptor/HttpServerRequestAdaptor.java
@@ -18,8 +18,12 @@ package com.navercorp.pinpoint.plugin.vertx.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.util.NetworkUtils;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SocketAddress;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -32,6 +36,12 @@ public class HttpServerRequestAdaptor implements RequestAdaptor<HttpServerReques
     @Override
     public String getHeader(HttpServerRequest request, String name) {
         return request.getHeader(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(HttpServerRequest request) {
+        final MultiMap headers = request.headers();
+        return headers == null ? Collections.<String>emptyList() : headers.names();
     }
 
 

--- a/plugins/weblogic/src/main/java/com/navercorp/pinpoint/plugin/weblogic/interceptor/ServletRequestImplAdaptor.java
+++ b/plugins/weblogic/src/main/java/com/navercorp/pinpoint/plugin/weblogic/interceptor/ServletRequestImplAdaptor.java
@@ -20,6 +20,9 @@ import com.navercorp.pinpoint.bootstrap.plugin.request.RequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.util.NetworkUtils;
 import weblogic.servlet.internal.ServletRequestImpl;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * @author jaehong.kim
  */
@@ -27,6 +30,13 @@ public class ServletRequestImplAdaptor implements RequestAdaptor<ServletRequestI
     @Override
     public String getHeader(ServletRequestImpl request, String name) {
         return request.getHeader(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(ServletRequestImpl request) {
+        //todo to be replaced with Weblogic ServletRequestImpl request
+        //throw new UnsupportedOperationException("not implemented yet!");
+        return Collections.emptyList();
     }
 
     @Override

--- a/plugins/websphere/src/main/java/com/navercorp/pinpoint/plugin/websphere/interceptor/IRequestAdaptor.java
+++ b/plugins/websphere/src/main/java/com/navercorp/pinpoint/plugin/websphere/interceptor/IRequestAdaptor.java
@@ -21,6 +21,9 @@ import com.navercorp.pinpoint.bootstrap.plugin.request.RequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.util.NetworkUtils;
 import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * @author Woonduk Kang(emeroad)
  */
@@ -28,6 +31,14 @@ public class IRequestAdaptor implements RequestAdaptor<IRequest> {
     @Override
     public String getHeader(IRequest request, String name) {
         return request.getHeader(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames(IRequest request) {
+        //todo to be replaced with websphere IRequest.getHeaderNames
+        //throw new UnsupportedOperationException("not implemented yet!");
+        //request.getHeaderNames() return enumeration of String ?
+        return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
Resolve #8042 

# Feature
Extend the feature introduced by #6893.  When the config _profiler.http.record.request.headers_ set to _HEADERS-ALL_, all of the request headers would be recorded. This feature would be useful at development/testing stage.

![image](https://user-images.githubusercontent.com/1879641/125737481-51d63b6e-0757-465c-bd1c-2c6aa66fcc43.png)


# Status
**Server   Status**
Jetty     supported / tested
Tomcat  supported / tested
Reactor-netty supported / tested
Undertow      supported / tested
Vertx             supported / not-tested
Weblogic       not-supported / todo
Websphere    not-supported / todo

# Todo
Due to lacking of dev/test environment for weblogic & websphere, support for these servers are not implemented and see [the PR commit 59e4ed8](https://github.com/pinpoint-apm/pinpoint/pull/8043/commits/59e4ed8879ccf594a4cf839ce4bebff255c0b880).  Further help/polishing needed.