### PR TITLE
[#noissue] Refactor Array utility

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/DoubleArray.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/DoubleArray.java
@@ -3,6 +3,7 @@ package com.navercorp.pinpoint.common.server.util.array;
 import com.google.common.primitives.Doubles;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.RandomAccess;
 import java.util.function.ToDoubleFunction;
@@ -18,19 +19,30 @@ public final class DoubleArray {
         return array;
     }
 
-    public static <T> List<Double> asList(List<T> list, ToDoubleFunction<T> function) {
-        final int size = list.size();
-        final double[] values = new double[size];
+    public static <T> double[] asDoubleArray(List<T> list, ToDoubleFunction<T> function) {
         if (list instanceof RandomAccess) {
+            final int size = list.size();
+            final double[] values = new double[size];
             for (int i = 0; i < size; i++) {
                 values[i] = function.applyAsDouble(list.get(i));
             }
-        } else {
-            int i = 0;
-            for (T element : list) {
-                values[i++] = function.applyAsDouble(element);
-            }
+            return values;
         }
-        return Doubles.asList(values);
+        return asDoubleArray((Collection<T>) list, function);
     }
+
+    public static <T> double[] asDoubleArray(Collection<T> list, ToDoubleFunction<T> function) {
+        final int size = list.size();
+        final double[] values = new double[size];
+        int i = 0;
+        for (T element : list) {
+            values[i++] = function.applyAsDouble(element);
+        }
+        return values;
+    }
+
+    public static <T> List<Double> asList(List<T> list, ToDoubleFunction<T> function) {
+        return Doubles.asList(asDoubleArray(list, function));
+    }
+
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/IntArray.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/IntArray.java
@@ -2,6 +2,7 @@ package com.navercorp.pinpoint.common.server.util.array;
 
 import com.google.common.primitives.Ints;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.RandomAccess;
 import java.util.function.ToIntFunction;
@@ -11,19 +12,30 @@ public final class IntArray {
     private IntArray() {
     }
 
-    public static <T> List<Integer> asList(List<T> list, ToIntFunction<T> function) {
-        final int size = list.size();
-        final int[] values = new int[size];
+    public static <T> int[] asIntArray(List<T> list, ToIntFunction<T> function) {
         if (list instanceof RandomAccess) {
+            final int size = list.size();
+            final int[] values = new int[size];
             for (int i = 0; i < size; i++) {
                 values[i] = function.applyAsInt(list.get(i));
             }
-        } else {
-            int i = 0;
-            for (T element : list) {
-                values[i++] = function.applyAsInt(element);
-            }
+            return values;
         }
-        return Ints.asList(values);
+
+        return asIntArray((Collection<T>) list, function);
+    }
+
+    public static <T> int[] asIntArray(Collection<T> list, ToIntFunction<T> function) {
+        final int size = list.size();
+        final int[] values = new int[size];
+        int i = 0;
+        for (T element : list) {
+            values[i++] = function.applyAsInt(element);
+        }
+        return values;
+    }
+
+    public static <T> List<Integer> asList(List<T> list, ToIntFunction<T> function) {
+        return Ints.asList(asIntArray(list, function));
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/LongArray.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/array/LongArray.java
@@ -2,6 +2,7 @@ package com.navercorp.pinpoint.common.server.util.array;
 
 import com.google.common.primitives.Longs;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.RandomAccess;
 import java.util.function.ToLongFunction;
@@ -11,20 +12,29 @@ public final class LongArray {
     private LongArray() {
     }
 
-    public static <T> List<Long> asList(List<T> list, ToLongFunction<T> function) {
-        final int size = list.size();
-        final long[] values = new long[size];
+    public static <T> long[] asLongArray(List<T> list, ToLongFunction<T> function) {
         if (list instanceof RandomAccess) {
+            final int size = list.size();
+            final long[] values = new long[size];
             for (int i = 0; i < size; i++) {
                 values[i] = function.applyAsLong(list.get(i));
             }
-        } else {
-            int i = 0;
-            for (T element : list) {
-                values[i++] = function.applyAsLong(element);
-            }
+            return values;
         }
-        return Longs.asList(values);
+        return asLongArray((Collection<T>) list, function);
     }
 
+    public static <T> long[] asLongArray(Collection<T> list, ToLongFunction<T> function) {
+        final int size = list.size();
+        final long[] values = new long[size];
+        int i = 0;
+        for (T element : list) {
+            values[i++] = function.applyAsLong(element);
+        }
+        return values;
+    }
+
+    public static <T> List<Long> asList(List<T> list, ToLongFunction<T> function) {
+        return Longs.asList(asLongArray(list, function));
+    }
 }


### PR DESCRIPTION
This pull request introduces several changes to the `DoubleArray`, `IntArray`, and `LongArray` utility classes in the `commons-server` module. The main goal of these changes is to improve the conversion of lists to arrays and vice versa by adding new methods and refactoring existing ones.

Key changes include:

### Improvements to `DoubleArray`, `IntArray`, and `LongArray` utility classes:

* Added `asDoubleArray`, `asIntArray`, and `asLongArray` methods to convert `Collection` objects to arrays for better flexibility. [[1]](diffhunk://#diff-2445ce332ca2a42edd959395415576f9990977d8ad4cd95bc73ca9934f29d493L21-R47) [[2]](diffhunk://#diff-09fd5d4194053d086a13fd4cb36adb510ca232644f16aef2ae9b578ce3f57fcaL14-R39) [[3]](diffhunk://#diff-2a1ab023f79f10e861f8bcedad1551c8b1ebfc69753adcd03d2c358983f47d2bL14-R39)
* Refactored existing `asList` methods to use the new array conversion methods, improving code reuse and readability. [[1]](diffhunk://#diff-2445ce332ca2a42edd959395415576f9990977d8ad4cd95bc73ca9934f29d493L21-R47) [[2]](diffhunk://#diff-09fd5d4194053d086a13fd4cb36adb510ca232644f16aef2ae9b578ce3f57fcaL14-R39) [[3]](diffhunk://#diff-2a1ab023f79f10e861f8bcedad1551c8b1ebfc69753adcd03d2c358983f47d2bL14-R39)
* Added necessary imports for `Collection` in `DoubleArray`, `IntArray`, and `LongArray` classes. [[1]](diffhunk://#diff-2445ce332ca2a42edd959395415576f9990977d8ad4cd95bc73ca9934f29d493R6) [[2]](diffhunk://#diff-09fd5d4194053d086a13fd4cb36adb510ca232644f16aef2ae9b578ce3f57fcaR5) [[3]](diffhunk://#diff-2a1ab023f79f10e861f8bcedad1551c8b1ebfc69753adcd03d2c358983f47d2bR5)