### PR TITLE
[#9666] New realtime active thread count with redis

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/CollectorAppPropertySources.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/CollectorAppPropertySources.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.PropertySources;
         @PropertySource(name = "CollectorAppPropertySources-GRPC", value = { CollectorAppPropertySources.GRPC_ROOT, CollectorAppPropertySources.GRPC_PROFILE}),
         @PropertySource(name = "CollectorAppPropertySources-HBase", value = { CollectorAppPropertySources.HBASE_ROOT, CollectorAppPropertySources.HBASE_PROFILE}),
         @PropertySource(name = "CollectorAppPropertySources-JDBC", value = { CollectorAppPropertySources.JDBC_ROOT, CollectorAppPropertySources.JDBC_PROFILE}),
+        @PropertySource(name = "CollectorAppPropertySources-Redis", value = { CollectorAppPropertySources.REDIS_ROOT, CollectorAppPropertySources.REDIS_PROFILE}),
 })
 public final class CollectorAppPropertySources {
     public static final String HBASE_ROOT= "classpath:hbase-root.properties";
@@ -35,6 +36,9 @@ public final class CollectorAppPropertySources {
 
     public static final String JDBC_ROOT = "classpath:jdbc-root.properties";
     public static final String JDBC_PROFILE = "classpath:profiles/${pinpoint.profiles.active:local}/jdbc.properties";
+
+    public static final String REDIS_ROOT = "classpath:redis-root.properties";
+    public static final String REDIS_PROFILE = "classpath:profiles/${pinpoint.profiles.active:local}/redis.properties";
 
     public static final String COLLECTOR_ROOT = "classpath:pinpoint-collector-root.properties";
     public static final String COLLECTOR_PROFILE = "classpath:profiles/${pinpoint.profiles.active:local}/pinpoint-collector.properties";

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/cluster/route/AbstractRouteHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/cluster/route/AbstractRouteHandler.java
@@ -22,9 +22,8 @@ import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
 import com.navercorp.pinpoint.thrift.dto.command.TCommandTransfer;
 import com.navercorp.pinpoint.thrift.dto.command.TCommandTransferResponse;
 import com.navercorp.pinpoint.thrift.dto.command.TRouteResult;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,7 +46,10 @@ public abstract class AbstractRouteHandler<T extends RouteEvent> implements Rout
         String agentId = deliveryCommand.getAgentId();
         long startTimeStamp = deliveryCommand.getStartTime();
         final ClusterKey sourceKey = new ClusterKey(applicationName, agentId, startTimeStamp);
+        return findClusterPoint(sourceKey);
+    }
 
+    public ClusterPoint<?> findClusterPoint(ClusterKey sourceKey) {
         List<ClusterPoint<?>> result = new ArrayList<>();
 
         for (ClusterPoint<?> targetClusterPoint : targetClusterPointLocator.getClusterPointList()) {
@@ -62,7 +64,7 @@ public abstract class AbstractRouteHandler<T extends RouteEvent> implements Rout
         }
 
         if (result.size() > 1) {
-            logger.warn("Ambiguous ClusterPoint {}, {}, {} (Valid Agent list={}).", applicationName, agentId, startTimeStamp, result);
+            logger.warn("Ambiguous ClusterPoint {} (Valid Agent list={}).", sourceKey, result);
             return null;
         }
 

--- a/collector/src/main/resources/pinpoint-collector-root.properties
+++ b/collector/src/main/resources/pinpoint-collector-root.properties
@@ -147,6 +147,11 @@ flink.cluster.zookeeper.address=${pinpoint.zookeeper.address}
 flink.cluster.zookeeper.znode_root=/pinpoint-cluster
 flink.cluster.zookeeper.sessiontimeout=3000
 
+# Active Thread Count
+pinpoint.collector.realtime.atc.demand.duration=12500
+pinpoint.collector.realtime.atc.supply.throttle.termMillis=100
+pinpoint.collector.realtime.atc.enable-count-metric=false
+
 ###########################################################
 # BANNER                                                  #
 ###########################################################
@@ -199,4 +204,7 @@ pinpoint.banner.configs=spring.active.profile,\
                         hbase.client.host,\
                         hbase.client.port,\
                         hbase.zookeeper.znode.parent,\
-                        hbase.namespace
+                        hbase.namespace,\
+                        spring.data.redis.host,\
+                        spring.data.redis.port,\
+                        spring.data.redis.cluster.nodes

--- a/collector/src/main/resources/profiles/local/redis.properties
+++ b/collector/src/main/resources/profiles/local/redis.properties
@@ -1,0 +1,13 @@
+spring.data.redis.lettuce.client.io-thread-pool-size=8
+spring.data.redis.lettuce.client.computation-thread-pool-size=8
+spring.data.redis.lettuce.client.request-queue-size=1024
+
+spring.data.redis.username=default
+spring.data.redis.password=
+
+# Standalone mode
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+
+# Cluster mode: Cluster mode is prior than Standalone
+spring.data.redis.cluster.nodes=

--- a/collector/src/main/resources/profiles/release/redis.properties
+++ b/collector/src/main/resources/profiles/release/redis.properties
@@ -1,0 +1,13 @@
+spring.data.redis.lettuce.client.io-thread-pool-size=8
+spring.data.redis.lettuce.client.computation-thread-pool-size=8
+spring.data.redis.lettuce.client.request-queue-size=1024
+
+spring.data.redis.username=default
+spring.data.redis.password=
+
+# Standalone mode
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+
+# Cluster mode: Cluster mode is prior than Standalone
+spring.data.redis.cluster.nodes=

--- a/collector/src/main/resources/redis-root.properties
+++ b/collector/src/main/resources/redis-root.properties
@@ -1,0 +1,1 @@
+spring.data.redis.lettuce.client.name=collectorRedis

--- a/metric-module/collector-starter/pom.xml
+++ b/metric-module/collector-starter/pom.xml
@@ -34,6 +34,10 @@
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-uristat-collector</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-realtime-collector</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/metric-module/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/BasicCollectorApp.java
+++ b/metric-module/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/BasicCollectorApp.java
@@ -4,6 +4,10 @@ import com.navercorp.pinpoint.collector.CollectorAppPropertySources;
 import com.navercorp.pinpoint.collector.config.FlinkContextConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
@@ -12,7 +16,15 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
 
 @SpringBootConfiguration
-@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, TransactionAutoConfiguration.class, SqlInitializationAutoConfiguration.class})
+@EnableAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        TransactionAutoConfiguration.class,
+        SqlInitializationAutoConfiguration.class,
+        SpringDataWebAutoConfiguration.class,
+        RedisAutoConfiguration.class,
+        RedisRepositoriesAutoConfiguration.class,
+        RedisReactiveAutoConfiguration.class
+})
 @ImportResource({"classpath:applicationContext-collector.xml", "classpath:servlet-context-collector.xml"})
 @Import({CollectorAppPropertySources.class, FlinkContextConfiguration.class})
 @ComponentScan({})

--- a/metric-module/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/MultiApplication.java
+++ b/metric-module/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/MultiApplication.java
@@ -10,11 +10,16 @@ import com.navercorp.pinpoint.metric.collector.CollectorType;
 import com.navercorp.pinpoint.metric.collector.CollectorTypeParser;
 import com.navercorp.pinpoint.metric.collector.MetricCollectorApp;
 import com.navercorp.pinpoint.metric.collector.TypeSet;
+import com.navercorp.pinpoint.collector.realtime.atc.config.ATCCollectorConfig;
 import com.navercorp.pinpoint.uristat.collector.UriStatCollectorConfig;
 import org.springframework.boot.Banner;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -22,7 +27,14 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import java.util.Arrays;
 
 @SpringBootConfiguration
-@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, TransactionAutoConfiguration.class})
+@EnableAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        TransactionAutoConfiguration.class,
+        SpringDataWebAutoConfiguration.class,
+        RedisAutoConfiguration.class,
+        RedisRepositoriesAutoConfiguration.class,
+        RedisReactiveAutoConfiguration.class
+})
 public class MultiApplication {
     private static final ServerBootLogger logger = ServerBootLogger.getLogger(MultiApplication.class);
 
@@ -44,7 +56,11 @@ public class MultiApplication {
 
         if (types.hasType(CollectorType.BASIC)) {
             logger.info(String.format("Start %s collector", CollectorType.BASIC));
-            SpringApplicationBuilder collectorAppBuilder = createAppBuilder(builder, 15400, BasicCollectorApp.class, UriStatCollectorConfig.class);
+            SpringApplicationBuilder collectorAppBuilder = createAppBuilder(builder, 15400,
+                    BasicCollectorApp.class,
+                    UriStatCollectorConfig.class,
+                    ATCCollectorConfig.class
+            );
             collectorAppBuilder.build().run(args);
         }
 

--- a/metric-module/web-starter/pom.xml
+++ b/metric-module/web-starter/pom.xml
@@ -44,6 +44,10 @@
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-uristat-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-realtime-web</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/metric-module/web-starter/src/main/java/com/navercorp/pinpoint/web/starter/multi/MetricAndWebApp.java
+++ b/metric-module/web-starter/src/main/java/com/navercorp/pinpoint/web/starter/multi/MetricAndWebApp.java
@@ -18,17 +18,22 @@ package com.navercorp.pinpoint.web.starter.multi;
 
 import com.navercorp.pinpoint.common.server.util.ServerBootLogger;
 import com.navercorp.pinpoint.metric.web.MetricWebApp;
+import com.navercorp.pinpoint.web.realtime.atc.config.ATCWebConfig;
 import com.navercorp.pinpoint.uristat.web.UriStatWebConfig;
+import com.navercorp.pinpoint.web.AuthorizationConfig;
 import com.navercorp.pinpoint.web.PinpointBasicLoginConfig;
 import com.navercorp.pinpoint.web.WebApp;
 import com.navercorp.pinpoint.web.WebAppPropertySources;
 import com.navercorp.pinpoint.web.WebMvcConfig;
 import com.navercorp.pinpoint.web.WebServerConfig;
 import com.navercorp.pinpoint.web.WebStarter;
-import com.navercorp.pinpoint.web.AuthorizationConfig;
 import com.navercorp.pinpoint.web.cache.CacheConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
@@ -38,8 +43,15 @@ import org.springframework.context.annotation.ImportResource;
  * @author minwoo.jung
  */
 @SpringBootConfiguration
-@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, TransactionAutoConfiguration.class,
-        SecurityAutoConfiguration.class})
+@EnableAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        TransactionAutoConfiguration.class,
+        SecurityAutoConfiguration.class,
+        SpringDataWebAutoConfiguration.class,
+        RedisAutoConfiguration.class,
+        RedisRepositoriesAutoConfiguration.class,
+        RedisReactiveAutoConfiguration.class
+})
 @ImportResource({"classpath:applicationContext-web.xml", "classpath:servlet-context-web.xml"})
 @Import({WebAppPropertySources.class, WebServerConfig.class, WebMvcConfig.class, CacheConfiguration.class})
 public class MetricAndWebApp {
@@ -47,7 +59,14 @@ public class MetricAndWebApp {
 
     public static void main(String[] args) {
         try {
-            WebStarter starter = new WebStarter(MetricAndWebApp.class, PinpointBasicLoginConfig.class, AuthorizationConfig.class, MetricWebApp.class, UriStatWebConfig.class);
+            WebStarter starter = new WebStarter(
+                    MetricAndWebApp.class,
+                    PinpointBasicLoginConfig.class,
+                    AuthorizationConfig.class,
+                    MetricWebApp.class,
+                    UriStatWebConfig.class,
+                    ATCWebConfig.class
+            );
             starter.start(args);
         } catch (Exception exception) {
             logger.error("[WebApp] could not launch app.", exception);

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <module>hbase2-module</module>
         <module>metric-module</module>
         <module>uristat</module>
+        <module>realtime</module>
 
         <!-- <module>agent-testweb</module> -->
         <!-- <module>plugins-it</module> -->
@@ -437,6 +438,21 @@
             <dependency>
                 <groupId>com.navercorp.pinpoint</groupId>
                 <artifactId>pinpoint-uristat-collector</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.navercorp.pinpoint</groupId>
+                <artifactId>pinpoint-realtime-web</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.navercorp.pinpoint</groupId>
+                <artifactId>pinpoint-realtime-collector</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.navercorp.pinpoint</groupId>
+                <artifactId>pinpoint-realtime-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/realtime/pom.xml
+++ b/realtime/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pinpoint</artifactId>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <version>2.5.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pinpoint-realtime</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>realtime-web</module>
+        <module>realtime-common</module>
+        <module>realtime-collector</module>
+    </modules>
+
+</project>

--- a/realtime/realtime-collector/pom.xml
+++ b/realtime/realtime-collector/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pinpoint-realtime</artifactId>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <version>2.5.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pinpoint-realtime-collector</artifactId>
+
+    <properties>
+        <jdk.version>11</jdk.version>
+        <jdk.home>${env.JAVA_11_HOME}</jdk.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-realtime-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-collector</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/config/ATCCollectorConfig.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/config/ATCCollectorConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.config;
+
+import com.navercorp.pinpoint.pubsub.SubChannel;
+import com.navercorp.pinpoint.pubsub.SubConsumer;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import com.navercorp.pinpoint.redis.StaticSubscriber;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+@ConditionalOnProperty(value = "pinpoint.collector.redis-realtime.enabled", havingValue = "true")
+@Import({ ATCCollectorServiceConfig.class })
+public class ATCCollectorConfig {
+
+    @Bean
+    StaticSubscriber<ATCDemand> registerDemandListener(
+            SubChannel<ATCDemand> channel,
+            SubConsumer<ATCDemand> consumer
+    ) {
+        return new StaticSubscriber<>(channel, consumer, null);
+    }
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/config/ATCCollectorDaoConfig.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/config/ATCCollectorDaoConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.config;
+
+import com.navercorp.pinpoint.collector.realtime.atc.dao.CountingMetricDao;
+import com.navercorp.pinpoint.collector.realtime.atc.dao.empty.EmptyCountingMetricDao;
+import com.navercorp.pinpoint.collector.realtime.atc.dao.redis.RedisCountingMetricDao;
+import com.navercorp.pinpoint.pubsub.PubChannel;
+import com.navercorp.pinpoint.pubsub.SubChannel;
+import com.navercorp.pinpoint.realtime.atc.dao.RedisATCDemandSubChannel;
+import com.navercorp.pinpoint.realtime.atc.dao.RedisATCSupplyPubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+import com.navercorp.pinpoint.redis.CommonRedisConfig;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+@Import({ CommonRedisConfig.class })
+public class ATCCollectorDaoConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "pinpoint.collector.realtime.atc.enable-count-metric", havingValue = "true")
+    CountingMetricDao countingMetricDao(ReactiveRedisConnectionFactory connectionFactory) {
+        return new RedisCountingMetricDao(connectionFactory);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(CountingMetricDao.class)
+    CountingMetricDao emptyCountingMetricDao() {
+        return new EmptyCountingMetricDao();
+    }
+
+    @Bean
+    PubChannel<ATCSupply> activeThreadCountSupplyPubChannel(ReactiveRedisConnectionFactory connectionFactory) {
+        return new RedisATCSupplyPubChannel(connectionFactory);
+    }
+
+    @Bean
+    SubChannel<ATCDemand> atcDemandSubChannel(RedisMessageListenerContainer container) {
+        return new RedisATCDemandSubChannel(container);
+    }
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/config/ATCCollectorServiceConfig.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/config/ATCCollectorServiceConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.config;
+
+import com.navercorp.pinpoint.collector.realtime.atc.dao.CountingMetricDao;
+import com.navercorp.pinpoint.collector.realtime.atc.listener.ActiveThreadCountDemandConsumer;
+import com.navercorp.pinpoint.collector.realtime.atc.service.ActiveThreadCountService;
+import com.navercorp.pinpoint.collector.realtime.atc.service.SupplyPublishService;
+import com.navercorp.pinpoint.collector.realtime.atc.service.cluster.ClusterActiveThreadCountService;
+import com.navercorp.pinpoint.collector.realtime.atc.service.redis.RedisSupplyPublishService;
+import com.navercorp.pinpoint.collector.realtime.config.RealtimeCollectorServiceConfig;
+import com.navercorp.pinpoint.collector.realtime.service.AgentCommandService;
+import com.navercorp.pinpoint.pubsub.PubChannel;
+import com.navercorp.pinpoint.pubsub.SubConsumer;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+import com.navercorp.pinpoint.thrift.io.DeserializerFactory;
+import com.navercorp.pinpoint.thrift.io.HeaderTBaseDeserializer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+@Import({ ATCCollectorDaoConfig.class, RealtimeCollectorServiceConfig.class })
+public class ATCCollectorServiceConfig {
+
+    @Value("${pinpoint.collector.realtime.atc.demand.duration:12500}")
+    long demandDurationMillis;
+
+    @Value("${pinpoint.collector.realtime.atc.supply.throttle.termMillis:100}")
+    long throttleTermMillis;
+
+    @Bean
+    @ConditionalOnBean(name = "commandHeaderTBaseDeserializerFactory")
+    ActiveThreadCountService activeThreadCountService(
+            AgentCommandService agentCommandService,
+            @Qualifier("commandHeaderTBaseDeserializerFactory")
+            DeserializerFactory<HeaderTBaseDeserializer> deserializerFactory
+    ) {
+        return new ClusterActiveThreadCountService(agentCommandService, deserializerFactory, demandDurationMillis);
+    }
+
+    @Bean
+    SupplyPublishService supplyPublishService(
+            PubChannel<ATCSupply> supplyChannel,
+            CountingMetricDao countingMetricDao
+    ) {
+        return new RedisSupplyPublishService(supplyChannel, countingMetricDao, throttleTermMillis);
+    }
+
+    @Bean("activeThreadCountDemandSubConsumer")
+    SubConsumer<ATCDemand> activeThreadCountDemandSubConsumer(
+            ActiveThreadCountService activeThreadCountService,
+            SupplyPublishService publisher
+    ) {
+        return new ActiveThreadCountDemandConsumer(activeThreadCountService, publisher);
+    }
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/dao/CountingMetricDao.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/dao/CountingMetricDao.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.dao;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface CountingMetricDao {
+
+    void incrementCountATCSupply();
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/dao/empty/EmptyCountingMetricDao.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/dao/empty/EmptyCountingMetricDao.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.dao.empty;
+
+import com.navercorp.pinpoint.collector.realtime.atc.dao.CountingMetricDao;
+
+/**
+ * @author youngjin.kim2
+ */
+public class EmptyCountingMetricDao implements CountingMetricDao {
+
+    @Override
+    public void incrementCountATCSupply() {
+        // Do nothing
+    }
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/dao/redis/RedisCountingMetricDao.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/dao/redis/RedisCountingMetricDao.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.dao.redis;
+
+import com.navercorp.pinpoint.collector.realtime.atc.dao.CountingMetricDao;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.ReactiveValueOperations;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public class RedisCountingMetricDao implements CountingMetricDao {
+
+    private static final String countATCSupplyKey = "metric:count:atc:supply";
+
+    private final ReactiveValueOperations<String, String> opsForValue;
+
+    public RedisCountingMetricDao(ReactiveRedisConnectionFactory connectionFactory) {
+        Objects.requireNonNull(connectionFactory, "connectionFactory");
+        final RedisSerializationContext<String, String> serContext = RedisSerializationContext.string();
+        this.opsForValue = new ReactiveRedisTemplate<>(connectionFactory, serContext).opsForValue();
+    }
+
+    @Override
+    public void incrementCountATCSupply() {
+        this.opsForValue.increment(countATCSupplyKey).subscribe();
+    }
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/listener/ActiveThreadCountDemandConsumer.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/listener/ActiveThreadCountDemandConsumer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.listener;
+
+import com.navercorp.pinpoint.collector.realtime.atc.service.ActiveThreadCountService;
+import com.navercorp.pinpoint.collector.realtime.atc.service.SupplyPublishService;
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.pubsub.SubConsumer;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public class ActiveThreadCountDemandConsumer implements SubConsumer<ATCDemand> {
+
+    private static final Logger logger = LogManager.getLogger(ActiveThreadCountDemandConsumer.class);
+
+    private final ActiveThreadCountService activeThreadCountService;
+    private final SupplyPublishService supplyPublishService;
+
+    public ActiveThreadCountDemandConsumer(
+            ActiveThreadCountService activeThreadCountService,
+            SupplyPublishService supplyPublishService
+    ) {
+        this.activeThreadCountService = Objects.requireNonNull(activeThreadCountService, "atcService");
+        this.supplyPublishService = Objects.requireNonNull(supplyPublishService, "supplyPublishService");
+    }
+
+    @Override
+    public void consume(ATCDemand demand, String postfix) {
+        try {
+            final ClusterKey clusterKey = getClusterKeyFrom(demand);
+            this.activeThreadCountService.requestAsync(
+                    clusterKey,
+                    values -> this.supplyPublishService.publish(clusterKey, values)
+            );
+        } catch (Exception e) {
+            logger.error("Failed to open atc stream", e);
+        }
+    }
+
+    private static ClusterKey getClusterKeyFrom(ATCDemand demand) {
+        final String applicationName = demand.getApplicationName();
+        final String agentId = demand.getAgentId();
+        final long startTimestamp = demand.getStartTimestamp();
+        return new ClusterKey(applicationName, agentId, startTimestamp);
+    }
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/service/ActiveThreadCountService.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/service/ActiveThreadCountService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.service;
+
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface ActiveThreadCountService {
+
+    void requestAsync(ClusterKey target, Consumer<List<Integer>> callback) throws Exception;
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/service/SupplyPublishService.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/service/SupplyPublishService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.service;
+
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+
+import java.util.List;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface SupplyPublishService {
+
+    void publish(ClusterKey clusterKey, List<Integer> values);
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/service/cluster/ClusterActiveThreadCountService.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/service/cluster/ClusterActiveThreadCountService.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.service.cluster;
+
+import com.navercorp.pinpoint.collector.cluster.ClusterPoint;
+import com.navercorp.pinpoint.collector.realtime.atc.service.ActiveThreadCountService;
+import com.navercorp.pinpoint.collector.realtime.service.AgentCommandService;
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.io.request.Message;
+import com.navercorp.pinpoint.rpc.packet.stream.StreamResponsePacket;
+import com.navercorp.pinpoint.rpc.stream.ClientStreamChannel;
+import com.navercorp.pinpoint.thrift.dto.command.TCmdActiveThreadCount;
+import com.navercorp.pinpoint.thrift.dto.command.TCmdActiveThreadCountRes;
+import com.navercorp.pinpoint.thrift.io.DeserializerFactory;
+import com.navercorp.pinpoint.thrift.io.HeaderTBaseDeserializer;
+import com.navercorp.pinpoint.thrift.util.SerializationUtils;
+import com.navercorp.pinpoint.util.ScheduleUtil;
+import org.apache.thrift.TBase;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * @author youngjin.kim2
+ */
+public class ClusterActiveThreadCountService implements ActiveThreadCountService {
+
+    private final ScheduledExecutorService closer = ScheduleUtil.makeScheduledExecutorService("closer");
+
+    private final AgentCommandService commandService;
+    private final DeserializerFactory<HeaderTBaseDeserializer> deserializerFactory;
+    private final long demandDurationMillis;
+
+    public ClusterActiveThreadCountService(
+            AgentCommandService commandService,
+            DeserializerFactory<HeaderTBaseDeserializer> deserializerFactory,
+            long demandDurationMillis
+    ) {
+        this.commandService = Objects.requireNonNull(commandService, "commandService");
+        this.deserializerFactory = Objects.requireNonNull(deserializerFactory, "deserializerFactory");
+        this.demandDurationMillis = demandDurationMillis;
+    }
+
+    @Override
+    public void requestAsync(ClusterKey target, Consumer<List<Integer>> callback) throws Exception {
+        final ClusterPoint<?> clusterPoint = commandService.findClusterPoint(target);
+        if (clusterPoint == null) {
+            return;
+        }
+
+        final TCmdActiveThreadCount command = new TCmdActiveThreadCount();
+        final DesConsumer desConsumer = new DesConsumer(deserializerFactory, callback);
+        final ClientStreamChannel clientChannel = commandService.request(clusterPoint, command, desConsumer);
+
+        closer.schedule(() -> clientChannel.close(), this.demandDurationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    private static class DesConsumer implements Consumer<StreamResponsePacket> {
+
+        private final DeserializerFactory<HeaderTBaseDeserializer> deserializerFactory;
+        private final Consumer<List<Integer>> delegate;
+
+        public DesConsumer(
+                DeserializerFactory<HeaderTBaseDeserializer> deserializerFactory,
+                Consumer<List<Integer>> delegate
+        ) {
+            this.deserializerFactory = deserializerFactory;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void accept(StreamResponsePacket packet) {
+            final byte[] payload = packet.getPayload();
+            TCmdActiveThreadCountRes res = this.deserialize(payload);
+            if (res != null) {
+                this.delegate.accept(res.getActiveThreadCount());
+            }
+        }
+
+        private TCmdActiveThreadCountRes deserialize(byte[] payload) {
+            final Message<TBase<?, ?>> message = SerializationUtils.deserialize(payload, deserializerFactory, null);
+            if (message == null) {
+                return null;
+            }
+
+            final TBase<?, ?> data = message.getData();
+            if (data instanceof  TCmdActiveThreadCountRes) {
+                return (TCmdActiveThreadCountRes) data;
+            } else {
+                return null;
+            }
+        }
+
+    }
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/service/redis/RedisSupplyPublishService.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/service/redis/RedisSupplyPublishService.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.service.redis;
+
+import com.navercorp.pinpoint.collector.realtime.atc.dao.CountingMetricDao;
+import com.navercorp.pinpoint.collector.realtime.atc.service.SupplyPublishService;
+import com.navercorp.pinpoint.collector.realtime.atc.util.MinTermThrottle;
+import com.navercorp.pinpoint.collector.realtime.atc.util.Throttle;
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.pubsub.PubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author youngjin.kim2
+ */
+public class RedisSupplyPublishService implements SupplyPublishService {
+
+    private static final Logger logger = LogManager.getLogger(RedisSupplyPublishService.class);
+    private static final String collectorIdForDebug = getCollectorIdForDebug();
+
+    private final PubChannel<ATCSupply> supplyChannel;
+    private final CountingMetricDao countingMetricDao;
+    private final long minPublishTermNanos;
+
+    private final Map<ClusterKey, Throttle> throttles = new ConcurrentHashMap<>();
+
+
+    public RedisSupplyPublishService(
+            PubChannel<ATCSupply> supplyChannel,
+            CountingMetricDao countingMetricDao,
+            long minPublishTermMillis
+    ) {
+        this.supplyChannel = Objects.requireNonNull(supplyChannel, "supplyChannel");
+        this.countingMetricDao = Objects.requireNonNull(countingMetricDao, "countingMetricDao");
+        this.minPublishTermNanos = TimeUnit.MILLISECONDS.toNanos(minPublishTermMillis);
+    }
+
+    @Override
+    public void publish(ClusterKey clusterKey, List<Integer> values) {
+        if (!getThrottle(clusterKey).hit()) {
+            return;
+        }
+
+        final String applicationName = clusterKey.getApplicationName();
+        final String agentId = clusterKey.getAgentId();
+        final long startTimestamp = clusterKey.getStartTimestamp();
+
+        final ATCSupply supply = makeSupply(agentId, startTimestamp, values);
+
+        try {
+            supplyChannel.publish(supply, applicationName);
+            countingMetricDao.incrementCountATCSupply();
+        } catch (Exception e) {
+            logger.warn("Failed to publish", e);
+        }
+    }
+
+    private Throttle getThrottle(ClusterKey clusterKey) {
+        if (this.minPublishTermNanos <= 0) {
+            return Throttle.alwaysTrue;
+        }
+
+        return this.throttles.computeIfAbsent(clusterKey, key -> new MinTermThrottle(this.minPublishTermNanos));
+    }
+
+    private ATCSupply makeSupply(String agentId, long startTimestamp, List<Integer> values) {
+        final ATCSupply supply = new ATCSupply();
+        supply.setAgentId(agentId);
+        supply.setStartTimestamp(startTimestamp);
+        supply.setCollectorId(collectorIdForDebug);
+        supply.setValues(values);
+        return supply;
+    }
+
+    private static String getCollectorIdForDebug() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (Exception ignored) {
+            return "unknown";
+        }
+    }
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/util/MinTermThrottle.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/util/MinTermThrottle.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.util;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author youngjin.kim2
+ */
+public class MinTermThrottle implements Throttle {
+
+    private final AtomicLong lastHit = new AtomicLong(0);
+    private final long minTermNanos;
+
+    public MinTermThrottle(long minTermNanos) {
+        this.minTermNanos = minTermNanos;
+    }
+
+    @Override
+    public boolean hit() {
+        final long now = System.nanoTime();
+        final long prev = lastHit.get();
+        if (now - prev >= this.minTermNanos) {
+            return lastHit.compareAndSet(prev, now);
+        }
+        return false;
+    }
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/util/Throttle.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/atc/util/Throttle.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.atc.util;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface Throttle {
+
+    Throttle alwaysTrue = new AlwaysTrueThrottle();
+
+    boolean hit();
+
+    class AlwaysTrueThrottle implements Throttle {
+        @Override
+        public boolean hit() {
+            return true;
+        }
+
+    }
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/config/RealtimeCollectorServiceConfig.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/config/RealtimeCollectorServiceConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.config;
+
+import com.navercorp.pinpoint.collector.cluster.route.StreamRouteHandler;
+import com.navercorp.pinpoint.collector.realtime.service.AgentCommandService;
+import com.navercorp.pinpoint.collector.realtime.service.cluster.ClusterAgentCommandService;
+import com.navercorp.pinpoint.thrift.io.HeaderTBaseSerializer;
+import com.navercorp.pinpoint.thrift.io.SerializerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+public class RealtimeCollectorServiceConfig {
+
+    @Bean
+    @ConditionalOnBean(name = "commandHeaderTBaseSerializerFactory")
+    AgentCommandService agentCommandService(
+            StreamRouteHandler routeHandler,
+            @Qualifier("commandHeaderTBaseSerializerFactory")
+            SerializerFactory<HeaderTBaseSerializer> serializerFactory
+    ) {
+        return new ClusterAgentCommandService(routeHandler, serializerFactory);
+    }
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/service/AgentCommandService.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/service/AgentCommandService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.service;
+
+import com.navercorp.pinpoint.collector.cluster.ClusterPoint;
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.rpc.packet.stream.StreamResponsePacket;
+import com.navercorp.pinpoint.rpc.stream.ClientStreamChannel;
+import org.apache.thrift.TBase;
+
+import java.util.function.Consumer;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface AgentCommandService {
+
+    ClusterPoint<?> findClusterPoint(ClusterKey clusterKey);
+
+    ClientStreamChannel request(
+            ClusterPoint<?> clusterPoint,
+            TBase<?, ?> command,
+            Consumer<StreamResponsePacket> callback
+    ) throws Exception;
+
+}

--- a/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/service/cluster/ClusterAgentCommandService.java
+++ b/realtime/realtime-collector/src/main/java/com/navercorp/pinpoint/collector/realtime/service/cluster/ClusterAgentCommandService.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.collector.realtime.service.cluster;
+
+import com.navercorp.pinpoint.collector.cluster.ClusterPoint;
+import com.navercorp.pinpoint.collector.cluster.GrpcAgentConnection;
+import com.navercorp.pinpoint.collector.cluster.ThriftAgentConnection;
+import com.navercorp.pinpoint.collector.cluster.route.StreamRouteHandler;
+import com.navercorp.pinpoint.collector.realtime.service.AgentCommandService;
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.rpc.packet.stream.StreamClosePacket;
+import com.navercorp.pinpoint.rpc.packet.stream.StreamResponsePacket;
+import com.navercorp.pinpoint.rpc.stream.ClientStreamChannel;
+import com.navercorp.pinpoint.rpc.stream.ClientStreamChannelEventHandler;
+import com.navercorp.pinpoint.rpc.stream.StreamChannelStateCode;
+import com.navercorp.pinpoint.rpc.stream.StreamException;
+import com.navercorp.pinpoint.thrift.io.HeaderTBaseSerializer;
+import com.navercorp.pinpoint.thrift.io.SerializerFactory;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * @author youngjin.kim2
+ */
+public class ClusterAgentCommandService implements AgentCommandService {
+
+    private final StreamRouteHandler streamRouteHandler;
+    private final SerializerFactory<HeaderTBaseSerializer> commandSerializerFactory;
+
+    public ClusterAgentCommandService(
+            StreamRouteHandler streamRouteHandler,
+            SerializerFactory<HeaderTBaseSerializer> commandSerializerFactory
+    ) {
+        this.streamRouteHandler = Objects.requireNonNull(streamRouteHandler, "streamRouteHandler");
+        this.commandSerializerFactory = Objects.requireNonNull(commandSerializerFactory, "commandSerializerFactory");
+    }
+
+    @Override
+    public ClusterPoint<?> findClusterPoint(ClusterKey clusterKey) {
+        return streamRouteHandler.findClusterPoint(clusterKey);
+    }
+
+    @Override
+    public ClientStreamChannel request(
+            ClusterPoint<?> clusterPoint,
+            TBase<?, ?> command,
+            Consumer<StreamResponsePacket> callback
+    ) throws Exception {
+        final ClientStreamChannelEventHandler handler = new ClientStreamCallbackAdapter(callback);
+        return openClientStreamChannel(clusterPoint, handler, command);
+    }
+
+    private ClientStreamChannel openClientStreamChannel(
+            ClusterPoint<?> clusterPoint,
+            ClientStreamChannelEventHandler handler,
+            TBase<?, ?> command
+    ) throws TException, StreamException {
+        if (!clusterPoint.isSupportCommand(command)) {
+            throw new RuntimeException("Unsupported command: " + command);
+        }
+
+        if (clusterPoint instanceof ThriftAgentConnection) {
+            final byte[] payload = commandSerializerFactory.createSerializer().serialize(command);
+            final long timeoutMillis = 3000;
+            return ((ThriftAgentConnection) clusterPoint)
+                    .getPinpointServer()
+                    .openStreamAndAwait(payload, handler, timeoutMillis);
+        }
+
+        if (clusterPoint instanceof GrpcAgentConnection) {
+            return ((GrpcAgentConnection) clusterPoint).openStream(command, handler);
+        }
+
+        throw new RuntimeException("Invalid clusterPoint: " + clusterPoint);
+    }
+
+    private static class ClientStreamCallbackAdapter extends ClientStreamChannelEventHandler {
+
+        private final Consumer<StreamResponsePacket> callback;
+
+        public ClientStreamCallbackAdapter(Consumer<StreamResponsePacket> callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public void handleStreamResponsePacket(ClientStreamChannel streamChannel, StreamResponsePacket packet) {
+            callback.accept(packet);
+        }
+
+        @Override
+        public void handleStreamClosePacket(ClientStreamChannel streamChannel, StreamClosePacket packet) {
+
+        }
+
+        @Override
+        public void stateUpdated(ClientStreamChannel streamChannel, StreamChannelStateCode updatedStateCode) {
+
+        }
+
+    }
+
+}

--- a/realtime/realtime-collector/src/test/java/com/navercorp/pinpoint/realtime/collector/atc/listener/ATCDemandConsumerTest.java
+++ b/realtime/realtime-collector/src/test/java/com/navercorp/pinpoint/realtime/collector/atc/listener/ATCDemandConsumerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.realtime.collector.atc.listener;
+
+import com.navercorp.pinpoint.collector.realtime.atc.listener.ActiveThreadCountDemandConsumer;
+import com.navercorp.pinpoint.collector.realtime.atc.service.ActiveThreadCountService;
+import com.navercorp.pinpoint.collector.realtime.atc.service.SupplyPublishService;
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Random;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author youngjin.kim2
+ */
+@ExtendWith(MockitoExtension.class)
+public class ATCDemandConsumerTest {
+
+    @Mock ActiveThreadCountService activeThreadCountService;
+    @Mock SupplyPublishService supplyPublishService;
+    @Captor ArgumentCaptor<Consumer<List<Integer>>> consumerCaptor;
+
+    @Test
+    public void testAccept() throws Exception {
+        final ActiveThreadCountDemandConsumer consumer =
+                new ActiveThreadCountDemandConsumer(activeThreadCountService, supplyPublishService);
+
+        final String applicationName = "test-application";
+        final String agentId = "test-agent";
+        final long startTimestamp = 12345;
+
+        final ATCDemand demand = new ATCDemand();
+        demand.setApplicationName(applicationName);
+        demand.setAgentId(agentId);
+        demand.setStartTimestamp(startTimestamp);
+
+        consumer.consume(demand, null);
+
+        final ClusterKey clusterKey = new ClusterKey(applicationName, agentId, startTimestamp);
+
+        verify(activeThreadCountService).requestAsync(eq(clusterKey), consumerCaptor.capture());
+        final Consumer<List<Integer>> capturedConsumer = consumerCaptor.getValue();
+
+        final Random random = new Random();
+        for (int i = 0; i < 10; i++) {
+            final List<Integer> testValueList = List.of(random.nextInt(), random.nextInt(), random.nextInt());
+            capturedConsumer.accept(testValueList);
+        }
+
+        verify(supplyPublishService, times(10)).publish(eq(clusterKey), any());
+    }
+
+}

--- a/realtime/realtime-collector/src/test/java/com/navercorp/pinpoint/realtime/collector/atc/service/redis/RedisSupplyPublishServiceTest.java
+++ b/realtime/realtime-collector/src/test/java/com/navercorp/pinpoint/realtime/collector/atc/service/redis/RedisSupplyPublishServiceTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.realtime.collector.atc.service.redis;
+
+import com.navercorp.pinpoint.collector.realtime.atc.dao.CountingMetricDao;
+import com.navercorp.pinpoint.collector.realtime.atc.service.redis.RedisSupplyPublishService;
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.pubsub.PubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author youngjin.kim2
+ */
+@ExtendWith(MockitoExtension.class)
+public class RedisSupplyPublishServiceTest {
+
+    @Mock PubChannel<ATCSupply> supplyChannel;
+    @Mock CountingMetricDao countingMetricDao;
+
+    @Captor ArgumentCaptor<ATCSupply> supplyCaptor;
+
+    @Test
+    public void testPublish() {
+        final RedisSupplyPublishService service = new RedisSupplyPublishService(supplyChannel, countingMetricDao, 0);
+
+        final String applicationName = "test-application";
+        final String agentId = "test-agent";
+        final long startTimestamp = 12345;
+        final ClusterKey clusterKey = new ClusterKey(applicationName, agentId, startTimestamp);
+
+        final List<Integer> values = List.of(3, 6, 9);
+
+        service.publish(clusterKey, values);
+
+        verify(supplyChannel, times(1)).publish(supplyCaptor.capture(), any());
+        verify(countingMetricDao, times(1)).incrementCountATCSupply();
+
+        final ATCSupply supply = supplyCaptor.getValue();
+        assertThat(supply.getAgentId()).isEqualTo(agentId);
+        assertThat(supply.getStartTimestamp()).isEqualTo(startTimestamp);
+        assertThat(supply.getValues()).isEqualTo(values);
+    }
+
+}

--- a/realtime/realtime-collector/src/test/java/com/navercorp/pinpoint/realtime/collector/atc/util/ThrottleTest.java
+++ b/realtime/realtime-collector/src/test/java/com/navercorp/pinpoint/realtime/collector/atc/util/ThrottleTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.realtime.collector.atc.util;
+
+import com.navercorp.pinpoint.collector.realtime.atc.util.MinTermThrottle;
+import com.navercorp.pinpoint.collector.realtime.atc.util.Throttle;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author youngjin.kim2
+ */
+public class ThrottleTest {
+
+    @Test
+    public void testMinTermThrottle() {
+        final Throttle throttle = new MinTermThrottle(TimeUnit.MILLISECONDS.toNanos(10));
+        final long threshold = TimeUnit.MILLISECONDS.toNanos(100);
+        final long now = System.nanoTime();
+        final AtomicLong numTry = new AtomicLong(0);
+        final AtomicLong numHit = new AtomicLong(0);
+        executeParallel(() -> {
+            while (System.nanoTime() - now < threshold) {
+                numTry.incrementAndGet();
+                if (throttle.hit()) {
+                    numHit.incrementAndGet();
+                }
+            }
+        });
+        System.out.println("numTry: " + numTry.get() + ", numHit: " + numHit.get() + ", maxHit: " + (long) 10 + ", minHit: " + (long) 8);
+        assertThat(numHit.get()).isLessThanOrEqualTo(10).isGreaterThanOrEqualTo(8);
+    }
+
+    private void executeParallel(Runnable target) {
+        final List<Thread> threads = new ArrayList<>(4);
+        for (int i = 0; i < 4; i++) {
+            final Thread thread = new Thread(target, "hitTester-" + (i + 1));
+            threads.add(thread);
+        }
+        for (final Thread thread: threads) {
+            thread.start();
+        }
+        for (final Thread thread: threads) {
+            while (true) {
+                try {
+                    thread.join();
+                    break;
+                } catch (Exception ignored) {}
+            }
+        }
+    }
+
+}

--- a/realtime/realtime-common/pom.xml
+++ b/realtime/realtime-common/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pinpoint-realtime</artifactId>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <version>2.5.1-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pinpoint-realtime-common</artifactId>
+
+    <properties>
+        <jdk.version>11</jdk.version>
+        <jdk.home>${env.JAVA_11_HOME}</jdk.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-commons</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <version>6.1.10.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>2.11.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/pubsub/PubChannel.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/pubsub/PubChannel.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.pubsub;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface PubChannel<T> {
+
+    void publish(T content, String postfix);
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/pubsub/RedisPubChannel.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/pubsub/RedisPubChannel.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.pubsub;
+
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public abstract class RedisPubChannel<T> implements PubChannel<T> {
+
+    private final ReactiveRedisTemplate<String, T> redisTemplate;
+
+    public RedisPubChannel(
+            ReactiveRedisConnectionFactory connectionFactory,
+            RedisSerializationContext<String, T> serContext
+    ) {
+        Objects.requireNonNull(connectionFactory, "connectionFactory");
+        Objects.requireNonNull(serContext, "serContext");
+
+        this.redisTemplate = new ReactiveRedisTemplate<>(connectionFactory, serContext);
+    }
+
+    protected abstract String getChannelBase();
+
+    @Override
+    public void publish(T content, String postfix) {
+        final String destination = append(getChannelBase(), postfix);
+        this.redisTemplate.convertAndSend(destination, content).subscribe();
+    }
+
+    private static String append(String dst, String target) {
+        if (target == null || target.length() == 0) {
+            return dst;
+        }
+        return dst + ':' + target;
+    }
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/pubsub/RedisSubChannel.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/pubsub/RedisSubChannel.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.pubsub;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.Topic;
+import org.springframework.data.redis.serializer.RedisElementReader;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.lang.NonNull;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public abstract class RedisSubChannel<T> implements SubChannel<T> {
+
+    private final RedisMessageListenerContainer container;
+    private final RedisSerializationContext<String, T> serContext;
+
+    public RedisSubChannel(RedisMessageListenerContainer container, RedisSerializationContext<String, T> serContext) {
+        this.container = Objects.requireNonNull(container, "container");
+        this.serContext = Objects.requireNonNull(serContext, "serContext");
+    }
+
+    protected abstract String getChannelBase();
+
+    @Override
+    public void subscribe(SubConsumer<T> consumer, String postfix) {
+        final MessageListener listener = wrapConsumer(consumer, postfix);
+        final Topic topic = getTopic(postfix);
+
+        this.container.addMessageListener(listener, topic);
+    }
+
+    @Override
+    public void unsubscribe(SubConsumer<T> consumer, String postfix) {
+        final MessageListener listener = wrapConsumer(consumer, postfix);
+        final Topic topic = getTopic(postfix);
+
+        this.container.removeMessageListener(listener, topic);
+    }
+
+    private Topic getTopic(String postfix) {
+        final String base = getChannelBase();
+        final String channel = appendPostfix(base, postfix);
+        if (hasAsterisk(channel)) {
+            return PatternTopic.of(channel);
+        } else {
+            return ChannelTopic.of(channel);
+        }
+    }
+
+    private static String appendPostfix(String prefix, String postfix) {
+        if (postfix == null || postfix.length() == 0) {
+            return prefix;
+        }
+        return prefix + ':' + postfix;
+    }
+
+    private static boolean hasAsterisk(String postfix) {
+        return postfix != null && postfix.indexOf('*') >= 0;
+    }
+
+    private MessageListener wrapConsumer(SubConsumer<T> consumer, String postfix) {
+        int baseLength = getChannelBase().length();
+        if (postfix != null && postfix.length() > 0) {
+            baseLength += 1;
+        }
+        return new SubConsumerWrapper<>(consumer, this.serContext, baseLength);
+    }
+
+    private static class SubConsumerWrapper<T> implements MessageListener {
+
+        private final SubConsumer<T> consumer;
+        private final RedisSerializationContext<String, T> serContext;
+        private final int channelPrefixLength;
+
+        public SubConsumerWrapper(
+                SubConsumer<T> consumer,
+                RedisSerializationContext<String, T> serContext,
+                int channelPrefixLength
+        ) {
+            this.consumer = consumer;
+            this.serContext = serContext;
+            this.channelPrefixLength = channelPrefixLength;
+        }
+
+        @Override
+        public void onMessage(@NonNull Message message, byte[] pattern) {
+            final RedisElementReader<T> reader = this.serContext.getValueSerializationPair().getReader();
+            final ByteBuffer body = ByteBuffer.wrap(message.getBody());
+            final T demand = reader.read(body);
+            final String channel = new String(message.getChannel());
+            final String postfix = channel.substring(channelPrefixLength);
+            this.consumer.consume(demand, postfix);
+        }
+
+    }
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/pubsub/SubChannel.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/pubsub/SubChannel.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.pubsub;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface SubChannel<T> {
+
+    void subscribe(SubConsumer<T> consumer, String postfix);
+
+    void unsubscribe(SubConsumer<T> consumer, String postfix);
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/pubsub/SubConsumer.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/pubsub/SubConsumer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.pubsub;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface SubConsumer<T> {
+
+    void consume(T content, String postfix);
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dao/RedisATCDemandPubChannel.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dao/RedisATCDemandPubChannel.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.realtime.atc.dao;
+
+import com.navercorp.pinpoint.pubsub.RedisPubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+/**
+ * @author youngjin.kim2
+ */
+public class RedisATCDemandPubChannel extends RedisPubChannel<ATCDemand> {
+
+    public RedisATCDemandPubChannel(ReactiveRedisConnectionFactory connectionFactory) {
+        super(connectionFactory, getSerdeContext());
+    }
+
+    static RedisSerializationContext<String, ATCDemand> getSerdeContext() {
+        final RedisSerializer<ATCDemand> demandSer = new Jackson2JsonRedisSerializer<>(ATCDemand.class);
+        return RedisSerializationContext
+                .<String, ATCDemand>newSerializationContext()
+                .key(RedisSerializer.string())
+                .value(demandSer)
+                .hashKey(RedisSerializer.string())
+                .hashValue(demandSer)
+                .build();
+    }
+
+    @Override
+    protected String getChannelBase() {
+        return "demand:atc";
+    }
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dao/RedisATCDemandSubChannel.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dao/RedisATCDemandSubChannel.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.realtime.atc.dao;
+
+import com.navercorp.pinpoint.pubsub.RedisSubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+/**
+ * @author youngjin.kim2
+ */
+public class RedisATCDemandSubChannel extends RedisSubChannel<ATCDemand> {
+
+    public RedisATCDemandSubChannel(RedisMessageListenerContainer container) {
+        super(container, RedisATCDemandPubChannel.getSerdeContext());
+    }
+
+    @Override
+    protected String getChannelBase() {
+        return "demand:atc";
+    }
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dao/RedisATCSupplyPubChannel.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dao/RedisATCSupplyPubChannel.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.realtime.atc.dao;
+
+import com.navercorp.pinpoint.pubsub.RedisPubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+/**
+ * @author youngjin.kim2
+ */
+public class RedisATCSupplyPubChannel extends RedisPubChannel<ATCSupply> {
+
+    public RedisATCSupplyPubChannel(ReactiveRedisConnectionFactory connectionFactory) {
+        super(connectionFactory, getSerdeContext());
+    }
+
+    static RedisSerializationContext<String, ATCSupply> getSerdeContext() {
+        final RedisSerializer<ATCSupply> demandSer = new Jackson2JsonRedisSerializer<>(ATCSupply.class);
+        return RedisSerializationContext
+                .<String, ATCSupply>newSerializationContext()
+                .key(RedisSerializer.string())
+                .value(demandSer)
+                .hashKey(RedisSerializer.string())
+                .hashValue(demandSer)
+                .build();
+    }
+
+    @Override
+    protected String getChannelBase() {
+        return "supply:atc";
+    }
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dao/RedisATCSupplySubChannel.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dao/RedisATCSupplySubChannel.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.realtime.atc.dao;
+
+import com.navercorp.pinpoint.pubsub.RedisSubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+/**
+ * @author youngjin.kim2
+ */
+public class RedisATCSupplySubChannel extends RedisSubChannel<ATCSupply> {
+
+    public RedisATCSupplySubChannel(RedisMessageListenerContainer container) {
+        super(container, RedisATCSupplyPubChannel.getSerdeContext());
+    }
+
+    @Override
+    protected String getChannelBase() {
+        return "supply:atc";
+    }
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dto/ATCDemand.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dto/ATCDemand.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.realtime.atc.dto;
+
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public class ATCDemand {
+    private String applicationName;
+    private String agentId;
+    private long startTimestamp;
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
+    }
+
+    public String getAgentId() {
+        return agentId;
+    }
+
+    public void setAgentId(String agentId) {
+        this.agentId = agentId;
+    }
+
+    public long getStartTimestamp() {
+        return startTimestamp;
+    }
+
+    public void setStartTimestamp(long startTimestamp) {
+        this.startTimestamp = startTimestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ATCDemand demand = (ATCDemand) o;
+        return startTimestamp == demand.startTimestamp && Objects.equals(applicationName, demand.applicationName) && Objects.equals(agentId, demand.agentId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(applicationName, agentId, startTimestamp);
+    }
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dto/ATCSupply.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/atc/dto/ATCSupply.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.realtime.atc.dto;
+
+import java.util.List;
+
+/**
+ * @author youngjin.kim2
+ */
+public class ATCSupply {
+    private String agentId;
+    private long startTimestamp;
+    private String collectorId;
+    private List<Integer> values;
+
+    public String getAgentId() {
+        return agentId;
+    }
+
+    public void setAgentId(String agentId) {
+        this.agentId = agentId;
+    }
+
+    public long getStartTimestamp() {
+        return startTimestamp;
+    }
+
+    public void setStartTimestamp(long startTimestamp) {
+        this.startTimestamp = startTimestamp;
+    }
+
+    @SuppressWarnings("unused")
+    public String getCollectorId() {
+        return collectorId;
+    }
+
+    public void setCollectorId(String collectorId) {
+        this.collectorId = collectorId;
+    }
+
+    public List<Integer> getValues() {
+        return values;
+    }
+
+    public void setValues(List<Integer> values) {
+        this.values = values;
+    }
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/redis/CommonRedisConfig.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/redis/CommonRedisConfig.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.redis;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.TimeoutOptions;
+import io.lettuce.core.resource.ClientResources;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.util.Assert;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+public class CommonRedisConfig {
+
+    @Value("${spring.data.redis.username:default}")
+    String username = "default";
+
+    @Value("${spring.data.redis.password:@null}")
+    String password;
+
+    @Value("${spring.data.redis.host:localhost}")
+    String host;
+
+    @Value("${spring.data.redis.port:6379}")
+    int port;
+
+    @Value("${spring.data.redis.cluster.nodes:@null}")
+    List<String> clusterNodes;
+
+    @Bean
+    RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        final RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+
+    @Bean
+    @ConditionalOnProperty("spring.redis.cluster.nodes")
+    RedisConfiguration redisClusterConfiguration() {
+        Assert.notNull(clusterNodes, "clusterNodes are required for redis-cluster mode");
+
+        final RedisClusterConfiguration config = new RedisClusterConfiguration(clusterNodes);
+        config.setUsername(username);
+        config.setPassword(password);
+        return config;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(RedisConfiguration.class)
+    RedisConfiguration redisStandaloneConfiguration() {
+        Assert.hasText(host, "host is required for redis-standalone mode");
+
+        final RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setUsername(username);
+        config.setPassword(password);
+        return config;
+    }
+
+    @Value("${spring.data.redis.lettuce.client.io-thread-pool-size:8}")
+    int lettuceIOThreadPoolSize;
+
+    @Value("${spring.data.redis.lettuce.client.computation-thread-pool-size:8}")
+    int lettuceComputationThreadPoolSize;
+
+    @Value("${spring.data.redis.lettuce.client.name:collectorRedis}")
+    String lettuceClientName;
+
+    @Value("${spring.data.redis.lettuce.client.request-queue-size:1024}")
+    int lettuceRequestQueueSize;
+
+    @Bean
+    LettuceClientConfiguration lettuceClientConfiguration() {
+        final ClientResources clientResources = ClientResources.builder()
+                .ioThreadPoolSize(lettuceIOThreadPoolSize)
+                .computationThreadPoolSize(lettuceComputationThreadPoolSize)
+                .build();
+
+        final SocketOptions.KeepAliveOptions keepAliveOptions = SocketOptions.KeepAliveOptions.builder()
+                .enable()
+                .count(9)
+                .idle(Duration.ofHours(2))
+                .interval(Duration.ofSeconds(75))
+                .build();
+
+        final SocketOptions socketOptions = SocketOptions.builder()
+                .connectTimeout(Duration.ofSeconds(20))
+                .keepAlive(keepAliveOptions)
+                .build();
+
+        final TimeoutOptions timeoutOptions = TimeoutOptions.builder()
+                .connectionTimeout()
+                .build();
+
+        final ClientOptions clientOptions = ClientOptions.builder()
+                .autoReconnect(true)
+                .publishOnScheduler(false)
+                .requestQueueSize(lettuceRequestQueueSize)
+                .socketOptions(socketOptions)
+                .timeoutOptions(timeoutOptions)
+                .build();
+
+        return LettuceClientConfiguration.builder()
+                .clientName(lettuceClientName)
+                .clientResources(clientResources)
+                .clientOptions(clientOptions)
+                .build();
+    }
+
+    @Bean
+    LettuceConnectionFactory redisConnectionFactory(
+            RedisConfiguration redisConfig,
+            LettuceClientConfiguration clientConfiguration
+    ) {
+        return new LettuceConnectionFactory(redisConfig, clientConfiguration);
+    }
+
+    @Bean
+    RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory) {
+        final RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        return container;
+    }
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/redis/StaticSubscriber.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/redis/StaticSubscriber.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.redis;
+
+import com.navercorp.pinpoint.pubsub.SubChannel;
+import com.navercorp.pinpoint.pubsub.SubConsumer;
+import org.springframework.beans.factory.InitializingBean;
+
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public class StaticSubscriber<T> implements InitializingBean {
+
+    private final SubChannel<T> channel;
+    private final SubConsumer<T> consumer;
+    private final String postfix;
+
+    public StaticSubscriber(
+            SubChannel<T> channel,
+            SubConsumer<T> consumer,
+            String postfix
+    ) {
+        this.channel = Objects.requireNonNull(channel, "channel");
+        this.consumer = Objects.requireNonNull(consumer, "consumer");
+        this.postfix = postfix;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        this.channel.subscribe(this.consumer, this.postfix);
+    }
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/util/PrefixThreadFactory.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/util/PrefixThreadFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.util;
+
+import org.springframework.lang.NonNull;
+
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author youngjin.kim2
+ */
+public class PrefixThreadFactory implements ThreadFactory {
+
+    private final String prefix;
+    private final AtomicInteger counter = new AtomicInteger(0);
+
+    public PrefixThreadFactory(String prefix) {
+        this.prefix = Objects.requireNonNull(prefix, "prefix");
+    }
+
+    @Override
+    public Thread newThread(@NonNull Runnable r) {
+        return new Thread(r, this.getName());
+    }
+
+    private String getName() {
+        return this.prefix + '-' + this.counter.incrementAndGet();
+    }
+
+}

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/util/ScheduleUtil.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/util/ScheduleUtil.java
@@ -1,0 +1,15 @@
+package com.navercorp.pinpoint.util;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+public class ScheduleUtil {
+
+    public static ScheduledExecutorService makeScheduledExecutorService(String timerName) {
+        final String name = "Schedule-" + timerName + "-Executor";
+        final ThreadFactory threadFactory = new PrefixThreadFactory(name);
+        return Executors.newSingleThreadScheduledExecutor(threadFactory);
+    }
+
+}

--- a/realtime/realtime-web/pom.xml
+++ b/realtime/realtime-web/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pinpoint-realtime</artifactId>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <version>2.5.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pinpoint-realtime-web</artifactId>
+
+    <properties>
+        <jdk.version>11</jdk.version>
+        <jdk.home>${env.JAVA_11_HOME}</jdk.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-realtime-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-web</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/config/ATCWebBackgroundTaskConfig.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/config/ATCWebBackgroundTaskConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.config;
+
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandPublishService;
+import com.navercorp.pinpoint.web.realtime.atc.service.SupplyFlushService;
+import com.navercorp.pinpoint.web.realtime.atc.service.SupplySubscribeService;
+import com.navercorp.pinpoint.web.realtime.atc.task.DemandPublishTask;
+import com.navercorp.pinpoint.web.realtime.atc.task.PeriodicTimerTask;
+import com.navercorp.pinpoint.web.realtime.atc.task.SupplyFlushTask;
+import com.navercorp.pinpoint.web.realtime.atc.task.SupplySubscribeTask;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+@Import({ ATCWebServiceConfig.class })
+public class ATCWebBackgroundTaskConfig {
+
+    @Value("${pinpoint.web.realtime.atc.supply.flush.periodMs:1000}")
+    long flushPeriodMs;
+
+    @Value("${pinpoint.web.realtime.atc.demand.periodMs:10000}")
+    long demandPeriodMs;
+
+    @Bean
+    PeriodicTimerTask supplySubscribeTask(SupplySubscribeService service) {
+        return new SupplySubscribeTask(service);
+    }
+
+    @Bean
+    PeriodicTimerTask supplyFlushTask(SupplyFlushService service) {
+        return new SupplyFlushTask(flushPeriodMs, service);
+    }
+
+    @Bean
+    PeriodicTimerTask demandPublishTask(DemandPublishService service) {
+        return new DemandPublishTask(demandPeriodMs, service);
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/config/ATCWebConfig.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/config/ATCWebConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+@ConditionalOnProperty(name = "pinpoint.web.redis-realtime.enabled", havingValue = "true")
+@Import({ ATCWebBackgroundTaskConfig.class, ATCWebSocketConfig.class })
+public class ATCWebConfig {
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/config/ATCWebDaoConfig.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/config/ATCWebDaoConfig.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.config;
+
+import com.navercorp.pinpoint.pubsub.PubChannel;
+import com.navercorp.pinpoint.pubsub.SubChannel;
+import com.navercorp.pinpoint.realtime.atc.dao.RedisATCDemandPubChannel;
+import com.navercorp.pinpoint.realtime.atc.dao.RedisATCSupplySubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+import com.navercorp.pinpoint.redis.CommonRedisConfig;
+import com.navercorp.pinpoint.web.realtime.atc.dao.ATCValueDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.CountingMetricDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.empty.EmptyCountingMetricDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.memory.ATCSessionRepository;
+import com.navercorp.pinpoint.web.realtime.atc.dao.memory.InMemoryATCValueDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.redis.RedisCountingMetricDao;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+@Import({ CommonRedisConfig.class })
+public class ATCWebDaoConfig {
+
+    @Value("${pinpoint.web.realtime.atc.supply.expireInMs:3000}")
+    long supplyExpireInMs;
+
+    @Bean
+    ATCValueDao atcValueDao() {
+        final long supplyExpireInNanos = TimeUnit.MILLISECONDS.toNanos(supplyExpireInMs);
+        return new InMemoryATCValueDao(supplyExpireInNanos);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "pinpoint.web.realtime.atc.enable-count-metric", havingValue = "true")
+    CountingMetricDao countingMetricDao(ReactiveRedisConnectionFactory connectionFactory) {
+        return new RedisCountingMetricDao(connectionFactory);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(CountingMetricDao.class)
+    CountingMetricDao emptyCountingMetricDao() {
+        return new EmptyCountingMetricDao();
+    }
+
+    @Bean
+    ATCSessionRepository atcSessionRepository() {
+        return new ATCSessionRepository();
+    }
+
+    @Bean
+    SubChannel<ATCSupply> atcSupplySubChannel(RedisMessageListenerContainer container) {
+        return new RedisATCSupplySubChannel(container);
+    }
+
+    @Bean
+    PubChannel<ATCDemand> atcDemandPubChannel(ReactiveRedisConnectionFactory connectionFactory) {
+        return new RedisATCDemandPubChannel(connectionFactory);
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/config/ATCWebServiceConfig.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/config/ATCWebServiceConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.config;
+
+import com.navercorp.pinpoint.pubsub.PubChannel;
+import com.navercorp.pinpoint.pubsub.SubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+import com.navercorp.pinpoint.web.realtime.atc.dao.ATCValueDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.CountingMetricDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.memory.ATCSessionRepository;
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandPublishService;
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandPublishServiceImpl;
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandRegisterService;
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandRegisterServiceImpl;
+import com.navercorp.pinpoint.web.realtime.atc.service.SupplyFlushService;
+import com.navercorp.pinpoint.web.realtime.atc.service.SupplyFlushServiceImpl;
+import com.navercorp.pinpoint.web.realtime.atc.service.SupplySubscribeService;
+import com.navercorp.pinpoint.web.realtime.atc.service.SupplySubscribeServiceImpl;
+import com.navercorp.pinpoint.web.realtime.config.RealtimeWebServiceConfig;
+import com.navercorp.pinpoint.web.realtime.service.AgentLookupService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+@Import({ ATCWebDaoConfig.class, RealtimeWebServiceConfig.class })
+public class ATCWebServiceConfig {
+
+    @Value("${pinpoint.web.realtime.atc.supply.flush.num-workers:2}")
+    int numFlushWorkers;
+
+    @Bean
+    DemandPublishService demandPublishService(
+            PubChannel<ATCDemand> pubChannel,
+            AgentLookupService agentLookupService,
+            ATCValueDao valueDao,
+            CountingMetricDao countingMetricDao,
+            ATCSessionRepository sessionRepository
+    ) {
+        return new DemandPublishServiceImpl(
+                pubChannel,
+                agentLookupService,
+                valueDao,
+                countingMetricDao,
+                sessionRepository
+        );
+    }
+
+    @Bean
+    DemandRegisterService demandRegisterService(
+            ATCSessionRepository sessionRepository,
+            DemandPublishService demandPublishService
+    ) {
+        return new DemandRegisterServiceImpl(sessionRepository, demandPublishService);
+    }
+
+    @Bean
+    SupplyFlushService supplyFlushService(
+            ATCSessionRepository sessionRepository,
+            ATCValueDao valueDao
+    ) {
+        return new SupplyFlushServiceImpl(sessionRepository, valueDao, numFlushWorkers);
+    }
+
+    @Bean
+    SupplySubscribeService supplySubscribeService(
+            ATCSessionRepository sessionRepository,
+            SubChannel<ATCSupply> supplyChannel,
+            ATCValueDao valueDao
+    ) {
+        return new SupplySubscribeServiceImpl(sessionRepository, supplyChannel, valueDao);
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/config/ATCWebSocketConfig.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/config/ATCWebSocketConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.config;
+
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandRegisterService;
+import com.navercorp.pinpoint.web.realtime.atc.websocket.RedisActiveThreadCountHandler;
+import com.navercorp.pinpoint.web.websocket.PinpointWebSocketHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+@Import({ ATCWebServiceConfig.class })
+public class ATCWebSocketConfig {
+
+    @Bean
+    PinpointWebSocketHandler redisActiveThreadCountHandler(DemandRegisterService service) {
+        return new RedisActiveThreadCountHandler(service);
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/ATCValueDao.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/ATCValueDao.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.dao;
+
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+
+import java.util.List;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface ATCValueDao {
+
+    List<Integer> query(ClusterKey clusterKey, long baseTime);
+
+    void put(String applicationName, ATCSupply ATCSupply);
+
+    void saveActiveAgents(String applicationName, List<ClusterKey> agents);
+
+    List<ClusterKey> getActiveAgents(String applicationName);
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/CountingMetricDao.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/CountingMetricDao.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.dao;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface CountingMetricDao {
+
+    void incrementCountATCDemand();
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/empty/EmptyCountingMetricDao.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/empty/EmptyCountingMetricDao.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.dao.empty;
+
+import com.navercorp.pinpoint.web.realtime.atc.dao.CountingMetricDao;
+
+/**
+ * @author youngjin.kim2
+ */
+public class EmptyCountingMetricDao implements CountingMetricDao {
+
+    @Override
+    public void incrementCountATCDemand() {
+        // Do nothing
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/memory/ATCSessionRepository.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/memory/ATCSessionRepository.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.dao.memory;
+
+import com.navercorp.pinpoint.web.realtime.atc.dto.ATCSession;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * @author youngjin.kim2
+ */
+public class ATCSessionRepository {
+
+    private final List<ATCSession> sessions = new CopyOnWriteArrayList<>();
+
+    public void add(WebSocketSession webSocketSession) {
+        add(ATCSession.of(webSocketSession));
+    }
+
+    private void add(ATCSession session) {
+        sessions.add(session);
+    }
+
+    void remove(ATCSession session) {
+        sessions.remove(session);
+    }
+
+    public List<ATCSession> getSessions() {
+        return this.sessions;
+    }
+
+    public Set<String> getAllDemandedApplicationNames() {
+        final List<String> applicationNames = new ArrayList<>(sessions.size());
+        for (final ATCSession session: sessions) {
+            final String applicationName = session.getDemandApplicationName();
+            if (applicationName != null) {
+                applicationNames.add(applicationName);
+            }
+        }
+        return new HashSet<>(applicationNames);
+    }
+
+    public void remove(WebSocketSession webSocketSession) {
+        final ATCSession session = get(webSocketSession);
+        if (session == null) {
+            return;
+        }
+        remove(session);
+    }
+
+    public ATCSession get(WebSocketSession webSocketSession) {
+        for (final ATCSession session: sessions) {
+            if (session.getWebSocketSession() == webSocketSession) {
+                return session;
+            }
+        }
+        return null;
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/memory/InMemoryATCValueDao.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/memory/InMemoryATCValueDao.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.dao.memory;
+
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+import com.navercorp.pinpoint.web.realtime.atc.dao.ATCValueDao;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author youngjin.kim2
+ */
+public class InMemoryATCValueDao implements ATCValueDao {
+
+    private final long supplyExpireInNanos;
+
+    private final Map<ClusterKey, Record> recordMap = new ConcurrentHashMap<>();
+    private final Map<String, List<ClusterKey>> recentActiveAgentMap = new ConcurrentHashMap<>();
+
+    public InMemoryATCValueDao(long supplyExpireInNanos) {
+        this.supplyExpireInNanos = supplyExpireInNanos;
+    }
+
+    @Override
+    public List<Integer> query(ClusterKey clusterKey, long baseTime) {
+        final Record record = recordMap.get(clusterKey);
+        if (record == null) {
+            return null;
+        }
+
+        final long age = baseTime - record.observedAt;
+        if (age > this.supplyExpireInNanos) {
+            return null;
+        }
+
+        return record.values;
+    }
+
+    @Override
+    public void put(String applicationName, ATCSupply ATCSupply) {
+        final ClusterKey clusterKey = new ClusterKey(
+                applicationName,
+                ATCSupply.getAgentId(),
+                ATCSupply.getStartTimestamp()
+        );
+
+        final Record record = new Record(ATCSupply.getValues(), System.nanoTime());
+
+        recordMap.put(clusterKey, record);
+    }
+
+    @Override
+    public void saveActiveAgents(String applicationName, List<ClusterKey> agents) {
+        recentActiveAgentMap.put(applicationName, agents);
+    }
+
+    @Override
+    public List<ClusterKey> getActiveAgents(String applicationName) {
+        final List<ClusterKey> agents = recentActiveAgentMap.get(applicationName);
+        if (agents == null) {
+            return Collections.emptyList();
+        }
+        return agents;
+    }
+
+    private static class Record {
+
+        final List<Integer> values;
+        final long observedAt;
+
+        public Record(List<Integer> values, long observedAt) {
+            this.values = values;
+            this.observedAt = observedAt;
+        }
+
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/redis/RedisCountingMetricDao.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dao/redis/RedisCountingMetricDao.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.dao.redis;
+
+import com.navercorp.pinpoint.web.realtime.atc.dao.CountingMetricDao;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.ReactiveValueOperations;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public class RedisCountingMetricDao implements CountingMetricDao {
+
+    private static final String countATCDemandKey = "metric:count:atc:demand";
+
+    private final ReactiveValueOperations<String, String> opsForValue;
+
+    public RedisCountingMetricDao(ReactiveRedisConnectionFactory connectionFactory) {
+        Objects.requireNonNull(connectionFactory, "connectionFactory");
+        final RedisSerializationContext<String, String> serContext = RedisSerializationContext.string();
+        this.opsForValue = new ReactiveRedisTemplate<>(connectionFactory, serContext).opsForValue();
+    }
+
+    @Override
+    public void incrementCountATCDemand() {
+        this.opsForValue.increment(countATCDemandKey).subscribe();
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dto/ATCSession.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dto/ATCSession.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.dto;
+
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+/**
+ * @author youngjin.kim2
+ */
+public class ATCSession {
+
+    private final WebSocketSession webSocketSession;
+    private final long createdAt;
+    private String demandApplicationName = null;
+
+    private ATCSession(WebSocketSession webSocketSession) {
+        this.webSocketSession = webSocketSession;
+        this.createdAt = System.nanoTime();
+    }
+
+    public static ATCSession of(WebSocketSession webSocketSession) {
+        return new ATCSession(webSocketSession);
+    }
+
+    public WebSocketSession getWebSocketSession() {
+        return webSocketSession;
+    }
+
+    public void setDemand(String applicationName) {
+        this.demandApplicationName = applicationName;
+    }
+
+    public String getDemandApplicationName() {
+        return demandApplicationName;
+    }
+
+    public void sendMessage(WebSocketMessage<?> message) throws IOException {
+        webSocketSession.sendMessage(message);
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dto/ActiveThreadCountResponse.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/dto/ActiveThreadCountResponse.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.dto;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author youngjin.kim2
+ */
+public class ActiveThreadCountResponse {
+
+    private static final String COMMAND = "activeThreadCount";
+    private static final String TYPE = "RESPONSE";
+
+    private final Result result;
+
+    public ActiveThreadCountResponse(String applicationName, long timeStamp) {
+        this.result = new Result(applicationName, timeStamp);
+    }
+
+    @SuppressWarnings("unused")
+    public String getCommand() {
+        return COMMAND;
+    }
+
+    @SuppressWarnings("unused")
+    public String getType() {
+        return TYPE;
+    }
+
+    @SuppressWarnings("unused")
+    public Result getResult() {
+        return result;
+    }
+
+    public void putActiveThreadCount(String agentId, int code, String message, List<Integer> status) {
+        final Result.Count count = new Result.Count(code, message, status);
+        result.activeThreadCounts.put(agentId, count);
+    }
+
+    public static class Result {
+        private final Map<String, Count> activeThreadCounts = new HashMap<>();
+        private final String applicationName;
+        private final long timeStamp;
+
+        public Result(String applicationName, long timeStamp) {
+            this.applicationName = applicationName;
+            this.timeStamp = timeStamp;
+        }
+
+        @SuppressWarnings("unused")
+        public String getApplicationName() {
+            return applicationName;
+        }
+
+        @SuppressWarnings("unused")
+        public long getTimeStamp() {
+            return timeStamp;
+        }
+
+        @SuppressWarnings("unused")
+        public Map<String, Count> getActiveThreadCounts() {
+            return activeThreadCounts;
+        }
+
+        public static class Count {
+            private final int code;
+            private final String message;
+            private final List<Integer> status;
+
+            public Count(int code, String message, List<Integer> status) {
+                this.code = code;
+                this.message = message;
+                this.status = status;
+            }
+
+            @SuppressWarnings("unused")
+            public int getCode() {
+                return code;
+            }
+
+            @SuppressWarnings("unused")
+            public String getMessage() {
+                return message;
+            }
+
+            @SuppressWarnings("unused")
+            public List<Integer> getStatus() {
+                return status;
+            }
+        }
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandPublishService.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandPublishService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface DemandPublishService {
+
+    void demand();
+
+    void demand(String applicationName);
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandPublishServiceImpl.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandPublishServiceImpl.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.pubsub.PubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import com.navercorp.pinpoint.web.realtime.atc.dao.ATCValueDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.CountingMetricDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.memory.ATCSessionRepository;
+import com.navercorp.pinpoint.web.realtime.service.AgentLookupService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author youngjin.kim2
+ */
+public class DemandPublishServiceImpl implements DemandPublishService {
+
+    private static final Logger logger = LogManager.getLogger(DemandPublishServiceImpl.class);
+
+    private static final long DEFAULT_AGENT_LOOKUP_TIME = TimeUnit.HOURS.toMillis(1);
+
+    private final PubChannel<ATCDemand> pubChannel;
+    private final AgentLookupService agentLookupService;
+    private final ATCValueDao valueDao;
+    private final CountingMetricDao countingMetricDao;
+    private final ATCSessionRepository sessionRepository;
+
+    public DemandPublishServiceImpl(
+            PubChannel<ATCDemand> pubChannel,
+            AgentLookupService agentLookupService,
+            ATCValueDao valueDao,
+            CountingMetricDao countingMetricDao,
+            ATCSessionRepository sessionRepository
+    ) {
+        this.pubChannel = Objects.requireNonNull(pubChannel, "pubChannel");
+        this.agentLookupService = Objects.requireNonNull(agentLookupService, "agentLookupService");
+        this.valueDao = Objects.requireNonNull(valueDao, "valueDao");
+        this.countingMetricDao = Objects.requireNonNull(countingMetricDao, "countingMetricDao");
+        this.sessionRepository = Objects.requireNonNull(sessionRepository, "sessionRepository");
+    }
+
+    @Override
+    public void demand() {
+        final Set<String> applicationNames = this.sessionRepository.getAllDemandedApplicationNames();
+        for (final String applicationName: applicationNames) {
+            demand(applicationName);
+        }
+    }
+
+    @Override
+    public void demand(String applicationName) {
+        try {
+            final List<ClusterKey> agents = this.agentLookupService.getRecentAgents(
+                    applicationName, DEFAULT_AGENT_LOOKUP_TIME);
+            valueDao.saveActiveAgents(applicationName, agents);
+            for (final ClusterKey agent: agents) {
+                demand(agent);
+            }
+        } catch (Exception e) {
+            logger.error("Failed to demand application: {}", applicationName);
+        }
+    }
+
+    @VisibleForTesting
+    void demand(ClusterKey agent) {
+        final ATCDemand demand = makeDemand(agent);
+        try {
+            pubChannel.publish(demand, null);
+            countingMetricDao.incrementCountATCDemand();
+        } catch (Exception e) {
+            logger.warn("Failed to publish", e);
+        }
+    }
+
+    private ATCDemand makeDemand(ClusterKey clusterKey) {
+        final ATCDemand demand = new ATCDemand();
+        demand.setApplicationName(clusterKey.getApplicationName());
+        demand.setAgentId(clusterKey.getAgentId());
+        demand.setStartTimestamp(clusterKey.getStartTimestamp());
+        return demand;
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandRegisterService.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandRegisterService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+import org.springframework.web.socket.WebSocketSession;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface DemandRegisterService {
+
+    void registerSession(WebSocketSession session);
+
+    void unregisterSession(WebSocketSession session);
+
+    void registerDemandToSession(WebSocketSession session, String applicationName);
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandRegisterServiceImpl.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandRegisterServiceImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+import com.navercorp.pinpoint.web.realtime.atc.dao.memory.ATCSessionRepository;
+import com.navercorp.pinpoint.web.realtime.atc.dto.ATCSession;
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandPublishService;
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandRegisterService;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public class DemandRegisterServiceImpl implements DemandRegisterService {
+
+    private final ATCSessionRepository sessionRepository;
+    private final DemandPublishService demandPublishService;
+
+    public DemandRegisterServiceImpl(
+            ATCSessionRepository sessionRepository,
+            DemandPublishService demandPublishService
+    ) {
+        this.sessionRepository = Objects.requireNonNull(sessionRepository, "sessionRepository");
+        this.demandPublishService = Objects.requireNonNull(demandPublishService, "demandPublishService");
+    }
+
+    @Override
+    public void registerSession(WebSocketSession session) {
+        this.sessionRepository.add(session);
+    }
+
+    @Override
+    public void unregisterSession(WebSocketSession session) {
+        this.sessionRepository.remove(session);
+    }
+
+    @Override
+    public void registerDemandToSession(WebSocketSession webSession, String applicationName) {
+        final ATCSession session = this.sessionRepository.get(webSession);
+        if (session != null) {
+            session.setDemand(applicationName);
+            this.demandPublishService.demand(applicationName);
+        }
+    }
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/SupplyFlushService.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/SupplyFlushService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface SupplyFlushService {
+
+    void flush();
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/SupplyFlushServiceImpl.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/SupplyFlushServiceImpl.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+import com.google.gson.Gson;
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.util.PrefixThreadFactory;
+import com.navercorp.pinpoint.web.realtime.atc.dao.ATCValueDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.memory.ATCSessionRepository;
+import com.navercorp.pinpoint.web.realtime.atc.dto.ATCSession;
+import com.navercorp.pinpoint.web.realtime.atc.dto.ActiveThreadCountResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.web.socket.TextMessage;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author youngjin.kim2
+ */
+public class SupplyFlushServiceImpl implements SupplyFlushService {
+
+    private static final Logger logger = LogManager.getLogger(SupplyFlushServiceImpl.class);
+    private static final long MAX_CONNECTION_WAITING_NANOS = TimeUnit.SECONDS.toNanos(5);
+
+    private final ATCSessionRepository sessionRepository;
+    private final ATCValueDao valueDao;
+    private final ExecutorService executor;
+
+    private final Gson gson = new Gson();
+
+    public SupplyFlushServiceImpl(ATCSessionRepository sessionRepository, ATCValueDao valueDao, int numWorker) {
+        this.sessionRepository = Objects.requireNonNull(sessionRepository, "sessionRepository");
+        this.valueDao = Objects.requireNonNull(valueDao, "valueDao");
+
+        final ThreadFactory threadFactory = new PrefixThreadFactory("ATC-Supply-Publisher");
+        this.executor = new ThreadPoolExecutor(
+                numWorker, numWorker, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(1024), threadFactory
+        );
+    }
+
+    @Override
+    public void flush() {
+        try {
+            final long now = System.nanoTime();
+            final long nowMs = System.currentTimeMillis();
+            final List<ATCSession> sessions = this.sessionRepository.getSessions();
+            for (final ATCSession session: sessions) {
+                executor.execute(() -> flush(session, now, nowMs));
+            }
+        } catch (Exception e) {
+            logger.error("Failed to flush", e);
+        }
+    }
+
+    private void flush(ATCSession session, long now, long nowMs) {
+        try {
+            final String applicationName = session.getDemandApplicationName();
+            final List<ClusterKey> agents = this.valueDao.getActiveAgents(applicationName);
+            final ActiveThreadCountResponse response = new ActiveThreadCountResponse(applicationName, nowMs);
+            for (final ClusterKey agent: agents) {
+                addInResponse(response, agent, now, session.getCreatedAt());
+            }
+            final TextMessage message = makeTextMessage(response);
+            sendMessage(session, message);
+        } catch (Exception e) {
+            logger.error("Failed to flush session: {}", session, e);
+        }
+    }
+
+    private void addInResponse(ActiveThreadCountResponse response, ClusterKey agent, long now, long sessionCreatedAt) {
+        final List<Integer> values = valueDao.query(agent, now);
+        final String agentId = agent.getAgentId();
+        if (values == null) {
+            response.putActiveThreadCount(agentId, -1, getValueNotFoundMessage(now - sessionCreatedAt), null);
+        } else {
+            response.putActiveThreadCount(agentId, 0, "OK", values);
+        }
+    }
+
+    private static String getValueNotFoundMessage(long ageNanos) {
+        if (ageNanos > MAX_CONNECTION_WAITING_NANOS) {
+            return "FAIL";
+        } else {
+            return "CONNECTING";
+        }
+    }
+
+    private TextMessage makeTextMessage(ActiveThreadCountResponse response) {
+        final String serialized = gson.toJson(response);
+        return new TextMessage(serialized);
+    }
+
+    private void sendMessage(ATCSession session, TextMessage message) {
+        try {
+            session.sendMessage(message);
+        } catch (IOException e) {
+            logger.warn("Failed to send message. session: {}", session);
+        }
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/SupplySubscribeService.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/SupplySubscribeService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+import java.util.Set;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface SupplySubscribeService {
+
+    Set<String> updateSubscriptions(Set<String> prevTopics);
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/SupplySubscribeServiceImpl.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/service/SupplySubscribeServiceImpl.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+import com.navercorp.pinpoint.pubsub.SubChannel;
+import com.navercorp.pinpoint.pubsub.SubConsumer;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCSupply;
+import com.navercorp.pinpoint.web.realtime.atc.dao.ATCValueDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.memory.ATCSessionRepository;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author youngjin.kim2
+ */
+public class SupplySubscribeServiceImpl implements SupplySubscribeService {
+
+    private static final Logger logger = LogManager.getLogger(SupplySubscribeServiceImpl.class);
+
+    private final Object subscriptionLock = new Object();
+
+    private final ATCSessionRepository sessionRepository;
+    private final SubChannel<ATCSupply> supplyChannel;
+    private final SubConsumer<ATCSupply> consumer;
+
+    public SupplySubscribeServiceImpl(
+            ATCSessionRepository sessionRepository,
+            SubChannel<ATCSupply> supplyChannel,
+            ATCValueDao valueDao
+    ) {
+        this.sessionRepository = Objects.requireNonNull(sessionRepository, "sessionRepository");
+        this.supplyChannel = Objects.requireNonNull(supplyChannel, "supplyChannel");
+
+        Objects.requireNonNull(valueDao, "valueDao");
+        this.consumer = new SupplyConsumer(valueDao);
+    }
+
+    @Override
+    public Set<String> updateSubscriptions(Set<String> prevApplications) {
+        synchronized (subscriptionLock) {
+            final Set<String> nextApplications = this.sessionRepository.getAllDemandedApplicationNames();
+            subscribeNewTopics(prevApplications, nextApplications);
+            unsubscribeOldTopics(prevApplications, nextApplications);
+            return nextApplications;
+        }
+    }
+
+    private void subscribeNewTopics(Set<String> prevApps, Set<String> nextApps) {
+        for (final String next: nextApps) {
+            if (!prevApps.contains(next)) {
+                logger.info("Subscribe {}", next);
+                this.supplyChannel.subscribe(this.consumer, next);
+            }
+        }
+    }
+
+    private void unsubscribeOldTopics(Set<String> prevTopics, Set<String> nextTopics) {
+        for (final String prev: prevTopics) {
+            if (!nextTopics.contains(prev)) {
+                logger.info("Unsubscribe {}", prev);
+                this.supplyChannel.unsubscribe(this.consumer, prev);
+            }
+        }
+    }
+
+    private static class SupplyConsumer implements SubConsumer<ATCSupply> {
+
+        private final ATCValueDao valueRepository;
+
+        SupplyConsumer(ATCValueDao valueRepository) {
+            this.valueRepository = Objects.requireNonNull(valueRepository, "valueRepository");
+        }
+
+        @Override
+        public void consume(ATCSupply content, String postfix) {
+            valueRepository.put(postfix, content);
+        }
+
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/task/DemandPublishTask.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/task/DemandPublishTask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.task;
+
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandPublishService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public class DemandPublishTask extends PeriodicTimerTask {
+
+    private static final Logger logger = LogManager.getLogger(DemandPublishTask.class);
+
+    private final DemandPublishService service;
+
+    public DemandPublishTask(long periodMs, DemandPublishService service) {
+        super(logger, "DemandPublish", periodMs);
+        this.service = Objects.requireNonNull(service, "service");
+    }
+
+    @Override
+    public void runPeriodicTask() {
+        this.service.demand();
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/task/PeriodicTimerTask.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/task/PeriodicTimerTask.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.task;
+
+import com.navercorp.pinpoint.util.ScheduleUtil;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.InitializingBean;
+
+import java.util.TimerTask;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author youngjin.kim2
+ */
+public abstract class PeriodicTimerTask extends TimerTask implements InitializingBean {
+
+    private final Logger logger;
+    private final ScheduledExecutorService executor;
+    private final long periodMs;
+
+    public PeriodicTimerTask(Logger logger, String name, long periodMs) {
+        this.logger = logger;
+        this.executor = ScheduleUtil.makeScheduledExecutorService(name);
+        this.periodMs = periodMs;
+    }
+
+    protected abstract void runPeriodicTask();
+
+    @Override
+    public void run() {
+        try {
+            runPeriodicTask();
+        } catch (Exception e) {
+            this.logger.error("runPeriodicTask", e);
+        }
+        scheduleNext();
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        scheduleNext();
+    }
+
+    private void scheduleNext() {
+        executor.schedule(this, this.periodMs, TimeUnit.MILLISECONDS);
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/task/SupplyFlushTask.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/task/SupplyFlushTask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.task;
+
+import com.navercorp.pinpoint.web.realtime.atc.service.SupplyFlushService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public class SupplyFlushTask extends PeriodicTimerTask {
+
+    private static final Logger logger = LogManager.getLogger(SupplyFlushTask.class);
+
+    private final SupplyFlushService service;
+
+    public SupplyFlushTask(long periodMs, SupplyFlushService service) {
+        super(logger, "SupplyFlush", periodMs);
+        this.service = Objects.requireNonNull(service, "service");
+    }
+
+    @Override
+    public void runPeriodicTask() {
+        this.service.flush();
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/task/SupplySubscribeTask.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/task/SupplySubscribeTask.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.task;
+
+import com.navercorp.pinpoint.web.realtime.atc.service.SupplySubscribeService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author youngjin.kim2
+ */
+public class SupplySubscribeTask extends PeriodicTimerTask {
+
+    private static final Logger logger = LogManager.getLogger(SupplySubscribeTask.class);
+
+    private final Object lock = new Object();
+
+    private Set<String> prevTopics = Set.of();
+
+    private final SupplySubscribeService service;
+
+    public SupplySubscribeTask(SupplySubscribeService service) {
+        super(logger, "SupplySubscribe", 500);
+        this.service = Objects.requireNonNull(service, "service");
+    }
+
+    @Override
+    protected void runPeriodicTask() {
+        sync();
+    }
+
+    public void sync() {
+        synchronized (lock) {
+            this.prevTopics = service.updateSubscriptions(this.prevTopics);
+        }
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/websocket/RedisActiveThreadCountHandler.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/atc/websocket/RedisActiveThreadCountHandler.java
@@ -1,0 +1,53 @@
+package com.navercorp.pinpoint.web.realtime.atc.websocket;
+
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandRegisterService;
+import com.navercorp.pinpoint.web.websocket.ActiveThreadCountHandler;
+import com.navercorp.pinpoint.web.websocket.PinpointWebSocketHandler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.lang.NonNull;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Objects;
+
+public class RedisActiveThreadCountHandler extends ActiveThreadCountHandler implements PinpointWebSocketHandler {
+
+    private static final Logger logger = LogManager.getLogger(RedisActiveThreadCountHandler.class);
+
+    private final DemandRegisterService demandRegisterService;
+
+    public RedisActiveThreadCountHandler(DemandRegisterService demandRegisterService) {
+        super(null);
+        this.demandRegisterService = Objects.requireNonNull(demandRegisterService, "demandRegisterService");
+    }
+
+    @Override
+    public void afterConnectionEstablished(@NonNull WebSocketSession session) {
+        logger.info("ATC Connection Established. session: {}", session);
+        this.demandRegisterService.registerSession(session);
+    }
+
+    @Override
+    public void afterConnectionClosed(@NonNull WebSocketSession session, @NonNull CloseStatus status) {
+        logger.info("ATC Connection Closed. session: {}, status: {}", session, status);
+        this.demandRegisterService.unregisterSession(session);
+    }
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void stop() {}
+
+    @Override
+    public int getPriority() {
+        return 1;
+    }
+
+    @Override
+    protected void handleActiveThreadCount(WebSocketSession webSocketSession, String applicationName) {
+        this.demandRegisterService.registerDemandToSession(webSocketSession, applicationName);
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/config/RealtimeWebServiceConfig.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/config/RealtimeWebServiceConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.config;
+
+import com.navercorp.pinpoint.web.realtime.service.AgentLookupService;
+import com.navercorp.pinpoint.web.realtime.service.AgentLookupServiceImpl;
+import com.navercorp.pinpoint.web.service.AgentService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author youngjin.kim2
+ */
+@Configuration
+public class RealtimeWebServiceConfig {
+
+    @Bean
+    @ConditionalOnBean(AgentService.class)
+    AgentLookupService agentLookupService(AgentService agentService) {
+        return new AgentLookupServiceImpl(agentService);
+    }
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/service/AgentLookupService.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/service/AgentLookupService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.service;
+
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+
+import java.util.List;
+
+/**
+ * @author youngjin.kim2
+ */
+public interface AgentLookupService {
+
+    List<ClusterKey> getRecentAgents(String applicationName, long timeDiffMs);
+
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/service/AgentLookupServiceImpl.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/service/AgentLookupServiceImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.service;
+
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
+import com.navercorp.pinpoint.web.cluster.ClusterKeyAndStatus;
+import com.navercorp.pinpoint.web.service.AgentService;
+import com.navercorp.pinpoint.web.vo.agent.AgentStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author youngjin.kim2
+ */
+public class AgentLookupServiceImpl implements AgentLookupService {
+
+    private static final Logger logger = LogManager.getLogger(AgentLookupServiceImpl.class);
+
+    private final AgentService agentService;
+
+    public AgentLookupServiceImpl(AgentService agentService) {
+        this.agentService = Objects.requireNonNull(agentService, "agentService");
+    }
+
+    @Override
+    public List<ClusterKey> getRecentAgents(String applicationName, long timeDiffMs) {
+        final List<ClusterKeyAndStatus> keyAndStatuses = getRecentAgentInfoList0(applicationName, timeDiffMs);
+        final List<ClusterKey> keys = new ArrayList<>(keyAndStatuses.size());
+        for (final ClusterKeyAndStatus keyAndStatus: keyAndStatuses) {
+            if (isActive(keyAndStatus)) {
+                keys.add(keyAndStatus.getClusterKey());
+            }
+        }
+        return keys;
+    }
+
+    private List<ClusterKeyAndStatus> getRecentAgentInfoList0(String applicationName, long timeDiffMs) {
+        try {
+            return agentService.getRecentAgentInfoList(applicationName, timeDiffMs);
+        } catch (Exception e) {
+            logger.warn("Failed to get recent agent info list for {}", applicationName, e);
+        }
+        return Collections.emptyList();
+    }
+
+    private boolean isActive(ClusterKeyAndStatus keyAndStatus) {
+        return isActive(keyAndStatus.getStatus()) || isActive(keyAndStatus.getClusterKey());
+    }
+
+    private boolean isActive(AgentStatus agentStatus) {
+        return agentStatus != null && agentStatus.getState() != AgentLifeCycleState.UNKNOWN;
+    }
+
+    private boolean isActive(ClusterKey clusterKey) {
+        return agentService.isConnected(clusterKey);
+    }
+
+}

--- a/realtime/realtime-web/src/test/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandPublishServiceImplTest.java
+++ b/realtime/realtime-web/src/test/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandPublishServiceImplTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.pubsub.PubChannel;
+import com.navercorp.pinpoint.realtime.atc.dto.ATCDemand;
+import com.navercorp.pinpoint.web.realtime.atc.dao.ATCValueDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.CountingMetricDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.memory.ATCSessionRepository;
+import com.navercorp.pinpoint.web.realtime.service.AgentLookupService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author youngjin.kim2
+ */
+@ExtendWith(MockitoExtension.class)
+public class DemandPublishServiceImplTest {
+
+    @Mock PubChannel<ATCDemand> pubChannel;
+    @Mock AgentLookupService agentLookupService;
+    @Mock ATCValueDao valueDao;
+    @Mock
+    CountingMetricDao countingMetricDao;
+    @Mock
+    ATCSessionRepository sessionRepository;
+
+    @Captor ArgumentCaptor<ATCDemand> demandCaptor;
+
+    @Test
+    public void testDemandSingle() {
+        final DemandPublishServiceImpl service = new DemandPublishServiceImpl(
+                pubChannel, agentLookupService, valueDao, countingMetricDao, sessionRepository);
+
+        final String applicationName = "test-application";
+        final String agentId = "test-agent";
+        final long startTimestamp = 12345;
+        final ClusterKey clusterKey = new ClusterKey(applicationName, agentId, startTimestamp);
+
+        service.demand(clusterKey);
+
+        verify(countingMetricDao, times(1)).incrementCountATCDemand();
+        verify(pubChannel, times(1)).publish(demandCaptor.capture(), isNull());
+        final ATCDemand demand = demandCaptor.getValue();
+
+        assertThat(demand.getApplicationName()).isEqualTo(applicationName);
+        assertThat(demand.getAgentId()).isEqualTo(agentId);
+        assertThat(demand.getStartTimestamp()).isEqualTo(startTimestamp);
+    }
+
+}

--- a/realtime/realtime-web/src/test/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandRegisterServiceImplTest.java
+++ b/realtime/realtime-web/src/test/java/com/navercorp/pinpoint/web/realtime/atc/service/DemandRegisterServiceImplTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+import com.navercorp.pinpoint.web.realtime.atc.dao.memory.ATCSessionRepository;
+import com.navercorp.pinpoint.web.realtime.atc.dto.ATCSession;
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandPublishService;
+import com.navercorp.pinpoint.web.realtime.atc.service.DemandRegisterServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.WebSocketSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author youngjin.kim2
+ */
+@ExtendWith(MockitoExtension.class)
+public class DemandRegisterServiceImplTest {
+
+    @Mock DemandPublishService demandPublishService;
+
+    @Test
+    public void testRegisterDemand() {
+        final ATCSessionRepository sessionRepository = new ATCSessionRepository();
+        final DemandRegisterServiceImpl service = new DemandRegisterServiceImpl(
+                sessionRepository, demandPublishService);
+
+        final WebSocketSession session = Mockito.mock(WebSocketSession.class);
+        final String applicationName = "test-application";
+
+        service.registerSession(session);
+        service.registerDemandToSession(session, applicationName);
+
+        final ATCSession atcSession = sessionRepository.get(session);
+        assertThat(atcSession.getDemandApplicationName()).isEqualTo(applicationName);
+        assertThat(atcSession.getWebSocketSession()).isEqualTo(session);
+
+        assertThat(sessionRepository.getAllDemandedApplicationNames()).containsExactly(applicationName);
+    }
+
+}

--- a/realtime/realtime-web/src/test/java/com/navercorp/pinpoint/web/realtime/atc/service/SupplyFlushServiceImplTest.java
+++ b/realtime/realtime-web/src/test/java/com/navercorp/pinpoint/web/realtime/atc/service/SupplyFlushServiceImplTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.realtime.atc.service;
+
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.web.realtime.atc.dao.ATCValueDao;
+import com.navercorp.pinpoint.web.realtime.atc.dao.memory.ATCSessionRepository;
+import com.navercorp.pinpoint.web.realtime.atc.dto.ATCSession;
+import com.navercorp.pinpoint.web.realtime.atc.service.SupplyFlushServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * @author youngjin.kim2
+ */
+@ExtendWith(MockitoExtension.class)
+public class SupplyFlushServiceImplTest {
+
+    @Mock ATCValueDao valueDao;
+    @Mock
+    ATCSessionRepository repo;
+
+    @Test
+    public void testFlush() throws IOException {
+        final String app1 = "test-application-1";
+        final String app2 = "test-application-2";
+
+        final ClusterKey clusterKey11 = new ClusterKey(app1, "test-agent-1-1", 999911);
+        final ClusterKey clusterKey12 = new ClusterKey(app1, "test-agent-1-2", 999912);
+        final ClusterKey clusterKey21 = new ClusterKey(app2, "test-agent-2-1", 999921);
+        final ClusterKey clusterKey22 = new ClusterKey(app2, "test-agent-2-2", 999922);
+
+        final ATCSession session1 = Mockito.mock(ATCSession.class);
+        final ATCSession session2 = Mockito.mock(ATCSession.class);
+
+        final long now = System.nanoTime();
+
+        when(repo.getSessions()).thenReturn(List.of(session1, session2));
+
+        when(session1.getDemandApplicationName()).thenReturn(app1);
+        when(session1.getCreatedAt()).thenReturn(now);
+        when(session2.getDemandApplicationName()).thenReturn(app2);
+        when(session2.getCreatedAt()).thenReturn(now);
+
+        when(valueDao.getActiveAgents(app1)).thenReturn(List.of(clusterKey11, clusterKey12));
+        when(valueDao.getActiveAgents(app2)).thenReturn(List.of(clusterKey21, clusterKey22));
+
+        when(valueDao.query(any(), anyLong())).thenReturn(List.of(0, 0, 2, 0));
+
+        final SupplyFlushServiceImpl service = new SupplyFlushServiceImpl(repo, valueDao, 4);
+        service.flush();
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ignored) {}
+
+        verify(valueDao, times(4)).query(any(), anyLong());
+
+        verify(valueDao).getActiveAgents(app1);
+        verify(valueDao).getActiveAgents(app2);
+
+        verify(session1).sendMessage(any());
+        verify(session2).sendMessage(any());
+    }
+
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/WebAppPropertySources.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/WebAppPropertySources.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.PropertySources;
         @PropertySource(name = "WebAppPropertySources", value = { WebAppPropertySources.WEB_ROOT, WebAppPropertySources.WEB_PROFILE}),
         @PropertySource(name = "WebAppPropertySources-HBase", value = { WebAppPropertySources.HBASE_ROOT, WebAppPropertySources.HBASE_PROFILE}),
         @PropertySource(name = "WebAppPropertySources-JDBC", value = { WebAppPropertySources.JDBC_ROOT, WebAppPropertySources.JDBC_PROFILE}),
+        @PropertySource(name = "WebAppPropertySources-Redis", value = { WebAppPropertySources.REDIS_ROOT, WebAppPropertySources.REDIS_PROFILE}),
 })
 public final class WebAppPropertySources {
     public static final String HBASE_ROOT= "classpath:hbase-root.properties";
@@ -31,6 +32,9 @@ public final class WebAppPropertySources {
 
     public static final String JDBC_ROOT = "classpath:jdbc-root.properties";
     public static final String JDBC_PROFILE = "classpath:profiles/${pinpoint.profiles.active:release}/jdbc.properties";
+
+    public static final String REDIS_ROOT = "classpath:redis-root.properties";
+    public static final String REDIS_PROFILE = "classpath:profiles/${pinpoint.profiles.active:release}/redis.properties";
 
     public static final String WEB_ROOT = "classpath:pinpoint-web-root.properties";
     public static final String WEB_PROFILE = "classpath:profiles/${pinpoint.profiles.active:release}/pinpoint-web.properties";

--- a/web/src/main/java/com/navercorp/pinpoint/web/websocket/PinpointWebSocketHandler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/websocket/PinpointWebSocketHandler.java
@@ -29,4 +29,6 @@ public interface PinpointWebSocketHandler extends WebSocketHandler {
 
     String getRequestMapping();
 
+    int getPriority();
+
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/websocket/PinpointWebSocketHandlerManager.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/websocket/PinpointWebSocketHandlerManager.java
@@ -20,7 +20,9 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Taejin Koo
@@ -30,7 +32,21 @@ public class PinpointWebSocketHandlerManager {
     private final List<PinpointWebSocketHandler> webSocketHandlerRepository;
 
     public PinpointWebSocketHandlerManager(List<PinpointWebSocketHandler> pinpointWebSocketHandlers) {
-        this.webSocketHandlerRepository = new ArrayList<>(pinpointWebSocketHandlers);
+        this.webSocketHandlerRepository = normalize(pinpointWebSocketHandlers);
+    }
+
+    private List<PinpointWebSocketHandler> normalize(List<PinpointWebSocketHandler> handlers) {
+        Map<String, PinpointWebSocketHandler> handlerMap = new HashMap<>(handlers.size());
+        for (final PinpointWebSocketHandler handler: handlers) {
+            final String requestMapping = handler.getRequestMapping();
+            final int priority = handler.getPriority();
+
+            final PinpointWebSocketHandler prev = handlerMap.get(requestMapping);
+            if (prev == null || prev.getPriority() < priority) {
+                handlerMap.put(requestMapping, handler);
+            }
+        }
+        return new ArrayList<>(handlerMap.values());
     }
 
     @PostConstruct

--- a/web/src/main/resources/applicationContext-web-websocket.xml
+++ b/web/src/main/resources/applicationContext-web-websocket.xml
@@ -14,13 +14,6 @@
     </bean>
 
 
-    <bean id="handlerRegister" class="com.navercorp.pinpoint.web.websocket.PinpointWebSocketHandlerManager">
-        <constructor-arg>
-            <list>
-                <ref bean="activeThreadHandler" />
-            </list>
-        </constructor-arg>
-    </bean>
-
+    <bean id="handlerRegister" class="com.navercorp.pinpoint.web.websocket.PinpointWebSocketHandlerManager" />
 
 </beans>

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -102,6 +102,12 @@ web.applicationList.cacheTime=30
 # webhook config
 webhook.enable=false
 
+# Active Thread Count
+pinpoint.web.realtime.atc.demand.periodMs=10000
+pinpoint.web.realtime.atc.supply.flush.periodMs=1000
+pinpoint.web.realtime.atc.supply.expireInMs=3000
+pinpoint.web.realtime.atc.enable-count-metric=false
+
 ###########################################################
 # BANNER                                                  #
 ###########################################################
@@ -120,7 +126,10 @@ pinpoint.banner.configs=spring.active.profile,\
                         hbase.client.port,\
                         hbase.zookeeper.znode.parent,\
                         hbase.namespace,\
-                        websocket.allowedOrigins
+                        websocket.allowedOrigins,\
+                        spring.data.redis.host,\
+                        spring.data.redis.port,\
+                        spring.data.redis.cluster.nodes
 
 # experimental config
 experimental.enableServerSideScanForScatter.description=Enable server-side scanning to query the data in the scatter chart.

--- a/web/src/main/resources/profiles/local/pinpoint-web.properties
+++ b/web/src/main/resources/profiles/local/pinpoint-web.properties
@@ -2,3 +2,6 @@ pinpoint.zookeeper.address={YOUR_LOCAL_ZOOKEEPER_ADDRESS}
 
 # Old version RegionServer has very high CPU usage when using FuzzyRowFilter
 web.scatter.serverside-scan.use-fuzzyrowfilter=false
+
+# Active Thread Count
+pinpoint.web.realtime.atc.supply.flush.num-workers=2

--- a/web/src/main/resources/profiles/local/redis.properties
+++ b/web/src/main/resources/profiles/local/redis.properties
@@ -1,0 +1,13 @@
+spring.data.redis.lettuce.client.io-thread-pool-size=8
+spring.data.redis.lettuce.client.computation-thread-pool-size=8
+spring.data.redis.lettuce.client.request-queue-size=1024
+
+spring.data.redis.username=default
+spring.data.redis.password=
+
+# Standalone mode
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+
+# Cluster mode: Cluster mode is prior than Standalone
+spring.data.redis.cluster.nodes=

--- a/web/src/main/resources/profiles/release/pinpoint-web.properties
+++ b/web/src/main/resources/profiles/release/pinpoint-web.properties
@@ -2,3 +2,6 @@ pinpoint.zookeeper.address={YOUR_RELEASE_ZOOKEEPER_ADDRESS}
 
 # Old version RegionServer has very high CPU usage when using FuzzyRowFilter
 web.scatter.serverside-scan.use-fuzzyrowfilter=false
+
+# Active Thread Count
+pinpoint.web.realtime.atc.supply.flush.num-workers=2

--- a/web/src/main/resources/profiles/release/redis.properties
+++ b/web/src/main/resources/profiles/release/redis.properties
@@ -1,0 +1,13 @@
+spring.data.redis.lettuce.client.io-thread-pool-size=8
+spring.data.redis.lettuce.client.computation-thread-pool-size=8
+spring.data.redis.lettuce.client.request-queue-size=1024
+
+spring.data.redis.username=default
+spring.data.redis.password=
+
+# Standalone mode
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+
+# Cluster mode: Cluster mode is prior than Standalone
+spring.data.redis.cluster.nodes=

--- a/web/src/main/resources/redis-root.properties
+++ b/web/src/main/resources/redis-root.properties
@@ -1,0 +1,1 @@
+spring.data.redis.lettuce.client.name=collectorRedis


### PR DESCRIPTION
### New property sources

* web/.../redis-root.properties
* collector/.../redis-root.properties
* web/.../{profile}/redis.properties
* collector/.../{profile}/redis.properties

### New properties

* **pinpoint.collector.redis-realtime.enabled (boolean, default: false)**
* **pinpoint.web.redis-realtime.enabled (boolean, default: false)**
* **pinpoint.web.realtime.atc.enable-count-metric (boolean, default: false)**
* pinpoint.web.realtime.atc.demand.periodMs
* pinpoint.web.realtime.atc.supply.flush.periodMs
* pinpoint.web.realtime.atc.supply.expireInMs
* pinpoint.web.realtime.atc.supply.flush.num-workers
* **pinpoint.collector.realtime.atc.enable-count-metric (boolean, default: false)**
* pinpoint.collector.realtime.atc.demand.duration
* pinpoint.collector.realtime.atc.supply.throttle.termMillis
* spring.data.redis.lettuce.client.io-thread-pool-size
* spring.data.redis.lettuce.client.computation-thread-pool-size
* spring.data.redis.lettuce.client.request-queue-size
* spring.data.redis.username
* spring.data.redis.password
* spring.data.redis.host (added in Banner)
* spring.data.redis.port (added in Banner)
* spring.data.redis.cluster.nodes (added in Banner)
* spring.data.redis.lettuce.client.name
  
### Excluded AutoConfigurations

* SpringDataWebAutoConfiguration.class
* RedisAutoConfiguration.class
* RedisRepositoriesAutoConfiguration.class
* RedisReactiveAutoConfiguration.class

### New modules

* pinpoint-realtime
  * pinpoint-realtime-web
  * pinpoint-realtime-collector
  * pinpoint-realtime-common

#### Module Description (pinpoint-realtime-web)

* Disabled by default (unless `pinpoint.web.redis-realtime.enabled=true`)
* Overrides some classic features
* Run 3 background tasks
  * supplySubscribeTask
    * Periodically renew subscriptions for `supply:atc:*` channel topic
  * supplyFlushTask
    * Periodically send activeThreadCount from collector to webSocket
  * demandPublishTask
    * Periodically publish proper `demand:atc` topics
* Add a PinpointWebSocketHandler `RedisActiveThreadCountHandler` which has same requestMapping with `ActiveThreadCountHandler` (Classic version)

#### Module Description (pinpoint-realtime-collector)

* Disabled by default (unless `pinpoint.collector.redis-realtime.enabled=true`)
* No overriding any classic features
* Subscribe & Handle `demand:atc` channel topic
	* Command agent to collect ActiveThreadCount
	* Publish ActiveThreadCount to `supply:atc:*` channel topic

### Modified Module (collector)

* Added `public AbstractRouteHandler::findClusterPoint(ClusterKey)`

### Modified Module (web)

* Added `protected ActiveThreadCountHandler::handleActiveThreadCount`
  * for overriding classic feature safely
* Added `PinpointWebSocketHandler::getPriority`
  * The handler which has higher priority wins when duplicated