### PR TITLE
application logger pattern full-replacement support

### DIFF
--- a/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
@@ -1188,7 +1188,9 @@ profiler.logback.logging.transactioninfo=false
 # variables/aliases: https://github.com/qos-ch/logback/blob/master/logback-classic/src/main/java/ch/qos/logback/classic/PatternLayout.java#L54-L149
 #profiler.logback.logging.pattern.replace.enable=false
 #profiler.logback.logging.pattern.replace.search=%message,%msg,%m
-#profiler.logback.logging.pattern.replace.with="TxId:%X{PtxId} %msg"
+#profiler.logback.logging.pattern.replace.with=TxId:%X{PtxId} %msg
+# the logger pattern would be fully replaced with the configured value if replace.enable=true
+#profiler.logback.logging.pattern.full_replace.with=
 
 ###########################################################
 # google httpclient 

--- a/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
@@ -1158,7 +1158,9 @@ profiler.log4j.logging.transactioninfo=false
 # variables/aliases: https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html
 #profiler.log4j.logging.pattern.replace.enable=false
 #profiler.log4j.logging.pattern.replace.search=%m
-#profiler.log4j.logging.pattern.replace.with="TxId:%X{PtxId} %m"
+#profiler.log4j.logging.pattern.replace.with=TxId:%X{PtxId} %m
+# the logger pattern would be fully replaced with the configured value if replace.enable=true
+#profiler.log4j.logging.pattern.full_replace.with=
 
 ###########################################################
 # log4j2 (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)

--- a/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
@@ -1173,7 +1173,9 @@ profiler.log4j2.logging.transactioninfo=false
 # variables/aliases: https://logging.apache.org/log4j/2.x/manual/layouts.html under section "Patterns"
 #profiler.log4j2.logging.pattern.replace.enable=false
 #profiler.log4j2.logging.pattern.replace.search=%message,%msg,%m
-#profiler.log4j2.logging.pattern.replace.with="TxId:%X{PtxId} %msg"
+#profiler.log4j2.logging.pattern.replace.with=TxId:%X{PtxId} %msg
+# the logger pattern would be fully replaced with the configured value if replace.enable=true
+#profiler.log4j2.logging.pattern.full_replace.with=
 
 ###########################################################
 # logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)

--- a/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jFullReplaceIT.java
+++ b/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jFullReplaceIT.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-log4j-plugin"})
 @PinpointConfig("pinpoint-spring-bean-test.config")
 @TransformInclude("org.apache.log4j.")
-@JvmArgument("-Dprofiler.log4j.logging.pattern.full_replace.with=IT TxId:%X{PtxId} %m")
+@JvmArgument("-Dprofiler.log4j.logging.pattern.full_replace.with=Log4jIT TxId:%X{PtxId} %m")
 public class Log4jFullReplaceIT extends Log4jTestBase {
 
     @Test
@@ -38,7 +38,7 @@ public class Log4jFullReplaceIT extends Log4jTestBase {
     @Test
     public void patternUpdate() {
         String log = checkPatternReplace();
-        Assertions.assertTrue(log.contains("IT"), "contains full-replace string IT");
+        Assertions.assertTrue(log.contains("Log4jIT"), "contains full-replace string Log4jIT");
     }
 
 }

--- a/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jFullReplaceIT.java
+++ b/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jFullReplaceIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.log4j;
+
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@PluginForkedTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"log4j:log4j:[1.2.16,)", PluginITConstants.VERSION})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-log4j-plugin"})
+@PinpointConfig("pinpoint-spring-bean-test.config")
+@TransformInclude("org.apache.log4j.")
+@JvmArgument("-Dprofiler.log4j.logging.pattern.full_replace.with=IT TxId:%X{PtxId} %m")
+public class Log4jFullReplaceIT extends Log4jTestBase {
+
+    @Test
+    public void test() {
+        checkMDC();
+    }
+
+    @Test
+    public void patternUpdate() {
+        String log = checkPatternReplace();
+        Assertions.assertTrue(log.contains("IT"), "contains full-replace string IT");
+    }
+
+}

--- a/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jIT.java
+++ b/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jIT.java
@@ -17,16 +17,12 @@ package com.navercorp.pinpoint.it.plugin.log4j;
 
 import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
 import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
-import com.navercorp.pinpoint.it.plugin.utils.StdoutRecorder;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.ImportPlugin;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
 import com.navercorp.pinpoint.test.plugin.TransformInclude;
-import org.apache.log4j.Logger;
-import org.apache.log4j.MDC;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @PluginForkedTest
@@ -35,63 +31,15 @@ import org.junit.jupiter.api.Test;
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-log4j-plugin"})
 @PinpointConfig("pinpoint-spring-bean-test.config")
 @TransformInclude("org.apache.log4j.")
-public class Log4jIT {
-
-    private Logger logger;
+public class Log4jIT extends Log4jTestBase {
 
     @Test
     public void test() {
-        Logger logger = Logger.getLogger(getClass());
-        logger.error("maru");
-
-        checkVersion(logger);
-
-        Assertions.assertNotNull(MDC.get("PtxId"), "txId");
-        Assertions.assertNotNull(MDC.get("PspanId"), "spanId");
+        checkMDC();
     }
 
     @Test
     public void patternUpdate() {
-        final String msg = "pattern";
-
-
-        StdoutRecorder stdoutRecorder = new StdoutRecorder();
-        final String log = stdoutRecorder.record(new Runnable() {
-            @Override
-            public void run() {
-                logger = Logger.getLogger("patternUpdateLogback");
-                logger.error(msg);
-            }
-        });
-
-        System.out.println(log);
-        Assertions.assertNotNull(log, "log null");
-        Assertions.assertTrue(log.contains(msg), "contains msg");
-        Assertions.assertTrue(log.contains("TxId"), "contains TxId");
-
-        Assertions.assertNotNull(logger, "logger null");
-        checkVersion(logger);
+        checkPatternReplace();
     }
-
-    private void checkVersion(Logger logger) {
-        final String location = getLoggerJarLocation(logger);
-        Assertions.assertNotNull(location, "location null");
-        System.out.println("Log4j jar location:" + location);
-
-        final String testVersion = getTestVersion();
-        Assertions.assertTrue(location.contains("/" + testVersion + "/"), "test version is not " + getTestVersion());
-    }
-
-    private String getTestVersion() {
-        final String[] threadInfo = Thread.currentThread().getName()
-                .replace(getClass().getName(), "")
-                .replace(" Thread", "")
-                .replace(" ", "").replace("log4j-", "").split(":");
-        return threadInfo[0];
-    }
-
-    private String getLoggerJarLocation(Object object) {
-        return object.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
-    }
-
 }

--- a/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jTestBase.java
+++ b/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jTestBase.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.log4j;
+
+import com.navercorp.pinpoint.it.plugin.utils.StdoutRecorder;
+import org.apache.log4j.Logger;
+import org.apache.log4j.MDC;
+import org.junit.jupiter.api.Assertions;
+
+public class Log4jTestBase {
+
+    private Logger logger;
+
+    protected void checkMDC() {
+        Logger logger = Logger.getLogger(getClass());
+        logger.error("maru");
+
+        checkVersion(logger);
+
+        Assertions.assertNotNull(MDC.get("PtxId"), "txId");
+        Assertions.assertNotNull(MDC.get("PspanId"), "spanId");
+    }
+
+    protected void checkPatternReplace() {
+        final String msg = "pattern";
+
+
+        StdoutRecorder stdoutRecorder = new StdoutRecorder();
+        final String log = stdoutRecorder.record(new Runnable() {
+            @Override
+            public void run() {
+                logger = Logger.getLogger("patternUpdateLogback");
+                logger.error(msg);
+            }
+        });
+
+        System.out.println(log);
+        Assertions.assertNotNull(log, "log null");
+        Assertions.assertTrue(log.contains(msg), "contains msg");
+        Assertions.assertTrue(log.contains("TxId"), "contains TxId");
+
+        Assertions.assertNotNull(logger, "logger null");
+        checkVersion(logger);
+    }
+
+    private void checkVersion(Logger logger) {
+        final String location = getLoggerJarLocation(logger);
+        Assertions.assertNotNull(location, "location null");
+        System.out.println("Log4j jar location:" + location);
+
+        final String testVersion = getTestVersion();
+        Assertions.assertTrue(location.contains("/" + testVersion + "/"), "test version is not " + getTestVersion());
+    }
+
+    private String getTestVersion() {
+        final String[] threadInfo = Thread.currentThread().getName()
+                .replace(getClass().getName(), "")
+                .replace(" Thread", "")
+                .replace(" ", "").replace("log4j-", "").split(":");
+        return threadInfo[0];
+    }
+
+    private String getLoggerJarLocation(Object object) {
+        return object.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
+    }
+
+}

--- a/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jTestBase.java
+++ b/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jTestBase.java
@@ -29,8 +29,11 @@ public class Log4jTestBase {
         logger.error("maru");
 
         checkVersion(logger);
-
-        Assertions.assertNotNull(MDC.get("PtxId"), "txId");
+        Object ptxId = MDC.get("PtxId");
+        Assertions.assertNotNull(ptxId, "TxId");
+        Assertions.assertInstanceOf(String.class, ptxId, "TxId type");
+        String id = (String) ptxId;
+        Assertions.assertTrue(id.contains("build.test.0^1"), "TxId value");
         Assertions.assertNotNull(MDC.get("PspanId"), "spanId");
     }
 
@@ -51,6 +54,7 @@ public class Log4jTestBase {
         Assertions.assertNotNull(log, "log null");
         Assertions.assertTrue(log.contains(msg), "contains msg");
         Assertions.assertTrue(log.contains("TxId"), "contains TxId");
+        Assertions.assertTrue(log.contains("build.test.0^1"), "contains TxId value");
 
         Assertions.assertNotNull(logger, "logger null");
         checkVersion(logger);

--- a/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jTestBase.java
+++ b/agent-module/plugins-it/log4j-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j/Log4jTestBase.java
@@ -34,7 +34,7 @@ public class Log4jTestBase {
         Assertions.assertNotNull(MDC.get("PspanId"), "spanId");
     }
 
-    protected void checkPatternReplace() {
+    protected String checkPatternReplace() {
         final String msg = "pattern";
 
 
@@ -54,6 +54,7 @@ public class Log4jTestBase {
 
         Assertions.assertNotNull(logger, "logger null");
         checkVersion(logger);
+        return log;
     }
 
     private void checkVersion(Logger logger) {

--- a/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4J2PatternFullReplaceTestIT.java
+++ b/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4J2PatternFullReplaceTestIT.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.log4j2;
+
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@PluginForkedTest
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-spring-bean-test.config")
+@JvmVersion(8)
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.17.1,2.20)", PluginITConstants.VERSION})
+@JvmArgument({"-DtestLoggerEnable=false", "-Dprofiler.log4j2.logging.pattern.full_replace.with=Log4j2IT TxId:%X{PtxId} %message"})
+public class Log4J2PatternFullReplaceTestIT extends Log4j2PatternTestBase {
+
+    @Test
+    public void patternUpdate() {
+        String log = checkPatternUpdate();
+        Assertions.assertTrue(log.contains("Log4j2IT"), "contains full-replace string Log4j2IT");
+    }
+
+}

--- a/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4J2PatternFullReplace_2_20_ITTest.java
+++ b/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4J2PatternFullReplace_2_20_ITTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.log4j2;
+
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@PluginForkedTest
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-spring-bean-test.config")
+@JvmVersion(11)
+@Dependency({"org.apache.logging.log4j:log4j-core:[2.20,2.22]", PluginITConstants.VERSION})
+@JvmArgument({"-DtestLoggerEnable=false", "-Dprofiler.log4j2.logging.pattern.full_replace.with=Log4j2IT TxId:%X{PtxId} %message"})
+public class Log4J2PatternFullReplace_2_20_ITTest extends Log4j2PatternTestBase {
+
+    @Test
+    public void patternUpdate() {
+        String log = checkPatternUpdate();
+        Assertions.assertTrue(log.contains("Log4j2IT"), "contains full-replace string Log4j2IT");
+    }
+
+}

--- a/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4J2PatternTestIT.java
+++ b/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4J2PatternTestIT.java
@@ -17,16 +17,12 @@ package com.navercorp.pinpoint.it.plugin.log4j2;
 
 import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
 import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
-import com.navercorp.pinpoint.it.plugin.utils.StdoutRecorder;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.JvmVersion;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @PluginForkedTest
@@ -35,32 +31,11 @@ import org.junit.jupiter.api.Test;
 @JvmVersion(8)
 @Dependency({"org.apache.logging.log4j:log4j-core:[2.17.1,2.20)", PluginITConstants.VERSION})
 @JvmArgument("-DtestLoggerEnable=false")
-public class Log4j2PatternIT extends Log4j2TestBase {
+public class Log4J2PatternTestIT extends Log4j2PatternTestBase {
 
-    private String location;
     @Test
     public void patternUpdate() {
-        final String msg = "pattern";
-
-        StdoutRecorder stdoutRecorder = new StdoutRecorder();
-        String log = stdoutRecorder.record(new Runnable() {
-            @Override
-            public void run() {
-                Logger logger = LogManager.getLogger("patternUpdateLog4j2Jvm7");
-                logger.error(msg);
-                location = getLoggerJarLocation(logger);
-            }
-        });
-
-        System.out.println(log);
-        Assertions.assertNotNull(log, "log null");
-        Assertions.assertTrue(log.contains(msg), "contains msg");
-        Assertions.assertTrue(log.contains("TxId"), "contains TxId");
-
-        Assertions.assertNotNull(location, "location null");
-        System.out.println("Log4j2 jar location:" + location);
-        final String testVersion = getTestVersion();
-        Assertions.assertTrue(location.contains("/" + testVersion + "/"), "test version is not " + getTestVersion());
+        checkPatternUpdate();
     }
 
 }

--- a/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4J2Pattern_2_20_ITTest.java
+++ b/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4J2Pattern_2_20_ITTest.java
@@ -17,16 +17,12 @@ package com.navercorp.pinpoint.it.plugin.log4j2;
 
 import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
 import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
-import com.navercorp.pinpoint.it.plugin.utils.StdoutRecorder;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.JvmArgument;
 import com.navercorp.pinpoint.test.plugin.JvmVersion;
 import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @PluginForkedTest
@@ -35,32 +31,11 @@ import org.junit.jupiter.api.Test;
 @JvmVersion(11)
 @Dependency({"org.apache.logging.log4j:log4j-core:[2.20,2.22]", PluginITConstants.VERSION})
 @JvmArgument("-DtestLoggerEnable=false")
-public class Log4j2Pattern_2_20_IT extends Log4j2TestBase {
+public class Log4J2Pattern_2_20_ITTest extends Log4j2PatternTestBase {
 
-    private String location;
     @Test
     public void patternUpdate() {
-        final String msg = "pattern";
-
-        StdoutRecorder stdoutRecorder = new StdoutRecorder();
-        String log = stdoutRecorder.record(new Runnable() {
-            @Override
-            public void run() {
-                Logger logger = LogManager.getLogger("patternUpdateLog4j2Jvm7");
-                logger.error(msg);
-                location = getLoggerJarLocation(logger);
-            }
-        });
-
-        System.out.println(log);
-        Assertions.assertNotNull(log, "log null");
-        Assertions.assertTrue(log.contains(msg), "contains msg");
-        Assertions.assertTrue(log.contains("TxId"), "contains TxId");
-
-        Assertions.assertNotNull(location, "location null");
-        System.out.println("Log4j2 jar location:" + location);
-        final String testVersion = getTestVersion();
-        Assertions.assertTrue(location.contains("/" + testVersion + "/"), "test version is not " + getTestVersion());
+        checkPatternUpdate();
     }
 
 }

--- a/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4j2PatternTestBase.java
+++ b/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4j2PatternTestBase.java
@@ -24,7 +24,7 @@ public class Log4j2PatternTestBase extends Log4j2TestBase {
 
     private String location;
 
-    public void checkPatternUpdate() {
+    protected String checkPatternUpdate() {
         final String msg = "pattern";
 
         StdoutRecorder stdoutRecorder = new StdoutRecorder();
@@ -46,6 +46,7 @@ public class Log4j2PatternTestBase extends Log4j2TestBase {
         System.out.println("Log4j2 jar location:" + location);
         final String testVersion = getTestVersion();
         Assertions.assertTrue(location.contains("/" + testVersion + "/"), "test version is not " + getTestVersion());
+        return log;
     }
 
 }

--- a/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4j2PatternTestBase.java
+++ b/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4j2PatternTestBase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.log4j2;
+
+import com.navercorp.pinpoint.it.plugin.utils.StdoutRecorder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
+public class Log4j2PatternTestBase extends Log4j2TestBase {
+
+    private String location;
+
+    public void checkPatternUpdate() {
+        final String msg = "pattern";
+
+        StdoutRecorder stdoutRecorder = new StdoutRecorder();
+        String log = stdoutRecorder.record(new Runnable() {
+            @Override
+            public void run() {
+                Logger logger = LogManager.getLogger("patternUpdateLog4j2Jvm7");
+                logger.error(msg);
+                location = getLoggerJarLocation(logger);
+            }
+        });
+
+        System.out.println(log);
+        Assertions.assertNotNull(log, "log null");
+        Assertions.assertTrue(log.contains(msg), "contains msg");
+        Assertions.assertTrue(log.contains("TxId"), "contains TxId");
+
+        Assertions.assertNotNull(location, "location null");
+        System.out.println("Log4j2 jar location:" + location);
+        final String testVersion = getTestVersion();
+        Assertions.assertTrue(location.contains("/" + testVersion + "/"), "test version is not " + getTestVersion());
+    }
+
+}

--- a/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4j2PatternTestBase.java
+++ b/agent-module/plugins-it/log4j2-it/src/test/java/com/navercorp/pinpoint/it/plugin/log4j2/Log4j2PatternTestBase.java
@@ -40,7 +40,7 @@ public class Log4j2PatternTestBase extends Log4j2TestBase {
         System.out.println(log);
         Assertions.assertNotNull(log, "log null");
         Assertions.assertTrue(log.contains(msg), "contains msg");
-        Assertions.assertTrue(log.contains("TxId"), "contains TxId");
+        Assertions.assertTrue(log.contains("build.test.0^1"), "contains TxId");
 
         Assertions.assertNotNull(location, "location null");
         System.out.println("Log4j2 jar location:" + location);

--- a/agent-module/plugins-it/logback-it/src/test/java/com/navercorp/pinpoint/it/plugin/logback/LogbackIT.java
+++ b/agent-module/plugins-it/logback-it/src/test/java/com/navercorp/pinpoint/it/plugin/logback/LogbackIT.java
@@ -48,7 +48,9 @@ public class LogbackIT {
 
         checkVersion(logger);
 
-        Assertions.assertNotNull(MDC.get("PtxId"), "txId");
+        String ptxId = MDC.get("PtxId");
+        Assertions.assertNotNull(ptxId, "TxId");
+        Assertions.assertTrue(ptxId.contains("build.test.0^1"), "TxId value");
         Assertions.assertNotNull(MDC.get("PspanId"), "spanId");
     }
 
@@ -72,6 +74,7 @@ public class LogbackIT {
         Assertions.assertNotNull(log, "log null");
         Assertions.assertTrue(log.contains(msg), "contains msg");
         Assertions.assertTrue(log.contains("TxId"), "contains TxId");
+        Assertions.assertTrue(log.contains("build.test.0^1"), "TxId value");
 
         Assertions.assertNotNull(logger, "logger null");
         checkVersion(logger);

--- a/agent-module/plugins-it/logback-it/src/test/java/com/navercorp/pinpoint/it/plugin/logback/LogbackIT.java
+++ b/agent-module/plugins-it/logback-it/src/test/java/com/navercorp/pinpoint/it/plugin/logback/LogbackIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 NAVER Corp.
+ * Copyright 2024 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.navercorp.pinpoint.it.plugin.logback;
 
 import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
 import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
-import com.navercorp.pinpoint.it.plugin.utils.StdoutRecorder;
 import com.navercorp.pinpoint.test.plugin.Dependency;
 import com.navercorp.pinpoint.test.plugin.ImportPlugin;
 import com.navercorp.pinpoint.test.plugin.JvmArgument;
@@ -25,11 +24,7 @@ import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PinpointConfig;
 import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
 import com.navercorp.pinpoint.test.plugin.TransformInclude;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 @PluginForkedTest
 @PinpointAgent(AgentPath.PATH)
@@ -38,67 +33,16 @@ import org.slf4j.MDC;
 @PinpointConfig("pinpoint-spring-bean-test.config")
 @JvmArgument("-DtestLoggerEnable=false")
 @TransformInclude("org.slf4j.")
-public class LogbackIT {
+public class LogbackIT extends LogbackTestBase {
 
     @Test
     public void test() {
-        //Logger logger = LogManager.getLogger(getClass());
-        Logger logger = LoggerFactory.getLogger(this.getClass());
-        logger.error("maru");
-
-        checkVersion(logger);
-
-        String ptxId = MDC.get("PtxId");
-        Assertions.assertNotNull(ptxId, "TxId");
-        Assertions.assertTrue(ptxId.contains("build.test.0^1"), "TxId value");
-        Assertions.assertNotNull(MDC.get("PspanId"), "spanId");
+        checkMDC();
     }
-
-    private Logger logger;
 
     @Test
     public void patternUpdate() {
-
-        final String msg = "pattern";
-        StdoutRecorder stdoutRecorder = new StdoutRecorder();
-
-        String log = stdoutRecorder.record(new Runnable() {
-            @Override
-            public void run() {
-                logger = LoggerFactory.getLogger("patternUpdateLogback");
-                logger.error(msg);
-            }
-        });
-
-        System.out.println(log);
-        Assertions.assertNotNull(log, "log null");
-        Assertions.assertTrue(log.contains(msg), "contains msg");
-        Assertions.assertTrue(log.contains("TxId"), "contains TxId");
-        Assertions.assertTrue(log.contains("build.test.0^1"), "TxId value");
-
-        Assertions.assertNotNull(logger, "logger null");
-        checkVersion(logger);
-    }
-
-    private void checkVersion(Logger logger) {
-        final String location = getLoggerJarLocation(logger);
-        Assertions.assertNotNull(location, "location null");
-        System.out.println("Logback classic jar location:" + location);
-
-        final String testVersion = getTestVersion();
-        Assertions.assertTrue(location.contains("/" + testVersion + "/"), "test version is not " + getTestVersion());
-    }
-
-    private String getTestVersion() {
-        final String[] threadInfo = Thread.currentThread().getName()
-                .replace(getClass().getName(), "")
-                .replace(" Thread", "")
-                .replace(" ", "").replace("logback-classic-", "").split(":");
-        return threadInfo[0];
-    }
-
-    private String getLoggerJarLocation(Object object) {
-        return object.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
+        checkPatternUpdate();
     }
 
 }

--- a/agent-module/plugins-it/logback-it/src/test/java/com/navercorp/pinpoint/it/plugin/logback/LogbackPatternFullReplaceIT.java
+++ b/agent-module/plugins-it/logback-it/src/test/java/com/navercorp/pinpoint/it/plugin/logback/LogbackPatternFullReplaceIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.logback;
+
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.test.plugin.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@PluginForkedTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"ch.qos.logback:logback-classic:[1.0.13],[1.1.0,1.1.11],[1.2.0,1.2.6]", "org.slf4j:slf4j-api:1.7.12", PluginITConstants.VERSION})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-logback-plugin"})
+@PinpointConfig("pinpoint-spring-bean-test.config")
+@JvmArgument({"-DtestLoggerEnable=false", "-Dprofiler.logback.logging.pattern.full_replace.with=%d{yyyy-MM-dd HH:mm:ss} [%p] [%t] %c [TxId:%X{PtxId} ReqId:%X{PreqId}] -LogbackIT- %m%n"})
+@TransformInclude("org.slf4j.")
+public class LogbackPatternFullReplaceIT extends LogbackTestBase {
+
+    @Test
+    public void test() {
+        checkMDC();
+    }
+
+    @Test
+    public void patternUpdate() {
+        String log = checkPatternUpdate();
+        Assertions.assertTrue(log.contains("-LogbackIT-"), "contains full-replace string LogbackIT");
+    }
+
+}

--- a/agent-module/plugins-it/logback-it/src/test/java/com/navercorp/pinpoint/it/plugin/logback/LogbackTestBase.java
+++ b/agent-module/plugins-it/logback-it/src/test/java/com/navercorp/pinpoint/it/plugin/logback/LogbackTestBase.java
@@ -37,7 +37,7 @@ public class LogbackTestBase {
 
     private Logger logger;
 
-    protected void checkPatternUpdate() {
+    protected String checkPatternUpdate() {
 
         final String msg = "pattern";
         StdoutRecorder stdoutRecorder = new StdoutRecorder();
@@ -58,6 +58,7 @@ public class LogbackTestBase {
 
         Assertions.assertNotNull(logger, "logger null");
         checkVersion(logger);
+        return log;
     }
 
     private void checkVersion(Logger logger) {

--- a/agent-module/plugins-it/logback-it/src/test/java/com/navercorp/pinpoint/it/plugin/logback/LogbackTestBase.java
+++ b/agent-module/plugins-it/logback-it/src/test/java/com/navercorp/pinpoint/it/plugin/logback/LogbackTestBase.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.logback;
+
+import com.navercorp.pinpoint.it.plugin.utils.StdoutRecorder;
+import org.junit.jupiter.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public class LogbackTestBase {
+
+    protected void checkMDC() {
+        Logger logger = LoggerFactory.getLogger(this.getClass());
+        logger.error("maru");
+
+        checkVersion(logger);
+
+        String ptxId = MDC.get("PtxId");
+        Assertions.assertNotNull(ptxId, "TxId");
+        Assertions.assertTrue(ptxId.contains("build.test.0^1"), "TxId value");
+        Assertions.assertNotNull(MDC.get("PspanId"), "spanId");
+    }
+
+    private Logger logger;
+
+    protected void checkPatternUpdate() {
+
+        final String msg = "pattern";
+        StdoutRecorder stdoutRecorder = new StdoutRecorder();
+
+        String log = stdoutRecorder.record(new Runnable() {
+            @Override
+            public void run() {
+                logger = LoggerFactory.getLogger("patternUpdateLogback");
+                logger.error(msg);
+            }
+        });
+
+        System.out.println(log);
+        Assertions.assertNotNull(log, "log null");
+        Assertions.assertTrue(log.contains(msg), "contains msg");
+        Assertions.assertTrue(log.contains("TxId"), "contains TxId");
+        Assertions.assertTrue(log.contains("build.test.0^1"), "TxId value");
+
+        Assertions.assertNotNull(logger, "logger null");
+        checkVersion(logger);
+    }
+
+    private void checkVersion(Logger logger) {
+        final String location = getLoggerJarLocation(logger);
+        Assertions.assertNotNull(location, "location null");
+        System.out.println("Logback classic jar location:" + location);
+
+        final String testVersion = getTestVersion();
+        Assertions.assertTrue(location.contains("/" + testVersion + "/"), "test version is not " + getTestVersion());
+    }
+
+    private String getTestVersion() {
+        final String[] threadInfo = Thread.currentThread().getName()
+                .replace(getClass().getName(), "")
+                .replace(" Thread", "")
+                .replace(" ", "").replace("logback-classic-", "").split(":");
+        return threadInfo[0];
+    }
+
+    private String getLoggerJarLocation(Object object) {
+        return object.getClass().getProtectionDomain().getCodeSource().getLocation().toString();
+    }
+
+}

--- a/agent-module/plugins/log4j/src/main/java/com/navercorp/pinpoint/plugin/log4j/Log4jConfig.java
+++ b/agent-module/plugins/log4j/src/main/java/com/navercorp/pinpoint/plugin/log4j/Log4jConfig.java
@@ -31,10 +31,13 @@ public class Log4jConfig {
     private static final String LOGGING_PATTERN_REPLACE_ENABLE = "profiler.log4j.logging.pattern.replace.enable";
     private static final String LOGGING_PATTERN_REPLACE_SEARCH = "profiler.log4j.logging.pattern.replace.search";
     private static final String LOGGING_PATTERN_REPLACE_WITH = "profiler.log4j.logging.pattern.replace.with";
+    private static final String LOGGING_PATTERN_FULL_REPLACE_WITH = "profiler.log4j.logging.pattern.full_replace.with";
 
     private final boolean patternReplaceEnable;
     private final List<String> patternReplaceSearchList;
     private final String patternReplaceWith;
+    private final String patternFullReplaceWith;
+    private final boolean patternFullReplace;
 
 
     public Log4jConfig(ProfilerConfig config) {
@@ -42,9 +45,11 @@ public class Log4jConfig {
 
         this.patternReplaceSearchList = config.readList(LOGGING_PATTERN_REPLACE_SEARCH);
         this.patternReplaceWith = config.readString(LOGGING_PATTERN_REPLACE_WITH, "");
+        this.patternFullReplaceWith = config.readString(LOGGING_PATTERN_FULL_REPLACE_WITH, "");
         boolean configEnabled = config.readBoolean(LOGGING_PATTERN_REPLACE_ENABLE, false);
-        boolean configOk = !CollectionUtils.isEmpty(patternReplaceSearchList) && StringUtils.hasText(patternReplaceWith);
+        boolean configOk = (!CollectionUtils.isEmpty(patternReplaceSearchList) && StringUtils.hasText(patternReplaceWith)) || StringUtils.hasText(patternFullReplaceWith);
         this.patternReplaceEnable = configEnabled && configOk;
+        this.patternFullReplace = configEnabled && StringUtils.hasText(patternFullReplaceWith);
     }
 
     public boolean isLog4jLoggingTransactionInfo() {
@@ -63,13 +68,23 @@ public class Log4jConfig {
         return patternReplaceWith;
     }
 
+    public String getPatternFullReplaceWith() {
+        return patternFullReplaceWith;
+    }
+
+    public boolean isPatternFullReplace() {
+        return patternFullReplace;
+    }
+
     @Override
     public String toString() {
         return "Log4jConfig{" +
                 "log4jLoggingTransactionInfo=" + log4jLoggingTransactionInfo +
                 ", patternReplaceEnable=" + patternReplaceEnable +
+                ", patternFullReplace='" + patternFullReplace + '\'' +
                 ", patternReplaceSearchList=" + patternReplaceSearchList +
                 ", patternReplaceWith='" + patternReplaceWith + '\'' +
+                ", patternFullReplaceWith='" + patternFullReplaceWith + '\'' +
                 '}';
     }
 

--- a/agent-module/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
+++ b/agent-module/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/Log4j2Config.java
@@ -32,12 +32,15 @@ public class Log4j2Config {
     private static final String LOGGING_PATTERN_REPLACE_ENABLE = "profiler.log4j2.logging.pattern.replace.enable";
     private static final String LOGGING_PATTERN_REPLACE_SEARCH = "profiler.log4j2.logging.pattern.replace.search";
     private static final String LOGGING_PATTERN_REPLACE_WITH = "profiler.log4j2.logging.pattern.replace.with";
+    private static final String LOGGING_PATTERN_FULL_REPLACE_WITH = "profiler.log4j2.logging.pattern.full_replace.with";
 
     private final boolean log4j2LoggingTransactionInfo;
 
     private final boolean patternReplaceEnable;
+    private final boolean patternFullReplace;
     private final List<String> patternReplaceSearchList;
     private final String patternReplaceWith;
+    private final String patternFullReplaceWith;
 
 
     public Log4j2Config(ProfilerConfig config) {
@@ -45,9 +48,11 @@ public class Log4j2Config {
 
         this.patternReplaceSearchList = config.readList(LOGGING_PATTERN_REPLACE_SEARCH);
         this.patternReplaceWith = config.readString(LOGGING_PATTERN_REPLACE_WITH, "");
+        this.patternFullReplaceWith = config.readString(LOGGING_PATTERN_FULL_REPLACE_WITH, "");
         boolean configEnabled = config.readBoolean(LOGGING_PATTERN_REPLACE_ENABLE, false);
-        boolean configOk = !CollectionUtils.isEmpty(patternReplaceSearchList) && StringUtils.hasText(patternReplaceWith);
+        boolean configOk = (!CollectionUtils.isEmpty(patternReplaceSearchList) && StringUtils.hasText(patternReplaceWith)) || StringUtils.hasText(patternFullReplaceWith);
         this.patternReplaceEnable = configEnabled && configOk;
+        this.patternFullReplace = configEnabled && StringUtils.hasText(patternFullReplaceWith);
     }
 
     public boolean isLog4j2LoggingTransactionInfo() {
@@ -58,6 +63,10 @@ public class Log4j2Config {
         return patternReplaceEnable;
     }
 
+    public boolean isPatternFullReplace() {
+        return patternFullReplace;
+    }
+
     public List<String> getPatternReplaceSearchList() {
         return patternReplaceSearchList;
     }
@@ -66,13 +75,19 @@ public class Log4j2Config {
         return patternReplaceWith;
     }
 
+    public String getPatternFullReplaceWith() {
+        return patternFullReplaceWith;
+    }
+
     @Override
     public String toString() {
         return "Log4j2Config{" +
                 "log4j2LoggingTransactionInfo=" + log4j2LoggingTransactionInfo +
                 ", patternReplaceEnable=" + patternReplaceEnable +
+                ", patternFullReplace='" + patternFullReplace + '\'' +
                 ", patternReplaceSearchList=" + patternReplaceSearchList +
                 ", patternReplaceWith='" + patternReplaceWith + '\'' +
+                ", patternFullReplaceWith='" + patternFullReplaceWith + '\'' +
                 '}';
     }
 

--- a/agent-module/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/interceptor/PatternLayoutInterceptor.java
+++ b/agent-module/plugins/log4j2/src/main/java/com/navercorp/pinpoint/plugin/log4j2/interceptor/PatternLayoutInterceptor.java
@@ -50,6 +50,10 @@ public class PatternLayoutInterceptor implements AroundInterceptor1 {
             return;
         }
         String oldPattern = (String) arg0;
+        if (config.isPatternFullReplace()) {
+            updatePattern(target, oldPattern, config.getPatternFullReplaceWith());
+            return;
+        }
         if (oldPattern.contains(PATTERN_TRANSACTION_ID)) {
             if (debug) {
                 logger.debug("Log4j2 pattern already have pinpoint pattern, pattern:{}", oldPattern);
@@ -59,26 +63,39 @@ public class PatternLayoutInterceptor implements AroundInterceptor1 {
         updatePattern(target, oldPattern, config.getPatternReplaceSearchList(), config.getPatternReplaceWith());
     }
 
-    private void updatePattern(Object target, String oldPattern, List<String> searchList, String replace) {
-        if (!(target instanceof PatternLayout.SerializerBuilder)) {
+    private void updatePattern(Object target, String old, String replace) {
+        if (replace.contentEquals(old)) {
             return;
         }
+        if (updatePattern(target, replace)) {
+            logger.info("Log4j pattern fully-replaced, old pattern({}) and new pattern({}).", old, replace);
+        }
+    }
+
+    private void updatePattern(Object target, String oldPattern, List<String> searchList, String replace) {
         String newPattern = oldPattern;
         boolean changed = false;
         for (String search : searchList) {
             newPattern = oldPattern.replace(search, replace);
             if (!oldPattern.contentEquals(newPattern)) {
                 changed = true;
-                if (debug) {
-                    logger.debug("Log4j2 pattern replaced, old pattern({}) and new pattern({})", oldPattern, newPattern);
-                }
                 break;
             }
         }
         if (changed) {
-            PatternLayout.SerializerBuilder builder = (PatternLayout.SerializerBuilder) target;
-            builder.setPattern(newPattern);
+            if(updatePattern(target, newPattern)) {
+                logger.info("Log4j2 pattern replaced, old pattern({}) and new pattern({})", oldPattern, newPattern);
+            }
         }
+    }
+
+    private boolean updatePattern(Object target, String pattern) {
+        if (!(target instanceof PatternLayout.SerializerBuilder)) {
+            return false;
+        }
+        PatternLayout.SerializerBuilder builder = (PatternLayout.SerializerBuilder) target;
+        builder.setPattern(pattern);
+        return true;
     }
 
 }

--- a/agent-module/plugins/logback/src/main/java/com/navercorp/pinpoint/plugin/logback/LogbackConfig.java
+++ b/agent-module/plugins/logback/src/main/java/com/navercorp/pinpoint/plugin/logback/LogbackConfig.java
@@ -31,12 +31,15 @@ public class LogbackConfig {
     private static final String LOGBACK_LOGGING_PATTERN_REPLACE_ENABLE = "profiler.logback.logging.pattern.replace.enable";
     private static final String LOGBACK_LOGGING_PATTERN_REPLACE_SEARCH = "profiler.logback.logging.pattern.replace.search";
     private static final String LOGBACK_LOGGING_PATTERN_REPLACE_WITH = "profiler.logback.logging.pattern.replace.with";
+    private static final String LOGBACK_LOGGING_PATTERN_FULL_REPLACE_WITH = "profiler.logback.logging.pattern.full_replace.with";
 
     private final boolean logbackLoggingTransactionInfo;
 
     private final boolean patternReplaceEnable;
+    private final boolean patternFullReplace;
     private final List<String> patternReplaceSearchList;
     private final String patternReplaceWith;
+    private final String patternFullReplaceWith;
 
 
     public LogbackConfig(ProfilerConfig config) {
@@ -44,9 +47,11 @@ public class LogbackConfig {
 
         this.patternReplaceSearchList = config.readList(LOGBACK_LOGGING_PATTERN_REPLACE_SEARCH);
         this.patternReplaceWith = config.readString(LOGBACK_LOGGING_PATTERN_REPLACE_WITH, "");
+        this.patternFullReplaceWith = config.readString(LOGBACK_LOGGING_PATTERN_FULL_REPLACE_WITH, "");
         boolean configEnabled = config.readBoolean(LOGBACK_LOGGING_PATTERN_REPLACE_ENABLE, false);
-        boolean configOk = !CollectionUtils.isEmpty(patternReplaceSearchList) && StringUtils.hasText(patternReplaceWith);
+        boolean configOk = (!CollectionUtils.isEmpty(patternReplaceSearchList) && StringUtils.hasText(patternReplaceWith)) || StringUtils.hasText(patternFullReplaceWith);
         this.patternReplaceEnable = configEnabled && configOk;
+        this.patternFullReplace = configEnabled && StringUtils.hasText(patternFullReplaceWith);
     }
     
     public boolean isLogbackLoggingTransactionInfo() {
@@ -57,6 +62,10 @@ public class LogbackConfig {
         return patternReplaceEnable;
     }
 
+    public boolean isPatternFullReplace() {
+        return patternFullReplace;
+    }
+
     public List<String> getPatternReplaceSearchList() {
         return patternReplaceSearchList;
     }
@@ -65,13 +74,19 @@ public class LogbackConfig {
         return patternReplaceWith;
     }
 
+    public String getPatternFullReplaceWith() {
+        return patternFullReplaceWith;
+    }
+
     @Override
     public String toString() {
         return "LogbackConfig{" +
                 "logbackLoggingTransactionInfo=" + logbackLoggingTransactionInfo +
                 ", patternReplaceEnable=" + patternReplaceEnable +
+                ", patternFullReplace='" + patternFullReplace + '\'' +
                 ", patternReplaceSearchList=" + patternReplaceSearchList +
                 ", patternReplaceWith='" + patternReplaceWith + '\'' +
+                ", patternFullReplaceWith='" + patternFullReplaceWith + '\'' +
                 '}';
     }
 }

--- a/agent-module/plugins/logback/src/main/java/com/navercorp/pinpoint/plugin/logback/interceptor/PatternLayoutInterceptor.java
+++ b/agent-module/plugins/logback/src/main/java/com/navercorp/pinpoint/plugin/logback/interceptor/PatternLayoutInterceptor.java
@@ -34,10 +34,10 @@ public class PatternLayoutInterceptor implements AroundInterceptor1 {
     private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
     private final boolean debug = logger.isDebugEnabled();
 
-    private final LogbackConfig logbackConfig;
+    private final LogbackConfig config;
 
     public PatternLayoutInterceptor(TraceContext traceContext) {
-        this.logbackConfig = new LogbackConfig(traceContext.getProfilerConfig());
+        this.config = new LogbackConfig(traceContext.getProfilerConfig());
     }
 
     @Override
@@ -50,35 +50,52 @@ public class PatternLayoutInterceptor implements AroundInterceptor1 {
             return;
         }
         String oldPattern = (String) arg0;
+        if (config.isPatternFullReplace()) {
+            updatePattern(target, oldPattern, config.getPatternFullReplaceWith());
+            return;
+        }
         if (oldPattern.contains(PATTERN_TRANSACTION_ID)) {
             if (debug) {
                 logger.debug("Logback pattern already have pinpoint pattern, pattern:{}", oldPattern);
             }
             return;
         }
-        updatePattern(target, oldPattern, logbackConfig.getPatternReplaceSearchList(), logbackConfig.getPatternReplaceWith());
+        updatePattern(target, oldPattern, config.getPatternReplaceSearchList(), config.getPatternReplaceWith());
+    }
+
+    private void updatePattern(Object target, String old, String replace) {
+        if (replace.contentEquals(old)) {
+            return;
+        }
+        if (updatePattern(target, replace)) {
+            logger.info("Logback pattern fully-replaced, old pattern({}) and new pattern({})", old, replace);
+        }
     }
 
     private void updatePattern(Object target, String oldPattern, List<String> searchList, String replace) {
-        if (!(target instanceof PatternLayoutBase<?>)) {
-            return;
-        }
         String newPattern = oldPattern;
         boolean changed = false;
         for (String search : searchList) {
             newPattern = oldPattern.replace(search, replace);
             if (!oldPattern.contentEquals(newPattern)) {
                 changed = true;
-                if (debug) {
-                    logger.debug("Logback pattern replaced, old pattern({}) and new pattern({})", oldPattern, newPattern);
-                }
                 break;
             }
         }
         if (changed) {
-            final PatternLayoutBase<?> patternLayout = (PatternLayoutBase<?>) target;
-            patternLayout.setPattern(newPattern);
+            if (updatePattern(target, newPattern)) {
+                logger.info("Logback pattern replaced, old pattern({}) and new pattern({})", oldPattern, newPattern);
+            }
         }
+    }
+
+    private boolean updatePattern(Object target, String pattern) {
+        if (!(target instanceof PatternLayoutBase<?>)) {
+            return false;
+        }
+        final PatternLayoutBase<?> patternLayout = (PatternLayoutBase<?>) target;
+        patternLayout.setPattern(pattern);
+        return true;
     }
 
 }


### PR DESCRIPTION
Fix #11290.

Automatically change logger's pattern with the configured value.

* log4j
profiler.log4j.logging.pattern.replace.enable=true
profiler.log4j.logging.pattern.full_replace.with=TxId:%X{PtxId} %m

* log4j2
profiler.log4j2.logging.pattern.replace.enable=true
profiler.log4j2.logging.pattern.full_replace.with=TxId:%X{PtxId} %msg

* logback
profiler.logback.logging.pattern.replace.enable=true
profiler.logback.logging.pattern.full_replace.with=%d{yyyy-MM-dd HH:mm:ss} [%p] [%t] %c [Txid:%X{PtxId} ReqId:%X{PreqId}] --- %m%n