### PR TITLE
[#12061] Backport: Remove comments from SQL queries

### DIFF
--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/DefaultProfilerConfig.java
@@ -75,6 +75,8 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     private int maxSqlCacheLength = 2048;
     @Value("${profiler.jdbc.maxsqllength}")
     private int maxSqlLength = 65536;
+    @Value("${profiler.jdbc.removecomments}")
+    private boolean removeSqlComments = true;
 
     @Value("${profiler.transport.grpc.stats.logging.period}")
     private String grpcStatLoggingPeriod = "PT1M";
@@ -183,6 +185,11 @@ public class DefaultProfilerConfig implements ProfilerConfig {
     @Override
     public int getLogDirMaxBackupSize() {
         return logDirMaxBackupSize;
+    }
+
+    @Override
+    public boolean isRemoveSqlComments() {
+        return removeSqlComments;
     }
 
     @Override
@@ -304,6 +311,7 @@ public class DefaultProfilerConfig implements ProfilerConfig {
                 ", injectionModuleFactoryClazzName='" + injectionModuleFactoryClazzName + '\'' +
                 ", applicationNamespace='" + applicationNamespace + '\'' +
                 ", agentClassloaderAdditionalLibs='" + agentClassloaderAdditionalLibs + '\'' +
+                ", removeSqlComments=" + removeSqlComments +
                 '}';
     }
 }

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/config/ProfilerConfig.java
@@ -48,6 +48,8 @@ public interface ProfilerConfig {
 
     int getMaxSqlLength();
 
+    boolean isRemoveSqlComments();
+
     String getGrpcStatLoggingPeriod();
 
     @InterfaceAudience.Private
@@ -79,5 +81,4 @@ public interface ProfilerConfig {
     Map<String, String> readPattern(String propertyNamePatternRegex);
 
     int getLogDirMaxBackupSize();
-
 }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/metadata/SqlMetadataServiceProvider.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/metadata/SqlMetadataServiceProvider.java
@@ -60,8 +60,9 @@ public class SqlMetadataServiceProvider implements Provider<SqlMetaDataService> 
 
         if (monitorConfig.isSqlStatEnable()) {
             final int maxSqlCacheLength = profilerConfig.getMaxSqlCacheLength();
+            final boolean removeComments = profilerConfig.isRemoveSqlComments();
 
-            UidCachingSqlNormalizer simpleCachingSqlNormalizer = new UidCachingSqlNormalizer(jdbcSqlCacheSize, maxSqlCacheLength);
+            UidCachingSqlNormalizer simpleCachingSqlNormalizer = new UidCachingSqlNormalizer(jdbcSqlCacheSize, maxSqlCacheLength, removeComments);
             SqlCacheService<byte[]> sqlCacheService = new SqlCacheService<>(enhancedDataSender, simpleCachingSqlNormalizer, maxSqlLength);
             return new SqlUidMetaDataService(sqlCacheService);
         } else {

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/metadata/UidCachingSqlNormalizer.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/metadata/UidCachingSqlNormalizer.java
@@ -21,9 +21,9 @@ public class UidCachingSqlNormalizer implements CachingSqlNormalizer<ParsingResu
     private final SqlNormalizer sqlNormalizer;
     private final int lengthLimit;
 
-    public UidCachingSqlNormalizer(int cacheSize, int lengthLimit) {
+    public UidCachingSqlNormalizer(int cacheSize, int lengthLimit, boolean removeComments) {
         this.sqlCache = new SimpleCache<>(cacheSize, hashFunction);
-        this.sqlNormalizer = new DefaultSqlNormalizer();
+        this.sqlNormalizer = new DefaultSqlNormalizer(removeComments);
         this.lengthLimit = lengthLimit;
     }
 

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/metadata/SqlUidMetaDataServiceTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/metadata/SqlUidMetaDataServiceTest.java
@@ -28,7 +28,7 @@ class SqlUidMetaDataServiceTest {
 
     @BeforeEach
     void setUp() {
-        UidCachingSqlNormalizer simpleCachingSqlNormalizer = new UidCachingSqlNormalizer(100, LENGTH_LIMIT);
+        UidCachingSqlNormalizer simpleCachingSqlNormalizer = new UidCachingSqlNormalizer(100, LENGTH_LIMIT, false);
         sqlCacheService = new SqlCacheService<>(dataSender, simpleCachingSqlNormalizer, 1000);
         sut = new SqlUidMetaDataService(sqlCacheService);
     }

--- a/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/sql/DefaultSqlNormalizerTest.java
+++ b/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/sql/DefaultSqlNormalizerTest.java
@@ -280,6 +280,53 @@ public class DefaultSqlNormalizerTest {
         Assertions.assertEquals(expected, result);
     }
 
+    @Test
+    public void skipComments() {
+        DefaultSqlNormalizer sut = new DefaultSqlNormalizer(true);
+
+        String sql1 = "/** comment ? */ select * from table id = 'foo'";
+        String sql2 = " select * from table id = 'foo'";
+        String result1 = sut.normalizeSql(sql1).getNormalizedSql();
+        String result2 = sut.normalizeSql(sql2).getNormalizedSql();
+        Assertions.assertEquals(result2, result1);
+
+        sql1 = "//comment\nselect * from table id = ?;";
+        sql2 = "\nselect * from table id = ?;";
+        result1 = sut.normalizeSql(sql1).getNormalizedSql();
+        result2 = sut.normalizeSql(sql2).getNormalizedSql();
+        Assertions.assertEquals(result2, result1);
+
+        sql1 = "--comment\nselect * from table id = ?;";
+        sql2 = "\nselect * from table id = ?;";
+        result1 = sut.normalizeSql(sql1).getNormalizedSql();
+        result2 = sut.normalizeSql(sql2).getNormalizedSql();
+        Assertions.assertEquals(result2, result1);
+
+        sql1 = "select */*comment*/ \nfrom table id = ?;";
+        sql2 = "select * \nfrom table id = ?;";
+        result1 = sut.normalizeSql(sql1).getNormalizedSql();
+        result2 = sut.normalizeSql(sql2).getNormalizedSql();
+        Assertions.assertEquals(result2, result1);
+
+        sql1 = "select * from table id = ?; /* This ? comment*/";
+        sql2 = "select * from table id = ?; ";
+        result1 = sut.normalizeSql(sql1).getNormalizedSql();
+        result2 = sut.normalizeSql(sql2).getNormalizedSql();
+        Assertions.assertEquals(result2, result1);
+
+        sql1 = "select * from table id = ?; // This ? comment";
+        sql2 = "select * from table id = ?; ";
+        result1 = sut.normalizeSql(sql1).getNormalizedSql();
+        result2 = sut.normalizeSql(sql2).getNormalizedSql();
+        Assertions.assertEquals(result2, result1);
+
+        sql1 = "select * from table id = ?; -- This ? comment";
+        sql2 = "select * from table id = ?; ";
+        result1 = sut.normalizeSql(sql1).getNormalizedSql();
+        result2 = sut.normalizeSql(sql2).getNormalizedSql();
+        Assertions.assertEquals(result2, result1);
+    }
+
     private void assertCombine(String result, String sql, String outputParams) {
         List<String> output = this.outputParameterParser.parseOutputParameter(outputParams);
 


### PR DESCRIPTION
Related issue: #12061.

Apply only for sqlUid feature enabled agents.