### PR TITLE
fix(sec): upgrade org.springframework.kafka:spring-kafka to 3.0.10

### DIFF
--- a/metric-module/metric/pom.xml
+++ b/metric-module/metric/pom.xml
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
-            <version>2.9.4</version>
+            <version>3.0.10</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.kafka</groupId>

--- a/pinot/pinot-kafka/pom.xml
+++ b/pinot/pinot-kafka/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
-            <version>2.9.4</version>
+            <version>3.0.10</version>
         </dependency>
 
         <!-- Logging dependencies -->

--- a/uristat/uristat-collector/pom.xml
+++ b/uristat/uristat-collector/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
-            <version>2.9.4</version>
+            <version>3.0.10</version>
         </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.kafka:spring-kafka 2.9.4
- [CVE-2023-34040](https://www.oscs1024.com/hd/CVE-2023-34040)


### What did I do？
Upgrade org.springframework.kafka:spring-kafka from 2.9.4 to 3.0.10 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS