### PR TITLE
Add support 5.6.0 ~ 7.4.x RestClient to elasticsearch plugin, and add elastic index and method Annotation 

### DIFF
--- a/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/ElasticPluginUtil.java
+++ b/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/ElasticPluginUtil.java
@@ -1,0 +1,41 @@
+/*
+ * www.msxf.com Inc.
+ * Copyright (c) 2017 All Rights Reserved
+ */
+
+/*
+ * 修订记录:
+ * shuijing 2021-12-10 15:52 创建
+ */
+package com.navercorp.pinpoint.plugin.elasticsearch;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author shuijing
+ */
+public class ElasticPluginUtil {
+    public static final Pattern INDEX_NAME_PATTERN = Pattern.compile("^/([^/]+)/.*");
+    public static final Pattern INDEX_NAME_PATTERN2 = Pattern.compile("([^/]+)/.*");
+
+    public static CharSequence toString(Object part) {
+        return (part instanceof CharSequence) ? (CharSequence) part : part.toString();
+    }
+
+
+    public static String getIndex(String url) {
+        final Matcher matcher = INDEX_NAME_PATTERN.matcher(url);
+        if (matcher.find()) {
+            return matcher.group(1);
+        } else {
+            final Matcher matcher2 = INDEX_NAME_PATTERN2.matcher(url);
+            if (matcher2.find()) {
+                return matcher2.group(1);
+            }
+        }
+        return url;
+    }
+
+
+}

--- a/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/ElasticsearchConstants.java
+++ b/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/ElasticsearchConstants.java
@@ -19,6 +19,7 @@ import com.navercorp.pinpoint.common.trace.AnnotationKeyFactory;
 import com.navercorp.pinpoint.common.trace.AnnotationKeyProperty;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeProvider;
+import com.navercorp.pinpoint.common.trace.AnnotationKeyProvider;
 
 /**
  * @author Roy Kim
@@ -27,9 +28,13 @@ public class ElasticsearchConstants {
 
     public static final AnnotationKey ARGS_DSL_ANNOTATION_KEY = AnnotationKeyFactory.of(173, "es.dsl", AnnotationKeyProperty.VIEW_IN_RECORD_SET);
     public static final AnnotationKey ARGS_VERSION_ANNOTATION_KEY = AnnotationKeyFactory.of(176, "es.version", AnnotationKeyProperty.VIEW_IN_RECORD_SET);
+    public static final AnnotationKey INDEX_KEY = AnnotationKeyProvider.getByCode(17777);;
+    public static final AnnotationKey INDEX_KEY_METHOD = AnnotationKeyProvider.getByCode(17778);;
+
 
     public static final ServiceType ELASTICSEARCH = ServiceTypeProvider.getByName("ELASTICSEARCH");
     public static final ServiceType ELASTICSEARCH_EXECUTOR = ServiceTypeProvider.getByName("ELASTICSEARCH_HIGHLEVEL_CLIENT");
+    public static final ServiceType ELASTICSEARCH_EEST = ServiceTypeProvider.getByName("ELASTICSEARCH_REST_CLIENT");
 
     public static final String ELASTICSEARCH_SCOPE = "Elasticsearch_SCOPE";
     public static final String ELASTICSEARCH_EXECUTOR_SCOPE = "ElasticsearchExecutor_SCOPE";

--- a/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/ElasticsearchMetadataProvider.java
+++ b/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/ElasticsearchMetadataProvider.java
@@ -30,9 +30,12 @@ public class ElasticsearchMetadataProvider implements TraceMetadataProvider {
         }
         context.addServiceType(ElasticsearchConstants.ELASTICSEARCH);
         context.addServiceType(ElasticsearchConstants.ELASTICSEARCH_EXECUTOR);
+        context.addServiceType(ElasticsearchConstants.ELASTICSEARCH_EEST);
 
         context.addAnnotationKey(ElasticsearchConstants.ARGS_VERSION_ANNOTATION_KEY);//Elasticsearch version info
         context.addAnnotationKey(ElasticsearchConstants.ARGS_DSL_ANNOTATION_KEY);//HTTP DSL body conent
+        context.addAnnotationKey(ElasticsearchConstants.INDEX_KEY);
+        context.addAnnotationKey(ElasticsearchConstants.INDEX_KEY_METHOD);
     }
 
 }

--- a/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/interceptor/HighLevelConnectInterceptor.java
+++ b/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/interceptor/HighLevelConnectInterceptor.java
@@ -72,7 +72,7 @@ public class HighLevelConnectInterceptor implements AroundInterceptor {
         }
     }
 
-    private String merge(List<String> host) {
+    public static String merge(List<String> host) {
         if (host.isEmpty()) {
             return "";
         }
@@ -95,12 +95,12 @@ public class HighLevelConnectInterceptor implements AroundInterceptor {
     }
 
 
-    private List<String> getHostList(Object arg) {
+    public static List<String> getHostList(Object arg) {
         if (!(arg instanceof RestClient)) {
             return Collections.emptyList();
         }
 
-        final List<String> hostList = new ArrayList<>();
+        final List<String> hostList = new ArrayList<String>();
 
         HttpHost[] httpHosts = null;
         if (arg instanceof HttpHostInfoAccessor) {

--- a/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/interceptor/RestClient6ConnectInterceptor.java
+++ b/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/interceptor/RestClient6ConnectInterceptor.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.elasticsearch.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.*;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
+import com.navercorp.pinpoint.plugin.elasticsearch.accessor.HttpHostInfoAccessor;
+import org.apache.http.HttpHost;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.navercorp.pinpoint.plugin.elasticsearch.ElasticPluginUtil.getIndex;
+import static com.navercorp.pinpoint.plugin.elasticsearch.ElasticsearchConstants.*;
+import static com.navercorp.pinpoint.plugin.elasticsearch.interceptor.HighLevelConnectInterceptor.merge;
+
+/**
+ * @author shuijing
+ */
+public class RestClient6ConnectInterceptor implements AroundInterceptor {
+
+    private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final MethodDescriptor descriptor;
+    private final TraceContext traceContext;
+
+    public RestClient6ConnectInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
+        this.traceContext = traceContext;
+        this.descriptor = descriptor;
+    }
+
+    @Override
+    public void before(Object target, Object[] args) {
+//        logger.info("RestClient5 Interceptor before");
+        if (isDebug) {
+            logger.beforeInterceptor(target, args);
+        }
+
+        Trace trace = traceContext.currentTraceObject();
+        if (null != trace) {
+            SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(ELASTICSEARCH_EEST);
+            TraceId nextId = trace.getTraceId().getNextTraceId();
+            recorder.recordNextSpanId(nextId.getSpanId());
+            recorder.recordDestinationId("ElasticSearch");
+        } else {
+            logger.debug("before(): no trace found, set new trace");
+            trace = traceContext.newTraceObject();
+            SpanRecorder recorder = trace.getSpanRecorder();
+            recorder.recordServiceType(ELASTICSEARCH_EEST);
+            recorder.attachFrameObject(true);
+        }
+    }
+
+    @Override
+    public void after(Object target, Object[] args, Object result, Throwable throwable) {
+//        logger.info("RestClient5 Interceptor after");
+        if (isDebug) {
+            logger.afterInterceptor(target, args);
+        }
+
+        Trace trace = traceContext.currentTraceObject();
+        if (trace == null || !trace.canSampled()) {
+            return;
+        }
+
+        try {
+            if (isNewTrace(trace.getSpanRecorder().getFrameObject())) {
+                //new Trace create
+                SpanRecorder recorder = trace.getSpanRecorder();
+                recorder.recordApi(descriptor);
+                recorder.recordEndPoint(merge(getEndpoints(target)));
+                recorder.recordAttribute(INDEX_KEY, getRequestEndpoint(args));
+                recorder.recordAttribute(INDEX_KEY_METHOD, getRequestMethod(args));
+                if (throwable != null) {
+                    logger.debug("after(): get throwable");
+                    recorder.recordException(throwable);
+                }
+            } else {
+                SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+                recorder.recordApi(descriptor);
+                recorder.recordDestinationId("ElasticSearch");
+                recorder.recordEndPoint(merge(getEndpoints(target)));
+                recorder.recordAttribute(INDEX_KEY, getRequestEndpoint(args));
+                recorder.recordAttribute(INDEX_KEY_METHOD, getRequestMethod(args));
+                if (throwable != null) {
+                    logger.debug("after(): get throwable");
+                    recorder.recordException(throwable);
+                }
+            }
+        } catch (Exception e) {
+            logger.error("after(): get throwable");
+        } finally {
+            if (isNewTrace(trace.getSpanRecorder().getFrameObject())) {
+                traceContext.removeTraceObject();
+                trace.close();
+            } else {
+                trace.traceBlockEnd();
+            }
+        }
+    }
+
+    private boolean isNewTrace(Object object) {
+        return object != null && (Boolean) object;
+    }
+
+    protected List<String> getEndpoints(Object target) {
+        final List<String> hostList = new ArrayList<String>();
+        try {
+
+            HttpHost[] httpHosts = null;
+            if (target instanceof HttpHostInfoAccessor) {
+                httpHosts = ((HttpHostInfoAccessor) target)._$PINPOINT$_getHttpHostInfo();
+            }
+
+            if (httpHosts != null) {
+                for (HttpHost httpHost : httpHosts) {
+                    final String hostAddress = HostAndPort.toHostAndPortString(httpHost.getHostName(), httpHost.getPort());
+                    hostList.add(hostAddress);
+                }
+            }
+
+            return hostList;
+        } catch (Exception e) {
+            if (isDebug) {
+                logger.info("failed to getRequestEndpoint method. caused:{}", e.getMessage(), e);
+            }
+        }
+        return hostList;
+    }
+
+    protected String getRequestEndpoint(Object[] args) {
+        try {
+            if (args.length > 1) {
+                if (args[1] != null && args[1] instanceof java.lang.String) {
+                    String endpoint = ((String) args[1]);
+                    return getIndex((endpoint));
+                }
+            }
+        } catch (Exception e) {
+            if (isDebug) {
+                logger.info("failed to getRequestEndpoint method. caused:{}", e.getMessage(), e);
+            }
+        }
+        return "";
+    }
+
+
+    protected String getRequestMethod(Object[] args) {
+        try {
+            if (args.length > 0) {
+                if (args[0] instanceof java.lang.String) {
+                    return ((String) args[0]);
+                }
+            }
+        } catch (Exception e) {
+            if (isDebug) {
+                logger.info("failed to getRequestMethod method. caused:{}", e.getMessage(), e);
+            }
+        }
+        return "";
+    }
+
+
+}

--- a/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/interceptor/RestClient7ConnectInterceptor.java
+++ b/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/interceptor/RestClient7ConnectInterceptor.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2019 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.elasticsearch.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.*;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PLogger;
+import com.navercorp.pinpoint.bootstrap.logging.PLoggerFactory;
+import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.navercorp.pinpoint.plugin.elasticsearch.ElasticPluginUtil.getIndex;
+import static com.navercorp.pinpoint.plugin.elasticsearch.ElasticsearchConstants.*;
+import static com.navercorp.pinpoint.plugin.elasticsearch.interceptor.HighLevelConnectInterceptor.merge;
+
+/**
+ * @author shuijing
+ */
+public class RestClient7ConnectInterceptor implements AroundInterceptor {
+
+
+    private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final MethodDescriptor descriptor;
+    private final TraceContext traceContext;
+
+    public RestClient7ConnectInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
+        this.traceContext = traceContext;
+        this.descriptor = descriptor;
+    }
+
+    @Override
+    public void before(Object target, Object[] args) {
+        if (isDebug) {
+            logger.beforeInterceptor(target, args);
+        }
+
+        Trace trace = traceContext.currentTraceObject();
+        if (null != trace) {
+            SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(ELASTICSEARCH_EEST);
+            TraceId nextId = trace.getTraceId().getNextTraceId();
+            recorder.recordNextSpanId(nextId.getSpanId());
+            recorder.recordDestinationId("ElasticSearch");
+        } else {
+            logger.debug("before(): no trace found, set new trace");
+            trace = traceContext.newTraceObject();
+            SpanRecorder recorder = trace.getSpanRecorder();
+            recorder.recordServiceType(ELASTICSEARCH_EEST);
+            recorder.attachFrameObject(true);
+        }
+    }
+
+    @Override
+    public void after(Object target, Object[] args, Object result, Throwable throwable) {
+        if (isDebug) {
+            logger.afterInterceptor(target, args);
+        }
+
+        Trace trace = traceContext.currentTraceObject();
+        if (trace == null || !trace.canSampled()) {
+            return;
+        }
+
+        try {
+            if (isNewTrace(trace.getSpanRecorder().getFrameObject())) {
+                //new Trace create
+                SpanRecorder recorder = trace.getSpanRecorder();
+                recorder.recordApi(descriptor);
+                recorder.recordEndPoint(merge(getEndpoints(target)));
+                recorder.recordAttribute(INDEX_KEY, getRequestEndpoint(args));
+                recorder.recordAttribute(INDEX_KEY_METHOD, getRequestMethod(args));
+                if (throwable != null) {
+                    logger.debug("after(): get throwable");
+                    recorder.recordException(throwable);
+                }
+            } else {
+                SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+                recorder.recordApi(descriptor);
+                recorder.recordDestinationId("ElasticSearch");
+                recorder.recordEndPoint(merge(getEndpoints(target)));
+                recorder.recordAttribute(INDEX_KEY, getRequestEndpoint(args));
+                recorder.recordAttribute(INDEX_KEY_METHOD, getRequestMethod(args));
+                if (throwable != null) {
+                    logger.debug("after(): get throwable");
+                    recorder.recordException(throwable);
+                }
+            }
+        } catch (Exception e) {
+            logger.error("after(): get throwable");
+        } finally {
+            if (isNewTrace(trace.getSpanRecorder().getFrameObject())) {
+                traceContext.removeTraceObject();
+                trace.close();
+            } else {
+                trace.traceBlockEnd();
+            }
+        }
+    }
+
+    private boolean isNewTrace(Object object) {
+        return object != null && (Boolean) object;
+    }
+
+    protected List<String> getEndpoints(Object target) {
+        final List<String> hostList = new ArrayList<String>();
+        try {
+            if (target instanceof org.elasticsearch.client.RestClient) {
+                List<Node> nodes = ((RestClient) target).getNodes();
+                if (nodes != null) {
+                    for (Node node : nodes) {
+                        final String hostAddress = HostAndPort.toHostAndPortString(node.getHost().getHostName(), node.getHost().getPort());
+                        hostList.add(hostAddress);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            if (isDebug) {
+                logger.info("failed to getEndpoints method. caused:{}", e.getMessage(), e);
+            }
+        }
+        return hostList;
+    }
+
+    protected String getRequestEndpoint(Object[] args) {
+        try {
+            if (args.length > 0) {
+                if (args[0] instanceof org.elasticsearch.client.Request) {
+                    Request request = ((Request) args[0]);
+                    String endpoint = request.getEndpoint();
+                    if (endpoint != null) {
+                        return getIndex((endpoint));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            if (isDebug) {
+                logger.info("failed to getRequestEndpoint method. caused:{}", e.getMessage(), e);
+            }
+        }
+        return "";
+    }
+
+
+    protected String getRequestMethod(Object[] args) {
+        try {
+            if (args.length > 0) {
+                if (args[0] instanceof org.elasticsearch.client.Request) {
+                    Request request = ((Request) args[0]);
+                    String method = request.getMethod();
+                    if (method != null) {
+                        return method;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            if (isDebug) {
+                logger.info("failed to getRequestMethod method. caused:{}", e.getMessage(), e);
+            }
+        }
+        return "";
+    }
+
+
+
+
+
+}

--- a/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/interceptor/RestClientHostsInterceptor.java
+++ b/plugins/elasticsearch/src/main/java/com/navercorp/pinpoint/plugin/elasticsearch/interceptor/RestClientHostsInterceptor.java
@@ -23,14 +23,14 @@ import com.navercorp.pinpoint.plugin.elasticsearch.accessor.HttpHostInfoAccessor
 import org.apache.http.HttpHost;
 
 /**
- * @author Roy Kim
+ * @author shuijing
  */
-public class RestClientConnectInterceptor implements AroundInterceptor {
+public class RestClientHostsInterceptor implements AroundInterceptor {
 
     private final PLogger logger = PLoggerFactory.getLogger(this.getClass());
     private final boolean isDebug = logger.isDebugEnabled();
 
-    public RestClientConnectInterceptor() {
+    public RestClientHostsInterceptor() {
     }
 
     @Override

--- a/plugins/elasticsearch/src/main/resources/META-INF/pinpoint/type-provider.yml
+++ b/plugins/elasticsearch/src/main/resources/META-INF/pinpoint/type-provider.yml
@@ -5,8 +5,22 @@ serviceTypes:
       name: 'ELASTICSEARCH_HIGHLEVEL_CLIENT'
       desc: 'ELASTICSEARCH'
       property:
-#          recordStatistics: true
-          alias: true
-#      matcher:
-#          type: 'exact'
-#          code: 40 # http.url
+          recordStatistics: true
+#          alias: true
+      matcher:
+          type: 'exact'
+          code: 40 # http.url
+    - code: 9205
+      name: 'ELASTICSEARCH_REST_CLIENT'
+      desc: 'ELASTICSEARCH'
+      property:
+           recordStatistics: true
+annotationKeys:
+    - code: 17777
+      name: 'es.index'
+      property:
+          viewInRecordSet: true
+    - code: 17778
+      name: 'es.index.method'
+      property:
+          viewInRecordSet: true


### PR DESCRIPTION
1. Add support 5.6.0 ~ 7.4.x RestClient to elasticsearch plugin. HighLevelClient is base on RestClient,so it is also support HighLevelClient 5.6.0 ~ 7.4.x
2. Add elastic index and method Annotation, The elastic api meet restful standards,so we can get index from rest url.
3. The plugin was tested and run in production environment 
![image](https://user-images.githubusercontent.com/20434652/149323032-c37b516b-aea3-408b-a9f4-6aff3371dfbe.png)
