### PR TITLE
[#8890] Merge all lib jars in custom filesystem

### DIFF
--- a/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/merger/InMemorySeekableByteChannel.java
+++ b/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/merger/InMemorySeekableByteChannel.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.java9.module.merger;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+
+/**
+ * @author youngjin.kim2
+ */
+public class InMemorySeekableByteChannel implements SeekableByteChannel {
+
+    private final byte[] bytes;
+    private long position = 0;
+
+    public InMemorySeekableByteChannel(byte[] bytes, long position) {
+        this(bytes);
+        this.position = Math.min(position, bytes.length);
+    }
+
+    public InMemorySeekableByteChannel(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) {
+        if (position >= bytes.length) {
+            return -1;
+        }
+
+        long remain = size() - position;
+        int sz = (int) Math.min(remain, dst.capacity());
+
+        dst.put(bytes, (int) position, sz);
+        position += sz;
+        return sz;
+    }
+
+    @Override
+    public int write(ByteBuffer src) {
+        bytes[(int) position++] = src.get();
+        return 1;
+    }
+
+    @Override
+    public long position() {
+        return position;
+    }
+
+    @Override
+    public SeekableByteChannel position(long newPosition) {
+        return new InMemorySeekableByteChannel(bytes, newPosition);
+    }
+
+    @Override
+    public long size() {
+        return bytes.length;
+    }
+
+    @Override
+    public SeekableByteChannel truncate(long size) {
+        throw new RuntimeException("Illegal truncate attempt");
+    }
+
+    @Override
+    public boolean isOpen() {
+        return true;
+    }
+
+    @Override
+    public void close() {}
+}

--- a/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/merger/JarMerger.java
+++ b/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/merger/JarMerger.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.java9.module.merger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.lang.module.ModuleFinder;
+import java.net.URI;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+
+/**
+ * @author youngjin.kim2
+ */
+public class JarMerger {
+
+    private final Set<String> entries = new HashSet<>();
+    private final Map<String, String> providesMap = new HashMap<>();
+
+    private final JarOutputStream jarStream;
+    private final ByteArrayOutputStream byteStream;
+    private final String moduleName;
+
+    private JarMerger(String moduleName, List<URI> uris) throws IOException {
+        this.moduleName = moduleName;
+        this.byteStream = new ByteArrayOutputStream();
+        this.jarStream = new JarOutputStream(byteStream);
+
+        entries.add("META-INF/MANIFEST.MF");
+        entries.add("module-info.class");
+
+        for (final URI uri: uris) {
+            add(uri);
+        }
+
+        addManifest();
+        addProvides();
+        this.jarStream.close();
+    }
+
+    private void add(URI uri) throws IOException {
+        if (!uri.toString().endsWith(".jar")) {
+            return;
+        }
+
+        final File file = new File(uri);
+        try (final JarFile jarFile = new JarFile(file)) {
+            final Enumeration<JarEntry> newEntries = jarFile.entries();
+            while (newEntries.hasMoreElements()) {
+                final JarEntry newEntry = newEntries.nextElement();
+                final String name = newEntry.getName();
+
+                if (name.startsWith("META-INF/services/")) {
+                    final String provides = new String(jarFile.getInputStream(newEntry).readAllBytes());
+                    provides(name, provides);
+                }
+
+                if (entries.contains(name)) {
+                    continue;
+                }
+                entries.add(newEntry.getName());
+
+                addEntry(name, jarFile.getInputStream(newEntry).readAllBytes());
+            }
+        }
+    }
+
+    private void provides(String name, String provides) {
+        providesMap.put(name, providesMap.getOrDefault(name, "") + provides);
+    }
+
+    public static ModuleFinder build(String moduleName, List<URI> uris) throws IOException {
+        return (new JarMerger(moduleName, uris)).getModuleFinder();
+    }
+
+    private ModuleFinder getModuleFinder() {
+        return ModuleFinder.of(SingleFileSystem.byteArrayToPath("combined.jar", byteStream.toByteArray()));
+    }
+
+    private void addManifest() throws IOException {
+        addEntry("META-INF/MANIFEST.MF", getManifestContent().getBytes());
+    }
+
+    private void addProvides() throws IOException {
+        for (Map.Entry<String, String> e: providesMap.entrySet()) {
+            addEntry("META-INF/services/" + e.getKey(), e.getValue().getBytes());
+        }
+    }
+
+    private void addEntry(String name, byte[] bytes) throws IOException {
+        jarStream.putNextEntry(new JarEntry(name));
+        jarStream.write(bytes);
+        jarStream.closeEntry();
+    }
+
+    private String getManifestContent() {
+        return "Manifest-Version: 1.0\r\nAutomatic-Module-Name: " + moduleName + "\r\n\r\n";
+    }
+
+}

--- a/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/merger/SingleFileSystem.java
+++ b/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/merger/SingleFileSystem.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.java9.module.merger;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author youngjin.kim2
+ */
+class SingleFileSystem extends FileSystem {
+
+    private final SingleFileSystemProvider provider;
+    private final SingleFileSystemPath path;
+
+    SingleFileSystem(SingleFileSystemProvider provider, String filename) {
+        this.provider = provider;
+        this.path = new SingleFileSystemPath(this, filename);
+    }
+
+    @Override
+    public FileSystemProvider provider() {
+        return provider;
+    }
+
+    @Override
+    public void close() throws IOException {}
+
+    @Override
+    public boolean isOpen() {
+        return true;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    public String getSeparator() {
+        return null;
+    }
+
+    @Override
+    public Iterable<Path> getRootDirectories() {
+        return List.of();
+    }
+
+    @Override
+    public Iterable<FileStore> getFileStores() {
+        return List.of();
+    }
+
+    @Override
+    public Set<String> supportedFileAttributeViews() {
+        return Set.of();
+    }
+
+    @Override
+    public Path getPath(String first, String... more) {
+        return path;
+    }
+
+    @Override
+    public PathMatcher getPathMatcher(String syntaxAndPattern) {
+        return null;
+    }
+
+    @Override
+    public UserPrincipalLookupService getUserPrincipalLookupService() {
+        return null;
+    }
+
+    @Override
+    public WatchService newWatchService() {
+        return null;
+    }
+
+    public static Path byteArrayToPath(String filename, byte[] bytes) {
+        return (new SingleFileSystemProvider(filename, bytes)).getFileSystem(null).getPath("/");
+    }
+}

--- a/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/merger/SingleFileSystemPath.java
+++ b/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/merger/SingleFileSystemPath.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.java9.module.merger;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.*;
+
+/**
+ * @author youngjin.kim2
+ */
+class SingleFileSystemPath implements Path {
+
+    private final SingleFileSystem fs;
+    private final String name;
+
+    SingleFileSystemPath(SingleFileSystem fs, String name) {
+        this.fs = fs;
+        this.name = name;
+    }
+
+    @Override
+    public FileSystem getFileSystem() {
+        return fs;
+    }
+
+    @Override
+    public boolean isAbsolute() {
+        return true;
+    }
+
+    @Override
+    public Path getRoot() {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public Path getFileName() {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public Path getParent() {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public int getNameCount() {
+        return 1;
+    }
+
+    @Override
+    public Path getName(int index) {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public Path subpath(int beginIndex, int endIndex) {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public boolean startsWith(Path other) {
+        return true;
+    }
+
+    @Override
+    public boolean endsWith(Path other) {
+        return true;
+    }
+
+    @Override
+    public Path normalize() {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public Path resolve(Path other) {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public Path relativize(Path other) {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public URI toUri() {
+        return null;
+    }
+
+    @Override
+    public Path toAbsolutePath() {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public Path toRealPath(LinkOption... options) {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public WatchKey register(WatchService watcher, WatchEvent.Kind<?>[] events, WatchEvent.Modifier... modifiers) {
+        throw new RuntimeException("SingleFileSystemPath::register is called");
+    }
+
+    @Override
+    public int compareTo(Path other) {
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/merger/SingleFileSystemProvider.java
+++ b/bootstraps/bootstrap-java9/src/main/java/com/navercorp/pinpoint/bootstrap/java9/module/merger/SingleFileSystemProvider.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.java9.module.merger;
+
+import java.net.URI;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author youngjin.kim2
+ */
+public class SingleFileSystemProvider extends FileSystemProvider {
+
+    private final byte[] bytes;
+    private final SingleFileSystem fs;
+
+    SingleFileSystemProvider(String filename, byte[] bytes) {
+        this.bytes = bytes;
+        this.fs = new SingleFileSystem(this, filename);
+    }
+
+    @Override
+    public String getScheme() {
+        return "sfs";
+    }
+
+    @Override
+    public FileSystem newFileSystem(URI uri, Map<String, ?> env) {
+        return fs;
+    }
+
+    @Override
+    public FileSystem getFileSystem(URI uri) {
+        return fs;
+    }
+
+    @Override
+    public Path getPath(URI uri) {
+        return fs.getPath(null);
+    }
+
+    @Override
+    public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) {
+        return new InMemorySeekableByteChannel(bytes);
+    }
+
+    @Override
+    public DirectoryStream<Path> newDirectoryStream(Path dir, DirectoryStream.Filter<? super Path> filter) {
+        return new DirectoryStream<>() {
+            @Override
+            public Iterator<Path> iterator() {
+                return Collections.emptyIterator();
+            }
+
+            @Override
+            public void close() {}
+        };
+    }
+
+    @Override
+    public void createDirectory(Path dir, FileAttribute<?>... attrs) {}
+
+    @Override
+    public void delete(Path path) {}
+
+    @Override
+    public void copy(Path source, Path target, CopyOption... options) {}
+
+    @Override
+    public void move(Path source, Path target, CopyOption... options) {}
+
+    @Override
+    public boolean isSameFile(Path path, Path path2) {
+        return true;
+    }
+
+    @Override
+    public boolean isHidden(Path path) {
+        return false;
+    }
+
+    @Override
+    public FileStore getFileStore(Path path) {
+        return null;
+    }
+
+    @Override
+    public void checkAccess(Path path, AccessMode... modes) {}
+
+    @Override
+    public <V extends FileAttributeView> V getFileAttributeView(Path path, Class<V> type, LinkOption... options) {
+        return null;
+    }
+
+    @Override
+    public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options) {
+        final BasicFileAttributes attrs = new SimpleFileAttribute(bytes.length);
+        if (type.isInstance(attrs)) {
+            return type.cast(attrs);
+        }
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) {
+        return null;
+    }
+
+    @Override
+    public void setAttribute(Path path, String attribute, Object value, LinkOption... options) {
+
+    }
+
+    private static class SimpleFileAttribute implements BasicFileAttributes {
+
+        private final long size;
+
+        public SimpleFileAttribute(long size) {
+            this.size = size;
+        }
+
+        @Override
+        public FileTime lastModifiedTime() {
+            return null;
+        }
+
+        @Override
+        public FileTime lastAccessTime() {
+            return null;
+        }
+
+        @Override
+        public FileTime creationTime() {
+            return null;
+        }
+
+        @Override
+        public boolean isRegularFile() {
+            return true;
+        }
+
+        @Override
+        public boolean isDirectory() {
+            return false;
+        }
+
+        @Override
+        public boolean isSymbolicLink() {
+            return false;
+        }
+
+        @Override
+        public boolean isOther() {
+            return false;
+        }
+
+        @Override
+        public long size() {
+            return size;
+        }
+
+        @Override
+        public Object fileKey() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
To utilize ModulePath instead of our custom jar parser, it creates a small file system which can contain only one single file for combined jar file.

This custom small filesystem can work as a bridge between ModulePath and combined jar in memory.