### PR TITLE
[#noissue] Check existing users to handle duplicate user id error in insertUser()

### DIFF
--- a/user/src/main/java/com/navercorp/pinpoint/web/service/UserService.java
+++ b/user/src/main/java/com/navercorp/pinpoint/web/service/UserService.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.service;
 import java.util.List;
 
 import com.navercorp.pinpoint.web.vo.User;
+import com.navercorp.pinpoint.web.vo.exception.PinpointUserException;
 
 /**
  * @author minwoo.jung
@@ -26,7 +27,7 @@ public interface UserService {
 
     void dropAndCreateUserTable();
     
-    void insertUser(User user);
+    void insertUser(User user) throws PinpointUserException;
 
     void insertUserList(List<User> users);
 

--- a/user/src/main/java/com/navercorp/pinpoint/web/service/UserServiceImpl.java
+++ b/user/src/main/java/com/navercorp/pinpoint/web/service/UserServiceImpl.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.web.util.SecurityContextUtils;
 import com.navercorp.pinpoint.web.util.UserInfoDecoder;
 import com.navercorp.pinpoint.web.util.UserInfoEncoder;
 import com.navercorp.pinpoint.web.vo.User;
+import com.navercorp.pinpoint.web.vo.exception.PinpointUserException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,7 +52,10 @@ public class UserServiceImpl implements UserService {
     }
     
     @Override
-    public void insertUser(User user) {
+    public void insertUser(User user) throws PinpointUserException {
+        if (isExistUserId(user.getUserId())) {
+            throw new PinpointUserException(String.format("There is already a user with %s ID.", user.getUserId()));
+        }
         User encodedUser = userInfoEncoder.encodeUserInfo(user);
         userDao.insertUser(encodedUser);
     }

--- a/user/src/main/java/com/navercorp/pinpoint/web/vo/exception/PinpointUserException.java
+++ b/user/src/main/java/com/navercorp/pinpoint/web/vo/exception/PinpointUserException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.vo.exception;
+
+/**
+ * @author fatihsaracoglu
+ */
+public class PinpointUserException extends Exception {
+
+    public PinpointUserException(String message) {
+        super(message);
+    }
+}

--- a/user/src/test/java/com/navercorp/pinpoint/web/service/UserServiceImplTest.java
+++ b/user/src/test/java/com/navercorp/pinpoint/web/service/UserServiceImplTest.java
@@ -7,6 +7,7 @@ import com.navercorp.pinpoint.web.dao.memory.MemoryUserDao;
 import com.navercorp.pinpoint.web.util.UserInfoDecoder;
 import com.navercorp.pinpoint.web.util.UserInfoEncoder;
 import com.navercorp.pinpoint.web.vo.User;
+import com.navercorp.pinpoint.web.vo.exception.PinpointUserException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,9 +19,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,7 +46,7 @@ public class UserServiceImplTest {
     }
 
     @Test
-    public void insertUserTest() {
+    public void insertUserTest() throws PinpointUserException {
         UserDao userDao = new MemoryUserDao(mock(UserGroupDao.class));
         UserService userService = new UserServiceImpl(userDao, Optional.of(userInfoDecoder), Optional.of(userInfoEncoder));
 
@@ -64,6 +63,19 @@ public class UserServiceImplTest {
         assertEquals(decodedUser.getPhoneCountryCode(), user.getPhoneCountryCode());
         assertEquals(decodedUser.getPhoneNumber(), ENCODED_PHONE_NUMBER);
         assertEquals(decodedUser.getEmail(), ENCODED_EMAIL);
+    }
+
+    @Test
+    public void insertUserDuplicateUserIdErrorTest() throws PinpointUserException {
+        UserDao userDao = new MemoryUserDao(mock(UserGroupDao.class));
+        UserService userService = new UserServiceImpl(userDao, Optional.of(userInfoDecoder), Optional.of(userInfoEncoder));
+
+        String userId = "userId01";
+        User user1 = new User(userId, "name01", "departmentName", 82, "01012341234", "name01@pinpoint.com");
+        userService.insertUser(user1);
+        User user2 = new User(userId, "name02", "departmentName", 82, "01012341235", "name02@pinpoint.com");
+
+        assertThrows(PinpointUserException.class, () -> userService.insertUser(user2));
     }
 
     @Test
@@ -94,7 +106,7 @@ public class UserServiceImplTest {
     }
 
     @Test
-    public void updateUserTest() {
+    public void updateUserTest() throws PinpointUserException {
         UserDao userDao = new MemoryUserDao(mock(UserGroupDao.class));
         UserService userService = new UserServiceImpl(userDao, Optional.of(userInfoDecoder), Optional.of(userInfoEncoder));
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/UserController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/UserController.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.web.service.UserService;
 import com.navercorp.pinpoint.web.util.ValueValidator;
 import com.navercorp.pinpoint.web.vo.User;
+import com.navercorp.pinpoint.web.vo.exception.PinpointUserException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpStatus;
@@ -57,7 +58,7 @@ public class UserController {
     }
 
     @PostMapping
-    public Response insertUser(@RequestBody User user) {
+    public Response insertUser(@RequestBody User user) throws PinpointUserException {
         if (!ValueValidator.validateUser(user)) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,


### PR DESCRIPTION
Adding a Pinpoint user that has the same ID as one of the existing users throws database constraint violation error. It can be handled in the service layer.

The error shown on the UI:
<details>
### Error updating database. Cause: java.sql.SQLIntegrityConstraintViolationException: Duplicate entry 'test' for key 'puser.user_id_idx'
...
### SQL: INSERT INTO puser (user_id, name, department, phone_country_code, phonenumber, email) VALUES (?, ?, ?, ?, ?, ?) ### Cause: java.sql.SQLIntegrityConstraintViolationException: Duplicate entry 'test' for key 'puser.user_id_idx' ; Duplicate entry 'test' for key 'puser.user_id_idx'; nested exception is java.sql.SQLIntegrityConstraintViolationException: Duplicate entry 'test' for key 'puser.user_id_idx'
</details>