### PR TITLE
[#noissue] Fix cxf-it test

### DIFF
--- a/plugins-it/cxf-it/src/test/java/com/navercorp/pinpoint/plugin/cxf/CxfClient_3_6_x_IT.java
+++ b/plugins-it/cxf-it/src/test/java/com/navercorp/pinpoint/plugin/cxf/CxfClient_3_6_x_IT.java
@@ -45,11 +45,11 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 
 @RunWith(PinpointPluginTestSuite.class)
 @PinpointAgent(AgentPath.PATH)
-@JvmVersion(8)
-@Dependency({"org.apache.cxf:cxf-rt-rs-client:[3.0.0][3.0.16][3.1.0][3.1.16],[3.2.1,3.6.0)", WebServer.VERSION, PluginITConstants.VERSION})
+@JvmVersion(11)
+@Dependency({"org.apache.cxf:cxf-rt-rs-client:[3.6.0,3.max)", WebServer.VERSION, PluginITConstants.VERSION})
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-cxf-plugin", "com.navercorp.pinpoint:pinpoint-jdk-http-plugin"})
 @PinpointConfig("cxf/pinpoint-cxf-test.config")
-public class CxfClientIT {
+public class CxfClient_3_6_x_IT {
 
     public static WebServer webServer;
 


### PR DESCRIPTION
## Fix cxf-it test

com.navercorp.pinpoint.plugin.cxf.CxfClientIT.test[cxf-rt-rs-client-3.6.0:child:8]

~~~
Error Message
java.lang.UnsupportedClassVersionError: org/apache/cxf/jaxrs/client/WebClient has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
~~~