### PR TITLE
[#noissue] Refactor AsyncQueueingUriStatStorage to use UriTransformer for improved URI handling

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/storage/UriMethodTransformer.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/storage/UriMethodTransformer.java
@@ -1,0 +1,13 @@
+package com.navercorp.pinpoint.profiler.context.storage;
+
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+public class UriMethodTransformer implements UriTransformer {
+    @Override
+    public String transform(String httpMethod, String uri) {
+        if (StringUtils.isEmpty(httpMethod)) {
+            return uri;
+        }
+        return httpMethod + " " + uri;
+    }
+}

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/storage/UriOnlyTransformer.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/storage/UriOnlyTransformer.java
@@ -1,0 +1,8 @@
+package com.navercorp.pinpoint.profiler.context.storage;
+
+public class UriOnlyTransformer implements UriTransformer {
+    @Override
+    public String transform(String httpMethod, String uri) {
+        return uri;
+    }
+}

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/storage/UriTransformer.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/storage/UriTransformer.java
@@ -1,0 +1,6 @@
+package com.navercorp.pinpoint.profiler.context.storage;
+
+public interface UriTransformer {
+
+    String transform(String method, String uri);
+}

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/storage/AsyncQueueingUriStatStorageTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/storage/AsyncQueueingUriStatStorageTest.java
@@ -40,6 +40,8 @@ public class AsyncQueueingUriStatStorageTest {
 
     private static final String[] HTTP_METHODS = {"GET", "POST", "PUT", "DELETE"};
 
+    UriTransformer uriTransformer = new UriMethodTransformer();
+
     @Test
     public void storageTest() {
         int collectInterval = 100;
@@ -51,7 +53,7 @@ public class AsyncQueueingUriStatStorageTest {
 
     private void storageTest(int collectInterval, int storeCount) {
         try (AsyncQueueingUriStatStorage storage
-                     = new AsyncQueueingUriStatStorage(true, 5012, 1000, "Test-Executor", collectInterval)) {
+                     = new AsyncQueueingUriStatStorage(uriTransformer, 5012, 1000, "Test-Executor", collectInterval)) {
 
             long sleepTime = System.currentTimeMillis() % collectInterval;
 

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/storage/UriMethodTransformerTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/storage/UriMethodTransformerTest.java
@@ -1,0 +1,15 @@
+package com.navercorp.pinpoint.profiler.context.storage;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class UriMethodTransformerTest {
+
+    @Test
+    void transform() {
+        UriMethodTransformer transformer = new UriMethodTransformer();
+        Assertions.assertEquals("GET /user", transformer.transform("GET", "/user"));
+
+        Assertions.assertEquals("/user", transformer.transform(null, "/user"));
+    }
+}


### PR DESCRIPTION
… for improved URI handling

This pull request includes several changes to the `agent-module/profiler` package to introduce and utilize the `UriTransformer` interface for transforming URIs based on HTTP methods. The most important changes include the addition of new classes implementing the `UriTransformer` interface, modifications to existing classes to use the new interface, and updates to tests to accommodate these changes.

### Introduction of `UriTransformer` Interface:
* [`agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/storage/UriTransformer.java`](diffhunk://#diff-67b7f5acf062bd87b31e81c44147f1499730755e64b13d112549ace936e1886eR1-R6): Added a new interface `UriTransformer` with a method `transform` to handle URI transformations.

### Implementation of `UriTransformer` Interface:
* [`agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/storage/UriMethodTransformer.java`](diffhunk://#diff-0dca9aa45e751b0496c1b33f61539844a327f150bf00098437a3105e11945131R1-R13): Added a new class `UriMethodTransformer` that implements `UriTransformer` to prepend HTTP methods to URIs.
* [`agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/storage/UriOnlyTransformer.java`](diffhunk://#diff-918ebda43acb9ab6fa0db6f9450dca26064ce2f8652376a44f0535a3d224aa4fR1-R8): Added a new class `UriOnlyTransformer` that implements `UriTransformer` to return URIs without modification.

### Modifications to Use `UriTransformer`:
* [`agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/UriStatStorageProvider.java`](diffhunk://#diff-7a087b7d41a3e9611a7c38426af0d6546990e771b1317327bd7d5fe4a2d7b905R24-R27): Modified to use `UriTransformer` for URI transformation based on configuration. [[1]](diffhunk://#diff-7a087b7d41a3e9611a7c38426af0d6546990e771b1317327bd7d5fe4a2d7b905R24-R27) [[2]](diffhunk://#diff-7a087b7d41a3e9611a7c38426af0d6546990e771b1317327bd7d5fe4a2d7b905L45-R61)
* [`agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/storage/AsyncQueueingUriStatStorage.java`](diffhunk://#diff-62fcf27de745846e14439271e189873a39d671265eaed979a498d6ec3917a3b1R33): Updated to use `UriTransformer` for URI transformation in the `store` method. [[1]](diffhunk://#diff-62fcf27de745846e14439271e189873a39d671265eaed979a498d6ec3917a3b1R33) [[2]](diffhunk://#diff-62fcf27de745846e14439271e189873a39d671265eaed979a498d6ec3917a3b1L45-R80)

### Updates to Tests:
* [`agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/storage/AsyncQueueingUriStatStorageTest.java`](diffhunk://#diff-f65729bdd8b158d9cfa1cadb268c1c07f1cd925fded4ceea378fe4fc2ed64640R43-R44): Updated tests to use `UriTransformer` in `AsyncQueueingUriStatStorage`. [[1]](diffhunk://#diff-f65729bdd8b158d9cfa1cadb268c1c07f1cd925fded4ceea378fe4fc2ed64640R43-R44) [[2]](diffhunk://#diff-f65729bdd8b158d9cfa1cadb268c1c07f1cd925fded4ceea378fe4fc2ed64640L54-R56)
* [`agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/storage/UriMethodTransformerTest.java`](diffhunk://#diff-dadc66f276ff35c99352c4cf572c4c67cea35ee916f691514fdd1bdd0d01df48R1-R15): Added new tests for `UriMethodTransformer`.