### PR TITLE
Fixed Change last exclamation point to dot and link issue for browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The current stable version is [v2.5.3](https://github.com/pinpoint-apm/pinpoint/
 
 ## Live Demo
 
-Take a quick look at Pinpoint with our [demo](http://125.209.240.10:10123/main/ApiGateway@SPRING_BOOT/5m?inbound=1&outbound=4&wasOnly=false&bidirectional=false)!
+Take a quick look at Pinpoint with our [demo](http://125.209.240.10:10123/main/ApiGateway@SPRING_BOOT/5m?inbound=1&outbound=4&wasOnly=false&bidirectional=false).
 
 ## PHP, PYTHON
 


### PR DESCRIPTION
#10609 

1. I've accessed it with that url(http://125.209.240.10:10123/main/ApiGateway@SPRING_BOOT/5m?inbound=1&outbound=4&wasOnly=false&bidirectional=false), but I can't WebSite.
2. The link to Live Demo (http://125.209.240.10:10123/) could not be reached on the https://pinpoint-apm.github.io/pinpoint/ WebSite either.

Hello, I'm so curious about why I can't access the site. Can you teach me, please.