### PR TITLE
fix(sec): upgrade io.projectreactor.netty:reactor-netty to 1.0.24

### DIFF
--- a/agent-testweb/reactor-netty-plugin-testweb/pom.xml
+++ b/agent-testweb/reactor-netty-plugin-testweb/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>
-            <version>1.0.16</version>
+            <version>1.0.24</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.projectreactor.netty:reactor-netty 1.0.16
- [CVE-2022-31684](https://www.oscs1024.com/hd/CVE-2022-31684)


### What did I do？
Upgrade io.projectreactor.netty:reactor-netty from 1.0.16 to 1.0.24 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS