### PR TITLE
Fix missing metadata trailer in ServerCall.close

### DIFF
--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/server/flowcontrol/DefaultServerCallWrapper.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/server/flowcontrol/DefaultServerCallWrapper.java
@@ -34,7 +34,7 @@ public class DefaultServerCallWrapper<ReqT, RespT> implements ServerCallWrapper 
 
     @Override
     public void cancel(Status status, Metadata trailers) {
-        this.serverCall.close(status, new Metadata());
+        this.serverCall.close(status, trailers);
     }
 
     @Override


### PR DESCRIPTION
Missing metadata trailer on stream close, but not a problem because it is not used