### PR TITLE
fix(sec): upgrade io.undertow:undertow-core to 2.3.0.Alpha2

### DIFF
--- a/agent-testweb/bom/pom.xml
+++ b/agent-testweb/bom/pom.xml
@@ -37,7 +37,7 @@
         <mongo.driver.version>3.9.0</mongo.driver.version>
         <apache.dubbo.version>2.7.2</apache.dubbo.version>
         <ehcache.version>2.10.6</ehcache.version>
-        <undertow.version>2.2.17.Final</undertow.version>
+        <undertow.version>2.3.0.Alpha2</undertow.version>
     </properties>
 
     <dependencyManagement>

--- a/agent-testweb/undertow-plugin-testweb/pom.xml
+++ b/agent-testweb/undertow-plugin-testweb/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <encoding>UTF-8</encoding>
-        <undertow.version>2.2.17.Final</undertow.version>
+        <undertow.version>2.3.0.Alpha2</undertow.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.undertow:undertow-core 2.2.17.Final
- [CVE-2021-3597](https://www.oscs1024.com/hd/CVE-2021-3597)


### What did I do？
Upgrade io.undertow:undertow-core from 2.2.17.Final to 2.3.0.Alpha2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS

Signed-off-by:pen4<948453219@qq.com>