### PR TITLE
fix(sec): upgrade com.google.guava:guava to 32.0.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <grpc.version>1.49.2</grpc.version>
         <protoc.version>3.21.7</protoc.version>
 
-        <guava.version>31.1-jre</guava.version>
+        <guava.version>32.0.0-jre</guava.version>
         <guice.version>7.0.0</guice.version>
         <gson.version>2.10.1</gson.version>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.guava:guava 31.1-jre
- [CVE-2023-2976](https://www.oscs1024.com/hd/CVE-2023-2976)


### What did I do？
Upgrade com.google.guava:guava from 31.1-jre to 32.0.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS