### PR TITLE
[#NotAssigned] Removed getRawStatusCode() method for removal in Spring Webflux 6.1

### DIFF
--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/ClientHttpResponseInterceptor.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/ClientHttpResponseInterceptor.java
@@ -53,7 +53,7 @@ public class ClientHttpResponseInterceptor extends SpanEventSimpleAroundIntercep
 
         if (target instanceof ClientHttpResponse) {
             ClientHttpResponse clientHttpResponse = (ClientHttpResponse) target;
-            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, clientHttpResponse.getRawStatusCode());
+            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, clientHttpResponse.getStatusCode().value());
             this.responseHeaderRecorder.recordHeader(recorder, clientHttpResponse);
         }
     }

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/HttpRequestInterceptor.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/HttpRequestInterceptor.java
@@ -48,7 +48,7 @@ public class HttpRequestInterceptor extends SpanEventSimpleAroundInterceptorForP
 
         if (result instanceof ClientHttpResponse) {
             ClientHttpResponse clientHttpResponse = (ClientHttpResponse) result;
-            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, clientHttpResponse.getRawStatusCode());
+            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, clientHttpResponse.getStatusCode().value());
         }
     }
 

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/ClientResponseFunctionInterceptor.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/ClientResponseFunctionInterceptor.java
@@ -52,7 +52,7 @@ public class ClientResponseFunctionInterceptor extends SpanEventSimpleAroundInte
 
         if (args[0] instanceof ClientHttpResponse) {
             ClientHttpResponse response = (ClientHttpResponse) args[0];
-            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, response.getRawStatusCode());
+            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, response.getStatusCode().value());
             this.responseHeaderRecorder.recordHeader(recorder, response);
         }
     }


### PR DESCRIPTION
## description
method `org.springframework.http.client.reactive.ClientHttpResponse.getRawStatusCode()`  was removed in Spring Webflux 6.1. (see: https://github.com/spring-projects/spring-framework/commit/7df2e2a8d2a845984cde806232181da486dcf7bd)

In addition, `org.springframework.http.client.ClientHttpResponse.getRawStatusCode()` will be removed in Spring MVC 6.2.

Instead of using `getRawStatusCode()`, replace it with `getHttpStatusCode().value()`.
