### PR TITLE
[#noissue] Handle PinotResultSet implicitly convert "null" to null

### DIFF
--- a/exceptiontrace/exceptiontrace-common/src/main/java/com/navercorp/pinpoint/exceptiontrace/common/model/ExceptionMetaData.java
+++ b/exceptiontrace/exceptiontrace-common/src/main/java/com/navercorp/pinpoint/exceptiontrace/common/model/ExceptionMetaData.java
@@ -17,10 +17,12 @@
 package com.navercorp.pinpoint.exceptiontrace.common.model;
 
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
+import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.exceptiontrace.common.util.HashUtils;
 
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author intr3p1d
@@ -77,7 +79,7 @@ public class ExceptionMetaData {
         this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
         this.uriTemplate = uriTemplate;
         this.errorClassName = StringPrecondition.requireHasLength(errorClassName, "errorClassName");
-        this.errorMessage = StringPrecondition.requireHasLength(errorMessage, "errorMessage");
+        this.errorMessage = StringUtils.defaultString(errorMessage, "null");
         this.exceptionDepth = exceptionDepth;
         this.stackTrace = stackTrace;
         this.stackTraceHash = stackTraceHash;

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/dao/PinotExceptionTraceDao.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/dao/PinotExceptionTraceDao.java
@@ -88,15 +88,21 @@ public class PinotExceptionTraceDao implements ExceptionTraceDao {
     public List<ExceptionTraceSummary> getSummaries(ExceptionTraceQueryParameter exceptionTraceQueryParameter) {
         List<ExceptionTraceSummaryEntity> entities = this.sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_SUMMARIES_QUERY, exceptionTraceQueryParameter);
         return entities.stream()
-                .map(mapper::entityToExceptionTraceSummary)
-                .collect(Collectors.toList());
+                .map((ExceptionTraceSummaryEntity e) ->
+                        mapper.toSummary(
+                                e, exceptionTraceQueryParameter.getGroupByAttributes()
+                        )
+                ).collect(Collectors.toList());
     }
 
     @Override
     public List<ExceptionTraceValueView> getValueViews(ExceptionTraceQueryParameter exceptionTraceQueryParameter) {
         List<ExceptionTraceValueViewEntity> valueViewEntities = this.sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_VALUEVIEWS_QUERY, exceptionTraceQueryParameter);
         return valueViewEntities.stream()
-                .map(mapper::entityToExceptionTraceValueView)
-                .collect(Collectors.toList());
+                .map((ExceptionTraceValueViewEntity e) ->
+                        mapper.toValueView(
+                                e, exceptionTraceQueryParameter.getGroupByAttributes()
+                        )
+                ).collect(Collectors.toList());
     }
 }

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/model/ExceptionTraceSummary.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/model/ExceptionTraceSummary.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author intr3p1d
  */
-public class ExceptionTraceSummary {
+public class ExceptionTraceSummary implements Grouped {
 
     private GroupedFieldName groupedFieldName;
     private String mostRecentErrorClass;

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/model/ExceptionTraceValueView.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/model/ExceptionTraceValueView.java
@@ -25,10 +25,10 @@ import java.util.List;
 /**
  * @author intr3p1d
  */
-public class ExceptionTraceValueView implements TimeSeriesValueView {
+public class ExceptionTraceValueView implements TimeSeriesValueView, Grouped {
 
-    private static final String TOTAL_FIELDNAME = "total";
-    private static final String EMPTY_STRING = "";
+    public static final String TOTAL_FIELDNAME = "total";
+    public static final String EMPTY_STRING = "(empty error message)";
     private GroupedFieldName groupedFieldName;
     private List<Integer> values;
 
@@ -44,7 +44,10 @@ public class ExceptionTraceValueView implements TimeSeriesValueView {
         if (groupedFieldName == null) {
             return TOTAL_FIELDNAME;
         }
-        return StringUtils.defaultString(groupedFieldName.inAString(), TOTAL_FIELDNAME);
+        return StringUtils.defaultIfEmpty(
+                StringUtils.defaultString(groupedFieldName.inAString(), TOTAL_FIELDNAME),
+                EMPTY_STRING
+        );
     }
 
     @JsonIgnore

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/model/Grouped.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/model/Grouped.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.exceptiontrace.web.model;
+
+/**
+ * @author intr3p1d
+ */
+public interface Grouped {
+    GroupedFieldName getGroupedFieldName();
+    void setGroupedFieldName(GroupedFieldName groupedFieldName);
+}

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/ExceptionTraceQueryParameter.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/ExceptionTraceQueryParameter.java
@@ -70,6 +70,10 @@ public class ExceptionTraceQueryParameter extends QueryParameter {
         this.timeWindowRangeCount = builder.timeWindowRangeCount;
     }
 
+    public List<GroupByAttributes> getGroupByAttributes() {
+        return groupByAttributes;
+    }
+
     public static class Builder extends QueryParameter.Builder<Builder> {
 
         private static final int MAX_LIMIT = 65536;

--- a/exceptiontrace/exceptiontrace-web/src/test/java/com/navercorp/pinpoint/exceptiontrace/web/mapper/ExceptionMetaDataEntityMapperTest.java
+++ b/exceptiontrace/exceptiontrace-web/src/test/java/com/navercorp/pinpoint/exceptiontrace/web/mapper/ExceptionMetaDataEntityMapperTest.java
@@ -10,6 +10,7 @@ import com.navercorp.pinpoint.exceptiontrace.web.entity.ExceptionTraceValueViewE
 import com.navercorp.pinpoint.exceptiontrace.web.entity.GroupedFieldNameEntity;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceSummary;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionTraceValueView;
+import com.navercorp.pinpoint.exceptiontrace.web.util.GroupByAttributes;
 import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionMetaDataView;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -180,7 +181,9 @@ class ExceptionMetaDataEntityMapperTest {
     public void testEntityToValueView() {
         ExceptionTraceValueViewEntity expected = newExceptionMetaDataEntity();
 
-        ExceptionTraceValueView actual = mapper.entityToExceptionTraceValueView(expected);
+        ExceptionTraceValueView actual = mapper.toValueView(
+                expected, List.of(GroupByAttributes.values())
+        );
 
         assertEquals(expected.getUriTemplate(), actual.getGroupedFieldName().getUriTemplate());
         assertEquals(expected.getErrorClassName(), actual.getGroupedFieldName().getErrorClassName());
@@ -208,7 +211,9 @@ class ExceptionMetaDataEntityMapperTest {
     public void testEntityToSummary() {
         ExceptionTraceSummaryEntity expected = newExceptionTraceSummaryEntity();
 
-        ExceptionTraceSummary actual = mapper.entityToExceptionTraceSummary(expected);
+        ExceptionTraceSummary actual = mapper.toSummary(
+                expected, List.of(GroupByAttributes.values())
+        );
 
         assertEquals(expected.getMostRecentErrorClass(), actual.getMostRecentErrorClass());
         assertEquals(expected.getMostRecentErrorMessage(), actual.getMostRecentErrorMessage());
@@ -239,14 +244,14 @@ class ExceptionMetaDataEntityMapperTest {
     }
 
     @Test
-    public void testSelectErrorMessage(){
+    public void testSelectErrorMessage() {
         GroupedFieldNameEntity entity = new GroupedFieldNameEntity();
         entity.setErrorMessage_logtype("getAgentsList.from: \u0011 ì\u009D´ì\u0083\u0081ì\u009D´ì\u0096´ì\u0095¼ í\u0095©ë\u008B\u0088ë\u008B¤");
 
         String result = mapper.selectErrorMessage(entity);
         assertEquals(
-                "getAgentsList.from: "+ CLPMapper.DICTIONARY_REPLACEMENT +" 이상이어야 합니다"
-                ,result
+                "getAgentsList.from: " + CLPMapper.DICTIONARY_REPLACEMENT + " 이상이어야 합니다"
+                , result
         );
     }
 }

--- a/exceptiontrace/exceptiontrace-web/src/test/java/com/navercorp/pinpoint/exceptiontrace/web/model/ExceptionTraceValueViewTest.java
+++ b/exceptiontrace/exceptiontrace-web/src/test/java/com/navercorp/pinpoint/exceptiontrace/web/model/ExceptionTraceValueViewTest.java
@@ -17,17 +17,22 @@ class ExceptionTraceValueViewTest {
         emptyFieldName.setErrorMessage("");
         view.setGroupedFieldName(emptyFieldName);
 
-        assertEquals("", view.getFieldName());
+        assertEquals(ExceptionTraceValueView.EMPTY_STRING, view.getFieldName());
 
+        GroupedFieldName nullStringFieldName = new GroupedFieldName();
+        emptyFieldName.setErrorMessage("null");
+        view.setGroupedFieldName(emptyFieldName);
+
+        assertEquals(ExceptionTraceValueView.EMPTY_STRING, view.getFieldName());
 
         GroupedFieldName nullFieldName = new GroupedFieldName();
         view.setGroupedFieldName(nullFieldName);
 
-        assertEquals("total", view.getFieldName());
+        assertEquals(ExceptionTraceValueView.TOTAL_FIELDNAME, view.getFieldName());
 
 
         view.setGroupedFieldName(null);
 
-        assertEquals("total", view.getFieldName());
+        assertEquals(ExceptionTraceValueView.TOTAL_FIELDNAME, view.getFieldName());
     }
 }


### PR DESCRIPTION
```java
public class PinotResultSet extends AbstractBaseResultSet {
    public static final String NULL_STRING = "null";
...
  @Override
  public String getString(int columnIndex)
      throws SQLException {
    validateColumn(columnIndex);

    String val = _resultSet.getString(_currentRow, columnIndex - 1);
    if (checkIsNull(val)) {
      return null;
    }

    return val;
  }

  private boolean checkIsNull(String val) {
    if (val == null || val.toLowerCase().contentEquals(NULL_STRING)) {
      _wasNull = true;
      return true;
    }
    return false;
  }
...
```