### PR TITLE
[#noissue] Add reactorNetty plugin custom sampling

### DIFF
--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/util/SimpleSamplerFactory.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/util/SimpleSamplerFactory.java
@@ -38,6 +38,13 @@ public class SimpleSamplerFactory {
         return new SamplingRateSampler(samplingRate);
     }
 
+    public static SimpleSampler createPercentSampler(boolean sampling, int samplingRate) {
+        if (!sampling || samplingRate <= 0) {
+            return FALSE_SAMPLER;
+        }
+        return new PercentRateSampler(samplingRate);
+    }
+
     public static class SimpleTrueSampler implements SimpleSampler {
         @Override
         public boolean isSampling() {
@@ -68,6 +75,25 @@ public class SimpleSamplerFactory {
             int samplingCount = MathUtils.fastAbs(counter.getAndIncrement());
             int isSampling = samplingCount % samplingRate;
             return isSampling == 0;
+        }
+    }
+
+    public static class PercentRateSampler implements SimpleSampler {
+        private final AtomicInteger counter = new AtomicInteger(0);
+        private final int samplingRate;
+
+        public PercentRateSampler(int samplingRate) {
+            if (samplingRate <= 0) {
+                throw new IllegalArgumentException("Invalid samplingRate " + samplingRate);
+            }
+            this.samplingRate = samplingRate;
+        }
+
+        @Override
+        public boolean isSampling() {
+            int samplingCount = MathUtils.fastAbs(counter.getAndIncrement());
+            int max = 100;
+            return samplingCount % max < samplingRate;
         }
     }
 }

--- a/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/ReactorNettyPluginConfig.java
+++ b/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/ReactorNettyPluginConfig.java
@@ -39,6 +39,9 @@ public class ReactorNettyPluginConfig {
     private final List<String> traceSubscribeErrorExcludeMessageList;
     private final boolean clientEnable;
     private boolean param = true;
+    private final boolean forceSample;
+    //Sampling percentage,max is 100.(1: 1%, 2: 2%,50: 50%)
+    private final int forceSampleRate;
 
     public ReactorNettyPluginConfig(ProfilerConfig config) {
         Objects.requireNonNull(config, "config");
@@ -61,6 +64,9 @@ public class ReactorNettyPluginConfig {
         // Reactor
         this.traceSubscribeError = config.readBoolean("profiler.reactor-netty.trace.subscribe.error", true);
         this.traceSubscribeErrorExcludeMessageList = config.readList("profiler.reactor-netty.trace.subscribe.error.exclude.message");
+
+        this.forceSample = config.readBoolean("profiler.reactor-netty.forceSample.enable", true);
+        this.forceSampleRate = config.readInt("profiler.reactor-netty.forceSample.rate", 100);
     }
 
     public boolean isEnable() {
@@ -111,6 +117,13 @@ public class ReactorNettyPluginConfig {
         return param;
     }
 
+    public boolean isForceSample() {
+        return forceSample;
+    }
+
+    public int getForceSampleRate() {
+        return forceSampleRate;
+    }
     @Override
     public String toString() {
         return "ReactorNettyPluginConfig{" +
@@ -126,6 +139,8 @@ public class ReactorNettyPluginConfig {
                 ", traceSubscribeErrorExcludeMessageList=" + traceSubscribeErrorExcludeMessageList +
                 ", clientEnable=" + clientEnable +
                 ", param=" + param +
+                ", forceSample=" + forceSample +
+                ", forceSampleRate=" + forceSampleRate +
                 '}';
     }
 }

--- a/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/AbstractHttpServerHandleInterceptor.java
+++ b/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/AbstractHttpServerHandleInterceptor.java
@@ -38,6 +38,8 @@ import com.navercorp.pinpoint.bootstrap.plugin.request.ServletRequestListenerBui
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.ParameterRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.response.ServletResponseListener;
 import com.navercorp.pinpoint.bootstrap.plugin.response.ServletResponseListenerBuilder;
+import com.navercorp.pinpoint.bootstrap.util.SimpleSampler;
+import com.navercorp.pinpoint.bootstrap.util.SimpleSamplerFactory;
 import com.navercorp.pinpoint.plugin.reactor.netty.ReactorNettyConstants;
 import com.navercorp.pinpoint.plugin.reactor.netty.ReactorNettyPluginConfig;
 
@@ -56,6 +58,7 @@ public abstract class AbstractHttpServerHandleInterceptor implements AroundInter
     private final boolean enableAsyncEndPoint;
     private final ServletRequestListener<HttpServerRequest> servletRequestListener;
     private final ServletResponseListener<HttpServerResponse> servletResponseListener;
+    private final SimpleSampler sampler;
 
     public AbstractHttpServerHandleInterceptor(TraceContext traceContext, MethodDescriptor descriptor, RequestRecorderFactory<HttpServerRequest> requestRecorderFactory) {
         this.traceContext = traceContext;
@@ -82,12 +85,22 @@ public abstract class AbstractHttpServerHandleInterceptor implements AroundInter
         this.servletResponseListener = new ServletResponseListenerBuilder<>(traceContext, new HttpResponseAdaptor()).build();
 
         this.enableAsyncEndPoint = config.isEnableAsyncEndPoint();
+        sampler = SimpleSamplerFactory.createPercentSampler(config.isForceSample(), config.getForceSampleRate());
+
     }
 
     @Override
     public void before(Object target, Object[] args) {
         if (isDebug) {
             logger.beforeInterceptor(target, args);
+        }
+
+        //not sample
+        if (!sampler.isSampling()){
+            if (isDebug) {
+                logger.debug("not sample");
+            }
+            return;
         }
 
         if (traceContext.currentRawTraceObject() != null) {
@@ -107,6 +120,7 @@ public abstract class AbstractHttpServerHandleInterceptor implements AroundInter
             // duplicate trace.
             return;
         }
+
 
         try {
             if (Boolean.FALSE == isReceived(args)) {


### PR DESCRIPTION
When we use reactorNetty ,this needs to be sampled separately in many scenes.
Sampling percentage,max is 100.
rate:`1: 1%, 2: 2%,50: 50%`
```
profiler.reactor-netty.forceSample.enable=true
profiler.reactor-netty.forceSample.rate=80
```
