### PR TITLE
[#noissue] Explicitly set curator zk34CompatibilityMode to true

### DIFF
--- a/commons-server-cluster/src/main/java/com/navercorp/pinpoint/common/server/cluster/zookeeper/CuratorZookeeperConnectionManager.java
+++ b/commons-server-cluster/src/main/java/com/navercorp/pinpoint/common/server/cluster/zookeeper/CuratorZookeeperConnectionManager.java
@@ -61,6 +61,8 @@ class CuratorZookeeperConnectionManager {
 
         builder.sessionTimeoutMs(sessionTimeout);
 
+        builder.zk34CompatibilityMode(true);
+
         this.curatorFramework = builder.build();
 
         this.connectionStateListener = new PinpointZookeeperConnectionStateListener(zookeeperEventWatcher);


### PR DESCRIPTION
Currently zookeeper version 3.4.14 is used in Pinpoint, so explicitly setting zk34CompatibilityMode to true has no effect on Pinpoint while fixes `java.lang.NoSuchMethodError: 'void org.apache.zookeeper.server.quorum.flexible.QuorumMaj.<init>(java.util.Map)'` error (possibly due to environment configuration issue) during initiating flink jobs.