### PR TITLE
fix(sec): upgrade org.apache.thrift:libthrift to 0.14.0

### DIFF
--- a/agent-testweb/thrift-plugin-testweb/pom.xml
+++ b/agent-testweb/thrift-plugin-testweb/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
@@ -45,7 +43,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.12.0</version>
+            <version>0.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <organization>
         <name>Naver Corporation</name>
@@ -167,7 +164,7 @@
 
 
         <asm.version>9.2</asm.version>
-        <thrift.version>0.16.0</thrift.version>
+        <thrift.version>0.14.0</thrift.version>
         <caffeine.version>2.9.2</caffeine.version>
 
         <netty3.version>3.10.6.Final</netty3.version>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.apache.thrift:libthrift 0.12.0
- [CVE-2019-0205](https://www.oscs1024.com/hd/CVE-2019-0205)
- [CVE-2020-13949](https://www.oscs1024.com/hd/CVE-2020-13949)


### What did I do？
Upgrade org.apache.thrift:libthrift from 0.12.0 to 0.14.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS