### PR TITLE
[#10776] If metricGroup, metric, and field name are empty string, put the default value

### DIFF
--- a/otlpmetric/otlpmetric-collector/src/main/java/com/navercorp/pinpoint/otlp/collector/mapper/GaugeMapper.java
+++ b/otlpmetric/otlpmetric-collector/src/main/java/com/navercorp/pinpoint/otlp/collector/mapper/GaugeMapper.java
@@ -16,10 +16,12 @@
 
 package com.navercorp.pinpoint.otlp.collector.mapper;
 
+import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.otlp.collector.model.OtlpMetricData;
 import com.navercorp.pinpoint.otlp.collector.model.OtlpMetricDataPoint;
 import com.navercorp.pinpoint.otlp.common.model.AggreFunc;
 import com.navercorp.pinpoint.otlp.common.model.DataType;
+import com.navercorp.pinpoint.otlp.common.model.MetricName;
 import com.navercorp.pinpoint.otlp.common.model.MetricType;
 import io.opentelemetry.proto.metrics.v1.DataPointFlags;
 import io.opentelemetry.proto.metrics.v1.Metric;
@@ -68,21 +70,30 @@ public class GaugeMapper extends OtlpMetricDataMapper {
 
     @Override
     protected String setMetricName(OtlpMetricData.Builder builder, String metricName) {
+        builder.setMetricGroupName(MetricName.EMPTY_METRIC_GROUP_NAME);
+        builder.setMetricName(MetricName.EMPTY_METRIC_NAME);
+
         List<String> names = new LinkedList<>(Arrays.asList(metricName.split("\\.")));
         int length = names.size();
 
-        if ( length == 1 ) {
-            builder.setMetricName(names.get(length - 1));
-            return "";
+        if ( length == 0 ) {
+            return MetricName.EMPTY_FIELD_NAME;
+        } else if ( length == 1 ) {
+            builder.setMetricGroupName(getName(names.get(length - 1), MetricName.EMPTY_METRIC_GROUP_NAME));
+            return MetricName.EMPTY_FIELD_NAME;
         } else if ( length == 2 ) {
-            builder.setMetricName(names.get(length - 1));
-            builder.setMetricGroupName(names.get(length - 2));
-            return "";
+            builder.setMetricName(getName(names.get(length - 1), MetricName.EMPTY_METRIC_NAME));
+            builder.setMetricGroupName(getName(names.get(length - 2), MetricName.EMPTY_METRIC_GROUP_NAME));
+            return MetricName.EMPTY_FIELD_NAME;
         } else {
-            String fieldName = names.remove(length - 1);
-            builder.setMetricName(names.remove(length - 2));
-            builder.setMetricGroupName(String.join(".", names));
+            String fieldName = getName(names.remove(length - 1), MetricName.EMPTY_FIELD_NAME);
+            builder.setMetricName(getName(names.remove(length - 2), MetricName.EMPTY_METRIC_NAME));
+            builder.setMetricGroupName(getName(String.join(".", names), MetricName.EMPTY_METRIC_GROUP_NAME));
             return fieldName;
         }
+    }
+
+    private String getName(String name, String defaultValue) {
+        return StringUtils.isEmpty(name) ? defaultValue : name;
     }
 }

--- a/otlpmetric/otlpmetric-collector/src/test/java/com/navercorp/pinpoint/otlp/collector/mapper/GaugeMapperTest.java
+++ b/otlpmetric/otlpmetric-collector/src/test/java/com/navercorp/pinpoint/otlp/collector/mapper/GaugeMapperTest.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.otlp.collector.mapper;
 
 import com.navercorp.pinpoint.otlp.collector.model.OtlpMetricData;
+import com.navercorp.pinpoint.otlp.common.model.MetricName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -30,20 +31,23 @@ class GaugeMapperTest {
     public void setMetricNameTest() {
         GaugeMapper gaugeMapper = new GaugeMapper();
         OtlpMetricData.Builder builder = new OtlpMetricData.Builder();
-        gaugeMapper.setMetricName(builder, "metricGroupName.metricName");
+        String fieldName = gaugeMapper.setMetricName(builder, "metricGroupName.metricName");
         OtlpMetricData otlpMetricData = builder.build();
         assertEquals("metricName", otlpMetricData.getMetricName());
         assertEquals("metricGroupName", otlpMetricData.getMetricGroupName());
+        assertEquals(MetricName.EMPTY_FIELD_NAME, fieldName);
     }
 
     @Test
     public void setMetricNameTest2() {
         GaugeMapper gaugeMapper = new GaugeMapper();
         OtlpMetricData.Builder builder = new OtlpMetricData.Builder();
-        gaugeMapper.setMetricName(builder, "metric");
+        String fieldName = gaugeMapper.setMetricName(builder, "metricGroupName");
         OtlpMetricData otlpMetricData = builder.build();
-        assertEquals("", otlpMetricData.getMetricGroupName());
-        assertEquals("metric", otlpMetricData.getMetricName());
+        assertEquals("metricGroupName", otlpMetricData.getMetricGroupName());
+        assertEquals(MetricName.EMPTY_METRIC_NAME, otlpMetricData.getMetricName());
+        assertEquals(MetricName.EMPTY_FIELD_NAME, fieldName);
+
     }
 
     @Test
@@ -55,5 +59,49 @@ class GaugeMapperTest {
         assertEquals("metricGroupName", otlpMetricData.getMetricGroupName());
         assertEquals("metricName", otlpMetricData.getMetricName());
         assertEquals("fieldName", fieldName);
+    }
+
+    @Test
+    public void setMetricNameTest4() {
+        GaugeMapper gaugeMapper = new GaugeMapper();
+        OtlpMetricData.Builder builder = new OtlpMetricData.Builder();
+        String fieldName = gaugeMapper.setMetricName(builder, "");
+        OtlpMetricData otlpMetricData = builder.build();
+        assertEquals(MetricName.EMPTY_METRIC_GROUP_NAME, otlpMetricData.getMetricGroupName());
+        assertEquals(MetricName.EMPTY_METRIC_NAME, otlpMetricData.getMetricName());
+        assertEquals(MetricName.EMPTY_FIELD_NAME, fieldName);
+    }
+
+    @Test
+    public void setMetricNameTest5() {
+        GaugeMapper gaugeMapper = new GaugeMapper();
+        OtlpMetricData.Builder builder = new OtlpMetricData.Builder();
+        String fieldName = gaugeMapper.setMetricName(builder, "...");
+        OtlpMetricData otlpMetricData = builder.build();
+        assertEquals(MetricName.EMPTY_METRIC_GROUP_NAME, otlpMetricData.getMetricGroupName());
+        assertEquals(MetricName.EMPTY_METRIC_NAME, otlpMetricData.getMetricName());
+        assertEquals(MetricName.EMPTY_FIELD_NAME, fieldName);
+    }
+
+    @Test
+    public void setMetricNameTest6() {
+        GaugeMapper gaugeMapper = new GaugeMapper();
+        OtlpMetricData.Builder builder = new OtlpMetricData.Builder();
+        String fieldName = gaugeMapper.setMetricName(builder, "...metric");
+        OtlpMetricData otlpMetricData = builder.build();
+        assertEquals(".", otlpMetricData.getMetricGroupName());
+        assertEquals(MetricName.EMPTY_METRIC_NAME, otlpMetricData.getMetricName());
+        assertEquals("metric", fieldName);
+    }
+
+    @Test
+    public void setMetricNameTest7() {
+        GaugeMapper gaugeMapper = new GaugeMapper();
+        OtlpMetricData.Builder builder = new OtlpMetricData.Builder();
+        String fieldName = gaugeMapper.setMetricName(builder, "process.info.cpu.jvm");
+        OtlpMetricData otlpMetricData = builder.build();
+        assertEquals("process.info", otlpMetricData.getMetricGroupName());
+        assertEquals("cpu", otlpMetricData.getMetricName());
+        assertEquals("jvm", fieldName);
     }
 }

--- a/otlpmetric/otlpmetric-common/src/main/java/com/navercorp/pinpoint/otlp/common/model/MetricName.java
+++ b/otlpmetric/otlpmetric-common/src/main/java/com/navercorp/pinpoint/otlp/common/model/MetricName.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.common.model;
+
+/**
+ * @author minwoo-jung
+ */
+public class MetricName {
+
+    public static final String EMPTY_METRIC_GROUP_NAME = "emptyMetricGroup";
+    public static final String EMPTY_METRIC_NAME = "emptyMetric";
+    public static final String EMPTY_FIELD_NAME = "emptyField";
+
+}


### PR DESCRIPTION
If metricGroup, metric, and field name are empty string, put the default value. This is to make it easier for users to define and search for metrics.