### PR TITLE
[#8263] kafka message tagging and filtering by tag(s)

### DIFF
--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -1154,6 +1154,20 @@ profiler.kafka.consumer.entryPoint=
 # you should disable kafka header(set the following config to false) if your kafka broker version is 0.11+ but the log.message.format.version is overridden by a lower version than 0.11 (e.g. 0.10) which can not be automatically detected.
 #profiler.kafka.header.enable=true
 
+# If the kafa header is enabled and add kafka tag(a header with list value) to message
+# the tags value can be one or more comma-joined list(eg. gray,cityA), empty to disable
+#pinpoint.kafka.producer.tags=
+# filter consumer records as the following strategy:
+#   1. If a message have one or more tags, and on the consumer side
+#       1.1. if no tag filtering, include the message.
+#       1.2. if tag filtering enabled, but no common tag(s), exclude/filter out the message.
+#       1.3. if tag filtering enabled and have common tag(s), include the message.
+#   2. If a message have no tags, and on the consumer side
+#       2.1. if no tag filtering, include the message.
+#       2.2. if tag filtering enabled, exclude/filter out the message.
+# the tags value can be one or more comma-joined list(eg. gray,cityA), empty to disable
+#pinpoint.kafka.consumer.filter.tags=
+
 ###########################################################
 # Hbase (Reliability and stability can not be guaranteed)
 ###########################################################

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -1153,6 +1153,20 @@ profiler.kafka.consumer.entryPoint=
 # you should disable kafka header(set the following config to false) if your kafka broker version is 0.11+ but the log.message.format.version is overridden by a lower version than 0.11 (e.g. 0.10) which can not be automatically detected.
 #profiler.kafka.header.enable=true
 
+# If the kafa header is enabled and add kafka tag(a header with list value) to message
+# the tags value can be one or more comma-joined list(eg. gray,cityA), empty to disable
+#pinpoint.kafka.producer.tags=
+# filter consumer records as the following strategy:
+#   1. If a message have one or more tags, and on the consumer side
+#       1.1. if no tag filtering, include the message.
+#       1.2. if tag filtering enabled, but no common tag(s), exclude/filter out the message.
+#       1.3. if tag filtering enabled and have common tag(s), include the message.
+#   2. If a message have no tags, and on the consumer side
+#       2.1. if no tag filtering, include the message.
+#       2.2. if tag filtering enabled, exclude/filter out the message.
+# the tags value can be one or more comma-joined list(eg. gray,cityA), empty to disable
+#pinpoint.kafka.consumer.filter.tags=
+
 ###########################################################
 # Hbase (Reliability and stability can not be guaranteed)
 ###########################################################

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/Header.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/Header.java
@@ -32,6 +32,7 @@ public enum Header {
     HTTP_PARENT_APPLICATION_NAME("Pinpoint-pAppName"),
     HTTP_PARENT_APPLICATION_TYPE("Pinpoint-pAppType"),
     HTTP_PARENT_APPLICATION_NAMESPACE("Pinpoint-pAppNamespace"),
+    HTTP_TAGS("Pinpoint-Tags"),
     HTTP_HOST("Pinpoint-Host");
 
     public static final String FILTER_PATTERN_PREFIX = "Pinpoint-";

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaClientUtils.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaClientUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+/**
+ * @author yjqg6666
+ */
+public class KafkaClientUtils {
+
+    private static final boolean clientSupportHeader;
+
+    static {
+        clientSupportHeader = clientSupportHeaders();
+    }
+
+    public static boolean isClientSupportHeader() {
+        return clientSupportHeader;
+    }
+
+    private static boolean clientSupportHeaders() {
+        try {
+            ConsumerRecord.class.getMethod("headers");
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+        return true;
+    }
+
+
+}

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfig.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfig.java
@@ -18,6 +18,8 @@ package com.navercorp.pinpoint.plugin.kafka;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 
+import java.util.List;
+
 public class KafkaConfig {
 
     public static final String HEADER_ENABLE = "profiler.kafka.header.enable";
@@ -28,12 +30,16 @@ public class KafkaConfig {
     static final String CONSUMER_ENTRY_POINT = "profiler.kafka.consumer.entryPoint";
 
     static final String SPRING_CONSUMER_ENABLE = "profiler.springkafka.consumer.enable";
+    private static final String PRODUCER_TAGS = "pinpoint.kafka.producer.tags";
+    static final String CONSUMER_FILTER_TAGS = "pinpoint.kafka.consumer.filter.tags";
 
     private final boolean producerEnable;
     private final boolean consumerEnable;
     private final boolean springConsumerEnable;
     private final boolean headerEnable;
     private final String kafkaEntryPoint;
+    private final String producerTags;
+    private final List<String> consumerFilterTagList;
 
     public KafkaConfig(ProfilerConfig config) {
         this.producerEnable = config.readBoolean(PRODUCER_ENABLE, false);
@@ -41,6 +47,8 @@ public class KafkaConfig {
         this.springConsumerEnable = config.readBoolean(SPRING_CONSUMER_ENABLE, false);
         this.headerEnable = config.readBoolean(KafkaConfig.HEADER_ENABLE, true);
         this.kafkaEntryPoint = config.readString(CONSUMER_ENTRY_POINT, "");
+        this.producerTags = config.readString(PRODUCER_TAGS, "");
+        this.consumerFilterTagList = config.readList(CONSUMER_FILTER_TAGS);
     }
 
     public boolean isProducerEnable() {
@@ -63,6 +71,14 @@ public class KafkaConfig {
         return kafkaEntryPoint;
     }
 
+    public String getProducerTags() {
+        return producerTags;
+    }
+
+    public List<String> getConsumerFilterTagList() {
+        return consumerFilterTagList;
+    }
+
     @Override
     public String toString() {
         return "KafkaConfig{" +
@@ -71,6 +87,8 @@ public class KafkaConfig {
                 ", springConsumerEnable=" + springConsumerEnable +
                 ", headerEnable=" + headerEnable +
                 ", kafkaEntryPoint='" + kafkaEntryPoint + '\'' +
+                ", producerTags='" + producerTags + '\'' +
+                ", consumerFilterTagList=" + consumerFilterTagList +
                 '}';
     }
 }

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerRecordsInterceptor.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerRecordsInterceptor.java
@@ -16,24 +16,42 @@
 
 package com.navercorp.pinpoint.plugin.kafka.interceptor;
 
+import com.navercorp.pinpoint.bootstrap.context.Header;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
 import com.navercorp.pinpoint.common.util.ArrayUtils;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.plugin.kafka.KafkaClientUtils;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConfig;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConstants;
 import com.navercorp.pinpoint.plugin.kafka.field.accessor.EndPointFieldAccessor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
  * @author Taejin Koo
+ * @author yjqg6666
  */
 public class ConsumerRecordsInterceptor implements AroundInterceptor {
 
     private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
     private final boolean isDebug = logger.isDebugEnabled();
+    private final List<String> filterTagList;
+    private final boolean recordSupportHeaders;
+    private static final String NULL_KEY = "NULL";
+
+    public ConsumerRecordsInterceptor(TraceContext traceContext) {
+        KafkaConfig config = new KafkaConfig(traceContext.getProfilerConfig());
+        this.filterTagList = config.getConsumerFilterTagList();
+        this.recordSupportHeaders = KafkaClientUtils.isClientSupportHeader();
+    }
 
     @Override
     public void before(Object target, Object[] args) {
@@ -75,6 +93,10 @@ public class ConsumerRecordsInterceptor implements AroundInterceptor {
                 }
             }
         }
+        if (recordSupportHeaders) {
+            //noinspection unchecked
+            filterConsumerRecords(consumerRecordsMap);
+        }
     }
 
     private String getEndPoint(Object endPointFieldAccessor) {
@@ -83,6 +105,83 @@ public class ConsumerRecordsInterceptor implements AroundInterceptor {
         }
 
         return null;
+    }
+
+    /**
+     * filter consumer records as the following strategy:
+     * <ul>
+     *   <li>1. If a message have one or more tags, and on the consumer side
+     *      <ul>
+     *          <li>1.1. if no tag filtering, include the message.</li>
+     *          <li>1.2. if tag filtering enabled, but no common tag(s), exclude/filter out the message.</li>
+     *          <li>1.3. if tag filtering enabled and have common tag(s), include the message.</li>
+     *      </ul>
+     *   </li>
+     *   <li>2. If a message have no tags, and on the consumer side
+     *      <ul>
+     *          <li>2.1. if no tag filtering, include the message.</li>
+     *          <li>2.2. if tag filtering enabled, exclude/filter out the message.</li>
+     *      </ul>
+     *   </li>
+     * </ul>
+     * @param records consumer records map used to construct ConsumerRecords
+     */
+    private void filterConsumerRecords(Map<Object, Object> records) {
+        final boolean emptyCheckTagList = CollectionUtils.isEmpty(filterTagList);
+        for (Map.Entry<Object, Object> entry : records.entrySet()) {
+            final Object value = entry.getValue();
+            if (value instanceof List) {
+                final List<?> recordList = (List<?>) value;
+                List<Object> newList = new ArrayList<>(recordList.size());
+                boolean changed = false;
+                for (Object lKey : recordList) {
+                    if (lKey instanceof ConsumerRecord) {
+                        ConsumerRecord<?, ?> consumerRecord = (ConsumerRecord<?, ?>) lKey;
+                        final org.apache.kafka.common.header.Headers headers = consumerRecord.headers();
+
+                        final org.apache.kafka.common.header.Header tagHeader = headers.lastHeader(Header.HTTP_TAGS.toString());
+                        if (tagHeader == null) {
+                            if (emptyCheckTagList) {
+                                newList.add(consumerRecord); //case 2.2, include message
+                            } else {
+                                logFilter(consumerRecord, true, 21, null);
+                                changed = true; //case 2.1, exclude message
+                            }
+                            continue;
+                        }
+                        final String headerValue = new String(tagHeader.value(), KafkaConstants.DEFAULT_PINPOINT_HEADER_CHARSET);
+                        final List<String> currentTagList = StringUtils.tokenizeToStringList(headerValue, ",");
+                        if (emptyCheckTagList && !CollectionUtils.isEmpty(currentTagList)) {
+                            logFilter(consumerRecord, false, 11, headerValue);
+                            newList.add(consumerRecord); //case 1.1, include message
+                        }
+                        currentTagList.retainAll(filterTagList);
+                        if (!currentTagList.isEmpty()) {
+                            logFilter(consumerRecord, false, 13, headerValue);
+                            newList.add(consumerRecord); //case 1.3, include message
+                        } else {
+                            logFilter(consumerRecord, true, 12, headerValue);
+                            changed = true; //case 1.2, exclude message
+                        }
+                    }
+                }
+                if (changed) {
+                    entry.setValue(newList);
+                }
+            }
+        }
+    }
+
+    private void logFilter(ConsumerRecord<?, ?> consumerRecord, boolean excluded, int type, String tags) {
+        if (!logger.isDebugEnabled()) {
+            return;
+        }
+        final String topic = consumerRecord.topic();
+        final int partition = consumerRecord.partition();
+        final Object key = consumerRecord.key();
+        final String keyStr = key != null ? key.toString() : NULL_KEY;
+        final long offset = consumerRecord.offset();
+        logger.debug("Kafka message received, filtered:{}, case:{}, topic:{}, partition:{}, offset:{}, key:{}, tags:{}", excluded, type, topic, partition, offset, keyStr, tags);
     }
 
 }

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfigTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfigTest.java
@@ -28,6 +28,16 @@ import java.util.Properties;
  */
 public class KafkaConfigTest {
 
+    public static final String HEADER_ENABLE = KafkaConfig.HEADER_ENABLE;
+
+    public static final String PRODUCER_ENABLE = KafkaConfig.PRODUCER_ENABLE;
+
+    public static final String CONSUMER_ENABLE = KafkaConfig.CONSUMER_ENABLE;
+
+    public static final String SPRING_CONSUMER_ENABLE = KafkaConfig.SPRING_CONSUMER_ENABLE;
+
+    public static final String CONSUMER_FILTER_TAGS = KafkaConfig.CONSUMER_FILTER_TAGS;
+
     @Test
     public void configTest1() throws Exception {
         KafkaConfig config = createConfig("true", "true", "entryPoint");

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerRecordsInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerRecordsInterceptorTest.java
@@ -1,0 +1,232 @@
+package com.navercorp.pinpoint.plugin.kafka.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConfig;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConfigTest;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConstants;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.mockito.Mockito.doReturn;
+
+/**
+ * @author yjqg6666
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerRecordsInterceptorTest {
+
+    private static final String TOPIC1 = "topic-test1";
+
+    private static final String TOPIC2 = "topic-test2";
+
+    @Mock
+    private TraceContext traceContext;
+
+    @Mock
+    private ProfilerConfig profilerConfig;
+
+    @Before
+    public void setup() {
+        doReturn(true).when(profilerConfig).readBoolean(KafkaConfigTest.PRODUCER_ENABLE, false);
+        doReturn(true).when(profilerConfig).readBoolean(KafkaConfigTest.CONSUMER_ENABLE, false);
+        doReturn(true).when(profilerConfig).readBoolean(KafkaConfigTest.SPRING_CONSUMER_ENABLE, false);
+        doReturn(profilerConfig).when(traceContext).getProfilerConfig();
+    }
+
+    @Test
+    public void enabled() {
+        doReturn(true).when(profilerConfig).readBoolean(KafkaConfigTest.HEADER_ENABLE, true);
+        KafkaConfig config = new KafkaConfig(profilerConfig);
+        Assert.assertTrue("producer", config.isProducerEnable());
+        Assert.assertTrue("consumer", config.isConsumerEnable());
+        Assert.assertTrue("spring consumer", config.isSpringConsumerEnable());
+
+        Assert.assertTrue("header enabled", config.isHeaderEnable());
+    }
+
+
+    /**
+     * test case: 2.1
+     */
+    @Test
+    public void consumeNoTagRecordNoFilter() {
+        doReturn(Collections.emptyList()).when(profilerConfig).readList(KafkaConfigTest.CONSUMER_FILTER_TAGS);
+        final int randomCount = new Random().nextInt(100) + 1;
+        Assert.assertEquals("left count", randomCount, interceptRecordWithoutTagGotLeft(randomCount));
+    }
+
+    /**
+     * test case: 2.2
+     */
+    @Test
+    public void consumeNoTagRecordHaveFilter() {
+        doReturn(Arrays.asList("test1", "test2")).when(profilerConfig).readList(KafkaConfigTest.CONSUMER_FILTER_TAGS);
+        final int randomCount = new Random().nextInt(100) + 1;
+        Assert.assertEquals("left count", 0, interceptRecordWithoutTagGotLeft(randomCount));
+    }
+
+    /**
+     * test case: 1.1
+     */
+    @Test
+    public void consumeTagRecordNoFilter() {
+        doReturn(Collections.emptyList()).when(profilerConfig).readList(KafkaConfigTest.CONSUMER_FILTER_TAGS);
+        final int randomCount = new Random().nextInt(100) + 1;
+        final String messageTags = "testTag1,testTag2";
+        Assert.assertEquals("left count", randomCount, interceptRecordWithTagGotLeft(messageTags, randomCount));
+
+        final int randomTagCount = new Random().nextInt(100) + 1;
+        final int randomNoTagCount = new Random().nextInt(100) + 1;
+        Assert.assertEquals("mixed left count", randomTagCount+randomNoTagCount, interceptRecordWithTagGotLeft(messageTags, randomTagCount, randomNoTagCount));
+    }
+
+    /**
+     * test case: 1.3
+     */
+    @Test
+    public void consumeTagRecordHaveSameTagFilter() {
+        final String messageTags = "testTag1,testTag2";
+        doReturn(StringUtils.tokenizeToStringList(messageTags, ",")).when(profilerConfig).readList(KafkaConfigTest.CONSUMER_FILTER_TAGS);
+        final int randomCount = new Random().nextInt(100) + 1;
+        Assert.assertEquals("left count", randomCount, interceptRecordWithTagGotLeft(messageTags, randomCount));
+
+        final int randomTagCount = new Random().nextInt(100) + 1;
+        final int randomNoTagCount = new Random().nextInt(100) + 1;
+        Assert.assertEquals("mixed left count", randomTagCount, interceptRecordWithTagGotLeft(messageTags, randomTagCount, randomNoTagCount));
+    }
+
+    /**
+     * test case: 1.3
+     */
+    @Test
+    public void consumeTagRecordHaveCommonTagFilter() {
+        final String commonTag = "testTag1";
+        final String messageTags = "testTag1,"+commonTag;
+        doReturn(Arrays.asList(commonTag, "anotherTag")).when(profilerConfig).readList(KafkaConfigTest.CONSUMER_FILTER_TAGS);
+        final int randomCount = new Random().nextInt(100) + 1;
+        Assert.assertEquals("left count", randomCount, interceptRecordWithTagGotLeft(messageTags, randomCount));
+
+        final int randomTagCount = new Random().nextInt(100) + 1;
+        final int randomNoTagCount = new Random().nextInt(100) + 1;
+        Assert.assertEquals("mixed left count", randomTagCount, interceptRecordWithTagGotLeft(messageTags, randomTagCount, randomNoTagCount));
+    }
+
+    /**
+     * test case: 1.2
+     */
+    @Test
+    public void consumeTagRecordNoCommonTagFilter() {
+        final String messageTags = "testTag1,testTag2";
+        doReturn(Arrays.asList("testTag3", "testTag4")).when(profilerConfig).readList(KafkaConfigTest.CONSUMER_FILTER_TAGS);
+        final int randomCount = new Random().nextInt(100) + 1;
+        Assert.assertEquals("left count", 0, interceptRecordWithTagGotLeft(messageTags, randomCount));
+
+        final int randomTagCount = new Random().nextInt(100) + 1;
+        final int randomNoTagCount = new Random().nextInt(100) + 1;
+        Assert.assertEquals("mixed left count", 0, interceptRecordWithTagGotLeft(messageTags, randomTagCount, randomNoTagCount));
+    }
+
+    private int interceptRecordWithTagGotLeft(String tags, int tagCount, int noTagCount) {
+        return generateFilterRecordGotLeft(tagCount, noTagCount, tags);
+    }
+
+    private int interceptRecordWithTagGotLeft(String tags, int total) {
+        return generateFilterRecordGotLeft(total, 0, tags);
+    }
+
+    private int interceptRecordWithoutTagGotLeft(int total) {
+        return generateFilterRecordGotLeft(0, total, null);
+    }
+
+    private int generateFilterRecordGotLeft(int tagCount, int noTagCount, String tags) {
+        ConsumerRecordsInterceptor interceptor = new ConsumerRecordsInterceptor(traceContext);
+
+        if (!StringUtils.hasText(tags)) {
+            noTagCount += tagCount;
+        }
+        final Map<TopicPartition, List<ConsumerRecord<String, String>>> records = consumerRecords(tags, tagCount, noTagCount);
+        ConsumerRecords<String, String> consumerRecords = new ConsumerRecords<>(records);
+        Object[] args = new Object[]{records};
+        interceptor.before(consumerRecords, args);
+        interceptor.after(consumerRecords, args, null, null);
+        return consumerRecords.count();
+    }
+
+    private Map<TopicPartition, List<ConsumerRecord<String, String>>> consumerRecords(String tags, int tagCount, int noTagCount) {
+        Map<TopicPartition, List<ConsumerRecord<String, String>>> map = new HashMap<>(2);
+        final Random random = new Random(System.currentTimeMillis());
+        int partition1 = random.nextInt(100);
+        int partition2 = random.nextInt(100);
+        int tagCount1 = tagCount;
+        int tagCount2 = 0;
+        int noTagCount1 = noTagCount;
+        int noTagCount2 = 0;
+        if (tagCount > 0) {
+            tagCount1 = random.nextInt(tagCount);
+            tagCount2 = tagCount - tagCount1;
+        }
+        if (noTagCount > 0) {
+            noTagCount1 = random.nextInt(noTagCount);
+            noTagCount2 = noTagCount - noTagCount1;
+        }
+        TopicPartition tp1 = new TopicPartition(TOPIC1, partition1);
+        TopicPartition tp2 = new TopicPartition(TOPIC2, partition2);
+        final List<ConsumerRecord<String, String>> recordList1 = recordList(TOPIC1, partition1, tags, tagCount1, noTagCount1);
+        final List<ConsumerRecord<String, String>> recordList2 = recordList(TOPIC2, partition2, tags, tagCount2, noTagCount2);
+        map.put(tp1, recordList1);
+        map.put(tp2, recordList2);
+        return map;
+    }
+
+    private List<ConsumerRecord<String, String>> recordList(String topic, int partition, String tags, int tagCount, int noTagCount) {
+        List<ConsumerRecord<String, String>> records = new ArrayList<>(tagCount + noTagCount);
+        for (int i = 0; i < tagCount; i++) {
+            if (StringUtils.hasText(tags)) {
+                records.add(record("record" + i, tags, topic, partition, i));
+            }
+        }
+        for (int i = 0; i < noTagCount; i++) {
+            records.add(record("record" + i, topic, partition, i));
+        }
+        return records;
+    }
+
+    private ConsumerRecord<String, String> record(String value, String topic, int partition, long offset) {
+        String key = UUID.randomUUID().toString();
+        return new ConsumerRecord<>(topic, partition, offset, key, value);
+    }
+
+    private ConsumerRecord<String, String> record(String value, String header, String topic, int partition, long offset) {
+        String key = UUID.randomUUID().toString();
+        final Headers headers = new RecordHeaders();
+        final String tagHeaderKey = com.navercorp.pinpoint.bootstrap.context.Header.HTTP_TAGS.toString();
+        final byte[] tagHeaderVal = String.valueOf(header).getBytes(KafkaConstants.DEFAULT_PINPOINT_HEADER_CHARSET);
+        final Header recordHeader = new RecordHeader(tagHeaderKey, tagHeaderVal);
+        headers.add(recordHeader);
+        return new ConsumerRecord<>(topic, partition, offset, ConsumerRecord.NO_TIMESTAMP, TimestampType.NO_TIMESTAMP_TYPE,
+                (long) ConsumerRecord.NULL_CHECKSUM, ConsumerRecord.NULL_SIZE, ConsumerRecord.NULL_SIZE, key, value, headers);
+        }
+    }

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ProducerAddHeaderInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ProducerAddHeaderInterceptorTest.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.context.TraceId;
-import com.navercorp.pinpoint.plugin.kafka.KafkaConfig;
+import com.navercorp.pinpoint.plugin.kafka.KafkaConfigTest;
 import com.navercorp.pinpoint.plugin.kafka.field.getter.ApiVersionsGetter;
 
 import org.apache.kafka.clients.ApiVersions;
@@ -69,7 +69,7 @@ public class ProducerAddHeaderInterceptorTest {
     @Test
     public void beforeWhenSampled() {
         doReturn(profilerConfig).when(traceContext).getProfilerConfig();
-        doReturn(true).when(profilerConfig).readBoolean(KafkaConfig.HEADER_ENABLE, true);
+        doReturn(true).when(profilerConfig).readBoolean(KafkaConfigTest.HEADER_ENABLE, true);
         Header[] headers = getHeadersWhenSampled();
         Assert.assertEquals(6, headers.length);
     }
@@ -77,7 +77,7 @@ public class ProducerAddHeaderInterceptorTest {
     @Test
     public void beforeWhenSampledNoHeader() {
         doReturn(profilerConfig).when(traceContext).getProfilerConfig();
-        doReturn(false).when(profilerConfig).readBoolean(KafkaConfig.HEADER_ENABLE, true);
+        doReturn(false).when(profilerConfig).readBoolean(KafkaConfigTest.HEADER_ENABLE, true);
 
         Header[] headers = getHeadersWhenSampled();
         Assert.assertEquals(0, headers.length);
@@ -112,7 +112,7 @@ public class ProducerAddHeaderInterceptorTest {
     @Test
     public void beforeWhenUnsampled() {
         doReturn(profilerConfig).when(traceContext).getProfilerConfig();
-        doReturn(true).when(profilerConfig).readBoolean(KafkaConfig.HEADER_ENABLE, true);
+        doReturn(true).when(profilerConfig).readBoolean(KafkaConfigTest.HEADER_ENABLE, true);
         doReturn(trace).when(traceContext).currentRawTraceObject();
         doReturn(false).when(trace).canSampled();
         doReturn(recorder).when(trace).currentSpanEventRecorder();
@@ -133,7 +133,7 @@ public class ProducerAddHeaderInterceptorTest {
     @Test
     public void beforeWhenV1() {
         doReturn(profilerConfig).when(traceContext).getProfilerConfig();
-        doReturn(true).when(profilerConfig).readBoolean(KafkaConfig.HEADER_ENABLE, true);
+        doReturn(true).when(profilerConfig).readBoolean(KafkaConfigTest.HEADER_ENABLE, true);
         doReturn(trace).when(traceContext).currentRawTraceObject();
 
         doReturn(apiVersions).when(apiVersionsGetter)._$PINPOINT$_getApiVersions();


### PR DESCRIPTION
To resolve #8263.

This feature is disabled by default, depends on header feature.

Related config:
1. pinpoint.kafka.producer.tags=
2. pinpoint.kafka.consumer.filter.tags=

Filter consumer records as the following strategy:
   1. If a message have one or more tags, and on the consumer side
       1.1. if no tag filtering, include the message.
       1.2. if tag filtering enabled, but no common tag(s), exclude/filter out the message.
       1.3. if tag filtering enabled and have common tag(s), include the message.
   2. If a message have no tags, and on the consumer side
       2.1. if no tag filtering, include the message.
       2.2. if tag filtering enabled, exclude/filter out the message.
