### PR TITLE
[#8890] ServiceLoader does not work properly in OpenJ9

### DIFF
--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/module/Providers.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/module/Providers.java
@@ -35,6 +35,14 @@ public class Providers {
         return services;
     }
 
+    public String getServicePackage() {
+        int lastDotIndex = services.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return services;
+        }
+        return services.substring(0, lastDotIndex);
+    }
+
     public List<String> getProviders() {
         return providers;
     }

--- a/bootstraps/bootstrap-java9-internal/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/SingleModuleFinder.java
+++ b/bootstraps/bootstrap-java9-internal/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/SingleModuleFinder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.java9.module;
+
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReader;
+import java.lang.module.ModuleReference;
+import java.net.URI;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * @author youngjin.kim2
+ */
+public class SingleModuleFinder implements ModuleFinder {
+    private final ModuleReference target;
+
+    public SingleModuleFinder(ModuleDescriptor descriptor, URI uri) {
+        this.target = new ModuleReference(descriptor, uri) {
+            @Override
+            public ModuleReader open() {
+                throw new RuntimeException("open must not be called");
+            }
+        };
+    }
+
+    @Override
+    public Optional<ModuleReference> find(String name) {
+        if (target.descriptor().name().equals(name)) {
+            return Optional.of(target);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Set<ModuleReference> findAll() {
+        return Set.of(target);
+    }
+}

--- a/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/JarFileAnalyzer.java
+++ b/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/JarFileAnalyzer.java
@@ -68,6 +68,7 @@ public class JarFileAnalyzer implements PackageAnalyzer {
 
             final Providers provides = this.serviceLoaderEntryFilter.filter(jarEntry);
             if (provides != null) {
+                packageSet.add(provides.getServicePackage());
                 providesList.add(provides);
             }
         }
@@ -124,7 +125,7 @@ public class JarFileAnalyzer implements PackageAnalyzer {
 
             final String fileName = jarEntry.getName();
             if (!checkFIleExtension(fileName, CLASS_EXTENSION)) {
-                // skip non class file
+                // skip non-class file
                 return null;
             }
 


### PR DESCRIPTION
In OpenJ9 JDK11, All modules are forced to have `System.bootLayer` as their layer when they are defined by `java.lang.Access::defineModule` [source](https://github.com/eclipse-openj9/openj9/blob/792a28f15e36a2764131ef28154bd38f27cc7619/jcl/src/java.base/share/classes/java/lang/Access.java#L301). This difference between HotSpot and OpenJ9 is currently disrupting `java.util.ServiceLoader` finding service providers in OpenJ9.

This problem can be resolved by binding Java9ClassLoader to System.bootLayer manually, but I'm not sure this is a good idea.