### PR TITLE
[#10832] Backport: Support `getStatusCode()` for compatibility with S…

### DIFF
--- a/plugins/assembly/pom.xml
+++ b/plugins/assembly/pom.xml
@@ -417,5 +417,10 @@
             <artifactId>pinpoint-spring-tx-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.navercorp.pinpoint</groupId>-->
+<!--            <artifactId>pinpoint-spring-stub</artifactId>-->
+<!--            <version>${project.version}</version>-->
+<!--        </dependency>-->
     </dependencies>
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -112,6 +112,7 @@
         <module>agentsdk-async</module>
         <module>spring-data-r2dbc</module>
         <module>spring-tx</module>
+        <module>spring-stub</module>
     </modules>
 
 

--- a/plugins/resttemplate/pom.xml
+++ b/plugins/resttemplate/pom.xml
@@ -22,6 +22,12 @@
             <artifactId>pinpoint-bootstrap-core</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-spring-stub</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
@@ -29,5 +35,19 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-	
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>com/navercorp/**/*</include>
+                        <include>META-INF/**/*</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/RestTemplatePlugin.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/RestTemplatePlugin.java
@@ -117,8 +117,10 @@ public class RestTemplatePlugin implements ProfilerPlugin, TransformTemplateAwar
         public byte[] doInTransform(Instrumentor instrumentor, ClassLoader classLoader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
             final InstrumentClass target = instrumentor.getInstrumentClass(classLoader, className, classfileBuffer);
             InstrumentMethod executeMethod = InstrumentUtils.findMethod(target, "execute");
+
+            final int springVersion = SpringVersion.getVersion(classLoader);
             if (executeMethod != null) {
-                executeMethod.addScopedInterceptor(HttpRequestInterceptor.class, RestTemplateConstants.SCOPE, ExecutionPolicy.BOUNDARY);
+                executeMethod.addScopedInterceptor(HttpRequestInterceptor.class, va(springVersion), RestTemplateConstants.SCOPE, ExecutionPolicy.BOUNDARY);
             }
 
             return target.toBytecode();
@@ -167,8 +169,9 @@ public class RestTemplatePlugin implements ProfilerPlugin, TransformTemplateAwar
 
             final List<InstrumentMethod> constructors = target.getDeclaredConstructors();
             if (constructors != null && constructors.size() == 1) { //only intercept one-constructor response, no overloading
+                final int springVersion = SpringVersion.getVersion(classLoader);
                 for (InstrumentMethod constructor : constructors) {
-                    constructor.addScopedInterceptor(ClientHttpResponseInterceptor.class, "HttpResponse", ExecutionPolicy.BOUNDARY);
+                    constructor.addScopedInterceptor(ClientHttpResponseInterceptor.class, va(springVersion), "HttpResponse", ExecutionPolicy.BOUNDARY);
                 }
             }
 

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/SpringVersion.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/SpringVersion.java
@@ -1,0 +1,56 @@
+package com.navercorp.pinpoint.plugin.resttemplate;/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Objects;
+
+/**
+ * @author intr3p1d
+ */
+public class SpringVersion {
+
+    public static final int SPRING_VERSION_UNKNOWN = -1;
+    public static final int SPRING_VERSION_5 = 5_00_00;
+    public static final int SPRING_VERSION_6 = 6_00_00;
+
+    static final String SPRING5_HTTP_STATUS_INTERFACE_NAME = "org.springframework.http.HttpStatus";
+    static final String SPRING6_HTTP_STATUS_INTERFACE_NAME = "org.springframework.http.HttpStatusCode";
+
+
+    public static int getVersion(ClassLoader classLoader) {
+        // Spring 6.0 + (boot 3.0 + )
+        final Class<?> httpStatusCode = getClass(classLoader, SPRING6_HTTP_STATUS_INTERFACE_NAME);
+        if (httpStatusCode != null) {
+            return SpringVersion.SPRING_VERSION_6;
+        }
+
+        // ~ Spring 5.x (boot 2.0 -)
+        final Class<?> httpStatus = getClass(classLoader, SPRING5_HTTP_STATUS_INTERFACE_NAME);
+        if (httpStatus != null) {
+            return SpringVersion.SPRING_VERSION_5;
+        }
+        return SpringVersion.SPRING_VERSION_UNKNOWN;
+    }
+
+
+    static Class<?> getClass(ClassLoader classLoader, String className) {
+        Objects.requireNonNull(className, "className");
+        try {
+            return Class.forName(className, false, classLoader);
+        } catch (ClassNotFoundException ignored) {
+            return null;
+        }
+    }
+}

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/HttpRequestInterceptor.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/HttpRequestInterceptor.java
@@ -23,6 +23,8 @@ import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventSimpleAroundInterce
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.plugin.resttemplate.RestTemplateConstants;
 
+import com.navercorp.pinpoint.plugin.resttemplate.interceptor.util.HttpStatusProvider;
+import com.navercorp.pinpoint.plugin.resttemplate.interceptor.util.HttpStatusProviderFactory;
 import org.springframework.http.client.ClientHttpResponse;
 
 import java.io.IOException;
@@ -32,8 +34,12 @@ import java.io.IOException;
  */
 public class HttpRequestInterceptor extends SpanEventSimpleAroundInterceptorForPlugin {
 
-    public HttpRequestInterceptor(TraceContext traceContext, MethodDescriptor descriptor) {
+    private final HttpStatusProvider statusCodeProvider;
+
+    public HttpRequestInterceptor(TraceContext traceContext, MethodDescriptor descriptor,
+                                  int springVersion) {
         super(traceContext, descriptor);
+        this.statusCodeProvider = HttpStatusProviderFactory.getHttpStatusProvider(springVersion);
     }
 
     @Override
@@ -48,7 +54,7 @@ public class HttpRequestInterceptor extends SpanEventSimpleAroundInterceptorForP
 
         if (result instanceof ClientHttpResponse) {
             ClientHttpResponse clientHttpResponse = (ClientHttpResponse) result;
-            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, clientHttpResponse.getRawStatusCode());
+            recorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, statusCodeProvider.getStatusCode(clientHttpResponse));
         }
     }
 

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/util/HttpStatusProvider.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/util/HttpStatusProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.resttemplate.interceptor.util;
+
+/**
+ * @author intr3p1d
+ */
+public interface HttpStatusProvider {
+    int getStatusCode(Object target);
+}

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/util/HttpStatusProviderFactory.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/util/HttpStatusProviderFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.resttemplate.interceptor.util;
+
+import com.navercorp.pinpoint.plugin.resttemplate.SpringVersion;
+
+/**
+ * @author intr3p1d
+ */
+public class HttpStatusProviderFactory {
+
+    public HttpStatusProviderFactory() {
+    }
+
+    public static HttpStatusProvider getHttpStatusProvider(int version) {
+        switch (version) {
+            case SpringVersion.SPRING_VERSION_5:
+                return new Spring5HttpStatusProvider();
+            case SpringVersion.SPRING_VERSION_6:
+                return new Spring6HttpStatusProvider();
+            default:
+                return new UnsupportedHttpStatusProvider();
+        }
+    }
+}

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/util/Spring5HttpStatusProvider.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/util/Spring5HttpStatusProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.resttemplate.interceptor.util;
+
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+
+/**
+ * @author intr3p1d
+ */
+public class Spring5HttpStatusProvider implements HttpStatusProvider {
+    @Override
+    public int getStatusCode(Object target) {
+        if (target instanceof ClientHttpResponse) {
+            final ClientHttpResponse response = (ClientHttpResponse) target;
+            try {
+                return response.getRawStatusCode();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return -1;
+    }
+}

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/util/Spring6HttpStatusProvider.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/util/Spring6HttpStatusProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.resttemplate.interceptor.util;
+
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+
+/**
+ * @author intr3p1d
+ */
+public class Spring6HttpStatusProvider implements HttpStatusProvider {
+    @Override
+    public int getStatusCode(Object target) {
+        if (target instanceof ClientHttpResponse) {
+            final ClientHttpResponse response = (ClientHttpResponse) target;
+            try {
+                return response.getStatusCode().value();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return -1;
+    }
+}

--- a/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/util/UnsupportedHttpStatusProvider.java
+++ b/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/interceptor/util/UnsupportedHttpStatusProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.resttemplate.interceptor.util;
+
+/**
+ * @author intr3p1d
+ */
+public class UnsupportedHttpStatusProvider implements HttpStatusProvider {
+
+    @Override
+    public int getStatusCode(Object target) {
+        return -1;
+    }
+}

--- a/plugins/spring-stub/pom.xml
+++ b/plugins/spring-stub/pom.xml
@@ -8,14 +8,15 @@
         <version>2.5.4-SNAPSHOT</version>
     </parent>
 
-    <artifactId>pinpoint-spring-webflux-plugin</artifactId>
-    <name>pinpoint-spring-webflux-plugin</name>
+    <artifactId>pinpoint-spring-stub</artifactId>
+    <name>pinpoint-spring-stub</name>
     <packaging>jar</packaging>
 
     <properties>
         <jdk.version>1.8</jdk.version>
         <jdk.home>${env.JAVA_8_HOME}</jdk.home>
         <test.jdk.home>${env.JAVA_8_HOME}</test.jdk.home>
+        <spring.version>${spring5.version}</spring.version>
     </properties>
 
     <dependencies>
@@ -24,39 +25,22 @@
             <artifactId>pinpoint-bootstrap-core</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.navercorp.pinpoint</groupId>
-            <artifactId>pinpoint-spring-stub</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <scope>provided</scope>
         </dependency>
-
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <includes>
-                        <include>com/navercorp/**/*</include>
-                        <include>META-INF/**/*</include>
-                    </includes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/plugins/spring-stub/src/main/java/org/springframework/http/HttpStatusCode.java
+++ b/plugins/spring-stub/src/main/java/org/springframework/http/HttpStatusCode.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.http;
+
+/**
+ * @author intr3p1d
+ */
+public interface HttpStatusCode {
+    int value();
+}

--- a/plugins/spring-stub/src/main/java/org/springframework/http/client/ClientHttpResponse.java
+++ b/plugins/spring-stub/src/main/java/org/springframework/http/client/ClientHttpResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.http.client;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpStatusCode;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * @author intr3p1d
+ */
+public interface ClientHttpResponse extends HttpInputMessage, Closeable {
+    HttpStatusCode getStatusCode() throws IOException;
+
+    int getRawStatusCode() throws IOException;
+}

--- a/plugins/spring-stub/src/main/java/org/springframework/http/client/reactive/ClientHttpResponse.java
+++ b/plugins/spring-stub/src/main/java/org/springframework/http/client/reactive/ClientHttpResponse.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.http.client.reactive;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.HttpInputMessage;
+
+import java.io.Closeable;
+
+/**
+ * @author intr3p1d
+ */
+public interface ClientHttpResponse extends HttpInputMessage, Closeable {
+    HttpStatusCode getStatusCode();
+
+    int getRawStatusCode();
+}

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringVersion.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringVersion.java
@@ -1,0 +1,56 @@
+package com.navercorp.pinpoint.plugin.spring.webflux;/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Objects;
+
+/**
+ * @author intr3p1d
+ */
+public class SpringVersion {
+
+    public static final int SPRING_VERSION_UNKNOWN = -1;
+    public static final int SPRING_VERSION_5 = 5_00_00;
+    public static final int SPRING_VERSION_6 = 6_00_00;
+
+    static final String SPRING5_HTTP_STATUS_INTERFACE_NAME = "org.springframework.http.HttpStatus";
+    static final String SPRING6_HTTP_STATUS_INTERFACE_NAME = "org.springframework.http.HttpStatusCode";
+
+
+    public static int getVersion(ClassLoader classLoader) {
+        // Spring 6.0 + (boot 3.0 + )
+        final Class<?> httpStatusCode = getClass(classLoader, SPRING6_HTTP_STATUS_INTERFACE_NAME);
+        if (httpStatusCode != null) {
+            return SpringVersion.SPRING_VERSION_6;
+        }
+
+        // ~ Spring 5.x (boot 2.0 -)
+        final Class<?> httpStatus = getClass(classLoader, SPRING5_HTTP_STATUS_INTERFACE_NAME);
+        if (httpStatus != null) {
+            return SpringVersion.SPRING_VERSION_5;
+        }
+        return SpringVersion.SPRING_VERSION_UNKNOWN;
+    }
+
+
+    static Class<?> getClass(ClassLoader classLoader, String className) {
+        Objects.requireNonNull(className, "className");
+        try {
+            return Class.forName(className, false, classLoader);
+        } catch (ClassNotFoundException ignored) {
+            return null;
+        }
+    }
+}

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringWebFluxPlugin.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringWebFluxPlugin.java
@@ -190,7 +190,8 @@ public class SpringWebFluxPlugin implements ProfilerPlugin, MatchableTransformTe
 
             final InstrumentMethod logResponseMethod = target.getDeclaredMethod("logResponse", "org.springframework.http.client.reactive.ClientHttpResponse", "java.lang.String");
             if (logResponseMethod != null) {
-                logResponseMethod.addInterceptor(ClientResponseFunctionInterceptor.class);
+                final int springVersion = SpringVersion.getVersion(loader);
+                logResponseMethod.addInterceptor(ClientResponseFunctionInterceptor.class, va(springVersion));
             }
 
             return target.toBytecode();

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/util/HttpStatusProvider.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/util/HttpStatusProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor.util;
+
+/**
+ * @author intr3p1d
+ */
+public interface HttpStatusProvider {
+    int getStatusCode(Object target);
+}

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/util/HttpStatusProviderFactory.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/util/HttpStatusProviderFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor.util;
+
+import com.navercorp.pinpoint.plugin.spring.webflux.SpringVersion;
+
+/**
+ * @author intr3p1d
+ */
+public class HttpStatusProviderFactory {
+
+    public HttpStatusProviderFactory() {
+    }
+
+    public static HttpStatusProvider getHttpStatusProvider(int version) {
+        switch (version) {
+            case SpringVersion.SPRING_VERSION_5:
+                return new Spring5HttpStatusProvider();
+            case SpringVersion.SPRING_VERSION_6:
+                return new Spring6HttpStatusProvider();
+            default:
+                return new UnsupportedHttpStatusProvider();
+        }
+    }
+}

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/util/Spring5HttpStatusProvider.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/util/Spring5HttpStatusProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor.util;
+
+import org.springframework.http.client.reactive.ClientHttpResponse;
+
+/**
+ * @author intr3p1d
+ */
+public class Spring5HttpStatusProvider implements HttpStatusProvider {
+    @Override
+    public int getStatusCode(Object target) {
+        if (target instanceof ClientHttpResponse) {
+            final ClientHttpResponse response = (ClientHttpResponse) target;
+            try {
+                return response.getRawStatusCode();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return -1;
+    }
+}

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/util/Spring6HttpStatusProvider.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/util/Spring6HttpStatusProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor.util;
+
+import org.springframework.http.client.reactive.ClientHttpResponse;
+
+/**
+ * @author intr3p1d
+ */
+public class Spring6HttpStatusProvider implements HttpStatusProvider {
+    @Override
+    public int getStatusCode(Object target) {
+        if (target instanceof ClientHttpResponse) {
+            final ClientHttpResponse response = (ClientHttpResponse) target;
+            try {
+                return response.getStatusCode().value();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return -1;
+    }
+}

--- a/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/util/UnsupportedHttpStatusProvider.java
+++ b/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/util/UnsupportedHttpStatusProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor.util;
+
+/**
+ * @author intr3p1d
+ */
+public class UnsupportedHttpStatusProvider implements HttpStatusProvider {
+
+    @Override
+    public int getStatusCode(Object target) {
+        return -1;
+    }
+}


### PR DESCRIPTION
…pring WebFlux 6.1 & Boot 3.x.

[#NotAssigned] Removed getRawStatusCode() method for removal in Spring Webflux 6.1

[#10736] Separate dummy java class not to disturb spring-web dependency

[#10736] Remove dummy classes after install the plugin

[#10736] Use maven-clean-plugin instead of exec

[#10736] Split spring-stub into separate modules