### PR TITLE
[#11358] add pinot systemd deploy files

### DIFF
--- a/pinot/pinot-deploy/etc-default/pinot
+++ b/pinot/pinot-deploy/etc-default/pinot
@@ -1,0 +1,1 @@
+PINOT_HOME=/opt/pinot

--- a/pinot/pinot-deploy/etc-systemd-system/pinot-broker.service
+++ b/pinot/pinot-deploy/etc-systemd-system/pinot-broker.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Apache Pinot broker
+Documentation=https://docs.pinot.apache.org/
+After=network-online.target 
+Requires=pinot-controller.service
+PartOf=pinot.service
+ 
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/pinot
+User=pinot
+Group=pinot
+WorkingDirectory=/opt/pinot
+ExecStart=/opt/pinot/sbin/run-pinot-broker
+StandardOutput=file:///var/log/pinot/broker-output.log
+StandardError=file:///var/log/pinot/broker-error.log
+SuccessExitStatus=0 143
+ 
+[Install]
+WantedBy=multi-user.target

--- a/pinot/pinot-deploy/etc-systemd-system/pinot-controller.service
+++ b/pinot/pinot-deploy/etc-systemd-system/pinot-controller.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Apache Pinot controller
+Documentation=https://docs.pinot.apache.org/
+After=network-online.target
+PartOf=pinot.service
+ 
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/pinot
+User=pinot
+Group=pinot
+WorkingDirectory=/opt/pinot
+ExecStart=/opt/pinot/sbin/run-pinot-controller
+StandardOutput=file:///var/log/pinot/controller-output.log
+StandardError=file:///var/log/pinot/controller-error.log
+SuccessExitStatus=0 143
+ 
+[Install]
+WantedBy=multi-user.target

--- a/pinot/pinot-deploy/etc-systemd-system/pinot-kafka.service
+++ b/pinot/pinot-deploy/etc-systemd-system/pinot-kafka.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Apache Pinot kafka
+Documentation=https://docs.pinot.apache.org/
+After=network-online.target 
+Wants=pinot-controller.service pinot-broker.service pinot-server.service
+PartOf=pinot.service
+ 
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/pinot
+User=pinot
+Group=pinot
+WorkingDirectory=/opt/pinot
+ExecStart=/opt/pinot/sbin/run-pinot-kafka
+StandardOutput=file:///var/log/pinot/kafka-output.log
+StandardError=file:///var/log/pinot/kafka-error.log
+SuccessExitStatus=0 143
+ 
+[Install]
+WantedBy=multi-user.target

--- a/pinot/pinot-deploy/etc-systemd-system/pinot-server.service
+++ b/pinot/pinot-deploy/etc-systemd-system/pinot-server.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Apache Pinot server
+Documentation=https://docs.pinot.apache.org/
+After=network-online.target 
+Requires=pinot-controller.service pinot-broker.service
+PartOf=pinot.service
+ 
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/pinot
+User=pinot
+Group=pinot
+WorkingDirectory=/opt/pinot
+ExecStart=/opt/pinot/sbin/run-pinot-server
+StandardOutput=file:///var/log/pinot/server-output.log
+StandardError=file:///var/log/pinot/server-error.log
+SuccessExitStatus=0 143
+ 
+[Install]
+WantedBy=multi-user.target

--- a/pinot/pinot-deploy/etc-systemd-system/pinot.service
+++ b/pinot/pinot-deploy/etc-systemd-system/pinot.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Apache Pinot Launcher Service
+Documentation=https://docs.pinot.apache.org/
+After=network-online.target 
+Requires=pinot-controller.service pinot-broker.service pinot-server.service pinot-kafka.service
+ 
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/default/pinot
+User=pinot
+Group=pinot
+WorkingDirectory=/opt/pinot
+ExecStart=/usr/bin/date
+StandardOutput=file:///var/log/pinot/launcher-output.log
+StandardError=file:///var/log/pinot/launcher-error.log
+SuccessExitStatus=0
+RemainAfterExit=yes
+ 
+[Install]
+WantedBy=multi-user.target

--- a/pinot/pinot-deploy/opt-pinot-sbin/run-pinot
+++ b/pinot/pinot-deploy/opt-pinot-sbin/run-pinot
@@ -1,0 +1,5 @@
+#!/bin/sh
+"${PINOT_HOME}/sbin/run-pinot-controller"
+"${PINOT_HOME}/sbin/run-pinot-broker"
+"${PINOT_HOME}/sbin/run-pinot-server"
+"${PINOT_HOME}/sbin/run-pinot-kafka"

--- a/pinot/pinot-deploy/opt-pinot-sbin/run-pinot-broker
+++ b/pinot/pinot-deploy/opt-pinot-sbin/run-pinot-broker
@@ -1,0 +1,3 @@
+#!/bin/sh
+export JAVA_OPTS="-Xms4G -Xmx4G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc:./logs/gc-pinot-broker.log"
+"${PINOT_HOME}/bin/pinot-admin.sh" StartBroker -zkAddress zk:2181

--- a/pinot/pinot-deploy/opt-pinot-sbin/run-pinot-controller
+++ b/pinot/pinot-deploy/opt-pinot-sbin/run-pinot-controller
@@ -1,0 +1,3 @@
+#!/bin/sh
+export JAVA_OPTS="-Xms4G -Xmx8G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc:logs/gc-pinot-controller.log"
+"${PINOT_HOME}/bin/pinot-admin.sh" StartController -zkAddress zk:2181 -controllerPort 9000

--- a/pinot/pinot-deploy/opt-pinot-sbin/run-pinot-kafka
+++ b/pinot/pinot-deploy/opt-pinot-sbin/run-pinot-kafka
@@ -1,0 +1,2 @@
+#!/bin/sh
+"${PINOT_HOME}/bin/pinot-admin.sh" StartKafka -zkAddress=zk:2181/kafka -port 19092

--- a/pinot/pinot-deploy/opt-pinot-sbin/run-pinot-server
+++ b/pinot/pinot-deploy/opt-pinot-sbin/run-pinot-server
@@ -1,0 +1,3 @@
+#!/bin/sh
+export JAVA_OPTS="-Xms4G -Xmx16G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc:logs/gc-pinot-server.log"
+"${PINOT_HOME}/bin/pinot-admin.sh" StartServer -zkAddress zk:2181


### PR DESCRIPTION
Fix #11358.

Use systemd to manage pinot. Add unit files and help scripts to run pinot.

Download pinot binaries from (official website)[https://pinot.apache.org/download], ex. [v1.1.0](https://www.apache.org/dyn/closer.lua/pinot/apache-pinot-1.1.0/apache-pinot-1.1.0-bin.tar.gz?action=download) .

```bash
mkdir -p /opt/pinot/sbin
cp -v pinot/pinot-deploy/opt-pinot-sbin/* /opt/pinot/sbin/
tar xzvf apache-pinot-<version>-bin.tar.gz -C /opt/pinot 
cp -v pinot/pinot-deploy/etc-default/pinot  /etc/default/pinot
cp -v pinot/pinot-deploy/etc-systemd-system/pinot* /etc/systemd/system/
adduser --system --group --no-create-home pinot
chown -R pinot:pinot /opt/pinot
systemctl daemon-reload
systemctl enable --now pinot.service
```