### PR TITLE
[#noissue] Fix rokectMQ plugin: judge the last char before append properties in ProducerSendInterceptor. 

### DIFF
--- a/plugins/rocketmq/src/main/java/com/navercorp/pinpoint/plugin/rocketmq/interceptor/ProducerSendInterceptor.java
+++ b/plugins/rocketmq/src/main/java/com/navercorp/pinpoint/plugin/rocketmq/interceptor/ProducerSendInterceptor.java
@@ -194,6 +194,10 @@ public class ProducerSendInterceptor implements AroundInterceptor {
         } else {
             paramMap.put(Header.HTTP_SAMPLED.toString(), SAMPLING_RATE_FALSE);
         }
+        // compatible
+        if (properties.length() > 0 && PROPERTY_SEPARATOR != properties.charAt(properties.length() - 1)) {
+            properties.append(PROPERTY_SEPARATOR);
+        }
         for (Map.Entry<String, Object> entry : paramMap.entrySet()) {
             properties.append(entry.getKey());
             properties.append(NAME_VALUE_SEPARATOR);


### PR DESCRIPTION
RocketMq 4.9.1: [ save 1 byte for each message](https://github.com/apache/rocketmq/commit/a23df96790ee81147abfb38fe1c58cbbf8941828).
It removes the last char, but the rocketMQ plugin does not judge the last char before append properties.  So use rocketMq 4.9.1+ with pinpoint, the last property will be modified.

eg: The last property  is DELAY, the following exception will appear in broker.

`java.lang.NumberFormatException: For input string: "4Pinpoint-Flags^A0"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Integer.parseInt(Integer.java:580)
        at java.lang.Integer.parseInt(Integer.java:615)
        at org.apache.rocketmq.common.message.Message.getDelayTimeLevel(Message.java:140)
        at org.apache.rocketmq.store.CommitLog.asyncPutMessage(CommitLog.java:624)
        at org.apache.rocketmq.store.DefaultMessageStore.asyncPutMessage(DefaultMessageStore.java:466)
        at org.apache.rocketmq.broker.processor.SendMessageProcessor.asyncSendMessage(SendMessageProcessor.java:327)
        at org.apache.rocketmq.broker.processor.SendMessageProcessor.asyncProcessRequest(SendMessageProcessor.java:106)
        at org.apache.rocketmq.broker.processor.SendMessageProcessor.asyncProcessRequest(SendMessageProcessor.java:87)
        at org.apache.rocketmq.remoting.netty.NettyRemotingAbstract$1.run(NettyRemotingAbstract.java:227)
        at org.apache.rocketmq.remoting.netty.RequestTask.run(RequestTask.java:80)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)`