### PR TITLE
fix(sec): upgrade org.apache.cxf:cxf-rt-transports-http to 3.5.5

### DIFF
--- a/plugins/bom/pom.xml
+++ b/plugins/bom/pom.xml
@@ -202,7 +202,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http</artifactId>
-                <version>3.0.16</version>
+                <version>3.5.5</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.cxf:cxf-rt-transports-http 3.0.16
- [CVE-2018-8039](https://www.oscs1024.com/hd/CVE-2018-8039)


### What did I do？
Upgrade org.apache.cxf:cxf-rt-transports-http from 3.0.16 to 3.5.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS