### PR TITLE
[#noissue] Handle ByteString annotation values of protobuf

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/AnnotationFactory.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/AnnotationFactory.java
@@ -59,6 +59,7 @@ public class AnnotationFactory<T> {
         } else if (value instanceof Double) {
             return value;
         } else if (value instanceof byte[]) {
+            // not supported by protobuf
             return value;
         }
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/GrpcAnnotationHandler.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/GrpcAnnotationHandler.java
@@ -16,20 +16,11 @@
 
 package com.navercorp.pinpoint.common.server.bo.grpc;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.navercorp.pinpoint.common.server.bo.AnnotationFactory;
-import com.navercorp.pinpoint.common.util.IntBooleanIntBooleanValue;
-import com.navercorp.pinpoint.common.util.IntStringStringValue;
-import com.navercorp.pinpoint.common.util.IntStringValue;
-import com.navercorp.pinpoint.common.util.LongIntIntByteByteStringValue;
-import com.navercorp.pinpoint.common.util.StringStringValue;
-import com.navercorp.pinpoint.grpc.trace.PAnnotation;
-import com.navercorp.pinpoint.grpc.trace.PAnnotationValue;
-import com.navercorp.pinpoint.grpc.trace.PIntBooleanIntBooleanValue;
-import com.navercorp.pinpoint.grpc.trace.PIntStringStringValue;
-import com.navercorp.pinpoint.grpc.trace.PIntStringValue;
-import com.navercorp.pinpoint.grpc.trace.PLongIntIntByteByteStringValue;
-import com.navercorp.pinpoint.grpc.trace.PStringStringValue;
+import com.navercorp.pinpoint.common.util.*;
+import com.navercorp.pinpoint.grpc.trace.*;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -57,7 +48,9 @@ public class GrpcAnnotationHandler implements AnnotationFactory.AnnotationTypeHa
 
     @Override
     public Object buildCustomAnnotationValue(Object annotationValue) {
-        if (annotationValue instanceof PIntStringValue) {
+        if (annotationValue instanceof ByteString) {
+            return ((ByteString) annotationValue).toByteArray();
+        } else if (annotationValue instanceof PIntStringValue) {
             return newIntStringValue(annotationValue);
         } else if (annotationValue instanceof PIntStringStringValue) {
             return newIntStringString(annotationValue);


### PR DESCRIPTION
Since `bytes` in protobuf model corresponds to `com.google.protobuf.ByteString` instead of `byte[]` in Java, I've added logic to convert `ByteString` to `byte[]` when `ByteString`-typed annotation value is received.