### PR TITLE
[#9631] Change format long to String; spanId, exceptionId

### DIFF
--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/controller/ExceptionTraceController.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/controller/ExceptionTraceController.java
@@ -16,12 +16,12 @@
 
 package com.navercorp.pinpoint.exceptiontrace.web.controller;
 
-import com.navercorp.pinpoint.exceptiontrace.common.model.ExceptionMetaData;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceSummary;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceValueView;
 import com.navercorp.pinpoint.exceptiontrace.web.service.ExceptionTraceService;
 import com.navercorp.pinpoint.exceptiontrace.web.util.ExceptionTraceQueryParameter;
 import com.navercorp.pinpoint.exceptiontrace.web.util.GroupByAttributes;
+import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionMetaDataView;
 import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionTraceView;
 import com.navercorp.pinpoint.metric.web.util.Range;
 import com.navercorp.pinpoint.metric.web.util.TimePrecision;
@@ -68,7 +68,7 @@ public class ExceptionTraceController {
     }
 
     @GetMapping("/transactionInfo")
-    public List<ExceptionMetaData> getListOfExceptionMetaDataFromTransactionId(
+    public List<ExceptionMetaDataView> getListOfExceptionMetaDataFromTransactionId(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("agentId") @NotBlank String agentId,
             @RequestParam("transactionId") @NotBlank String transactionId,
@@ -89,7 +89,7 @@ public class ExceptionTraceController {
     }
 
     @GetMapping("/errorList")
-    public List<ExceptionMetaData> getListOfExceptionMetaDataByGivenRange(
+    public List<ExceptionMetaDataView> getListOfExceptionMetaDataByGivenRange(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "agentId", required = false) String agentId,
             @RequestParam("from") @PositiveOrZero long from,

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/dao/ExceptionTraceDao.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/dao/ExceptionTraceDao.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.exceptiontrace.common.model.ExceptionMetaData;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceSummary;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceValueView;
 import com.navercorp.pinpoint.exceptiontrace.web.util.ExceptionTraceQueryParameter;
+import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionMetaDataView;
 
 import java.util.List;
 
@@ -28,8 +29,8 @@ import java.util.List;
  * @author intr3p1d
  */
 public interface ExceptionTraceDao {
-    List<ExceptionMetaData> getExceptions(ExceptionTraceQueryParameter exceptionTraceQueryParameter);
-    List<ExceptionMetaData> getSummarizedExceptions(ExceptionTraceQueryParameter exceptionTraceQueryParameter);
+    List<ExceptionMetaDataView> getExceptions(ExceptionTraceQueryParameter exceptionTraceQueryParameter);
+    List<ExceptionMetaDataView> getSummarizedExceptions(ExceptionTraceQueryParameter exceptionTraceQueryParameter);
     ExceptionMetaData getException(ExceptionTraceQueryParameter exceptionTraceQueryParameter);
     List<ExceptionTraceSummary> getSummaries(ExceptionTraceQueryParameter exceptionTraceQueryParameter);
     List<ExceptionTraceValueView> getValueViews(ExceptionTraceQueryParameter exceptionTraceQueryParameter);

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/dao/PinotExceptionTraceDao.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/dao/PinotExceptionTraceDao.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.exceptiontrace.web.mapper.ExceptionMetaDataEntityM
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceSummary;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceValueView;
 import com.navercorp.pinpoint.exceptiontrace.web.util.ExceptionTraceQueryParameter;
+import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionMetaDataView;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mybatis.spring.SqlSessionTemplate;
@@ -62,18 +63,18 @@ public class PinotExceptionTraceDao implements ExceptionTraceDao {
     }
 
     @Override
-    public List<ExceptionMetaData> getExceptions(ExceptionTraceQueryParameter exceptionTraceQueryParameter) {
+    public List<ExceptionMetaDataView> getExceptions(ExceptionTraceQueryParameter exceptionTraceQueryParameter) {
         List<ExceptionMetaDataEntity> dataEntities = this.sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_QUERY, exceptionTraceQueryParameter);
         return dataEntities.stream()
-                .map(mapper::toModel)
+                .map(mapper::toView)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<ExceptionMetaData> getSummarizedExceptions(ExceptionTraceQueryParameter exceptionTraceQueryParameter) {
+    public List<ExceptionMetaDataView> getSummarizedExceptions(ExceptionTraceQueryParameter exceptionTraceQueryParameter) {
         List<ExceptionMetaDataEntity> dataEntities = this.sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_SUMMARIZED_QUERY, exceptionTraceQueryParameter);
         return dataEntities.stream()
-                .map(mapper::toModel)
+                .map(mapper::toView)
                 .collect(Collectors.toList());
     }
 

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/mapper/ExceptionMetaDataEntityMapper.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/mapper/ExceptionMetaDataEntityMapper.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.exceptiontrace.web.entity.ExceptionTraceSummaryEnt
 import com.navercorp.pinpoint.exceptiontrace.web.entity.ExceptionTraceValueViewEntity;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceSummary;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceValueView;
+import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionMetaDataView;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
@@ -36,6 +37,11 @@ public interface ExceptionMetaDataEntityMapper {
             @Mapping(source = ".", target = "stackTrace", qualifiedBy = StackTraceMapper.StringsToStackTrace.class)
     )
     ExceptionMetaData toModel(ExceptionMetaDataEntity entity);
+
+    @Mappings(
+            @Mapping(source = ".", target = "stackTrace", qualifiedBy = StackTraceMapper.StringsToStackTrace.class)
+    )
+    ExceptionMetaDataView toView(ExceptionMetaDataEntity entity);
 
     @Mappings({
             @Mapping(source = "values", target = "values", qualifiedBy = MapStructUtils.JsonStrToList.class),

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/service/ExceptionTraceService.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/service/ExceptionTraceService.java
@@ -16,10 +16,10 @@
 
 package com.navercorp.pinpoint.exceptiontrace.web.service;
 
-import com.navercorp.pinpoint.exceptiontrace.common.model.ExceptionMetaData;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceSummary;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceValueView;
 import com.navercorp.pinpoint.exceptiontrace.web.util.ExceptionTraceQueryParameter;
+import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionMetaDataView;
 
 import java.util.List;
 
@@ -28,9 +28,9 @@ import java.util.List;
  */
 public interface ExceptionTraceService {
 
-    List<ExceptionMetaData> getTransactionExceptions(ExceptionTraceQueryParameter queryParameter);
+    List<ExceptionMetaDataView> getTransactionExceptions(ExceptionTraceQueryParameter queryParameter);
 
-    List<ExceptionMetaData> getSummarizedExceptionsInRange(ExceptionTraceQueryParameter queryParameter);
+    List<ExceptionMetaDataView> getSummarizedExceptionsInRange(ExceptionTraceQueryParameter queryParameter);
 
     List<ExceptionTraceSummary> getSummaries(ExceptionTraceQueryParameter queryParameter);
 

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/service/ExceptionTraceServiceImpl.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/service/ExceptionTraceServiceImpl.java
@@ -16,11 +16,11 @@
 
 package com.navercorp.pinpoint.exceptiontrace.web.service;
 
-import com.navercorp.pinpoint.exceptiontrace.common.model.ExceptionMetaData;
 import com.navercorp.pinpoint.exceptiontrace.web.dao.ExceptionTraceDao;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceSummary;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceValueView;
 import com.navercorp.pinpoint.exceptiontrace.web.util.ExceptionTraceQueryParameter;
+import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionMetaDataView;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -44,7 +44,7 @@ public class ExceptionTraceServiceImpl implements ExceptionTraceService {
     }
 
     @Override
-    public List<ExceptionMetaData> getTransactionExceptions(
+    public List<ExceptionMetaDataView> getTransactionExceptions(
             ExceptionTraceQueryParameter queryParameter
     ) {
         return applyQueryFunction(
@@ -54,7 +54,7 @@ public class ExceptionTraceServiceImpl implements ExceptionTraceService {
     }
 
     @Override
-    public List<ExceptionMetaData> getSummarizedExceptionsInRange(ExceptionTraceQueryParameter queryParameter) {
+    public List<ExceptionMetaDataView> getSummarizedExceptionsInRange(ExceptionTraceQueryParameter queryParameter) {
         return applyQueryFunction(
                 queryParameter,
                 this::getSummarizedExeptionMetaDataList
@@ -84,11 +84,11 @@ public class ExceptionTraceServiceImpl implements ExceptionTraceService {
         return queryFunction.apply(queryParameter);
     }
 
-    private List<ExceptionMetaData> getExeptionMetaDataList(ExceptionTraceQueryParameter queryParameter) {
+    private List<ExceptionMetaDataView> getExeptionMetaDataList(ExceptionTraceQueryParameter queryParameter) {
         return exceptionTraceDao.getExceptions(queryParameter);
     }
 
-    private List<ExceptionMetaData> getSummarizedExeptionMetaDataList(ExceptionTraceQueryParameter queryParameter) {
+    private List<ExceptionMetaDataView> getSummarizedExeptionMetaDataList(ExceptionTraceQueryParameter queryParameter) {
         return exceptionTraceDao.getSummarizedExceptions(queryParameter);
     }
 

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/view/ExceptionMetaDataView.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/view/ExceptionMetaDataView.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.exceptiontrace.web.view;
+
+import com.navercorp.pinpoint.exceptiontrace.common.model.StackTraceElementWrapper;
+
+import java.util.List;
+
+/**
+ * @author intr3p1d
+ */
+public class ExceptionMetaDataView {
+
+    private long timestamp;
+
+    private String transactionId;
+    private String spanId;
+    private String exceptionId;
+
+    private String applicationServiceType;
+    private String applicationName;
+    private String agentId;
+    private String uriTemplate;
+
+    private String errorClassName;
+    private String errorMessage;
+    private int exceptionDepth;
+
+    private List<StackTraceElementWrapper> stackTrace;
+
+    private String stackTraceHash;
+
+    public ExceptionMetaDataView() {
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public String getSpanId() {
+        return spanId;
+    }
+
+    public void setSpanId(String spanId) {
+        this.spanId = spanId;
+    }
+
+    public String getExceptionId() {
+        return exceptionId;
+    }
+
+    public void setExceptionId(String exceptionId) {
+        this.exceptionId = exceptionId;
+    }
+
+    public String getApplicationServiceType() {
+        return applicationServiceType;
+    }
+
+    public void setApplicationServiceType(String applicationServiceType) {
+        this.applicationServiceType = applicationServiceType;
+    }
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
+    }
+
+    public String getAgentId() {
+        return agentId;
+    }
+
+    public void setAgentId(String agentId) {
+        this.agentId = agentId;
+    }
+
+    public String getUriTemplate() {
+        return uriTemplate;
+    }
+
+    public void setUriTemplate(String uriTemplate) {
+        this.uriTemplate = uriTemplate;
+    }
+
+    public String getErrorClassName() {
+        return errorClassName;
+    }
+
+    public void setErrorClassName(String errorClassName) {
+        this.errorClassName = errorClassName;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public int getExceptionDepth() {
+        return exceptionDepth;
+    }
+
+    public void setExceptionDepth(int exceptionDepth) {
+        this.exceptionDepth = exceptionDepth;
+    }
+
+    public List<StackTraceElementWrapper> getStackTrace() {
+        return stackTrace;
+    }
+
+    public void setStackTrace(List<StackTraceElementWrapper> stackTrace) {
+        this.stackTrace = stackTrace;
+    }
+
+    public String getStackTraceHash() {
+        return stackTraceHash;
+    }
+
+    public void setStackTraceHash(String stackTraceHash) {
+        this.stackTraceHash = stackTraceHash;
+    }
+}

--- a/exceptiontrace/exceptiontrace-web/src/test/java/com/navercorp/pinpoint/exceptiontrace/web/mapper/ExceptionMetaDataEntityMapperTest.java
+++ b/exceptiontrace/exceptiontrace-web/src/test/java/com/navercorp/pinpoint/exceptiontrace/web/mapper/ExceptionMetaDataEntityMapperTest.java
@@ -9,6 +9,7 @@ import com.navercorp.pinpoint.exceptiontrace.web.entity.ExceptionTraceSummaryEnt
 import com.navercorp.pinpoint.exceptiontrace.web.entity.ExceptionTraceValueViewEntity;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceSummary;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceValueView;
+import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionMetaDataView;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -57,6 +58,52 @@ class ExceptionMetaDataEntityMapperTest {
         Assertions.assertEquals(expected.getTransactionId(), actual.getTransactionId());
         Assertions.assertEquals(expected.getSpanId(), actual.getSpanId());
         Assertions.assertEquals(expected.getExceptionId(), actual.getExceptionId());
+
+        Assertions.assertEquals(expected.getApplicationServiceType(), actual.getApplicationServiceType());
+        Assertions.assertEquals(expected.getApplicationName(), actual.getApplicationName());
+        Assertions.assertEquals(expected.getAgentId(), actual.getAgentId());
+        Assertions.assertEquals(expected.getUriTemplate(), actual.getUriTemplate());
+
+        Assertions.assertEquals(expected.getErrorClassName(), actual.getErrorClassName());
+        Assertions.assertEquals(expected.getErrorMessage(), actual.getErrorMessage());
+        Assertions.assertEquals(expected.getExceptionDepth(), actual.getExceptionDepth());
+
+        Assertions.assertEquals(expected.getStackTraceHash(), actual.getStackTraceHash());
+
+
+        int size = throwable.getStackTrace().length;
+
+        String classNames = expected.getStackTraceClassName();
+        String fileNames = expected.getStackTraceFileName();
+        String lineNumbers = expected.getStackTraceLineNumber();
+        String methodNames = expected.getStackTraceMethodName();
+
+        List<String> classNameIter = convertToList(classNames);
+        List<String> fileNameIter = convertToList(fileNames);
+        List<Integer> lineNumberIter = convertToList(lineNumbers);
+        List<String> methodNameIter = convertToList(methodNames);
+
+        List<StackTraceElementWrapper> actualStackTrace = actual.getStackTrace();
+
+        for (int i = 0; i < size; i++) {
+            Assertions.assertEquals(classNameIter.get(i), actualStackTrace.get(i).getClassName());
+            Assertions.assertEquals(fileNameIter.get(i), actualStackTrace.get(i).getFileName());
+            Assertions.assertEquals(lineNumberIter.get(i), actualStackTrace.get(i).getLineNumber());
+            Assertions.assertEquals(methodNameIter.get(i), actualStackTrace.get(i).getMethodName());
+        }
+    }
+
+    @Test
+    public void testEntityToView() {
+        Throwable throwable = new RuntimeException();
+
+        ExceptionMetaDataEntity expected = newExceptionMetaDataEntity(throwable);
+        ExceptionMetaDataView actual = mapper.toView(expected);
+
+        Assertions.assertEquals(expected.getTimestamp(), actual.getTimestamp());
+        Assertions.assertEquals(expected.getTransactionId(), actual.getTransactionId());
+        Assertions.assertEquals(Long.toString(expected.getSpanId()), actual.getSpanId());
+        Assertions.assertEquals(Long.toString(expected.getExceptionId()), actual.getExceptionId());
 
         Assertions.assertEquals(expected.getApplicationServiceType(), actual.getApplicationServiceType());
         Assertions.assertEquals(expected.getApplicationName(), actual.getApplicationName());


### PR DESCRIPTION
Sometimes, `long` may be rounded by js.
To prevent unwanted rounding, change format long to String of `spanId` and `exceptionId`