### PR TITLE
[#12220] Backport: Bump ASM from 9.6 to 9.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,8 +223,7 @@
 
         <jakarta.validation-api.version>${jakarta.validation-api3.version}</jakarta.validation-api.version>
 
-
-        <asm.version>9.6</asm.version>
+        <asm.version>9.7.1</asm.version>
         <thrift.version>0.16.0</thrift.version>
         <caffeine.version>2.9.2</caffeine.version>
         <resilience4j-jdk8.version>1.7.1</resilience4j-jdk8.version>


### PR DESCRIPTION
#12220 