### PR TITLE
[#7742] export trace info for agent-sdk

### DIFF
--- a/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/trace/info/DefaultTraceInfo.java
+++ b/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/trace/info/DefaultTraceInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.sdk.v1.trace.info;
+
+/**
+ * @author yjqg6666
+ * @since 2020-05-15 14:43:39
+ */
+@SuppressWarnings("unused")
+public class DefaultTraceInfo implements TraceInfo {
+
+    private String transactionId;
+
+    private long spanId;
+
+    public DefaultTraceInfo(String txId, long spanId) {
+        setTransactionId(txId);
+        setSpanId(spanId);
+    }
+
+    public DefaultTraceInfo() {
+    }
+
+    @Override
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    @Override
+    public void setTransactionId(String txId) {
+        if (txId == null) {
+            throw new NullPointerException("TransactionId can NOT be null");
+        }
+        this.transactionId = txId;
+    }
+
+    @Override
+    public long getSpanId() {
+        return spanId;
+    }
+
+    @Override
+    public void setSpanId(long spanId) {
+        this.spanId = spanId;
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultTraceInfo{" +
+                "transactionId='" + transactionId + '\'' +
+                ", spanId=" + spanId +
+                '}';
+    }
+}

--- a/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/trace/info/TraceInfo.java
+++ b/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/trace/info/TraceInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.sdk.v1.trace.info;
+
+/**
+ * @author yjqg6666
+ */
+@SuppressWarnings("unused")
+public interface TraceInfo {
+
+    /**
+     * get transaction id
+     *
+     * @return txId
+     */
+    String getTransactionId();
+
+    /**
+     * set transaction id
+     *
+     * @param txId txId
+     */
+    void setTransactionId(String txId);
+
+    /**
+     * get span id
+     *
+     * @return span id
+     */
+    long getSpanId();
+
+    /**
+     * set span id
+     *
+     * @param spanId span id
+     */
+    void setSpanId(long spanId);
+
+}

--- a/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/trace/info/TraceInfoHolder.java
+++ b/agent-sdk/src/main/java/com/navercorp/pinpoint/sdk/v1/trace/info/TraceInfoHolder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.sdk.v1.trace.info;
+
+/**
+ * @author yjqg6666
+ * @since 2020-05-15 14:25:50
+ */
+@SuppressWarnings("unused")
+public class TraceInfoHolder {
+
+    private static final ThreadLocal<TraceInfo> HOLDER = new ThreadLocal<>();
+
+    public static String getTransactionId() {
+        TraceInfo traceInfo = getTraceInfo();
+        return traceInfo == null ? null : traceInfo.getTransactionId();
+    }
+
+    public static long getSpanId() {
+        TraceInfo traceInfo = getTraceInfo();
+        return traceInfo == null ? 0 : traceInfo.getSpanId();
+    }
+
+    public static TraceInfo getTraceInfo() {
+        return HOLDER.get();
+    }
+
+    public static void setTraceInfo(TraceInfo traceInfo) {
+        if (traceInfo == null) {
+            throw new NullPointerException("TraceInfo can NOT be null");
+        }
+        if (traceInfo.getTransactionId() == null) {
+            throw new NullPointerException("TraceInfo.transactionId can NOT be null");
+        }
+        HOLDER.set(traceInfo);
+    }
+
+    public static void setTraceInfo(String txId, long spanId) {
+        HOLDER.set(new DefaultTraceInfo(txId, spanId));
+    }
+
+    public static void clearTraceInfo() {
+        HOLDER.remove();
+    }
+
+    public static String toInfoString() {
+        return "DefaultTraceInfoHolder{data=" + getTraceInfo() + "}";
+    }
+}

--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -218,6 +218,10 @@ profiler.instrument.matcher.super.cache.entry.size=4
 # Lambda expressions.
 profiler.lambda.expressions.support=true
 
+# Export trace info to application
+#profiler.export.trace.info=false
+
+
 # Proxy HTTP headers.
 # Please see (https://github.com/naver/pinpoint/blob/master/doc/proxy-http-header.md) for more information.
 profiler.proxy.http.header.enable=true

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -218,6 +218,9 @@ profiler.instrument.matcher.super.cache.entry.size=4
 # Lambda expressions.
 profiler.lambda.expressions.support=true
 
+# Export trace info to application
+#profiler.export.trace.info=false
+
 # Proxy HTTP headers.
 # Please see (https://github.com/naver/pinpoint/blob/master/doc/proxy-http-header.md) for more information.
 profiler.proxy.http.header.enable=true

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/util/ClassLoaderUtils.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/util/ClassLoaderUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.request.util;
+
+/**
+ * @author yjqg6666
+ */
+@SuppressWarnings("unused")
+class ClassLoaderUtils {
+
+    public static Class<?> loadClassFromAppObject(Object appLoadedObject, String className) {
+        ClassLoader appClassLoader = getAppClassLoader(appLoadedObject);
+        return loadClassFromClassLoader(appClassLoader, className);
+    }
+
+    public static Class<?> loadClassFromClassLoader(ClassLoader appClassLoader, String className) {
+        if (appClassLoader == null || className == null) {
+            return null;
+        }
+        try {
+            return Class.forName(className, false, appClassLoader);
+        } catch (Throwable t) {
+            //t.printStackTrace();
+            //do nothing even no logging for no introduced dependency
+        }
+        return null;
+    }
+
+    public static ClassLoader getAppClassLoader(Object appLoadedObject) {
+        if (appLoadedObject == null) {
+            return null;
+        }
+        Class<?> targetClass = appLoadedObject.getClass();
+        if (targetClass == null) {
+            return null;
+        }
+        return targetClass.getClassLoader();
+    }
+}

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/util/TraceInfoExportHelper.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/request/util/TraceInfoExportHelper.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.request.util;
+
+
+import java.lang.reflect.Method;
+
+/**
+ * @author yjqg6666
+ */
+public class TraceInfoExportHelper {
+
+    private static final String TRACE_INFO_CLZ_NAME = "com.navercorp.pinpoint.sdk.v1.trace.info.DefaultTraceInfo";
+
+    private static final String TRACE_INFO_INTERFACE_NAME = "com.navercorp.pinpoint.sdk.v1.trace.info.TraceInfo";
+
+    private static final String TRACE_INFO_HOLDER_CLZ_NAME = "com.navercorp.pinpoint.sdk.v1.trace.info.TraceInfoHolder";
+
+    private TraceInfoExportHelper() {
+    }
+
+    public static void exportTraceInfo(Object appLoadedObject, String transactionId, Long spanId) {
+        if (transactionId == null || spanId == null) {
+            return;
+        }
+
+        try {
+            ClassLoader appClassLoader = ClassLoaderUtils.getAppClassLoader(appLoadedObject);
+            Class<?> traceInfoInterfaceClass = ClassLoaderUtils.loadClassFromClassLoader(appClassLoader, TRACE_INFO_INTERFACE_NAME);
+            if (traceInfoInterfaceClass == null) {
+                return;
+            }
+            Class<?> traceInfoClass = ClassLoaderUtils.loadClassFromClassLoader(appClassLoader, TRACE_INFO_CLZ_NAME);
+            if (traceInfoClass == null) {
+                return;
+            }
+            Class<?> traceInfoHolderClass = ClassLoaderUtils.loadClassFromClassLoader(appClassLoader, TRACE_INFO_HOLDER_CLZ_NAME);
+            if (traceInfoHolderClass == null) {
+                return;
+            }
+            Object traceInfoObj = traceInfoClass.getDeclaredConstructor().newInstance();
+            Method setTxIdMethod = traceInfoClass.getDeclaredMethod("setTransactionId", String.class);
+            setTxIdMethod.invoke(traceInfoObj, transactionId);
+            Method setSpanIdMethod = traceInfoClass.getDeclaredMethod("setSpanId", Long.TYPE);
+            setSpanIdMethod.invoke(traceInfoObj, spanId);
+            Method setTraceInfoMethod = traceInfoHolderClass.getDeclaredMethod("setTraceInfo", traceInfoInterfaceClass);
+            //noinspection JavaReflectionInvocation
+            setTraceInfoMethod.invoke(traceInfoHolderClass, traceInfoObj);
+        } catch (Throwable t) {
+            //t.printStackTrace();
+            //do nothing even no logging for no introduced dependency
+        }
+    }
+
+    public static void clearExportedTraceInfo(Object appLoadedObject) {
+        try {
+            Class<?> traceInfoHolderClass = ClassLoaderUtils.loadClassFromAppObject(appLoadedObject, TRACE_INFO_HOLDER_CLZ_NAME);
+            if (traceInfoHolderClass == null) {
+                return;
+            }
+            Method setTraceInfoMethod = traceInfoHolderClass.getDeclaredMethod("clearTraceInfo");
+            setTraceInfoMethod.invoke(traceInfoHolderClass);
+        } catch (Throwable t) {
+            //t.printStackTrace();
+            //do nothing even no logging for no introduced dependency
+        }
+    }
+
+}


### PR DESCRIPTION
Resolve issue #7742.
Related PR #6801.

# Feature
Export txId & spanId to application via pinpoint agent sdk. Disabled by default. It can be enabled by pinpoint config profiler.export.trace.info=true or jvm property: -Dprofiler.export.trace.info=true.

# Usage
If my application need to save/notify some system the txId/spanId, i could 
1) import         com.navercorp.pinpoint:pinpoint-agent-sdk:2.5.0-SNAPSHOT as dependency.
```
<dependency>
   <groupId>com.navercorp.pinpoint</groupId>
   <artifactId>pinpoint-agent-sdk</artifactId>
   <version>2.5.0-SNAPSHOT</version>
</dependency>
```
2)  fetch the txId/spanId

> TraceInfo traceInfo = TraceInfoHolder.getTraceInfo(); 
> String altTxId = traceInfo.getTransactionId(); 
> String txId = TraceInfoHolder.getTransactionId();  
> long spanId = TraceInfoHolder.getSpanId();  

# Scene
Get the transaction id and process it in a programming way(like saving to a persistent db).

Before this PR, we could only get the txId/spanId from slf4j.MDC in a hacky way.