### PR TITLE
[#8162] cache applications api on browser/server side

### DIFF
--- a/web/src/main/angular/src/app/core/components/application-list/application-list-data.service.ts
+++ b/web/src/main/angular/src/app/core/components/application-list/application-list-data.service.ts
@@ -15,8 +15,10 @@ export class ApplicationListDataService {
         private http: HttpClient,
     ) {}
 
-    getApplicationList(): Observable<IApplication[]> {
-        return this.http.get<IApplication[]>(this.url).pipe(
+    getApplicationList(force: boolean): Observable<IApplication[]> {
+        const options = force ? {params: {clearCache:'true', from: 'reload', _t: Date.now().toString()}} : {};
+
+        return this.http.get<IApplication[]>(this.url, options).pipe(
             // TODO: 워커적용?
             map((res: IApplication[]) => res.map(({applicationName, serviceType, code}) => new Application(applicationName, serviceType, code))),
         );

--- a/web/src/main/angular/src/app/shared/store/effects/application-list.effect.ts
+++ b/web/src/main/angular/src/app/shared/store/effects/application-list.effect.ts
@@ -15,7 +15,7 @@ export class ApplicationListEffect {
             ofType(getApplicationList),
             withLatestFrom(this.storeHelperService.getApplicationList()),
             filter(([{force}, appList]: [{force: boolean}, IApplication[]]) => force || isEmpty(appList)),
-            switchMap(() => this.applicationListDataService.getApplicationList().pipe(
+            switchMap(([{force}]: [{force: boolean}, IApplication[]]) => this.applicationListDataService.getApplicationList(force).pipe(
                 map((appList: IApplication[]) => getApplicationListSuccess(appList)),
                 catchError((error: IServerErrorFormat) => of(getApplicationListFail(error)))
             )),

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.java
@@ -16,23 +16,25 @@
 
 package com.navercorp.pinpoint.web.controller;
 
-import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.web.service.CacheService;
 import com.navercorp.pinpoint.web.service.CommonService;
+import com.navercorp.pinpoint.web.util.etag.ETag;
+import com.navercorp.pinpoint.web.util.etag.ETagUtils;
 import com.navercorp.pinpoint.web.view.ApplicationGroup;
 import com.navercorp.pinpoint.web.view.ServerTime;
+import com.navercorp.pinpoint.web.view.TagApplications;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Objects;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * @author emeroad
@@ -47,33 +49,87 @@ public class MainController {
 
     private final CacheService cacheService;
 
-    public MainController(CommonService commonService, CacheService cacheService) {
+    // Reserve key
+    private final String key = CacheService.DEFAULT_KEY;
+
+    public MainController(CommonService commonService,
+                          CacheService cacheService) {
         this.commonService = Objects.requireNonNull(commonService, "commonService");
         this.cacheService = Objects.requireNonNull(cacheService, "cacheService");
     }
 
     @GetMapping(value = "/applications")
     public ResponseEntity<ApplicationGroup> getApplicationGroup(
-            @RequestHeader(value = "If-None-Match", required = false) String eTag,
-            @RequestParam(value="clearCache", required = false) String clearCache
-    ) {
+            @RequestHeader(value = "If-None-Match", required = false) String eTagHeader,
+            @RequestParam(value = "clearCache", required = false) String clearCache) {
 
-        final boolean needClearCache = StringUtils.isEmpty(eTag) || clearCache != null;
-        if (needClearCache) {
-            cacheService.clearApplicationListCache();
+        final ETag eTag = ETagUtils.parseETag(eTagHeader);
+        if (needClearCache(eTag, clearCache)) {
+            cacheService.remove(key);
+        }
+
+        TagApplications cachedApplications;
+        if (eTag != null) {
+            logger.debug("eTag:{} ", eTag);
+
+            cachedApplications = cacheService.get(key);
+            if (cachedApplications != null) {
+                if (eTag.getTag().equals(cachedApplications.getTag())) {
+                    logger.debug("applicationList {} cache hit", key);
+                    return notModified();
+                } else {
+                    logger.debug("applicationList {} cache hit, ETag miss {}={}", key, clearCache, cachedApplications.getTag());
+                }
+            } else {
+                // ETag changed by another node.
+                logger.debug("applicationList {} cache miss", key);
+            }
         }
 
         List<Application> applicationList = commonService.selectAllApplicationNames();
         logger.debug("/applications size:{}", applicationList.size());
         logger.trace("/applications {}", applicationList);
 
-        final String newETag = cacheService.getApplicationListETag();
-        final boolean noUpdate = eTag != null && eTag.replace("\"", "").contentEquals(newETag);
-        if (noUpdate) {
-            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).contentLength(0L).build();
-        } else {
-            return ResponseEntity.ok().eTag(newETag).body(new ApplicationGroup(applicationList));
-        }
+
+        // Update atomicity between multiple nodes is not guaranteed
+        TagApplications tagApplications = wrapApplicationList(applicationList);
+
+        cacheService.put(key, tagApplications);
+
+        ETag newETag = new ETag(true, tagApplications.getTag());
+        logger.debug("eTag cache {} -> {}", eTag, newETag);
+
+        // force
+        // !etag.isWeak()
+        // if (cachedApplications.getApplicationList().equals(applicationList))
+        //
+        // weak
+        return ResponseEntity.ok()
+                .eTag(newETag.toString())
+                .body(new ApplicationGroup(applicationList));
+    }
+
+    private TagApplications wrapApplicationList(List<Application> applicationList) {
+        String tag = newTag(applicationList);
+        return new TagApplications(tag, applicationList);
+    }
+
+
+    private String newTag(List<Application> applicationList) {
+        // Precondition : If the application list of hbase is the same,
+        // ETag value of multiple web servers is also the same.
+        // need MD5 hash (128 bit)
+        return String.valueOf(applicationList.hashCode());
+    }
+
+    private ResponseEntity<ApplicationGroup> notModified() {
+        return ResponseEntity
+                .status(HttpStatus.NOT_MODIFIED)
+                .build();
+    }
+
+    private boolean needClearCache(ETag eTag, String clearCache) {
+        return eTag == null || clearCache != null;
     }
 
     @GetMapping(value = "/serverTime")

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.java
@@ -16,17 +16,23 @@
 
 package com.navercorp.pinpoint.web.controller;
 
+import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.web.service.CacheService;
 import com.navercorp.pinpoint.web.service.CommonService;
 import com.navercorp.pinpoint.web.view.ApplicationGroup;
 import com.navercorp.pinpoint.web.view.ServerTime;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Objects;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * @author emeroad
@@ -39,21 +45,40 @@ public class MainController {
 
     private final CommonService commonService;
 
-    public MainController(CommonService commonService) {
+    private final CacheService cacheService;
+
+    public MainController(CommonService commonService, CacheService cacheService) {
         this.commonService = Objects.requireNonNull(commonService, "commonService");
+        this.cacheService = Objects.requireNonNull(cacheService, "cacheService");
     }
 
     @GetMapping(value = "/applications")
-    public ApplicationGroup getApplicationGroup() {
+    public ResponseEntity<ApplicationGroup> getApplicationGroup(
+            @RequestHeader(value = "If-None-Match", required = false) String eTag,
+            @RequestParam(value="clearCache", required = false) String clearCache
+    ) {
+
+        final boolean needClearCache = StringUtils.isEmpty(eTag) || clearCache != null;
+        if (needClearCache) {
+            cacheService.clearApplicationListCache();
+        }
+
         List<Application> applicationList = commonService.selectAllApplicationNames();
         logger.debug("/applications size:{}", applicationList.size());
         logger.trace("/applications {}", applicationList);
 
-        return new ApplicationGroup(applicationList);
+        final String newETag = cacheService.getApplicationListETag();
+        final boolean noUpdate = eTag != null && eTag.replace("\"", "").contentEquals(newETag);
+        if (noUpdate) {
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).contentLength(0L).build();
+        } else {
+            return ResponseEntity.ok().eTag(newETag).body(new ApplicationGroup(applicationList));
+        }
     }
 
     @GetMapping(value = "/serverTime")
     public ServerTime getServerTime() {
         return new ServerTime();
     }
+
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CacheService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CacheService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.service;
+
+/**
+ * @author yjqg6666
+ */
+public interface CacheService {
+
+    String APPLICATION_LIST_CACHE_NAME = "applicationNameList";
+
+    String getApplicationListETag();
+
+    void clearApplicationListCache();
+
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CacheService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CacheService.java
@@ -16,15 +16,21 @@
 
 package com.navercorp.pinpoint.web.service;
 
+import com.navercorp.pinpoint.web.view.TagApplications;
+
 /**
  * @author yjqg6666
  */
 public interface CacheService {
 
+    String DEFAULT_KEY = "DEFAULT";
+
     String APPLICATION_LIST_CACHE_NAME = "applicationNameList";
 
-    String getApplicationListETag();
+    TagApplications get(String key);
 
-    void clearApplicationListCache();
+    void put(String key, TagApplications tagApplications);
+
+    void remove(String key);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CacheServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CacheServiceImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.service;
+
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Ehcache;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * @author yjqg6666
+ */
+@Service
+public class CacheServiceImpl implements CacheService {
+
+    private final EhCacheCacheManager cacheManager;
+
+    public CacheServiceImpl(EhCacheCacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    public String getApplicationListETag() {
+        final long cacheUpdateCount = this.getApplicationListUpdateCount();
+
+        return cacheUpdateCount > 0 ? APPLICATION_LIST_CACHE_NAME + "Ver" + cacheUpdateCount : UUID.randomUUID().toString();
+    }
+
+    public void clearApplicationListCache() {
+        getApplicationListCache().ifPresent(Ehcache::removeAll);
+    }
+
+    private long getApplicationListUpdateCount() {
+        return getApplicationListCache()
+                .map(ehcache -> ehcache.getStatistics().cachePutCount())
+                .orElse(0L);
+    }
+
+    private Optional<Ehcache> getApplicationListCache() {
+        final CacheManager cacheManager = this.cacheManager.getCacheManager();
+        if (cacheManager != null) {
+            return Optional.ofNullable(cacheManager.getEhcache(APPLICATION_LIST_CACHE_NAME));
+        }
+        return Optional.empty();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CommonServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CommonServiceImpl.java
@@ -19,7 +19,6 @@ package com.navercorp.pinpoint.web.service;
 import java.util.List;
 import java.util.Objects;
 
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
@@ -39,7 +38,6 @@ public class CommonServiceImpl implements CommonService {
     }
 
     @Override
-    @Cacheable(value=CacheService.APPLICATION_LIST_CACHE_NAME)
     public List<Application> selectAllApplicationNames() {
         return applicationIndexDao.selectAllApplicationNames();
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CommonServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CommonServiceImpl.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.web.service;
 import java.util.List;
 import java.util.Objects;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
@@ -26,6 +27,7 @@ import com.navercorp.pinpoint.web.vo.Application;
 
 /**
  * @author netspider
+ * @author yjqg6666
  */
 @Service
 public class CommonServiceImpl implements CommonService {
@@ -37,7 +39,9 @@ public class CommonServiceImpl implements CommonService {
     }
 
     @Override
+    @Cacheable(value=CacheService.APPLICATION_LIST_CACHE_NAME)
     public List<Application> selectAllApplicationNames() {
         return applicationIndexDao.selectAllApplicationNames();
     }
+
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/util/etag/ETag.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/util/etag/ETag.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.util.etag;
+
+import java.util.Objects;
+
+/**
+ * copy from io.undertow.util.ETag
+ */
+public class ETag {
+
+    private final boolean weak;
+    private final String tag;
+
+    public ETag(boolean weak, String tag) {
+        this.weak = weak;
+        this.tag = Objects.requireNonNull(tag, "etag");
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public boolean isWeak() {
+        return weak;
+    }
+
+    @Override
+    public String toString() {
+        if (weak) {
+            return "W/\"" + tag + "\"";
+        } else {
+            return "\"" + tag + "\"";
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/util/etag/ETagUtils.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/util/etag/ETagUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.util.etag;
+
+/**
+ * copy from io.undertow.util.ETagUtils
+ */
+public class ETagUtils {
+
+    private static final char COMMA = ',';
+    private static final char QUOTE = '"';
+    private static final char W = 'W';
+    private static final char SLASH = '/';
+
+    public static ETag parseETag(final String tag) {
+        if (tag == null) {
+            return null;
+        }
+        char[] headerChars = tag.toCharArray();
+        SearchingFor searchingFor = SearchingFor.START_OF_VALUE;
+        int valueStart = 0;
+        boolean weak = false;
+        boolean malformed = false;
+        for (int i = 0; i < headerChars.length; i++) {
+            switch (searchingFor) {
+                case START_OF_VALUE:
+                    if (headerChars[i] != COMMA && !Character.isWhitespace(headerChars[i])) {
+                        if (headerChars[i] == QUOTE) {
+                            valueStart = i + 1;
+                            searchingFor = SearchingFor.LAST_QUOTE;
+                            weak = false;
+                            malformed = false;
+                        } else if (headerChars[i] == W) {
+                            searchingFor = SearchingFor.WEAK_SLASH;
+                        }
+                    }
+                    break;
+                case WEAK_SLASH:
+                    if (headerChars[i] == QUOTE) {
+                        valueStart = i + 1;
+                        searchingFor = SearchingFor.LAST_QUOTE;
+                        weak = true;
+                        malformed = false;
+                    } else if (headerChars[i] != SLASH) {
+                        return null; //malformed
+                    }
+                    break;
+                case LAST_QUOTE:
+                    if (headerChars[i] == QUOTE) {
+                        String value = String.valueOf(headerChars, valueStart, i - valueStart);
+                        return new ETag(weak, value.trim());
+                    }
+                    break;
+                case END_OF_VALUE:
+                    if (headerChars[i] == COMMA || Character.isWhitespace(headerChars[i])) {
+                        if (!malformed) {
+                            String value = String.valueOf(headerChars, valueStart, i - valueStart);
+                            return new ETag(weak, value.trim());
+                        }
+                    }
+                    break;
+            }
+        }
+        if (searchingFor == SearchingFor.END_OF_VALUE || searchingFor == SearchingFor.LAST_QUOTE) {
+            if (!malformed) {
+                // Special case where we reached the end of the array containing the header values.
+                String value = String.valueOf(headerChars, valueStart, headerChars.length - valueStart);
+                return new ETag(weak, value.trim());
+            }
+        }
+
+        return null;
+    }
+
+    enum SearchingFor {
+        START_OF_VALUE, LAST_QUOTE, END_OF_VALUE, WEAK_SLASH;
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/TagApplications.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/TagApplications.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.view;
+
+import com.navercorp.pinpoint.web.vo.Application;
+
+import java.util.List;
+
+public class TagApplications {
+    private final String tag;
+    private final List<Application> applicationList;
+
+    public TagApplications(String tag, List<Application> applicationList) {
+        this.tag = tag;
+        this.applicationList = applicationList;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public List<Application> getApplicationList() {
+        return applicationList;
+    }
+}

--- a/web/src/main/resources/ehcache.xml
+++ b/web/src/main/resources/ehcache.xml
@@ -13,4 +13,11 @@
 		diskPersistent="false" diskExpiryThreadIntervalSeconds="120"
 		memoryStoreEvictionPolicy="LRU">
 	</cache>
+
+	<cache name="applicationNameList" maxElementsInMemory="10000" eternal="false"
+		   timeToIdleSeconds="0" timeToLiveSeconds="120" overflowToDisk="false"
+		   diskPersistent="false" diskExpiryThreadIntervalSeconds="120"
+		   memoryStoreEvictionPolicy="LRU">
+	</cache>
+
 </ehcache>

--- a/web/src/main/resources/ehcache.xml
+++ b/web/src/main/resources/ehcache.xml
@@ -15,8 +15,8 @@
 	</cache>
 
 	<cache name="applicationNameList" maxElementsInMemory="10000" eternal="false"
-		   timeToIdleSeconds="0" timeToLiveSeconds="120" overflowToDisk="false"
-		   diskPersistent="false" diskExpiryThreadIntervalSeconds="120"
+		   timeToIdleSeconds="0" timeToLiveSeconds="60" overflowToDisk="false"
+		   diskPersistent="false"
 		   memoryStoreEvictionPolicy="LRU">
 	</cache>
 

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -95,4 +95,4 @@ web.installation.downloadUrl=
 #web.security.auth.jwt.secretkey=PINPOINT_JWT_SECRET
 
 # cache application list in seconds
-web.applicationList.cacheTime=60
+web.applicationList.cacheTime=30

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -93,3 +93,6 @@ web.installation.downloadUrl=
 #web.security.auth.user=alice:foo, bob:bar
 #web.security.auth.admin=eve:baz
 #web.security.auth.jwt.secretkey=PINPOINT_JWT_SECRET
+
+# cache application list in seconds
+web.applicationList.cacheTime=60

--- a/web/src/main/resources/servlet-context-web.xml
+++ b/web/src/main/resources/servlet-context-web.xml
@@ -30,6 +30,11 @@
     <mvc:interceptors>
         <bean id="webContentInterceptor" class="org.springframework.web.servlet.mvc.WebContentInterceptor">
             <property name="cacheSeconds" value="0"/>
+            <property name="cacheMappings">
+                <props>
+                    <prop key="/applications.pinpoint">${web.applicationList.cacheTime:60}</prop>
+                </props>
+            </property>
         </bean>
         <mvc:interceptor>
             <mvc:mapping path="/admin/**"/>

--- a/web/src/test/http/.gitignore
+++ b/web/src/test/http/.gitignore
@@ -1,0 +1,1 @@
+http-client.private.env.json

--- a/web/src/test/http/applicationCache.http
+++ b/web/src/test/http/applicationCache.http
@@ -1,0 +1,2 @@
+###
+GET http://{{host}}/applications

--- a/web/src/test/http/http-client.env.json
+++ b/web/src/test/http/http-client.env.json
@@ -1,0 +1,5 @@
+{
+  "dev": {
+    "host": "localhost:8080"
+  }
+}

--- a/web/src/test/java/com/navercorp/pinpoint/web/util/etag/ETagUtilsTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/util/etag/ETagUtilsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.util.etag;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ETagUtilsTest {
+
+    @Test
+    public void parse_weak() {
+        ETag eTag = ETagUtils.parseETag("W/\"0815\"");
+        Assert.assertEquals("0815", eTag.getTag());
+        Assert.assertTrue(eTag.isWeak());
+    }
+
+    @Test
+    public void parse_string() {
+        ETag eTag = ETagUtils.parseETag("\"0815\"");
+        Assert.assertEquals("0815", eTag.getTag());
+        Assert.assertFalse(eTag.isWeak());
+    }
+}


### PR DESCRIPTION
Resolve #8162 

# Feature
By default, the application list would be cached by Ehcache for 120 seconds(configured in ehcache.xml) and be cached by browser  for 60 seconds (configured by web.applicationList.cacheTime in pinpoint-web-root.properties). If the request having no "If-Non-Match" header(when it's the first time to request or after expired browser cache time), ehcache would be evicted and retrieve data from hbase. The cache can also be clear by requesting {web_host}/applications.pinpoint?clearCache manually.
**The first time to request for a user, there would be no cache in use.**

You may let the web browser cache for a longer time by setting `-Dweb.applicationList.cacheTime` to a bigger value (in seconds). The following request would get "304 Not Modified response header" and no response body. The browser would use previously cached data.

![image](https://user-images.githubusercontent.com/1879641/131119178-57c25cc8-9374-444e-99cc-f1b93456b412.png)

In the above picture:
1. no cache on the browser & server sides.
2. cache on the browser side.
3. cache on the server side only and no application list data to transfer.


# Verification
```
# request for the first time or with expired cache
$ curl 'http://localhost:8080/applications.pinpoint' -D-   

# request with eTag returned by the previous response eTag header value
$ curl 'http://localhost:8080/applications.pinpoint' -D- -H 'If-None-Match: "applicationNameListVer1"'  

# clear server cached list
$ curl 'http://localhost:8080/applications.pinpoint?clearCache' -D-

```


