### PR TITLE
Support FockJoinTask Trace

### DIFF
--- a/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/concurrent/TraceForkJoinTask.java
+++ b/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/concurrent/TraceForkJoinTask.java
@@ -4,6 +4,8 @@ import com.navercorp.pinpoint.sdk.v1.concurrent.util.Counter;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ForkJoinTask;
 
 /**
@@ -13,14 +15,54 @@ import java.util.concurrent.ForkJoinTask;
  **/
 public class TraceForkJoinTask<V> extends ForkJoinTask<V> {
 
+    private static class MethodCache {
+        Method exec;
+        Method compute;
+
+        public MethodCache(Method exec, Method compute) {
+            this.exec = exec;
+            this.compute = compute;
+        }
+    }
+
     private final ForkJoinTask<V> task;
     /**
      * The result of the computation.
      */
     private V result;
 
+    private static final Map<String, MethodCache> cacheMethodMap = new HashMap<>(16);
+
+    private MethodCache cacheMethod;
+
     public TraceForkJoinTask(ForkJoinTask<V> task) {
         this.task = task;
+        setMethodCache();
+    }
+
+    /**
+     * getMethod is the key of performance loss using reflection, so we cache it,
+     * and the performance improves dozens of times
+     */
+    private void setMethodCache() {
+        String className = task.getClass().getCanonicalName();
+        MethodCache cache = cacheMethodMap.get(className);
+        if (cache == null) {
+            cache = new MethodCache(reflectMethod("exec"), reflectMethod("compute"));
+            cacheMethodMap.put(className, cache);
+        }
+        cacheMethod = cache;
+    }
+
+    private Method reflectMethod(String method) {
+        try {
+            Method exec = task.getClass().getDeclaredMethod(method);
+            exec.setAccessible(true);
+            return exec;
+        } catch (NoSuchMethodException e) {
+            // ignore
+        }
+        return null;
     }
 
     @Override
@@ -37,25 +79,24 @@ public class TraceForkJoinTask<V> extends ForkJoinTask<V> {
      * if the task is a direct subclass of ForkJoinTask, we can get the exec method through reflect.
      * otherwise, we try the compute method.
      * eg: for {@link java.util.concurrent.RecursiveAction},{@link java.util.concurrent.RecursiveTask},
-     * they all have the compute method, which seems an implicit convention.
+     * * they all have the compute method, which seems an implicit convention.
      */
+
     @Override
     protected boolean exec() {
         try {
-            Method exec = task.getClass().getDeclaredMethod("exec");
-            exec.setAccessible(true);
-            boolean finished = (boolean) exec.invoke(task);
-            if (finished) {
-                result = task.getRawResult();
+            if (cacheMethod.exec != null) {
+                boolean ok = (boolean) cacheMethod.exec.invoke(task);
+                if (ok) {
+                    result = task.getRawResult();
+                }
+                // test
+                Counter.add();
+                return ok;
             }
-            // for performance test
-            Counter.add();
-            return finished;
+            result = compute();
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
-        } catch (NoSuchMethodException e) {
-            // no exec method, then try the compute method
-            result = compute();
         }
         return true;
     }
@@ -65,17 +106,15 @@ public class TraceForkJoinTask<V> extends ForkJoinTask<V> {
      */
     public V compute() {
         try {
-            Method compute = task.getClass().getDeclaredMethod("compute");
-            compute.setAccessible(true);
-            //noinspection unchecked
-            result = (V) compute.invoke(task);
-            // for performance test
-            Counter.add();
-            return result;
+            if (cacheMethod.compute != null) {
+                //noinspection unchecked
+                result = (V) cacheMethod.compute.invoke(task);
+                // test
+                Counter.add();
+                return result;
+            }
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
-        } catch (NoSuchMethodException e) {
-            // ignore
         }
         return null;
     }

--- a/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/concurrent/TraceForkJoinTask.java
+++ b/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/concurrent/TraceForkJoinTask.java
@@ -1,5 +1,7 @@
 package com.navercorp.pinpoint.sdk.v1.concurrent;
 
+import com.navercorp.pinpoint.sdk.v1.concurrent.util.Counter;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.ForkJoinTask;
@@ -46,6 +48,8 @@ public class TraceForkJoinTask<V> extends ForkJoinTask<V> {
             if (finished) {
                 result = task.getRawResult();
             }
+            // for performance test
+            Counter.add();
             return finished;
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
@@ -65,6 +69,8 @@ public class TraceForkJoinTask<V> extends ForkJoinTask<V> {
             compute.setAccessible(true);
             //noinspection unchecked
             result = (V) compute.invoke(task);
+            // for performance test
+            Counter.add();
             return result;
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);

--- a/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/concurrent/TraceForkJoinTask.java
+++ b/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/concurrent/TraceForkJoinTask.java
@@ -1,0 +1,84 @@
+package com.navercorp.pinpoint.sdk.v1.concurrent;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.ForkJoinTask;
+
+/**
+ * {@link ForkJoinTask} for TraceContext propagation
+ *
+ * @author jimolonely
+ **/
+public class TraceForkJoinTask<V> extends ForkJoinTask<V> {
+
+    private final ForkJoinTask<V> task;
+    /**
+     * The result of the computation.
+     */
+    private V result;
+
+    public TraceForkJoinTask(ForkJoinTask<V> task) {
+        this.task = task;
+    }
+
+    @Override
+    public V getRawResult() {
+        return result;
+    }
+
+    @Override
+    protected void setRawResult(V value) {
+        result = value;
+    }
+
+    /**
+     * if the task is a direct subclass of ForkJoinTask, we can get the exec method through reflect.
+     * otherwise, we try the compute method.
+     * eg: for {@link java.util.concurrent.RecursiveAction},{@link java.util.concurrent.RecursiveTask},
+     * they all have the compute method, which seems an implicit convention.
+     */
+    @Override
+    protected boolean exec() {
+        try {
+            Method exec = task.getClass().getDeclaredMethod("exec");
+            exec.setAccessible(true);
+            boolean finished = (boolean) exec.invoke(task);
+            if (finished) {
+                result = task.getRawResult();
+            }
+            return finished;
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        } catch (NoSuchMethodException e) {
+            // no exec method, then try the compute method
+            result = compute();
+        }
+        return true;
+    }
+
+    /**
+     * for most child classes of {@link ForkJoinTask} with compute method
+     */
+    public V compute() {
+        try {
+            Method compute = task.getClass().getDeclaredMethod("compute");
+            compute.setAccessible(true);
+            //noinspection unchecked
+            result = (V) compute.invoke(task);
+            return result;
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        } catch (NoSuchMethodException e) {
+            // ignore
+        }
+        return null;
+    }
+
+    public static <V> ForkJoinTask<V> wrap(ForkJoinTask<V> delegate) {
+        return new TraceForkJoinTask<>(delegate);
+    }
+
+    public static <V> ForkJoinTask<V> asyncEntry(ForkJoinTask<V> delegate) {
+        return new TraceForkJoinTask<>(delegate);
+    }
+}

--- a/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/concurrent/util/Counter.java
+++ b/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/concurrent/util/Counter.java
@@ -1,0 +1,17 @@
+package com.navercorp.pinpoint.sdk.v1.concurrent.util;
+
+public class Counter {
+    private static long cnt;
+
+    public static void add() {
+        cnt++;
+    }
+
+    public static long get() {
+        return cnt;
+    }
+
+    public static void reset() {
+        cnt = 0;
+    }
+}

--- a/agent-sdk/src/test/java/com/navercorp/pinpoint/sdk/v1/concurrent/TraceForkJoinPerformanceTest.java
+++ b/agent-sdk/src/test/java/com/navercorp/pinpoint/sdk/v1/concurrent/TraceForkJoinPerformanceTest.java
@@ -1,0 +1,132 @@
+package com.navercorp.pinpoint.sdk.v1.concurrent;
+
+import com.navercorp.pinpoint.sdk.v1.concurrent.util.Counter;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+// it's slow
+@Ignore
+public class TraceForkJoinPerformanceTest {
+
+    private final ForkJoinPool forkJoinPool = new ForkJoinPool(Runtime.getRuntime().availableProcessors(),
+            ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true);
+
+    public static class OriginFibonacciForkJoinTask extends RecursiveTask<Long> {
+
+        private final long n;
+
+        public OriginFibonacciForkJoinTask(long n) {
+            this.n = n;
+        }
+
+        @Override
+        protected Long compute() {
+            Counter.add();
+            if (n <= 1) {
+                return n;
+            }
+            OriginFibonacciForkJoinTask f1 = new OriginFibonacciForkJoinTask(n - 1);
+            OriginFibonacciForkJoinTask f2 = new OriginFibonacciForkJoinTask(n - 2);
+            f1.fork();
+            f2.fork();
+            return f2.join() + f1.join();
+        }
+    }
+
+    public static class WrappedFibonacciForkJoinTask extends RecursiveTask<Long> {
+
+        private final long n;
+
+        public WrappedFibonacciForkJoinTask(long n) {
+            this.n = n;
+        }
+
+        @Override
+        protected Long compute() {
+            if (n <= 1) {
+                return n;
+            }
+            ForkJoinTask<Long> f1 = TraceForkJoinTask.asyncEntry(new WrappedFibonacciForkJoinTask(n - 1));
+            ForkJoinTask<Long> f2 = TraceForkJoinTask.asyncEntry(new WrappedFibonacciForkJoinTask(n - 2));
+            f1.fork();
+            f2.fork();
+            return f2.join() + f1.join();
+        }
+    }
+
+    private static class Result {
+        public long n;
+        public long callCnt;
+        public long time;
+
+        public Result(long n, long callCnt, long time) {
+            this.n = n;
+            this.callCnt = callCnt;
+            this.time = time;
+        }
+    }
+
+    private interface ForkJoinParam {
+        ForkJoinTask<Long> get(int n);
+    }
+
+    @Test
+    public void testReflectPerformance() throws ExecutionException, InterruptedException {
+        // warm up
+        testForkJoinTime(new ForkJoinParam() {
+            @Override
+            public ForkJoinTask<Long> get(int n) {
+                return TraceForkJoinTask.asyncEntry(new WrappedFibonacciForkJoinTask(n));
+            }
+        });
+        testForkJoinTime(new ForkJoinParam() {
+            @Override
+            public ForkJoinTask<Long> get(int n1) {
+                return new OriginFibonacciForkJoinTask(n1);
+            }
+        });
+
+        TimeUnit.SECONDS.sleep(2);
+        // real start
+        List<Result> wrappedResults = testForkJoinTime(new ForkJoinParam() {
+            @Override
+            public ForkJoinTask<Long> get(int n) {
+                return TraceForkJoinTask.asyncEntry(new WrappedFibonacciForkJoinTask(n));
+            }
+        });
+        List<Result> originResults = testForkJoinTime(new ForkJoinParam() {
+            @Override
+            public ForkJoinTask<Long> get(int n) {
+                return new OriginFibonacciForkJoinTask(n);
+            }
+        });
+
+        // compute performance loss
+        for (int i = 0; i < originResults.size(); i++) {
+            Result origin = originResults.get(i);
+            Result wrapped = wrappedResults.get(i);
+            double percent = origin.time == 0 ? 0 : (wrapped.time - origin.time) * 100.0 / origin.time;
+            double each = wrapped.time * 1.0 / wrapped.callCnt;
+            System.out.format("n=%s,direct call %s times(take %sms),reflect call %s times(take %sms), take more %.2f%%,avg every time %.6fms\n",
+                    origin.n, origin.callCnt, origin.time, wrapped.callCnt, wrapped.time, percent, each);
+        }
+    }
+
+    private List<Result> testForkJoinTime(ForkJoinParam param) throws InterruptedException, ExecutionException {
+        int n = 30;
+        List<Result> results = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            Counter.reset();
+            long start = System.currentTimeMillis();
+            ForkJoinTask<Long> f = forkJoinPool.submit(param.get(i));
+            f.get();
+            long end = System.currentTimeMillis();
+            results.add(new Result(i, Counter.get(), end - start));
+        }
+        return results;
+    }
+}

--- a/agent-sdk/src/test/java/com/navercorp/pinpoint/sdk/v1/concurrent/TraceForkJoinTaskTest.java
+++ b/agent-sdk/src/test/java/com/navercorp/pinpoint/sdk/v1/concurrent/TraceForkJoinTaskTest.java
@@ -1,0 +1,106 @@
+package com.navercorp.pinpoint.sdk.v1.concurrent;
+
+import org.junit.Test;
+
+import java.util.concurrent.*;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class TraceForkJoinTaskTest {
+
+    private final ForkJoinPool pool = new ForkJoinPool(Runtime.getRuntime().availableProcessors(),
+            ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true);
+
+    private static class DirectFibonacciForkJoin extends ForkJoinTask<Long> {
+
+        private final long n;
+        private long result;
+
+        private DirectFibonacciForkJoin(long n) {
+            this.n = n;
+        }
+
+        @Override
+        public Long getRawResult() {
+            return result;
+        }
+
+        @Override
+        protected void setRawResult(Long value) {
+            result = value;
+        }
+
+        @Override
+        protected boolean exec() {
+            if (n <= 1) {
+                result = n;
+                return true;
+            }
+            TraceForkJoinTask<Long> f1 = new TraceForkJoinTask<>(new DirectFibonacciForkJoin(n - 1));
+            TraceForkJoinTask<Long> f2 = new TraceForkJoinTask<>(new DirectFibonacciForkJoin(n - 2));
+            f1.fork();
+            f2.fork();
+            result = f1.join() + f2.join();
+            return true;
+        }
+    }
+
+    private static class RecursiveFibonacciTask extends RecursiveTask<Long> {
+
+        private final long n;
+
+        private RecursiveFibonacciTask(long n) {
+            this.n = n;
+        }
+
+        @Override
+        protected Long compute() {
+            if (n <= 1) {
+                return n;
+            }
+            ForkJoinTask<Long> f1 = TraceForkJoinTask.asyncEntry(new RecursiveFibonacciTask(n - 1));
+            ForkJoinTask<Long> f2 = TraceForkJoinTask.asyncEntry(new RecursiveFibonacciTask(n - 2));
+            f1.fork();
+            f2.fork();
+            return f1.join() + f2.join();
+        }
+    }
+
+    private static class RecursiveActionTask extends RecursiveAction {
+        private final long[] array;
+        private final int lo, hi;
+
+        RecursiveActionTask(long[] array, int lo, int hi) {
+            this.array = array;
+            this.lo = lo;
+            this.hi = hi;
+        }
+
+        protected void compute() {
+            int THRESHOLD = 2;
+            if (hi - lo < THRESHOLD) {
+                for (int i = lo; i < hi; ++i) array[i]++;
+            } else {
+                int mid = (lo + hi) >>> 1;
+                invokeAll(new TraceForkJoinTask<>(new RecursiveActionTask(array, lo, mid)),
+                        new TraceForkJoinTask<>(new RecursiveActionTask(array, mid, hi)));
+            }
+        }
+    }
+
+    @Test
+    public void testTraceForkJoin() throws ExecutionException, InterruptedException {
+        ForkJoinTask<Long> f = pool.submit(new TraceForkJoinTask<>(new DirectFibonacciForkJoin(10)));
+        assertEquals(55, f.get().longValue());
+
+        f = pool.submit(new TraceForkJoinTask<>(new RecursiveFibonacciTask(10)));
+        assertEquals(55, f.get().longValue());
+
+        long[] arr = {1, 2, 3, 4, 5, 6, 7, 8};
+        long[] resArr = {2, 3, 4, 5, 6, 7, 8, 9};
+        ForkJoinTask<Void> f1 = pool.submit(new TraceForkJoinTask<>(new RecursiveActionTask(arr, 0, arr.length)));
+        f1.get();
+        assertArrayEquals(resArr, arr);
+    }
+}


### PR DESCRIPTION
since https://github.com/pinpoint-apm/pinpoint/pull/7750 , the ForkJoinTask is TODO, exactly we have the requirement, so I made an implementation.

ForkJoinTask cannot be delegated directly, since its method is protected. I delegate it by reflection, and the biggest problem is performance loss of reflection.

I have done a test to show the performance loss.
The test code is in the [PR](https://github.com/pinpoint-apm/pinpoint/pull/8891/files#diff-9fb281e50be1255a2110a4d578ec2e2e0f356f66d5486edd4b7defc44b138248).

# reflecting performance 

```shell
n=0,direct call 1 times(take 0ms),reflect call 1 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=1,direct call 1 times(take 0ms),reflect call 1 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=2,direct call 3 times(take 0ms),reflect call 3 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=3,direct call 5 times(take 0ms),reflect call 5 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=4,direct call 9 times(take 0ms),reflect call 9 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=5,direct call 15 times(take 0ms),reflect call 15 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=6,direct call 20 times(take 1ms),reflect call 25 times(take 0ms), take more -100.00%,avg every time 0.000000ms
n=7,direct call 41 times(take 0ms),reflect call 40 times(take 2ms), take more 0.00%,avg every time 0.050000ms
n=8,direct call 55 times(take 0ms),reflect call 64 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=9,direct call 94 times(take 0ms),reflect call 109 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=10,direct call 117 times(take 0ms),reflect call 175 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=11,direct call 233 times(take 0ms),reflect call 282 times(take 1ms), take more 0.00%,avg every time 0.003546ms
n=12,direct call 275 times(take 0ms),reflect call 457 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=13,direct call 429 times(take 0ms),reflect call 744 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=14,direct call 611 times(take 1ms),reflect call 1190 times(take 0ms), take more -100.00%,avg every time 0.000000ms
n=15,direct call 828 times(take 0ms),reflect call 1921 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=16,direct call 1439 times(take 0ms),reflect call 3112 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=17,direct call 2007 times(take 1ms),reflect call 5070 times(take 28ms), take more 2700.00%,avg every time 0.005523ms
n=18,direct call 2988 times(take 0ms),reflect call 8167 times(take 24ms), take more 0.00%,avg every time 0.002939ms
n=19,direct call 4405 times(take 1ms),reflect call 13236 times(take 30ms), take more 2900.00%,avg every time 0.002267ms
n=20,direct call 9526 times(take 3ms),reflect call 21502 times(take 64ms), take more 2033.33%,avg every time 0.002976ms
n=21,direct call 22878 times(take 3ms),reflect call 34852 times(take 100ms), take more 3233.33%,avg every time 0.002869ms
n=22,direct call 23464 times(take 5ms),reflect call 56598 times(take 181ms), take more 3520.00%,avg every time 0.003198ms
n=23,direct call 48487 times(take 7ms),reflect call 91539 times(take 285ms), take more 3971.43%,avg every time 0.003113ms
n=24,direct call 106666 times(take 38ms),reflect call 148149 times(take 481ms), take more 1165.79%,avg every time 0.003247ms
n=25,direct call 92687 times(take 17ms),reflect call 240026 times(take 876ms), take more 5052.94%,avg every time 0.003650ms
n=26,direct call 142017 times(take 23ms),reflect call 389521 times(take 1641ms), take more 7034.78%,avg every time 0.004213ms
n=27,direct call 351377 times(take 52ms),reflect call 630126 times(take 2593ms), take more 4886.54%,avg every time 0.004115ms
n=28,direct call 459072 times(take 72ms),reflect call 1021672 times(take 5516ms), take more 7561.11%,avg every time 0.005399ms
n=29,direct call 710869 times(take 116ms),reflect call 1653875 times(take 11098ms), take more 9467.24%,avg every time 0.006710ms
```

**we can see that reflecting is 50-100 times slower than direct invocation.** 

# reflecting performance with cache

After adding a method cache, the performance is about 5 times slower than direct invocation.

```shell
n=0,direct call 1 times(take 0ms),reflect call 1 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=1,direct call 1 times(take 0ms),reflect call 1 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=2,direct call 3 times(take 0ms),reflect call 3 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=3,direct call 5 times(take 0ms),reflect call 5 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=4,direct call 8 times(take 0ms),reflect call 9 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=5,direct call 14 times(take 0ms),reflect call 15 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=6,direct call 24 times(take 0ms),reflect call 25 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=7,direct call 38 times(take 1ms),reflect call 41 times(take 0ms), take more -100.00%,avg every time 0.000000ms
n=8,direct call 67 times(take 0ms),reflect call 66 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=9,direct call 88 times(take 0ms),reflect call 105 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=10,direct call 164 times(take 0ms),reflect call 174 times(take 5ms), take more 0.00%,avg every time 0.028736ms
n=11,direct call 256 times(take 0ms),reflect call 287 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=12,direct call 411 times(take 1ms),reflect call 465 times(take 6ms), take more 500.00%,avg every time 0.012903ms
n=13,direct call 673 times(take 0ms),reflect call 753 times(take 1ms), take more 0.00%,avg every time 0.001328ms
n=14,direct call 1109 times(take 1ms),reflect call 1123 times(take 14ms), take more 1300.00%,avg every time 0.012467ms
n=15,direct call 1828 times(take 0ms),reflect call 1820 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=16,direct call 2793 times(take 0ms),reflect call 2934 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=17,direct call 4832 times(take 26ms),reflect call 4744 times(take 0ms), take more -100.00%,avg every time 0.000000ms
n=18,direct call 8199 times(take 2ms),reflect call 7667 times(take 0ms), take more -100.00%,avg every time 0.000000ms
n=19,direct call 11612 times(take 6ms),reflect call 12269 times(take 0ms), take more -100.00%,avg every time 0.000000ms
n=20,direct call 9347 times(take 0ms),reflect call 18619 times(take 0ms), take more 0.00%,avg every time 0.000000ms
n=21,direct call 15598 times(take 14ms),reflect call 31543 times(take 24ms), take more 71.43%,avg every time 0.000761ms
n=22,direct call 27643 times(take 6ms),reflect call 47335 times(take 0ms), take more -100.00%,avg every time 0.000000ms
n=23,direct call 30546 times(take 6ms),reflect call 78914 times(take 49ms), take more 716.67%,avg every time 0.000621ms
n=24,direct call 56666 times(take 0ms),reflect call 112352 times(take 13ms), take more 0.00%,avg every time 0.000116ms
n=25,direct call 126246 times(take 57ms),reflect call 182563 times(take 75ms), take more 31.58%,avg every time 0.000411ms
n=26,direct call 144414 times(take 18ms),reflect call 218402 times(take 45ms), take more 150.00%,avg every time 0.000206ms
n=27,direct call 232676 times(take 52ms),reflect call 363413 times(take 58ms), take more 11.54%,avg every time 0.000160ms
n=28,direct call 435134 times(take 73ms),reflect call 696073 times(take 98ms), take more 34.25%,avg every time 0.000141ms
n=29,direct call 607488 times(take 116ms),reflect call 1071880 times(take 172ms), take more 48.28%,avg every time 0.000160ms
```

Hope a better idea.


