### PR TITLE
Revert "[#NotAssigned] Removed getRawStatusCode() method for removal …

### DIFF
--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/ClientHttpResponseInterceptor.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/ClientHttpResponseInterceptor.java
@@ -53,7 +53,7 @@ public class ClientHttpResponseInterceptor extends SpanEventSimpleAroundIntercep
 
         if (target instanceof ClientHttpResponse) {
             ClientHttpResponse clientHttpResponse = (ClientHttpResponse) target;
-            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, clientHttpResponse.getStatusCode().value());
+            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, clientHttpResponse.getRawStatusCode());
             this.responseHeaderRecorder.recordHeader(recorder, clientHttpResponse);
         }
     }

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/HttpRequestInterceptor.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/HttpRequestInterceptor.java
@@ -48,7 +48,7 @@ public class HttpRequestInterceptor extends SpanEventSimpleAroundInterceptorForP
 
         if (result instanceof ClientHttpResponse) {
             ClientHttpResponse clientHttpResponse = (ClientHttpResponse) result;
-            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, clientHttpResponse.getStatusCode().value());
+            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, clientHttpResponse.getRawStatusCode());
         }
     }
 

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/ClientResponseFunctionInterceptor.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/ClientResponseFunctionInterceptor.java
@@ -52,7 +52,7 @@ public class ClientResponseFunctionInterceptor extends SpanEventSimpleAroundInte
 
         if (args[0] instanceof ClientHttpResponse) {
             ClientHttpResponse response = (ClientHttpResponse) args[0];
-            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, response.getStatusCode().value());
+            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, response.getRawStatusCode());
             this.responseHeaderRecorder.recordHeader(recorder, response);
         }
     }


### PR DESCRIPTION
…in Spring Webflux 6.1"

This reverts commit cd938961f533257eeea16c68138a9026f2b21dca.

Revert first.
This is an applicable commit until support for Spring 6.0 and Boot 3.0 is added.