### PR TITLE
[#12238] Add virtual TimeseriesWindows to TimeWindow

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesIterator.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesIterator.java
@@ -1,0 +1,45 @@
+package com.navercorp.pinpoint.common.server.util.timewindow;
+
+import org.springframework.util.Assert;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * @author emeroad
+ */
+public class TimeSeriesIterator implements Iterator<Long> {
+    private final int size;
+    private final long start;
+    private final long increment;
+
+    private int index = 0;
+
+    public TimeSeriesIterator(int size, long start, long increment) {
+        Assert.isTrue(size >= 0, "negative size");
+        this.size = size;
+        this.start = start;
+        this.increment = increment;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return index < size;
+    }
+
+    @Override
+    public Long next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        return get(index++);
+    }
+
+    private long get(int index) {
+        if (index < 0 || index >= size) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
+        }
+        return start + (index * increment);
+    }
+}
+

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualList.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualList.java
@@ -1,0 +1,41 @@
+package com.navercorp.pinpoint.common.server.util.timewindow;
+
+import org.springframework.util.Assert;
+
+import java.util.AbstractList;
+import java.util.Iterator;
+
+/**
+ * A virtual list that represents a time series.
+ * @author emeroad
+ */
+public class TimeSeriesVirtualList extends AbstractList<Long> {
+    private final int size;
+    private final long start;
+    private final long increment;
+
+    public TimeSeriesVirtualList(int size, long start, long increment) {
+        Assert.isTrue(size >= 0, "negative size");
+        this.size = size;
+        this.start = start;
+        this.increment = increment;
+    }
+
+    @Override
+    public Long get(int index) {
+        if (index < 0 || index >= size) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
+        }
+        return start + (index * increment);
+    }
+
+    @Override
+    public Iterator<Long> iterator() {
+        return new TimeSeriesIterator(this.size, this.start, this.increment);
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualListTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualListTest.java
@@ -1,0 +1,23 @@
+package com.navercorp.pinpoint.common.server.util.timewindow;
+
+import com.google.common.collect.ImmutableList;
+import com.navercorp.pinpoint.common.server.util.time.Range;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class TimeSeriesVirtualListTest {
+
+    @Test
+    void list() {
+        TimeWindowSampler sampler = new FixedTimeWindowSampler(100);
+        TimeWindow timeWindow = new TimeWindow(Range.between(0L, 10000L), sampler);
+        List<Long> timeWindowList = ImmutableList.copyOf(timeWindow.iterator());
+
+        List<Long> list = new TimeSeriesVirtualList(timeWindow.getWindowRangeCount(), 0, timeWindow.getWindowSlotSize());
+
+        assertThat(list).isEqualTo(timeWindowList);
+    }
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeWindowTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeWindowTest.java
@@ -23,58 +23,74 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author emeroad
  */
-public class TimeWindowTest {
+class TimeWindowTest {
     private final Logger logger = LogManager.getLogger(this.getClass());
 
 
     @Test
-    public void testGetNextWindowFirst() {
+    void testGetTimeseriesWindows() {
         TimeWindow window = new TimeWindow(Range.between(0L, 1000));
         logger.debug("{}", window.getWindowRange());
-        Iterator<Long> iterator = window.iterator();
-        Assertions.assertEquals(0L, iterator.next());
+        List<Long> timeWindows = window.getTimeseriesWindows();
 
-        Assertions.assertThrows(Exception.class, iterator::next);
+        assertThat(timeWindows).hasSize(1)
+                .containsExactly(0L);
+    }
 
+    @Test
+    void testTimestampWindows2() {
         TimeWindow window2 = new TimeWindow(Range.between(0L, TimeUnit.MINUTES.toMillis(1)));
         logger.debug("{}", window2.getWindowRange());
-        Iterator<Long> iterator2 = window2.iterator();
-        Assertions.assertEquals(0L, iterator2.next());
-        Assertions.assertEquals(1000*60L, iterator2.next());
-        Assertions.assertThrows(Exception.class, iterator2::next);
+        List<Long> timeWindows2 = window2.getTimeseriesWindows();
+        assertThat(timeWindows2).hasSize(2)
+                .containsExactly(0L, 1000 * 60L);
     }
 
+
     @Test
-    public void testGetNextWindow() {
+    void testTimestampWindowsSize() {
         Range range = Range.between(0L, TimeUnit.MINUTES.toMillis(1));
         TimeWindow window = new TimeWindow(range);
-        ImmutableList<Long> longs = ImmutableList.copyOf(window.iterator());
-        Assertions.assertEquals(2, longs.size());
+        List<Long> timestamps = window.getTimeseriesWindows();
+        Assertions.assertEquals(2, timestamps.size());
         Assertions.assertEquals(2, window.getWindowRangeCount());
     }
 
     @Test
-    public void testGetNextWindow2() {
+    void testTimestampWindowsSize2() {
         Range range = Range.between(1L, TimeUnit.MINUTES.toMillis(1));
         TimeWindow window = new TimeWindow(range);
-        ImmutableList<Long> longs = ImmutableList.copyOf(window.iterator());
-        Assertions.assertEquals(2, longs.size());
+        List<Long> timestamps = window.getTimeseriesWindows();
+        Assertions.assertEquals(2, timestamps.size());
         Assertions.assertEquals(2, window.getWindowRangeCount());
     }
 
     @Test
-    public void testRefineTimestamp() {
+    void testGetNextWindow_iter() {
+        Range range = Range.between(1L, TimeUnit.MINUTES.toMillis(1));
+        TimeWindow window = new TimeWindow(range);
+
+        List<Long> iter = ImmutableList.copyOf(window.iterator());
+        List<Long> timestamps = window.getTimeseriesWindows();
+        assertThat(timestamps)
+                .isEqualTo(iter);
+    }
+
+    @Test
+    void testRefineTimestamp() {
 
     }
 
     @Test
-    public void testGetWindowSize() {
+    void testGetWindowSize() {
         testWindowSize(0, TimeUnit.MINUTES.toMillis(1));
         testWindowSize(0, TimeUnit.HOURS.toMillis(1));
         testWindowSize(0, TimeUnit.HOURS.toMillis(23));
@@ -88,8 +104,8 @@ public class TimeWindowTest {
     }
 
     @Test
-    public void refineRange() {
-        Range range = Range.between(1L, TimeUnit.MINUTES.toMillis(1)+1);
+    void refineRange() {
+        Range range = Range.between(1L, TimeUnit.MINUTES.toMillis(1) + 1);
         TimeWindow window = new TimeWindow(range);
         Range windowRange = window.getWindowRange();
         // 1 should be replace by 0.
@@ -100,7 +116,7 @@ public class TimeWindowTest {
     }
 
     @Test
-    public void testGetWindowRangeLength() {
+    void testGetWindowRangeLength() {
         Range range = Range.between(1L, 2L);
         TimeWindow window = new TimeWindow(range);
         int windowRangeLength = window.getWindowRangeCount();
@@ -110,8 +126,8 @@ public class TimeWindowTest {
     }
 
     @Test
-    public void testGetWindowRangeLength2() {
-        Range range = Range.between(1L, 1000*60L + 1);
+    void testGetWindowRangeLength2() {
+        Range range = Range.between(1L, 1000 * 60L + 1);
         TimeWindow window = new TimeWindow(range);
         int windowRangeLength = window.getWindowRangeCount();
         logger.debug("{}", windowRangeLength);
@@ -119,8 +135,8 @@ public class TimeWindowTest {
     }
 
     @Test
-     public void testRefineIndex1() {
-        Range range = Range.between(1L, 1000*60L);
+    void testRefineIndex1() {
+        Range range = Range.between(1L, 1000 * 60L);
         TimeWindow window = new TimeWindow(range);
         long index = window.getWindowIndex(2);
         logger.debug("{}", index);
@@ -128,8 +144,8 @@ public class TimeWindowTest {
     }
 
     @Test
-     public void testRefineIndex2() {
-        Range range = Range.between(1L, 1000*60L);
+    void testRefineIndex2() {
+        Range range = Range.between(1L, 1000 * 60L);
         TimeWindow window = new TimeWindow(range);
         long index = window.getWindowIndex(1000 * 60L);
         logger.debug("{}", index);

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/TimeSeriesUtils.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/TimeSeriesUtils.java
@@ -19,7 +19,6 @@ import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindow;
 import com.navercorp.pinpoint.exceptiontrace.web.model.ExceptionChartGroup;
 import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionChartValueView;
 import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionChartView;
-import com.navercorp.pinpoint.metric.common.util.TimeUtils;
 import com.navercorp.pinpoint.metric.web.view.TimeSeriesValueView;
 import com.navercorp.pinpoint.metric.web.view.TimeseriesValueGroupView;
 
@@ -48,7 +47,7 @@ public class TimeSeriesUtils {
         Objects.requireNonNull(timeWindow, "timeWindow");
         Objects.requireNonNull(exceptionChartValueViews, "exceptionTraceValueViews");
 
-        List<Long> timestampList = TimeUtils.createTimeStampList(timeWindow);
+        List<Long> timestampList = timeWindow.getTimeseriesWindows();
         List<TimeseriesValueGroupView> timeSeriesValueGroupViews = new ArrayList<>();
         timeSeriesValueGroupViews.add(
                 newGroupFromValueViews(groupName, exceptionChartValueViews)

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultApplicationStatService.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultApplicationStatService.java
@@ -22,7 +22,6 @@ import com.navercorp.pinpoint.metric.common.model.chart.Point;
 import com.navercorp.pinpoint.metric.common.model.chart.SystemMetricPoint;
 import com.navercorp.pinpoint.metric.common.util.DoubleUncollectedDataCreator;
 import com.navercorp.pinpoint.metric.common.util.TimeSeriesBuilder;
-import com.navercorp.pinpoint.metric.common.util.TimeUtils;
 import com.navercorp.pinpoint.metric.common.util.UncollectedDataCreator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -91,7 +90,7 @@ public class DefaultApplicationStatService implements ApplicationStatService {
 
         List<InspectorMetricValue> processedMetricValueList = postprocessMetricData(metricDefinition, metricValueList);
         processedMetricValueList = sortingMetricValueList(processedMetricValueList);
-        List<Long> timeStampList = TimeUtils.createTimeStampList(timeWindow);
+        List<Long> timeStampList = timeWindow.getTimeseriesWindows();
         return new InspectorMetricData(metricDefinition.getTitle(), timeStampList, processedMetricValueList);
     }
 
@@ -157,7 +156,7 @@ public class DefaultApplicationStatService implements ApplicationStatService {
 
 
         List<InspectorMetricValue> processedMetricValueList = postprocessMetricData(newMetricDefinition, metricValueList);
-        List<Long> timeStampList = TimeUtils.createTimeStampList(timeWindow);
+        List<Long> timeStampList = timeWindow.getTimeseriesWindows();
         Map<List<Tag>, List<InspectorMetricValue>> metricValueGroups = groupingMetricValue(processedMetricValueList, metricDefinition);
         metricValueGroups = sortingMetricValueGroups(metricValueGroups);
         return new InspectorMetricGroupData(metricDefinition.getTitle(), timeStampList, metricValueGroups);

--- a/metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/util/TimeUtils.java
+++ b/metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/util/TimeUtils.java
@@ -18,22 +18,19 @@ package com.navercorp.pinpoint.metric.common.util;
 
 import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindow;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * @author minwoo-jung
  */
+@Deprecated
 public class TimeUtils {
-
+    /**
+     * @deprecated Since 3.1.0. Use {@link TimeWindow#getTimeseriesWindows()} instead.
+     */
+    @Deprecated
     public static List<Long> createTimeStampList(TimeWindow timeWindow) {
-        List<Long> timestampList = new ArrayList<>(timeWindow.getWindowRangeCount());
-
-        for (Long timestamp : timeWindow) {
-            timestampList.add(timestamp);
-        }
-
-        return timestampList;
+        return timeWindow.getTimeseriesWindows();
     }
 
 }

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/service/SystemMetricDataServiceImpl.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/service/SystemMetricDataServiceImpl.java
@@ -17,16 +17,16 @@
 package com.navercorp.pinpoint.metric.web.service;
 
 
+import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindow;
 import com.navercorp.pinpoint.metric.common.model.MetricDataName;
 import com.navercorp.pinpoint.metric.common.model.MetricDataType;
 import com.navercorp.pinpoint.metric.common.model.MetricTag;
 import com.navercorp.pinpoint.metric.common.model.Tag;
-import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindow;
 import com.navercorp.pinpoint.metric.common.model.chart.SystemMetricPoint;
 import com.navercorp.pinpoint.metric.common.util.DoubleUncollectedDataCreator;
 import com.navercorp.pinpoint.metric.common.util.LongUncollectedDataCreator;
+import com.navercorp.pinpoint.metric.common.util.TagUtils;
 import com.navercorp.pinpoint.metric.common.util.TimeSeriesBuilder;
-import com.navercorp.pinpoint.metric.common.util.TimeUtils;
 import com.navercorp.pinpoint.metric.common.util.UncollectedDataCreator;
 import com.navercorp.pinpoint.metric.web.dao.SystemMetricDao;
 import com.navercorp.pinpoint.metric.web.mapping.Field;
@@ -36,7 +36,6 @@ import com.navercorp.pinpoint.metric.web.model.MetricValue;
 import com.navercorp.pinpoint.metric.web.model.MetricValueGroup;
 import com.navercorp.pinpoint.metric.web.model.SystemMetricData;
 import com.navercorp.pinpoint.metric.web.model.basic.metric.group.GroupingRule;
-import com.navercorp.pinpoint.metric.common.util.TagUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -84,7 +83,7 @@ public class SystemMetricDataServiceImpl implements SystemMetricDataService {
         GroupingRule groupingRule = systemMetricBasicGroupManager.findGroupingRule(metricDefinitionId);
         List<MetricValueGroup<?>> metricValueGroupList = groupingMetricValue(metricValueList, groupingRule);
 
-        List<Long> timeStampList = TimeUtils.createTimeStampList(timeWindow);
+        List<Long> timeStampList = timeWindow.getTimeseriesWindows();
         String title = systemMetricBasicGroupManager.findMetricTitle(metricDefinitionId);
         String unit = systemMetricBasicGroupManager.findUnit(metricDefinitionId);
         return new SystemMetricData(title, unit, timeStampList, metricValueGroupList);

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/view/SystemMetricChartSerializer.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/view/SystemMetricChartSerializer.java
@@ -26,7 +26,6 @@ import com.navercorp.pinpoint.metric.web.model.chart.Chart;
 import com.navercorp.pinpoint.metric.web.model.chart.SystemMetricChart;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -51,11 +50,7 @@ public class SystemMetricChartSerializer extends JsonSerializer<SystemMetricChar
     }
 
     private void writeTimestamp(JsonGenerator jgen, TimeWindow timeWindow) throws IOException {
-        List<Long> timestamps = new ArrayList<>(timeWindow.getWindowRangeCount());
-        for (Long timestamp : timeWindow) {
-            timestamps.add(timestamp);
-        }
-        jgen.writeObjectField("x", timestamps);
+        jgen.writeObjectField("x", timeWindow.getTimeseriesWindows());
     }
 
     private void writeCharts(JsonGenerator jgen, List<List<Tag>> tagsList, List<Chart<? extends Point>> charts) throws IOException {

--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/service/OtlpMetricWebServiceImpl.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/service/OtlpMetricWebServiceImpl.java
@@ -5,7 +5,6 @@ import com.navercorp.pinpoint.common.server.util.time.Range;
 import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindow;
 import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindowSampler;
 import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindowSlotCentricSampler;
-import com.navercorp.pinpoint.metric.common.util.TimeUtils;
 import com.navercorp.pinpoint.otlp.common.model.MetricPoint;
 import com.navercorp.pinpoint.otlp.common.model.MetricType;
 import com.navercorp.pinpoint.otlp.common.util.DoubleUncollectedDataCreator;
@@ -166,7 +165,7 @@ public class OtlpMetricWebServiceImpl implements OtlpMetricWebService {
             queryResult.add(new QueryResult<>(chartPoints, chartQueryParameter));
         }
 
-        List<Long> timeStampList = TimeUtils.createTimeStampList(timeWindow);
+        List<Long> timeStampList = timeWindow.getTimeseriesWindows();
         // TODO: (minwoo) set unit data
         MetricData metricData = new MetricData(timeStampList, chartType, fields.get(0).unit());
 
@@ -185,7 +184,8 @@ public class OtlpMetricWebServiceImpl implements OtlpMetricWebService {
     }
 
     private MetricData createEmptyMetricData(TimeWindow timeWindow, ChartType chartType) {
-        return new MetricData(TimeUtils.createTimeStampList(timeWindow), chartType, EMPTY_STRING, "There is no metadata for the metric query.");
+        List<Long> windows = timeWindow.getTimeseriesWindows();
+        return new MetricData(windows, chartType, EMPTY_STRING, "There is no metadata for the metric query.");
     }
 
     private String getLegendName(OtlpMetricDataQueryParameter chartQueryParameter, PrimaryForFieldAndTagRelation primaryForFieldAndTagRelation) {

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/view/UriStatView.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/view/UriStatView.java
@@ -16,12 +16,11 @@
 package com.navercorp.pinpoint.uristat.web.view;
 
 import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindow;
-import com.navercorp.pinpoint.metric.common.util.TimeUtils;
-import com.navercorp.pinpoint.uristat.web.chart.UriStatChartType;
-import com.navercorp.pinpoint.uristat.web.model.UriStatGroup;
 import com.navercorp.pinpoint.metric.web.view.TimeSeriesView;
 import com.navercorp.pinpoint.metric.web.view.TimeseriesValueGroupView;
+import com.navercorp.pinpoint.uristat.web.chart.UriStatChartType;
 import com.navercorp.pinpoint.uristat.web.model.UriStatChartValue;
+import com.navercorp.pinpoint.uristat.web.model.UriStatGroup;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +36,7 @@ public class UriStatView implements TimeSeriesView {
         Objects.requireNonNull(uriStats, "uriStats");
         Objects.requireNonNull(chartType, "chartType");
 
-        this.timestampList = TimeUtils.createTimeStampList(timeWindow);
+        this.timestampList = timeWindow.getTimeseriesWindows();
         if (uriStats.isEmpty()) {
             this.uriStats.add(UriStatGroup.EMPTY_URI_STAT_GROUP);
         } else {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogram.java
@@ -186,7 +186,7 @@ public class AgentTimeHistogram {
     }
 
     private List<Histogram> getDefaultHistograms(TimeWindow window, ServiceType serviceType) {
-        List<Histogram> sum = new ArrayList<>((int) window.getWindowRangeCount());
+        List<Histogram> sum = new ArrayList<>(window.getWindowRangeCount());
         for (long timestamp : window) {
             sum.add(new TimeHistogram(serviceType, timestamp));
         }

--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/ResponseHistogramsTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/ResponseHistogramsTest.java
@@ -65,8 +65,8 @@ public class ResponseHistogramsTest {
         SpanBo fastSpan = new TestTraceUtils.SpanBuilder(applicationName, "test-app").elapsed(500).build();
 
         ResponseHistograms.Builder builder = new ResponseHistograms.Builder(range);
-        Iterator<Long> timeslotIterator = builder.getWindow().iterator();
-        long timeslot = timeslotIterator.next();
+        List<Long> timeslotIterator = builder.getWindow().getTimeseriesWindows();
+        long timeslot = timeslotIterator.get(0);
         builder.addHistogram(application, fastSpan, timeslot);
         ResponseHistograms responseHistograms = builder.build();
 
@@ -95,7 +95,7 @@ public class ResponseHistogramsTest {
         SpanBo errorSpan = new TestTraceUtils.SpanBuilder(applicationName, "test-app").elapsed(500).errorCode(1).build();
 
         ResponseHistograms.Builder builder = new ResponseHistograms.Builder(range);
-        Iterator<Long> timeslotIterator = builder.getWindow().iterator();
+        Iterator<Long> timeslotIterator = builder.getWindow().getTimeseriesWindows().iterator();
         long timeslot1 = timeslotIterator.next();
         long timeslot2 = timeslotIterator.next();
         long timeslot3 = timeslotIterator.next();
@@ -161,8 +161,7 @@ public class ResponseHistogramsTest {
         SpanBo errorSpan = new TestTraceUtils.SpanBuilder(applicationName, errorAgentId).elapsed(500).errorCode(1).build();
 
         ResponseHistograms.Builder builder = new ResponseHistograms.Builder(range);
-        Iterator<Long> timeslotIterator = builder.getWindow().iterator();
-        long timeslot = timeslotIterator.next();
+        long timeslot = builder.getWindow().getTimeseriesWindows().get(0);
         builder.addHistogram(application, fastSpan, timeslot);
         builder.addHistogram(application, normalSpan, timeslot);
         builder.addHistogram(application, slowSpan, timeslot);
@@ -208,8 +207,8 @@ public class ResponseHistogramsTest {
         SpanBo appBSpan = new TestTraceUtils.SpanBuilder(appBName, appBAgentId).elapsed(1500).build();
 
         ResponseHistograms.Builder builder = new ResponseHistograms.Builder(range);
-        Iterator<Long> timeslotIterator = builder.getWindow().iterator();
-        long timeslot = timeslotIterator.next();
+        List<Long> timeslotIterator = builder.getWindow().getTimeseriesWindows();
+        long timeslot = timeslotIterator.get(0);
 
         builder.addHistogram(appA, appASpan, timeslot);
         builder.addHistogram(appA, appASpan, timeslot);


### PR DESCRIPTION
This pull request includes several changes aimed at improving the handling of time series data in the `commons-server` and related modules. The changes introduce new utility classes, refactor existing classes, and update test cases accordingly.

### Introduction of Time Series Utility Classes:
* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesIterator.java`](diffhunk://#diff-63b4f40db74f33a9114c76d481db3895d1bea9424c53a1414bf6f09fb4bbcb3aR1-R45): Added a new `TimeSeriesIterator` class to iterate over time series data.
* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualList.java`](diffhunk://#diff-1f54a1524503a25b119dcb85f3db1bd3cc01d64284bda61ef373c4470e6dc7faR1-R41): Added a new `TimeSeriesVirtualList` class to represent a virtual list of time series data.

### Refactoring of Time Window Class:
* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeWindow.java`](diffhunk://#diff-9296ccf1f55d882c901e94622e9010a84e1e9a1599336d534b40d8def023da63L23-L36): Refactored the `TimeWindow` class to use `TimeSeriesIterator` and `TimeSeriesVirtualList` for better handling of time series data. Removed the internal `Itr` class and updated methods to use the new utility classes. [[1]](diffhunk://#diff-9296ccf1f55d882c901e94622e9010a84e1e9a1599336d534b40d8def023da63L23-L36) [[2]](diffhunk://#diff-9296ccf1f55d882c901e94622e9010a84e1e9a1599336d534b40d8def023da63L46-R46) [[3]](diffhunk://#diff-9296ccf1f55d882c901e94622e9010a84e1e9a1599336d534b40d8def023da63R58-R70) [[4]](diffhunk://#diff-9296ccf1f55d882c901e94622e9010a84e1e9a1599336d534b40d8def023da63L94-R102) [[5]](diffhunk://#diff-9296ccf1f55d882c901e94622e9010a84e1e9a1599336d534b40d8def023da63L105-L134)

### Updates to Test Cases:
* [`commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualListTest.java`](diffhunk://#diff-7cf287c0f5b1266a1c3e2c7c154d658cf2b40181cd0f51830c66b16be01d8c42R1-R23): Added new test cases for `TimeSeriesVirtualList`.
* [`commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeWindowTest.java`](diffhunk://#diff-1a810b9d3d3f93d6d349a39c3d15db49a5bf5b0c1597fa9e09b5d4628683594dL26-R93): Updated existing test cases to reflect changes in the `TimeWindow` class and added new assertions using `assertThat` for better readability. [[1]](diffhunk://#diff-1a810b9d3d3f93d6d349a39c3d15db49a5bf5b0c1597fa9e09b5d4628683594dL26-R93) [[2]](diffhunk://#diff-1a810b9d3d3f93d6d349a39c3d15db49a5bf5b0c1597fa9e09b5d4628683594dL91-R107) [[3]](diffhunk://#diff-1a810b9d3d3f93d6d349a39c3d15db49a5bf5b0c1597fa9e09b5d4628683594dL103-R119) [[4]](diffhunk://#diff-1a810b9d3d3f93d6d349a39c3d15db49a5bf5b0c1597fa9e09b5d4628683594dL113-R129) [[5]](diffhunk://#diff-1a810b9d3d3f93d6d349a39c3d15db49a5bf5b0c1597fa9e09b5d4628683594dL122-R138)

### Integration with Other Modules:
* [`exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/TimeSeriesUtils.java`](diffhunk://#diff-f1f7cba1d7da858604b502cb63845d1da679d7acd9e2debbcf06b06a04ce2a28L22): Updated to use `timeWindow.getTimeseriesWindows()` instead of `TimeUtils.createTimeStampList(timeWindow)`. [[1]](diffhunk://#diff-f1f7cba1d7da858604b502cb63845d1da679d7acd9e2debbcf06b06a04ce2a28L22) [[2]](diffhunk://#diff-f1f7cba1d7da858604b502cb63845d1da679d7acd9e2debbcf06b06a04ce2a28L51-R50)
* [`inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultAgentStatService.java`](diffhunk://#diff-da3941a1521260c8e7be0a0c2e8460f99d5958dcc8d8f4c0b785305b56ebfc0eL39): Refactored to use the new `timeWindow.getTimeseriesWindows()` method. [[1]](diffhunk://#diff-da3941a1521260c8e7be0a0c2e8460f99d5958dcc8d8f4c0b785305b56ebfc0eL39) [[2]](diffhunk://#diff-da3941a1521260c8e7be0a0c2e8460f99d5958dcc8d8f4c0b785305b56ebfc0eL66-R68) [[3]](diffhunk://#diff-da3941a1521260c8e7be0a0c2e8460f99d5958dcc8d8f4c0b785305b56ebfc0eL95-R97) [[4]](diffhunk://#diff-da3941a1521260c8e7be0a0c2e8460f99d5958dcc8d8f4c0b785305b56ebfc0eL135-R137) [[5]](diffhunk://#diff-da3941a1521260c8e7be0a0c2e8460f99d5958dcc8d8f4c0b785305b56ebfc0eL178-R180)
* [`inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultApplicationStatService.java`](diffhunk://#diff-adf565553572f98f00727745b71a2a545613f40b2785e3f67accb2c371c7a58cL25): Modified to use `timeWindow.getTimeseriesWindows()` for time series data. [[1]](diffhunk://#diff-adf565553572f98f00727745b71a2a545613f40b2785e3f67accb2c371c7a58cL25) [[2]](diffhunk://#diff-adf565553572f98f00727745b71a2a545613f40b2785e3f67accb2c371c7a58cL94-R93)