### PR TITLE
[#8557] Send caller app name

### DIFF
--- a/agent/src/main/resources/pinpoint-root.config
+++ b/agent/src/main/resources/pinpoint-root.config
@@ -332,6 +332,10 @@ profiler.http.status.code.errors=5xx
 # e.g. profiler.http.record.response.headers=Set-Cookie
 #profiler.http.record.response.headers=
 
+#always send caller application name regardless of sampling rate or async calling
+#profiler.sendAppName.enable=false
+#profiler.sendAppName.headerName=X-Caller-Application-Name
+
 ###########################################################
 # Application Type                                        #
 ###########################################################

--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -220,6 +220,10 @@ profiler.http.record.request.cookies=
 # e.g. profiler.http.record.response.headers=Set-Cookie
 #profiler.http.record.response.headers=
 
+#always send caller application name regardless of sampling rate or async calling
+profiler.sendAppName.enable=true
+profiler.sendAppName.headerName=X-Caller-App
+
 ###########################################################
 # application type                                        # 
 ###########################################################

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ApplicationInfoSender.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ApplicationInfoSender.java
@@ -1,0 +1,7 @@
+package com.navercorp.pinpoint.bootstrap.plugin.request;
+
+public interface ApplicationInfoSender<REQ> {
+
+    void sendCallerApplicationName(REQ request);
+
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/DefaultApplicationInfoSender.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/DefaultApplicationInfoSender.java
@@ -1,0 +1,41 @@
+package com.navercorp.pinpoint.bootstrap.plugin.request;
+
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+
+import java.util.Objects;
+
+public class DefaultApplicationInfoSender<REQ> implements ApplicationInfoSender<REQ> {
+
+    private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+
+    private final ClientHeaderAdaptor<REQ> clientHeaderAdaptor;
+
+    private final boolean enabled;
+    private final String headerName;
+    private final String applicationName;
+
+    public DefaultApplicationInfoSender(ClientHeaderAdaptor<REQ> clientHeaderAdaptor, TraceContext traceContext) {
+        this.clientHeaderAdaptor = Objects.requireNonNull(clientHeaderAdaptor, "clientHeaderAdaptor");
+        this.applicationName = traceContext.getApplicationName();
+        final ProfilerConfig config = traceContext.getProfilerConfig();
+        this.enabled = config.readBoolean("profiler.sendAppName.enable", false);
+        this.headerName = config.readString("profiler.sendAppName.headerName", "X-Caller-Application-Name");
+    }
+
+    @Override
+    public void sendCallerApplicationName(REQ request) {
+        if (!enabled || request == null) {
+            return;
+        }
+
+        try {
+            clientHeaderAdaptor.setHeader(request, headerName, applicationName);
+        } catch (Exception e) {
+            logger.info("Add caller application name header failed, caused by: ", e);
+        }
+    }
+
+}

--- a/plugins-it/httpclient3-it/src/test/java/com/navercorp/pinpoint/plugin/httpclient3/HttpClientIT.java
+++ b/plugins-it/httpclient3-it/src/test/java/com/navercorp/pinpoint/plugin/httpclient3/HttpClientIT.java
@@ -21,13 +21,12 @@ import com.navercorp.pinpoint.pluginit.utils.WebServer;
 import com.navercorp.pinpoint.test.plugin.ImportPlugin;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
+import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HostConfiguration;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.params.HttpMethodParams;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -37,6 +36,11 @@ import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 import com.navercorp.pinpoint.test.plugin.shared.AfterSharedClass;
 import com.navercorp.pinpoint.test.plugin.shared.BeforeSharedClass;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author jaehong.kim
@@ -90,6 +94,7 @@ public class HttpClientIT {
         try {
             // Execute the method.
             client.executeMethod(method);
+            assertCaller(method);
         } catch (Exception ignored) {
         } finally {
             method.releaseConnection();
@@ -124,4 +129,15 @@ public class HttpClientIT {
         PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
         verifier.printCache();
     }
+
+
+    private void assertCaller(GetMethod method) {
+        final Header[] headers = method.getResponseHeaders(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        assertNotNull("caller headers null", headers);
+        assertEquals("caller headers count", 1, headers.length);
+        final String caller = headers[0].getValue();
+        assertNotNull("caller null", caller);
+        assertTrue("not caller test", "test".contentEquals(caller));
+    }
+
 }

--- a/plugins-it/httpclient4-it/src/test/java/com/navercorp/pinpoint/plugin/httpclient4/ClosableAsyncHttpClientIT.java
+++ b/plugins-it/httpclient4-it/src/test/java/com/navercorp/pinpoint/plugin/httpclient4/ClosableAsyncHttpClientIT.java
@@ -48,6 +48,8 @@ import java.util.concurrent.Future;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.async;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author netspider
@@ -64,6 +66,8 @@ public class ClosableAsyncHttpClientIT extends HttpClientITBase {
         CloseableHttpAsyncClient httpClient = HttpAsyncClients.custom().useSystemProperties().build();
         httpClient.start();
 
+
+        String caller=null;
         try {
             HttpPost httpRequest = new HttpPost(getCallUrl());
 
@@ -77,6 +81,7 @@ public class ClosableAsyncHttpClientIT extends HttpClientITBase {
             if ((response != null) && (response.getEntity() != null)) {
                 EntityUtils.consume(response.getEntity());
             }
+            caller = getCallerApp(response);
         } finally {
             httpClient.close();
         }
@@ -98,5 +103,7 @@ public class ClosableAsyncHttpClientIT extends HttpClientITBase {
         verifier.verifyTrace(event("HTTP_CLIENT_4_INTERNAL", BasicFuture.class.getMethod("get")));
 
         verifier.verifyTraceCount(0);
+        assertNotNull("caller null", caller);
+        assertTrue("not caller test", "test".contentEquals(caller));
     }
 }

--- a/plugins-it/httpclient4-it/src/test/java/com/navercorp/pinpoint/plugin/httpclient4/HttpClientITBase.java
+++ b/plugins-it/httpclient4-it/src/test/java/com/navercorp/pinpoint/plugin/httpclient4/HttpClientITBase.java
@@ -19,6 +19,8 @@ package com.navercorp.pinpoint.plugin.httpclient4;
 import com.navercorp.pinpoint.pluginit.utils.WebServer;
 import com.navercorp.pinpoint.test.plugin.shared.AfterSharedClass;
 import com.navercorp.pinpoint.test.plugin.shared.BeforeSharedClass;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
 
 public abstract class HttpClientITBase {
 
@@ -56,6 +58,17 @@ public abstract class HttpClientITBase {
     @AfterSharedClass
     public static void sharedTearDown() {
         webServer = WebServer.cleanup(webServer);
+    }
+
+    public String getCallerApp(HttpResponse response) {
+        if (response == null) {
+            return null;
+        }
+        final Header callerHeader = response.getFirstHeader(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        if (callerHeader != null) {
+            return callerHeader.getValue();
+        }
+        return null;
     }
 
 }

--- a/plugins-it/jdk-http-it/src/test/java/com/navercorp/pinpoint/plugin/jdk/http/HttpURLConnectionIT.java
+++ b/plugins-it/jdk-http-it/src/test/java/com/navercorp/pinpoint/plugin/jdk/http/HttpURLConnectionIT.java
@@ -16,6 +16,8 @@
 package com.navercorp.pinpoint.plugin.jdk.http;
 
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
@@ -80,6 +82,8 @@ public class HttpURLConnectionIT {
         verifier.verifyTrace(event("JDK_HTTPURLCONNECTOR", getInputStream, null, null, destinationId,
                 annotation("http.url", httpUrl),
                 annotation("http.resp.header", anyAnnotationValue())));
+
+        assertCaller(connection);
     }
     
     @Test
@@ -105,8 +109,16 @@ public class HttpURLConnectionIT {
         verifier.verifyTrace(event("JDK_HTTPURLCONNECTOR", getInputStream, null, null, destinationId,
                 annotation("http.url", httpUrl),
                 annotation("http.resp.header", anyAnnotationValue())));
+
+        assertCaller(connection);
     }
-    
+
+    private void assertCaller(HttpURLConnection connection) {
+        final String caller = connection.getHeaderField(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        assertNotNull("caller null", caller);
+        assertTrue("not caller test", "test".contentEquals(caller));
+    }
+
     @Test
     public void testConnecting() throws Exception {
 

--- a/plugins-it/ning-asyncclient-it/src/test/java/com/navercorp/pinpoint/plugin/ning/asynchttpclient/NingAsyncHttpClientIT.java
+++ b/plugins-it/ning-asyncclient-it/src/test/java/com/navercorp/pinpoint/plugin/ning/asynchttpclient/NingAsyncHttpClientIT.java
@@ -17,6 +17,8 @@
 package com.navercorp.pinpoint.plugin.ning.asynchttpclient;
 
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.Future;
 
@@ -70,6 +72,7 @@ public class NingAsyncHttpClientIT {
         try {
             Future<Response> f = client.preparePost(webServer.getCallHttpUrl()).addParameter("param1", "value1").execute();
             Response response = f.get();
+            assertCaller(response);
         } finally {
             client.close();
         }
@@ -83,4 +86,10 @@ public class NingAsyncHttpClientIT {
                 annotation("http.url", httpUrl)));
         verifier.verifyTraceCount(0);
    }
+
+    private void assertCaller(Response response) {
+        final String caller = response.getHeader(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        assertNotNull("caller null", caller);
+        assertTrue("not caller test", "test".contentEquals(caller));
+    }
 }

--- a/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_2_BaseIT.java
+++ b/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_2_BaseIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.okhttp;
+
+import com.navercorp.pinpoint.pluginit.utils.WebServer;
+import com.squareup.okhttp.Response;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author yjqg6666
+ */
+public class OkHttpClient_2_BaseIT {
+
+    protected void assertCaller(Response response) {
+        final String caller = response.header(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        assertNotNull("caller null", caller);
+        assertTrue("not caller test", "test".contentEquals(caller));
+    }
+
+}

--- a/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_2_x_IT.java
+++ b/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_2_x_IT.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
-import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.anyAnnotationValue;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 import static com.navercorp.pinpoint.common.trace.ServiceType.ASYNC;
 import static com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants.OK_HTTP_CLIENT;
@@ -54,7 +53,7 @@ import static com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants.OK_HTTP_CLIEN
 @PinpointAgent(AgentPath.PATH)
 @ImportPlugin("com.navercorp.pinpoint:pinpoint-okhttp-plugin")
 @Dependency({"com.squareup.okhttp:okhttp:[2.0.0,3.0.0)", WebServer.VERSION, PluginITConstants.VERSION})
-public class OkHttpClient_2_x_IT {
+public class OkHttpClient_2_x_IT extends OkHttpClient_2_BaseIT {
 
     private static WebServer webServer;
 
@@ -101,6 +100,9 @@ public class OkHttpClient_2_x_IT {
         );
 
         verifier.verifyTraceCount(0);
+
+        assertCaller(response);
+
     }
 
     @Test
@@ -159,6 +161,9 @@ public class OkHttpClient_2_x_IT {
         );
 
         verifier.verifyTraceCount(0);
+
+        assertCaller(response);
+
     }
 
     private Method getConnectMethod() {

--- a/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_3_0_0_to_3_3_x_IT.java
+++ b/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_3_0_0_to_3_3_x_IT.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
-import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.anyAnnotationValue;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 import static com.navercorp.pinpoint.common.trace.ServiceType.ASYNC;
 import static com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants.OK_HTTP_CLIENT;
@@ -55,7 +54,7 @@ import static com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants.OK_HTTP_CLIEN
 @PinpointAgent(AgentPath.PATH)
 @ImportPlugin("com.navercorp.pinpoint:pinpoint-okhttp-plugin")
 @Dependency({"com.squareup.okhttp3:okhttp:[3.0.0,3.3.max]", WebServer.VERSION, PluginITConstants.VERSION})
-public class OkHttpClient_3_0_0_to_3_3_x_IT {
+public class OkHttpClient_3_0_0_to_3_3_x_IT extends OkHttpClient_3_BaseIT {
 
     private static WebServer webServer;
 
@@ -99,6 +98,9 @@ public class OkHttpClient_3_0_0_to_3_3_x_IT {
         ));
 
         verifier.verifyTraceCount(0);
+
+        assertCaller(response);
+
     }
 
     @Test

--- a/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_3_4_0_BaseIT.java
+++ b/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_3_4_0_BaseIT.java
@@ -38,13 +38,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
-import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.anyAnnotationValue;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 import static com.navercorp.pinpoint.common.trace.ServiceType.ASYNC;
 import static com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants.OK_HTTP_CLIENT;
 import static com.navercorp.pinpoint.plugin.okhttp.OkHttpConstants.OK_HTTP_CLIENT_INTERNAL;
 
-public abstract class OkHttpClient_3_4_0_BaseIT {
+public abstract class OkHttpClient_3_4_0_BaseIT extends OkHttpClient_3_BaseIT {
 
     private static WebServer webServer;
 
@@ -83,6 +82,9 @@ public abstract class OkHttpClient_3_4_0_BaseIT {
                 annotation("http.internal.display", hostAndPort)));
 
         verifier.verifyTraceCount(0);
+
+        assertCaller(response);
+
     }
 
     @Test
@@ -134,6 +136,8 @@ public abstract class OkHttpClient_3_4_0_BaseIT {
                 annotation("http.internal.display", hostAndPort)));
 
         verifier.verifyTraceCount(0);
+
+        assertCaller(response);
     }
 
     private Method getConnectMethod(Class<?> realConnectionClass) throws ClassNotFoundException {

--- a/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_3_BaseIT.java
+++ b/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_3_BaseIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.okhttp;
+
+import com.navercorp.pinpoint.pluginit.utils.WebServer;
+import okhttp3.Response;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author yjqg6666
+ */
+public class OkHttpClient_3_BaseIT {
+
+    protected void assertCaller(Response response) {
+        final String caller = response.header(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        assertNotNull("caller null", caller);
+        assertTrue("not caller test", "test".contentEquals(caller));
+    }
+
+}

--- a/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_BaseIT.java
+++ b/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/plugin/okhttp/OkHttpClient_BaseIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.okhttp;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author yjqg6666
+ */
+public class OkHttpClient_BaseIT {
+
+    protected void assertCaller(String caller) {
+        assertNotNull("caller null", caller);
+        assertTrue("not caller test", "test".contentEquals(caller));
+    }
+
+}

--- a/plugins-it/plugins-it-utils/src/main/java/com/navercorp/pinpoint/pluginit/utils/WebServer.java
+++ b/plugins-it/plugins-it-utils/src/main/java/com/navercorp/pinpoint/pluginit/utils/WebServer.java
@@ -29,6 +29,8 @@ public class WebServer extends NanoHTTPD {
     public static final String VERSION = "org.nanohttpd:nanohttpd:2.3.1";
     public static final String LOCAL_HOST = "localhost";
 
+    public static final String CALLER_RESPONSE_HEADER_NAME = "caller-app";
+
     public WebServer(String hostname, int port) {
         super(hostname, port);
     }
@@ -43,7 +45,11 @@ public class WebServer extends NanoHTTPD {
     @Override
     public Response serve(IHTTPSession session) {
         Map<String, List<String>> parameters = session.getParameters();
+        final String caller = session.getHeaders().get("x-caller-app");
         Response response = newFixedLengthResponse(parameters.toString());
+        if (caller != null) {
+            response.addHeader(CALLER_RESPONSE_HEADER_NAME, caller);
+        }
         return response;
     }
 

--- a/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/interceptor/HttpMethodBaseExecuteMethodInterceptor.java
+++ b/plugins/httpclient3/src/main/java/com/navercorp/pinpoint/plugin/httpclient3/interceptor/HttpMethodBaseExecuteMethodInterceptor.java
@@ -17,11 +17,13 @@
 package com.navercorp.pinpoint.plugin.httpclient3.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.config.HttpDumpConfig;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapperAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
@@ -74,6 +76,7 @@ public class HttpMethodBaseExecuteMethodInterceptor implements AroundInterceptor
     private final InterceptorScope interceptorScope;
     private final ClientRequestRecorder<ClientRequestWrapper> clientRequestRecorder;
     private final RequestTraceWriter<HttpMethod> requestTraceWriter;
+    private final ApplicationInfoSender<HttpMethod> applicationInfoSender;
 
     private final boolean io;
     private final CookieRecorder<HttpMethod> cookieRecorder;
@@ -102,6 +105,7 @@ public class HttpMethodBaseExecuteMethodInterceptor implements AroundInterceptor
 
         ClientHeaderAdaptor<HttpMethod> clientHeaderAdaptor = new HttpMethodClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
 
         this.io = config.isIo();
     }
@@ -117,9 +121,11 @@ public class HttpMethodBaseExecuteMethodInterceptor implements AroundInterceptor
             return;
         }
 
+        final HttpMethod httpMethod = getHttpMethod(target);
+        applicationInfoSender.sendCallerApplicationName(httpMethod);
+
         if (!trace.canSampled()) {
-            if (target instanceof HttpMethod) {
-                final HttpMethod httpMethod = (HttpMethod) target;
+            if (httpMethod != null) {
                 this.requestTraceWriter.write(httpMethod);
             }
             return;
@@ -131,8 +137,7 @@ public class HttpMethodBaseExecuteMethodInterceptor implements AroundInterceptor
         recorder.recordNextSpanId(nextId.getSpanId());
         recorder.recordServiceType(HttpClient3Constants.HTTP_CLIENT_3);
         // set http header for trace.
-        if (target instanceof HttpMethod) {
-            final HttpMethod httpMethod = (HttpMethod) target;
+        if (httpMethod != null) {
             final HttpConnection httpConnection = getHttpConnection(args);
             final String host = getHost(httpMethod, httpConnection);
             this.requestTraceWriter.write(httpMethod, nextId, host);
@@ -142,6 +147,9 @@ public class HttpMethodBaseExecuteMethodInterceptor implements AroundInterceptor
         initAttachment();
     }
 
+    private HttpMethod getHttpMethod(Object target) {
+        return target instanceof HttpMethod ? (HttpMethod) target : null;
+    }
 
     private String getHost(HttpMethod httpMethod, HttpConnection httpConnection) {
         try {

--- a/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/DefaultClientExchangeHandlerImplStartMethodInterceptor.java
+++ b/plugins/httpclient4/src/main/java/com/navercorp/pinpoint/plugin/httpclient4/interceptor/DefaultClientExchangeHandlerImplStartMethodInterceptor.java
@@ -19,11 +19,13 @@ package com.navercorp.pinpoint.plugin.httpclient4.interceptor;
 import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
 import com.navercorp.pinpoint.bootstrap.config.HttpDumpConfig;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapperAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
@@ -71,6 +73,7 @@ public class DefaultClientExchangeHandlerImplStartMethodInterceptor implements A
     private final EntityRecorder<HttpRequest> entityRecorder;
 
     private final RequestTraceWriter<HttpRequest> requestTraceWriter;
+    private final ApplicationInfoSender<HttpRequest> applicationInfoSender;
 
     public DefaultClientExchangeHandlerImplStartMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
         this.traceContext = traceContext;
@@ -91,6 +94,7 @@ public class DefaultClientExchangeHandlerImplStartMethodInterceptor implements A
 
         ClientHeaderAdaptor<HttpRequest> clientHeaderAdaptor = new HttpRequest4ClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     @Override
@@ -105,6 +109,8 @@ public class DefaultClientExchangeHandlerImplStartMethodInterceptor implements A
         }
 
         final HttpRequest httpRequest = getHttpRequest(target);
+        this.applicationInfoSender.sendCallerApplicationName(httpRequest);
+
         final NameIntValuePair<String> host = getHost(target);
         final boolean sampling = trace.canSampled();
         if (!sampling) {

--- a/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/interceptor/AbstractHttpURLConnectionInterceptor.java
+++ b/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/interceptor/AbstractHttpURLConnectionInterceptor.java
@@ -92,16 +92,7 @@ public abstract class AbstractHttpURLConnectionInterceptor implements AroundInte
             }
         }
 
-        boolean connected = isConnected(target);
-        boolean connecting = false;
-        if (target instanceof ConnectingGetter) {
-            connecting = ((ConnectingGetter) target)._$PINPOINT$_isConnecting();
-        }
-
-        boolean addRequestHeader = !connected && !connecting;
-        if (isInterceptingHttps()) {
-            addRequestHeader = addRequestHeader && isInterceptingConnect();
-        }
+        final boolean addRequestHeader = canAddHeaderToRequest(target);
 
         final HttpURLConnection request = (HttpURLConnection) target;
         final boolean canSample = trace.canSampled();
@@ -120,6 +111,20 @@ public abstract class AbstractHttpURLConnectionInterceptor implements AroundInte
                 this.requestTraceWriter.write(request);
             }
         }
+    }
+
+    private boolean canAddHeaderToRequest(Object target) {
+        boolean connected = isConnected(target);
+        boolean connecting = false;
+        if (target instanceof ConnectingGetter) {
+            connecting = ((ConnectingGetter) target)._$PINPOINT$_isConnecting();
+        }
+
+        boolean canAddHeader = !connected && !connecting;
+        if (isInterceptingHttps()) {
+            canAddHeader = canAddHeader && isInterceptingConnect();
+        }
+        return canAddHeader;
     }
 
     @Override

--- a/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/interceptor/AbstractHttpURLConnectionInterceptor.java
+++ b/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/interceptor/AbstractHttpURLConnectionInterceptor.java
@@ -49,6 +49,7 @@ public abstract class AbstractHttpURLConnectionInterceptor implements AroundInte
     private final ServerResponseHeaderRecorder<HttpURLConnection> responseHeaderRecorder;
 
     private final RequestTraceWriter<HttpURLConnection> requestTraceWriter;
+    private final ApplicationInfoSender<HttpURLConnection> applicationInfoSender;
 
     public AbstractHttpURLConnectionInterceptor(TraceContext traceContext, MethodDescriptor descriptor, InterceptorScope scope) {
         this.traceContext = traceContext;
@@ -63,6 +64,7 @@ public abstract class AbstractHttpURLConnectionInterceptor implements AroundInte
 
         ClientHeaderAdaptor<HttpURLConnection> clientHeaderAdaptor = new HttpURLConnectionClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     abstract boolean isConnected(Object target);
@@ -111,6 +113,11 @@ public abstract class AbstractHttpURLConnectionInterceptor implements AroundInte
                 this.requestTraceWriter.write(request);
             }
         }
+
+        if (addRequestHeader) {
+            this.applicationInfoSender.sendCallerApplicationName(request);
+        }
+
     }
 
     private boolean canAddHeaderToRequest(Object target) {

--- a/plugins/ning-asynchttpclient/src/main/java/com/navercorp/pinpoint/plugin/ning/asynchttpclient/interceptor/ExecuteInterceptor.java
+++ b/plugins/ning-asynchttpclient/src/main/java/com/navercorp/pinpoint/plugin/ning/asynchttpclient/interceptor/ExecuteInterceptor.java
@@ -23,9 +23,11 @@ import com.navercorp.pinpoint.bootstrap.context.TraceId;
 import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
@@ -56,6 +58,7 @@ public class ExecuteInterceptor implements AroundInterceptor {
 
     private final ClientRequestRecorder<Request> clientRequestRecorder;
     private final RequestTraceWriter<Request> requestTraceWriter;
+    private final ApplicationInfoSender<Request> applicationInfoSender;
     private final CookieRecorder<Request> cookieRecorder;
     private final EntityRecorder<Request> entityRecorder;
 
@@ -75,6 +78,7 @@ public class ExecuteInterceptor implements AroundInterceptor {
 
         ClientHeaderAdaptor<Request> clientHeaderAdaptor = new RequestHeaderAdaptorV2();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     @Override
@@ -93,6 +97,8 @@ public class ExecuteInterceptor implements AroundInterceptor {
         }
 
         final Request httpRequest = (Request) args[0];
+        applicationInfoSender.sendCallerApplicationName(httpRequest);
+
         final boolean sampling = trace.canSampled();
         if (!sampling) {
             if (httpRequest != null) {

--- a/plugins/ning-asynchttpclient/src/main/java/com/navercorp/pinpoint/plugin/ning/asynchttpclient/interceptor/ExecuteRequestInterceptor.java
+++ b/plugins/ning-asynchttpclient/src/main/java/com/navercorp/pinpoint/plugin/ning/asynchttpclient/interceptor/ExecuteRequestInterceptor.java
@@ -23,9 +23,11 @@ import com.navercorp.pinpoint.bootstrap.context.TraceId;
 import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PLogger;
 import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
@@ -63,6 +65,7 @@ public class ExecuteRequestInterceptor implements AroundInterceptor {
     private final EntityRecorder<Request> entityRecorder;
 
     private final RequestTraceWriter<Request> requestTraceWriter;
+    private final ApplicationInfoSender<Request> applicationInfoSender;
 
     // for 1.8.x and 1.9.x
     public ExecuteRequestInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
@@ -81,6 +84,7 @@ public class ExecuteRequestInterceptor implements AroundInterceptor {
 
         ClientHeaderAdaptor<Request> clientHeaderAdaptor = new RequestHeaderAdaptorV1();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     @Override
@@ -99,6 +103,8 @@ public class ExecuteRequestInterceptor implements AroundInterceptor {
         }
 
         final Request httpRequest = (Request) args[0];
+        applicationInfoSender.sendCallerApplicationName(httpRequest);
+
         final boolean sampling = trace.canSampled();
         if (!sampling) {
             if (httpRequest != null) {

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/BodyInserterRequestBuilderWriteToInterceptor.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/BodyInserterRequestBuilderWriteToInterceptor.java
@@ -24,10 +24,12 @@ import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.context.TraceId;
 import com.navercorp.pinpoint.bootstrap.interceptor.AsyncContextSpanEventSimpleAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapperAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
@@ -49,6 +51,7 @@ public class BodyInserterRequestBuilderWriteToInterceptor extends AsyncContextSp
     private final ClientRequestRecorder<ClientRequestWrapper> clientRequestRecorder;
     private final CookieRecorder<ClientHttpRequest> cookieRecorder;
     private final RequestTraceWriter<ClientHttpRequest> requestTraceWriter;
+    private final ApplicationInfoSender<ClientHttpRequest> applicationInfoSender;
 
     public BodyInserterRequestBuilderWriteToInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
         super(traceContext, methodDescriptor);
@@ -62,6 +65,7 @@ public class BodyInserterRequestBuilderWriteToInterceptor extends AsyncContextSp
 
         final ClientHttpRequestClientHeaderAdaptor clientHeaderAdaptor = new ClientHttpRequestClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     @Override
@@ -88,6 +92,7 @@ public class BodyInserterRequestBuilderWriteToInterceptor extends AsyncContextSp
             host = HostAndPort.toHostAndPortString(url.getHost(), url.getPort());
         }
         requestTraceWriter.write(request, nextId, host);
+        applicationInfoSender.sendCallerApplicationName(request);
     }
 
     private boolean validate(final Object[] args) {


### PR DESCRIPTION
Resolve #8557.

This feature is disabled by default. 

It can be enabled by configuration "profiler.sendAppName.enable=true". The header for caller application name can be configured by "profiler.sendAppName.headerName", default to "X-Caller-Application-Name". If you want to have less traffic consumed, you can configure the header to "X-CAN" or "CAN". 

It's useful to combine this feature with PR #6987 "record server received request header/cookie" which has been available since version v2.1.0.

Supported http client:

- [x] Apache http client 4  (IT updated)
- [x] Apache http client 3   (IT updated)
- [x] jdk http url connection  (IT updated)
- [x] ning async http client  (IT updated)
- [x] okhttp (IT updated)
- [x] reactor-netty
- [x] webflux
- [x] vertx

