### PR TITLE
[#11589] Disable OtlpMetricsExportAutoConfiguration. 

### DIFF
--- a/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/BasicCollectorApp.java
+++ b/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/BasicCollectorApp.java
@@ -4,6 +4,7 @@ import com.navercorp.pinpoint.collector.PinpointCollectorModule;
 import com.navercorp.pinpoint.collector.event.config.CollectorEventConfiguration;
 import com.navercorp.pinpoint.redis.RedisPropertySources;
 import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.otlp.OtlpMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration;
@@ -22,7 +23,8 @@ import org.springframework.context.annotation.Import;
         RedisAutoConfiguration.class,
         RedisRepositoriesAutoConfiguration.class,
         RedisReactiveAutoConfiguration.class,
-        DataSourceTransactionManagerAutoConfiguration.class
+        DataSourceTransactionManagerAutoConfiguration.class,
+        OtlpMetricsExportAutoConfiguration.class
 })
 @Import({
         PinpointCollectorModule.class,

--- a/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/PinpointCollectorStarter.java
+++ b/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/PinpointCollectorStarter.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.uristat.collector.UriStatCollectorConfig;
 import org.springframework.boot.Banner;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.otlp.OtlpMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration;
@@ -42,6 +43,7 @@ import java.util.Arrays;
         RedisRepositoriesAutoConfiguration.class,
         RedisReactiveAutoConfiguration.class,
         ApplicationRunnerAutoConfiguration.class,
+        OtlpMetricsExportAutoConfiguration.class
 })
 public class PinpointCollectorStarter {
     private static final ServerBootLogger logger = ServerBootLogger.getLogger(PinpointCollectorStarter.class);


### PR DESCRIPTION
Disable OtlpMetricsExportAutoConfiguration. Because it is not used.