### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.5.1

### DIFF
--- a/plugins-it/postgresql-jdbc-it/pom.xml
+++ b/plugins-it/postgresql-jdbc-it/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.4.1212</version>
+            <version>42.5.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 9.4.1212
- [CVE-2018-10936](https://www.oscs1024.com/hd/CVE-2018-10936)


### What did I do？
Upgrade org.postgresql:postgresql from 9.4.1212 to 42.5.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS