### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka_2.12 to 3.2.3

### DIFF
--- a/plugins-it/kafka-it/kafka-3-it/pom.xml
+++ b/plugins-it/kafka-it/kafka-3-it/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
-            <version>2.8.0</version>
+            <version>3.2.3</version>
         </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka_2.12 2.8.0
- [CVE-2022-34917](https://www.oscs1024.com/hd/CVE-2022-34917)


### What did I do？
Upgrade org.apache.kafka:kafka_2.12 from 2.8.0 to 3.2.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS