### PR TITLE
[#11464] UI v3, inspector can be configured hidden.

### DIFF
--- a/web-frontend/src/main/v3/apps/web/src/hooks/useMenuItems.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/hooks/useMenuItems.tsx
@@ -35,6 +35,7 @@ export const useMenuItems = () => {
       name: 'Inspector',
       path: APP_PATH.INSPECTOR,
       href: getInspectorPath(application, searchParameters),
+      hide: !configuration?.showV3Inspector,
     },
     {
       icon: <PiChartBar />,

--- a/web-frontend/src/main/v3/packages/constants/src/types/Configuration.ts
+++ b/web-frontend/src/main/v3/packages/constants/src/types/Configuration.ts
@@ -5,6 +5,7 @@ export interface Configuration {
   sendUsage: boolean;
   editUserInfo: boolean;
   enableServerMapRealTime: boolean;
+  showV3Inspector: boolean;
   showApplicationStat: boolean;
   showStackTraceOnError: boolean;
   showSystemMetric: boolean;

--- a/web/src/main/java/com/navercorp/pinpoint/web/config/ConfigProperties.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/config/ConfigProperties.java
@@ -55,6 +55,9 @@ public class ConfigProperties {
     @Value("${security.guide.url:#{null}}")
     private String securityGuideUrl;
 
+    @Value("${config.show.v3Inspector:false}")
+    private boolean showV3Inspector;
+
     @Value("${config.show.applicationStat:false}")
     private boolean showApplicationStat;
 
@@ -111,6 +114,10 @@ public class ConfigProperties {
         return this.openSource;
     }
 
+    public boolean isShowV3Inspector() {
+        return showV3Inspector;
+    }
+
     public boolean isShowApplicationStat() {
         return this.showApplicationStat;
     }
@@ -161,6 +168,7 @@ public class ConfigProperties {
         sb.append(", enableServerMapRealTime=").append(enableServerMapRealTime);
         sb.append(", openSource=").append(openSource);
         sb.append(", securityGuideUrl='").append(securityGuideUrl).append('\'');
+        sb.append(", showV3Inspector=").append(showV3Inspector);
         sb.append(", showApplicationStat=").append(showApplicationStat);
         sb.append(", showStackTraceOnError=").append(showStackTraceOnError);
         sb.append(", webSocketAllowedOrigins=").append(webSocketAllowedOrigins);

--- a/web/src/main/java/com/navercorp/pinpoint/web/config/ConfigProperties.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/config/ConfigProperties.java
@@ -55,7 +55,7 @@ public class ConfigProperties {
     @Value("${security.guide.url:#{null}}")
     private String securityGuideUrl;
 
-    @Value("${config.show.v3Inspector:false}")
+    @Value("${config.show.v3Inspector:true}")
     private boolean showV3Inspector;
 
     @Value("${config.show.applicationStat:false}")

--- a/web/src/main/java/com/navercorp/pinpoint/web/frontend/export/ConfigPropertiesExporter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/frontend/export/ConfigPropertiesExporter.java
@@ -22,6 +22,7 @@ public class ConfigPropertiesExporter implements FrontendConfigExporter {
         export.put("sendUsage", webProperties.getSendUsage());
         export.put("editUserInfo", webProperties.getEditUserInfo());
         export.put("enableServerMapRealTime", webProperties.isEnableServerMapRealTime());
+        export.put("showV3Inspector", webProperties.isShowV3Inspector());
         export.put("showApplicationStat", webProperties.isShowApplicationStat());
         export.put("showStackTraceOnError", webProperties.isShowStackTraceOnError());
         export.put("showSystemMetric", webProperties.isShowSystemMetric());

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -44,6 +44,7 @@ config.openSource=true
 config.show.activeThread=true
 config.show.activeThreadDump=true
 config.enable.activeThreadDump=true
+config.show.v3Inspector=false
 config.show.applicationStat=false
 config.show.stackTraceOnError=true
 

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -44,7 +44,7 @@ config.openSource=true
 config.show.activeThread=true
 config.show.activeThreadDump=true
 config.enable.activeThreadDump=true
-config.show.v3Inspector=false
+config.show.v3Inspector=true
 config.show.applicationStat=false
 config.show.stackTraceOnError=true
 


### PR DESCRIPTION
Fix #11464.

The inspector (which depends on Apache Pinot) sub-menu in UI v3 can be hide by web configuration `-Dconfig.show.v3Inspector=false`.