### PR TITLE
[#9918] Support version like patch form

### DIFF
--- a/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/agentdir/AgentDirBaseClassPathResolver.java
+++ b/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/agentdir/AgentDirBaseClassPathResolver.java
@@ -35,7 +35,7 @@ public class AgentDirBaseClassPathResolver implements ClassPathResolver {
 
     private final BootLogger logger = BootLogger.getLogger(this.getClass());
 
-    static final String VERSION_PATTERN = "(-[0-9]+\\.[0-9]+\\.[0-9]+((\\-SNAPSHOT)|(-RC[0-9]+))?)?";
+    static final String VERSION_PATTERN = "(-[0-9]+\\.[0-9]+\\.[0-9]+((\\-SNAPSHOT)|(-RC[0-9]+)|(-p[0-9]+))?)?";
 
     static final JarDescription bootstrap = new JarDescription("pinpoint-bootstrap", true);
     private static final String EXTENSIONS = "*.{jar,xml,properties}";

--- a/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/agentdir/JarDescription.java
+++ b/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/agentdir/JarDescription.java
@@ -24,8 +24,8 @@ import java.util.regex.Pattern;
  */
 public class JarDescription {
 
-    static final String VERSION_PATTERN = "(-[0-9]+\\.[0-9]+\\.[0-9]+((\\-SNAPSHOT)|(-RC[0-9]+))?)?";
-    static final String SIMPLE_PATTERN = "-x.x.x(-SNAPSHOT)(-RCx)";
+    static final String VERSION_PATTERN = "(-[0-9]+\\.[0-9]+\\.[0-9]+((\\-SNAPSHOT)|(-RC[0-9]+)|(-p[0-9]+))?)?";
+    static final String SIMPLE_PATTERN = "-x.x.x(-SNAPSHOT)(-RCx)(-px)";
 
     private final String prefix;
     private final boolean required;

--- a/bootstraps/bootstrap/src/test/java/com/navercorp/pinpoint/bootstrap/agentdir/AgentVersionTest.java
+++ b/bootstraps/bootstrap/src/test/java/com/navercorp/pinpoint/bootstrap/agentdir/AgentVersionTest.java
@@ -42,7 +42,7 @@ public class AgentVersionTest {
         assertVersion("-1.6.0-RC0");
         assertVersion("-1.6.0-RC11");
 
-
+        assertVersion("-2.5.1-p1");
     }
 
     @Test


### PR DESCRIPTION
Hi.

I have checked that an error occurs when running with agent of latest released 2.5.1-p1 version.
(If you build and use the 2.5.1-p1 tag, then you can get following error .)

```
java.lang.IllegalStateException: pinpoint-bootstrap-x.x.x(-SNAPSHOT)(-RCx).jar not found.
	at com.navercorp.pinpoint.bootstrap.agentdir.AgentDirBaseClassPathResolver.resolve(AgentDirBaseClassPathResolver.java:73)
	at com.navercorp.pinpoint.bootstrap.PinpointBootStrap.resolveAgentDir(PinpointBootStrap.java:132)
	at com.navercorp.pinpoint.bootstrap.PinpointBootStrap.start(PinpointBootStrap.java:100)
```

It seems that the version like patch from (-p1) is not supported, I have fixed it.

You can close the PR at any time if your intention is to not support building and using it.

Thanks :) 