### PR TITLE
fix(sec): upgrade com.ning:async-http-client to 1.9.0

### DIFF
--- a/plugins-it/ning-asyncclient-it/pom.xml
+++ b/plugins-it/ning-asyncclient-it/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.ning</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>1.8.3</version>
+            <version>1.9.0</version>
         </dependency>
 
         <dependency>

--- a/plugins/bom/pom.xml
+++ b/plugins/bom/pom.xml
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>com.ning</groupId>
                 <artifactId>async-http-client</artifactId>
-                <version>1.8.3</version>
+                <version>1.9.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.ning:async-http-client 1.8.3
- [CVE-2013-7398](https://www.oscs1024.com/hd/CVE-2013-7398)


### What did I do？
Upgrade com.ning:async-http-client from 1.8.3 to 1.9.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS