### PR TITLE
fix(sec): upgrade org.apache.cxf:cxf-rt-frontend-jaxrs to 3.2.1

### DIFF
--- a/plugins/bom/pom.xml
+++ b/plugins/bom/pom.xml
@@ -192,7 +192,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-                <version>3.0.16</version>
+                <version>3.2.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.cxf:cxf-rt-frontend-jaxrs 3.0.16
- [CVE-2017-12624](https://www.oscs1024.com/hd/CVE-2017-12624)


### What did I do？
Upgrade org.apache.cxf:cxf-rt-frontend-jaxrs from 3.0.16 to 3.2.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS