### PR TITLE
fix(sec): upgrade org.apache.dubbo:dubbo to 3.1.6

### DIFF
--- a/agent-testweb/dubbo-plugin-testweb/pom.xml
+++ b/agent-testweb/dubbo-plugin-testweb/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo</artifactId>
-            <version>2.7.18</version>
+            <version>3.1.6</version>
         </dependency>
 
         <dependency>

--- a/plugins/bom/pom.xml
+++ b/plugins/bom/pom.xml
@@ -39,7 +39,7 @@
         <mongo.driver.4.version>4.6.1</mongo.driver.4.version>
 
         <alibaba.dubbo.version>2.6.12</alibaba.dubbo.version>
-        <apache.dubbo.version>2.7.18</apache.dubbo.version>
+        <apache.dubbo.version>3.1.6</apache.dubbo.version>
         <ehcache.version>2.10.6</ehcache.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.dubbo:dubbo 2.7.18
- [CVE-2023-23638](https://www.oscs1024.com/hd/CVE-2023-23638)


### What did I do？
Upgrade org.apache.dubbo:dubbo from 2.7.18 to 3.1.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS