### PR TITLE
[#12241] Apply Primitive Containers to optimize memory usage

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/scatter/OneByteFuzzyRowKeyFactory.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/scatter/OneByteFuzzyRowKeyFactory.java
@@ -1,6 +1,7 @@
 package com.navercorp.pinpoint.common.server.scatter;
 
 
+import com.google.common.primitives.Longs;
 import com.navercorp.pinpoint.common.server.util.pair.LongPair;
 import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.ExponentialBackOff;
@@ -28,17 +29,9 @@ public class OneByteFuzzyRowKeyFactory implements FuzzyRowKeyFactory<Byte> {
                 break;
             }
         }
-        return toLongArray(backOffTimeList);
+        return Longs.toArray(backOffTimeList);
     }
 
-    private long[] toLongArray(List<Long> list) {
-        long[] buffer = new long[list.size()];
-        for (int i = 0; i < list.size(); i++) {
-            long time = list.get(i);
-            buffer[i] = time;
-        }
-        return buffer;
-    }
 
     @Override
     public Byte getKey(long timeStamp) {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/DoubleArray.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/DoubleArray.java
@@ -1,0 +1,36 @@
+package com.navercorp.pinpoint.common.server.util.array;
+
+import com.google.common.primitives.Doubles;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.RandomAccess;
+import java.util.function.ToDoubleFunction;
+
+public final class DoubleArray {
+
+    private DoubleArray() {
+    }
+
+    public static double[] newArray(int size, double defaultValue) {
+        double[] array = new double[size];
+        Arrays.fill(array, defaultValue);
+        return array;
+    }
+
+    public static <T> List<Double> asList(List<T> list, ToDoubleFunction<T> function) {
+        final int size = list.size();
+        final double[] values = new double[size];
+        if (list instanceof RandomAccess) {
+            for (int i = 0; i < size; i++) {
+                values[i] = function.applyAsDouble(list.get(i));
+            }
+        } else {
+            int i = 0;
+            for (T element : list) {
+                values[i++] = function.applyAsDouble(element);
+            }
+        }
+        return Doubles.asList(values);
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/IntArray.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/IntArray.java
@@ -1,0 +1,29 @@
+package com.navercorp.pinpoint.common.server.util.array;
+
+import com.google.common.primitives.Ints;
+
+import java.util.List;
+import java.util.RandomAccess;
+import java.util.function.ToIntFunction;
+
+public final class IntArray {
+
+    private IntArray() {
+    }
+
+    public static <T> List<Integer> asList(List<T> list, ToIntFunction<T> function) {
+        final int size = list.size();
+        final int[] values = new int[size];
+        if (list instanceof RandomAccess) {
+            for (int i = 0; i < size; i++) {
+                values[i] = function.applyAsInt(list.get(i));
+            }
+        } else {
+            int i = 0;
+            for (T element : list) {
+                values[i++] = function.applyAsInt(element);
+            }
+        }
+        return Ints.asList(values);
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/LongArray.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/LongArray.java
@@ -1,0 +1,30 @@
+package com.navercorp.pinpoint.common.server.util.array;
+
+import com.google.common.primitives.Longs;
+
+import java.util.List;
+import java.util.RandomAccess;
+import java.util.function.ToLongFunction;
+
+public final class LongArray {
+
+    private LongArray() {
+    }
+
+    public static <T> List<Long> asList(List<T> list, ToLongFunction<T> function) {
+        final int size = list.size();
+        final long[] values = new long[size];
+        if (list instanceof RandomAccess) {
+            for (int i = 0; i < size; i++) {
+                values[i] = function.applyAsLong(list.get(i));
+            }
+        } else {
+            int i = 0;
+            for (T element : list) {
+                values[i++] = function.applyAsLong(element);
+            }
+        }
+        return Longs.asList(values);
+    }
+
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/array/DoubleArrayTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/array/DoubleArrayTest.java
@@ -1,0 +1,24 @@
+package com.navercorp.pinpoint.common.server.util.array;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DoubleArrayTest {
+    @Test
+    void asDoubleList() {
+        DoubleRecord doubleRecord1 = new DoubleRecord(1.0);
+        DoubleRecord doubleRecord2 = new DoubleRecord(2.0);
+        DoubleRecord doubleRecord3 = new DoubleRecord(3.0);
+
+        List<DoubleRecord> records = List.of(doubleRecord1, doubleRecord2, doubleRecord3);
+        List<Double> doubleList = DoubleArray.asList(records, DoubleRecord::value);
+        assertThat(doubleList).containsExactly(1.0, 2.0, 3.0);
+    }
+
+    record DoubleRecord(double value) {
+    }
+
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/array/LongArrayTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/array/LongArrayTest.java
@@ -1,0 +1,39 @@
+package com.navercorp.pinpoint.common.server.util.array;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LongArrayTest {
+
+    @Test
+    void asLongList() {
+        LongRecord longRecord1 = new LongRecord(1L);
+        LongRecord longRecord2 = new LongRecord(2L);
+        LongRecord longRecord3 = new LongRecord(3L);
+
+        List<LongRecord> records = List.of(longRecord1, longRecord2, longRecord3);
+        List<Long> longList = LongArray.asList(records, LongRecord::value);
+        assertThat(longList).containsExactly(1L, 2L, 3L);
+    }
+
+    record LongRecord(long value) {
+    }
+
+    @Test
+    void asLongList_linkedList() {
+        LongRecord longRecord2 = new LongRecord(2L);
+        LongRecord longRecord1 = new LongRecord(1L);
+        LongRecord longRecord3 = new LongRecord(3L);
+
+        List<LongRecord> records = new LinkedList<>();
+        records.add(longRecord1);
+        records.add(longRecord2);
+        records.add(longRecord3);
+        List<Long> longList = LongArray.asList(records, LongRecord::value);
+        assertThat(longList).containsExactly(1L, 2L, 3L);
+    }
+}

--- a/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/StackTraceMapper.java
+++ b/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/StackTraceMapper.java
@@ -16,6 +16,7 @@
 package com.navercorp.pinpoint.exceptiontrace.collector.mapper;
 
 import com.navercorp.pinpoint.common.server.mapper.MapStructUtils;
+import com.navercorp.pinpoint.common.server.util.array.IntArray;
 import com.navercorp.pinpoint.exceptiontrace.common.model.StackTraceElementWrapper;
 import org.mapstruct.Qualifier;
 import org.springframework.stereotype.Component;
@@ -80,9 +81,7 @@ public class StackTraceMapper {
 
     @StackTraceToLineNumbers
     public List<Integer> stackTraceToLineNumber(List<StackTraceElementWrapper> lineNumbers) {
-        return lineNumbers.stream()
-                .map(StackTraceElementWrapper::getLineNumber)
-                .collect(Collectors.toList());
+        return IntArray.asList(lineNumbers, StackTraceElementWrapper::getLineNumber);
     }
 
     @StackTraceToMethodNames

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/AvgUsingIntervalPostProcessor.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/AvgUsingIntervalPostProcessor.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.inspector.web.definition.metric;
 
+import com.google.common.primitives.Doubles;
 import com.navercorp.pinpoint.inspector.web.model.InspectorMetricValue;
 import org.apache.commons.math3.util.Precision;
 import org.springframework.stereotype.Component;
@@ -54,17 +55,17 @@ public class AvgUsingIntervalPostProcessor implements MetricPostProcessor {
 
     private void addTotalMetricValue(List<InspectorMetricValue> processedMetricValueList, int metricValueSize) {
 
-        List<Double> totalValueList = new ArrayList<>(metricValueSize);
+        double[] totalValueList = new double[metricValueSize];
         for (int i = 0; i < metricValueSize; i++) {
             double total = 0;
             for (InspectorMetricValue metricValue : processedMetricValueList) {
                 total += metricValue.getValueList().get(i);
             }
             total = Precision.round(total, NUM_DECIMAL_PLACES);
-            totalValueList.add(total);
+            totalValueList[i] = total;
         }
 
-        processedMetricValueList.add(new InspectorMetricValue("totalCount", Collections.emptyList(), "tooltip", "count", totalValueList));
+        processedMetricValueList.add(new InspectorMetricValue("totalCount", Collections.emptyList(), "tooltip", "count", Doubles.asList(totalValueList)));
     }
 
     private void calculateAvg(InspectorMetricValue collectInterval, List<InspectorMetricValue> metricCountList, List<InspectorMetricValue> processedMetricValueList) {
@@ -77,16 +78,16 @@ public class AvgUsingIntervalPostProcessor implements MetricPostProcessor {
     protected List<Double> calculateAvg(InspectorMetricValue collectInterval, InspectorMetricValue metricCount) {
         List<Double> valueList = metricCount.getValueList();
         List<Double> commitIntervalList = collectInterval.getValueList();
-        List<Double> avgList = new ArrayList<>(valueList.size());
+        double[] avgList = new double[valueList.size()];
         for (int i = 0; i < valueList.size(); i++) {
             if (commitIntervalList.get(i) < 0) {
-                avgList.add(i, -1.0);
+                avgList[i] = -1.0;
                 continue;
             }
-            avgList.add(calculateTps(valueList.get(i), commitIntervalList.get(i)));
+            avgList[i] = calculateTps(valueList.get(i), commitIntervalList.get(i));
         }
 
-        return avgList;
+        return Doubles.asList(avgList);
     }
 
     private double calculateTps(double count, double intervalMs) {

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/PercentageScalePostProcessor.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/PercentageScalePostProcessor.java
@@ -16,11 +16,11 @@
 
 package com.navercorp.pinpoint.inspector.web.definition.metric;
 
+import com.navercorp.pinpoint.common.server.util.array.DoubleArray;
 import com.navercorp.pinpoint.inspector.web.model.InspectorMetricValue;
 import com.navercorp.pinpoint.metric.common.util.DoubleUncollectedDataCreator;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -45,9 +45,8 @@ public class PercentageScalePostProcessor implements MetricPostProcessor {
     }
 
     private InspectorMetricValue processInspectorMetric(InspectorMetricValue inspectorMetric) {
-        List<Double> scaledValues = inspectorMetric.getValueList().stream()
-                .map(this::scaleToPercentage)
-                .collect(Collectors.toList());
+        List<Double> valueList = inspectorMetric.getValueList();
+        List<Double> scaledValues = DoubleArray.asList(valueList, this::scaleToPercentage);
 
         return new InspectorMetricValue(
                 inspectorMetric.getFieldName(),

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultAgentStatService.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultAgentStatService.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.inspector.web.service;
 
+import com.navercorp.pinpoint.common.server.util.array.DoubleArray;
 import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindow;
 import com.navercorp.pinpoint.inspector.web.dao.AgentStatDao;
 import com.navercorp.pinpoint.inspector.web.definition.AggregationFunction;
@@ -168,9 +169,7 @@ public class DefaultAgentStatService implements AgentStatService {
         TimeSeriesBuilder<Double> builder = new TimeSeriesBuilder<>(timeWindow, uncollectedDataCreator);
         List<SystemMetricPoint<Double>> filledSystemMetricDataList = builder.build(postProcessedDataList);
 
-        List<Double> valueList = filledSystemMetricDataList.stream()
-                .map(SystemMetricPoint::getYVal)
-                .collect(Collectors.toList());
+        List<Double> valueList = DoubleArray.asList(filledSystemMetricDataList, SystemMetricPoint::getYVal);
 
         return new InspectorMetricValue(field.getFieldAlias(), field.getTags(), field.getChartType(), field.getUnit(), valueList);
     }

--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/legacy/OtlpChartViewBuilder.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/legacy/OtlpChartViewBuilder.java
@@ -16,8 +16,8 @@
 
 package com.navercorp.pinpoint.otlp.web.view.legacy;
 
-import com.navercorp.pinpoint.otlp.common.web.definition.property.ChartType;
 import com.navercorp.pinpoint.otlp.common.model.MetricType;
+import com.navercorp.pinpoint.otlp.common.web.definition.property.ChartType;
 import com.navercorp.pinpoint.otlp.web.view.OtlpParsingException;
 import com.navercorp.pinpoint.otlp.web.vo.FieldAttribute;
 import com.navercorp.pinpoint.otlp.web.vo.OtlpMetricChartResult;

--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/vo/MetricData.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/vo/MetricData.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 public class MetricData {
     private final static String EMPTY_MESSAEG = "";
-    private List<Long> timestampList;
+    private final List<Long> timestampList;
     private final ChartType chartType;
     private final String unit;
     private final List<MetricValue> metricValueList;

--- a/otlpmetric/otlpmetric-web/src/test/java/com/navercorp/pinpoint/otlp/web/view/OtlpChartViewTest.java
+++ b/otlpmetric/otlpmetric-web/src/test/java/com/navercorp/pinpoint/otlp/web/view/OtlpChartViewTest.java
@@ -1,9 +1,9 @@
 package com.navercorp.pinpoint.otlp.web.view;
 
-import com.navercorp.pinpoint.otlp.common.web.definition.property.AggregationFunction;
 import com.navercorp.pinpoint.otlp.common.model.AggreTemporality;
 import com.navercorp.pinpoint.otlp.common.model.DataType;
 import com.navercorp.pinpoint.otlp.common.model.MetricType;
+import com.navercorp.pinpoint.otlp.common.web.definition.property.AggregationFunction;
 import com.navercorp.pinpoint.otlp.web.view.legacy.OtlpChartView;
 import com.navercorp.pinpoint.otlp.web.view.legacy.OtlpChartViewBuilder;
 import com.navercorp.pinpoint.otlp.web.vo.FieldAttribute;
@@ -14,7 +14,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OtlpChartViewTest {
 
@@ -28,7 +29,7 @@ public class OtlpChartViewTest {
     @Test
     public void shiftFillEmptyValueShouldAddTimestampAndValue() {
         FieldAttribute fieldAttribute = new FieldAttribute("test", MetricType.GAUGE, DataType.DOUBLE, AggregationFunction.AVG, AggreTemporality.DELTA, "description", "unit", "version");
-        List<OtlpMetricChartResult> dataPoints = Arrays.asList(new OtlpMetricChartResult(123456789L, "", 100));
+        List<OtlpMetricChartResult> dataPoints = List.of(new OtlpMetricChartResult(123456789L, "", 100));
 
         otlpChartViewBuilder.add(fieldAttribute, dataPoints);
         otlpChartViewBuilder.shiftFillEmptyValue(0, 123456789L);
@@ -46,11 +47,11 @@ public class OtlpChartViewTest {
     @Test
     public void addShouldAddFieldData() {
         FieldAttribute fieldAttribute = new FieldAttribute("test", MetricType.GAUGE, DataType.DOUBLE, AggregationFunction.AVG, AggreTemporality.DELTA, "description", "unit", "version");
-        List<OtlpMetricChartResult> dataPoints1 = Arrays.asList(new OtlpMetricChartResult(123456789L, "", 100));
+        List<OtlpMetricChartResult> dataPoints1 = List.of(new OtlpMetricChartResult(123456789L, "", 100));
         otlpChartViewBuilder.add(fieldAttribute, dataPoints1);
         assertEquals(1, otlpChartViewBuilder.getFields().size());
 
-        List<OtlpMetricChartResult> dataPoints2 = Arrays.asList(new OtlpMetricChartResult(123456789L, "", 100));
+        List<OtlpMetricChartResult> dataPoints2 = List.of(new OtlpMetricChartResult(123456789L, "", 100));
         otlpChartViewBuilder.add(fieldAttribute, dataPoints2);
         assertEquals(2, otlpChartViewBuilder.getFields().size());
     }

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/view/UriStatView.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/view/UriStatView.java
@@ -16,11 +16,12 @@
 package com.navercorp.pinpoint.uristat.web.view;
 
 import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindow;
+import com.navercorp.pinpoint.metric.common.util.TimeUtils;
+import com.navercorp.pinpoint.uristat.web.chart.UriStatChartType;
+import com.navercorp.pinpoint.uristat.web.model.UriStatGroup;
 import com.navercorp.pinpoint.metric.web.view.TimeSeriesView;
 import com.navercorp.pinpoint.metric.web.view.TimeseriesValueGroupView;
-import com.navercorp.pinpoint.uristat.web.chart.UriStatChartType;
 import com.navercorp.pinpoint.uristat.web.model.UriStatChartValue;
-import com.navercorp.pinpoint.uristat.web.model.UriStatGroup;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +29,7 @@ import java.util.Objects;
 
 public class UriStatView implements TimeSeriesView {
 
-    private final List<Long> timestampList;
+    private final TimeWindow timeWindow;
     private final List<TimeseriesValueGroupView> uriStats = new ArrayList<>();
 
     public UriStatView(String uri, TimeWindow timeWindow, List<UriStatChartValue> uriStats, UriStatChartType chartType) {
@@ -36,11 +37,11 @@ public class UriStatView implements TimeSeriesView {
         Objects.requireNonNull(uriStats, "uriStats");
         Objects.requireNonNull(chartType, "chartType");
 
-        this.timestampList = timeWindow.getTimeseriesWindows();
+        this.timeWindow = Objects.requireNonNull(timeWindow, "timeWindow");
         if (uriStats.isEmpty()) {
             this.uriStats.add(UriStatGroup.EMPTY_URI_STAT_GROUP);
         } else {
-            this.uriStats.add(new UriStatGroup(uri, timestampList.size(), timeWindow, uriStats, chartType.getFieldNames()));
+            this.uriStats.add(new UriStatGroup(uri, timeWindow, uriStats, chartType.getFieldNames()));
         }
     }
 
@@ -51,7 +52,7 @@ public class UriStatView implements TimeSeriesView {
 
     @Override
     public List<Long> getTimestamp() {
-        return timestampList;
+        return timeWindow.getTimeseriesWindows();
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/histogram/TimeHistogramChartBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/histogram/TimeHistogramChartBuilder.java
@@ -17,6 +17,7 @@
 
 package com.navercorp.pinpoint.web.view.histogram;
 
+import com.navercorp.pinpoint.common.server.util.array.LongArray;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
@@ -26,8 +27,6 @@ import com.navercorp.pinpoint.web.vo.ResponseTimeStatics;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class TimeHistogramChartBuilder {
     private final List<TimeHistogram> orderedTimeHistograms;
@@ -47,7 +46,7 @@ public class TimeHistogramChartBuilder {
 
     public TimeHistogramChart buildLoadChart() {
         List<TimeSeriesValueView> metricValueList = createLoadValueList(orderedTimeHistograms);
-        return new TimeHistogramChart("Load", getTimeStampList(orderedTimeHistograms),
+        return new TimeHistogramChart("Load", LongArray.asList(orderedTimeHistograms, TimeHistogram::getTimeStamp),
                 List.of(new TimeHistogramValueGroupView("load", "count", "area-step", metricValueList)));
     }
 
@@ -57,39 +56,27 @@ public class TimeHistogramChartBuilder {
         }
         HistogramSchema schema = histogramList.get(0).getHistogramSchema();
         return List.of(
-                new TimeHistogramValueView(schema.getFastSlot().getSlotName(), getValueList(histogramList, Histogram::getFastCount)),
-                new TimeHistogramValueView(schema.getNormalSlot().getSlotName(), getValueList(histogramList, Histogram::getNormalCount)),
-                new TimeHistogramValueView(schema.getSlowSlot().getSlotName(), getValueList(histogramList, Histogram::getSlowCount)),
-                new TimeHistogramValueView(schema.getVerySlowSlot().getSlotName(), getValueList(histogramList, Histogram::getVerySlowCount)),
-                new TimeHistogramValueView(schema.getErrorSlot().getSlotName(), getValueList(histogramList, Histogram::getErrorCount))
+                new TimeHistogramValueView(schema.getFastSlot().getSlotName(), LongArray.asList(histogramList, Histogram::getFastCount)),
+                new TimeHistogramValueView(schema.getNormalSlot().getSlotName(), LongArray.asList(histogramList, Histogram::getNormalCount)),
+                new TimeHistogramValueView(schema.getSlowSlot().getSlotName(), LongArray.asList(histogramList, Histogram::getSlowCount)),
+                new TimeHistogramValueView(schema.getVerySlowSlot().getSlotName(), LongArray.asList(histogramList, Histogram::getVerySlowCount)),
+                new TimeHistogramValueView(schema.getErrorSlot().getSlotName(), LongArray.asList(histogramList, Histogram::getErrorCount))
         );
     }
 
     public TimeHistogramChart buildLoadStatisticsChart() {
         List<TimeSeriesValueView> metricValueList = createLoadStatisticsValueList(orderedTimeHistograms);
-        return new TimeHistogramChart("Load Avg & Max", getTimeStampList(orderedTimeHistograms),
+        return new TimeHistogramChart("Load Avg & Max", LongArray.asList(orderedTimeHistograms, TimeHistogram::getTimeStamp),
                 List.of(new TimeHistogramValueGroupView("loadStatistics", "ms", "area-step", metricValueList)));
     }
 
     private List<TimeSeriesValueView> createLoadStatisticsValueList(List<TimeHistogram> histogramList) {
+
         return List.of(
-                new TimeHistogramValueView(ResponseTimeStatics.AVG_ELAPSED_TIME, getValueList(histogramList, Histogram::getAvgElapsed)),
-                new TimeHistogramValueView(ResponseTimeStatics.MAX_ELAPSED_TIME, getValueList(histogramList, Histogram::getMaxElapsed))
+                new TimeHistogramValueView(ResponseTimeStatics.AVG_ELAPSED_TIME, LongArray.asList(histogramList, Histogram::getAvgElapsed)),
+                new TimeHistogramValueView(ResponseTimeStatics.MAX_ELAPSED_TIME, LongArray.asList(histogramList, Histogram::getMaxElapsed))
         );
     }
 
-
-    private List<Long> getTimeStampList(List<TimeHistogram> histogramList) {
-        return histogramList.stream()
-                .map(TimeHistogram::getTimeStamp)
-                .collect(Collectors.toList());
-    }
-
-    public List<? extends Number> getValueList(List<TimeHistogram> histogramList, Function<TimeHistogram, Number> function) {
-        return histogramList
-                .stream()
-                .map(function)
-                .collect(Collectors.toList());
-    }
 
 }


### PR DESCRIPTION
This pull request includes various changes to improve array handling and simplify code by using utility methods from the Guava library. The most significant changes involve refactoring code to utilize `Doubles`, `Ints`, and `Longs` utility classes, and introducing new utility classes for array handling.

Refactoring to use Guava utility methods:

* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/scatter/OneByteFuzzyRowKeyFactory.java`](diffhunk://#diff-9015fc50bf14a6926f1f93c856cc7118bb39c263fc8533338d64cb05dd394dccL31-L41): Replaced custom `toLongArray` method with `Longs.toArray` for converting a list of `Long` to a primitive array.

Introduction of new utility classes:

* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/DoubleArray.java`](diffhunk://#diff-2445ce332ca2a42edd959395415576f9990977d8ad4cd95bc73ca9934f29d493R1-R36): Added `DoubleArray` class with methods to create arrays and convert lists using `ToDoubleFunction`.
* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/IntArray.java`](diffhunk://#diff-09fd5d4194053d086a13fd4cb36adb510ca232644f16aef2ae9b578ce3f57fcaR1-R29): Added `IntArray` class with methods to convert lists using `ToIntFunction`.
* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/LongArray.java`](diffhunk://#diff-2a1ab023f79f10e861f8bcedad1551c8b1ebfc69753adcd03d2c358983f47d2bR1-R30): Added `LongArray` class with methods to convert lists using `ToLongFunction`.

Updates to existing code to use new utility classes:

* [`exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/StackTraceMapper.java`](diffhunk://#diff-8b4ec9e271c5a2ca585b3ba11640bb86221d6d00efb2210b59c09d092d0e6a0fL83-R84): Updated `stackTraceToLineNumber` method to use `IntArray.asList` for converting line numbers.
* [`inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/AvgUsingIntervalPostProcessor.java`](diffhunk://#diff-60dd808312bd629df450108a8cf31ff060a610ab5aa43db06f8d07105d569f74L57-R68): Refactored methods to use `Doubles.asList` for array handling and `DoubleArray.asList` for list conversion. [[1]](diffhunk://#diff-60dd808312bd629df450108a8cf31ff060a610ab5aa43db06f8d07105d569f74L57-R68) [[2]](diffhunk://#diff-60dd808312bd629df450108a8cf31ff060a610ab5aa43db06f8d07105d569f74L80-R90)