### PR TITLE
Add hbase tableName to hbase plugin 

### DIFF
--- a/plugins/hbase/src/main/java/com/navercorp/pinpoint/plugin/hbase/HbasePlugin.java
+++ b/plugins/hbase/src/main/java/com/navercorp/pinpoint/plugin/hbase/HbasePlugin.java
@@ -158,8 +158,9 @@ public class HbasePlugin implements ProfilerPlugin, TransformTemplateAware {
 
             HbasePluginConfig config = new HbasePluginConfig(instrumentor.getProfilerConfig());
             final boolean paramsProfile = config.isParamsProfile();
+            final boolean tableNameProfile = config.isTableNameProfile();
             for (InstrumentMethod method : target.getDeclaredMethods(MethodFilters.name(HbasePluginConstants.tableMethodNames))) {
-                method.addInterceptor(HbaseTableMethodInterceptor.class, va(paramsProfile));
+                method.addInterceptor(HbaseTableMethodInterceptor.class, va(paramsProfile,tableNameProfile));
             }
             return target.toBytecode();
         }

--- a/plugins/hbase/src/main/java/com/navercorp/pinpoint/plugin/hbase/HbasePluginConfig.java
+++ b/plugins/hbase/src/main/java/com/navercorp/pinpoint/plugin/hbase/HbasePluginConfig.java
@@ -29,6 +29,7 @@ public class HbasePluginConfig {
     private final boolean adminProfile;
     private final boolean tableProfile;
     private final boolean paramsProfile;
+    private final boolean tableNameProfile;
 
     /**
      * Instantiates a new Hbase plugin config.
@@ -40,6 +41,7 @@ public class HbasePluginConfig {
         this.adminProfile = config.readBoolean(HbasePluginConstants.HBASE_CLIENT_ADMIN_CONFIG, true);
         this.tableProfile = config.readBoolean(HbasePluginConstants.HBASE_CLIENT_TABLE_CONFIG, true);
         this.paramsProfile = config.readBoolean(HbasePluginConstants.HBASE_CLIENT_PARAMS_CONFIG, false);
+        this.tableNameProfile = config.readBoolean(HbasePluginConstants.HBASE_CLIENT_TABLENAME_CONFIG, true);
     }
 
     /**
@@ -76,6 +78,15 @@ public class HbasePluginConfig {
      */
     public boolean isParamsProfile() {
         return paramsProfile;
+    }
+
+    /**
+     * Is tableName profile boolean.
+     *
+     * @return the boolean
+     */
+    public boolean isTableNameProfile() {
+        return tableNameProfile;
     }
 
     @Override

--- a/plugins/hbase/src/main/java/com/navercorp/pinpoint/plugin/hbase/HbasePluginConstants.java
+++ b/plugins/hbase/src/main/java/com/navercorp/pinpoint/plugin/hbase/HbasePluginConstants.java
@@ -61,6 +61,11 @@ public final class HbasePluginConstants {
     public static final AnnotationKey HBASE_CLIENT_PARAMS = AnnotationKeyFactory.of(320, "hbase.client.params", VIEW_IN_RECORD_SET);
 
     /**
+     * The constant HBASE_TABLE_NAME.
+     */
+    public static final AnnotationKey HBASE_TABLE_NAME = AnnotationKeyFactory.of(110999, "hbase.table.name", VIEW_IN_RECORD_SET);
+
+    /**
      * The constant HBASE_DESTINATION_ID.
      */
     public static final String HBASE_DESTINATION_ID = "HBASE";
@@ -89,6 +94,11 @@ public final class HbasePluginConstants {
      * The constant HBASE_CLIENT_PARAMS_CONFIG.
      */
     public static final String HBASE_CLIENT_PARAMS_CONFIG = "profiler.hbase.client.params.enable";
+
+    /**
+     * The constant HBASE_CLIENT_TABLENAME_CONFIG.
+     */
+    public static final String HBASE_CLIENT_TABLENAME_CONFIG = "profiler.hbase.client.tablename.enable";
 
     /**
      * The constant tableMethodNames.

--- a/plugins/hbase/src/main/java/com/navercorp/pinpoint/plugin/hbase/HbasePluginMetadataProvider.java
+++ b/plugins/hbase/src/main/java/com/navercorp/pinpoint/plugin/hbase/HbasePluginMetadataProvider.java
@@ -33,5 +33,6 @@ public class HbasePluginMetadataProvider implements TraceMetadataProvider {
         context.addServiceType(HbasePluginConstants.HBASE_CLIENT_TABLE);
         context.addServiceType(HbasePluginConstants.HBASE_ASYNC_CLIENT);
         context.addAnnotationKey(HbasePluginConstants.HBASE_CLIENT_PARAMS);
+        context.addAnnotationKey(HbasePluginConstants.HBASE_TABLE_NAME);
     }
 }

--- a/plugins/hbase/src/test/java/com/navercorp/pinpoint/plugin/hbase/HbasePluginConfigTest.java
+++ b/plugins/hbase/src/test/java/com/navercorp/pinpoint/plugin/hbase/HbasePluginConfigTest.java
@@ -40,4 +40,12 @@ public class HbasePluginConfigTest {
         assertFalse(config.isParamsProfile());
         System.out.println(config);
     }
+
+    @Test
+    public void isTableNameProfile() {
+        ProfilerConfig profilerConfig = new DefaultProfilerConfig();
+        HbasePluginConfig config = new HbasePluginConfig(profilerConfig);
+        assertTrue(config.isTableNameProfile());
+        System.out.println(config);
+    }
 }

--- a/plugins/hbase/src/test/java/com/navercorp/pinpoint/plugin/hbase/interceptor/HbaseTableMethodInterceptorTest.java
+++ b/plugins/hbase/src/test/java/com/navercorp/pinpoint/plugin/hbase/interceptor/HbaseTableMethodInterceptorTest.java
@@ -4,6 +4,11 @@ import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.plugin.hbase.HbasePluginConstants;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ClusterConnection;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Table;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -11,6 +16,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -25,13 +31,16 @@ public class HbaseTableMethodInterceptorTest {
     @Mock
     private SpanEventRecorder recorder;
 
+    @Mock
+    private ClusterConnection connection;
+
     @Test
     public void doInBeforeTrace() {
 
         Object target = new Object();
         Object[] args = new Object[]{};
 
-        HbaseTableMethodInterceptor interceptor = new HbaseTableMethodInterceptor(traceContext, descriptor,true);
+        HbaseTableMethodInterceptor interceptor = new HbaseTableMethodInterceptor(traceContext, descriptor,true, false);
         interceptor.doInBeforeTrace(recorder, target, args);
         verify(recorder).recordServiceType(HbasePluginConstants.HBASE_CLIENT_TABLE);
     }
@@ -42,9 +51,25 @@ public class HbaseTableMethodInterceptorTest {
         Object target = new Object();
         Object[] args = new Object[]{Collections.singletonList("test")};
 
-        HbaseTableMethodInterceptor interceptor = new HbaseTableMethodInterceptor(traceContext, descriptor, true);
+        HbaseTableMethodInterceptor interceptor = new HbaseTableMethodInterceptor(traceContext, descriptor, true ,true);
         interceptor.doInAfterTrace(recorder, target, args, null, null);
         verify(recorder).recordAttribute(HbasePluginConstants.HBASE_CLIENT_PARAMS, "size: 1");
+        verify(recorder).recordApi(descriptor);
+        verify(recorder).recordException(null);
+    }
+
+    @Test
+    public void doTestHbaseTableName() throws Exception{
+
+        doReturn(new Configuration()).when(connection).getConfiguration();
+
+        Table target = new HTable(TableName.valueOf("test"), connection);
+
+        Object[] args = new Object[]{Collections.singletonList("test")};
+
+        HbaseTableMethodInterceptor interceptor = new HbaseTableMethodInterceptor(traceContext, descriptor, true, true);
+        interceptor.doInAfterTrace(recorder, target, args, null, null);
+        verify(recorder).recordAttribute(HbasePluginConstants.HBASE_TABLE_NAME, "test");
         verify(recorder).recordApi(descriptor);
         verify(recorder).recordException(null);
     }


### PR DESCRIPTION
Hbase tableName is very useful when we fast location the hbase problem. So we can record the tableName to the table trace.
![ppHbaseTableName](https://user-images.githubusercontent.com/20434652/127472777-9e37335e-9561-44cd-b4f8-14fa3bf5a2d3.png)

