### PR TITLE
[#8374] show date of start time as a tooltip in web call tree

### DIFF
--- a/web/src/main/angular/src/app/core/components/call-tree/call-tree.component.ts
+++ b/web/src/main/angular/src/app/core/components/call-tree/call-tree.component.ts
@@ -210,6 +210,10 @@ export class CallTreeComponent implements OnInit, OnChanges, AfterViewInit {
                 suppressSizeToFit: true,
                 valueFormatter: (params: any) => {
                     return params.value === 0 ? '' : moment(params.value).tz(this.timezone).format(this.dateFormat);
+                },
+                tooltipValueGetter: (params: any) => {
+                    const dayFormat = 'YYYY-MM-DD';
+                    return params.value === 0 ? '' : moment(params.value).tz(this.timezone).format(dayFormat);
                 }
             },
             {


### PR DESCRIPTION
Resolve #8374.

## Feature:

Before:
![image](https://user-images.githubusercontent.com/1879641/140498214-c08b290c-ea84-4fa8-b55a-501a99174422.png)

After:
![image](https://user-images.githubusercontent.com/1879641/140498117-fc4becad-8214-4bd9-9500-1eabae6e8e03.png)

