### PR TITLE
[#noissue] Cleanup redundant springboot.bootstrap.main

### DIFF
--- a/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent/src/main/resources/profiles/local/pinpoint.config
@@ -578,7 +578,7 @@ profiler.undertow.excludeurl=
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # Reactor Netty

--- a/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent/src/main/resources/profiles/release/pinpoint.config
@@ -576,7 +576,7 @@ profiler.undertow.excludeurl=
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # Reactor Netty

--- a/plugins-it/activemq-it/activemq-5-15-it/src/test/resources/activemq/client/pinpoint-activemq-client.config
+++ b/plugins-it/activemq-it/activemq-5-15-it/src/test/resources/activemq/client/pinpoint-activemq-client.config
@@ -156,7 +156,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins-it/activemq-it/activemq-5-17-it/src/test/resources/activemq/client/pinpoint-activemq-client.config
+++ b/plugins-it/activemq-it/activemq-5-17-it/src/test/resources/activemq/client/pinpoint-activemq-client.config
@@ -156,7 +156,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins-it/cxf-it/cxf-3-0-it/src/test/resources/cxf/pinpoint-cxf-test.config
+++ b/plugins-it/cxf-it/cxf-3-0-it/src/test/resources/cxf/pinpoint-cxf-test.config
@@ -366,7 +366,7 @@ profiler.undertow.excludeurl=
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JSP                                                     #

--- a/plugins-it/cxf-it/cxf-3-6-it/src/test/resources/cxf/pinpoint-cxf-test.config
+++ b/plugins-it/cxf-it/cxf-3-6-it/src/test/resources/cxf/pinpoint-cxf-test.config
@@ -366,7 +366,7 @@ profiler.undertow.excludeurl=
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JSP                                                     #

--- a/plugins-it/druid-it/src/test/resources/druid/pinpoint-druid-test.config
+++ b/plugins-it/druid-it/src/test/resources/druid/pinpoint-druid-test.config
@@ -366,7 +366,7 @@ profiler.undertow.excludeurl=
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JSP                                                     #

--- a/plugins-it/fastjson-it/src/test/resources/fastjson/pinpoint-fastjson-test.config
+++ b/plugins-it/fastjson-it/src/test/resources/fastjson/pinpoint-fastjson-test.config
@@ -366,7 +366,7 @@ profiler.undertow.excludeurl=
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JSP                                                     #

--- a/plugins-it/google-grpc-it/google-grpc-1-42-it/src/test/resources/pinpoint-grpc-plugin-test.config
+++ b/plugins-it/google-grpc-it/google-grpc-1-42-it/src/test/resources/pinpoint-grpc-plugin-test.config
@@ -140,7 +140,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JDBC                                                    #

--- a/plugins-it/google-grpc-it/google-grpc-1-8-it/src/test/resources/pinpoint-grpc-plugin-test.config
+++ b/plugins-it/google-grpc-it/google-grpc-1-8-it/src/test/resources/pinpoint-grpc-plugin-test.config
@@ -140,7 +140,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JDBC                                                    #

--- a/plugins-it/hbase-it/src/test/resources/hbase/pinpoint-hbase-test.config
+++ b/plugins-it/hbase-it/src/test/resources/hbase/pinpoint-hbase-test.config
@@ -366,7 +366,7 @@ profiler.undertow.excludeurl=
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JSP                                                     #

--- a/plugins-it/hystrix-it/src/test/resources/hystrix/pinpoint-hystrix.config
+++ b/plugins-it/hystrix-it/src/test/resources/hystrix/pinpoint-hystrix.config
@@ -239,7 +239,7 @@ profiler.vertx.http.client.entity.statuscode=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JSP                                                     #

--- a/plugins-it/jtds-it/src/test/resources/pinpoint.config
+++ b/plugins-it/jtds-it/src/test/resources/pinpoint.config
@@ -144,7 +144,7 @@ profiler.bloc.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JDBC                                                    # 

--- a/plugins-it/lambda-it/src/test/resources/pinpoint-lambda-test.config
+++ b/plugins-it/lambda-it/src/test/resources/pinpoint-lambda-test.config
@@ -122,7 +122,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins-it/log4j-it/src/test/resources/pinpoint-spring-bean-test.config
+++ b/plugins-it/log4j-it/src/test/resources/pinpoint-spring-bean-test.config
@@ -126,7 +126,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JDBC                                                    #

--- a/plugins-it/log4j2-it/src/test/resources/pinpoint-spring-bean-test.config
+++ b/plugins-it/log4j2-it/src/test/resources/pinpoint-spring-bean-test.config
@@ -125,7 +125,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JDBC                                                    #

--- a/plugins-it/logback-it/src/test/resources/pinpoint-spring-bean-test.config
+++ b/plugins-it/logback-it/src/test/resources/pinpoint-spring-bean-test.config
@@ -125,7 +125,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JDBC                                                    #

--- a/plugins-it/netty-it/src/test/resources/pinpoint-netty-plugin-test.config
+++ b/plugins-it/netty-it/src/test/resources/pinpoint-netty-plugin-test.config
@@ -126,7 +126,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JDBC                                                    # 

--- a/plugins-it/process-it/src/test/resources/pinpoint-process-test.config
+++ b/plugins-it/process-it/src/test/resources/pinpoint-process-test.config
@@ -127,7 +127,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JDBC                                                    #

--- a/plugins-it/rxjava-it/src/test/resources/rxjava/pinpoint-rxjava.config
+++ b/plugins-it/rxjava-it/src/test/resources/rxjava/pinpoint-rxjava.config
@@ -239,7 +239,7 @@ profiler.vertx.http.client.entity.statuscode=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JSP                                                     #

--- a/plugins/akka-http/src/test/resources/pinpoint.config
+++ b/plugins/akka-http/src/test/resources/pinpoint.config
@@ -254,7 +254,7 @@ profiler.vertx.http.client.entity.statuscode=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JSP                                                     #

--- a/plugins/google-httpclient/src/test/resources/pinpoint.config
+++ b/plugins/google-httpclient/src/test/resources/pinpoint.config
@@ -116,7 +116,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins/httpclient3/src/test/resources/pinpoint.config
+++ b/plugins/httpclient3/src/test/resources/pinpoint.config
@@ -120,7 +120,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins/httpclient4/src/test/resources/pinpoint.config
+++ b/plugins/httpclient4/src/test/resources/pinpoint.config
@@ -120,7 +120,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins/jboss/src/test/resources/pinpoint.config
+++ b/plugins/jboss/src/test/resources/pinpoint.config
@@ -119,7 +119,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins/jsp/src/test/resources/pinpoint.config
+++ b/plugins/jsp/src/test/resources/pinpoint.config
@@ -119,7 +119,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins/redis/src/test/resources/pinpoint.config
+++ b/plugins/redis/src/test/resources/pinpoint.config
@@ -120,7 +120,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins/spring-boot/README.md
+++ b/plugins/spring-boot/README.md
@@ -10,7 +10,7 @@ pinpoint.config
 ~~~
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 ~~~
 
 ### Include the Java agent with a Spring Boot

--- a/plugins/tomcat/src/test/resources/pinpoint.config
+++ b/plugins/tomcat/src/test/resources/pinpoint.config
@@ -119,7 +119,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins/user/src/test/resources/pinpoint.config
+++ b/plugins/user/src/test/resources/pinpoint.config
@@ -120,7 +120,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/plugins/weblogic/src/test/resources/pinpoint.config
+++ b/plugins/weblogic/src/test/resources/pinpoint.config
@@ -168,7 +168,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 
 ###########################################################

--- a/profiler/src/test/resources/pinpoint.config
+++ b/profiler/src/test/resources/pinpoint.config
@@ -180,7 +180,7 @@ profiler.jboss.tracerequestparam=true
 ###########################################################
 profiler.springboot.enable=true
 # Classes for detecting application server type. Comma separated list of fully qualified class names. Wildcard not supported.
-profiler.springboot.bootstrap.main=org.springframework.boot.loader.launch.JarLauncher, org.springframework.boot.loader.launch.WarLauncher, org.springframework.boot.loader.launch.PropertiesLauncher, org.springframework.boot.loader.JarLauncher, org.springframework.boot.loader.WarLauncher, org.springframework.boot.loader.PropertiesLauncher
+profiler.springboot.bootstrap.main=
 
 ###########################################################
 # JDBC                                                    # 


### PR DESCRIPTION
remove redundant 'springboot.bootstrap.main' value from configuration file.
default value is handled in SpringBootDetector