### PR TITLE
fix(sec): upgrade com.squareup.okhttp:okhttp to 2.7.4

### DIFF
--- a/plugins/bom/pom.xml
+++ b/plugins/bom/pom.xml
@@ -143,7 +143,7 @@
             <dependency>
                 <groupId>com.squareup.okhttp</groupId>
                 <artifactId>okhttp</artifactId>
-                <version>2.5.0</version>
+                <version>2.7.4</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.squareup.okhttp:okhttp 2.5.0
- [CVE-2016-2402](https://www.oscs1024.com/hd/CVE-2016-2402)


### What did I do？
Upgrade com.squareup.okhttp:okhttp from 2.5.0 to 2.7.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS