### PR TITLE
Fix link to feature guide

### DIFF
--- a/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
@@ -1236,17 +1236,17 @@ profiler.reactor.trace.timeout=true
 profiler.reactor.trace.subscribe=true
 
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# log4j2 (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j2 (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j2.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
@@ -1232,7 +1232,7 @@ profiler.reactor.trace.timeout=true
 profiler.reactor.trace.subscribe=true
 
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
@@ -1245,7 +1245,7 @@ profiler.log4j.logging.transactioninfo=false
 #profiler.log4j.logging.pattern.replace.with="TxId:%X{PtxId} %m"
 
 ###########################################################
-# log4j2 (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j2 (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j2.logging.transactioninfo=false
 
@@ -1258,7 +1258,7 @@ profiler.log4j2.logging.transactioninfo=false
 #profiler.log4j2.logging.pattern.replace.with="TxId:%X{PtxId} %msg"
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins-it/activemq-it/activemq-5-15-it/src/test/resources/activemq/client/pinpoint-activemq-client.config
+++ b/agent-module/plugins-it/activemq-it/activemq-5-15-it/src/test/resources/activemq/client/pinpoint-activemq-client.config
@@ -440,12 +440,12 @@ profiler.spring.beans.1.annotation=org.springframework.stereotype.Controller,org
 
 profiler.spring.beans.mark.error=false
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins-it/activemq-it/activemq-5-17-it/src/test/resources/activemq/client/pinpoint-activemq-client.config
+++ b/agent-module/plugins-it/activemq-it/activemq-5-17-it/src/test/resources/activemq/client/pinpoint-activemq-client.config
@@ -440,12 +440,12 @@ profiler.spring.beans.1.annotation=org.springframework.stereotype.Controller,org
 
 profiler.spring.beans.mark.error=false
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins-it/cxf-it/cxf-3-0-it/src/test/resources/cxf/pinpoint-cxf-test.config
+++ b/agent-module/plugins-it/cxf-it/cxf-3-0-it/src/test/resources/cxf/pinpoint-cxf-test.config
@@ -725,12 +725,12 @@ profiler.spring.async.enable=true
 profiler.spring.async.executor.class.names=
 
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins-it/cxf-it/cxf-3-6-it/src/test/resources/cxf/pinpoint-cxf-test.config
+++ b/agent-module/plugins-it/cxf-it/cxf-3-6-it/src/test/resources/cxf/pinpoint-cxf-test.config
@@ -725,12 +725,12 @@ profiler.spring.async.enable=true
 profiler.spring.async.executor.class.names=
 
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins-it/druid-it/src/test/resources/druid/pinpoint-druid-test.config
+++ b/agent-module/plugins-it/druid-it/src/test/resources/druid/pinpoint-druid-test.config
@@ -731,12 +731,12 @@ profiler.spring.async.enable=true
 profiler.spring.async.executor.class.names=
 
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins-it/fastjson-it/src/test/resources/fastjson/pinpoint-fastjson-test.config
+++ b/agent-module/plugins-it/fastjson-it/src/test/resources/fastjson/pinpoint-fastjson-test.config
@@ -725,12 +725,12 @@ profiler.spring.async.enable=true
 profiler.spring.async.executor.class.names=
 
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins-it/hbase-it/src/test/resources/hbase/pinpoint-hbase-test.config
+++ b/agent-module/plugins-it/hbase-it/src/test/resources/hbase/pinpoint-hbase-test.config
@@ -731,12 +731,12 @@ profiler.spring.async.enable=true
 profiler.spring.async.executor.class.names=
 
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins-it/hystrix-it/src/test/resources/hystrix/pinpoint-hystrix.config
+++ b/agent-module/plugins-it/hystrix-it/src/test/resources/hystrix/pinpoint-hystrix.config
@@ -575,12 +575,12 @@ profiler.spring.beans.1.annotation=org.springframework.stereotype.Controller,org
 
 profiler.spring.beans.mark.error=false
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins-it/jtds-it/src/test/resources/pinpoint.config
+++ b/agent-module/plugins-it/jtds-it/src/test/resources/pinpoint.config
@@ -306,16 +306,16 @@ profiler.spring.beans.mark.error=false
 profiler.spring.beans.intersection=false
 
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=true
 
 ###########################################################
-# log4j2 (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j2 (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j2.logging.transactioninfo=true
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=true

--- a/agent-module/plugins-it/rxjava-it/src/test/resources/rxjava/pinpoint-rxjava.config
+++ b/agent-module/plugins-it/rxjava-it/src/test/resources/rxjava/pinpoint-rxjava.config
@@ -561,12 +561,12 @@ profiler.spring.beans.1.annotation=org.springframework.stereotype.Controller,org
 
 profiler.spring.beans.mark.error=false
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins/akka-http/src/test/resources/pinpoint.config
+++ b/agent-module/plugins/akka-http/src/test/resources/pinpoint.config
@@ -590,12 +590,12 @@ profiler.spring.beans.1.annotation=org.springframework.stereotype.Controller,org
 
 profiler.spring.beans.mark.error=false
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/agent-module/plugins/weblogic/src/test/resources/pinpoint.config
+++ b/agent-module/plugins/weblogic/src/test/resources/pinpoint.config
@@ -486,12 +486,12 @@ profiler.spring.beans.1.annotation=org.springframework.stereotype.Controller,org
 
 profiler.spring.beans.mark.error=false
 ###########################################################
-# log4j (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.log4j.logging.transactioninfo=false
 
 ###########################################################
-# logback (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+# logback (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 ###########################################################
 profiler.logback.logging.transactioninfo=false
 

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -3,7 +3,7 @@ pinpoint.zookeeper.address=localhost
 # FIXME - should be removed for proper authentication
 admin.password=admin
 
-#log site link (guide url : https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md)
+#log site link (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)
 #log.enable=false
 #log.page.url=
 #log.button.name=


### PR DESCRIPTION
As indicated in #11911, the links to the feature guides are outdated. This is fixed by this PR, done using:

```
for file in $(fgrep -Rl "https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md" *)
do     
   sed -i 's|https://github.com/naver/pinpoint/blob/master/doc/per-request_feature_guide.md|https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md|g' "$file"
done
```