### PR TITLE
fix(sec): upgrade org.apache.qpid:qpid-broker to 6.1.5

### DIFF
--- a/plugins-it/rabbitmq-it/pom.xml
+++ b/plugins-it/rabbitmq-it/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>qpid-broker</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.5</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.qpid:qpid-broker 6.1.1
- [CVE-2017-15701](https://www.oscs1024.com/hd/CVE-2017-15701)


### What did I do？
Upgrade org.apache.qpid:qpid-broker from 6.1.1 to 6.1.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS