### PR TITLE
fix(sec): upgrade org.apache.dubbo:dubbo to 2.7.8

### DIFF
--- a/agent-testweb/dubbo-plugin-testweb/pom.xml
+++ b/agent-testweb/dubbo-plugin-testweb/pom.xml
@@ -13,11 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
@@ -62,7 +58,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo</artifactId>
-            <version>2.7.7</version>
+            <version>2.7.8</version>
         </dependency>
 
         <dependency>

--- a/plugins/bom/pom.xml
+++ b/plugins/bom/pom.xml
@@ -13,10 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
@@ -36,7 +33,7 @@
         <dubbo.version>2.5.3</dubbo.version>
         <mongo.driver.3.version>3.12.11</mongo.driver.3.version>
         <mongo.driver.4.version>4.6.1</mongo.driver.4.version>
-        <apache.dubbo.version>2.7.2</apache.dubbo.version>
+        <apache.dubbo.version>2.7.8</apache.dubbo.version>
         <ehcache.version>2.10.6</ehcache.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.dubbo:dubbo 2.7.7
- [CVE-2020-11995](https://www.oscs1024.com/hd/CVE-2020-11995)


### What did I do？
Upgrade org.apache.dubbo:dubbo from 2.7.7 to 2.7.8 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS