### PR TITLE
[#8313] Add null check to kafka header values to prevent NPE

### DIFF
--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -1153,6 +1153,8 @@ profiler.springkafka.consumer.enable=false
 profiler.kafka.consumer.entryPoint=
 # you should disable kafka header(set the following config to false) if your kafka broker version is 0.11+ but the log.message.format.version is overridden by a lower version than 0.11 (e.g. 0.10) which can not be automatically detected.
 #profiler.kafka.header.enable=true
+# you should set profiler.kafka.header.record as false below if you don't want to collect kafka header values.
+#profiler.kafka.header.record=true
 
 ###########################################################
 # Hbase (Reliability and stability can not be guaranteed)

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -1176,6 +1176,8 @@ profiler.springkafka.consumer.enable=false
 profiler.kafka.consumer.entryPoint=
 # you should disable kafka header(set the following config to false) if your kafka broker version is 0.11+ but the log.message.format.version is overridden by a lower version than 0.11 (e.g. 0.10) which can not be automatically detected.
 #profiler.kafka.header.enable=true
+# you should set profiler.kafka.header.record as false below if you don't want to collect kafka header values.
+#profiler.kafka.header.record=true
 
 ###########################################################
 # Hbase (Reliability and stability can not be guaranteed)

--- a/plugins/kafka/README.md
+++ b/plugins/kafka/README.md
@@ -27,6 +27,12 @@ profiler.kafka.consumer.enable=true
 # ex) profiler.kafka.consumer.entryPoint=clazzName.methodName
 profiler.kafka.consumer.entryPoint=
 ```
+
+#### to collect kafka header information
+``` 
+# You should set profiler.kafka.header.record as false below if you don't want to collect kafka header values.
+profiler.kafka.header.record=true
+```
 <br><br>
 
 

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfig.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfig.java
@@ -20,7 +20,11 @@ import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 
 public class KafkaConfig {
 
+    // whether this plugin intercepts org.apache.kafka.common.header.Headers
     public static final String HEADER_ENABLE = "profiler.kafka.header.enable";
+
+    // whether this plugin records kafka headers contents to Pinpoint
+    static final String HEADER_RECORD = "profiler.kafka.header.record";
 
     static final String PRODUCER_ENABLE = "profiler.kafka.producer.enable";
 
@@ -33,13 +37,15 @@ public class KafkaConfig {
     private final boolean consumerEnable;
     private final boolean springConsumerEnable;
     private final boolean headerEnable;
+    private final boolean headerRecorded;
     private final String kafkaEntryPoint;
 
     public KafkaConfig(ProfilerConfig config) {
         this.producerEnable = config.readBoolean(PRODUCER_ENABLE, false);
         this.consumerEnable = config.readBoolean(CONSUMER_ENABLE, false);
         this.springConsumerEnable = config.readBoolean(SPRING_CONSUMER_ENABLE, false);
-        this.headerEnable = config.readBoolean(KafkaConfig.HEADER_ENABLE, true);
+        this.headerEnable = config.readBoolean(HEADER_ENABLE, true);
+        this.headerRecorded = config.readBoolean(HEADER_RECORD, true);
         this.kafkaEntryPoint = config.readString(CONSUMER_ENTRY_POINT, "");
     }
 
@@ -57,6 +63,10 @@ public class KafkaConfig {
 
     public boolean isHeaderEnable() {
         return headerEnable;
+    }
+
+    public boolean isHeaderRecorded() {
+        return headerRecorded;
     }
 
     public String getKafkaEntryPoint() {

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerRecordEntryPointInterceptor.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerRecordEntryPointInterceptor.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.bootstrap.sampler.SamplingFlagUtils;
 import com.navercorp.pinpoint.bootstrap.util.NumberUtils;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.ArrayUtils;
+import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.plugin.kafka.KafkaClientUtils;
 import com.navercorp.pinpoint.plugin.kafka.KafkaConstants;
@@ -258,7 +259,7 @@ public class ConsumerRecordEntryPointInterceptor extends SpanRecursiveAroundInte
                     return true;
                 }
 
-                String sampledFlag = new String(sampledHeader.value(), KafkaConstants.DEFAULT_PINPOINT_HEADER_CHARSET);
+                String sampledFlag = BytesUtils.toString(sampledHeader.value());
                 return SamplingFlagUtils.isSamplingFlag(sampledFlag);
             }
 
@@ -269,13 +270,13 @@ public class ConsumerRecordEntryPointInterceptor extends SpanRecursiveAroundInte
                 String flags = null;
                 for (org.apache.kafka.common.header.Header header : headers.toArray()) {
                     if (header.key().equals(Header.HTTP_TRACE_ID.toString())) {
-                        transactionId = new String(header.value(), KafkaConstants.DEFAULT_PINPOINT_HEADER_CHARSET);
+                        transactionId = BytesUtils.toString(header.value());
                     } else if (header.key().equals(Header.HTTP_PARENT_SPAN_ID.toString())) {
-                        parentSpanID = new String(header.value(), KafkaConstants.DEFAULT_PINPOINT_HEADER_CHARSET);
+                        parentSpanID = BytesUtils.toString(header.value());
                     } else if (header.key().equals(Header.HTTP_SPAN_ID.toString())) {
-                        spanID = new String(header.value(), KafkaConstants.DEFAULT_PINPOINT_HEADER_CHARSET);
+                        spanID = BytesUtils.toString(header.value());
                     } else if (header.key().equals(Header.HTTP_FLAGS.toString())) {
-                        flags = new String(header.value(), KafkaConstants.DEFAULT_PINPOINT_HEADER_CHARSET);
+                        flags = BytesUtils.toString(header.value());
                     }
                 }
 
@@ -300,9 +301,9 @@ public class ConsumerRecordEntryPointInterceptor extends SpanRecursiveAroundInte
                 org.apache.kafka.common.header.Headers headers = consumerRecord.headers();
                 for (org.apache.kafka.common.header.Header header : headers.toArray()) {
                     if (header.key().equals(Header.HTTP_PARENT_APPLICATION_NAME.toString())) {
-                        parentApplicationName = new String(header.value(), KafkaConstants.DEFAULT_PINPOINT_HEADER_CHARSET);
+                        parentApplicationName = BytesUtils.toString(header.value());
                     } else if (header.key().equals(Header.HTTP_PARENT_APPLICATION_TYPE.toString())) {
-                        parentApplicationType = new String(header.value(), KafkaConstants.DEFAULT_PINPOINT_HEADER_CHARSET);
+                        parentApplicationType = BytesUtils.toString(header.value());
                     }
                 }
 

--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/recorder/DefaultHeaderRecorder.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/recorder/DefaultHeaderRecorder.java
@@ -17,12 +17,11 @@ package com.navercorp.pinpoint.plugin.kafka.recorder;
 
 import com.navercorp.pinpoint.bootstrap.context.AttributeRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Header;
+import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.plugin.kafka.KafkaClientUtils;
 import com.navercorp.pinpoint.plugin.kafka.KafkaConstants;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
-
-import java.nio.charset.StandardCharsets;
 
 /**
  * @author yjqg6666
@@ -51,7 +50,8 @@ public class DefaultHeaderRecorder implements HeaderRecorder {
         }
         for (org.apache.kafka.common.header.Header header : headers) {
             final String key = header.key();
-            final String val = new String(header.value(), StandardCharsets.UTF_8);
+            final String val = BytesUtils.toString(header.value());
+
             if (!Header.startWithPinpointHeader(key)) {
                 recorder.recordAttribute(KafkaConstants.KAFKA_HEADER_ANNOTATION_KEY, key + "=" + val);
             }

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerMultiRecordEntryPointInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerMultiRecordEntryPointInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.navercorp.pinpoint.plugin.kafka.interceptor;
 
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
@@ -26,6 +27,9 @@ public class ConsumerMultiRecordEntryPointInterceptorTest {
     private TraceContext traceContext;
 
     @Mock
+    private ProfilerConfig profilerConfig;
+
+    @Mock
     private MethodDescriptor descriptor;
 
     @Mock
@@ -43,6 +47,7 @@ public class ConsumerMultiRecordEntryPointInterceptorTest {
         consumerRecordList.add(new ConsumerRecord("Test", 1, 1, "hello", "hello too"));
 
         doReturn(trace).when(traceContext).newTraceObject();
+        doReturn(profilerConfig).when(traceContext).getProfilerConfig();
         doReturn(true).when(trace).canSampled();
         doReturn(recorder).when(trace).getSpanRecorder();
         doReturn(consumerRecordList.iterator()).when(consumerRecords).iterator();
@@ -63,6 +68,7 @@ public class ConsumerMultiRecordEntryPointInterceptorTest {
         consumerRecordList.add(new ConsumerRecord("Test2", 2, 1, "hello2", "hello too2"));
 
         doReturn(trace).when(traceContext).newTraceObject();
+        doReturn(profilerConfig).when(traceContext).getProfilerConfig();
         doReturn(true).when(trace).canSampled();
         doReturn(recorder).when(trace).getSpanRecorder();
         doReturn(consumerRecordList.iterator()).when(consumerRecords).iterator();

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerRecordEntryPointInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ConsumerRecordEntryPointInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.navercorp.pinpoint.plugin.kafka.interceptor;
 
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 import com.navercorp.pinpoint.bootstrap.context.*;
 import com.navercorp.pinpoint.plugin.kafka.KafkaConstants;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -22,6 +23,9 @@ public class ConsumerRecordEntryPointInterceptorTest {
     private TraceContext traceContext;
 
     @Mock
+    private ProfilerConfig profilerConfig;
+
+    @Mock
     private MethodDescriptor descriptor;
 
     @Mock
@@ -41,6 +45,7 @@ public class ConsumerRecordEntryPointInterceptorTest {
 
     @Test
     public void doInBeforeTrace() {
+        doReturn(profilerConfig).when(traceContext).getProfilerConfig();
 
         ConsumerRecordEntryPointInterceptor interceptor = new ConsumerRecordEntryPointInterceptor(traceContext, descriptor, 0);
 
@@ -51,6 +56,7 @@ public class ConsumerRecordEntryPointInterceptorTest {
 
     @Test
     public void doInAfterTrace() {
+        doReturn(profilerConfig).when(traceContext).getProfilerConfig();
 
         ConsumerRecordEntryPointInterceptor interceptor = new ConsumerRecordEntryPointInterceptor(traceContext, descriptor, 0);
 
@@ -64,6 +70,7 @@ public class ConsumerRecordEntryPointInterceptorTest {
     public void createTrace() {
 
         doReturn(trace).when(traceContext).newTraceObject();
+        doReturn(profilerConfig).when(traceContext).getProfilerConfig();
         doReturn(true).when(trace).canSampled();
         doReturn(recorder).when(trace).getSpanRecorder();
 
@@ -72,7 +79,6 @@ public class ConsumerRecordEntryPointInterceptorTest {
         doReturn(0).when(consumerRecord).partition();
         doReturn(headers).when(consumerRecord).headers();
         doReturn(new Header[]{}).when(headers).toArray();
-        doReturn(Collections.emptyIterator()).when(headers).iterator();
 
         ConsumerRecordEntryPointInterceptor interceptor = new ConsumerRecordEntryPointInterceptor(traceContext, descriptor, 0);
 

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ProducerSendInterceptorTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/interceptor/ProducerSendInterceptorTest.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.plugin.kafka.interceptor;
 
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
@@ -39,6 +40,9 @@ public class ProducerSendInterceptorTest {
     private TraceContext traceContext;
 
     @Mock
+    private ProfilerConfig profilerConfig;
+
+    @Mock
     private MethodDescriptor descriptor;
 
     @Mock
@@ -56,6 +60,7 @@ public class ProducerSendInterceptorTest {
     @Test
     public void before() {
         doReturn(trace).when(traceContext).currentRawTraceObject();
+        doReturn(profilerConfig).when(traceContext).getProfilerConfig();
         doReturn(true).when(trace).canSampled();
         doReturn(recorder).when(trace).traceBlockBegin();
 
@@ -71,6 +76,7 @@ public class ProducerSendInterceptorTest {
     @Test
     public void after() {
         doReturn(trace).when(traceContext).currentTraceObject();
+        doReturn(profilerConfig).when(traceContext).getProfilerConfig();
         doReturn(true).when(trace).canSampled();
         doReturn(recorder).when(trace).currentSpanEventRecorder();
         doReturn("test").when(record).topic();


### PR DESCRIPTION
- Added null check to kafka header values to prevent NPE
- Added profiler.kafka.header.record property to let users to choose whether they want to collect header values to Pinpoint