### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 12.0.0.beta0

### DIFF
--- a/agent-testweb/jetty-plugin-testweb/pom.xml
+++ b/agent-testweb/jetty-plugin-testweb/pom.xml
@@ -16,7 +16,7 @@
         <pinpoint.agent.jvmargument>
             ${pinpoint.agent.default.jvmargument}
         </pinpoint.agent.jvmargument>
-        <jetty.version>9.4.42.v20210604</jetty.version>
+        <jetty.version>12.0.0.beta0</jetty.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.42.v20210604
- [CVE-2023-26049](https://www.oscs1024.com/hd/CVE-2023-26049)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.42.v20210604 to 12.0.0.beta0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS