### PR TITLE
[#noissue] Fix postgresql it 42.50

### DIFF
--- a/plugins-it/postgresql-jdbc-it/src/test/java/com/navercorp/pinpoint/plugin/jdbc/postgresql/PostgreSql_Post_9_4_1208_IT.java
+++ b/plugins-it/postgresql-jdbc-it/src/test/java/com/navercorp/pinpoint/plugin/jdbc/postgresql/PostgreSql_Post_9_4_1208_IT.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.pluginit.utils.TestcontainersOption;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.JvmVersion;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
 
 import com.navercorp.pinpoint.test.plugin.shared.SharedTestLifeCycleClass;
@@ -44,6 +45,7 @@ import java.net.URL;
 @JvmVersion(8)
 //@Dependency({"org.postgresql:postgresql:[42.2.15.jre6]",
 //        JDBCTestConstants.VERSION, TestcontainersOption.TEST_CONTAINER, TestcontainersOption.POSTGRESQL})
+@PinpointConfig("pinpoint-postgresql.config")
 @Dependency({"org.postgresql:postgresql:[9.4.1208,)",
         JDBCTestConstants.VERSION, TestcontainersOption.TEST_CONTAINER, TestcontainersOption.POSTGRESQL})
 @SharedTestLifeCycleClass(PostgreSqlServer.class)

--- a/plugins-it/postgresql-jdbc-it/src/test/resources/pinpoint-postgresql.config
+++ b/plugins-it/postgresql-jdbc-it/src/test/resources/pinpoint-postgresql.config
@@ -35,6 +35,8 @@ profiler.enable=true
 # Differentiate from external pinpoint agents. (e.g., com.pinpoint)
 profiler.application.namespace=
 
+profiler.interceptorregistry.size=10240
+
 # Manually override jvm vendor name (Oracle, IBM, OpenJDK, etc)
 # You probably won't ever need to set this value.
 profiler.jvm.vendor.name=
@@ -77,15 +79,15 @@ profiler.tcpdatasender.command.accept.enable=true
 #profiler.applicationservertype=BLOC
 
 #
-# POSTGRESSQL
+# PostgreSQL
 #
-# Profile POSTGRESSQL.
+# Profile PostgreSQL.
 profiler.jdbc.postgresql=true
+# trace bindvalues for PreparedStatements
+profiler.jdbc.postgresql.tracesqlbindvalue=true
 # Allow profiling of setautocommit.
 profiler.jdbc.postgresql.setautocommit=true
 # Allow profiling of commit.
 profiler.jdbc.postgresql.commit=true
 # Allow profiling of rollback.
 profiler.jdbc.postgresql.rollback=true
-# Trace bindvalues for POSTGRESSQL PreparedStatements (overrides profiler.jdbc.tracesqlbindvalue)
-#profiler.jdbc.postgresql.tracesqlbindvalue=true


### PR DESCRIPTION
Fix postgresql IT 

~~~
Cause:Interceptor registry size exceeded. Check the "profiler.interceptorregistry.size" setting. size=8192 id=8193
java.lang.IndexOutOfBoundsException: Interceptor registry size exceeded. Check the "profiler.interceptorregistry.size" setting. size=8192 id=8193
	at com.navercorp.pinpoint.bootstrap.interceptor.registry.DefaultInterceptorRegistryAdaptor.addInterceptor(DefaultInterceptorRegistryAdaptor.java:42) ~[?:2.5.0-SNAPSHOT]
~~~