### PR TITLE
[#9748] skip java 17 it-test

### DIFF
--- a/test/src/main/java/com/navercorp/pinpoint/test/plugin/AbstractPinpointPluginTestSuite.java
+++ b/test/src/main/java/com/navercorp/pinpoint/test/plugin/AbstractPinpointPluginTestSuite.java
@@ -364,10 +364,11 @@ public abstract class AbstractPinpointPluginTestSuite extends Suite {
             for (int ver : jvmVersions) {
                 String javaExe = getJavaExecutable(ver);
 
-                // TODO for now, java 8 is not mandatory to build pinpoint.
+                // TODO for now, java 17 is not mandatory to build pinpoint.
                 // so failing to find java installation should not cause build failure.
                 if (javaExe == null) {
                     logger.error("Cannot find Java version {}. Skip test with Java {}", ver, ver);
+                    runners.add(new PinpointPluginTestAssumptionViolationRunner(getTestClass().getName(), "assumptionFailed:" + ver, "Cannot find Java version " + ver));
                     continue;
                 }
 

--- a/test/src/main/java/com/navercorp/pinpoint/test/plugin/PinpointPluginTestAssumptionViolationRunner.java
+++ b/test/src/main/java/com/navercorp/pinpoint/test/plugin/PinpointPluginTestAssumptionViolationRunner.java
@@ -1,0 +1,30 @@
+package com.navercorp.pinpoint.test.plugin;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+
+import java.util.Objects;
+
+public class PinpointPluginTestAssumptionViolationRunner extends Runner {
+    private final Description description;
+    private final String message;
+
+    public PinpointPluginTestAssumptionViolationRunner(String className, String name, String message) {
+        Objects.requireNonNull(className, "className");
+        Objects.requireNonNull(name, "name");
+        this.description = Description.createTestDescription(className, name);
+        this.message = Objects.requireNonNull(message, "message");
+    }
+
+    @Override
+    public Description getDescription() {
+        return description;
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+        notifier.fireTestAssumptionFailed(new Failure(description, new PinpointPluginTestException(description.getClassName(), message, null)));
+    }
+}


### PR DESCRIPTION
skiped tests because of no java 17 installation should not create error log