### PR TITLE
[#9052] Improve AlarmJob performance

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmProcessor.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmProcessor.java
@@ -17,16 +17,144 @@
 package com.navercorp.pinpoint.batch.alarm;
 
 import com.navercorp.pinpoint.batch.alarm.checker.AlarmChecker;
+import com.navercorp.pinpoint.batch.alarm.collector.DataCollector;
+import com.navercorp.pinpoint.batch.alarm.vo.AppAlarmChecker;
+import com.navercorp.pinpoint.common.server.util.time.Range;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
+import com.navercorp.pinpoint.web.alarm.CheckerCategory;
+import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
+import com.navercorp.pinpoint.web.alarm.vo.Rule;
+import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
+import com.navercorp.pinpoint.web.service.AgentInfoService;
+import com.navercorp.pinpoint.web.service.AlarmService;
+import com.navercorp.pinpoint.web.vo.Application;
 import org.springframework.batch.item.ItemProcessor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * @author minwoo.jung
  */
-public class AlarmProcessor implements ItemProcessor<AlarmChecker<?>, AlarmChecker<?>> {
-    
-    public AlarmChecker<?> process(AlarmChecker<?> checker) {
-        checker.check();
-        return checker;
+public class AlarmProcessor implements ItemProcessor<Application, AppAlarmChecker> {
+
+    private static final long activeDuration = TimeUnit.MINUTES.toMillis(5);
+
+    private final AlarmService alarmService;
+
+    private final DataCollectorFactory dataCollectorFactory;
+
+    private final ApplicationIndexDao applicationIndexDao;
+
+    private final AgentInfoService agentInfoService;
+
+    public AlarmProcessor(
+            DataCollectorFactory dataCollectorFactory,
+            AlarmService alarmService,
+            ApplicationIndexDao applicationIndexDao,
+            AgentInfoService agentInfoService
+    ) {
+        this.dataCollectorFactory = Objects.requireNonNull(dataCollectorFactory, "dataCollectorFactory");
+        this.alarmService = Objects.requireNonNull(alarmService, "alarmService");
+        this.applicationIndexDao = Objects.requireNonNull(applicationIndexDao, "applicationIndexDao");
+        this.agentInfoService = Objects.requireNonNull(agentInfoService, "agentInfoService");
+    }
+
+    public AppAlarmChecker process(@Nonnull Application application) {
+        List<AlarmChecker<?>> checkers = getAlarmCheckers(application);
+        if (CollectionUtils.isEmpty(checkers)) {
+            return null;
+        }
+
+        AppAlarmChecker appChecker = new AppAlarmChecker(checkers);
+        appChecker.check();
+
+        return appChecker;
+    }
+
+    private List<AlarmChecker<?>> getAlarmCheckers(Application application) {
+        List<Rule> rules = alarmService.selectRuleByApplicationId(application.getName());
+        List<AlarmChecker<?>> checkers = new ArrayList<>(rules.size());
+
+        long now = System.currentTimeMillis();
+        List<String> agentIds = prepareActiveAgentIds(application, rules, now);
+
+        RuleTransformer transformer = new RuleTransformer(application, agentIds, now, dataCollectorFactory);
+        for (Rule rule: rules) {
+            checkers.add(transformer.apply(rule));
+        }
+
+        return checkers;
+    }
+
+    @Nullable
+    private List<String> prepareActiveAgentIds(Application application, List<Rule> rules, long now) {
+        Range activeRange = Range.between(now - activeDuration, now);
+        List<String> agentIds = null;
+        if (isRequireAgentList(rules)) {
+            agentIds = fetchActiveAgents(application.getName(), activeRange);
+        }
+        return agentIds;
+    }
+
+    private static boolean isRequireAgentList(List<Rule> rules) {
+        return rules.stream()
+                .anyMatch(rule ->
+                        CheckerCategory.getValue(rule.getCheckerName())
+                            .getDataCollectorCategory()
+                            .isRequireAgentList()
+                );
+    }
+
+    private List<String> fetchActiveAgents(String applicationId, Range activeRange) {
+        return applicationIndexDao.selectAgentIds(applicationId)
+                .stream()
+                .filter(id -> agentInfoService.isActiveAgent(id, activeRange))
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private static class RuleTransformer implements Function<Rule, AlarmChecker<?>> {
+
+        private static final CheckerRegistry checkerRegistry = CheckerRegistry.newCheckerRegistry();
+
+        private final long timeSlotEndTime;
+        private final Map<DataCollectorCategory, DataCollector> collectorMap = new HashMap<>();
+
+        private final Application application;
+        private final List<String> agentIds;
+        private final DataCollectorFactory dataCollectorFactory;
+
+        public RuleTransformer(
+                Application application,
+                List<String> agentIds,
+                long timeSlotEndTime,
+                DataCollectorFactory dataCollectorFactory
+        ) {
+            this.application = application;
+            this.agentIds = agentIds;
+            this.timeSlotEndTime = timeSlotEndTime;
+            this.dataCollectorFactory = dataCollectorFactory;
+        }
+
+        @Override
+        public AlarmChecker<?> apply(Rule rule) {
+            CheckerCategory checkerCategory = CheckerCategory.getValue(rule.getCheckerName());
+
+            DataCollector collector = collectorMap.computeIfAbsent(
+                    checkerCategory.getDataCollectorCategory(),
+                    k -> dataCollectorFactory.createDataCollector(
+                            checkerCategory, application, agentIds, timeSlotEndTime
+                    )
+            );
+
+            return checkerRegistry
+                    .getCheckerFactory(checkerCategory)
+                    .createChecker(collector, rule);
+        }
     }
 
 }

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/DataCollectorFactory.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/DataCollectorFactory.java
@@ -16,13 +16,7 @@
 
 package com.navercorp.pinpoint.batch.alarm;
 
-import com.navercorp.pinpoint.batch.alarm.collector.AgentEventDataCollector;
-import com.navercorp.pinpoint.batch.alarm.collector.AgentStatDataCollector;
-import com.navercorp.pinpoint.batch.alarm.collector.DataCollector;
-import com.navercorp.pinpoint.batch.alarm.collector.DataSourceDataCollector;
-import com.navercorp.pinpoint.batch.alarm.collector.FileDescriptorDataCollector;
-import com.navercorp.pinpoint.batch.alarm.collector.MapStatisticsCallerDataCollector;
-import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
+import com.navercorp.pinpoint.batch.alarm.collector.*;
 import com.navercorp.pinpoint.common.server.bo.stat.CpuLoadBo;
 import com.navercorp.pinpoint.common.server.bo.stat.DataSourceListBo;
 import com.navercorp.pinpoint.common.server.bo.stat.FileDescriptorBo;
@@ -30,13 +24,13 @@ import com.navercorp.pinpoint.common.server.bo.stat.JvmGcBo;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.web.dao.AgentEventDao;
-import com.navercorp.pinpoint.web.dao.hbase.HbaseApplicationIndexDao;
 import com.navercorp.pinpoint.web.dao.hbase.HbaseMapResponseTimeDao;
 import com.navercorp.pinpoint.web.dao.hbase.HbaseMapStatisticsCallerDao;
 import com.navercorp.pinpoint.web.dao.stat.AgentStatDao;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -61,8 +55,6 @@ public class DataCollectorFactory {
 
     private final AgentEventDao agentEventDao;
 
-    private final HbaseApplicationIndexDao hbaseApplicationIndexDao;
-
     private final HbaseMapStatisticsCallerDao mapStatisticsCallerDao;
 
     public DataCollectorFactory(HbaseMapResponseTimeDao hbaseMapResponseTimeDao,
@@ -71,7 +63,6 @@ public class DataCollectorFactory {
                                 AgentStatDao<DataSourceListBo> dataSourceDao,
                                 AgentStatDao<FileDescriptorBo> fileDescriptorDao,
                                 AgentEventDao agentEventDao,
-                                HbaseApplicationIndexDao hbaseApplicationIndexDao,
                                 HbaseMapStatisticsCallerDao mapStatisticsCallerDao) {
         this.hbaseMapResponseTimeDao = Objects.requireNonNull(hbaseMapResponseTimeDao, "hbaseMapResponseTimeDao");
         this.jvmGcDao = Objects.requireNonNull(jvmGcDao, "jvmGcDao");
@@ -79,24 +70,23 @@ public class DataCollectorFactory {
         this.dataSourceDao = Objects.requireNonNull(dataSourceDao, "dataSourceDao");
         this.fileDescriptorDao = Objects.requireNonNull(fileDescriptorDao, "fileDescriptorDao");
         this.agentEventDao = Objects.requireNonNull(agentEventDao, "agentEventDao");
-        this.hbaseApplicationIndexDao = Objects.requireNonNull(hbaseApplicationIndexDao, "hbaseApplicationIndexDao");
         this.mapStatisticsCallerDao = Objects.requireNonNull(mapStatisticsCallerDao, "mapStatisticsCallerDao");
     }
 
-    public DataCollector createDataCollector(CheckerCategory checker, Application application, long timeSlotEndTime) {
+    public DataCollector  createDataCollector(CheckerCategory checker, Application application, List<String> agentIds, long timeSlotEndTime) {
         switch (checker.getDataCollectorCategory()) {
             case RESPONSE_TIME:
                 return new ResponseTimeDataCollector(DataCollectorCategory.RESPONSE_TIME, application, hbaseMapResponseTimeDao, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
             case AGENT_STAT:
-                return new AgentStatDataCollector(DataCollectorCategory.AGENT_STAT, application, jvmGcDao, cpuLoadDao, hbaseApplicationIndexDao, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
+                return new AgentStatDataCollector(DataCollectorCategory.AGENT_STAT, jvmGcDao, cpuLoadDao, agentIds, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
             case AGENT_EVENT:
-                return new AgentEventDataCollector(DataCollectorCategory.AGENT_EVENT, application, agentEventDao, hbaseApplicationIndexDao, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
+                return new AgentEventDataCollector(DataCollectorCategory.AGENT_EVENT, agentEventDao, agentIds, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
             case CALLER_STAT:
                 return new MapStatisticsCallerDataCollector(DataCollectorCategory.CALLER_STAT, application, mapStatisticsCallerDao, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
             case DATA_SOURCE_STAT:
-                return new DataSourceDataCollector(DataCollectorCategory.DATA_SOURCE_STAT, application, dataSourceDao, hbaseApplicationIndexDao, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
+                return new DataSourceDataCollector(DataCollectorCategory.DATA_SOURCE_STAT, dataSourceDao, agentIds, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
             case FILE_DESCRIPTOR:
-                return new FileDescriptorDataCollector(DataCollectorCategory.FILE_DESCRIPTOR, application, fileDescriptorDao, hbaseApplicationIndexDao, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
+                return new FileDescriptorDataCollector(DataCollectorCategory.FILE_DESCRIPTOR, fileDescriptorDao, agentIds, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
         }
 
         throw new IllegalArgumentException("unable to create DataCollector : " + checker.getName());

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/AgentEventDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/AgentEventDataCollector.java
@@ -16,13 +16,11 @@
 
 package com.navercorp.pinpoint.batch.alarm.collector;
 
-import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.common.server.bo.event.AgentEventBo;
 import com.navercorp.pinpoint.common.server.util.AgentEventType;
-import com.navercorp.pinpoint.web.dao.AgentEventDao;
-import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
-import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.common.server.util.time.Range;
+import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
+import com.navercorp.pinpoint.web.dao.AgentEventDao;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,10 +33,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class AgentEventDataCollector extends DataCollector {
 
-    private final Application application;
-
-    private final ApplicationIndexDao applicationIndexDao;
     private final AgentEventDao agentEventDao;
+
+    private final List<String> agentIds;
 
     private final long timeSlotEndTime;
     private final long slotInterval;
@@ -46,15 +43,18 @@ public class AgentEventDataCollector extends DataCollector {
 
     private final Map<String, Boolean> agentDeadlockEventDetected = new HashMap<>();
 
-    public AgentEventDataCollector(DataCollectorCategory dataCollectorCategory, Application application, AgentEventDao agentEventDao, ApplicationIndexDao applicationIndexDao, long timeSlotEndTime, long slotInterval) {
+    public AgentEventDataCollector(
+            DataCollectorCategory dataCollectorCategory,
+            AgentEventDao agentEventDao,
+            List<String> agentIds,
+            long timeSlotEndTime,
+            long slotInterval
+    ) {
         super(dataCollectorCategory);
-        this.application = application;
 
         this.agentEventDao = agentEventDao;
-        this.applicationIndexDao = applicationIndexDao;
-
+        this.agentIds = agentIds;
         this.timeSlotEndTime = timeSlotEndTime;
-
         this.slotInterval = slotInterval;
     }
 
@@ -65,7 +65,6 @@ public class AgentEventDataCollector extends DataCollector {
         }
 
         Range range = Range.newUncheckedRange(timeSlotEndTime - slotInterval, timeSlotEndTime);
-        List<String> agentIds = applicationIndexDao.selectAgentIds(application.getName());
 
         for (String agentId : agentIds) {
             List<AgentEventBo> agentEventBoList = agentEventDao.getAgentEvents(agentId, range, Collections.emptySet());

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/DataSourceDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/DataSourceDataCollector.java
@@ -16,33 +16,27 @@
 
 package com.navercorp.pinpoint.batch.alarm.collector;
 
-import com.navercorp.pinpoint.common.util.CollectionUtils;
-import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.batch.alarm.vo.DataSourceAlarmVO;
 import com.navercorp.pinpoint.common.server.bo.stat.DataSourceBo;
 import com.navercorp.pinpoint.common.server.bo.stat.DataSourceListBo;
-import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
-import com.navercorp.pinpoint.web.dao.stat.AgentStatDao;
-import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.common.server.util.time.Range;
-
+import com.navercorp.pinpoint.common.util.CollectionUtils;
+import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
+import com.navercorp.pinpoint.web.dao.stat.AgentStatDao;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Taejin Koo
  */
 public class DataSourceDataCollector extends DataCollector {
-
-    private final Application application;
-
     private final AgentStatDao<DataSourceListBo> dataSourceDao;
-
-    private final ApplicationIndexDao applicationIndexDao;
+    private final List<String> agentIds;
     private final long timeSlotEndTime;
     private final long slotInterval;
 
@@ -50,13 +44,17 @@ public class DataSourceDataCollector extends DataCollector {
 
     private final AtomicBoolean init = new AtomicBoolean(false); // need to consider a race condition when checkers start simultaneously.
 
-    public DataSourceDataCollector(DataCollectorCategory dataCollectorCategory, Application application, AgentStatDao<DataSourceListBo> dataSourceDao, ApplicationIndexDao applicationIndexDao, long timeSlotEndTime, long slotInterval) {
+    public DataSourceDataCollector(
+            DataCollectorCategory dataCollectorCategory,
+            AgentStatDao<DataSourceListBo> dataSourceDao,
+            List<String> agentIds,
+            long timeSlotEndTime,
+            long slotInterval
+    ) {
         super(dataCollectorCategory);
-        this.application = application;
 
         this.dataSourceDao = dataSourceDao;
-
-        this.applicationIndexDao = applicationIndexDao;
+        this.agentIds = agentIds;
         this.timeSlotEndTime = timeSlotEndTime;
         this.slotInterval = slotInterval;
     }
@@ -68,7 +66,7 @@ public class DataSourceDataCollector extends DataCollector {
         }
 
         Range range = Range.newUncheckedRange(timeSlotEndTime - slotInterval, timeSlotEndTime);
-        List<String> agentIds = applicationIndexDao.selectAgentIds(application.getName());
+
         for (String agentId : agentIds) {
             List<DataSourceListBo> dataSourceListBos = dataSourceDao.getAgentStatList(agentId, range);
             MultiValueMap<Integer, DataSourceBo> partitions = partitionDataSourceId(dataSourceListBos);
@@ -86,6 +84,10 @@ public class DataSourceDataCollector extends DataCollector {
                             .average()
                             .orElse(-1);
                     DataSourceBo dataSourceBo = org.springframework.util.CollectionUtils.firstElement(dataSourceBoList);
+                    if (Objects.isNull(dataSourceBo)) {
+                        continue;
+                    }
+
                     DataSourceAlarmVO dataSourceAlarmVO = new DataSourceAlarmVO(dataSourceBo.getId(), dataSourceBo.getDatabaseName(),
                             (int) Math.floor(activeConnectionAvg), (int) Math.floor(maxConnectionAvg));
 

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/FileDescriptorDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/FileDescriptorDataCollector.java
@@ -15,12 +15,10 @@
  */
 package com.navercorp.pinpoint.batch.alarm.collector;
 
-import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.common.server.bo.stat.FileDescriptorBo;
-import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
-import com.navercorp.pinpoint.web.dao.stat.AgentStatDao;
-import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.common.server.util.time.Range;
+import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
+import com.navercorp.pinpoint.web.dao.stat.AgentStatDao;
 
 import java.util.HashMap;
 import java.util.List;
@@ -31,21 +29,25 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author minwoo.jung
  */
 public class FileDescriptorDataCollector extends DataCollector {
-
-    private final Application application;
     private final AgentStatDao<FileDescriptorBo> fileDescriptorDao;
-    private final ApplicationIndexDao applicationIndexDao;
+    private final List<String> agentIds;
     private final long timeSlotEndTime;
     private final long slotInterval;
     private final AtomicBoolean init = new AtomicBoolean(false);
 
     private final Map<String, Long> fileDescriptorCount = new HashMap<>();
 
-    public FileDescriptorDataCollector(DataCollectorCategory dataCollectorCategory, Application application, AgentStatDao<FileDescriptorBo> fileDescriptorDao, ApplicationIndexDao applicationIndexDao, long timeSlotEndTime, long slotInterval) {
+    public FileDescriptorDataCollector(
+            DataCollectorCategory dataCollectorCategory,
+            AgentStatDao<FileDescriptorBo> fileDescriptorDao,
+            List<String> agentIds,
+            long timeSlotEndTime,
+            long slotInterval
+    ) {
         super(dataCollectorCategory);
-        this.application = application;
+
         this.fileDescriptorDao = fileDescriptorDao;
-        this.applicationIndexDao = applicationIndexDao;
+        this.agentIds = agentIds;
         this.timeSlotEndTime = timeSlotEndTime;
         this.slotInterval = slotInterval;
     }
@@ -57,7 +59,6 @@ public class FileDescriptorDataCollector extends DataCollector {
         }
 
         Range range = Range.newUncheckedRange(timeSlotEndTime - slotInterval, timeSlotEndTime);
-        List<String> agentIds = applicationIndexDao.selectAgentIds(application.getName());
 
         for(String agentId : agentIds) {
             List<FileDescriptorBo> fileDescriptorBoList = fileDescriptorDao.getAgentStatList(agentId, range);

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/vo/AppAlarmChecker.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/vo/AppAlarmChecker.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.batch.alarm.vo;
+
+import com.navercorp.pinpoint.batch.alarm.checker.AlarmChecker;
+
+import java.util.List;
+
+/**
+ * @author youngjin.kim2
+ */
+public class AppAlarmChecker {
+    private final List<AlarmChecker<?>> children;
+
+    public AppAlarmChecker(List<AlarmChecker<?>> children) {
+        this.children = children;
+    }
+
+    public void check() {
+        for (AlarmChecker<?> child : this.children) {
+            child.check();
+        }
+    }
+
+    public List<AlarmChecker<?>> getChildren() {
+        return children;
+    }
+}

--- a/batch/src/main/resources/applicationContext-batch-datasource-config.xml
+++ b/batch/src/main/resources/applicationContext-batch-datasource-config.xml
@@ -16,8 +16,8 @@
 
         <property name="maxLifetime" value="1200000"/>
 
-        <property name="maximumPoolSize" value="30"/>
-        <property name="minimumIdle" value="30"/>
+        <property name="maximumPoolSize" value="64"/>
+        <property name="minimumIdle" value="64"/>
     </bean>
 
     <bean id="dataSourceHikariConfig" class="com.zaxxer.hikari.HikariConfig" parent="abstractHikariConfig">

--- a/batch/src/main/resources/job/applicationContext-alarmJob.xml
+++ b/batch/src/main/resources/job/applicationContext-alarmJob.xml
@@ -2,7 +2,6 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:batch="http://www.springframework.org/schema/batch"
-       xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:task="http://www.springframework.org/schema/task"
        xsi:schemaLocation="
@@ -25,10 +24,17 @@
     </batch:job>
 
     <batch:step id="alarmStep">
-        <batch:tasklet>
+        <batch:tasklet task-executor="alarmExecutor" throttle-limit="${alarm.worker.maxSize:2}">
             <batch:chunk reader="reader" processor="processor" writer="writer" commit-interval="1"/>
         </batch:tasklet>
     </batch:step>
+
+    <bean id="alarmExecutor" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
+        <property name="queueCapacity" value="1024" />
+        <property name="waitForTasksToCompleteOnShutdown" value="false" />
+        <property name="maxPoolSize" value="${alarm.worker.maxSize:2}" />
+        <property name="corePoolSize" value="${alarm.worker.coreSize:2}" />
+    </bean>
 
     <bean id="alarmPartitioner" class="com.navercorp.pinpoint.batch.alarm.AlarmPartitioner"/>
     <bean id="reader" class="com.navercorp.pinpoint.batch.alarm.AlarmReader" scope="step"/>

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/AlarmProcessorTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/AlarmProcessorTest.java
@@ -1,0 +1,92 @@
+package com.navercorp.pinpoint.batch.alarm;
+
+import com.navercorp.pinpoint.batch.alarm.collector.AgentStatDataCollector;
+import com.navercorp.pinpoint.batch.alarm.vo.AppAlarmChecker;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.web.alarm.CheckerCategory;
+import com.navercorp.pinpoint.web.alarm.vo.Rule;
+import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
+import com.navercorp.pinpoint.web.service.AgentInfoService;
+import com.navercorp.pinpoint.web.service.AlarmService;
+import com.navercorp.pinpoint.web.vo.Application;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AlarmProcessorTest {
+
+
+    @Mock
+    private DataCollectorFactory dataCollectorFactory;
+
+    @Mock
+    private AlarmService alarmService;
+
+    @Mock
+    private ApplicationIndexDao applicationIndexDao;
+
+    @Mock
+    private AgentInfoService agentInfoService;
+
+    @Mock
+    private AgentStatDataCollector agentStatDataCollector;
+
+    private static final String SERVICE_NAME = "local_tomcat";
+
+    private static final List<String> agentIds = List.of("agent0", "agent1", "agent2");
+
+    @Test
+    public void shouldSkipIfNoRule() {
+        Application app = new Application(SERVICE_NAME, ServiceType.STAND_ALONE);
+
+        when(alarmService.selectRuleByApplicationId(SERVICE_NAME)).thenReturn(List.of());
+
+        AlarmProcessor proc = new AlarmProcessor(dataCollectorFactory, alarmService, applicationIndexDao, agentInfoService);
+        AppAlarmChecker checker = proc.process(app);
+
+        assertNull(checker, "should be skipped");
+    }
+
+    @Test
+    public void test() {
+        // Assumptions
+        Application application = new Application(SERVICE_NAME, ServiceType.STAND_ALONE);
+        Rule rule1 = new Rule(SERVICE_NAME, ServiceType.STAND_ALONE.getName(), CheckerCategory.HEAP_USAGE_RATE.getName(), 70, "testGroup", false, false, false, "");
+        Rule rule2 = new Rule(SERVICE_NAME, ServiceType.STAND_ALONE.getName(), CheckerCategory.HEAP_USAGE_RATE.getName(), 90, "testGroup", false, false, false, "");
+        Map<String, Long> heapUsageRate = Map.of(agentIds.get(1), 80L, agentIds.get(2), 85L);
+
+        when(alarmService.selectRuleByApplicationId(SERVICE_NAME)).thenReturn(List.of(rule1, rule2));
+        when(applicationIndexDao.selectAgentIds(SERVICE_NAME)).thenReturn(agentIds);
+        when(agentInfoService.isActiveAgent(anyString(), any())).then(invocation -> {
+           String agentId = invocation.getArgument(0, String.class);
+           return !agentId.equals("agent0");
+        });
+        when(dataCollectorFactory.createDataCollector(any(), any(), any(), anyLong())).thenReturn(agentStatDataCollector);
+        when(agentStatDataCollector.getHeapUsageRate()).thenReturn(heapUsageRate);
+
+        // Executions
+        AlarmProcessor processor = new AlarmProcessor(dataCollectorFactory, alarmService, applicationIndexDao, agentInfoService);
+        AppAlarmChecker appChecker = processor.process(application);
+
+        // Validations
+        verify(alarmService, times(1)).selectRuleByApplicationId(SERVICE_NAME);
+        verify(applicationIndexDao, times(1)).selectAgentIds(SERVICE_NAME);
+        verify(agentInfoService, times(3)).isActiveAgent(anyString(), any());
+        verify(dataCollectorFactory, times(1)).createDataCollector(any(), any(), any(), anyLong());
+
+        assertNotNull(appChecker, "processed object is null");
+        assertEquals(2, appChecker.getChildren().size(), "rules should be propagated");
+        assertTrue(appChecker.getChildren().get(0).isDetected());
+        assertFalse(appChecker.getChildren().get(1).isDetected());
+    }
+
+}

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/AlarmWriterIsolationTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/AlarmWriterIsolationTest.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.batch.alarm;
 
 import com.navercorp.pinpoint.batch.alarm.checker.AlarmChecker;
 import com.navercorp.pinpoint.batch.alarm.checker.SlowCountChecker;
+import com.navercorp.pinpoint.batch.alarm.vo.AppAlarmChecker;
 import com.navercorp.pinpoint.batch.alarm.vo.CheckerResult;
 import com.navercorp.pinpoint.batch.service.AlarmService;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
@@ -34,12 +35,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class AlarmWriterIsolationTest {
@@ -59,14 +56,14 @@ public class AlarmWriterIsolationTest {
     Map<String, CheckerResult> beforeCheckerResults;
 
     @BeforeEach
-    public void setUp() throws Exception {
-        writer = new AlarmWriter(alarmMessageSender, alarmService, Optional.empty());
+    public void setUp() {
+        writer = new AlarmWriter(alarmMessageSender, alarmService, null);
 
         beforeCheckerResults = new HashMap<>();
     }
 
     @Test
-    public void whenSequenceCountIsLessThanTimingCountDoSendAlarm() throws Exception {
+    public void whenSequenceCountIsLessThanTimingCountDoSendAlarm() {
         // given
         Rule rule = getRuleStub(APPLICATION_ID, RULE_ID);
 
@@ -79,7 +76,7 @@ public class AlarmWriterIsolationTest {
         mockingAlarmMessageSender(checker);
 
         // when
-        writer.write(checkers);
+        writer.write(List.of(new AppAlarmChecker(checkers)));
 
         // then
         verify(alarmMessageSender, times(1)).sendSms(checker, 1, null);
@@ -88,7 +85,7 @@ public class AlarmWriterIsolationTest {
 
     @Test
     @MockitoSettings(strictness = Strictness.LENIENT)
-    public void whenSequenceCountIsEqualToTimingCountDoNotSendAlarm() throws Exception {
+    public void whenSequenceCountIsEqualToTimingCountDoNotSendAlarm() {
         //given
         Rule rule = getRuleStub(APPLICATION_ID, RULE_ID);
 
@@ -101,7 +98,7 @@ public class AlarmWriterIsolationTest {
         mockingAlarmMessageSender(checker);
 
         // when
-        writer.write(checkers);
+        writer.write(List.of(new AppAlarmChecker(checkers)));
 
         // then
         verify(alarmMessageSender, times(0)).sendSms(checker, 1, null);

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/AlarmWriterTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/AlarmWriterTest.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.batch.alarm;
 
 import com.navercorp.pinpoint.batch.alarm.checker.AlarmChecker;
 import com.navercorp.pinpoint.batch.alarm.checker.SlowCountChecker;
+import com.navercorp.pinpoint.batch.alarm.vo.AppAlarmChecker;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
 import org.junit.jupiter.api.Disabled;
@@ -40,7 +41,7 @@ public class AlarmWriterTest {
 
     @Disabled
     @Test
-    public void smsSendTest() throws Exception {
+    public void smsSendTest() {
         Rule rule = new Rule("testService", "tomcat", CheckerCategory.SLOW_COUNT.getName(), 100, "testGroup", true, false, false, "");
         SlowCountChecker checker = new SlowCountChecker(null, rule) {
             @Override
@@ -56,12 +57,12 @@ public class AlarmWriterTest {
 
         List<AlarmChecker<?>> checkers = new LinkedList<>();
         checkers.add(checker);
-        writer.write(checkers);
+        writer.write(List.of(new AppAlarmChecker(checkers)));
     }
 
     @Disabled
     @Test
-    public void emailSendTest() throws Exception {
+    public void emailSendTest() {
         Rule rule = new Rule("testService", "tomcat", CheckerCategory.SLOW_COUNT.getName(), 100, "testGroup", false, true, false, "");
         SlowCountChecker checker = new SlowCountChecker(null, rule) {
             @Override
@@ -77,7 +78,7 @@ public class AlarmWriterTest {
 
         List<AlarmChecker<?>> checkers = new LinkedList<>();
         checkers.add(checker);
-        writer.write(checkers);
+        writer.write(List.of(new AppAlarmChecker(checkers)));
     }
 
 }

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/DataSourceConnectionUsageRateCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/DataSourceConnectionUsageRateCheckerTest.java
@@ -26,9 +26,7 @@ import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
-import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
 import com.navercorp.pinpoint.web.dao.stat.AgentStatDao;
-import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,7 +36,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -58,19 +55,16 @@ public class DataSourceConnectionUsageRateCheckerTest {
     private static final long INTERVAL_MILLIS = 300000;
     private static final long START_TIME_MILLIS = CURRENT_TIME_MILLIS - INTERVAL_MILLIS;
 
+    private static final List<String> mockAgentIds = List.of(AGENT_ID);
+
 
     private static final long TIMESTAMP_INTERVAL = 5000L;
 
     @Mock
     private AgentStatDao<DataSourceListBo> mockDataSourceDao;
 
-    @Mock
-    private ApplicationIndexDao mockApplicationIndexDao;
-
     @BeforeEach
     public void before() {
-        when(mockApplicationIndexDao.selectAgentIds(APPLICATION_NAME)).thenReturn(Arrays.asList(AGENT_ID));
-
         Range range = Range.newUncheckedRange(START_TIME_MILLIS, CURRENT_TIME_MILLIS);
 
         List<DataSourceListBo> dataSourceListBoList = new ArrayList<>();
@@ -84,9 +78,8 @@ public class DataSourceConnectionUsageRateCheckerTest {
     @Test
     public void checkTest1() {
         Rule rule = new Rule(APPLICATION_NAME, SERVICE_TYPE, CheckerCategory.ERROR_COUNT.getName(), 50, "testGroup", false, false, false, "");
-        Application application = new Application(APPLICATION_NAME, ServiceType.STAND_ALONE);
 
-        DataSourceDataCollector collector = new DataSourceDataCollector(DataCollectorCategory.DATA_SOURCE_STAT, application, mockDataSourceDao, mockApplicationIndexDao, CURRENT_TIME_MILLIS, INTERVAL_MILLIS);
+        DataSourceDataCollector collector = new DataSourceDataCollector(DataCollectorCategory.DATA_SOURCE_STAT, mockDataSourceDao, mockAgentIds, CURRENT_TIME_MILLIS, INTERVAL_MILLIS);
         DataSourceConnectionUsageRateChecker checker = new DataSourceConnectionUsageRateChecker(collector, rule);
         checker.check();
         Assertions.assertTrue(checker.isDetected());
@@ -101,9 +94,8 @@ public class DataSourceConnectionUsageRateCheckerTest {
     @Test
     public void checkTest2() {
         Rule rule = new Rule(APPLICATION_NAME, SERVICE_TYPE, CheckerCategory.ERROR_COUNT.getName(), 80, "testGroup", false, false, false, "");
-        Application application = new Application(APPLICATION_NAME, ServiceType.STAND_ALONE);
 
-        DataSourceDataCollector collector = new DataSourceDataCollector(DataCollectorCategory.DATA_SOURCE_STAT, application, mockDataSourceDao, mockApplicationIndexDao, CURRENT_TIME_MILLIS, INTERVAL_MILLIS);
+        DataSourceDataCollector collector = new DataSourceDataCollector(DataCollectorCategory.DATA_SOURCE_STAT, mockDataSourceDao, mockAgentIds, CURRENT_TIME_MILLIS, INTERVAL_MILLIS);
         DataSourceConnectionUsageRateChecker checker = new DataSourceConnectionUsageRateChecker(collector, rule);
         checker.check();
         Assertions.assertFalse(checker.isDetected());

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/JvmCpuUsageRateCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/JvmCpuUsageRateCheckerTest.java
@@ -22,20 +22,16 @@ import com.navercorp.pinpoint.common.server.bo.stat.AgentStatType;
 import com.navercorp.pinpoint.common.server.bo.stat.CpuLoadBo;
 import com.navercorp.pinpoint.common.server.bo.stat.JvmGcBo;
 import com.navercorp.pinpoint.common.server.util.time.Range;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
-import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
 import com.navercorp.pinpoint.web.dao.stat.AgentStatDao;
-import com.navercorp.pinpoint.web.vo.Application;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,8 +40,8 @@ public class JvmCpuUsageRateCheckerTest {
 
     private static final String SERVICE_NAME = "local_service";
     private static final String SERVICE_TYPE = "tomcat";
+    private static final List<String> mockAgentIds = List.of("local_tomcat");
 
-    private static ApplicationIndexDao applicationIndexDao;
 
     private static AgentStatDao<JvmGcBo> jvmGcDao;
 
@@ -94,55 +90,14 @@ public class JvmCpuUsageRateCheckerTest {
                 return true;
             }
         };
-
-        applicationIndexDao = new ApplicationIndexDao() {
-
-            @Override
-            public List<Application> selectAllApplicationNames() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public List<Application> selectApplicationName(String applicationName) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public List<String> selectAgentIds(String applicationName) {
-                if (SERVICE_NAME.equals(applicationName)) {
-                    List<String> agentIds = new LinkedList<>();
-                    agentIds.add("local_tomcat");
-                    return agentIds;
-                }
-
-                throw new IllegalArgumentException();
-            }
-
-            @Override
-            public void deleteApplicationName(String applicationName) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void deleteAgentIds(Map<String, List<String>> applicationAgentIdMap) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void deleteAgentId(String applicationName, String agentId) {
-                throw new UnsupportedOperationException();
-            }
-
-        };
     }
 
 
     @Test
     public void checkTest1() {
         Rule rule = new Rule(SERVICE_NAME, SERVICE_TYPE, CheckerCategory.JVM_CPU_USAGE_RATE.getName(), 60, "testGroup", false, false, false, "");
-        Application application = new Application(SERVICE_NAME, ServiceType.STAND_ALONE);
-        AgentStatDataCollector collector = new AgentStatDataCollector(DataCollectorCategory.AGENT_STAT, application, jvmGcDao, cpuLoadDao, applicationIndexDao, System.currentTimeMillis(), DataCollectorFactory.SLOT_INTERVAL_FIVE_MIN);
-        AgentChecker checker = new JvmCpuUsageRateChecker(collector, rule);
+        AgentStatDataCollector collector = new AgentStatDataCollector(DataCollectorCategory.AGENT_STAT, jvmGcDao, cpuLoadDao, mockAgentIds, System.currentTimeMillis(), DataCollectorFactory.SLOT_INTERVAL_FIVE_MIN);
+        AgentChecker<Long> checker = new JvmCpuUsageRateChecker(collector, rule);
 
         checker.check();
         assertTrue(checker.isDetected());
@@ -151,9 +106,8 @@ public class JvmCpuUsageRateCheckerTest {
     @Test
     public void checkTest2() {
         Rule rule = new Rule(SERVICE_NAME, SERVICE_TYPE, CheckerCategory.JVM_CPU_USAGE_RATE.getName(), 61, "testGroup", false, false, false, "");
-        Application application = new Application(SERVICE_NAME, ServiceType.STAND_ALONE);
-        AgentStatDataCollector collector = new AgentStatDataCollector(DataCollectorCategory.AGENT_STAT, application, jvmGcDao, cpuLoadDao, applicationIndexDao, System.currentTimeMillis(), DataCollectorFactory.SLOT_INTERVAL_FIVE_MIN);
-        AgentChecker checker = new JvmCpuUsageRateChecker(collector, rule);
+        AgentStatDataCollector collector = new AgentStatDataCollector(DataCollectorCategory.AGENT_STAT, jvmGcDao, cpuLoadDao, mockAgentIds, System.currentTimeMillis(), DataCollectorFactory.SLOT_INTERVAL_FIVE_MIN);
+        AgentChecker<Long> checker = new JvmCpuUsageRateChecker(collector, rule);
 
         checker.check();
         assertFalse(checker.isDetected());

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/collector/FileDescriptorDataCollectorTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/collector/FileDescriptorDataCollectorTest.java
@@ -19,11 +19,8 @@ package com.navercorp.pinpoint.batch.alarm.collector;
 import com.navercorp.pinpoint.batch.alarm.DataCollectorFactory;
 import com.navercorp.pinpoint.common.server.bo.stat.FileDescriptorBo;
 import com.navercorp.pinpoint.common.server.util.time.Range;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
-import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
 import com.navercorp.pinpoint.web.dao.stat.AgentStatDao;
-import com.navercorp.pinpoint.web.vo.Application;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -41,17 +38,14 @@ public class FileDescriptorDataCollectorTest {
 
     @Test
     public void collect() {
-        String applicationId = "test";
         String agentId1 = "testAgent1";
         String agentId2 = "testAgent2";
-        Application application = new Application(applicationId, ServiceType.STAND_ALONE);
+
         List<String> agentList = new ArrayList<>();
         agentList.add(agentId1);
         agentList.add(agentId2);
-        ApplicationIndexDao applicationIndexDao = mock(ApplicationIndexDao.class);
-        when(applicationIndexDao.selectAgentIds(applicationId)).thenReturn(agentList);
 
-        AgentStatDao<FileDescriptorBo> fileDescriptorDao = mock(AgentStatDao.class);
+        AgentStatDao<FileDescriptorBo> fileDescriptorDao = (AgentStatDao<FileDescriptorBo>) mock(AgentStatDao.class);
         long timeStamp = 1558936971494L;
         Range range = Range.newUncheckedRange(timeStamp - DataCollectorFactory.SLOT_INTERVAL_FIVE_MIN, timeStamp);
 
@@ -79,11 +73,18 @@ public class FileDescriptorDataCollectorTest {
         fileDescriptorBoList2.add(fileDescriptorBo2_3);
         when(fileDescriptorDao.getAgentStatList(agentId2, range)).thenReturn(fileDescriptorBoList2);
 
-        FileDescriptorDataCollector fileDescriptorDataCollector = new FileDescriptorDataCollector(DataCollectorCategory.FILE_DESCRIPTOR, application, fileDescriptorDao, applicationIndexDao, timeStamp, DataCollectorFactory.SLOT_INTERVAL_FIVE_MIN);
+        FileDescriptorDataCollector fileDescriptorDataCollector = new FileDescriptorDataCollector(
+                DataCollectorCategory.FILE_DESCRIPTOR,
+                fileDescriptorDao,
+                agentList,
+                timeStamp,
+                DataCollectorFactory.SLOT_INTERVAL_FIVE_MIN
+        );
+
         fileDescriptorDataCollector.collect();
         Map<String, Long> fileDescriptorCount = fileDescriptorDataCollector.getFileDescriptorCount();
         assertEquals(fileDescriptorCount.size(), 2);
-        assertEquals(fileDescriptorCount.get(agentId1), new Long(300L));
-        assertEquals(fileDescriptorCount.get(agentId2), new Long(350L));
+        assertEquals(fileDescriptorCount.get(agentId1), Long.valueOf(300L));
+        assertEquals(fileDescriptorCount.get(agentId2), Long.valueOf(350L));
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/DataCollectorCategory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/DataCollectorCategory.java
@@ -1,10 +1,42 @@
 package com.navercorp.pinpoint.web.alarm;
 
 public enum DataCollectorCategory {
-    RESPONSE_TIME,
-    AGENT_STAT,
-    AGENT_EVENT,
-    DATA_SOURCE_STAT,
-    CALLER_STAT,
-    FILE_DESCRIPTOR
+    RESPONSE_TIME {
+        @Override
+        public boolean isRequireAgentList() {
+            return false;
+        }
+    },
+    AGENT_STAT {
+        @Override
+        public boolean isRequireAgentList() {
+            return true;
+        }
+    },
+    AGENT_EVENT {
+        @Override
+        public boolean isRequireAgentList() {
+            return true;
+        }
+    },
+    DATA_SOURCE_STAT {
+        @Override
+        public boolean isRequireAgentList() {
+            return true;
+        }
+    },
+    CALLER_STAT {
+        @Override
+        public boolean isRequireAgentList() {
+            return false;
+        }
+    },
+    FILE_DESCRIPTOR {
+        @Override
+        public boolean isRequireAgentList() {
+            return true;
+        }
+    };
+
+    public abstract boolean isRequireAgentList();
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/AlarmDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/AlarmDao.java
@@ -38,6 +38,8 @@ public interface AlarmDao {
     
     List<Rule> selectRuleByApplicationId(String applicationId);
 
+    List<String> selectApplicationId();
+
     void updateRule(Rule rule);
     
     void updateRuleExceptWebhookSend(Rule rule);

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/memory/MemoryAlarmDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/memory/MemoryAlarmDao.java
@@ -15,11 +15,8 @@
  */
 package com.navercorp.pinpoint.web.dao.memory;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -101,6 +98,17 @@ public class MemoryAlarmDao implements AlarmDao {
         }
         
         return ruleList;
+    }
+
+    @Override
+    public List<String> selectApplicationId() {
+        Set<String> ids = new HashSet<>();
+
+        for (Entry<String, Rule> entry : alarmRule.entrySet()) {
+            ids.add(entry.getValue().getApplicationId());
+        }
+
+        return new ArrayList<>(ids);
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/mysql/MysqlAlarmDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/mysql/MysqlAlarmDao.java
@@ -75,6 +75,11 @@ public class MysqlAlarmDao implements AlarmDao {
     }
 
     @Override
+    public List<String> selectApplicationId() {
+        return sqlSessionTemplate.selectList(NAMESPACE + "selectApplicationId");
+    }
+
+    @Override
     public void updateRule(Rule rule) {
         sqlSessionTemplate.update(NAMESPACE + "updateRule", rule);
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AlarmService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AlarmService.java
@@ -35,6 +35,8 @@ public interface AlarmService {
 
     List<Rule> selectRuleByApplicationId(String applicationId);
 
+    List<String> selectApplicationId();
+
     void updateRule(Rule rule);
 
     void updateRuleWithWebhooks(Rule rule, List<String> webhookIds);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AlarmServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AlarmServiceImpl.java
@@ -78,6 +78,12 @@ public class AlarmServiceImpl implements AlarmService {
     public List<Rule> selectRuleByApplicationId(String applicationId) {
         return alarmDao.selectRuleByApplicationId(applicationId);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<String> selectApplicationId() {
+        return alarmDao.selectApplicationId();
+    }
     
     @Override
     public void updateRule(Rule rule) {

--- a/web/src/main/resources/mapper/AlarmMapper.xml
+++ b/web/src/main/resources/mapper/AlarmMapper.xml
@@ -38,6 +38,11 @@
         FROM alarm_rule
         WHERE application_id = #{applicationId}
     </select>
+
+    <select id="selectApplicationId" resultType="string">
+        SELECT DISTINCT(application_id)
+        FROM alarm_rule
+    </select>
     
     <update id="updateRule">
         UPDATE alarm_rule


### PR DESCRIPTION
### Changes

* DataCollectors do not collect agents themselves, but require to caller
  * AlarmProcessor collects required agents instead of DataCollector
* AlarmReader does not initialize DataCollector, and AlarmChecker, but AlarmProcess does
* Chunk of AlarmJob is changed from AlarmChecker into Application, AppAlarmChecker
* AlarmWriter retrieves AppAlarmChecker instead of AlarmChecker
* AlarmDao queries all distinct application ids which has at least one alarm rule

### AppAlarmChecker

List of AlarmChecker, which is all related to the same application.