### PR TITLE
[#noisie] Improved debuggability of TimeSeriesVirtualList

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualList.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualList.java
@@ -2,7 +2,9 @@ package com.navercorp.pinpoint.common.server.util.timewindow;
 
 import org.springframework.util.Assert;
 
+import java.lang.reflect.Array;
 import java.util.AbstractList;
+import java.util.Collection;
 import java.util.Iterator;
 
 /**
@@ -38,4 +40,83 @@ public class TimeSeriesVirtualList extends AbstractList<Long> {
     public int size() {
         return size;
     }
+
+    @Override
+    public Object[] toArray() {
+        final Long[] longs = new Long[size];
+        copyOfTimeSeries(longs);
+        return longs;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private <T> void copyOfTimeSeries(T[] longs) {
+        long value = start;
+        for (int i = 0; i < size; i++) {
+            longs[i] = (T) Long.valueOf(value);
+            value += increment;
+        }
+    }
+
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        if (a.length < size) {
+            @SuppressWarnings("unchecked")
+            final T[] newArray = ((T[]) Array.newInstance(a.getClass().getComponentType(), size));
+            copyOfTimeSeries(newArray);
+            return newArray;
+        }
+        copyOfTimeSeries(a);
+        return a;
+    }
+
+    // for debug -----------
+
+    @Override
+    public Long set(int index, Long element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean add(Long element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void add(int index, Long element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Long remove(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void removeRange(int fromIndex, int toIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends Long> c) {
+        throw new UnsupportedOperationException();
+    }
+
+
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualListTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualListTest.java
@@ -1,7 +1,10 @@
 package com.navercorp.pinpoint.common.server.util.timewindow;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.navercorp.pinpoint.common.server.util.time.Range;
+import org.apache.hadoop.hbase.shaded.org.apache.curator.shaded.com.google.common.collect.Iterators;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -19,5 +22,57 @@ class TimeSeriesVirtualListTest {
         List<Long> list = new TimeSeriesVirtualList(timeWindow.getWindowRangeCount(), 0, timeWindow.getWindowSlotSize());
 
         assertThat(list).isEqualTo(timeWindowList);
+    }
+
+    @Test
+    void toArray() {
+        List<Long> list = new TimeSeriesVirtualList(10, 0, 1000);
+
+        Object[] array = list.toArray();
+        Long[] iter = Iterators.toArray(list.iterator(), Long.class);
+        assertThat(array).isEqualTo(iter);
+
+        // Compatibility check with java.util.List
+        List<Long> arrayList = Lists.newArrayList(list.iterator());
+        assertThat(array).isEqualTo(arrayList.toArray());
+    }
+
+    @Test
+    void toArray_generic() {
+        List<Long> list = new TimeSeriesVirtualList(10, 0, 1000);
+
+        Long[] array = list.toArray(new Long[0]);
+        Long[] iter = Iterators.toArray(list.iterator(), Long.class);
+        assertThat(array).isEqualTo(iter);
+
+        // Compatibility check with java.util.List
+        List<Long> arrayList = Lists.newArrayList(list.iterator());
+        assertThat(array).isEqualTo(arrayList.toArray(new Long[0]));
+    }
+
+    @Test
+    void toArray_generic_copy() {
+        List<Long> list = new TimeSeriesVirtualList(10, 0, 1000);
+
+        Long[] copy = new Long[10];
+        list.toArray(copy);
+
+        Long[] iter = Iterators.toArray(list.iterator(), Long.class);
+        assertThat(copy).isEqualTo(iter);
+
+        // Compatibility check with java.util.List
+        List<Long> arrayList = Lists.newArrayList(list.iterator());
+        assertThat(copy).isEqualTo(arrayList.toArray());
+    }
+
+
+    @Test
+    void unsupportedOperationException() {
+        List<Long> list = new TimeSeriesVirtualList(10, 0, 1000);
+
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> list.set(0, 100L));
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> list.add(0, 100L));
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> list.remove(0));
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> list.remove(Long.valueOf(1)));
     }
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `TimeSeriesVirtualList` class and its corresponding tests. The main changes include adding support for the `toArray` method, implementing unsupported operations, and updating the test cases to cover these new functionalities.

Enhancements to `TimeSeriesVirtualList`:

* Added `toArray` method to convert the list to an array. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualList.java`)
* Implemented unsupported operations to throw `UnsupportedOperationException`. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualList.java`)

Updates to test cases:

* Added new test cases to validate the `toArray` method and ensure compatibility with `java.util.List`. (`commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualListTest.java`)
* Added test cases to verify that unsupported operations throw `UnsupportedOperationException`. (`commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/timewindow/TimeSeriesVirtualListTest.java`)