### PR TITLE
[#8159] fix failed jdk-plugin-it

### DIFF
--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -218,7 +218,7 @@ profiler.http.record.request.cookies=
 # record HTTP response headers case-sensitive
 # set to HEADERS-ALL to record all of the headers.
 # e.g. profiler.http.record.response.headers=Set-Cookie
-profiler.http.record.response.headers=Connection
+#profiler.http.record.response.headers=
 
 ###########################################################
 # application type                                        # 


### PR DESCRIPTION
Related issue #8159 #7962. A continuation to PR #8161.

Update com.navercorp.pinpoint.plugin.jdk.http.HttpURLConnectionIT#testConnectTwice test.