### PR TITLE
[#noissue] Add specific filter for Instrument

### DIFF
--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/instrument/InstrumentClass.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/instrument/InstrumentClass.java
@@ -38,6 +38,8 @@ public interface InstrumentClass {
     
     InstrumentMethod getConstructor(String... parameterTypes);
 
+    InstrumentMethod getConstructor(MethodFilter filter);
+
     List<InstrumentMethod> getDeclaredConstructors();
 
     List<InstrumentMethod> getDeclaredMethods();
@@ -45,6 +47,8 @@ public interface InstrumentClass {
     List<InstrumentMethod> getDeclaredMethods(MethodFilter filter);
 
     InstrumentMethod getDeclaredMethod(String name, String... parameterTypes);
+    
+    InstrumentMethod getDeclaredMethod(String name, MethodFilter filter);
 
     @Deprecated
     InstrumentMethod getLambdaMethod(String... parameterTypes);

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClass.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClass.java
@@ -162,8 +162,32 @@ public class ASMClass implements InstrumentClass {
     }
 
     @Override
+    public InstrumentMethod getDeclaredMethod(final String methodName, final MethodFilter methodFilter) {
+        Objects.requireNonNull(methodName, "name");
+        Objects.requireNonNull(methodFilter, "methodFilter");
+
+        final List<ASMMethodNodeAdapter> declaredMethod = this.classNode.getDeclaredMethod(methodName);
+        if (declaredMethod.isEmpty()) {
+            return null;
+        }
+        for (ASMMethodNodeAdapter methodNode : declaredMethod) {
+            final InstrumentMethod method = new ASMMethod(this.engineComponent, this.pluginContext, this, methodNode);
+            if (methodFilter.accept(method)) {
+                return method;
+            }
+        }
+        
+        return null;
+    }
+
+    @Override
     public InstrumentMethod getConstructor(final String... parameterTypes) {
         return getDeclaredMethod("<init>", parameterTypes);
+    }
+
+    @Override
+    public InstrumentMethod getConstructor(final MethodFilter methodFilter) {
+        return getDeclaredMethod("<init>", methodFilter);
     }
 
     @Override

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClassNodeAdapter.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClassNodeAdapter.java
@@ -188,6 +188,14 @@ public class ASMClassNodeAdapter {
         return findDeclaredMethod(methodName, desc);
     }
 
+    public List<ASMMethodNodeAdapter> getDeclaredMethod(final String methodName) {
+        if (this.skipCode) {
+            throw new IllegalStateException("not supported operation, skipCode option is true.");
+        }
+        
+        return findDeclaredMethod(methodName);
+    }
+
     public List<ASMMethodNodeAdapter> getDeclaredConstructors() {
         if (this.skipCode) {
             throw new IllegalStateException("not supported operation, skipCode option is true.");

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMNestedClass.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMNestedClass.java
@@ -75,6 +75,11 @@ public class ASMNestedClass implements InstrumentClass {
     }
 
     @Override
+    public InstrumentMethod getDeclaredMethod(String name, MethodFilter filter) {
+        return null;
+    }
+
+    @Override
     @Deprecated
     public InstrumentMethod getLambdaMethod(String... parameterTypes) {
         return null;
@@ -107,6 +112,11 @@ public class ASMNestedClass implements InstrumentClass {
 
     @Override
     public InstrumentMethod getConstructor(String... parameterTypes) {
+        return null;
+    }
+
+    @Override
+    public InstrumentMethod getConstructor(MethodFilter filter) {
         return null;
     }
 

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMClassNodeAdapterTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMClassNodeAdapterTest.java
@@ -253,7 +253,7 @@ public class ASMClassNodeAdapterTest {
         ASMClassNodeAdapter adapter = ASMClassNodeAdapter.get(pluginClassInputStreamProvider, ASMClassNodeLoader.getClassLoader(),
                 getClass().getProtectionDomain(), "com/navercorp/pinpoint/profiler/instrument/mock/ArgsClass");
         List<ASMMethodNodeAdapter> constructors = adapter.getDeclaredConstructors();
-        assertThat(constructors).hasSize(2);
+        assertThat(constructors).hasSize(4);
         assertEquals("ArgsClass", constructors.get(0).getName());
 
         assertEquals("ArgsClass", constructors.get(1).getName());

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMClassTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMClassTest.java
@@ -93,6 +93,7 @@ import org.mockito.stubbing.Answer;
 import org.objectweb.asm.tree.ClassNode;
 
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -257,15 +258,37 @@ public class ASMClassTest {
     }
 
     @Test
+    public void getSpecificDeclaredMethod() throws Exception {
+        ASMClass clazz = getClass("com.navercorp.pinpoint.profiler.instrument.mock.ArgsClass");
+        InstrumentMethod method1 = clazz.getDeclaredMethod("argSpecificMethod", MethodFilters.chain(
+                MethodFilters.argAt(1, "long")
+        ));
+        assertNotNull(method1);
+        assertEquals(2, method1.getParameterTypes().length);
+        assertEquals("int", method1.getParameterTypes()[0]);
+    }
+
+    @Test
     public void getDeclaredConstructors() throws Exception {
         ASMClass clazz = getClass("com.navercorp.pinpoint.profiler.instrument.mock.ArgsClass");
         List<InstrumentMethod> constructors = clazz.getDeclaredConstructors();
         assertNotNull(constructors);
-        assertThat(constructors).hasSize(2);
+        assertThat(constructors).hasSize(4);
         assertEquals("ArgsClass", constructors.get(0).getName());
 
         assertEquals("ArgsClass", constructors.get(1).getName());
         assertArrayEquals(new String[]{"int"}, constructors.get(1).getParameterTypes());
+    }
+
+    @Test
+    public void getSpecificDeclaredConstructor() throws Exception {
+        ASMClass clazz = getClass("com.navercorp.pinpoint.profiler.instrument.mock.ArgsClass");
+        InstrumentMethod constructor = clazz.getConstructor(MethodFilters.chain(
+                MethodFilters.name("ArgsClass"),
+                MethodFilters.argAt(1, "int")
+        ));
+        assertNotNull(constructor);
+        assertEquals("java.lang.String", constructor.getParameterTypes()[0]);
     }
 
     @Test

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/mock/ArgsClass.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/mock/ArgsClass.java
@@ -9,6 +9,12 @@ public class ArgsClass {
     public ArgsClass(int a) {
     }
 
+    public ArgsClass(String a) {
+    }
+
+    public ArgsClass(String a, int b) {
+    }
+
 
     public void arg() {
     }
@@ -107,6 +113,12 @@ public class ArgsClass {
     }
 
     public void argString5(String a, String b, String c, String d, String e) {
+    }
+
+    public void argSpecificMethod(int a) {
+    }
+
+    public void argSpecificMethod(int a, long b) {
     }
 
 }


### PR DESCRIPTION
- In some cases, some methods and constructors have many parameters, this PR adds methodName + MethodFilter filtering in addition to `String... parameterTypes` to find the desired specified method.
- Add tests for all change.