### PR TITLE
[#noissue] Support tls certification chain

### DIFF
--- a/collector/src/main/resources/profiles/local/pinpoint-collector-grpc.properties
+++ b/collector/src/main/resources/profiles/local/pinpoint-collector-grpc.properties
@@ -64,7 +64,7 @@ collector.receiver.grpc.ssl.provider_type=jdk
 collector.receiver.grpc.ssl.key_file_path=
 # please insert .crt file path
 # (prefix for claspath = claspath:, prefix for absoulute path = file:)
-collector.receiver.grpc.ssl.key_cert_file_path=
+collector.receiver.grpc.ssl.key_cert_file_paths=
 
 # Agent
 collector.receiver.grpc.agent.ssl.enable=false

--- a/collector/src/main/resources/profiles/release/pinpoint-collector-grpc.properties
+++ b/collector/src/main/resources/profiles/release/pinpoint-collector-grpc.properties
@@ -71,7 +71,7 @@ collector.receiver.grpc.ssl.provider_type=jdk
 collector.receiver.grpc.ssl.key_file_path=
 # please insert .crt file path
 # (prefix for claspath = claspath:, prefix for absoulute path = file:)
-collector.receiver.grpc.ssl.key_cert_file_path=
+collector.receiver.grpc.ssl.key_cert_file_paths=
 
 # Agent
 collector.receiver.grpc.agent.ssl.enable=false

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/grpc/config/GrpcAgentDataSslReceiverConfigurationTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/grpc/config/GrpcAgentDataSslReceiverConfigurationTest.java
@@ -61,7 +61,9 @@ public class GrpcAgentDataSslReceiverConfigurationTest {
         assertEquals("server0.pem", keyFile.getName());
         assertEquals(Boolean.TRUE, keyFile.exists());
 
-        Resource keyCertFileUrl = sslConfiguration.getKeyCertChainResource();
+        Resource[] keyCertFileUrls = sslConfiguration.getKeyCertChainResources();
+        assertEquals("# of cert files", 1, keyCertFileUrls.length);
+        Resource keyCertFileUrl = keyCertFileUrls[0];
         File keyCertFile = keyCertFileUrl.getFile();
         assertEquals("server0.key", keyCertFile.getName());
         assertEquals(Boolean.TRUE, keyCertFile.exists());

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/grpc/config/GrpcSpanSslReceiverConfigurationTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/grpc/config/GrpcSpanSslReceiverConfigurationTest.java
@@ -63,7 +63,9 @@ public class GrpcSpanSslReceiverConfigurationTest {
         assertEquals("server0.pem", keyFile.getName());
         assertEquals(Boolean.TRUE, keyFile.exists());
 
-        Resource keyCertFileUrl = sslConfiguration.getKeyCertChainResource();
+        Resource[] keyCertFileUrls = sslConfiguration.getKeyCertChainResources();
+        assertEquals("# of cert files", 1, keyCertFileUrls.length);
+        Resource keyCertFileUrl = keyCertFileUrls[0];
         File keyCertFile = keyCertFileUrl.getFile();
         assertEquals("server0.key", keyCertFile.getName());
         assertEquals(Boolean.TRUE, keyCertFile.exists());

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/grpc/config/GrpcStatSslReceiverConfigurationTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/grpc/config/GrpcStatSslReceiverConfigurationTest.java
@@ -63,7 +63,9 @@ public class GrpcStatSslReceiverConfigurationTest {
         assertEquals("server0.pem", keyFile.getName());
         assertEquals(Boolean.TRUE, keyFile.exists());
 
-        Resource keyCertFileUrl = sslConfiguration.getKeyCertChainResource();
+        Resource[] keyCertFileUrls = sslConfiguration.getKeyCertChainResources();
+        assertEquals("# of cert files", 1, keyCertFileUrls.length);
+        Resource keyCertFileUrl = keyCertFileUrls[0];
         File keyCertFile = keyCertFileUrl.getFile();
         assertEquals("server0.key", keyCertFile.getName());
         assertEquals(Boolean.TRUE, keyCertFile.exists());

--- a/collector/src/test/resources/test-pinpoint-collector.properties
+++ b/collector/src/test/resources/test-pinpoint-collector.properties
@@ -204,7 +204,7 @@ collector.receiver.grpc.ssl.provider_type=jdk
 # please insert .pem file path
 collector.receiver.grpc.ssl.key_file_path=certs/server0.pem
 # please insert .crt file path
-collector.receiver.grpc.ssl.key_cert_file_path=certs/server0.key
+collector.receiver.grpc.ssl.key_cert_file_paths=certs/server0.key
 
 # Agent
 collector.receiver.grpc.agent.ssl.enable=true

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/client/DefaultChannelFactoryBuilder.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/client/DefaultChannelFactoryBuilder.java
@@ -100,8 +100,8 @@ public class DefaultChannelFactoryBuilder implements ChannelFactoryBuilder {
         SslClientConfig sslClientConfig = SslClientConfig.DISABLED_CONFIG;
         if (sslOption != null && sslOption.isEnable()) {
             String providerType = sslOption.getProviderType();
-            Resource trustCertResource = sslOption.getTrustCertResource();
-            sslClientConfig = new SslClientConfig(true, providerType, trustCertResource);
+            Resource[] trustCertResources = sslOption.getTrustCertResources();
+            sslClientConfig = new SslClientConfig(true, providerType, trustCertResources);
         }
 
         return new DefaultChannelFactory(factoryName, executorQueueSize,

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/security/SslClientConfig.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/security/SslClientConfig.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.grpc.security;
 
 import com.navercorp.pinpoint.grpc.util.Resource;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -32,13 +33,13 @@ public class SslClientConfig {
 
     private final boolean enable;
     private final String sslProviderType;
-    private final Resource trustCertResource;
+    private final Resource[] trustCertResources;
 
-    public SslClientConfig(boolean enable, String sslProviderType, Resource trustCertResource) {
+    public SslClientConfig(boolean enable, String sslProviderType, Resource[] trustCertResources) {
         this.enable = enable;
 
         this.sslProviderType = Objects.requireNonNull(sslProviderType, "sslProviderType");
-        this.trustCertResource = trustCertResource;
+        this.trustCertResources = trustCertResources;
     }
 
     public boolean isEnable() {
@@ -49,8 +50,8 @@ public class SslClientConfig {
         return sslProviderType;
     }
 
-    public Resource getTrustCertResource() {
-        return trustCertResource;
+    public Resource[] getTrustCertResources() {
+        return trustCertResources;
     }
 
     @Override
@@ -58,7 +59,7 @@ public class SslClientConfig {
         final StringBuilder sb = new StringBuilder("SslClientConfig{");
         sb.append("enable=").append(enable);
         sb.append(", sslProviderType='").append(sslProviderType).append('\'');
-        sb.append(", trustCertResource=").append(trustCertResource);
+        sb.append(", trustCertResource=").append(Arrays.toString(trustCertResources));
         sb.append('}');
         return sb.toString();
     }

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/security/SslServerConfig.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/security/SslServerConfig.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.grpc.security;
 
 import com.navercorp.pinpoint.grpc.util.Resource;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -29,19 +30,21 @@ public final class SslServerConfig {
     private static final boolean DISABLED = false;
     private static final String EMPTY_STRING = "";
 
-    public static final SslServerConfig DISABLED_CONFIG = new SslServerConfig(DISABLED, EMPTY_STRING, null, null);
+    public static final SslServerConfig DISABLED_CONFIG = new SslServerConfig(DISABLED, EMPTY_STRING, null, null, null);
 
     private final boolean enable;
 
     private final String sslProviderType;
     private final Resource keyResource;
-    private final Resource keyCertChainResource;
+    private final Resource[] keyCertChainResources;
+    private final String keyPassword;
 
-    public SslServerConfig(boolean enable, String sslProviderType, Resource keyResource, Resource keyCertChainResource) {
+    public SslServerConfig(boolean enable, String sslProviderType, Resource keyResource, Resource[] keyCertChainResources, String keyPassword) {
         this.enable = enable;
         this.sslProviderType = Objects.requireNonNull(sslProviderType, "sslProviderType");
         this.keyResource = keyResource;
-        this.keyCertChainResource = keyCertChainResource;
+        this.keyCertChainResources = keyCertChainResources;
+        this.keyPassword = keyPassword;
     }
 
     public boolean isEnable() {
@@ -56,8 +59,12 @@ public final class SslServerConfig {
         return keyResource;
     }
 
-    public Resource getKeyCertChainResource() {
-        return keyCertChainResource;
+    public Resource[] getKeyCertChainResources() {
+        return keyCertChainResources;
+    }
+
+    public String getKeyPassword() {
+        return keyPassword;
     }
 
     @Override
@@ -66,7 +73,7 @@ public final class SslServerConfig {
                 "enable=" + enable +
                 ", sslProviderType='" + sslProviderType + '\'' +
                 ", keyFileUrl='" + keyResource + '\'' +
-                ", keyCertChainFileUrl='" + keyCertChainResource + '\'' +
+                ", keyCertChainFileUrls='" + Arrays.toString(keyCertChainResources) + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
Currently, `GrpcSslConfiguration`, and `SslServerConfig` can't contain multiple certification file, but only support utilizing a self-signed certification.

These configurations are mostly for arguments of `SslContextBuilder.forServer` ([javadoc](https://netty.io/4.0/api/io/netty/handler/ssl/SslContextBuilder.html)), but there is no way to call `forServer(java.security.PrivateKey key, java.lang.String keyPassword, java.security.cert.X509Certificate... keyCertChain)`