### PR TITLE
[#8990] Bump jackson from 2.12.6 to 2.13.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,7 @@
         <!-- library -->
         <metrics.version>3.2.6</metrics.version>
 
-        <fastxml.jackson.version>2.12.6</fastxml.jackson.version>
-        <fastxml.jackson-databind.version>2.12.6.1</fastxml.jackson-databind.version>
+        <fastxml.jackson.version>2.13.3</fastxml.jackson.version>
         <snakeyaml.version>1.27</snakeyaml.version>
 
         <httpcomponents.version>4.5.13</httpcomponents.version>
@@ -559,7 +558,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${fastxml.jackson-databind.version}</version>
+                <version>${fastxml.jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
Remove jackson-databind version for security issue.