### PR TITLE
fix [UnderTow does not collect data] bug

### DIFF
--- a/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/interceptor/ConnectorsExecuteRootHandlerInterceptor.java
+++ b/plugins/undertow/src/main/java/com/navercorp/pinpoint/plugin/undertow/interceptor/ConnectorsExecuteRootHandlerInterceptor.java
@@ -153,7 +153,7 @@ public class ConnectorsExecuteRootHandlerInterceptor implements AroundIntercepto
                 if (!httpHandlerClassNameFilter.filter(httpHandlerClassName)) {
                     return false;
                 }
-                return false;
+                return true;
             }
 
             @Override


### PR DESCRIPTION
UnderTow does not collect data, befause 
[com.navercorp.pinpoint.plugin.undertow.interceptor.ConnectorsExecuteRootHandlerInterceptor#handlerPredicate ] return a Predicate， but the Predicate‘s test method always return false.
![image](https://github.com/pinpoint-apm/pinpoint/assets/6245152/cb6bae0d-cd32-4b4d-a21d-c95a6a7b2bbd)
