### PR TITLE
[#noissue] Fix spring-amqp-rabbit it

### DIFF
--- a/plugins-it/rabbitmq-it/src/test/java/com/navercorp/pinpoint/plugin/rabbitmq/spring/SpringAmqpRabbit_2_1_x_to_2_x_IT.java
+++ b/plugins-it/rabbitmq-it/src/test/java/com/navercorp/pinpoint/plugin/rabbitmq/spring/SpringAmqpRabbit_2_1_x_to_2_x_IT.java
@@ -135,8 +135,8 @@ public class SpringAmqpRabbit_2_1_x_to_2_x_IT extends SpringAmqpRabbitITBase {
         Method abstractMessageListenerContainerExecuteListener = getExecuteListenerMethod(abstractMessageListenerContainerClass);
 
         ExpectedTrace abstractMessageListenerContainerExecuteListenerTrace = Expectations.event(
-                    ServiceType.INTERNAL_METHOD.getName(),
-                    abstractMessageListenerContainerExecuteListener);
+                ServiceType.INTERNAL_METHOD.getName(),
+                abstractMessageListenerContainerExecuteListener);
 
         Class<?> propagationMarkerClass = PropagationMarker.class;
         Method propagationMarkerMark = propagationMarkerClass.getDeclaredMethod("mark");
@@ -169,13 +169,11 @@ public class SpringAmqpRabbit_2_1_x_to_2_x_IT extends SpringAmqpRabbitITBase {
 
     private Method getExecuteListenerMethod(Class<?> abstractMessageListenerContainerClass) throws NoSuchMethodException {
         Method abstractMessageListenerContainerExecuteListener = getExecuteListenerMethod0(abstractMessageListenerContainerClass);
-
-        if (abstractMessageListenerContainerExecuteListener.getParameterCount() != 2) {
-            final Class<?>[] parameterTypes = abstractMessageListenerContainerExecuteListener.getParameterTypes();
+        final Class<?>[] parameterTypes = abstractMessageListenerContainerExecuteListener.getParameterTypes();
+        if (parameterTypes.length >= 2) {
             if (!parameterTypes[0].equals(Channel.class)) {
                 throw new NoSuchMethodException("executeListener");
             }
-
             if (parameterTypes[1].equals(Message.class) || parameterTypes[1].equals(Object.class)) {
                 return abstractMessageListenerContainerExecuteListener;
             }


### PR DESCRIPTION
## SpringAmqpRabbit_2_1_x_to_2_x_IT

`com.navercorp.pinpoint.test.plugin.PinpointPluginTestException: java.lang.NoSuchMethodException: executeListener`

~~~
#####testStarted#####testPush[spring-rabbit-2.1.0.RELEASE:child:8](com.navercorp.pinpoint.plugin.rabbitmq.spring.SpringAmqpRabbit_2_1_x_to_2_x_IT)
10-13 12:51:18.018 [:child:8 Thread] DEBUG c.n.p.p.c.LoggingBaseTraceFactory        -- newTraceObject()
10-13 12:51:18.018 [:child:8 Thread] DEBUG c.n.p.p.c.a.DefaultActiveTraceRepository -- register ActiveTrace key:SampledActiveTrace{traceRoot=DefaultTraceRoot{traceId=DefaultTraceId{agentId='build.test.0', agentStartTime=1665633072568, transactionSequence=3, parentSpanId=-1, spanId=-357831799267100369, flags=0}, agentId='build.test.0', traceStartTime=1665633078432}}
#####testFailure#####testPush[spring-rabbit-2.1.0.RELEASE:child:8](com.navercorp.pinpoint.plugin.rabbitmq.spring.SpringAmqpRabbit_2_1_x_to_2_x_IT)#####java.lang.NoSuchMethodException#####executeListener#####com.navercorp.pinpoint.plugin.rabbitmq.spring.SpringAmqpRabbit_2_1_x_to_2_x_IT,getExecuteListenerMethod,SpringAmqpRabbit_2_1_x_to_2_x_IT.java,183#####com.navercorp.pinpoint.plugin.rabbitmq.spring.SpringAmqpRabbit_2_1_x_to_2_x_IT,testPush,SpringAmqpRabbit_2_1_x_to_2_x_IT.java,135#####sun.reflect.NativeMethodAccessorImpl,invoke0,NativeMethodAccessorImpl.java,-2#####sun.reflect.NativeMethodAccessorImpl,invoke,NativeMethodAccessorImpl.java,62#####sun.reflect.DelegatingMethodAccessorImpl,invoke,DelegatingMethodAccessorImpl.java,43#####java.lang.reflect.Method,invoke,Method.java,498#####org.junit.runners.model.FrameworkMethod$1,runReflectiveCall,FrameworkMethod.java,59#####org.junit.internal.runners.model.ReflectiveCallable,run,ReflectiveCallable.java,12#####org.junit.runners.model.FrameworkMethod,invokeExplosively,FrameworkMethod.java,56#####org.junit.internal.runners.statements.InvokeMethod,evaluate,InvokeMethod.java,17#####org.junit.runners.ParentRunner$3,evaluate,ParentRunner.java,306#####com.navercorp.pinpoint.test.plugin.ForkedPinpointPluginTestRunner$1,evaluate,ForkedPinpointPluginTestRunner.java,60#####org.junit.runners.BlockJUnit4ClassRunner$1,evaluate,BlockJUnit4ClassRunner.java,100#####org.junit.runners.ParentRunner,runLeaf,ParentRunner.java,366#####org.junit.runners.BlockJUnit4ClassRunner,runChild,BlockJUnit4ClassRunner.java,103#####org.junit.runners.BlockJUnit4ClassRunner,runChild,BlockJUnit4ClassRunner.java,63#####org.junit.runners.ParentRunner$4,run,ParentRunner.java,331#####org.junit.runners.ParentRunner$1,schedule,ParentRunner.java,79#####org.junit.runners.ParentRunner,runChildren,ParentRunner.java,329#####org.junit.runners.ParentRunner,access$100,ParentRunner.java,66#####org.junit.runners.ParentRunner$2,evaluate,ParentRunner.java,293#####org.junit.internal.runners.statements.RunBefores,evaluate,RunBefores.java,26#####org.junit.internal.runners.statements.RunAfters,evaluate,RunAfters.java,27#####org.junit.runners.ParentRunner$3,evaluate,ParentRunner.java,306#####org.junit.runners.ParentRunner,run,ParentRunner.java,413#####org.junit.runner.JUnitCore,run,JUnitCore.java,137#####com.navercorp.pinpoint.test.plugin.shared.SharedPinpointPluginTest$2,run,SharedPinpointPluginTest.java,265#####java.lang.Thread,run,Thread.java,748#####

~~~