### PR TITLE
[#8246] fix log4j2 plugin-it

### DIFF
--- a/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
+++ b/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
@@ -28,17 +28,23 @@ import org.junit.runner.RunWith;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("pinpoint-spring-bean-test.config")
-@JvmArgument("-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
 @JvmVersion(7)
 @Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)", "com.lmax:disruptor:[3.4.2]"})
-public class Log4j2ForAsyncLoggerIT {
+@JvmArgument({"-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector", "-DtestLoggerEnable=false"})
+public class Log4j2ForAsyncLoggerIT extends Log4j2TestBase {
 
     @Test
     public void test() {
         Logger logger = LogManager.getLogger();
-        logger.error("for log4j2 plugin async logger test");
 
-        Assert.assertNotNull(ThreadContext.get("PtxId"));
-        Assert.assertNotNull(ThreadContext.get("PspanId"));
+        final String location = getLoggerJarLocation(logger);
+        final String testVersion = getTestVersion();
+        System.out.println("Log4j2 jar location:" + location);
+        Assert.assertTrue("test version is not " + getTestVersion(), location.contains("/" + testVersion + "/"));
+
+        logger.error("for log4j2 plugin async logger test");
+        Assert.assertNotNull("txId", ThreadContext.get("PtxId"));
+        Assert.assertNotNull("spanId", ThreadContext.get("PspanId"));
     }
+
 }

--- a/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
+++ b/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
@@ -30,14 +30,20 @@ import org.junit.runner.RunWith;
 @JvmVersion(7)
 @Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)"})
 @JvmArgument("-DtestLoggerEnable=false")
-public class Log4j2IT {
+public class Log4j2IT extends Log4j2TestBase {
 
     @Test
     public void test() {
         Logger logger = LogManager.getLogger();
-        logger.error("for log4j2 plugin test");
 
-        Assert.assertNotNull(ThreadContext.get("PtxId"));
-        Assert.assertNotNull(ThreadContext.get("PspanId"));
+        final String location = getLoggerJarLocation(logger);
+        System.out.println("Log4j2 jar location:" + location);
+        final String testVersion = getTestVersion();
+        Assert.assertTrue("test version is not " + getTestVersion(), location.contains("/" + testVersion + "/"));
+
+        logger.error("for log4j2 plugin test");
+        Assert.assertNotNull("txId", ThreadContext.get("PtxId"));
+        Assert.assertNotNull("spanId", ThreadContext.get("PspanId"));
     }
+
 }

--- a/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2TestBase.java
+++ b/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2TestBase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.log4j2;
+
+/**
+ * @author yjqg6666
+ */
+public class Log4j2TestBase {
+
+    public String getTestVersion() {
+        final String[] threadInfo = Thread.currentThread().getName()
+                .replace(getClass().getName(), "")
+                .replace(" Thread", "")
+                .replace(" ", "").replace("log4j-core-", "").split(":");
+        return threadInfo[0];
+    }
+
+    public String getLoggerJarLocation(Object object) {
+        return object.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
+    }
+
+}

--- a/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
+++ b/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2ForAsyncLoggerIT.java
@@ -28,18 +28,24 @@ import org.junit.runner.RunWith;
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
 @PinpointConfig("pinpoint-spring-bean-test.config")
-@JvmArgument("-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
 @JvmVersion(8)
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-log4j2-plugin"})
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)", "com.lmax:disruptor:[3.4.2]"})
-public class Log4j2ForAsyncLoggerIT {
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.14.1]", "com.lmax:disruptor:[3.4.2]"})
+@JvmArgument({"-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector", "-DtestLoggerEnable=false"})
+public class Log4j2ForAsyncLoggerIT extends Log4j2TestBase {
 
     @Test
     public void test() {
         Logger logger = LogManager.getLogger();
-        logger.error("for log4j2 plugin async logger test");
 
-        Assert.assertNotNull(ThreadContext.get("PtxId"));
-        Assert.assertNotNull(ThreadContext.get("PspanId"));
+        final String location = getLoggerJarLocation(logger);
+        System.out.println("Log4j2 jar location:" + location);
+        final String testVersion = getTestVersion();
+        Assert.assertTrue("test version is not " + getTestVersion(), location.contains("/" + testVersion + "/"));
+
+        logger.error("for log4j2 plugin async logger test");
+        Assert.assertNotNull("txId", ThreadContext.get("PtxId"));
+        Assert.assertNotNull("spanId", ThreadContext.get("PspanId"));
     }
+
 }

--- a/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
+++ b/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2IT.java
@@ -29,16 +29,22 @@ import org.junit.runner.RunWith;
 @PinpointConfig("pinpoint-spring-bean-test.config")
 @JvmVersion(8)
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-log4j2-plugin"})
-@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.13)"})
-//@Dependency({"org.apache.logging.log4j:log4j-core:[2.9.0]"})
-public class Log4j2IT {
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.0,2.14.1]"})
+@JvmArgument("-DtestLoggerEnable=false")
+public class Log4j2IT extends Log4j2TestBase {
 
     @Test
     public void test() {
         Logger logger = LogManager.getLogger();
-        logger.error("for log4j2 plugin test");
 
-        Assert.assertNotNull(ThreadContext.get("PtxId"));
-        Assert.assertNotNull(ThreadContext.get("PspanId"));
+        final String location = getLoggerJarLocation(logger);
+        System.out.println("Log4j2 jar location:" + location);
+        final String testVersion = getTestVersion();
+        Assert.assertTrue("test version is not " + getTestVersion(), location.contains("/" + testVersion + "/"));
+
+        logger.error("for log4j2 plugin test");
+        Assert.assertNotNull("txId", ThreadContext.get("PtxId"));
+        Assert.assertNotNull("spanId", ThreadContext.get("PspanId"));
     }
+
 }

--- a/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2TestBase.java
+++ b/plugins-it/log4j2-jdk8-it/src/test/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2TestBase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.log4j2;
+
+/**
+ * @author yjqg6666
+ */
+public class Log4j2TestBase {
+
+    public String getTestVersion() {
+        final String[] threadInfo = Thread.currentThread().getName()
+                .replace(getClass().getName(), "")
+                .replace(" Thread", "")
+                .replace(" ", "").replace("log4j-core-", "").split(":");
+        return threadInfo[0];
+    }
+
+    public String getLoggerJarLocation(Object object) {
+        return object.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
+    }
+
+}

--- a/testcase/src/main/resources/log4j2-test.xml
+++ b/testcase/src/main/resources/log4j2-test.xml
@@ -6,7 +6,7 @@
     </Properties>
 
     <Appenders>
-        <Console name="console" target="system_out">
+        <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="${file_message_pattern}"/>
         </Console>
     </Appenders>


### PR DESCRIPTION
Resolve #8246.

This PR also fix another error caused by log4j2-test.xml config.

>   Caused by: java.lang.IllegalArgumentException: No enum constant
>    org.apache.logging.log4j.core.appender.ConsoleAppender.Target.system_out
>        at java.lang.Enum.valueOf(Enum.java:238)
>        at org.apache.logging.log4j.core.appender.ConsoleAppender$Target.valueOf(ConsoleAppender.java:57)
