### PR TITLE
[#noissue] Increased thrift container max length

### DIFF
--- a/thrift/src/main/java/com/navercorp/pinpoint/thrift/io/ProtocolFactory.java
+++ b/thrift/src/main/java/com/navercorp/pinpoint/thrift/io/ProtocolFactory.java
@@ -5,7 +5,7 @@ import org.apache.thrift.protocol.TProtocolFactory;
 
 public final class ProtocolFactory {
 
-    private static final TProtocolFactory FACTORY = new TCompactProtocol.Factory(1024 * 60, 128);
+    private static final TProtocolFactory FACTORY = new TCompactProtocol.Factory(1024 * 60, 4096);
 
     public static TProtocolFactory getFactory() {
         return FACTORY;


### PR DESCRIPTION
Currently the maximum length of containers in thrift is 128, which can be too small for containing agent info