### PR TITLE
[#noissue] MySQL-tolerant alarm

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmReader.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmReader.java
@@ -19,27 +19,34 @@ package com.navercorp.pinpoint.batch.alarm;
 import com.navercorp.pinpoint.web.dao.ApplicationIndexDao;
 import com.navercorp.pinpoint.web.service.AlarmService;
 import com.navercorp.pinpoint.web.vo.Application;
-import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
-import org.springframework.batch.item.ItemReader;
-
 import jakarta.annotation.Nonnull;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamReader;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author minwoo.jung
  */
-public class AlarmReader implements ItemReader<Application>, StepExecutionListener {
+public class AlarmReader implements ItemStreamReader<Application> {
+
+    private static final Logger logger = LogManager.getLogger(AlarmReader.class);
+    private static final String CURRENT_INDEX = "current.index";
 
     private final ApplicationIndexDao applicationIndexDao;
     private final AlarmService alarmService;
 
-    private Queue<Application> applicationQueue;
+    private final AtomicReference<List<Application>> lastApplicationsRef = new AtomicReference<>();
+    private final AtomicInteger currentIndexAtom = new AtomicInteger(0);
+
+    private List<Application> applications;
 
     public AlarmReader(ApplicationIndexDao applicationIndexDao, AlarmService alarmService) {
         this.applicationIndexDao = Objects.requireNonNull(applicationIndexDao, "applicationIndexDao");
@@ -47,12 +54,54 @@ public class AlarmReader implements ItemReader<Application>, StepExecutionListen
     }
     
     public Application read() {
-        return applicationQueue.poll();
+        int currentIndex = currentIndexAtom.getAndIncrement();
+        if (currentIndex < applications.size()) {
+            logger.info("Reading application: {} / {}", currentIndex, applications.size());
+            return applications.get(currentIndex);
+        } else {
+            return null;
+        }
     }
 
     @Override
-    public void beforeStep(@Nonnull StepExecution stepExecution) {
-        this.applicationQueue = new ConcurrentLinkedQueue<>(fetchApplications());
+    public void open(@Nonnull ExecutionContext executionContext) throws ItemStreamException {
+        logger.info("Opened alarm reader");
+        this.applications = getApplications();
+        logger.info("Alarm reader has {} applications", applications.size());
+        if (executionContext.containsKey(CURRENT_INDEX)) {
+            int loadedIndex = executionContext.getInt(CURRENT_INDEX);
+            this.currentIndexAtom.set(loadedIndex);
+            logger.info("Alarm reader starts from index {}", loadedIndex);
+        } else {
+            this.currentIndexAtom.set(0);
+            logger.info("Alarm reader starts from beginning");
+        }
+    }
+
+    @Override
+    public void update(@Nonnull ExecutionContext executionContext) throws ItemStreamException {
+        executionContext.putInt(CURRENT_INDEX, this.currentIndexAtom.get());
+    }
+
+    @Override
+    public void close() throws ItemStreamException {
+        logger.info("Closing alarm reader");
+    }
+
+    private List<Application> getApplications() {
+        try {
+            List<Application> applications = fetchApplications();
+            lastApplicationsRef.set(applications);
+            return applications;
+        } catch (Exception e) {
+            logger.error("Error occurred while fetching applications.", e);
+            logger.info("Fallback to last application list.");
+            List<Application> lastApplications = lastApplicationsRef.get();
+            if (lastApplications == null) {
+                throw new IllegalStateException("Failed to fetch applications and there is no last application list.");
+            }
+            return lastApplications;
+        }
     }
 
     private List<Application> fetchApplications() {
@@ -68,8 +117,4 @@ public class AlarmReader implements ItemReader<Application>, StepExecutionListen
         return validApplications;
     }
 
-    @Override
-    public ExitStatus afterStep(@Nonnull StepExecution stepExecution) {
-        return null;
-    }
 }

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/service/AlarmServiceImpl.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/service/AlarmServiceImpl.java
@@ -64,7 +64,13 @@ public class AlarmServiceImpl implements AlarmService {
             beforeCheckerResult.increseCount();
             alarmDao.insertCheckerResult(beforeCheckerResult);
         } else {
-            alarmDao.insertCheckerResult(new CheckerResult(checker.getRule().getRuleId(), checker.getRule().getApplicationId(), checker.getRule().getCheckerName(), false, 0, 1));
+            CheckerResult checkerResult = new CheckerResult(
+                    checker.getRule().getRuleId(),
+                    checker.getRule().getApplicationId(),
+                    checker.getRule().getCheckerName(),
+                    false, 0, 1
+            );
+            alarmDao.insertCheckerResult(checkerResult);
         }
         
          

--- a/batch/src/main/resources/job/applicationContext-alarmJob.xml
+++ b/batch/src/main/resources/job/applicationContext-alarmJob.xml
@@ -21,7 +21,7 @@
 
     <batch:step id="alarmStep">
         <batch:tasklet task-executor="alarmExecutor" throttle-limit="${alarm.worker.maxSize:2}">
-            <batch:chunk reader="reader" processor="processor" writer="writer" commit-interval="1"/>
+            <batch:chunk reader="alarmReader" processor="alarmProcessor" writer="alarmWriter" commit-interval="1"/>
         </batch:tasklet>
     </batch:step>
 
@@ -33,9 +33,9 @@
     </bean>
 
     <bean id="alarmPartitioner" class="com.navercorp.pinpoint.batch.alarm.AlarmPartitioner"/>
-    <bean id="reader" class="com.navercorp.pinpoint.batch.alarm.AlarmReader" scope="step"/>
-    <bean id="processor" class="com.navercorp.pinpoint.batch.alarm.AlarmProcessor" scope="step"/>
-    <bean id="writer" class="com.navercorp.pinpoint.batch.alarm.AlarmWriter" scope="step"/>
+    <bean id="alarmReader" class="com.navercorp.pinpoint.batch.alarm.AlarmReader" />
+    <bean id="alarmProcessor" class="com.navercorp.pinpoint.batch.alarm.AlarmProcessor" />
+    <bean id="alarmWriter" class="com.navercorp.pinpoint.batch.alarm.AlarmWriter" />
 
     <task:executor id="alarmPoolTaskExecutorForPartition" pool-size="1"/>
 


### PR DESCRIPTION
Alarm batch job proceeds its work regardless the responsiveness of MySQL.

When MySQL does not respond in time, it utilizes the previous records(or cache).

The alarm in normal situation, does not send alarm serially but send only one time at the very first time it detects the situation that meets the condition. This behavior is achieved by persisting records of sending alarm in MySQL, but this can be not done when the MySQL does not work.