### PR TITLE
[#8557] Send caller app name

### DIFF
--- a/agent-module/agent/src/main/resources/pinpoint-root.config
+++ b/agent-module/agent/src/main/resources/pinpoint-root.config
@@ -344,6 +344,10 @@ profiler.http.status.code.errors=5xx
 # e.g. profiler.http.record.response.headers=Set-Cookie
 #profiler.http.record.response.headers=
 
+#always send caller application name regardless of sampling rate or async calling
+#profiler.sendAppName.enable=false
+#profiler.sendAppName.headerName=X-Caller-Application-Name
+
 ###########################################################
 # Application Type                                        #
 ###########################################################

--- a/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
@@ -243,6 +243,10 @@ profiler.http.record.request.cookies=
 # e.g. profiler.http.record.response.headers=Set-Cookie
 #profiler.http.record.response.headers=
 
+#always send caller application name regardless of sampling rate or async calling
+profiler.sendAppName.enable=true
+profiler.sendAppName.headerName=X-Caller-App
+
 ###########################################################
 # application type                                        #
 ###########################################################

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ApplicationInfoSender.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/ApplicationInfoSender.java
@@ -1,0 +1,7 @@
+package com.navercorp.pinpoint.bootstrap.plugin.request;
+
+public interface ApplicationInfoSender<REQ> {
+
+    void sendCallerApplicationName(REQ request);
+
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/DefaultApplicationInfoSender.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/DefaultApplicationInfoSender.java
@@ -1,0 +1,41 @@
+package com.navercorp.pinpoint.bootstrap.plugin.request;
+
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+
+import java.util.Objects;
+
+public class DefaultApplicationInfoSender<REQ> implements ApplicationInfoSender<REQ> {
+
+    private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
+
+    private final ClientHeaderAdaptor<REQ> clientHeaderAdaptor;
+
+    private final boolean enabled;
+    private final String headerName;
+    private final String applicationName;
+
+    public DefaultApplicationInfoSender(ClientHeaderAdaptor<REQ> clientHeaderAdaptor, TraceContext traceContext) {
+        this.clientHeaderAdaptor = Objects.requireNonNull(clientHeaderAdaptor, "clientHeaderAdaptor");
+        this.applicationName = traceContext.getApplicationName();
+        final ProfilerConfig config = traceContext.getProfilerConfig();
+        this.enabled = config.readBoolean("profiler.sendAppName.enable", false);
+        this.headerName = config.readString("profiler.sendAppName.headerName", "X-Caller-Application-Name");
+    }
+
+    @Override
+    public void sendCallerApplicationName(REQ request) {
+        if (!enabled || request == null) {
+            return;
+        }
+
+        try {
+            clientHeaderAdaptor.setHeader(request, headerName, applicationName);
+        } catch (Exception e) {
+            logger.info("Add caller application name header failed, caused by: ", e);
+        }
+    }
+
+}

--- a/agent-module/plugins-it/httpclient-it/httpclient-3-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient3/HttpClientIT.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-3-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient3/HttpClientIT.java
@@ -25,12 +25,14 @@ import com.navercorp.pinpoint.test.plugin.ImportPlugin;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PluginTest;
 import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
+import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HostConfiguration;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -84,6 +86,7 @@ public class HttpClientIT {
         try {
             // Execute the method.
             client.executeMethod(method);
+            assertCaller(method);
         } catch (Exception ignored) {
         } finally {
             method.releaseConnection();
@@ -118,4 +121,14 @@ public class HttpClientIT {
         PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
         verifier.printCache();
     }
+
+    private void assertCaller(GetMethod method) {
+        final Header[] headers = method.getResponseHeaders(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        Assertions.assertNotNull(headers, "caller headers null");
+        Assertions.assertEquals(1, headers.length, "caller headers count");
+        final String caller = headers[0].getValue();
+        Assertions.assertNotNull(caller, "caller null");
+        Assertions.assertTrue("mockApplicationName".contentEquals(caller), "not caller mockApplicationName");
+    }
+
 }

--- a/agent-module/plugins-it/httpclient-it/httpclient-4-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient4/ClosableAsyncHttpClientIT.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-4-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient4/ClosableAsyncHttpClientIT.java
@@ -35,6 +35,7 @@ import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -59,6 +60,8 @@ public class ClosableAsyncHttpClientIT extends HttpClientITBase {
         CloseableHttpAsyncClient httpClient = HttpAsyncClients.custom().useSystemProperties().build();
         httpClient.start();
 
+
+        String caller=null;
         try {
             HttpPost httpRequest = new HttpPost(getAddress());
 
@@ -72,6 +75,7 @@ public class ClosableAsyncHttpClientIT extends HttpClientITBase {
             if ((response != null) && (response.getEntity() != null)) {
                 EntityUtils.consume(response.getEntity());
             }
+            caller = getCallerApp(response);
         } finally {
             httpClient.close();
         }
@@ -93,5 +97,7 @@ public class ClosableAsyncHttpClientIT extends HttpClientITBase {
         verifier.verifyTrace(event("HTTP_CLIENT_4_INTERNAL", BasicFuture.class.getMethod("get")));
 
         verifier.verifyTraceCount(0);
+        Assertions.assertNotNull(caller, "caller null");
+        Assertions.assertTrue("mockApplicationName".contentEquals(caller),"not caller mockApplicationName");
     }
 }

--- a/agent-module/plugins-it/httpclient-it/httpclient-4-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient4/ClosableHttpClientIT.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-4-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient4/ClosableHttpClientIT.java
@@ -50,7 +50,7 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 @PinpointAgent(AgentPath.PATH)
 @Dependency({"org.apache.httpcomponents:httpclient:[4.3],[4.3.1],[4.3.2],[4.3.3],[4.3.4],[4.3.6],[4.4],[4.4.1],[4.5],[4.5.1],[4.5.2],[4.5.3],[4.5.4],[4.3.5]",
         WebServer.VERSION})
-public class CloaeableHttpClientIT extends HttpClientITBase {
+public class ClosableHttpClientIT extends HttpClientITBase {
 
     @Test
     public void test() throws Exception {

--- a/agent-module/plugins-it/httpclient-it/httpclient-4-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient4/HttpClientITBase.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-4-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient4/HttpClientITBase.java
@@ -17,6 +17,9 @@
 package com.navercorp.pinpoint.it.plugin.httpclient4;
 
 import com.navercorp.pinpoint.it.plugin.utils.WebServer;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -41,4 +44,16 @@ public abstract class HttpClientITBase {
     public static String getHostPort() {
         return webServer.getHostAndPort();
     }
+
+    public String getCallerApp(HttpResponse response) {
+        if (response == null) {
+            return null;
+        }
+        final Header callerHeader = response.getFirstHeader(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        if (callerHeader != null) {
+            return callerHeader.getValue();
+        }
+        return null;
+    }
+
 }

--- a/agent-module/plugins-it/jdk-http-it/src/test/java/com/navercorp/pinpoint/it/plugin/jdk/http/HttpURLConnectionIT.java
+++ b/agent-module/plugins-it/jdk-http-it/src/test/java/com/navercorp/pinpoint/it/plugin/jdk/http/HttpURLConnectionIT.java
@@ -26,6 +26,7 @@ import com.navercorp.pinpoint.test.plugin.JvmVersion;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -97,6 +98,7 @@ public class HttpURLConnectionIT {
         verifier.verifyTraceCount(3);
         verifier.verifyTrace(event("JDK_HTTPURLCONNECTOR", connect, null, null, destinationId,
                 annotation("http.url", httpUrl)));
+        assertCaller(connection);
     }
 
     @Test
@@ -131,4 +133,11 @@ public class HttpURLConnectionIT {
         verifier.printMethod();
         verifier.verifyTraceCount(2);
     }
+
+    private void assertCaller(HttpURLConnection connection) {
+        final String caller = connection.getHeaderField(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        Assertions.assertNotNull(caller, "caller null");
+        Assertions.assertTrue("test".contentEquals(caller), "not caller test");
+    }
+
 }

--- a/agent-module/plugins-it/ning-asyncclient-it/src/test/java/com/navercorp/pinpoint/it/plugin/ning/asynchttpclient/NingAsyncHttpClientIT.java
+++ b/agent-module/plugins-it/ning-asyncclient-it/src/test/java/com/navercorp/pinpoint/it/plugin/ning/asynchttpclient/NingAsyncHttpClientIT.java
@@ -30,6 +30,7 @@ import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.Request;
 import com.ning.http.client.Response;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -67,6 +68,7 @@ public class NingAsyncHttpClientIT {
         try {
             Future<Response> f = client.preparePost(webServer.getCallHttpUrl()).addParameter("param1", "value1").execute();
             Response response = f.get();
+            assertCaller(response);
         } finally {
             client.close();
         }
@@ -80,4 +82,10 @@ public class NingAsyncHttpClientIT {
                 annotation("http.url", httpUrl)));
         verifier.verifyTraceCount(0);
    }
+
+    private void assertCaller(Response response) {
+        final String caller = response.getHeader(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        Assertions.assertNotNull(caller, "caller null");
+        Assertions.assertTrue("mockApplicationName".contentEquals(caller), "not caller mockApplicationName");
+    }
 }

--- a/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_2_BaseIT.java
+++ b/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_2_BaseIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.okhttp;
+
+import com.navercorp.pinpoint.it.plugin.utils.WebServer;
+import com.squareup.okhttp.Response;
+
+/**
+ * @author yjqg6666
+ */
+public class OkHttpClient_2_BaseIT extends OkHttpClient_BaseIT {
+
+    protected void assertCaller(Response response) {
+        final String caller = response.header(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        assertCaller(caller);
+    }
+
+}

--- a/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_2_x_IT.java
+++ b/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_2_x_IT.java
@@ -55,7 +55,7 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 @PinpointAgent(AgentPath.PATH)
 @ImportPlugin("com.navercorp.pinpoint:pinpoint-okhttp-plugin")
 @Dependency({"com.squareup.okhttp:okhttp:[2.0.0,3.0.0)", WebServer.VERSION, PluginITConstants.VERSION})
-public class OkHttpClient_2_x_IT {
+public class OkHttpClient_2_x_IT extends OkHttpClient_2_BaseIT {
 
     static final String ASYNC = "ASYNC";
     static final String OK_HTTP_CLIENT = "OK_HTTP_CLIENT";
@@ -106,6 +106,8 @@ public class OkHttpClient_2_x_IT {
         );
 
         verifier.verifyTraceCount(0);
+
+        assertCaller(response);
     }
 
     @Test
@@ -164,6 +166,8 @@ public class OkHttpClient_2_x_IT {
         );
 
         verifier.verifyTraceCount(0);
+
+        assertCaller(response);
     }
 
     private Method getConnectMethod() {

--- a/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_3_0_0_to_3_3_x_IT.java
+++ b/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_3_0_0_to_3_3_x_IT.java
@@ -49,7 +49,7 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 @PinpointAgent(AgentPath.PATH)
 @ImportPlugin("com.navercorp.pinpoint:pinpoint-okhttp-plugin")
 @Dependency({"com.squareup.okhttp3:okhttp:[3.0.0,3.3.max]", WebServer.VERSION, PluginITConstants.VERSION})
-public class OkHttpClient_3_0_0_to_3_3_x_IT {
+public class OkHttpClient_3_0_0_to_3_3_x_IT extends OkHttpClient_3_BaseIT {
     static final String ASYNC = "ASYNC";
     static final String OK_HTTP_CLIENT = "OK_HTTP_CLIENT";
     static final String OK_HTTP_CLIENT_INTERNAL = "OK_HTTP_CLIENT_INTERNAL";
@@ -96,6 +96,9 @@ public class OkHttpClient_3_0_0_to_3_3_x_IT {
         ));
 
         verifier.verifyTraceCount(0);
+
+        assertCaller(response);
+
     }
 
     @Test

--- a/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_3_4_0_BaseIT.java
+++ b/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_3_4_0_BaseIT.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
 import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 
-public abstract class OkHttpClient_3_4_0_BaseIT {
+public abstract class OkHttpClient_3_4_0_BaseIT extends OkHttpClient_3_BaseIT {
     static final String ASYNC = "ASYNC";
     static final String OK_HTTP_CLIENT = "OK_HTTP_CLIENT";
     static final String OK_HTTP_CLIENT_INTERNAL = "OK_HTTP_CLIENT_INTERNAL";
@@ -80,6 +80,8 @@ public abstract class OkHttpClient_3_4_0_BaseIT {
                 annotation("http.internal.display", hostAndPort)));
 
         verifier.verifyTraceCount(0);
+
+        assertCaller(response);
     }
 
     @Test
@@ -131,6 +133,8 @@ public abstract class OkHttpClient_3_4_0_BaseIT {
                 annotation("http.internal.display", hostAndPort)));
 
         verifier.verifyTraceCount(0);
+
+        assertCaller(response);
     }
 
     private Method getConnectMethod(Class<?> realConnectionClass) throws ClassNotFoundException {

--- a/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_3_BaseIT.java
+++ b/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_3_BaseIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.okhttp;
+
+import com.navercorp.pinpoint.it.plugin.utils.WebServer;
+import okhttp3.Response;
+
+/**
+ * @author yjqg6666
+ */
+public class OkHttpClient_3_BaseIT extends OkHttpClient_BaseIT {
+
+    protected void assertCaller(Response response) {
+        final String caller = response.header(WebServer.CALLER_RESPONSE_HEADER_NAME);
+        assertCaller(caller);
+    }
+
+}

--- a/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_BaseIT.java
+++ b/agent-module/plugins-it/okhttp-it/src/test/java/com/navercorp/pinpoint/it/plugin/okhttp/OkHttpClient_BaseIT.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.okhttp;
+
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * @author yjqg6666
+ */
+public class OkHttpClient_BaseIT {
+
+    protected void assertCaller(String caller) {
+        Assertions.assertNotNull(caller, "caller null");
+        Assertions.assertTrue("mockApplicationName".contentEquals(caller), "not caller mockApplicationName");
+    }
+
+}

--- a/agent-module/plugins-test-module/plugins-it-utils/src/main/java/com/navercorp/pinpoint/it/plugin/utils/WebServer.java
+++ b/agent-module/plugins-test-module/plugins-it-utils/src/main/java/com/navercorp/pinpoint/it/plugin/utils/WebServer.java
@@ -31,6 +31,8 @@ public class WebServer extends NanoHTTPD {
     public static final String VERSION = "org.nanohttpd:nanohttpd:2.3.1";
     public static final String LOCAL_HOST = "localhost";
 
+    public static final String CALLER_RESPONSE_HEADER_NAME = "caller-app";
+
     public WebServer(String hostname, int port) {
         super(hostname, port);
     }
@@ -45,7 +47,11 @@ public class WebServer extends NanoHTTPD {
     @Override
     public Response serve(IHTTPSession session) {
         Map<String, List<String>> parameters = session.getParameters();
+        final String caller = session.getHeaders().get("x-caller-app");
         Response response = newFixedLengthResponse(parameters.toString());
+        if (caller != null) {
+            response.addHeader(CALLER_RESPONSE_HEADER_NAME, caller);
+        }
         return response;
     }
 

--- a/agent-module/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/interceptor/AbstractHttpURLConnectionInterceptor.java
+++ b/agent-module/plugins/jdk-http/src/main/java/com/navercorp/pinpoint/plugin/jdk/http/interceptor/AbstractHttpURLConnectionInterceptor.java
@@ -26,9 +26,11 @@ import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScopeInvocation;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.plugin.jdk.http.HttpURLConnectionClientHeaderAdaptor;
@@ -55,6 +57,7 @@ public abstract class AbstractHttpURLConnectionInterceptor implements AroundInte
     private final ClientRequestRecorder<HttpURLConnection> clientRequestRecorder;
     private final RequestTraceWriter<HttpURLConnection> requestTraceWriter;
     private final ClientRequestAdaptor<HttpURLConnection> clientRequestAdaptor = new JdkHttpClientRequestAdaptor();
+    private final ApplicationInfoSender<HttpURLConnection> applicationInfoSender;
 
     public AbstractHttpURLConnectionInterceptor(TraceContext traceContext, MethodDescriptor descriptor, InterceptorScope scope) {
         this.traceContext = traceContext;
@@ -65,6 +68,7 @@ public abstract class AbstractHttpURLConnectionInterceptor implements AroundInte
         this.clientRequestRecorder = new ClientRequestRecorder<>(config.isParam(), clientRequestAdaptor);
         final ClientHeaderAdaptor<HttpURLConnection> clientHeaderAdaptor = new HttpURLConnectionClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     @Override
@@ -107,6 +111,7 @@ public abstract class AbstractHttpURLConnectionInterceptor implements AroundInte
                     }
                 }
             }
+            this.applicationInfoSender.sendCallerApplicationName(request);
         } catch (Throwable th) {
             if (logger.isWarnEnabled()) {
                 logger.warn("BEFORE. Caused:{}", th.getMessage(), th);

--- a/agent-module/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v2/interceptor/AbstractRequestBuilderBuildMethodInterceptor.java
+++ b/agent-module/plugins/okhttp/src/main/java/com/navercorp/pinpoint/plugin/okhttp/v2/interceptor/AbstractRequestBuilderBuildMethodInterceptor.java
@@ -25,7 +25,9 @@ import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScopeInvocation;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.plugin.okhttp.v2.RequestBuilder2ClientHeaderAdaptor;
@@ -42,6 +44,7 @@ public abstract class AbstractRequestBuilderBuildMethodInterceptor implements Ar
     protected final MethodDescriptor methodDescriptor;
     protected final InterceptorScope interceptorScope;
     protected final RequestTraceWriter<Request.Builder> requestTraceWriter;
+    protected final ApplicationInfoSender<Request.Builder> applicationInfoSender;
 
     public AbstractRequestBuilderBuildMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, InterceptorScope interceptorScope) {
         this.traceContext = traceContext;
@@ -50,6 +53,7 @@ public abstract class AbstractRequestBuilderBuildMethodInterceptor implements Ar
 
         ClientHeaderAdaptor<Request.Builder> clientHeaderAdaptor = new RequestBuilder2ClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     abstract String toHost(Object target);
@@ -60,17 +64,18 @@ public abstract class AbstractRequestBuilderBuildMethodInterceptor implements Ar
             logger.beforeInterceptor(target, args);
         }
 
-        final Trace trace = traceContext.currentRawTraceObject();
-        if (trace == null) {
+        if (!(target instanceof Request.Builder)) {
             return;
         }
 
         try {
-            if (!(target instanceof Request.Builder)) {
+            final Request.Builder builder = ((Request.Builder) target);
+            applicationInfoSender.sendCallerApplicationName(builder);
+
+            final Trace trace = traceContext.currentRawTraceObject();
+            if (trace == null) {
                 return;
             }
-            final Request.Builder builder = ((Request.Builder) target);
-
             if (trace.canSampled()) {
                 final InterceptorScopeInvocation invocation = interceptorScope.getCurrentInvocation();
                 final Object attachment = getAttachment(invocation);

--- a/agent-module/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpClientOperationsSendInterceptor.java
+++ b/agent-module/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpClientOperationsSendInterceptor.java
@@ -23,10 +23,12 @@ import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.context.TraceId;
 import com.navercorp.pinpoint.bootstrap.interceptor.AsyncContextSpanEventApiIdAwareAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapperAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.plugin.reactor.netty.ReactorNettyConstants;
@@ -39,6 +41,7 @@ import reactor.netty.http.client.HttpClientRequest;
 public class HttpClientOperationsSendInterceptor extends AsyncContextSpanEventApiIdAwareAroundInterceptor {
     private final ClientRequestRecorder<ClientRequestWrapper> clientRequestRecorder;
     private final RequestTraceWriter<HttpClientRequest> requestTraceWriter;
+    private final ApplicationInfoSender<HttpClientRequest> applicationInfoSender;
 
     public HttpClientOperationsSendInterceptor(TraceContext traceContext) {
         super(traceContext);
@@ -49,6 +52,7 @@ public class HttpClientOperationsSendInterceptor extends AsyncContextSpanEventAp
         this.clientRequestRecorder = new ClientRequestRecorder<>(param, clientRequestAdaptor);
         final HttpClientRequestHeaderAdaptor clientHeaderAdaptor = new HttpClientRequestHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     // BEFORE
@@ -75,6 +79,7 @@ public class HttpClientOperationsSendInterceptor extends AsyncContextSpanEventAp
             // Set sampling rate to false
             this.requestTraceWriter.write(request);
         }
+        this.applicationInfoSender.sendCallerApplicationName(request);
     }
 
     @Override

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/BodyInserterRequestBuilderWriteToInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/BodyInserterRequestBuilderWriteToInterceptor.java
@@ -24,10 +24,12 @@ import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.context.TraceId;
 import com.navercorp.pinpoint.bootstrap.interceptor.AsyncContextSpanEventSimpleAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapperAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
@@ -48,6 +50,7 @@ public class BodyInserterRequestBuilderWriteToInterceptor extends AsyncContextSp
     private final ClientRequestRecorder<ClientRequestWrapper> clientRequestRecorder;
     private final CookieRecorder<ClientHttpRequest> cookieRecorder;
     private final RequestTraceWriter<ClientHttpRequest> requestTraceWriter;
+    private final ApplicationInfoSender<ClientHttpRequest> applicationInfoSender;
 
     public BodyInserterRequestBuilderWriteToInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
         super(traceContext, methodDescriptor);
@@ -61,6 +64,7 @@ public class BodyInserterRequestBuilderWriteToInterceptor extends AsyncContextSp
 
         final ClientHttpRequestClientHeaderAdaptor clientHeaderAdaptor = new ClientHttpRequestClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     @Override
@@ -88,6 +92,7 @@ public class BodyInserterRequestBuilderWriteToInterceptor extends AsyncContextSp
         } else {
             requestTraceWriter.write(request);
         }
+        applicationInfoSender.sendCallerApplicationName(request);
     }
 
     @Override

--- a/agent-module/plugins/vertx/src/main/java/com/navercorp/pinpoint/plugin/vertx/interceptor/Http1xClientConnectionCreateRequestInterceptor.java
+++ b/agent-module/plugins/vertx/src/main/java/com/navercorp/pinpoint/plugin/vertx/interceptor/Http1xClientConnectionCreateRequestInterceptor.java
@@ -23,11 +23,13 @@ import com.navercorp.pinpoint.bootstrap.context.TraceId;
 import com.navercorp.pinpoint.bootstrap.interceptor.ApiIdAwareAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapperAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
@@ -50,6 +52,7 @@ public abstract class Http1xClientConnectionCreateRequestInterceptor implements 
     private final ClientRequestRecorder<ClientRequestWrapper> clientRequestRecorder;
     private final CookieRecorder<HttpRequest> cookieRecorder;
     private final RequestTraceWriter<HttpRequest> requestTraceWriter;
+    private final ApplicationInfoSender<HttpRequest> applicationInfoSender;
 
     abstract String getHost(Object[] args);
 
@@ -65,6 +68,7 @@ public abstract class Http1xClientConnectionCreateRequestInterceptor implements 
 
         ClientHeaderAdaptor<HttpRequest> clientHeaderAdaptor = new HttpRequestClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     @Override
@@ -122,6 +126,7 @@ public abstract class Http1xClientConnectionCreateRequestInterceptor implements 
                 // write samplingRateFalse
                 requestTraceWriter.write(request);
             }
+            applicationInfoSender.sendCallerApplicationName(request);
         } catch (Throwable t) {
             if (logger.isWarnEnabled()) {
                 logger.warn("AFTER. Caused:{}", t.getMessage(), t);

--- a/agent-module/plugins/vertx/src/main/java/com/navercorp/pinpoint/plugin/vertx/interceptor/HttpClientStreamInterceptor.java
+++ b/agent-module/plugins/vertx/src/main/java/com/navercorp/pinpoint/plugin/vertx/interceptor/HttpClientStreamInterceptor.java
@@ -22,11 +22,13 @@ import com.navercorp.pinpoint.bootstrap.context.TraceId;
 import com.navercorp.pinpoint.bootstrap.interceptor.ApiIdAwareAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapperAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultApplicationInfoSender;
 import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
@@ -52,6 +54,7 @@ public class HttpClientStreamInterceptor implements ApiIdAwareAroundInterceptor 
     private final ClientRequestRecorder<ClientRequestWrapper> clientRequestRecorder;
     private final CookieRecorder<HttpRequest> cookieRecorder;
     private final RequestTraceWriter<HttpRequest> requestTraceWriter;
+    private final ApplicationInfoSender<HttpRequest> applicationInfoSender;
 
     public HttpClientStreamInterceptor(TraceContext traceContext) {
         this.traceContext = traceContext;
@@ -65,6 +68,7 @@ public class HttpClientStreamInterceptor implements ApiIdAwareAroundInterceptor 
 
         ClientHeaderAdaptor<HttpRequest> clientHeaderAdaptor = new HttpRequestClientHeaderAdaptor();
         this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+        this.applicationInfoSender = new DefaultApplicationInfoSender<>(clientHeaderAdaptor, traceContext);
     }
 
     @Override
@@ -100,6 +104,7 @@ public class HttpClientStreamInterceptor implements ApiIdAwareAroundInterceptor 
             } else {
                 requestTraceWriter.write(request);
             }
+            applicationInfoSender.sendCallerApplicationName(request);
         } catch (Throwable t) {
             if (logger.isWarnEnabled()) {
                 logger.warn("BEFORE. Caused:{}", t.getMessage(), t);


### PR DESCRIPTION
Resolve #8557.

This feature is disabled by default. 

It can be enabled by configuration "profiler.sendAppName.enable=true". The header for caller application name can be configured by "profiler.sendAppName.headerName", default to "X-Caller-Application-Name". If you want to have less traffic consumed, you can configure the header to "X-CAN" or "CAN" or "Caller". 

It's useful to combine this feature with PR #6987 "record server received request header/cookie" which has been available since version v2.1.0.

Supported http client:

- [x] Apache http client 4  (IT updated)
- [x] Apache http client 3   (IT updated)
- [x] jdk http url connection  (IT updated)
- [x] ning async http client  (IT updated)
- [x] okhttp (IT updated)
- [x] reactor-netty
- [x] webflux
- [x] vertx
