### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka_2.12 to 3.2.3

### DIFF
--- a/agent-testweb/kafka-plugin-testweb/pom.xml
+++ b/agent-testweb/kafka-plugin-testweb/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
-            <version>3.2.0</version>
+            <version>3.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka_2.12 3.2.0
- [CVE-2022-34917](https://www.oscs1024.com/hd/CVE-2022-34917)


### What did I do？
Upgrade org.apache.kafka:kafka_2.12 from 3.2.0 to 3.2.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS