### PR TITLE
[#9424] Export the 'mail.smtp.ssl.enable' in the batch. 

### DIFF
--- a/batch/src/main/resources/applicationContext-batch-sender.xml
+++ b/batch/src/main/resources/applicationContext-batch-sender.xml
@@ -30,6 +30,7 @@
                 <prop key="mail.smtp.auth">${alarm.mail.smtp.auth:false}</prop>
                 <prop key="mail.smtp.starttls.enable">${alarm.mail.smtp.starttls.enable:false}</prop>
                 <prop key="mail.smtp.starttls.required">${alarm.mail.smtp.starttls.required:false}</prop>
+                <prop key="mail.smtp.ssl.enable">${alarm.mail.smtp.ssl.enable:false}</prop>
                 <prop key="mail.debug">${alarm.mail.debug:false}</prop>
             </props>
         </property>

--- a/batch/src/main/resources/batch-root.properties
+++ b/batch/src/main/resources/batch-root.properties
@@ -13,6 +13,7 @@ alarm.mail.smtp.port=25
 alarm.mail.smtp.auth=false
 alarm.mail.smtp.starttls.enable=false
 alarm.mail.smtp.starttls.required=false
+alarm.mail.smtp.ssl.enable=false
 alarm.mail.debug=false
 
 # webhook config


### PR DESCRIPTION
Which module is your feature request related to?
Batch/.../applicationContext-batch-sender.xml

Is your feature request related to a problem?
Cannot use Gmail's SMTP easily cause by default, the sender does not enabled to use 'mail.smtp.ssl.enable' configuration.
Cause a lot of users in pinpoint might using gmail to send mail via pinpoint's batch, this feature will be useful to lots of develpers!

Describe the solution you'd like

Add the below property between line number 30 and 31 in 'pinpoint/batch/src/main/resources/applicationContext-batch-sender.xml'
<prop key="mail.smtp.ssl.enable>${alarm.mail.smtp.ssl.enable:false}</prop>
Update the configuration guide of pinpoint batch with 'Setting the value alarm.mail.smtp.ssl.enable if you needed'.
Describe alternatives you've considered
Nothing for now

Additional context
Thanks for sharing the most useful APM tool for me.
Me and my team always thanks to your team.
추가적으로 문의사항이 있으시다면 [junminkim@jobis.co](mailto:junminkim@jobis.co)로 연락주시면 감사하겠습니다!