### PR TITLE
[#8722] Fix a Spring 5.3 JDK compatibility issue

### DIFF
--- a/plugins/netty/pom.xml
+++ b/plugins/netty/pom.xml
@@ -31,12 +31,5 @@
             <artifactId>netty-all</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/plugins/resttemplate/pom.xml
+++ b/plugins/resttemplate/pom.xml
@@ -12,6 +12,10 @@
     <name>pinpoint-resttemplate-plugin</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <spring.version>${spring4.version}</spring.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>


### PR DESCRIPTION
ref: #8722 
```
❯ mvn dependency:tree
[INFO] Scanning for projects...
[INFO] 
[INFO] --------< com.navercorp.pinpoint:pinpoint-resttemplate-plugin >---------
[INFO] Building pinpoint-resttemplate-plugin 2.4.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ pinpoint-resttemplate-plugin ---
[INFO] com.navercorp.pinpoint:pinpoint-resttemplate-plugin:jar:2.4.0-SNAPSHOT
[INFO] +- com.navercorp.pinpoint:pinpoint-bootstrap-core:jar:2.4.0-SNAPSHOT:provided
[INFO] |  +- com.navercorp.pinpoint:pinpoint-annotations:jar:2.4.0-SNAPSHOT:provided
[INFO] |  \- com.navercorp.pinpoint:pinpoint-commons:jar:2.4.0-SNAPSHOT:provided
[INFO] +- org.springframework:spring-web:jar:4.3.30.RELEASE:provided
[INFO] |  +- org.springframework:spring-aop:jar:4.3.30.RELEASE:provided
[INFO] |  +- org.springframework:spring-beans:jar:4.3.30.RELEASE:provided
[INFO] |  +- org.springframework:spring-context:jar:4.3.30.RELEASE:provided
[INFO] |  |  \- org.springframework:spring-expression:jar:4.3.30.RELEASE:provided
[INFO] |  \- org.springframework:spring-core:jar:4.3.30.RELEASE:provided
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] +- org.hamcrest:hamcrest:jar:2.2:test
[INFO] \- org.mockito:mockito-core:jar:2.28.2:test
[INFO]    +- net.bytebuddy:byte-buddy:jar:1.9.10:test
[INFO]    +- net.bytebuddy:byte-buddy-agent:jar:1.9.10:test
[INFO]    \- org.objenesis:objenesis:jar:2.6:test
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.986 s
[INFO] Finished at: 2022-03-28T19:56:30+09:00
[INFO] ------------------------------------------------------------------------
```