### PR TITLE
[#9631] Store errorMessage as the replaced string in the collector

### DIFF
--- a/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/ExceptionTraceCollectorConfig.java
+++ b/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/ExceptionTraceCollectorConfig.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.PropertySource;
  * @author intr3p1d
  */
 @Configuration
-@Import({PinotConfiguration.class, ExceptionMetricKafkaConfiguration.class})
+@Import({PinotConfiguration.class, ExceptionMetricKafkaConfiguration.class, ExceptionTraceCollectorPropertySources.class})
 @ComponentScan({
         "com.navercorp.pinpoint.common.server.mapper",
         "com.navercorp.pinpoint.exceptiontrace.collector.service",

--- a/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/ExceptionTraceCollectorPropertySources.java
+++ b/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/ExceptionTraceCollectorPropertySources.java
@@ -16,8 +16,15 @@
 
 package com.navercorp.pinpoint.exceptiontrace.collector;
 
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
+
 /**
  * @author intr3p1d
  */
+@PropertySources({
+        @PropertySource(name = "ExceptionTracePropertySources", value = ExceptionTraceCollectorPropertySources.EXCEPTIONTRACE_COLLECTOR_PROPERTIES)
+})
 public class ExceptionTraceCollectorPropertySources {
+    public static final String EXCEPTIONTRACE_COLLECTOR_PROPERTIES = "classpath:pinpoint-collector-exceptiontrace.properties";
 }

--- a/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/ErrorMessageMapper.java
+++ b/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/ErrorMessageMapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.exceptiontrace.collector.mapper;
+
+import org.mapstruct.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author intr3p1d
+ */
+@Component
+public class ErrorMessageMapper {
+
+    @Qualifier
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.CLASS)
+    public @interface ReplaceCharacters {
+    }
+
+    private boolean replaceCharacters = false;
+
+    public ErrorMessageMapper(@Value("${pinpoint.collector.exceptiontrace.replace.characters:true}") boolean replaceCharacters) {
+        this.replaceCharacters = replaceCharacters;
+    }
+
+    @ReplaceCharacters
+    public String replaceCharacters(String errorMessage) {
+        String replacementCharacter = "";
+        if (replaceCharacters) {
+            return errorMessage.replaceAll("[^\\p{Alnum}\\x21-\\x7E\\s]", replacementCharacter);
+        }
+        return errorMessage;
+    }
+}

--- a/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/ExceptionMetaDataMapper.java
+++ b/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/ExceptionMetaDataMapper.java
@@ -24,14 +24,15 @@ import org.mapstruct.Mappings;
 /**
  * @author intr3p1d
  */
-@Mapper(componentModel = "spring", uses = {StackTraceMapper.class})
+@Mapper(componentModel = "spring", uses = {StackTraceMapper.class, ErrorMessageMapper.class})
 public interface ExceptionMetaDataMapper {
 
     @Mappings({
             @Mapping(source = "stackTrace", target = "stackTraceClassName", qualifiedBy = StackTraceMapper.StackTraceToClassNames.class),
             @Mapping(source = "stackTrace", target = "stackTraceFileName", qualifiedBy = StackTraceMapper.StackTraceToFileNames.class),
             @Mapping(source = "stackTrace", target = "stackTraceLineNumber", qualifiedBy = StackTraceMapper.StackTraceToLineNumbers.class),
-            @Mapping(source = "stackTrace", target = "stackTraceMethodName", qualifiedBy = StackTraceMapper.StackTraceToMethodNames.class)
+            @Mapping(source = "stackTrace", target = "stackTraceMethodName", qualifiedBy = StackTraceMapper.StackTraceToMethodNames.class),
+            @Mapping(source = "errorMessage", target = "errorMessage", qualifiedBy = ErrorMessageMapper.ReplaceCharacters.class)
     })
     ExceptionMetaDataEntity toEntity(ExceptionMetaData model);
 

--- a/exceptiontrace/exceptiontrace-collector/src/main/resources/pinpoint-collector-exceptiontrace.properties
+++ b/exceptiontrace/exceptiontrace-collector/src/main/resources/pinpoint-collector-exceptiontrace.properties
@@ -1,0 +1,1 @@
+pinpoint.collector.exceptiontrace.replace.characters=true

--- a/exceptiontrace/exceptiontrace-collector/src/test/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/ExceptionMetaDataMapperTest.java
+++ b/exceptiontrace/exceptiontrace-collector/src/test/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/ExceptionMetaDataMapperTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 import java.util.Random;
 import java.util.stream.Collectors;
 
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 @ContextConfiguration(classes = {
         ExceptionMetaDataMapperImpl.class,
         StackTraceMapper.class,
+        ErrorMessageMapper.class,
         MapStructUtils.class,
         JacksonAutoConfiguration.class
 })
@@ -112,6 +114,15 @@ class ExceptionMetaDataMapperTest {
                         s.getClassName(), s.getFileName(), s.getLineNumber(), s.getMethodName()
                 )
         ).collect(Collectors.toList());
+    }
+
+
+    @Test
+    public void testReplaceCharacter() {
+        ErrorMessageMapper errorMessageMapper = new ErrorMessageMapper(true);
+        String text = "가나다라마바사아자차카타파하";
+        String replaced = errorMessageMapper.replaceCharacters(text);
+        Assertions.assertEquals("", replaced);
     }
 
 }

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/controller/ExceptionTraceController.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/controller/ExceptionTraceController.java
@@ -71,14 +71,14 @@ public class ExceptionTraceController {
     public List<ExceptionMetaData> getListOfExceptionMetaDataFromTransactionId(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("traceId") @NotBlank String traceId,
+            @RequestParam("transactionId") @NotBlank String transactionId,
             @RequestParam("spanId") long spanId,
             @RequestParam("exceptionId") long exceptionId
     ) {
         ExceptionTraceQueryParameter queryParameter = new ExceptionTraceQueryParameter.Builder()
                 .setApplicationName(applicationName)
                 .setAgentId(agentId)
-                .setTransactionId(traceId)
+                .setTransactionId(transactionId)
                 .setSpanId(spanId)
                 .setExceptionId(exceptionId)
                 .setTimePrecision(DETAILED_TIME_PRECISION)
@@ -122,26 +122,16 @@ public class ExceptionTraceController {
 
             @RequestParam("groupBy") List<String> groupByList
     ) {
-        ExceptionTraceQueryParameter.Builder builder = new ExceptionTraceQueryParameter.Builder()
+        ExceptionTraceQueryParameter queryParameter = new ExceptionTraceQueryParameter.Builder()
                 .setApplicationName(applicationName)
                 .setAgentId(agentId)
                 .setRange(Range.newRange(from, to))
                 .setTimePrecision(DETAILED_TIME_PRECISION)
-                .addAllGroupByList(groupByList);
-
-        try {
-            ExceptionTraceQueryParameter queryParameter = builder.build();
-            return exceptionTraceService.getSummaries(
-                    queryParameter
-            );
-        } catch (Exception e) {
-            ExceptionTraceQueryParameter queryParameter = builder
-                    .setMessageLengthLimit(ExceptionTraceQueryParameter.MESSAGE_MAX_LENGTH)
-                    .build();
-            return exceptionTraceService.getSummaries(
-                    queryParameter
-            );
-        }
+                .addAllGroupByList(groupByList)
+                .build();
+        return exceptionTraceService.getSummaries(
+                queryParameter
+        );
     }
 
     @GetMapping("/chart")

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/ExceptionTraceQueryParameter.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/ExceptionTraceQueryParameter.java
@@ -33,8 +33,6 @@ import java.util.stream.Collectors;
 public class ExceptionTraceQueryParameter extends QueryParameter {
 
     public static final int STACKTRACE_COUNT = 3;
-    public static final int MESSAGE_MAX_LENGTH = 20;
-    private final static String TOTAL_FIELD_NAME = "total";
 
     private final String applicationName;
     private final String agentId;
@@ -49,7 +47,6 @@ public class ExceptionTraceQueryParameter extends QueryParameter {
     private final List<GroupByAttributes> groupByAttributes;
 
     private final long timeWindowRangeCount;
-    private final int messageLengthLimit;
 
     protected ExceptionTraceQueryParameter(Builder builder) {
         super(builder.getRange(), builder.getTimePrecision(), builder.getLimit());
@@ -63,7 +60,6 @@ public class ExceptionTraceQueryParameter extends QueryParameter {
         this.isDesc = builder.isDesc;
         this.groupByAttributes = builder.groupByAttributes;
         this.timeWindowRangeCount = builder.timeWindowRangeCount;
-        this.messageLengthLimit = builder.messageLengthLimit;
     }
 
     public static class Builder extends QueryParameter.Builder<Builder> {
@@ -85,7 +81,6 @@ public class ExceptionTraceQueryParameter extends QueryParameter {
         private final List<GroupByAttributes> groupByAttributes = new ArrayList<>();
 
         private long timeWindowRangeCount = 0;
-        private int messageLengthLimit = -1;
 
         @Override
         protected Builder self() {
@@ -131,11 +126,6 @@ public class ExceptionTraceQueryParameter extends QueryParameter {
             if (limit > 200) {
                 this.hardLimit = 200;
             } else this.hardLimit = Math.max(limit, 50);
-            return self();
-        }
-
-        public Builder setMessageLengthLimit(int messageLengthLimit) {
-            this.messageLengthLimit = messageLengthLimit;
             return self();
         }
 
@@ -209,7 +199,6 @@ public class ExceptionTraceQueryParameter extends QueryParameter {
                 ", isDesc='" + isDesc + '\'' +
                 ", groupByAttributes=" + groupByAttributes +
                 ", timeWindowRangeCount=" + timeWindowRangeCount +
-                ", messageLengthLimit=" + messageLengthLimit +
                 '}';
     }
 }

--- a/exceptiontrace/exceptiontrace-web/src/main/resources/exceptiontrace/mapper/ExceptionTraceMapper.xml
+++ b/exceptiontrace/exceptiontrace-web/src/main/resources/exceptiontrace/mapper/ExceptionTraceMapper.xml
@@ -163,9 +163,7 @@
         SELECT
         <include refid="getGroupedFieldNameEntity"></include>
         LASTWITHTIME(errorClassName, "timestamp", 'STRING') as "mostRecentErrorClass",
-        LASTWITHTIME(
-            substr("errorMessage", 0, ${messageLengthLimit}),
-            "timestamp", 'STRING') as "mostRecentErrorMessage",
+        LASTWITHTIME("errorMessage", "timestamp", 'STRING') as "mostRecentErrorMessage",
         count(*) as "count",
         FIRSTWITHTIME("timestamp", "timestamp", 'LONG') as "firstOccurred",
         LASTWITHTIME("timestamp", "timestamp", 'LONG') as "lastOccurred"


### PR DESCRIPTION
This issue is fixed in pinot 0.12.0, BTW add this fallback for more stability and compatibility
ref: github.com/apache/pinot/issues/10061