### PR TITLE
Use GITHUB_OUTPUT envvar instead of set-output command as the latter is deprecated

### DIFF
--- a/.github/workflows/it-command.yml
+++ b/.github/workflows/it-command.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Create URL to the run output
         id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
       - name: Update success comment
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -22,11 +22,11 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
         with:
-          ref: 'refs/pull/${{ env.PR_NUMBER }}/merge'
+          ref: "refs/pull/${{ env.PR_NUMBER }}/merge"
       - name: Cache node modules
         uses: actions/cache@v3
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-modules-
@@ -39,7 +39,7 @@ jobs:
       - name: Cache node install
         uses: actions/cache@v3
         with:
-          path: 'node_install'
+          path: "node_install"
           key: ${{ runner.os }}-node_install-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-node_install-
@@ -51,7 +51,7 @@ jobs:
       - name: Set up JDK 7
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: "zulu"
           java-version: 7
       - name: Set JAVA_HOME
         run: |
@@ -84,8 +84,8 @@ jobs:
         with:
           name: pinpoint-test-results
           reporter: java-junit
-          path: './plugins-it/temp/TEST-*.xml'
-          fail-on-error: 'false'
+          path: "./plugins-it/temp/TEST-*.xml"
+          fail-on-error: "false"
       - name: Update  comment
         uses: peter-evans/create-or-update-comment@v1
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
