### PR TITLE
[#noissue] Cleanup TableNameManager

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/metric/dao/TableNameManager.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/metric/dao/TableNameManager.java
@@ -31,16 +31,14 @@ public class TableNameManager {
 
     public TableNameManager(String tablePrefix, int paddingLength, int count) {
         this.tablePrefix = tablePrefix;
-        this.numberFormat = "%0" + String.valueOf(paddingLength) + "d";
+        this.numberFormat = "%0" + paddingLength + "d";
         this.count = count;
     }
 
     public String getTableName(String applicationName) {
         int hashValue = getHashValue(applicationName);
         String postfix = String.format(numberFormat, hashValue);
-        StringBuilder sb = new StringBuilder();
-        sb.append(tablePrefix).append(postfix);
-        return sb.toString();
+        return tablePrefix.concat(postfix);
     }
 
     protected int getHashValue(String applicationName) {


### PR DESCRIPTION
This pull request includes changes to the `TableNameManager` class in the `commons-server` module to simplify and optimize string operations.

String operation optimizations:

* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/metric/dao/TableNameManager.java`](diffhunk://#diff-4d01da3616a88aac0dd9f9fecd62a4f20114995fbcf70d6d5a2fc1c966157bc9L34-R41): Simplified the `numberFormat` initialization by removing an unnecessary conversion to `String.valueOf` and directly concatenating `paddingLength`.
* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/metric/dao/TableNameManager.java`](diffhunk://#diff-4d01da3616a88aac0dd9f9fecd62a4f20114995fbcf70d6d5a2fc1c966157bc9L34-R41): Replaced the `StringBuilder` usage with the `concat` method for combining `tablePrefix` and `postfix`, reducing the lines of code and improving readability.