### PR TITLE
[#noissue] Refactor QueryParameter

### DIFF
--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/ExceptionTraceQueryParameter.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/ExceptionTraceQueryParameter.java
@@ -16,10 +16,11 @@
 
 package com.navercorp.pinpoint.exceptiontrace.web.util;
 
+import com.google.common.primitives.Ints;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
+import com.navercorp.pinpoint.common.server.util.timewindow.TimePrecision;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.metric.web.util.QueryParameter;
-import com.navercorp.pinpoint.common.server.util.timewindow.TimePrecision;
 
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
@@ -151,9 +152,7 @@ public class ExceptionTraceQueryParameter extends QueryParameter {
         }
 
         public Builder setHardLimit(int limit) {
-            if (limit > 200) {
-                this.hardLimit = 200;
-            } else this.hardLimit = Math.max(limit, 50);
+            this.hardLimit = Ints.constrainToRange(limit, 50, 200);
             return self();
         }
 
@@ -204,7 +203,7 @@ public class ExceptionTraceQueryParameter extends QueryParameter {
             return self();
         }
 
-        public long useLimitIfSet() {
+        public int useLimitIfSet() {
             if (hardLimit != null) {
                 return hardLimit;
             }
@@ -212,9 +211,9 @@ public class ExceptionTraceQueryParameter extends QueryParameter {
         }
 
         @Override
-        public long estimateLimit() {
+        public int estimateLimit() {
             if (this.range != null) {
-                return (range.getRange() / Math.max(timePrecision.getInterval(), 30000) + 1);
+                return Math.toIntExact(range.getRange() / Math.max(timePrecision.getInterval(), 30000)) + 1;
             } else {
                 return MAX_LIMIT;
             }

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/util/QueryParameter.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/util/QueryParameter.java
@@ -21,11 +21,12 @@ import com.navercorp.pinpoint.common.server.util.timewindow.TimePrecision;
 
 public abstract class QueryParameter {
     protected static final int TAG_SET_COUNT = 10;
+
     protected final Range range;
     protected final TimePrecision timePrecision;
-    protected final long limit;
+    protected final int limit;
 
-    protected QueryParameter(Range range, TimePrecision timePrecision, long limit) {
+    protected QueryParameter(Range range, TimePrecision timePrecision, int limit) {
         this.range = range;
         this.timePrecision = timePrecision;
         this.limit = limit;
@@ -39,7 +40,7 @@ public abstract class QueryParameter {
         return timePrecision;
     }
 
-    public long getLimit() {
+    public int getLimit() {
         return limit;
     }
 
@@ -47,7 +48,7 @@ public abstract class QueryParameter {
         protected Range range;
         protected TimePrecision timePrecision;
         protected long timeSize = 10000;
-        protected long limit;
+        protected int limit;
 
         protected abstract S self();
 
@@ -66,8 +67,8 @@ public abstract class QueryParameter {
             return self();
         }
 
-        public long estimateLimit() {
-            return (range.getRange() / timePrecision.getInterval() + 1) * TAG_SET_COUNT;
+        public int estimateLimit() {
+            return Math.toIntExact((range.getRange() / timePrecision.getInterval() + 1) * TAG_SET_COUNT);
         }
 
         public Range getRange() {
@@ -78,7 +79,7 @@ public abstract class QueryParameter {
             return this.timePrecision;
         }
 
-        public long getLimit() {
+        public int getLimit() {
             return this.limit;
         }
 

--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/vo/OtlpMetricChartQueryParameter.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/vo/OtlpMetricChartQueryParameter.java
@@ -1,5 +1,6 @@
 package com.navercorp.pinpoint.otlp.web.vo;
 
+import com.google.common.primitives.Ints;
 import com.navercorp.pinpoint.common.server.util.timewindow.TimePrecision;
 import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindow;
 import com.navercorp.pinpoint.metric.web.util.QueryParameter;
@@ -106,14 +107,8 @@ public class OtlpMetricChartQueryParameter extends QueryParameter {
             return self();
         }
 
-        public Builder setLimit(long limit) {
-            if (limit > 200) {
-                this.limit = 200;
-            } else if (limit < 50) {
-                this.limit = 50;
-            } else {
-                this.limit = limit;
-            }
+        public Builder setLimit(int limit) {
+            this.limit = Ints.constrainToRange(limit, 50, 200);
             return self();
         }
 

--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/vo/OtlpMetricDataQueryParameter.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/vo/OtlpMetricDataQueryParameter.java
@@ -16,11 +16,12 @@
 
 package com.navercorp.pinpoint.otlp.web.vo;
 
+import com.google.common.primitives.Ints;
 import com.navercorp.pinpoint.common.server.metric.dao.TableNameManager;
 import com.navercorp.pinpoint.common.server.util.timewindow.TimePrecision;
-import com.navercorp.pinpoint.otlp.common.model.DataType;
 import com.navercorp.pinpoint.common.server.util.timewindow.TimeWindow;
 import com.navercorp.pinpoint.metric.web.util.QueryParameter;
+import com.navercorp.pinpoint.otlp.common.model.DataType;
 import com.navercorp.pinpoint.otlp.common.web.definition.property.AggregationFunction;
 
 import java.security.InvalidParameterException;
@@ -44,7 +45,6 @@ public class OtlpMetricDataQueryParameter extends QueryParameter {
     private final String version;
     private final AggregationFunction aggregationFunction;
     private final int dataType;
-    private final TimeWindow timeWindow;
 
     public DataType getDataType() {
         return DataType.forNumber(dataType);
@@ -76,7 +76,6 @@ public class OtlpMetricDataQueryParameter extends QueryParameter {
         this.aggregationFunction = builder.aggregationFunction;
         this.dataType = builder.dataType;
         this.version = builder.version;
-        this.timeWindow = builder.timeWindow;
     }
 
     public static class Builder extends QueryParameter.Builder<Builder> {
@@ -149,14 +148,8 @@ public class OtlpMetricDataQueryParameter extends QueryParameter {
             return self();
         }
 
-        public Builder setLimit(long limit) {
-            if (limit > 200) {
-                this.limit = 200;
-            } else if (limit < 50) {
-                this.limit = 50;
-            } else {
-                this.limit = limit;
-            }
+        public Builder setLimit(int limit) {
+            this.limit = Ints.constrainToRange(limit, 50, 200);
             return self();
         }
 

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/util/UriStatChartQueryParameter.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/util/UriStatChartQueryParameter.java
@@ -16,9 +16,10 @@
 
 package com.navercorp.pinpoint.uristat.web.util;
 
+import com.google.common.primitives.Ints;
+import com.navercorp.pinpoint.common.server.util.timewindow.TimePrecision;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.metric.web.util.QueryParameter;
-import com.navercorp.pinpoint.common.server.util.timewindow.TimePrecision;
 
 import java.util.concurrent.TimeUnit;
 
@@ -101,14 +102,8 @@ public class UriStatChartQueryParameter extends QueryParameter {
             return self();
         }
 
-        public Builder setLimit(long limit) {
-            if (limit > 200) {
-                this.limit = 200;
-            } else if (limit < 50) {
-                this.limit = 50;
-            } else {
-                this.limit = limit;
-            }
+        public Builder setLimit(int limit) {
+            this.limit = Ints.constrainToRange(limit, 50, 200);
             return self();
         }
 

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/util/UriStatSummaryQueryParameter.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/util/UriStatSummaryQueryParameter.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.uristat.web.util;
 
+import com.google.common.primitives.Ints;
 import com.navercorp.pinpoint.common.server.util.EnumGetter;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 import com.navercorp.pinpoint.common.server.util.timewindow.TimePrecision;
@@ -181,14 +182,8 @@ public class UriStatSummaryQueryParameter extends QueryParameter {
             return self();
         }
 
-        public Builder setLimit(long limit) {
-            if (limit > 200) {
-                this.limit = 200;
-            } else if (limit < 50) {
-                this.limit = 50;
-            } else {
-                this.limit = limit;
-            }
+        public Builder setLimit(int limit) {
+            this.limit = Ints.constrainToRange(limit, 50, 200);
             return self();
         }
 


### PR DESCRIPTION
This pull request includes several changes to various query parameter classes across multiple modules to standardize the handling of limit values and improve type consistency by switching from `long` to `int` for limit-related fields and methods.

Standardizing limit handling and type consistency:

* [`exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/ExceptionTraceQueryParameter.java`](diffhunk://#diff-192c0cff0590236540b8cad6521117b6305523e5d90aa36ee8c7686ea91a38e3L154-R155): Updated `setHardLimit` method to use `Ints.constrainToRange` for constraining limit values and changed `useLimitIfSet` and `estimateLimit` methods to return `int` instead of `long`. [[1]](diffhunk://#diff-192c0cff0590236540b8cad6521117b6305523e5d90aa36ee8c7686ea91a38e3L154-R155) [[2]](diffhunk://#diff-192c0cff0590236540b8cad6521117b6305523e5d90aa36ee8c7686ea91a38e3L207-R216)
* [`metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/util/QueryParameter.java`](diffhunk://#diff-da6b7d4ce2c758e6953e4c049e11f24fd4e1c449721f6629961a33df07b366beR24-R29): Changed the `limit` field and related methods to use `int` instead of `long`. [[1]](diffhunk://#diff-da6b7d4ce2c758e6953e4c049e11f24fd4e1c449721f6629961a33df07b366beR24-R29) [[2]](diffhunk://#diff-da6b7d4ce2c758e6953e4c049e11f24fd4e1c449721f6629961a33df07b366beL42-R51) [[3]](diffhunk://#diff-da6b7d4ce2c758e6953e4c049e11f24fd4e1c449721f6629961a33df07b366beL69-R71) [[4]](diffhunk://#diff-da6b7d4ce2c758e6953e4c049e11f24fd4e1c449721f6629961a33df07b366beL81-R82)
* [`otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/vo/OtlpMetricChartQueryParameter.java`](diffhunk://#diff-8568109eedf8e109631a8b37450f3c89d825aff364d3a8816ef1ddd75e88bac3L109-R111): Updated `setLimit` method to use `Ints.constrainToRange` for limit values.
* [`otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/vo/OtlpMetricDataQueryParameter.java`](diffhunk://#diff-635359b4a3c9f18c415185647ca2e434054dd30120caf973a88c1424482b4040L47): Removed the `timeWindow` field and updated `setLimit` method to use `Ints.constrainToRange`. [[1]](diffhunk://#diff-635359b4a3c9f18c415185647ca2e434054dd30120caf973a88c1424482b4040L47) [[2]](diffhunk://#diff-635359b4a3c9f18c415185647ca2e434054dd30120caf973a88c1424482b4040L152-R152)
* `uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/util/UriStatChartQueryParameter.java` and `uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/util/UriStatSummaryQueryParameter.java`: Updated `setLimit` methods to use `Ints.constrainToRange`. [[1]](diffhunk://#diff-8169d609f3b1fcb537522513fdc3342ea07049e49be83a2f65d51a46af3cded2L104-R106) [[2]](diffhunk://#diff-89863e299a94d61ae069974ca04b19a474187cf63d84233989d5120676932fcfL184-R186)

These changes ensure consistent handling of limit values across different modules and improve type safety by using `int` instead of `long` for limit-related fields and methods.