### PR TITLE
[#11967] Skip leading space when binding values

### DIFF
--- a/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/sql/OutputParameterParser.java
+++ b/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/sql/OutputParameterParser.java
@@ -40,10 +40,14 @@ public class OutputParameterParser {
         for (int index = 0; index < outputParams.length(); index++) {
             final char ch = outputParams.charAt(index);
             if (ch == SEPARATOR) {
-                if (lookAhead1(outputParams, index) == SEPARATOR) {
+                int ahead = lookAhead1(outputParams, index);
+                if (ahead == SEPARATOR) {
                     params.append(SEPARATOR);
                     index++;
                 } else {
+                    if (ahead == ' ') {
+                        index++;
+                    }
                     result.add(params.toString());
                     params = new StringBuilder();
                 }

--- a/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/sql/DefaultSqlNormalizerTest.java
+++ b/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/sql/DefaultSqlNormalizerTest.java
@@ -244,7 +244,13 @@ public class DefaultSqlNormalizerTest {
 
         sql = "select * from table a = ? and b=? and c=? and d=?";
         expected = "select * from table a = '1' and b='50' and c=' foo ' and d='11'";
-        bindValues = parameterParser.parseOutputParameter("1,50, foo ,11");
+        bindValues = parameterParser.parseOutputParameter("1,50,  foo ,11");
+        result = sqlNormalizer.combineBindValues(sql, bindValues);
+        Assertions.assertEquals(expected, result);
+
+        sql = "select * from table a = ? and b=? and c=? and d=?";
+        expected = "select * from table a = '1' and b='50' and c='foo' and d='11'";
+        bindValues = parameterParser.parseOutputParameter("1, 50, foo, 11");
         result = sqlNormalizer.combineBindValues(sql, bindValues);
         Assertions.assertEquals(expected, result);
 

--- a/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/sql/OutputParameterParserTest.java
+++ b/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/sql/OutputParameterParserTest.java
@@ -45,6 +45,9 @@ public class OutputParameterParserTest {
 
         assertOutputParameter("");
 
+        assertOutputParameter("1, 2, 3", "1", "2", "3");
+
+        assertOutputParameter("1 , 2,  3", "1 ", "2", " 3");
     }
 
     private void assertOutputParameter(String outputParam, String... params) {


### PR DESCRIPTION
Ignore leading space when binding parameters since an extra space is added at the agent side when packing values in `String`.

https://github.com/pinpoint-apm/pinpoint/blob/7c92d5de7d9bafba9e341256608a49eec1922695/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/jdbc/BindValueUtils.java#L82-L103

Resolves #11967.