### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmPartitioner.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmPartitioner.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.batch.alarm;
 
 import com.navercorp.pinpoint.batch.common.DefaultDivider;
 import com.navercorp.pinpoint.batch.common.Divider;
+import jakarta.annotation.Nonnull;
 import org.springframework.batch.core.partition.support.Partitioner;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -39,6 +40,7 @@ public class AlarmPartitioner implements Partitioner {
     }
 
     @Override
+    @Nonnull
     public Map<String, ExecutionContext> partition(int gridSize) {
         return divider.divide(PARTITION_NAME_PREFIX, BATCH_NAME);
     }

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmProcessor.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmProcessor.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.batch.alarm;
 
+import com.google.common.base.Suppliers;
 import com.navercorp.pinpoint.batch.alarm.checker.AlarmChecker;
 import com.navercorp.pinpoint.batch.alarm.collector.DataCollector;
 import com.navercorp.pinpoint.batch.alarm.vo.AppAlarmChecker;
@@ -28,18 +29,16 @@ import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
 import com.navercorp.pinpoint.web.service.AgentInfoService;
 import com.navercorp.pinpoint.web.service.AlarmService;
 import com.navercorp.pinpoint.web.vo.Application;
+import jakarta.annotation.Nonnull;
 import org.springframework.batch.item.ItemProcessor;
 
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.function.Supplier;
 
 /**
  * @author minwoo.jung
@@ -72,6 +71,7 @@ public class AlarmProcessor implements ItemProcessor<Application, AppAlarmChecke
         this.checkerRegistry = Objects.requireNonNull(checkerRegistry, "checkerRegistry");
     }
 
+    @Override
     public AppAlarmChecker process(@Nonnull Application application) {
         List<AlarmChecker<?>> checkers = getAlarmCheckers(application);
         if (CollectionUtils.isEmpty(checkers)) {
@@ -86,58 +86,45 @@ public class AlarmProcessor implements ItemProcessor<Application, AppAlarmChecke
 
     private List<AlarmChecker<?>> getAlarmCheckers(Application application) {
         List<Rule> rules = alarmService.selectRuleByApplicationId(application.getName());
-        List<AlarmChecker<?>> checkers = new ArrayList<>(rules.size());
 
         long now = System.currentTimeMillis();
-        List<String> agentIds = prepareActiveAgentIds(application, rules, now);
+        Supplier<List<String>> agentIds = getAgentIdsSupplier(application, now);
 
-        RuleTransformer transformer = new RuleTransformer(application, agentIds, now, dataCollectorFactory, checkerRegistry);
+        AlarmCheckerFactory alarmCheckerFactory = new AlarmCheckerFactory(
+                application, agentIds, now, dataCollectorFactory, checkerRegistry);
+
+        List<AlarmChecker<?>> checkers = new ArrayList<>(rules.size());
         for (Rule rule: rules) {
-            checkers.add(transformer.apply(rule));
+            checkers.add(alarmCheckerFactory.create(rule));
         }
-
         return checkers;
     }
 
-    @Nullable
-    private List<String> prepareActiveAgentIds(Application application, List<Rule> rules, long now) {
-        Range activeRange = Range.between(now - activeDuration, now);
-        List<String> agentIds = null;
-        if (isRequireAgentList(rules)) {
-            agentIds = fetchActiveAgents(application.getName(), activeRange);
-        }
-        return agentIds;
-    }
-
-    private static boolean isRequireAgentList(List<Rule> rules) {
-        return rules.stream()
-                .anyMatch(rule ->
-                        CheckerCategory.getValue(rule.getCheckerName())
-                            .getDataCollectorCategory()
-                            .isRequireAgentList()
-                );
+    private Supplier<List<String>> getAgentIdsSupplier(Application application, long now) {
+        Range range = Range.between(now - activeDuration, now);
+        return Suppliers.memoize(() -> fetchActiveAgents(application.getName(), range));
     }
 
     private List<String> fetchActiveAgents(String applicationId, Range activeRange) {
         return applicationIndexDao.selectAgentIds(applicationId)
                 .stream()
                 .filter(id -> agentInfoService.isActiveAgent(id, activeRange))
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 
-    private static class RuleTransformer implements Function<Rule, AlarmChecker<?>> {
+    private static class AlarmCheckerFactory {
 
         private final long timeSlotEndTime;
         private final Map<DataCollectorCategory, DataCollector> collectorMap = new HashMap<>();
 
         private final Application application;
-        private final List<String> agentIds;
+        private final Supplier<List<String>> agentIds;
         private final DataCollectorFactory dataCollectorFactory;
         private final CheckerRegistry checkerRegistry;
 
-        public RuleTransformer(
+        public AlarmCheckerFactory(
                 Application application,
-                List<String> agentIds,
+                Supplier<List<String>> agentIds,
                 long timeSlotEndTime,
                 DataCollectorFactory dataCollectorFactory,
                 CheckerRegistry checkerRegistry) {
@@ -148,8 +135,7 @@ public class AlarmProcessor implements ItemProcessor<Application, AppAlarmChecke
             this.checkerRegistry = Objects.requireNonNull(checkerRegistry, "checkerRegistry");
         }
 
-        @Override
-        public AlarmChecker<?> apply(Rule rule) {
+        public AlarmChecker<?> create(Rule rule) {
             CheckerCategory checkerCategory = CheckerCategory.getValue(rule.getCheckerName());
 
             DataCollector collector = collectorMap.computeIfAbsent(

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/DataCollectorFactory.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/DataCollectorFactory.java
@@ -38,6 +38,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * @author minwoo.jung
@@ -79,24 +80,21 @@ public class DataCollectorFactory {
         this.mapStatisticsCallerDao = Objects.requireNonNull(mapStatisticsCallerDao, "mapStatisticsCallerDao");
     }
 
-    public DataCollector createDataCollector(CheckerCategory checker, Application application, List<String> agentIds, long timeSlotEndTime) {
+    public DataCollector createDataCollector(CheckerCategory checker, Application application, Supplier<List<String>> agentIds, long timeSlotEndTime) {
         return switch (checker.getDataCollectorCategory()) {
             case RESPONSE_TIME ->
                     new ResponseTimeDataCollector(DataCollectorCategory.RESPONSE_TIME, application, hbaseMapResponseTimeDao, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
             case AGENT_STAT ->
-                    new AgentStatDataCollector(DataCollectorCategory.AGENT_STAT, jvmGcDao, cpuLoadDao, agentIds, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
+                    new AgentStatDataCollector(DataCollectorCategory.AGENT_STAT, jvmGcDao, cpuLoadDao, agentIds.get(), timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
             case AGENT_EVENT ->
-                    new AgentEventDataCollector(DataCollectorCategory.AGENT_EVENT, agentEventDao, agentIds, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
+                    new AgentEventDataCollector(DataCollectorCategory.AGENT_EVENT, agentEventDao, agentIds.get(), timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
             case CALLER_STAT ->
                     new MapStatisticsCallerDataCollector(DataCollectorCategory.CALLER_STAT, application, mapStatisticsCallerDao, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
             case DATA_SOURCE_STAT ->
-                    new DataSourceDataCollector(DataCollectorCategory.DATA_SOURCE_STAT, dataSourceDao, agentIds, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
+                    new DataSourceDataCollector(DataCollectorCategory.DATA_SOURCE_STAT, dataSourceDao, agentIds.get(), timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
             case FILE_DESCRIPTOR ->
-                    new FileDescriptorDataCollector(DataCollectorCategory.FILE_DESCRIPTOR, fileDescriptorDao, agentIds, timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
-            default ->
-                    throw new IllegalArgumentException("unable to create DataCollector : " + checker.getName());
+                    new FileDescriptorDataCollector(DataCollectorCategory.FILE_DESCRIPTOR, fileDescriptorDao, agentIds.get(), timeSlotEndTime, SLOT_INTERVAL_FIVE_MIN);
         };
-
 
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/DataCollectorCategory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/DataCollectorCategory.java
@@ -1,42 +1,10 @@
 package com.navercorp.pinpoint.web.alarm;
 
 public enum DataCollectorCategory {
-    RESPONSE_TIME {
-        @Override
-        public boolean isRequireAgentList() {
-            return false;
-        }
-    },
-    AGENT_STAT {
-        @Override
-        public boolean isRequireAgentList() {
-            return true;
-        }
-    },
-    AGENT_EVENT {
-        @Override
-        public boolean isRequireAgentList() {
-            return true;
-        }
-    },
-    DATA_SOURCE_STAT {
-        @Override
-        public boolean isRequireAgentList() {
-            return true;
-        }
-    },
-    CALLER_STAT {
-        @Override
-        public boolean isRequireAgentList() {
-            return false;
-        }
-    },
-    FILE_DESCRIPTOR {
-        @Override
-        public boolean isRequireAgentList() {
-            return true;
-        }
-    };
-
-    public abstract boolean isRequireAgentList();
+    RESPONSE_TIME,
+    AGENT_STAT,
+    AGENT_EVENT,
+    DATA_SOURCE_STAT,
+    CALLER_STAT,
+    FILE_DESCRIPTOR,
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AlarmServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AlarmServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -66,7 +67,14 @@ public class AlarmServiceImpl implements AlarmService {
     @Override
     @Transactional(readOnly = true)
     public List<Rule> selectRuleByApplicationId(String applicationId) {
-        return alarmDao.selectRuleByApplicationId(applicationId);
+        List<Rule> rules = alarmDao.selectRuleByApplicationId(applicationId);
+        List<Rule> result = new ArrayList<>(rules.size());
+        for (Rule rule : rules) {
+            if (rule.getApplicationId().equals(applicationId)) {
+                result.add(rule);
+            }
+        }
+        return result;
     }
 
     @Override


### PR DESCRIPTION
`AlarmServiceImpl::selectRuleByApplicationId` may not have results to have all exactly same applicationId because mysql database can be case in-sensitive, so I added second filter that checks whether the rule have the intended applicationId.

Some of alarm checkers need the list of agentId of the target application, but the others don't. This characteristic was distinguished by special boolean flag, but now the agentId is provided as memoized supplier, so they are simply able to avoid the situation of loading useless agentIds