### PR TITLE
[#noissue] Update kafka IT 3.x

### DIFF
--- a/agent-testweb/kafka-plugin-testweb/pom.xml
+++ b/agent-testweb/kafka-plugin-testweb/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint-agent-testweb</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-kafka-plugin-testweb</artifactId>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <pinpoint.agent.jvmargument>
+            ${pinpoint.agent.default.jvmargument}
+        </pinpoint.agent.jvmargument>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>1.17.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.12</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/KafkaPluginController.java
+++ b/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/KafkaPluginController.java
@@ -1,0 +1,47 @@
+package com.pinpoint.test.plugin;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.InetAddress;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@RestController
+public class KafkaPluginController {
+    public static final String TOPIC = "kafka-it-topic";
+    public static final String MESSAGE = "message-" + UUID.randomUUID().toString();
+    public static final String TRACE_TYPE_RECORD = "RECORD";
+
+    @GetMapping("/")
+    public String welcome() {
+        return "WELCOME";
+    }
+
+    @GetMapping("/producer")
+    public String producer() {
+        TestProducer producer = new TestProducer();
+        producer.sendMessage(KafkaPluginTestConstants.BROKER_URL, 1, KafkaPluginTestConstants.TRACE_TYPE_RECORD);
+
+        return "OK";
+    }
+
+    @GetMapping("/consumer")
+    public String consumer() {
+        TestConsumer consumer = new TestConsumer(KafkaPluginTestConstants.BROKER_URL);
+        consumer.start();
+
+        try {
+            TimeUnit.SECONDS.sleep(3);
+        } catch (InterruptedException e) {
+        }
+
+        return "OK";
+    }
+}

--- a/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/KafkaPluginTestConstants.java
+++ b/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/KafkaPluginTestConstants.java
@@ -1,0 +1,16 @@
+package com.pinpoint.test.plugin;
+
+import java.util.UUID;
+
+public class KafkaPluginTestConstants {
+    public static final String BROKER_URL = "localhost:62365";
+    public static final String TOPIC = "kafka-it-topic";
+    public static final String MESSAGE = "message-" + UUID.randomUUID().toString();
+    public static final String GROUP_ID = "kafka-it-group";
+    public static final String KAFKA_CLIENT_SERVICE_TYPE = "KAFKA_CLIENT";
+    public static final String KAFKA_CLIENT_INTERNAL_SERVICE_TYPE = "KAFKA_CLIENT_INTERNAL";
+    public static final int PARTITION = 0;
+    public static final String TRACE_TYPE_RECORD = "RECORD";
+    public static final String TRACE_TYPE_MULTI_RECORDS = "MULTI_RECORDS";
+    public static final long MAX_TRACE_WAIT_TIME = 10000;
+}

--- a/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/KafkaPluginTestStarter.java
+++ b/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/KafkaPluginTestStarter.java
@@ -1,0 +1,12 @@
+package com.pinpoint.test.plugin;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class KafkaPluginTestStarter {
+
+    public static void main(String[] args) {
+        SpringApplication.run(KafkaPluginTestStarter.class, args);
+    }
+}

--- a/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/TestConsumer.java
+++ b/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/TestConsumer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pinpoint.test.plugin;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Properties;
+
+import static com.pinpoint.test.plugin.KafkaPluginTestConstants.TRACE_TYPE_MULTI_RECORDS;
+import static com.pinpoint.test.plugin.KafkaPluginTestConstants.TRACE_TYPE_RECORD;
+
+public class TestConsumer {
+    private final Thread consumerThread;
+    private final Poller poller;
+
+    public TestConsumer(String brokerUrl) {
+        poller = new Poller(brokerUrl);
+        consumerThread = new Thread(poller);
+        consumerThread.setDaemon(true);
+    }
+
+    public void shutdown() throws InterruptedException {
+        poller.shutdown();
+        consumerThread.join(100L);
+    }
+
+    public void start() {
+        consumerThread.start();
+    }
+
+    private static class Poller implements Runnable {
+
+        private final KafkaConsumer<String, String> consumer;
+        private final TestConsumerRecordEntryPoint entryPoint = new TestConsumerRecordEntryPoint();
+
+        private Poller(String brokerUrl) {
+            Properties props = new Properties();
+            props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerUrl);
+            props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "10000");
+            props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+            props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+            props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, String.valueOf(true));
+            props.put(ConsumerConfig.GROUP_ID_CONFIG, KafkaPluginTestConstants.GROUP_ID);
+            consumer = new KafkaConsumer<>(props);
+        }
+
+        private void shutdown() {
+            consumer.wakeup();
+        }
+
+        @Override
+        public void run() {
+            consumer.subscribe(Collections.singleton(KafkaPluginTestConstants.TOPIC));
+            consumer.poll(0);
+            consumer.seekToBeginning(Collections.singleton(new TopicPartition(KafkaPluginTestConstants.TOPIC, KafkaPluginTestConstants.PARTITION)));
+            final int count = 1;
+
+            try {
+                for(int i = 0; i < count; i++) {
+                    ConsumerRecords<String, String> records = consumer.poll(1000L);
+                    if(records != null && records.count() > 0) {
+                        Iterator<ConsumerRecord<String, String>> iterator = records.iterator();
+                        if (!iterator.hasNext()) {
+                            continue;
+                        }
+                        ConsumerRecord<String, String> firstRecord = iterator.next();
+                        String traceType = firstRecord.key();
+                        if (traceType.equals(TRACE_TYPE_MULTI_RECORDS)) {
+                            entryPoint.consumeRecord(records);
+                        } else if (traceType.equals(TRACE_TYPE_RECORD)) {
+                            records.forEach(record -> entryPoint.consumeRecord(record));
+                        }
+                    }
+                }
+            } catch (WakeupException e) {
+            }
+        }
+    }
+}

--- a/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/TestConsumerRecordEntryPoint.java
+++ b/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/TestConsumerRecordEntryPoint.java
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
-package test.pinpoint.plugin.kafka;
+package com.pinpoint.test.plugin;
 
-/**
- * @author Younsung Hwang
- */
-public class OffsetStore {
-    private volatile long offset = 0L;
-    public long getOffset() {
-        return offset;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+public class TestConsumerRecordEntryPoint {
+
+    public void consumeRecord(ConsumerRecord<String, String> record) {
+        // cosume record ...
+        // This method is called for kafka consumer invocatino. This method does nothing.
     }
-    public void setOffset(long offset) {
-        this.offset = offset;
+
+    public void consumeRecord(ConsumerRecords<String, String> records) {
+        // cosume records ...
+        // This method is called for kafka consumer invocatino. This method does nothing.
     }
 }

--- a/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/TestProducer.java
+++ b/agent-testweb/kafka-plugin-testweb/src/main/java/com/pinpoint/test/plugin/TestProducer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pinpoint.test.plugin;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.util.Properties;
+
+public class TestProducer {
+
+    public void sendMessage(String brokerUrl, int messageCount) {
+        sendMessage(brokerUrl, messageCount, KafkaPluginTestConstants.TRACE_TYPE_RECORD);
+    }
+
+    public void sendMessage(String brokerUrl, int messageCount, String traceType) {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerUrl);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        KafkaProducer<String, String> producer = new KafkaProducer<>(props);
+        for (int i = 0; i < messageCount; i++) {
+            ProducerRecord<String, String> record = new ProducerRecord<>(KafkaPluginTestConstants.TOPIC, traceType, KafkaPluginTestConstants.MESSAGE);
+            producer.send(record);
+        }
+        producer.flush();
+        producer.close();
+    }
+}

--- a/agent-testweb/kafka-plugin-testweb/src/main/resources/application.yml
+++ b/agent-testweb/kafka-plugin-testweb/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+# Defined in commandlineArgument of agent-test pom.xml
+
+server:
+  port: 18080
+
+logging:
+  level:
+    root: info
+
+springdoc:
+  swagger-ui:
+    path: /

--- a/agent-testweb/kafka-plugin-testweb/src/test/java/com/pinpoint/test/plugin/kafka/KafkaTest.java
+++ b/agent-testweb/kafka-plugin-testweb/src/test/java/com/pinpoint/test/plugin/kafka/KafkaTest.java
@@ -1,0 +1,38 @@
+package com.pinpoint.test.plugin.kafka;
+
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.concurrent.TimeUnit;
+
+public class KafkaTest {
+    private static KafkaContainer container;
+
+    @BeforeClass
+    public static void beforeClass() {
+        Assume.assumeTrue("Docker not enabled", DockerClientFactory.instance().isDockerAvailable());
+
+        container = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"));
+
+        container.start();
+        final String bootstrapServers = container.getBootstrapServers();
+        final int port = container.getFirstMappedPort();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if (container != null) {
+            container.stop();
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+        System.out.println("TEST");
+    }
+}

--- a/agent-testweb/pom.xml
+++ b/agent-testweb/pom.xml
@@ -74,6 +74,7 @@
         <module>jetty-plugin-testweb</module>
         <module>spring-data-r2dbc-plugin-testweb</module>
         <module>httpclient5-plugin-testweb</module>
+        <module>kafka-plugin-testweb</module>
     </modules>
 
     <dependencyManagement>

--- a/plugins-it/kafka-it/kafka-3-it/pom.xml
+++ b/plugins-it/kafka-it/kafka-3-it/pom.xml
@@ -52,6 +52,18 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/plugins-it/kafka-it/kafka-3-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClientITBase.java
+++ b/plugins-it/kafka-it/kafka-3-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClientITBase.java
@@ -25,6 +25,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import test.pinpoint.plugin.kafka.Kafka3UnitServer;
+import test.pinpoint.plugin.kafka.KafkaITConstants;
 import test.pinpoint.plugin.kafka.TestConsumerRecordEntryPoint;
 
 import java.lang.reflect.Method;
@@ -68,6 +70,7 @@ public class KafkaClientITBase {
 
         PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
         verifier.awaitTraceCount(3, 100, MAX_TRACE_WAIT_TIME);
+
 
         String expectedRpc = "kafka://topic=" + TOPIC + "?partition=" + PARTITION + "&offset=" + offset;
         verifyConsumerEntryPoint(verifier, brokerUrl, TOPIC, expectedRpc, ConsumerRecord.class,

--- a/plugins-it/kafka-it/kafka-3-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_8_x_3_IT.java
+++ b/plugins-it/kafka-it/kafka-3-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_2_8_x_3_IT.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.kafka;
 
 import com.navercorp.pinpoint.common.Version;
 import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.pluginit.utils.TestcontainersOption;
 import com.navercorp.pinpoint.test.plugin.*;
 import com.navercorp.pinpoint.test.plugin.shared.SharedTestLifeCycleClass;
 import org.junit.Ignore;
@@ -37,7 +38,8 @@ import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
 @Dependency({
         "org.apache.kafka:kafka_2.12:[2.8.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
-        "org.apache.kafka:kafka-clients:[2.8.0,2.max]"
+        "org.apache.kafka:kafka-clients:[2.8.0,2.max]",
+        TestcontainersOption.TEST_CONTAINER, TestcontainersOption.KAFKA
 })
 @JvmVersion(8)
 @SharedTestLifeCycleClass(Kafka3UnitServer.class)

--- a/plugins-it/kafka-it/kafka-3-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_3_0_x_3_IT.java
+++ b/plugins-it/kafka-it/kafka-3-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_3_0_x_3_IT.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.kafka;
 
 import com.navercorp.pinpoint.common.Version;
 import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.pluginit.utils.TestcontainersOption;
 import com.navercorp.pinpoint.test.plugin.*;
 import com.navercorp.pinpoint.test.plugin.shared.SharedTestLifeCycleClass;
 import org.junit.Ignore;
@@ -37,7 +38,8 @@ import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
 @Dependency({
         "org.apache.kafka:kafka_2.12:[3.0.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
-        "org.apache.kafka:kafka-clients:[3.0.0,3.0.max]"
+        "org.apache.kafka:kafka-clients:[3.0.0,3.0.max]",
+        TestcontainersOption.TEST_CONTAINER, TestcontainersOption.KAFKA
 })
 @JvmVersion(8)
 @SharedTestLifeCycleClass(Kafka3UnitServer.class)

--- a/plugins-it/kafka-it/kafka-3-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_3_1_x_3_IT.java
+++ b/plugins-it/kafka-it/kafka-3-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_3_1_x_3_IT.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.plugin.kafka;
 
 import com.navercorp.pinpoint.common.Version;
 import com.navercorp.pinpoint.pluginit.utils.AgentPath;
+import com.navercorp.pinpoint.pluginit.utils.TestcontainersOption;
 import com.navercorp.pinpoint.test.plugin.*;
 import com.navercorp.pinpoint.test.plugin.shared.SharedTestLifeCycleClass;
 import org.junit.Ignore;
@@ -37,7 +38,8 @@ import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
 @Dependency({
         "org.apache.kafka:kafka_2.12:[3.1.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
-        "org.apache.kafka:kafka-clients:[3.1.0,3.1.max]"
+        "org.apache.kafka:kafka-clients:[3.1.0,3.1.max]",
+        TestcontainersOption.TEST_CONTAINER, TestcontainersOption.KAFKA
 })
 @JvmVersion(8)
 @SharedTestLifeCycleClass(Kafka3UnitServer.class)

--- a/plugins-it/kafka-it/kafka-3-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_3_2_x_3_IT.java
+++ b/plugins-it/kafka-it/kafka-3-it/src/test/java/com/navercorp/pinpoint/plugin/kafka/KafkaClient_3_2_x_3_IT.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.common.Version;
 import com.navercorp.pinpoint.pluginit.utils.AgentPath;
 import com.navercorp.pinpoint.test.plugin.*;
 import com.navercorp.pinpoint.test.plugin.shared.SharedTestLifeCycleClass;
+import com.navercorp.pinpoint.pluginit.utils.TestcontainersOption;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +38,8 @@ import static test.pinpoint.plugin.kafka.KafkaITConstants.TRACE_TYPE_RECORD;
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-kafka-plugin"})
 @Dependency({
         "org.apache.kafka:kafka_2.12:[3.2.0]", "log4j:log4j:[1.2.17]", "commons-io:commons-io:[2.5.0]",
-        "org.apache.kafka:kafka-clients:[3.2.0,3.max]"
+        "org.apache.kafka:kafka-clients:[3.2.0,3.max]",
+        TestcontainersOption.TEST_CONTAINER, TestcontainersOption.KAFKA
 })
 @JvmVersion(8)
 @SharedTestLifeCycleClass(Kafka3UnitServer.class)

--- a/plugins-it/plugins-it-utils/src/main/java/com/navercorp/pinpoint/pluginit/utils/TestcontainersOption.java
+++ b/plugins-it/plugins-it-utils/src/main/java/com/navercorp/pinpoint/pluginit/utils/TestcontainersOption.java
@@ -34,4 +34,5 @@ public final class TestcontainersOption {
 
     public static final String ELASTICSEARCH = "org.testcontainers:elasticsearch:" + VERSION;
     public static final String MONGODB = "org.testcontainers:mongodb:" + VERSION;
+    public static final String KAFKA = "org.testcontainers:kafka:" + VERSION;
 }


### PR DESCRIPTION
Stacktrace
~~~
com.navercorp.pinpoint.test.plugin.PinpointPluginTestException: java.lang.AssertionError: Failed to match 1th expectation: Span(serviceType: 8660, apiId: -4, exception: null, rpc: ExpectedTraceField{expectedType=EQUALS, expected='kafka://topic=kafka-it-topic?batch=1'}, endPoint: ExpectedTraceField{expectedType=ALWAYS_TRUE, expected='null'}, remoteAddr: ExpectedTraceField{expectedType=EQUALS, expected='localhost:25790'}, destinationId: ExpectedTraceField{expectedType=ALWAYS_TRUE, expected='null'}, annotations: [kafka.topic=kafka-it-topic, kafka.batch=1], localAsyncId: null)
~~~