### PR TITLE
[#8166] disable sampling flag header can be ignored

### DIFF
--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/DefaultTraceHeaderReader.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/DefaultTraceHeaderReader.java
@@ -33,10 +33,12 @@ public class DefaultTraceHeaderReader<T> implements TraceHeaderReader<T> {
     private final boolean isDebug = logger.isDebugEnabled();
 
     private final RequestAdaptor<T> requestAdaptor;
+    private final boolean ignoreDisableSamplingFlag;
 
 
-    public DefaultTraceHeaderReader(RequestAdaptor<T> requestAdaptor) {
+    public DefaultTraceHeaderReader(RequestAdaptor<T> requestAdaptor, boolean ignoreDisableSamplingFlag) {
         this.requestAdaptor = Objects.requireNonNull(requestAdaptor, "requestAdaptor");
+        this.ignoreDisableSamplingFlag = ignoreDisableSamplingFlag;
     }
 
     // Read the transaction information from the request.
@@ -46,7 +48,7 @@ public class DefaultTraceHeaderReader<T> implements TraceHeaderReader<T> {
 
         // Check sampling flag from client. If the flag is false, do not sample this request.
         final boolean sampling = samplingEnable(request);
-        if (!sampling) {
+        if (!sampling && !ignoreDisableSamplingFlag) {
             return DisableTraceHeader.INSTANCE;
         }
 

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/RequestTraceReader.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/RequestTraceReader.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.bootstrap.plugin.request;
 
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.context.TraceId;
@@ -47,9 +48,12 @@ public class RequestTraceReader<T> {
     public RequestTraceReader(final TraceContext traceContext, RequestAdaptor<T> requestAdaptor, final boolean async) {
         this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
         this.requestAdaptor = Objects.requireNonNull(requestAdaptor, "requestAdaptor");
-         this.traceHeaderReader = new DefaultTraceHeaderReader<T>(requestAdaptor);
+
+        final ProfilerConfig profilerConfig = traceContext.getProfilerConfig();
+        final boolean ignoreDisableSamplingFlag = profilerConfig.readBoolean("profiler.sampling.ignoreDisableSamplingFlag", false);
+        this.traceHeaderReader = new DefaultTraceHeaderReader<T>(requestAdaptor, ignoreDisableSamplingFlag);
         this.async = async;
-        String applicationNamespace = traceContext.getProfilerConfig().getApplicationNamespace();
+        String applicationNamespace = profilerConfig.getApplicationNamespace();
         this.nameSpaceChecker = NameSpaceCheckFactory.newNamespace(requestAdaptor, applicationNamespace);
     }
 


### PR DESCRIPTION
Resolve #8166.

This feature is off by default, can be enabled  by setting profiler.sampling.ignoreDisableSamplingFlag=true.