### PR TITLE
[#9666] Fixed realtime to maintain valid value

### DIFF
--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/dao/ActiveThreadCountWebDaoConfig.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/dao/ActiveThreadCountWebDaoConfig.java
@@ -42,6 +42,9 @@ public class ActiveThreadCountWebDaoConfig {
     @Value("${pinpoint.web.realtime.atc.supply.expireInMs:3000}")
     long supplyExpireInMs;
 
+    @Value("${pinpoint.web.realtime.atc.supply.prepareInMs:10000}")
+    long prepareInMs;
+
     @Bean
     PubSubFluxClient<ATCDemand, ATCSupply> atcEndpoint(PubSubClientFactory clientFactory) {
         return clientFactory.build(RealtimePubSubServiceDescriptors.ATC);
@@ -62,7 +65,9 @@ public class ActiveThreadCountWebDaoConfig {
             Cache<ClusterKey, Fetcher<ATCSupply>> fetcherCache
     ) {
         final long recordMaxAgeNanos = TimeUnit.MILLISECONDS.toNanos(supplyExpireInMs);
-        final ActiveThreadCountFetcherFactory fetcherFactory = new ActiveThreadCountFetcherFactory(endpoint, recordMaxAgeNanos);
+        final long prepareInNanos = TimeUnit.MILLISECONDS.toNanos(prepareInMs);
+        final ActiveThreadCountFetcherFactory fetcherFactory
+                = new ActiveThreadCountFetcherFactory(endpoint, recordMaxAgeNanos, prepareInNanos);
         return new CachedFetcherFactory<>(fetcherFactory, fetcherCache);
     }
 


### PR DESCRIPTION
When updating flux of activeThreadCount, connection message overrides meaningful payload.

This patch restrict the connection message to be passed only one time per websocket request