### PR TITLE
[#noissue] Refactor UriMetric

### DIFF
--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/config/UriRegistryHandler.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/config/UriRegistryHandler.java
@@ -1,10 +1,11 @@
 package com.navercorp.pinpoint.uristat.web.config;
 
 import com.navercorp.pinpoint.mybatis.MyBatisRegistryHandler;
-import com.navercorp.pinpoint.uristat.web.entity.UriStatChartEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriApdexChartEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriHistogramEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriHistogramFailEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriLatencyChartEntity;
 import com.navercorp.pinpoint.uristat.web.entity.UriStatSummaryEntity;
-import com.navercorp.pinpoint.uristat.web.model.UriStatChartValue;
-import com.navercorp.pinpoint.uristat.web.model.UriStatSummary;
 import com.navercorp.pinpoint.uristat.web.util.UriStatChartQueryParameter;
 import com.navercorp.pinpoint.uristat.web.util.UriStatSummaryQueryParameter;
 import org.apache.ibatis.type.TypeAliasRegistry;
@@ -13,9 +14,12 @@ import org.apache.ibatis.type.TypeHandlerRegistry;
 public class UriRegistryHandler implements MyBatisRegistryHandler {
     @Override
     public void registerTypeAlias(TypeAliasRegistry typeAliasRegistry) {
-        typeAliasRegistry.registerAlias(UriStatChartValue.class);
-        typeAliasRegistry.registerAlias(UriStatSummary.class);
-        typeAliasRegistry.registerAlias(UriStatChartEntity.class);
+        typeAliasRegistry.registerAlias(UriHistogramEntity.class);
+        typeAliasRegistry.registerAlias(UriHistogramFailEntity.class);
+
+        typeAliasRegistry.registerAlias(UriApdexChartEntity.class);
+        typeAliasRegistry.registerAlias(UriLatencyChartEntity.class);
+
         typeAliasRegistry.registerAlias(UriStatSummaryEntity.class);
         typeAliasRegistry.registerAlias(UriStatSummaryQueryParameter.class);
         typeAliasRegistry.registerAlias(UriStatChartQueryParameter.class);

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/dao/PinotApdexChartDao.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/dao/PinotApdexChartDao.java
@@ -1,6 +1,6 @@
 package com.navercorp.pinpoint.uristat.web.dao;
 
-import com.navercorp.pinpoint.uristat.web.entity.UriStatChartEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriApdexChartEntity;
 import com.navercorp.pinpoint.uristat.web.mapper.EntityToModelMapper;
 import com.navercorp.pinpoint.uristat.web.model.UriStatChartValue;
 import com.navercorp.pinpoint.uristat.web.util.UriStatChartQueryParameter;
@@ -29,9 +29,9 @@ public class PinotApdexChartDao implements UriStatChartDao {
 
     @Override
     public List<UriStatChartValue> getChartData(UriStatChartQueryParameter queryParameter) {
-        List<UriStatChartEntity> entities = sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_APDEX_CHART, queryParameter);
+        List<UriApdexChartEntity> entities = sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_APDEX_CHART, queryParameter);
         return entities.stream()
-                .map(mapper::toApdexChart
+                .map(mapper::toSimpleApdexChart
                 ).toList();
     }
 }

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/dao/PinotFailureCountChartDao.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/dao/PinotFailureCountChartDao.java
@@ -1,6 +1,6 @@
 package com.navercorp.pinpoint.uristat.web.dao;
 
-import com.navercorp.pinpoint.uristat.web.entity.UriStatChartEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriHistogramFailEntity;
 import com.navercorp.pinpoint.uristat.web.mapper.EntityToModelMapper;
 import com.navercorp.pinpoint.uristat.web.model.UriStatChartValue;
 import com.navercorp.pinpoint.uristat.web.util.UriStatChartQueryParameter;
@@ -29,9 +29,8 @@ public class PinotFailureCountChartDao implements UriStatChartDao {
 
     @Override
     public List<UriStatChartValue> getChartData(UriStatChartQueryParameter queryParameter) {
-        List<UriStatChartEntity> entities = sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_FAILURE_CHART, queryParameter);
+        List<UriHistogramFailEntity> entities = sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_FAILURE_CHART, queryParameter);
         return entities.stream()
-                .map(mapper::toFailureChart
-                ).toList();
+                .map(mapper::toFailureChart).toList();
     }
 }

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/dao/PinotLatencyChartDao.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/dao/PinotLatencyChartDao.java
@@ -1,6 +1,6 @@
 package com.navercorp.pinpoint.uristat.web.dao;
 
-import com.navercorp.pinpoint.uristat.web.entity.UriStatChartEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriLatencyChartEntity;
 import com.navercorp.pinpoint.uristat.web.mapper.EntityToModelMapper;
 import com.navercorp.pinpoint.uristat.web.model.UriStatChartValue;
 import com.navercorp.pinpoint.uristat.web.util.UriStatChartQueryParameter;
@@ -29,9 +29,9 @@ public class PinotLatencyChartDao implements UriStatChartDao {
 
     @Override
     public List<UriStatChartValue> getChartData(UriStatChartQueryParameter queryParameter) {
-        List<UriStatChartEntity> entities = sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_LATENCY_CHART, queryParameter);
+        List<UriLatencyChartEntity> entities = sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_LATENCY_CHART, queryParameter);
         return entities.stream()
-                .map(mapper::toLatencyChart
+                .map(mapper::toSimpleLatencyChart
                 ).toList();
     }
 

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/dao/PinotTotalCountChartDao.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/dao/PinotTotalCountChartDao.java
@@ -1,6 +1,6 @@
 package com.navercorp.pinpoint.uristat.web.dao;
 
-import com.navercorp.pinpoint.uristat.web.entity.UriStatChartEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriHistogramEntity;
 import com.navercorp.pinpoint.uristat.web.mapper.EntityToModelMapper;
 import com.navercorp.pinpoint.uristat.web.model.UriStatChartValue;
 import com.navercorp.pinpoint.uristat.web.util.UriStatChartQueryParameter;
@@ -30,9 +30,9 @@ public class PinotTotalCountChartDao implements UriStatChartDao {
 
     @Override
     public List<UriStatChartValue> getChartData(UriStatChartQueryParameter queryParameter) {
-        List<UriStatChartEntity> entities = sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_TOTAL_CHART, queryParameter);
+        List<UriHistogramEntity> entities = sqlPinotSessionTemplate.selectList(NAMESPACE + SELECT_TOTAL_CHART, queryParameter);
         return entities.stream()
-                .map(mapper::toTotalChart
+                .map((mapper::toTotalChart)
                 ).toList();
     }
 }

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriApdexChartEntity.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriApdexChartEntity.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.uristat.web.entity;
+
+/**
+ * @author emeroad
+ */
+public class UriApdexChartEntity extends UriEntity {
+    // apdex
+    private double apdexRaw;
+    private double count;
+
+
+    public UriApdexChartEntity() {
+    }
+
+
+    public double getApdexRaw() {
+        return apdexRaw;
+    }
+
+    public void setApdexRaw(double apdexRaw) {
+        this.apdexRaw = apdexRaw;
+    }
+
+    public double getCount() {
+        return count;
+    }
+
+    public void setCount(double count) {
+        this.count = count;
+    }
+
+}

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriEntity.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriEntity.java
@@ -1,0 +1,31 @@
+package com.navercorp.pinpoint.uristat.web.entity;
+
+/**
+ * @author emeroad
+ */
+public class UriEntity {
+   // common
+    protected long timestamp;
+    protected String version;
+
+    public UriEntity() {
+    }
+
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+}

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriHistogramEntity.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriHistogramEntity.java
@@ -1,0 +1,109 @@
+package com.navercorp.pinpoint.uristat.web.entity;
+
+import com.google.common.primitives.Doubles;
+
+import java.util.List;
+
+/**
+ * @author emeroad
+ */
+public class UriHistogramEntity extends UriEntity {
+    // total
+    private double tot0;
+    private double tot1;
+    private double tot2;
+    private double tot3;
+    private double tot4;
+    private double tot5;
+    private double tot6;
+    private double tot7;
+
+    public UriHistogramEntity() {
+    }
+
+    public double getTot0() {
+        return tot0;
+    }
+
+    public void setTot0(double tot0) {
+        this.tot0 = tot0;
+    }
+
+    public double getTot1() {
+        return tot1;
+    }
+
+    public void setTot1(double tot1) {
+        this.tot1 = tot1;
+    }
+
+    public double getTot2() {
+        return tot2;
+    }
+
+    public void setTot2(double tot2) {
+        this.tot2 = tot2;
+    }
+
+    public double getTot3() {
+        return tot3;
+    }
+
+    public void setTot3(double tot3) {
+        this.tot3 = tot3;
+    }
+
+    public double getTot4() {
+        return tot4;
+    }
+
+    public void setTot4(double tot4) {
+        this.tot4 = tot4;
+    }
+
+    public double getTot5() {
+        return tot5;
+    }
+
+    public void setTot5(double tot5) {
+        this.tot5 = tot5;
+    }
+
+    public double getTot6() {
+        return tot6;
+    }
+
+    public void setTot6(double tot6) {
+        this.tot6 = tot6;
+    }
+
+    public double getTot7() {
+        return tot7;
+    }
+
+    public void setTot7(double tot7) {
+        this.tot7 = tot7;
+    }
+
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public List<Double> getTotalHistogram() {
+        return Doubles.asList(this.tot0, this.tot1, this.tot2, this.tot3,
+                this.tot4, this.tot5, this.tot6, this.tot7);
+    }
+}

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriHistogramFailEntity.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriHistogramFailEntity.java
@@ -1,0 +1,95 @@
+package com.navercorp.pinpoint.uristat.web.entity;
+
+import com.google.common.primitives.Doubles;
+
+import java.util.List;
+
+/**
+ * @author emeroad
+ */
+public class UriHistogramFailEntity extends UriEntity {
+    // fail
+    private double fail0;
+    private double fail1;
+    private double fail2;
+    private double fail3;
+    private double fail4;
+    private double fail5;
+    private double fail6;
+    private double fail7;
+
+
+    public UriHistogramFailEntity() {
+    }
+
+    public double getFail0() {
+        return fail0;
+    }
+
+    public void setFail0(double fail0) {
+        this.fail0 = fail0;
+    }
+
+    public double getFail1() {
+        return fail1;
+    }
+
+    public void setFail1(double fail1) {
+        this.fail1 = fail1;
+    }
+
+    public double getFail2() {
+        return fail2;
+    }
+
+    public void setFail2(double fail2) {
+        this.fail2 = fail2;
+    }
+
+    public double getFail3() {
+        return fail3;
+    }
+
+    public void setFail3(double fail3) {
+        this.fail3 = fail3;
+    }
+
+    public double getFail4() {
+        return fail4;
+    }
+
+    public void setFail4(double fail4) {
+        this.fail4 = fail4;
+    }
+
+    public double getFail5() {
+        return fail5;
+    }
+
+    public void setFail5(double fail5) {
+        this.fail5 = fail5;
+    }
+
+    public double getFail6() {
+        return fail6;
+    }
+
+    public void setFail6(double fail6) {
+        this.fail6 = fail6;
+    }
+
+    public double getFail7() {
+        return fail7;
+    }
+
+    public void setFail7(double fail7) {
+        this.fail7 = fail7;
+    }
+
+    public List<Double> getFailureHistogram() {
+        return Doubles.asList(
+                this.fail0, this.fail1, this.fail2, this.fail3,
+                this.fail4, this.fail5, this.fail6, this.fail7
+        );
+    }
+}

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriLatencyChartEntity.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriLatencyChartEntity.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.uristat.web.entity;
+
+/**
+ * @author emeroad
+ */
+public class UriLatencyChartEntity extends UriEntity {
+
+    // latency
+    private double totalTimeMs;
+    private double maxLatencyMs;
+    private double count;
+
+
+    public UriLatencyChartEntity() {
+    }
+
+    public double getTotalTimeMs() {
+        return totalTimeMs;
+    }
+
+    public void setTotalTimeMs(double totalTimeMs) {
+        this.totalTimeMs = totalTimeMs;
+    }
+
+    public double getMaxLatencyMs() {
+        return maxLatencyMs;
+    }
+
+    public void setMaxLatencyMs(double maxLatencyMs) {
+        this.maxLatencyMs = maxLatencyMs;
+    }
+
+    public double getCount() {
+        return count;
+    }
+
+    public void setCount(double count) {
+        this.count = count;
+    }
+
+}

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriStatChartEntity.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriStatChartEntity.java
@@ -15,10 +15,14 @@
  */
 package com.navercorp.pinpoint.uristat.web.entity;
 
+import com.google.common.primitives.Doubles;
+
+import java.util.List;
+
 /**
  * @author intr3p1d
  */
-public class UriStatChartEntity {
+public class UriStatChartEntity extends UriEntity {
 
     // total
     private double tot0;
@@ -48,9 +52,6 @@ public class UriStatChartEntity {
     // apdex
     private double apdexRaw;
 
-    // common
-    private long timestamp;
-    private String version;
 
     public UriStatChartEntity() {
     }
@@ -215,33 +216,17 @@ public class UriStatChartEntity {
         this.apdexRaw = apdexRaw;
     }
 
-    public long getTimestamp() {
-        return timestamp;
-    }
-
-    public void setTimestamp(long timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    public double[] toTotalHistogram() {
-        return new double[]{
+    public List<Double> getTotalHistogram() {
+        return Doubles.asList(
                 this.tot0, this.tot1, this.tot2, this.tot3,
                 this.tot4, this.tot5, this.tot6, this.tot7
-        };
+        );
     }
 
-    public double[] toFailureHistogram() {
-        return new double[]{
+    public List<Double> getFailureHistogram() {
+        return Doubles.asList(
                 this.fail0, this.fail1, this.fail2, this.fail3,
                 this.fail4, this.fail5, this.fail6, this.fail7
-        };
+        );
     }
 }

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriStatSummaryEntity.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/entity/UriStatSummaryEntity.java
@@ -25,7 +25,6 @@ public class UriStatSummaryEntity extends UriStatChartEntity {
     private double failureCount;
     private double maxTimeMs;
     private double sumOfTotalTimeMs;
-    private String version;
 
     public UriStatSummaryEntity() {
     }
@@ -76,13 +75,5 @@ public class UriStatSummaryEntity extends UriStatChartEntity {
 
     public void setSumOfTotalTimeMs(double totalTimeMs) {
         this.sumOfTotalTimeMs = totalTimeMs;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
     }
 }

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/mapper/EntityToModelMapper.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/mapper/EntityToModelMapper.java
@@ -15,8 +15,10 @@
  */
 package com.navercorp.pinpoint.uristat.web.mapper;
 
-import com.google.common.primitives.Doubles;
-import com.navercorp.pinpoint.common.util.MathUtils;
+import com.navercorp.pinpoint.uristat.web.entity.UriApdexChartEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriHistogramEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriHistogramFailEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriLatencyChartEntity;
 import com.navercorp.pinpoint.uristat.web.entity.UriStatChartEntity;
 import com.navercorp.pinpoint.uristat.web.entity.UriStatSummaryEntity;
 import com.navercorp.pinpoint.uristat.web.model.UriStatChartValue;
@@ -82,6 +84,7 @@ public interface EntityToModelMapper {
         return summary;
     }
 
+
     @Retention(RetentionPolicy.CLASS)
     @Mapping(target = "timestamp", source = "timestamp")
     @Mapping(target = "version", source = "version")
@@ -92,15 +95,37 @@ public interface EntityToModelMapper {
     @Named("toTotalChart")
     @Mapping(target = "chartType", constant = "bar")
     @Mapping(target = "unit", constant = "count")
-    @Mapping(target = "values", source = "entity", qualifiedByName = "toTotalHistogram")
+    @Mapping(target = "values", source = "totalHistogram")
+    UriStatChartValue toTotalChart(UriHistogramEntity entity);
+
+    @ToChartValue
+    @Named("toFailureChart")
+    @Mapping(target = "chartType", constant = "bar")
+    @Mapping(target = "unit", constant = "count")
+    @Mapping(target = "values", source = "failureHistogram")
+    UriStatChartValue toFailureChart(UriHistogramFailEntity entity);
+
+
+    @ToChartValue
+    @Named("toTotalChart")
+    @Mapping(target = "chartType", constant = "bar")
+    @Mapping(target = "unit", constant = "count")
+    @Mapping(target = "values", source = "totalHistogram")
     UriStatChartValue toTotalChart(UriStatChartEntity entity);
 
     @ToChartValue
     @Named("toFailureChart")
     @Mapping(target = "chartType", constant = "bar")
     @Mapping(target = "unit", constant = "count")
-    @Mapping(target = "values", source = "entity", qualifiedByName = "toFailureHistogram")
+    @Mapping(target = "values", source = "totalHistogram")
     UriStatChartValue toFailureChart(UriStatChartEntity entity);
+
+    @ToChartValue
+    @Named("toLatencyChart")
+    @Mapping(target = "chartType", constant = "line")
+    @Mapping(target = "unit", constant = "ms")
+    @Mapping(target = "values", source = "entity", qualifiedByName = "toSimpleLatency")
+    UriStatChartValue toSimpleLatencyChart(UriLatencyChartEntity entity);
 
     @ToChartValue
     @Named("toLatencyChart")
@@ -109,6 +134,13 @@ public interface EntityToModelMapper {
     @Mapping(target = "values", source = "entity", qualifiedByName = "toLatency")
     UriStatChartValue toLatencyChart(UriStatChartEntity entity);
 
+
+    @ToChartValue
+    @Named("toApdexChart")
+    @Mapping(target = "chartType", constant = "line")
+    @Mapping(target = "unit", constant = "")
+    @Mapping(target = "values", source = "entity", qualifiedByName = "toApdexList")
+    UriStatChartValue toSimpleApdexChart(UriApdexChartEntity entity);
 
     @ToChartValue
     @Named("toApdexChart")

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/mapper/MapperUtils.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/mapper/MapperUtils.java
@@ -15,8 +15,9 @@
  */
 package com.navercorp.pinpoint.uristat.web.mapper;
 
-import com.google.common.primitives.Doubles;
 import com.navercorp.pinpoint.common.util.MathUtils;
+import com.navercorp.pinpoint.uristat.web.entity.UriApdexChartEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriLatencyChartEntity;
 import com.navercorp.pinpoint.uristat.web.entity.UriStatChartEntity;
 import com.navercorp.pinpoint.uristat.web.entity.UriStatSummaryEntity;
 import org.mapstruct.Named;
@@ -74,23 +75,24 @@ public class MapperUtils {
         return MathUtils.average(entity.getSumOfTotalTimeMs(), entity.getTotalCount());
     }
 
-    @Named("toTotalHistogram")
-    public static List<Double> toTotalHistogram(UriStatChartEntity entity) {
-        return Doubles.asList(entity.toTotalHistogram());
-    }
-
-    @Named("toFailureHistogram")
-    public static List<Double> toFailureHistogram(UriStatChartEntity entity) {
-        return Doubles.asList(entity.toFailureHistogram());
-    }
-
     @Named("toLatency")
     public static List<Double> toLatency(UriStatChartEntity entity) {
-        return Doubles.asList((entity.getCount() == 0) ? -1 : (entity.getTotalTimeMs() / entity.getCount()), entity.getMaxLatencyMs());
+        return List.of((entity.getCount() == 0) ? -1 : (entity.getTotalTimeMs() / entity.getCount()), entity.getMaxLatencyMs());
+    }
+
+    @Named("toSimpleLatency")
+    public static List<Double> toSimpleLatency(UriLatencyChartEntity entity) {
+        return List.of((entity.getCount() == 0) ? -1 : (entity.getTotalTimeMs() / entity.getCount()), entity.getMaxLatencyMs());
+    }
+
+    @Named("toApdexList")
+    public static List<Double> toSimpleApdexList(UriApdexChartEntity entity) {
+        return List.of((entity.getCount() == 0) ? -1 : (entity.getApdexRaw() / entity.getCount()));
     }
 
     @Named("toApdexList")
     public static List<Double> toApdexList(UriStatChartEntity entity) {
-        return Doubles.asList((entity.getCount() == 0) ? -1 : (entity.getApdexRaw() / entity.getCount()));
+        return List.of((entity.getCount() == 0) ? -1 : (entity.getApdexRaw() / entity.getCount()));
     }
 }
+

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/model/UriStatChartValue.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/model/UriStatChartValue.java
@@ -1,6 +1,5 @@
 package com.navercorp.pinpoint.uristat.web.model;
 
-import com.google.common.primitives.Doubles;
 import com.navercorp.pinpoint.metric.web.view.TimeseriesChartType;
 
 import java.util.List;

--- a/uristat/uristat-web/src/main/resources/mapper/uristat/UriStatChartMapper.xml
+++ b/uristat/uristat-web/src/main/resources/mapper/uristat/UriStatChartMapper.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.navercorp.pinpoint.uristat.web.dao.UriStatChartDao">
-    <resultMap id="uriStatChartEntity" type="UriStatChartEntity">
+
+    <resultMap id="uriHistogramEntity" type="UriHistogramEntity">
+    </resultMap>
+    <resultMap id="uriHistogramFailEntity" type="UriHistogramFailEntity">
     </resultMap>
 
-    <select id="selectTotalUriStat" resultMap="uriStatChartEntity" parameterType="UriStatChartQueryParameter">
+    <resultMap id="uriApdexChartEntity" type="UriApdexChartEntity">
+    </resultMap>
+
+    <resultMap id="uriLatencyChartEntity" type="UriLatencyChartEntity">
+    </resultMap>
+
+
+    <select id="selectTotalUriStat" resultMap="uriHistogramEntity" parameterType="UriStatChartQueryParameter">
         SELECT
             DATETIME_CONVERT("timestamp", '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH',
                 '#{timePrecision.timeSize}:${timePrecision.timeUnit}') as "timestamp",
@@ -31,7 +41,7 @@
         LIMIT ${limit}
     </select>
 
-    <select id="selectFailedUriStat" resultMap="uriStatChartEntity" parameterType="UriStatChartQueryParameter">
+    <select id="selectFailedUriStat" resultMap="uriHistogramFailEntity" parameterType="UriStatChartQueryParameter">
         SELECT
             DATETIME_CONVERT("timestamp", '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH',
                 '#{timePrecision.timeSize}:${timePrecision.timeUnit}') as "timestamp",
@@ -58,7 +68,7 @@
         LIMIT ${limit}
     </select>
 
-    <select id="selectUriApdex" resultMap="uriStatChartEntity" parameterType="UriStatChartQueryParameter">
+    <select id="selectUriApdex" resultMap="uriApdexChartEntity" parameterType="UriStatChartQueryParameter">
         SELECT
             DATETIME_CONVERT("timestamp", '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH',
                 '#{timePrecision.timeSize}:${timePrecision.timeUnit}') as "timestamp",
@@ -79,7 +89,7 @@
         LIMIT ${limit}
     </select>
 
-    <select id="selectUriLatency" resultMap="uriStatChartEntity" parameterType="UriStatChartQueryParameter">
+    <select id="selectUriLatency" resultMap="uriLatencyChartEntity" parameterType="UriStatChartQueryParameter">
         SELECT
             DATETIME_CONVERT("timestamp", '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH',
                 '#{timePrecision.timeSize}:${timePrecision.timeUnit}') as "timestamp",

--- a/uristat/uristat-web/src/test/java/com/navercorp/pinpoint/uristat/web/mapper/EntityToModelMapperTest.java
+++ b/uristat/uristat-web/src/test/java/com/navercorp/pinpoint/uristat/web/mapper/EntityToModelMapperTest.java
@@ -1,5 +1,8 @@
 package com.navercorp.pinpoint.uristat.web.mapper;
 
+import com.navercorp.pinpoint.uristat.web.entity.UriHistogramEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriHistogramFailEntity;
+import com.navercorp.pinpoint.uristat.web.entity.UriLatencyChartEntity;
 import com.navercorp.pinpoint.uristat.web.entity.UriStatChartEntity;
 import com.navercorp.pinpoint.uristat.web.entity.UriStatSummaryEntity;
 import com.navercorp.pinpoint.uristat.web.model.UriStatChartValue;
@@ -7,7 +10,7 @@ import com.navercorp.pinpoint.uristat.web.model.UriStatSummary;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author intr3p1d
@@ -40,7 +43,7 @@ class EntityToModelMapperTest {
 
     @Test
     void testTotalEntityToModel() {
-        UriStatChartEntity entity = new UriStatChartEntity();
+        UriHistogramEntity entity = new UriHistogramEntity();
         entity.setTimestamp(1000);
         entity.setVersion("version");
         entity.setTot0(10.0);
@@ -71,7 +74,7 @@ class EntityToModelMapperTest {
 
     @Test
     void testFailureEntityToModel() {
-        UriStatChartEntity entity = new UriStatChartEntity();
+        UriHistogramFailEntity entity = new UriHistogramFailEntity();
         entity.setTimestamp(1000);
         entity.setVersion("version");
         entity.setFail0(10.0);
@@ -102,14 +105,14 @@ class EntityToModelMapperTest {
 
     @Test
     void testLatencyEntityToModel() {
-        UriStatChartEntity entity = new UriStatChartEntity();
+        UriLatencyChartEntity entity = new UriLatencyChartEntity();
         entity.setTimestamp(1000);
         entity.setVersion("version");
         entity.setTotalTimeMs(1200.0);
         entity.setMaxLatencyMs(500.0);
         entity.setCount(3.0);
 
-        UriStatChartValue model = mapper.toLatencyChart(entity);
+        UriStatChartValue model = mapper.toSimpleLatencyChart(entity);
 
         assertEquals(entity.getTimestamp(), model.getTimestamp());
         assertEquals(entity.getVersion(), model.getVersion());


### PR DESCRIPTION
This pull request includes several updates to the `uristat` module, focusing on refactoring entity classes and updating DAO classes to use the new entities. The changes aim to improve the structure and functionality of the codebase.

### Refactoring of Entity Classes:

* Added new entity classes: `UriApdexChartEntity`, `UriHistogramEntity`, `UriHistogramFailEntity`, and `UriLatencyChartEntity`, which extend the new base class `UriEntity`. (`[[1]](diffhunk://#diff-bc42c8d5a84a03289d8f7256fcadbdbf2884d7960213ada248e5b84d6e65a4edR1-R47)`, `[[2]](diffhunk://#diff-bdd316e8ec55e7da06505b5aeb750d83c4fb1346adea948e065480c220f36e3aR1-R109)`, `[[3]](diffhunk://#diff-516af0c295e515985480eac024debf7a12859853bbc8d5db0acf70e6397d56c0R1-R95)`, `[[4]](diffhunk://#diff-8fafbf9bb6a9167b58d6982d2dd12d306e89aff6eeb898e4f3c32edc28e50e8fR1-R56)`, `[[5]](diffhunk://#diff-4f58d8e7b4873604f0c14925acbf3827fb360d1155f6ff4c78c57b48f929a308R1-R31)`)

### Updates to DAO Classes:

* Updated `PinotApdexChartDao`, `PinotFailureCountChartDao`, `PinotLatencyChartDao`, and `PinotTotalCountChartDao` to use the new entity classes instead of `UriStatChartEntity`. (`[[1]](diffhunk://#diff-1fa0df3e60dde7101b1fed0348295b245379943efe9df49a45910af367904607L3-R3)`, `[[2]](diffhunk://#diff-f1a2697d580af8c7b3394fb8165655d6e8bc0c933f7d66d8a7a7dbe849deb719L3-R3)`, `[[3]](diffhunk://#diff-3b424a4020be7ddd827fa674c3539f95d14cae5c6f35451390e009590dd1b799L3-R3)`, `[[4]](diffhunk://#diff-550a60b81c22d12acacea22f4d4f8f82ee0741635cadfaa745d7c4c3fc31b493L3-R3)`)

### Changes in Configuration and Registration:

* Modified `UriRegistryHandler` to register the new entity classes and removed the registration of the old `UriStatChartEntity` and related classes. (`[[1]](diffhunk://#diff-0c6fe8526fd3f95416c90b54c2f9ab24c12809e9dbb4ec7583960bdca53086abL4-L7)`, `[[2]](diffhunk://#diff-0c6fe8526fd3f95416c90b54c2f9ab24c12809e9dbb4ec7583960bdca53086abL16-R22)`)

### Mapper Updates:

* Updated `EntityToModelMapper` to include mappings for the new entity classes. (`[[1]](diffhunk://#diff-dc0dc2496d2792a77e0e60b380dd2c4d78f5bfa2fd652e8111382eff2b294e3eL18-R21)`, `[[2]](diffhunk://#diff-dc0dc2496d2792a77e0e60b380dd2c4d78f5bfa2fd652e8111382eff2b294e3eR87)`)