### PR TITLE
[#8171] agent boot logger level can be configured

### DIFF
--- a/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/BootLogLevel.java
+++ b/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/BootLogLevel.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.navercorp.pinpoint.bootstrap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author yjqg6666
+ */
+enum BootLogLevel {
+
+    ERROR(40, "ERROR"),
+    WARN(30, "WARN"),
+    INFO(20, "INFO"),
+    DEBUG(10, "DEBUG"),
+    TRACE(0, "TRACE");
+
+    private static final Map<String, BootLogLevel> labelMap = new HashMap<>(5);
+
+    private static final Map<Integer, BootLogLevel> valueMap = new HashMap<>(5);
+
+    static {
+        setup();
+    }
+
+    private final int value;
+
+    private final String label;
+
+    BootLogLevel(int value, String label) {
+        this.label = label;
+        this.value = value;
+    }
+
+    public static BootLogLevel of(String label) {
+        return label != null ? labelMap.get(label.toUpperCase()) : null;
+    }
+
+    public static BootLogLevel of(int value) {
+        return valueMap.get(value);
+    }
+
+    public boolean logTrace() {
+        return checkLevel(TRACE);
+    }
+
+    public boolean logDebug() {
+        return checkLevel(DEBUG);
+    }
+
+    public boolean logInfo() {
+        return checkLevel(INFO);
+    }
+
+    public boolean logWarn() {
+        return checkLevel(WARN);
+    }
+
+    public boolean logError() {
+        return checkLevel(ERROR);
+    }
+
+    private boolean checkLevel(BootLogLevel check) {
+        return check.value >= this.value;
+    }
+
+    private static void setup() {
+        for (BootLogLevel i : values()) {
+            labelMap.put(i.label, i);
+            valueMap.put(i.value, i);
+        }
+    }
+
+}

--- a/bootstraps/bootstrap/src/test/java/com/navercorp/pinpoint/bootstrap/BootLogLevelTest.java
+++ b/bootstraps/bootstrap/src/test/java/com/navercorp/pinpoint/bootstrap/BootLogLevelTest.java
@@ -1,0 +1,72 @@
+package com.navercorp.pinpoint.bootstrap;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class BootLogLevelTest {
+
+    private static final BootLogLevel TRACE = BootLogLevel.TRACE;
+    private static final BootLogLevel DEBUG = BootLogLevel.DEBUG;
+    private static final BootLogLevel INFO = BootLogLevel.INFO;
+    private static final BootLogLevel WARN = BootLogLevel.WARN;
+    private static final BootLogLevel ERROR = BootLogLevel.ERROR;
+
+    @Test
+    public void of() {
+        assertEquals("trace", TRACE, BootLogLevel.of("trace"));
+        assertEquals("debug", DEBUG, BootLogLevel.of("debug"));
+        assertEquals("info", INFO, BootLogLevel.of("info"));
+        assertEquals("warn", WARN, BootLogLevel.of("warn"));
+        assertEquals("error", ERROR, BootLogLevel.of("error"));
+        assertNull("invalid", BootLogLevel.of("notExist"));
+    }
+
+    @Test
+    public void logTrace() {
+        assertTrue("trace", TRACE.logTrace());
+        assertFalse("debug", DEBUG.logTrace());
+        assertFalse("info", INFO.logTrace());
+        assertFalse("warn", WARN.logTrace());
+        assertFalse("error", ERROR.logTrace());
+    }
+
+    @Test
+    public void logDebug() {
+        assertTrue("trace", TRACE.logDebug());
+        assertTrue("debug", DEBUG.logDebug());
+        assertFalse("info", INFO.logDebug());
+        assertFalse("warn", WARN.logDebug());
+        assertFalse("error", ERROR.logDebug());
+    }
+
+    @Test
+    public void logInfo() {
+        assertTrue("trace", TRACE.logInfo());
+        assertTrue("debug", DEBUG.logInfo());
+        assertTrue("info", INFO.logInfo());
+        assertFalse("warn", WARN.logInfo());
+        assertFalse("error", ERROR.logInfo());
+    }
+
+    @Test
+    public void logWarn() {
+        assertTrue("trace", TRACE.logWarn());
+        assertTrue("debug", DEBUG.logWarn());
+        assertTrue("info", INFO.logWarn());
+        assertTrue("warn", WARN.logWarn());
+        assertFalse("error", ERROR.logWarn());
+    }
+
+    @Test
+    public void logError() {
+        assertTrue("trace", TRACE.logError());
+        assertTrue("debug", DEBUG.logError());
+        assertTrue("info", INFO.logError());
+        assertTrue("warn", WARN.logError());
+        assertTrue("error", ERROR.logError());
+    }
+}


### PR DESCRIPTION
Resolve #8171.

Agent boot logger level can be configured  by

>  -Dpinpoint.agent.bootlogger.loglevel=debug

Supported boot logger levels(case-insensitive) are:

- trace
- debug
- info
- warn
- error
