### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka-clients to 3.4.0

### DIFF
--- a/plugins/bom/pom.xml
+++ b/plugins/bom/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>3.1.0</version>
+                <version>3.4.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka-clients 3.1.0
- [CVE-2023-25194](https://www.oscs1024.com/hd/CVE-2023-25194)


### What did I do？
Upgrade org.apache.kafka:kafka-clients from 3.1.0 to 3.4.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS