### PR TITLE
[#9322] Remove unnecessary guava dependencies

### DIFF
--- a/plugins-it/cassandra-it/pom.xml
+++ b/plugins-it/cassandra-it/pom.xml
@@ -50,12 +50,6 @@
             <artifactId>pinpoint-commons-profiler</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>14.0.1</version>
-        </dependency>
-
 
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.google.guava:guava 14.0.1
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237)
- [CVE-2020-8908](https://www.oscs1024.com/hd/CVE-2020-8908)


### What did I do？
Upgrade com.google.guava:guava from 14.0.1 to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS