### PR TITLE
[#noissue] Deploy executable JAR on repositories

### DIFF
--- a/agent-testweb/pom.xml
+++ b/agent-testweb/pom.xml
@@ -110,7 +110,7 @@
                     <configuration>
                         <skip>${spring-boot-build-skip}</skip>
                         <executable>true</executable>
-                        <attach>${spring-boot-maven-plugin.attatch}</attach>
+                        <attach>${spring-boot-maven-plugin.attach}</attach>
                         <classifier>exec</classifier>
                         <jvmArguments>${pinpoint.agent.jvmargument}</jvmArguments>
                         <agents>${maven.multiModuleProjectDirectory}/agent/target/pinpoint-agent-${project.version}/pinpoint-bootstrap.jar</agents>

--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -14,8 +14,6 @@
     <properties>
         <jdk.version>11</jdk.version>
         <jdk.home>${env.JAVA_11_HOME}</jdk.home>
-
-        <pinpoint.batch.executable.name>${project.artifactId}-${project.version}</pinpoint.batch.executable.name>
     </properties>
 
     <dependencies>
@@ -233,10 +231,9 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>com.navercorp.pinpoint.batch.BatchApp</mainClass>
-                    <outputDirectory>${project.build.directory}/deploy</outputDirectory>
                     <executable>true</executable>
-                    <attach>false</attach>
-                    <finalName>${pinpoint.batch.executable.name}</finalName>
+                    <attach>${spring-boot-maven-plugin.attach}</attach>
+                    <classifier>exec</classifier>
                 </configuration>
             </plugin>
             <!--

--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -33,8 +33,6 @@
         <jdk.home>${env.JAVA_11_HOME}</jdk.home>
 
         <javax.servlet.version>${javax.servlet4.version}</javax.servlet.version>
-
-        <pinpoint.collector.executable.name>${project.artifactId}-boot-${project.version}</pinpoint.collector.executable.name>
     </properties>
 
     <dependencies>
@@ -285,10 +283,9 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>com.navercorp.pinpoint.collector.CollectorApp</mainClass>
-                    <outputDirectory>${project.build.directory}/deploy</outputDirectory>
                     <executable>true</executable>
-                    <attach>false</attach>
-                    <finalName>${pinpoint.collector.executable.name}</finalName>
+                    <attach>${spring-boot-maven-plugin.attach}</attach>
+                    <classifier>exec</classifier>
                 </configuration>
             </plugin>
         </plugins>

--- a/metric-module/collector-starter/pom.xml
+++ b/metric-module/collector-starter/pom.xml
@@ -17,8 +17,6 @@
         <jdk.version>11</jdk.version>
         <jdk.home>${env.JAVA_11_HOME}</jdk.home>
         <javax.servlet.version>${javax.servlet4.version}</javax.servlet.version>
-
-        <pinpoint.collector.executable.name>${project.artifactId}-boot-${project.version}</pinpoint.collector.executable.name>
     </properties>
 
     <dependencies>
@@ -51,10 +49,9 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>com.navercorp.pinpoint.collector.starter.multi.application.MultiApplication</mainClass>
-                    <outputDirectory>target/deploy</outputDirectory>
                     <executable>true</executable>
-                    <attach>false</attach>
-                    <finalName>${pinpoint.collector.executable.name}</finalName>
+                    <attach>${spring-boot-maven-plugin.attach}</attach>
+                    <classifier>exec</classifier>
                 </configuration>
             </plugin>
         </plugins>

--- a/metric-module/web-starter/pom.xml
+++ b/metric-module/web-starter/pom.xml
@@ -17,8 +17,6 @@
         <jdk.home>${env.JAVA_11_HOME}</jdk.home>
 
         <javax.servlet.version>${javax.servlet4.version}</javax.servlet.version>
-
-        <pinpoint.web.executable.name>${project.artifactId}-boot-${project.version}</pinpoint.web.executable.name>
     </properties>
 
     <dependencies>
@@ -61,10 +59,9 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>com.navercorp.pinpoint.web.starter.multi.MetricAndWebApp</mainClass>
-                    <outputDirectory>target/deploy</outputDirectory>
                     <executable>true</executable>
-                    <attach>false</attach>
-                    <finalName>${pinpoint.web.executable.name}</finalName>
+                    <attach>${spring-boot-maven-plugin.attach}</attach>
+                    <classifier>exec</classifier>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
         <plugin.frontend.yarn.version>v1.22.19</plugin.frontend.yarn.version>
         <plugin.frontend.node.install.dir>/node_install/node-${plugin.frontend.node.version}</plugin.frontend.node.install.dir>
 
-        <spring-boot-maven-plugin.attatch>false</spring-boot-maven-plugin.attatch>
+        <spring-boot-maven-plugin.attach>false</spring-boot-maven-plugin.attach>
     </properties>
 
     <dependencies>
@@ -1755,7 +1755,7 @@
             <properties>
                 <env>local</env>
                 <spring.profiles.active>local</spring.profiles.active>
-                <spring-boot-maven-plugin.attatch>false</spring-boot-maven-plugin.attatch>
+                <spring-boot-maven-plugin.attach>false</spring-boot-maven-plugin.attach>
             </properties>
         </profile>
         <!-- for Release -->
@@ -1767,7 +1767,7 @@
             <properties>
                 <env>release</env>
                 <spring.profiles.active>release</spring.profiles.active>
-                <spring-boot-maven-plugin.attatch>true</spring-boot-maven-plugin.attatch>
+                <spring-boot-maven-plugin.attach>true</spring-boot-maven-plugin.attach>
             </properties>
         </profile>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -33,7 +33,6 @@
         <jdk.home>${env.JAVA_11_HOME}</jdk.home>
 
         <javax.servlet.version>${javax.servlet4.version}</javax.servlet.version>
-        <pinpoint.web.executable.name>${project.artifactId}-boot-${project.version}</pinpoint.web.executable.name>
     </properties>
 
     <dependencies>
@@ -397,10 +396,9 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>com.navercorp.pinpoint.web.WebApp</mainClass>
-                    <outputDirectory>${project.build.directory}/deploy</outputDirectory>
                     <executable>true</executable>
-                    <attach>false</attach>
-                    <finalName>${pinpoint.web.executable.name}</finalName>
+                    <attach>${spring-boot-maven-plugin.attach}</attach>
+                    <classifier>exec</classifier>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The executable JAR files have been usually generated in `target/deploy` directory with the name of `{artifactId}-boot-{version}.jar` before.

It changes the position of those JAR files into the `target` directory, and changes the name into `{artifactId}-{version}-exec.jar`.

Those JAR files had not been deployed on local or remote repositories by `install`, but now they are attached by default.