### PR TITLE
[#noissue] Refactor QueryParameter

### DIFF
--- a/uristat/uristat-web/src/test/java/com/navercorp/pinpoint/uristat/web/mapper/MapperUtilsTest.java
+++ b/uristat/uristat-web/src/test/java/com/navercorp/pinpoint/uristat/web/mapper/MapperUtilsTest.java
@@ -1,0 +1,54 @@
+package com.navercorp.pinpoint.uristat.web.mapper;
+
+import com.navercorp.pinpoint.uristat.web.entity.UriStatSummaryEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MapperUtilsTest {
+
+    @Test
+    void groupByUriAndVersion() {
+        UriStatSummaryEntity entity0 = new UriStatSummaryEntity();
+        entity0.setUri("uri0");
+        entity0.setVersion("version0");
+
+        UriStatSummaryEntity entity1 = new UriStatSummaryEntity();
+        entity1.setUri("uri1");
+        entity1.setVersion("version1");
+
+        List<List<UriStatSummaryEntity>> groupBy = MapperUtils.groupByUriAndVersion(List.of(entity0, entity1), 2);
+        assertEquals(2, groupBy.size());
+    }
+
+    @Test
+    void groupByUriAndVersion_limit() {
+        UriStatSummaryEntity entity0 = new UriStatSummaryEntity();
+        entity0.setUri("uri0");
+        entity0.setVersion("version0");
+
+        UriStatSummaryEntity entity1 = new UriStatSummaryEntity();
+        entity1.setUri("uri1");
+        entity1.setVersion("version1");
+
+        List<List<UriStatSummaryEntity>> groupBy = MapperUtils.groupByUriAndVersion(List.of(entity0, entity1), 1);
+        assertEquals(1, groupBy.size());
+    }
+
+
+    @Test
+    void groupByUriAndVersion_1() {
+        UriStatSummaryEntity entity0 = new UriStatSummaryEntity();
+        entity0.setUri("uri0");
+        entity0.setVersion("version0");
+
+        UriStatSummaryEntity entity1 = new UriStatSummaryEntity();
+        entity1.setUri("uri0");
+        entity1.setVersion("version0");
+
+        List<List<UriStatSummaryEntity>> groupBy = MapperUtils.groupByUriAndVersion(List.of(entity0, entity1), 2);
+        assertEquals(1, groupBy.size());
+    }
+}


### PR DESCRIPTION
This pull request includes changes to improve the grouping functionality in the `MapperUtils` class and adds corresponding unit tests to ensure the correctness of the new implementation. The most important changes include refactoring the `groupByUriAndVersion` method, introducing a new `groupBy` method, and adding tests to validate the grouping logic.

Improvements to grouping functionality:

* [`uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/mapper/MapperUtils.java`](diffhunk://#diff-e73928dcf75788457be447f2d5d6363c5b5ccc81aeca453e3c724daafc3511c6R24-R64): Refactored the `groupByUriAndVersion` method to use a new `groupBy` method for better modularity and readability. Introduced a `Key` record to encapsulate the grouping keys.

Addition of unit tests:

* [`uristat/uristat-web/src/test/java/com/navercorp/pinpoint/uristat/web/mapper/MapperUtilsTest.java`](diffhunk://#diff-ec4e155e82bdb7ea4c8f1cd8c837adb16c8f9ebf298de1057bd39d0030e44552R1-R54): Added unit tests for the `groupByUriAndVersion` method to verify the grouping logic and the limit functionality.