### PR TITLE
[#noissue] Fix copyJavaSystemProperty()

### DIFF
--- a/agent-module/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointStarter.java
+++ b/agent-module/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointStarter.java
@@ -145,7 +145,9 @@ class PinpointStarter {
     }
 
     private Properties copyJavaSystemProperty() {
-        return new Properties(System.getProperties());
+        Properties copy = new Properties();
+        copy.putAll(System.getProperties());
+        return copy;
     }
 
     private Properties copyOSEnvVariables() {


### PR DESCRIPTION
Related PR: #11797.

There was an issue where the system property was not applied to the agent configuration.

When copying system properties, `new Properties(System.getProperties())` was used. This means that the new `Properties` object only refers to system properties for keys that are not explicitly set, and these default properties will not be included in the iteration like the code below.

https://github.com/pinpoint-apm/pinpoint/blob/f2e771bd4f7688ba3989f9abff3fc6015ec3e406/agent-module/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/config/PropertyLoaderUtils.java#L27-L40