### PR TITLE
Add support 5.6.0 ~ 7.4.x RestClient to elasticsearch plugin

### DIFF
--- a/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfig.java
+++ b/plugins/kafka/src/main/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfig.java
@@ -17,6 +17,10 @@
 package com.navercorp.pinpoint.plugin.kafka;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
 
 public class KafkaConfig {
 
@@ -38,7 +42,7 @@ public class KafkaConfig {
     private final boolean springConsumerEnable;
     private final boolean headerEnable;
     private final boolean headerRecorded;
-    private final String kafkaEntryPoint;
+    private final List<String> kafkaEntryPoints;
 
     public KafkaConfig(ProfilerConfig config) {
         this.producerEnable = config.readBoolean(PRODUCER_ENABLE, false);
@@ -46,7 +50,7 @@ public class KafkaConfig {
         this.springConsumerEnable = config.readBoolean(SPRING_CONSUMER_ENABLE, false);
         this.headerEnable = config.readBoolean(HEADER_ENABLE, true);
         this.headerRecorded = config.readBoolean(HEADER_RECORD, true);
-        this.kafkaEntryPoint = config.readString(CONSUMER_ENTRY_POINT, "");
+        this.kafkaEntryPoints = split(config.readString(CONSUMER_ENTRY_POINT, ""));
     }
 
     public boolean isProducerEnable() {
@@ -69,8 +73,16 @@ public class KafkaConfig {
         return headerRecorded;
     }
 
-    public String getKafkaEntryPoint() {
-        return kafkaEntryPoint;
+    public List<String> getKafkaEntryPoints() {
+        return kafkaEntryPoints;
+    }
+
+    private List<String> split(String values) {
+        if (StringUtils.isEmpty(values)) {
+            return Collections.emptyList();
+        }
+
+        return StringUtils.tokenizeToStringList(values, ",");
     }
 
     @Override
@@ -80,7 +92,7 @@ public class KafkaConfig {
                 ", consumerEnable=" + consumerEnable +
                 ", springConsumerEnable=" + springConsumerEnable +
                 ", headerEnable=" + headerEnable +
-                ", kafkaEntryPoint='" + kafkaEntryPoint + '\'' +
+                ", kafkaEntryPoints='" + kafkaEntryPoints.toString() + '\'' +
                 '}';
     }
 }

--- a/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfigTest.java
+++ b/plugins/kafka/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaConfigTest.java
@@ -30,11 +30,11 @@ public class KafkaConfigTest {
 
     @Test
     public void configTest1() throws Exception {
-        KafkaConfig config = createConfig("true", "true", "entryPoint");
+        KafkaConfig config = createConfig("true", "true", "entryPoint1,entryPoint2");
 
         Assert.assertTrue(config.isProducerEnable());
         Assert.assertTrue(config.isConsumerEnable());
-        Assert.assertEquals("entryPoint", config.getKafkaEntryPoint());
+        Assert.assertEquals("[entryPoint1, entryPoint2]", config.getKafkaEntryPoints().toString());
     }
 
     @Test
@@ -43,7 +43,7 @@ public class KafkaConfigTest {
 
         Assert.assertTrue(config.isProducerEnable());
         Assert.assertFalse(config.isConsumerEnable());
-        Assert.assertEquals("", config.getKafkaEntryPoint());
+        Assert.assertEquals("[]", config.getKafkaEntryPoints().toString());
     }
 
     @Test
@@ -52,7 +52,7 @@ public class KafkaConfigTest {
 
         Assert.assertFalse(config.isProducerEnable());
         Assert.assertTrue(config.isConsumerEnable());
-        Assert.assertEquals("", config.getKafkaEntryPoint());
+        Assert.assertEquals("[]", config.getKafkaEntryPoints().toString());
     }
 
     @Test
@@ -61,7 +61,7 @@ public class KafkaConfigTest {
 
         Assert.assertFalse(config.isProducerEnable());
         Assert.assertFalse(config.isConsumerEnable());
-        Assert.assertEquals("", config.getKafkaEntryPoint());
+        Assert.assertEquals("[]", config.getKafkaEntryPoints().toString());
     }
 
     @Test
@@ -71,7 +71,7 @@ public class KafkaConfigTest {
         Assert.assertTrue(config.isProducerEnable());
         Assert.assertFalse(config.isConsumerEnable());
         Assert.assertTrue(config.isHeaderEnable());
-        Assert.assertEquals("entryPoint1", config.getKafkaEntryPoint());
+        Assert.assertEquals("[entryPoint1]", config.getKafkaEntryPoints().toString());
     }
 
     @Test
@@ -81,7 +81,7 @@ public class KafkaConfigTest {
         Assert.assertTrue(config.isProducerEnable());
         Assert.assertFalse(config.isConsumerEnable());
         Assert.assertFalse(config.isHeaderEnable());
-        Assert.assertEquals("entryPoint2", config.getKafkaEntryPoint());
+        Assert.assertEquals("[entryPoint2]", config.getKafkaEntryPoints().toString());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class KafkaConfigTest {
         Assert.assertFalse(config.isProducerEnable());
         Assert.assertTrue(config.isConsumerEnable());
         Assert.assertFalse(config.isHeaderEnable());
-        Assert.assertEquals("entryPoint3", config.getKafkaEntryPoint());
+        Assert.assertEquals("[entryPoint3]", config.getKafkaEntryPoints().toString());
     }
 
     private KafkaConfig createConfig(String producerEnable, String consumerEnable) {


### PR DESCRIPTION
1. Add support 5.6.0 ~ 7.4.x RestClient to elasticsearch plugin. HighLevelClient is base on RestClient,so it is also support HighLevelClient 5.6.0 ~ 7.4.x
2. Add elastic index and method Annotation, The elastic api meet restful standards,so we can get index from rest url.
3. The plugin was tested and run in production environment 
![image](https://user-images.githubusercontent.com/20434652/149323032-c37b516b-aea3-408b-a9f4-6aff3371dfbe.png)
