### PR TITLE
Fix mismatched version numbers

### DIFF
--- a/agent-testweb/grpc-plugin-testweb/pom.xml
+++ b/agent-testweb/grpc-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.5.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>pinpoint-grpc-plugin-testweb</artifactId>

--- a/agent-testweb/ning-asynchttpclient-plugin-testweb/pom.xml
+++ b/agent-testweb/ning-asynchttpclient-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.5.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>pinpoint-ning-asynchttpclient-plugin-testweb</artifactId>

--- a/agent-testweb/okhttp-plugin-testweb/pom.xml
+++ b/agent-testweb/okhttp-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.5.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>pinpoint-okhttp-plugin-testweb</artifactId>

--- a/commons/src/main/java/com/navercorp/pinpoint/common/Version.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/Version.java
@@ -1,4 +1,4 @@
 package com.navercorp.pinpoint.common;
 public final class Version {
-    public static final String VERSION = "2.5.4";
+    public static final String VERSION = "2.5.4-SNAPSHOT";
 }


### PR DESCRIPTION
There are some version numbers errors on the 2.5.x.

Somebody want use this branch but it  can't build success directly after clone.

