### PR TITLE
[#8851] Fix javadoc generation failure

### DIFF
--- a/agent-module/bootstraps/bootstrap-java9-internal/pom.xml
+++ b/agent-module/bootstraps/bootstrap-java9-internal/pom.xml
@@ -136,7 +136,9 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${plugin.javadoc.version}</version>
                         <configuration>
-                            <skip>true</skip>
+                            <doclint>none</doclint>
+                            <source>8</source>
+                            <javadocExecutable>${jdk.home}/bin/javadoc</javadocExecutable>
                         </configuration>
                         <executions>
                             <execution>

--- a/agent-module/bootstraps/bootstrap-java9/pom.xml
+++ b/agent-module/bootstraps/bootstrap-java9/pom.xml
@@ -29,7 +29,6 @@
         <jdk.version>9</jdk.version>
         <jdk.home>${env.JAVA_11_HOME}</jdk.home>
         <maven.compiler.release>9</maven.compiler.release>
-
     </properties>
 
     <artifactId>pinpoint-bootstrap-java9</artifactId>
@@ -109,4 +108,36 @@
         </plugins>
     </build>
 
+
+    <profiles>
+        <profile>
+            <id>maven.central.release</id>
+            <properties>
+                <env>release</env>
+                <spring.profiles.active>release</spring.profiles.active>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${plugin.javadoc.version}</version>
+                        <configuration>
+                            <doclint>none</doclint>
+                            <source>8</source>
+                            <javadocExecutable>${jdk.home}/bin/javadoc</javadocExecutable>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
The issue likely occurred during the process of integrating multiple modules under the `agent-module`. While modifying the settings to use standard Maven properties, the javadoc source configuration was removed, leading to the javadoc generation failure.

ref: #8851 #8852