### PR TITLE
[#8222] replace logger pattern automatically

### DIFF
--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -991,15 +991,39 @@ profiler.reactor.trace.schedule.periodically=false
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
+# replace logger pattern automatically
+# %message, $msg or %m would be replace with "TxId:%X{PtxId} %msg"
+# in the search config, put the longest/longer variable first.
+# variables/aliases: https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html
+#profiler.log4j.logging.pattern.replace.enable=false
+#profiler.log4j.logging.pattern.replace.search=%m
+#profiler.log4j.logging.pattern.replace.with="TxId:%X{PtxId} %m"
+
 ###########################################################
 # log4j2 (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j2.logging.transactioninfo=false
 
+# replace logger pattern automatically
+# %message, $msg or %m would be replace with "TxId:%X{PtxId} %msg"
+# in the search config, put the longest/longer variable first.
+# variables/aliases: https://logging.apache.org/log4j/2.x/manual/layouts.html under section "Patterns"
+#profiler.log4j2.logging.pattern.replace.enable=false
+#profiler.log4j2.logging.pattern.replace.search=%message,%msg,%m
+#profiler.log4j2.logging.pattern.replace.with="TxId:%X{PtxId} %msg"
+
 ###########################################################
 # logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
+
+# replace logger pattern automatically
+# %message, $msg or %m would be replace with "TxId:%X{PtxId} %msg"
+# in the search config, put the longest/longer variable first.
+# variables/aliases: https://github.com/qos-ch/logback/blob/master/logback-classic/src/main/java/ch/qos/logback/classic/PatternLayout.java#L54-L149
+#profiler.logback.logging.pattern.replace.enable=false
+#profiler.logback.logging.pattern.replace.search=%message,%msg,%m
+#profiler.logback.logging.pattern.replace.with="TxId:%X{PtxId} %msg"
 
 ###########################################################
 # google httpclient 

--- a/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/plugin/log4j/Log4jIT.java
+++ b/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/plugin/log4j/Log4jIT.java
@@ -16,6 +16,8 @@
 package com.navercorp.pinpoint.plugin.log4j;
 
 import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.pluginit.utils.PluginITConstants;
+import com.navercorp.pinpoint.pluginit.utils.StdoutRecorder;
 import com.navercorp.pinpoint.test.plugin.ImportPlugin;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import org.apache.log4j.Logger;
@@ -28,16 +30,16 @@ import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
-@Dependency({"log4j:log4j:[1.2.16,)"})
+@Dependency({"log4j:log4j:[1.2.16,)", PluginITConstants.VERSION})
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-log4j-plugin"})
 @PinpointConfig("pinpoint-spring-bean-test.config")
 public class Log4jIT {
+
+    private Logger logger;
 
     @Test
     public void test() {
@@ -51,22 +53,19 @@ public class Log4jIT {
     }
 
     @Test
-    public void patternUpdate() throws IOException {
-        final PrintStream originalOut = System.out;
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
+    public void patternUpdate() {
         final String msg = "pattern";
-        Logger logger;
-        try {
-            System.setOut(new PrintStream(outputStream));
-            logger = Logger.getLogger("patternUpdateLogback");
-            logger.error(msg);
-        } finally {
-            System.setOut(originalOut);
-        }
 
-        final String log = outputStream.toString();
-        outputStream.close();
+
+        StdoutRecorder stdoutRecorder = new StdoutRecorder();
+        final String log = stdoutRecorder.record(new Runnable() {
+            @Override
+            public void run() {
+                logger = Logger.getLogger("patternUpdateLogback");
+                logger.error(msg);
+            }
+        });
+
         System.out.println(log);
         Assert.assertNotNull("log null", log);
         Assert.assertTrue("contains msg", log.contains(msg));

--- a/plugins-it/log4j-it/src/test/resources/log4j.properties
+++ b/plugins-it/log4j-it/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.consoleAppender.layout.ConversionPattern=[%t] %-5p %c %x - %m%n

--- a/plugins-it/log4j-it/src/test/resources/pinpoint-spring-bean-test.config
+++ b/plugins-it/log4j-it/src/test/resources/pinpoint-spring-bean-test.config
@@ -340,6 +340,9 @@ profiler.spring.beans.mark.error=false
 # log4j
 ###########################################################
 profiler.log4j.logging.transactioninfo=true
+profiler.log4j.logging.pattern.replace.enable=true
+profiler.log4j.logging.pattern.replace.search=%m
+profiler.log4j.logging.pattern.replace.with=TxId:%X{PtxId} %m
 
 ###########################################################
 # log4j2

--- a/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
+++ b/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
@@ -28,17 +28,23 @@ import org.junit.runner.RunWith;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("pinpoint-spring-bean-test.config")
-@JvmArgument("-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
 @JvmVersion(7)
 @Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)", "com.lmax:disruptor:[3.4.2]"})
-public class Log4j2ForAsyncLoggerIT {
+@JvmArgument({"-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector", "-DtestLoggerEnable=false"})
+public class Log4j2ForAsyncLoggerIT extends Log4j2TestBase {
 
     @Test
     public void test() {
         Logger logger = LogManager.getLogger();
-        logger.error("for log4j2 plugin async logger test");
 
-        Assert.assertNotNull(ThreadContext.get("PtxId"));
-        Assert.assertNotNull(ThreadContext.get("PspanId"));
+        final String location = getLoggerJarLocation(logger);
+        final String testVersion = getTestVersion();
+        System.out.println("Log4j2 jar location:" + location);
+        Assert.assertTrue("test version is not " + getTestVersion(), location.contains("/" + testVersion + "/"));
+
+        logger.error("for log4j2 plugin async logger test");
+        Assert.assertNotNull("txId", ThreadContext.get("PtxId"));
+        Assert.assertNotNull("spanId", ThreadContext.get("PspanId"));
     }
+
 }

--- a/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
+++ b/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
@@ -30,14 +30,20 @@ import org.junit.runner.RunWith;
 @JvmVersion(7)
 @Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)"})
 @JvmArgument("-DtestLoggerEnable=false")
-public class Log4j2IT {
+public class Log4j2IT extends Log4j2TestBase {
 
     @Test
     public void test() {
         Logger logger = LogManager.getLogger();
-        logger.error("for log4j2 plugin test");
 
-        Assert.assertNotNull(ThreadContext.get("PtxId"));
-        Assert.assertNotNull(ThreadContext.get("PspanId"));
+        final String location = getLoggerJarLocation(logger);
+        System.out.println("Log4j2 jar location:" + location);
+        final String testVersion = getTestVersion();
+        Assert.assertTrue("test version is not " + getTestVersion(), location.contains("/" + testVersion + "/"));
+
+        logger.error("for log4j2 plugin test");
+        Assert.assertNotNull("txId", ThreadContext.get("PtxId"));
+        Assert.assertNotNull("spanId", ThreadContext.get("PspanId"));
     }
+
 }

--- a/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2PatternIT.java
+++ b/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2PatternIT.java
@@ -16,6 +16,8 @@
 package com.navercorp.pinpoint.plugin.log4j2;
 
 import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.pluginit.utils.PluginITConstants;
+import com.navercorp.pinpoint.pluginit.utils.StdoutRecorder;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.JvmVersion;
@@ -28,36 +30,29 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("pinpoint-spring-bean-test.config")
 @JvmVersion(7)
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.8,2.13)"})
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.8,2.13)", PluginITConstants.VERSION})
 @JvmArgument("-DtestLoggerEnable=false")
 public class Log4j2PatternIT extends Log4j2TestBase {
 
+    private String location;
     @Test
-    public void patternUpdate() throws IOException {
-        final PrintStream originalOut = System.out;
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    public void patternUpdate() {
         final String msg = "pattern";
 
-        String location;
-        try {
-            System.setOut(new PrintStream(outputStream));
-            Logger logger = LogManager.getLogger("patternUpdateLog4j2Jvm7");
-            logger.error(msg);
-            location = getLoggerJarLocation(logger);
-        } finally {
-            System.setOut(originalOut);
-        }
+        StdoutRecorder stdoutRecorder = new StdoutRecorder();
+        String log = stdoutRecorder.record(new Runnable() {
+            @Override
+            public void run() {
+                Logger logger = LogManager.getLogger("patternUpdateLog4j2Jvm7");
+                logger.error(msg);
+                location = getLoggerJarLocation(logger);
+            }
+        });
 
-        final String log = outputStream.toString();
-        outputStream.close();
         System.out.println(log);
         Assert.assertNotNull("log null", log);
         Assert.assertTrue("contains msg", log.contains(msg));

--- a/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2TestBase.java
+++ b/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2TestBase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.log4j2;
+
+/**
+ * @author yjqg6666
+ */
+public class Log4j2TestBase {
+
+    public String getTestVersion() {
+        final String[] threadInfo = Thread.currentThread().getName()
+                .replace(getClass().getName(), "")
+                .replace(" Thread", "")
+                .replace(" ", "").replace("log4j-core-", "").split(":");
+        return threadInfo[0];
+    }
+
+    public String getLoggerJarLocation(Object object) {
+        return object.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
+    }
+
+}

--- a/plugins-it/log4j2-it/src/test/resources/pinpoint-spring-bean-test.config
+++ b/plugins-it/log4j2-it/src/test/resources/pinpoint-spring-bean-test.config
@@ -345,6 +345,9 @@ profiler.log4j.logging.transactioninfo=true
 # log4j2
 ###########################################################
 profiler.log4j2.logging.transactioninfo=true
+profiler.log4j2.logging.pattern.replace.enable=true
+profiler.log4j2.logging.pattern.replace.search=%message,%msg,%m
+profiler.log4j2.logging.pattern.replace.with=TxId:%X{PtxId} %msg
 
 ###########################################################
 # logback

--- a/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
+++ b/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
@@ -28,18 +28,24 @@ import org.junit.runner.RunWith;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("pinpoint-spring-bean-test.config")
-@JvmArgument("-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
 @JvmVersion(8)
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-log4j2-plugin"})
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)", "com.lmax:disruptor:[3.4.2]"})
-public class Log4j2ForAsyncLoggerIT {
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.14.1]", "com.lmax:disruptor:[3.4.2]"})
+@JvmArgument({"-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector", "-DtestLoggerEnable=false"})
+public class Log4j2ForAsyncLoggerIT extends Log4j2TestBase {
 
     @Test
     public void test() {
         Logger logger = LogManager.getLogger();
-        logger.error("for log4j2 plugin async logger test");
 
-        Assert.assertNotNull(ThreadContext.get("PtxId"));
-        Assert.assertNotNull(ThreadContext.get("PspanId"));
+        final String location = getLoggerJarLocation(logger);
+        System.out.println("Log4j2 jar location:" + location);
+        final String testVersion = getTestVersion();
+        Assert.assertTrue("test version is not " + getTestVersion(), location.contains("/" + testVersion + "/"));
+
+        logger.error("for log4j2 plugin async logger test");
+        Assert.assertNotNull("txId", ThreadContext.get("PtxId"));
+        Assert.assertNotNull("spanId", ThreadContext.get("PspanId"));
     }
+
 }

--- a/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
+++ b/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
@@ -29,16 +29,22 @@ import org.junit.runner.RunWith;
 @PinpointConfig("pinpoint-spring-bean-test.config")
 @JvmVersion(8)
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-log4j2-plugin"})
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)"})
-//@Dependency({"org.apache.logging.log4j:log4j-core:[2.9.0]"})
-public class Log4j2IT {
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.14.1]"})
+@JvmArgument("-DtestLoggerEnable=false")
+public class Log4j2IT extends Log4j2TestBase {
 
     @Test
     public void test() {
         Logger logger = LogManager.getLogger();
-        logger.error("for log4j2 plugin test");
 
-        Assert.assertNotNull(ThreadContext.get("PtxId"));
-        Assert.assertNotNull(ThreadContext.get("PspanId"));
+        final String location = getLoggerJarLocation(logger);
+        System.out.println("Log4j2 jar location:" + location);
+        final String testVersion = getTestVersion();
+        Assert.assertTrue("test version is not " + getTestVersion(), location.contains("/" + testVersion + "/"));
+
+        logger.error("for log4j2 plugin test");
+        Assert.assertNotNull("txId", ThreadContext.get("PtxId"));
+        Assert.assertNotNull("spanId", ThreadContext.get("PspanId"));
     }
+
 }

--- a/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2PatternIT.java
+++ b/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2PatternIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 NAVER Corp.
+ * Copyright 2021 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.navercorp.pinpoint.plugin.logback;
+package com.navercorp.pinpoint.plugin.log4j2;
 
 import com.navercorp.pinpoint.pluginit.utils.AgentPath;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.ImportPlugin;
 import com.navercorp.pinpoint.test.plugin.JvmArgument;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -35,34 +35,25 @@ import java.io.PrintStream;
 
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
-@Dependency({"ch.qos.logback:logback-classic:[1.0.13],[1.1.0,1.1.11],[1.2.0,1.2.6]", "org.slf4j:slf4j-api:1.7.12"})
-@ImportPlugin({"com.navercorp.pinpoint:pinpoint-logback-plugin"})
 @PinpointConfig("pinpoint-spring-bean-test.config")
+@JvmVersion(8)
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-log4j2-plugin"})
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.8,2.14.1]"})
 @JvmArgument("-DtestLoggerEnable=false")
-public class LogbackIT {
-
-    @Test
-    public void test() {
-        Logger logger = LoggerFactory.getLogger(getClass());
-        logger.error("maru");
-
-        checkVersion(logger);
-        
-        Assert.assertNotNull("txId", MDC.get("PtxId"));
-        Assert.assertNotNull("spanId", MDC.get("PspanId"));
-    }
+public class Log4j2PatternIT extends Log4j2TestBase {
 
     @Test
     public void patternUpdate() throws IOException {
         final PrintStream originalOut = System.out;
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
         final String msg = "pattern";
-        Logger logger;
+
+        String location;
         try {
             System.setOut(new PrintStream(outputStream));
-            logger = LoggerFactory.getLogger("patternUpdateLogback");
+            Logger logger = LogManager.getLogger("patternUpdateLog4j2Jvm8");
             logger.error(msg);
+            location = getLoggerJarLocation(logger);
         } finally {
             System.setOut(originalOut);
         }
@@ -74,29 +65,10 @@ public class LogbackIT {
         Assert.assertTrue("contains msg", log.contains(msg));
         Assert.assertTrue("contains TxId", log.contains("TxId"));
 
-        Assert.assertNotNull("logger null", logger);
-        checkVersion(logger);
-    }
-
-    private void checkVersion(Logger logger) {
-        final String location = getLoggerJarLocation(logger);
         Assert.assertNotNull("location null", location);
-        System.out.println("Logback classic jar location:" + location);
-
+        System.out.println("Log4j2 jar location:" + location);
         final String testVersion = getTestVersion();
         Assert.assertTrue("test version is not " + getTestVersion(), location.contains("/" + testVersion + "/"));
-    }
-
-    private String getTestVersion() {
-        final String[] threadInfo = Thread.currentThread().getName()
-                .replace(getClass().getName(), "")
-                .replace(" Thread", "")
-                .replace(" ", "").replace("logback-classic-", "").split(":");
-        return threadInfo[0];
-    }
-
-    private String getLoggerJarLocation(Object object) {
-        return object.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
     }
 
 }

--- a/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2PatternIT.java
+++ b/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2PatternIT.java
@@ -16,6 +16,7 @@
 package com.navercorp.pinpoint.plugin.log4j2;
 
 import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.pluginit.utils.StdoutRecorder;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.ImportPlugin;
 import com.navercorp.pinpoint.test.plugin.JvmArgument;
@@ -29,9 +30,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
 
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
@@ -41,25 +39,21 @@ import java.io.PrintStream;
 @Dependency({"org.apache.logging.log4j:log4j-core:[2.8,2.14.1]"})
 @JvmArgument("-DtestLoggerEnable=false")
 public class Log4j2PatternIT extends Log4j2TestBase {
-
+    private String location;
     @Test
-    public void patternUpdate() throws IOException {
-        final PrintStream originalOut = System.out;
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    public void patternUpdate() {
         final String msg = "pattern";
 
-        String location;
-        try {
-            System.setOut(new PrintStream(outputStream));
-            Logger logger = LogManager.getLogger("patternUpdateLog4j2Jvm8");
-            logger.error(msg);
-            location = getLoggerJarLocation(logger);
-        } finally {
-            System.setOut(originalOut);
-        }
+        StdoutRecorder stdoutRecorder = new StdoutRecorder();
+        String log = stdoutRecorder.record(new Runnable() {
+            @Override
+            public void run() {
+                Logger logger = LogManager.getLogger("patternUpdateLog4j2Jvm8");
+                logger.error(msg);
+                location = getLoggerJarLocation(logger);
+            }
+        });
 
-        final String log = outputStream.toString();
-        outputStream.close();
         System.out.println(log);
         Assert.assertNotNull("log null", log);
         Assert.assertTrue("contains msg", log.contains(msg));

--- a/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2TestBase.java
+++ b/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2TestBase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.log4j2;
+
+/**
+ * @author yjqg6666
+ */
+public class Log4j2TestBase {
+
+    public String getTestVersion() {
+        final String[] threadInfo = Thread.currentThread().getName()
+                .replace(getClass().getName(), "")
+                .replace(" Thread", "")
+                .replace(" ", "").replace("log4j-core-", "").split(":");
+        return threadInfo[0];
+    }
+
+    public String getLoggerJarLocation(Object object) {
+        return object.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
+    }
+
+}

--- a/plugins-it/log4j2-jdk8-it/src/test/resources/pinpoint-spring-bean-test.config
+++ b/plugins-it/log4j2-jdk8-it/src/test/resources/pinpoint-spring-bean-test.config
@@ -345,6 +345,9 @@ profiler.log4j.logging.transactioninfo=true
 # log4j2
 ###########################################################
 profiler.log4j2.logging.transactioninfo=true
+profiler.log4j2.logging.pattern.replace.enable=true
+profiler.log4j2.logging.pattern.replace.search=%message,%msg,%m
+profiler.log4j2.logging.pattern.replace.with=TxId:%X{PtxId} %msg
 
 ###########################################################
 # logback

--- a/plugins-it/logback-it/src/test/resources/logback.xml
+++ b/plugins-it/logback-it/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="60 seconds" debug="false">
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%p] [%t] %c -- %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="stdout"/>
+    </root>
+
+</configuration>

--- a/plugins-it/logback-it/src/test/resources/pinpoint-spring-bean-test.config
+++ b/plugins-it/logback-it/src/test/resources/pinpoint-spring-bean-test.config
@@ -350,6 +350,9 @@ profiler.log4j2.logging.transactioninfo=true
 # logback
 ###########################################################
 profiler.logback.logging.transactioninfo=true
+profiler.logback.logging.pattern.replace.enable=true
+profiler.logback.logging.pattern.replace.search=%message,%msg,%m
+profiler.logback.logging.pattern.replace.with=TxId:%X{PtxId} %msg
 
 ###########################################################
 # gson

--- a/plugins-it/plugins-it-utils/src/main/java/com/navercorp/pinpoint/pluginit/utils/StdoutRecorder.java
+++ b/plugins-it/plugins-it-utils/src/main/java/com/navercorp/pinpoint/pluginit/utils/StdoutRecorder.java
@@ -1,0 +1,31 @@
+package com.navercorp.pinpoint.pluginit.utils;
+
+import com.navercorp.pinpoint.common.util.IOUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.Objects;
+
+public class StdoutRecorder {
+
+    public String record(Runnable runnable) {
+        Objects.requireNonNull(runnable, "runnable");
+
+        final PrintStream originalOut = System.out;
+
+        final OutputStream stream = new ByteArrayOutputStream();
+        final PrintStream printStream = new PrintStream(stream);
+
+        System.setOut(printStream);
+        try {
+            runnable.run();
+            return stream.toString();
+        } finally {
+            System.setOut(originalOut);
+            IOUtils.closeQuietly(printStream);
+            IOUtils.closeQuietly(stream);
+        }
+    }
+
+}

--- a/plugins/log4j/src/main/java/com/navercorp/pinpoint/plugin/log4j/Log4jConfig.java
+++ b/plugins/log4j/src/main/java/com/navercorp/pinpoint/plugin/log4j/Log4jConfig.java
@@ -15,28 +15,62 @@
 package com.navercorp.pinpoint.plugin.log4j;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+import java.util.List;
 
 /**
  * @author Minwoo Jung
- *
  */
 public class Log4jConfig {
     public static final String LOG4J_LOGGING_TRANSACTION_INFO = "profiler.log4j.logging.transactioninfo";
 
     private final boolean log4jLoggingTransactionInfo;
 
+    private static final String LOGGING_PATTERN_REPLACE_ENABLE = "profiler.log4j.logging.pattern.replace.enable";
+    private static final String LOGGING_PATTERN_REPLACE_SEARCH = "profiler.log4j.logging.pattern.replace.search";
+    private static final String LOGGING_PATTERN_REPLACE_WITH = "profiler.log4j.logging.pattern.replace.with";
+
+    private final boolean patternReplaceEnable;
+    private final List<String> patternReplaceSearchList;
+    private final String patternReplaceWith;
+
 
     public Log4jConfig(ProfilerConfig config) {
         this.log4jLoggingTransactionInfo = config.readBoolean(LOG4J_LOGGING_TRANSACTION_INFO, false);
+
+        this.patternReplaceSearchList = config.readList(LOGGING_PATTERN_REPLACE_SEARCH);
+        this.patternReplaceWith = config.readString(LOGGING_PATTERN_REPLACE_WITH, "");
+        boolean configEnabled = config.readBoolean(LOGGING_PATTERN_REPLACE_ENABLE, false);
+        boolean configOk = !CollectionUtils.isEmpty(patternReplaceSearchList) && StringUtils.hasText(patternReplaceWith);
+        this.patternReplaceEnable = configEnabled && configOk;
     }
-    
+
     public boolean isLog4jLoggingTransactionInfo() {
         return log4jLoggingTransactionInfo;
     }
 
+    public boolean isPatternReplaceEnable() {
+        return patternReplaceEnable;
+    }
+
+    public List<String> getPatternReplaceSearchList() {
+        return patternReplaceSearchList;
+    }
+
+    public String getPatternReplaceWith() {
+        return patternReplaceWith;
+    }
+
     @Override
     public String toString() {
-        return "Log4jConfig [ log4jLoggingTransactionInfo=" + log4jLoggingTransactionInfo + "]";
+        return "Log4jConfig{" +
+                "log4jLoggingTransactionInfo=" + log4jLoggingTransactionInfo +
+                ", patternReplaceEnable=" + patternReplaceEnable +
+                ", patternReplaceSearchList=" + patternReplaceSearchList +
+                ", patternReplaceWith='" + patternReplaceWith + '\'' +
+                '}';
     }
 
 }

--- a/plugins/log4j/src/main/java/com/navercorp/pinpoint/plugin/log4j/interceptor/PatternLayoutInterceptor.java
+++ b/plugins/log4j/src/main/java/com/navercorp/pinpoint/plugin/log4j/interceptor/PatternLayoutInterceptor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.log4j.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor1;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.plugin.log4j.Log4jConfig;
+import org.apache.log4j.PatternLayout;
+
+import java.util.List;
+
+/**
+ * @author yjqg6666
+ */
+public class PatternLayoutInterceptor implements AroundInterceptor1 {
+
+    private static final String PATTERN_TRANSACTION_ID = "%X{PtxId}";
+
+    private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+    private final boolean debug = logger.isDebugEnabled();
+
+    private final Log4jConfig config;
+
+    public PatternLayoutInterceptor(TraceContext traceContext) {
+        this.config = new Log4jConfig(traceContext.getProfilerConfig());
+    }
+
+    @Override
+    public void before(Object target, Object arg0) {
+    }
+
+    @Override
+    public void after(Object target, Object arg0, Object result, Throwable throwable) {
+        if (!(arg0 instanceof String)) {
+            return;
+        }
+        String oldPattern = (String) arg0;
+        if (oldPattern.contains(PATTERN_TRANSACTION_ID)) {
+            if (debug) {
+                logger.debug("Log4j pattern already have pinpoint pattern, pattern:" + oldPattern);
+            }
+            return;
+        }
+        updatePattern(target, oldPattern, config.getPatternReplaceSearchList(), config.getPatternReplaceWith());
+    }
+
+    private void updatePattern(Object target, String oldPattern, List<String> searchList, String replace) {
+        if (!(target instanceof PatternLayout)) {
+            return;
+        }
+        String newPattern = oldPattern;
+        boolean changed = false;
+        for (String search : searchList) {
+            newPattern = oldPattern.replace(search, replace);
+            if (!oldPattern.contentEquals(newPattern)) {
+                changed = true;
+                if (debug) {
+                    logger.debug("Log4j pattern replaced, old pattern(" + oldPattern + ") and new pattern(" +
+                            newPattern + ").");
+                }
+                break;
+            }
+        }
+        if (changed) {
+            final PatternLayout layout = (PatternLayout) target;
+            layout.setConversionPattern(newPattern);
+        }
+    }
+
+}

--- a/plugins/log4j/src/main/java/com/navercorp/pinpoint/plugin/log4j/interceptor/PatternLayoutInterceptor.java
+++ b/plugins/log4j/src/main/java/com/navercorp/pinpoint/plugin/log4j/interceptor/PatternLayoutInterceptor.java
@@ -70,8 +70,7 @@ public class PatternLayoutInterceptor implements AroundInterceptor1 {
             if (!oldPattern.contentEquals(newPattern)) {
                 changed = true;
                 if (debug) {
-                    logger.debug("Log4j pattern replaced, old pattern(" + oldPattern + ") and new pattern(" +
-                            newPattern + ").");
+                    logger.debug("Log4j pattern replaced, old pattern({}) and new pattern({}).", oldPattern, newPattern);
                 }
                 break;
             }

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
@@ -17,6 +17,10 @@
 package com.navercorp.pinpoint.plugin.log4j2;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+import java.util.List;
 
 /**
  * @author https://github.com/licoco/pinpoint
@@ -25,20 +29,51 @@ public class Log4j2Config {
     public static final String LOG4J2_LOGGING_TRANSACTION_INFO = "profiler.log4j2.logging.transactioninfo";
     public static final String REUSABLELOGEVENTFACTORY_SCOPE = "reusableLogEventFactoryScope";
 
+    private static final String LOGGING_PATTERN_REPLACE_ENABLE = "profiler.log4j2.logging.pattern.replace.enable";
+    private static final String LOGGING_PATTERN_REPLACE_SEARCH = "profiler.log4j2.logging.pattern.replace.search";
+    private static final String LOGGING_PATTERN_REPLACE_WITH = "profiler.log4j2.logging.pattern.replace.with";
+
     private final boolean log4j2LoggingTransactionInfo;
+
+    private final boolean patternReplaceEnable;
+    private final List<String> patternReplaceSearchList;
+    private final String patternReplaceWith;
 
 
     public Log4j2Config(ProfilerConfig config) {
         this.log4j2LoggingTransactionInfo = config.readBoolean(LOG4J2_LOGGING_TRANSACTION_INFO, false);
+
+        this.patternReplaceSearchList = config.readList(LOGGING_PATTERN_REPLACE_SEARCH);
+        this.patternReplaceWith = config.readString(LOGGING_PATTERN_REPLACE_WITH, "");
+        boolean configEnabled = config.readBoolean(LOGGING_PATTERN_REPLACE_ENABLE, false);
+        boolean configOk = !CollectionUtils.isEmpty(patternReplaceSearchList) && StringUtils.hasText(patternReplaceWith);
+        this.patternReplaceEnable = configEnabled && configOk;
     }
 
     public boolean isLog4j2LoggingTransactionInfo() {
         return log4j2LoggingTransactionInfo;
     }
 
+    public boolean isPatternReplaceEnable() {
+        return patternReplaceEnable;
+    }
+
+    public List<String> getPatternReplaceSearchList() {
+        return patternReplaceSearchList;
+    }
+
+    public String getPatternReplaceWith() {
+        return patternReplaceWith;
+    }
+
     @Override
     public String toString() {
-        return "Log4j2Config [ log4j2LoggingTransactionInfo=" + log4j2LoggingTransactionInfo + "]";
+        return "Log4j2Config{" +
+                "log4j2LoggingTransactionInfo=" + log4j2LoggingTransactionInfo +
+                ", patternReplaceEnable=" + patternReplaceEnable +
+                ", patternReplaceSearchList=" + patternReplaceSearchList +
+                ", patternReplaceWith='" + patternReplaceWith + '\'' +
+                '}';
     }
 
 }

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Plugin.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Plugin.java
@@ -30,11 +30,13 @@ import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
 import com.navercorp.pinpoint.plugin.log4j2.interceptor.LogEventFactoryInterceptor;
+import com.navercorp.pinpoint.plugin.log4j2.interceptor.PatternLayoutInterceptor;
 
 import java.security.ProtectionDomain;
 
 /**
  * @author https://github.com/licoco/pinpoint
+ * @author yjqg6666
  */
 public class Log4j2Plugin implements ProfilerPlugin, TransformTemplateAware {
 
@@ -60,6 +62,10 @@ public class Log4j2Plugin implements ProfilerPlugin, TransformTemplateAware {
 
         //for case : Making All Loggers Asynchronous
         transformTemplate.transform("org.apache.logging.log4j.core.async.RingBufferLogEventTranslator", RingBufferLogEventTranslatorTransform.class);
+
+        if (config.isPatternReplaceEnable()) {
+            transformTemplate.transform("org.apache.logging.log4j.core.layout.PatternLayout$SerializerBuilder", LoggingPatternTransform.class);
+        }
 
     }
 
@@ -155,6 +161,20 @@ public class Log4j2Plugin implements ProfilerPlugin, TransformTemplateAware {
             }
 
             return true;
+        }
+    }
+
+    public static class LoggingPatternTransform implements TransformCallback {
+
+        @Override
+        public byte[] doInTransform(Instrumentor instrumentor, ClassLoader classLoader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
+            InstrumentClass target = instrumentor.getInstrumentClass(classLoader, className, classfileBuffer);
+            InstrumentMethod setPattern = target.getDeclaredMethod("setPattern", "java.lang.String");
+            if (setPattern == null) {
+                return null;
+            }
+            setPattern.addScopedInterceptor(PatternLayoutInterceptor.class, "ModifyPattern");
+            return target.toBytecode();
         }
     }
 

--- a/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/interceptor/PatternLayoutInterceptor.java
+++ b/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/interceptor/PatternLayoutInterceptor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.log4j2.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor1;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.plugin.log4j2.Log4j2Config;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import java.util.List;
+
+/**
+ * @author yjqg6666
+ */
+public class PatternLayoutInterceptor implements AroundInterceptor1 {
+
+    private static final String PATTERN_TRANSACTION_ID = "%X{PtxId}";
+
+    private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+    private final boolean debug = logger.isDebugEnabled();
+
+    private final Log4j2Config config;
+
+    public PatternLayoutInterceptor(TraceContext traceContext) {
+        this.config = new Log4j2Config(traceContext.getProfilerConfig());
+    }
+
+    @Override
+    public void before(Object target, Object arg0) {
+    }
+
+    @Override
+    public void after(Object target, Object arg0, Object result, Throwable throwable) {
+        if (!(arg0 instanceof String)) {
+            return;
+        }
+        String oldPattern = (String) arg0;
+        if (oldPattern.contains(PATTERN_TRANSACTION_ID)) {
+            if (debug) {
+                logger.debug("Log4j2 pattern already have pinpoint pattern, pattern:" + oldPattern);
+            }
+            return;
+        }
+        updatePattern(target, oldPattern, config.getPatternReplaceSearchList(), config.getPatternReplaceWith());
+    }
+
+    private void updatePattern(Object target, String oldPattern, List<String> searchList, String replace) {
+        if (!(target instanceof PatternLayout.SerializerBuilder)) {
+            return;
+        }
+        String newPattern = oldPattern;
+        boolean changed = false;
+        for (String search : searchList) {
+            newPattern = oldPattern.replace(search, replace);
+            if (!oldPattern.contentEquals(newPattern)) {
+                changed = true;
+                if (debug) {
+                    logger.debug("Log4j2 pattern replaced, old pattern(" + oldPattern + ") and new pattern(" +
+                            newPattern + ").");
+                }
+                break;
+            }
+        }
+        if (changed) {
+            PatternLayout.SerializerBuilder builder = (PatternLayout.SerializerBuilder) target;
+            builder.setPattern(newPattern);
+        }
+    }
+
+}

--- a/plugins/logback/pom.xml
+++ b/plugins/logback/pom.xml
@@ -23,5 +23,11 @@
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.2.5</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/plugins/logback/src/main/java/com/navercorp/pinpoint/plugin/logback/LogbackConfig.java
+++ b/plugins/logback/src/main/java/com/navercorp/pinpoint/plugin/logback/LogbackConfig.java
@@ -15,28 +15,63 @@
 package com.navercorp.pinpoint.plugin.logback;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+import java.util.List;
 
 /**
  * @author Minwoo Jung
  *
  */
 public class LogbackConfig {
-    public static final String LOGBACK_LOGGING_TRANSACTION_INFO = "profiler.logback.logging.transactioninfo";
+
+    private static final String LOGBACK_LOGGING_TRANSACTION_INFO = "profiler.logback.logging.transactioninfo";
+
+    private static final String LOGBACK_LOGGING_PATTERN_REPLACE_ENABLE = "profiler.logback.logging.pattern.replace.enable";
+    private static final String LOGBACK_LOGGING_PATTERN_REPLACE_SEARCH = "profiler.logback.logging.pattern.replace.search";
+    private static final String LOGBACK_LOGGING_PATTERN_REPLACE_WITH = "profiler.logback.logging.pattern.replace.with";
 
     private final boolean logbackLoggingTransactionInfo;
+
+    private final boolean patternReplaceEnable;
+    private final List<String> patternReplaceSearchList;
+    private final String patternReplaceWith;
 
 
     public LogbackConfig(ProfilerConfig config) {
         this.logbackLoggingTransactionInfo = config.readBoolean(LOGBACK_LOGGING_TRANSACTION_INFO, false);
+
+        this.patternReplaceSearchList = config.readList(LOGBACK_LOGGING_PATTERN_REPLACE_SEARCH);
+        this.patternReplaceWith = config.readString(LOGBACK_LOGGING_PATTERN_REPLACE_WITH, "");
+        boolean configEnabled = config.readBoolean(LOGBACK_LOGGING_PATTERN_REPLACE_ENABLE, false);
+        boolean configOk = !CollectionUtils.isEmpty(patternReplaceSearchList) && StringUtils.hasText(patternReplaceWith);
+        this.patternReplaceEnable = configEnabled && configOk;
     }
     
     public boolean isLogbackLoggingTransactionInfo() {
         return logbackLoggingTransactionInfo;
     }
 
-    @Override
-    public String toString() {
-        return "LogbackConfig [ logbackLoggingTransactionInfo=" + logbackLoggingTransactionInfo + "]";
+    public boolean isPatternReplaceEnable() {
+        return patternReplaceEnable;
     }
 
+    public List<String> getPatternReplaceSearchList() {
+        return patternReplaceSearchList;
+    }
+
+    public String getPatternReplaceWith() {
+        return patternReplaceWith;
+    }
+
+    @Override
+    public String toString() {
+        return "LogbackConfig{" +
+                "logbackLoggingTransactionInfo=" + logbackLoggingTransactionInfo +
+                ", patternReplaceEnable=" + patternReplaceEnable +
+                ", patternReplaceSearchList=" + patternReplaceSearchList +
+                ", patternReplaceWith='" + patternReplaceWith + '\'' +
+                '}';
+    }
 }

--- a/plugins/logback/src/main/java/com/navercorp/pinpoint/plugin/logback/interceptor/PatternLayoutInterceptor.java
+++ b/plugins/logback/src/main/java/com/navercorp/pinpoint/plugin/logback/interceptor/PatternLayoutInterceptor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.logback.interceptor;
+
+import ch.qos.logback.core.pattern.PatternLayoutBase;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor1;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.plugin.logback.LogbackConfig;
+
+import java.util.List;
+
+/**
+ * @author yjqg6666
+ */
+public class PatternLayoutInterceptor implements AroundInterceptor1 {
+
+    private static final String PATTERN_TRANSACTION_ID = "%X{PtxId}";
+
+    private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+    private final boolean debug = logger.isDebugEnabled();
+
+    private final LogbackConfig logbackConfig;
+
+    public PatternLayoutInterceptor(TraceContext traceContext) {
+        this.logbackConfig = new LogbackConfig(traceContext.getProfilerConfig());
+    }
+
+    @Override
+    public void before(Object target, Object arg0) {
+    }
+
+    @Override
+    public void after(Object target, Object arg0, Object result, Throwable throwable) {
+        if (!(arg0 instanceof String)) {
+            return;
+        }
+        String oldPattern = (String) arg0;
+        if (oldPattern.contains(PATTERN_TRANSACTION_ID)) {
+            if (debug) {
+                logger.debug("Logback pattern already have pinpoint pattern, pattern:" + oldPattern);
+            }
+            return;
+        }
+        updatePattern(target, oldPattern, logbackConfig.getPatternReplaceSearchList(), logbackConfig.getPatternReplaceWith());
+    }
+
+    private void updatePattern(Object target, String oldPattern, List<String> searchList, String replace) {
+        if (!(target instanceof PatternLayoutBase<?>)) {
+            return;
+        }
+        String newPattern = oldPattern;
+        boolean changed = false;
+        for (String search : searchList) {
+            newPattern = oldPattern.replace(search, replace);
+            if (!oldPattern.contentEquals(newPattern)) {
+                changed = true;
+                if (debug) {
+                    logger.debug("Logback pattern replaced, old pattern(" + oldPattern + ") and new pattern(" +
+                            newPattern + ").");
+                }
+                break;
+            }
+        }
+        if (changed) {
+            final PatternLayoutBase<?> patternLayout = (PatternLayoutBase<?>) target;
+            patternLayout.setPattern(newPattern);
+        }
+    }
+
+}

--- a/testcase/src/main/resources/log4j2-test.xml
+++ b/testcase/src/main/resources/log4j2-test.xml
@@ -6,7 +6,7 @@
     </Properties>
 
     <Appenders>
-        <Console name="console" target="system_out">
+        <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="${file_message_pattern}"/>
         </Console>
     </Appenders>


### PR DESCRIPTION
Resolve #8222 and #8246.
Related to #8217.

# feature
If you are using logback as the logger, the config is:
> profiler.logback.logging.pattern.replace.enable=true
> profiler.logback.logging.pattern.replace.search=%message,%msg,%m
> profiler.logback.logging.pattern.replace.with="TxId:%X{PtxId} %msg"

and the original logger pattern is:

> %d{yyyy-MM-dd HH:mm:ss} [%p] [%t] %c -- %m%n

then the logger pattern would be updated automatically(no modification to application manually) to:
> %d{yyyy-MM-dd HH:mm:ss} [%p] [%t] %c -- TxId:%X{PtxId} %msg%n

# task

- [x] logback support
- [x] log4j support
- [x] log4j2 support (since version 2.8)
- [x] update/fix plugin-it

# reference
* logback variables/aliases: https://github.com/qos-ch/logback/blob/master/logback-classic/src/main/java/ch/qos/logback/classic/PatternLayout.java#L54-L149
* log4j2 variables/aliases: https://logging.apache.org/log4j/2.x/manual/layouts.html under section "Patterns"
* log4j variables: https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html