### PR TITLE
[#noissue] Fix filteredMap merge logic

### DIFF
--- a/web-frontend/src/main/v3/packages/atoms/src/scatter.ts
+++ b/web-frontend/src/main/v3/packages/atoms/src/scatter.ts
@@ -53,7 +53,9 @@ export const scatterDataByApplicationKeyAtom = atom(
       const mergedKeys = newData ? getMergedKeys(prevData, newData) : undefined;
       const resultData = mergedKeys?.reduce((acc, key) => {
         const prevScatterData = prevData?.[key];
-        const newScatterData = getScatterData(newData[key], prevScatterData);
+        const newScatterData = newData[key]
+          ? getScatterData(newData[key], prevScatterData)
+          : prevScatterData;
         return {
           ...acc,
           [key]: newScatterData,

--- a/web-frontend/src/main/v3/packages/utils/src/helper/filteredMap/merge.ts
+++ b/web-frontend/src/main/v3/packages/utils/src/helper/filteredMap/merge.ts
@@ -188,16 +188,17 @@ function mergeTimeSeriesHistogram(
           return;
         }
         if (obj.key === 'Max') {
-          obj.values.forEach((chartValue, innerIndex: number) => {
-            old.timeSeriesHistogram[outerIndex].values[innerIndex][1] = Math.max(
-              old.timeSeriesHistogram[outerIndex].values[innerIndex][1],
-              chartValue[1],
+          old.timeSeriesHistogram[outerIndex].values.forEach((value) => {
+            value[1] = Math.max(
+              value[1],
+              obj.values.find((chartValue) => chartValue[0] === value[0])?.[1] || 0,
             );
           });
+
           return;
         }
-        obj.values.forEach((chartValue, innerIndex: number) => {
-          old.timeSeriesHistogram[outerIndex].values[innerIndex][1] += chartValue[1];
+        old.timeSeriesHistogram[outerIndex].values.forEach((value) => {
+          value[1] += obj.values.find((chartValue) => chartValue[0] === value[0])?.[1] || 0;
         });
       });
       updateAvgTimeSeriesHistogram(old.timeSeriesHistogram);
@@ -252,16 +253,17 @@ function mergeAgentTimeSeriesHistogramByType(
               return;
             }
             if (obj.key === 'Max') {
-              obj.values.forEach((chartValue, innerIndex) => {
-                old[agentId][outerIndex].values[innerIndex][1] = Math.max(
-                  old[agentId][outerIndex].values[innerIndex][1],
-                  chartValue[1],
+              old[agentId][outerIndex].values.forEach((value) => {
+                value[1] = Math.max(
+                  value[1],
+                  obj.values.find((chartValue) => chartValue[0] === value[0])?.[1] || 0,
                 );
               });
+
               return;
             }
-            obj.values.forEach((chartValue, innerIndex) => {
-              old[agentId][outerIndex].values[innerIndex][1] += chartValue[1];
+            old[agentId][outerIndex].values.forEach((value) => {
+              value[1] += obj.values.find((chartValue) => chartValue[0] === value[0])?.[1] || 0;
             });
           });
           updateAvgTimeSeriesHistogram(old[agentId]);

--- a/web-frontend/src/main/v3/packages/utils/src/helper/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/utils/src/helper/serverMap.ts
@@ -11,7 +11,7 @@ export const getBaseNodeId = ({
     const nodeList = applicationMapData.nodeDataArray;
     const baseNodeId = `${application?.applicationName}^${application?.serviceType}`;
 
-    return nodeList.some(({ key }: { key: string }) => key === baseNodeId)
+    return nodeList.length === 0 || nodeList.some(({ key }: { key: string }) => key === baseNodeId)
       ? baseNodeId
       : baseNodeId.replace(/(.*)\^(.*)/i, '$1^UNAUTHORIZED');
   }


### PR DESCRIPTION
- Pass the previous data if there's no data for the same key(agent) in the merging scatter process
- Match servermap data with timestamp, not with the data index
- Consider unauthorized condition only when there is node-list