### PR TITLE
[#noissue] Fix possible NPE in ConnectionCountServerTransportFilter

### DIFF
--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/server/ConnectionCountServerTransportFilter.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/server/ConnectionCountServerTransportFilter.java
@@ -47,6 +47,10 @@ public class ConnectionCountServerTransportFilter extends ServerTransportFilter 
 
     @Override
     public void transportTerminated(Attributes transportAttrs) {
+        if (transportAttrs == null) {
+            // transportTerminated() can be called before transportReady()
+            return;
+        }
         final AtomicInteger terminated = transportAttrs.get(TERMINATED);
         if (terminated == null) {
             return;


### PR DESCRIPTION
If `transportTerminated()` is called before `transportReady()`, `transportAttrs` in `transportTerminated()` can be `null` because it is initialized in `transportReady()`.