### PR TITLE
fix(sec): upgrade io.vertx:vertx-web to 4.3.8

### DIFF
--- a/agent-testweb/vertx-4-plugin-testweb/pom.xml
+++ b/agent-testweb/vertx-4-plugin-testweb/pom.xml
@@ -32,7 +32,7 @@
         <jdk.version>1.8</jdk.version>
         <jdk.home>${env.JAVA_8_HOME}</jdk.home>
 
-        <vertx.version>4.2.2</vertx.version>
+        <vertx.version>4.3.8</vertx.version>
 
         <spring-boot-build-skip>true</spring-boot-build-skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/plugins/vertx/pom.xml
+++ b/plugins/vertx/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
-            <version>4.2.2</version>
+            <version>4.3.8</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.vertx:vertx-web 4.2.2
- [CVE-2023-24815](https://www.oscs1024.com/hd/CVE-2023-24815)


### What did I do？
Upgrade io.vertx:vertx-web from 4.2.2 to 4.3.8 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS