### PR TITLE
[#noissue] Apply GuardLogStatement for classes that execute a lot

### DIFF
--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/AsyncContextSpanEventEndPointInterceptor.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/AsyncContextSpanEventEndPointInterceptor.java
@@ -90,7 +90,9 @@ public abstract class AsyncContextSpanEventEndPointInterceptor implements Around
 
         final AsyncContext asyncContext = getAsyncContext(target, args);
         if (asyncContext == null) {
-            logger.debug("Not found asynchronous invocation metadata");
+            if (isDebug) {
+                logger.debug("Not found asynchronous invocation metadata");
+            }
             return;
         }
         if (isDebug) {

--- a/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/AsyncContextSpanEventSimpleAroundInterceptor.java
+++ b/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/AsyncContextSpanEventSimpleAroundInterceptor.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 public abstract class AsyncContextSpanEventSimpleAroundInterceptor implements AroundInterceptor {
     protected final PLogger logger = PLoggerFactory.getLogger(getClass());
     protected final boolean isDebug = logger.isDebugEnabled();
+    protected final boolean isTrace = logger.isTraceEnabled();
     protected static final String ASYNC_TRACE_SCOPE = AsyncContext.ASYNC_TRACE_SCOPE;
 
     protected final MethodDescriptor methodDescriptor;
@@ -47,7 +48,9 @@ public abstract class AsyncContextSpanEventSimpleAroundInterceptor implements Ar
 
         final AsyncContext asyncContext = getAsyncContext(target, args);
         if (asyncContext == null) {
-            logger.trace("AsyncContext not found");
+            if (isTrace) {
+                logger.trace("AsyncContext not found");
+            }
             return;
         }
 
@@ -80,7 +83,9 @@ public abstract class AsyncContextSpanEventSimpleAroundInterceptor implements Ar
 
         final AsyncContext asyncContext = getAsyncContext(target, args, result, throwable);
         if (asyncContext == null) {
-            logger.trace("AsyncContext not found");
+            if (isTrace) {
+                logger.trace("AsyncContext not found");
+            }
             return;
         }
 

--- a/plugins/netty/src/main/java/com/navercorp/pinpoint/plugin/netty/interceptor/http/HttpEncoderInterceptor.java
+++ b/plugins/netty/src/main/java/com/navercorp/pinpoint/plugin/netty/interceptor/http/HttpEncoderInterceptor.java
@@ -107,7 +107,9 @@ public class HttpEncoderInterceptor implements AroundInterceptor {
 
         final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 1);
         if (asyncContext == null) {
-            logger.debug("AsyncContext not found");
+            if (isDebug) {
+                logger.debug("AsyncContext not found");
+            }
             return;
         }
 
@@ -186,7 +188,9 @@ public class HttpEncoderInterceptor implements AroundInterceptor {
     private void afterAsync(Object target, Object[] args, Object result, Throwable throwable) {
         final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 1);
         if (asyncContext == null) {
-            logger.debug("AsyncContext not found");
+            if (isDebug) {
+                logger.debug("AsyncContext not found");
+            }
             return;
         }
 


### PR DESCRIPTION
While analyzing webflux application performance issues, I found that some pinpoint logs use a lot of CPU.
To reduce CPU usage, GuardLogStatement has been applied to classes that execute a lot.

![pinpoint_log_trace](https://user-images.githubusercontent.com/10057874/206657422-ad04a292-a843-4c06-a068-1abf09d4b216.JPG)

Thanks.  :) 