### PR TITLE
[#noissue] Refactor LinkData

### DIFF
--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountToCalleCheckerTest.java
@@ -76,8 +76,7 @@ public class ErrorCountToCalleCheckerTest {
                     }
 
                     linkCallDataMap.addCallData(fromApplication, toApplication, timeHistogramList);
-                    LinkData linkData = new LinkData(fromApplication, toApplication);
-                    linkData.setLinkCallDataMap(linkCallDataMap);
+                    LinkData linkData = LinkData.copyOf(fromApplication, toApplication, linkCallDataMap);
                     linkDataMap.addLinkData(linkData);
                 }
 

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateToCalleCheckerTest.java
@@ -72,8 +72,7 @@ public class ErrorRateToCalleCheckerTest {
                     }
 
                     linkCallDataMap.addCallData(fromApplication, toApplication, timeHistogramList);
-                    LinkData linkData = new LinkData(fromApplication, toApplication);
-                    linkData.setLinkCallDataMap(linkCallDataMap);
+                    LinkData linkData = LinkData.copyOf(fromApplication, toApplication, linkCallDataMap);
                     linkDataMap.addLinkData(linkData);
                 }
 

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountToCalleCheckerTest.java
@@ -65,8 +65,7 @@ public class SlowCountToCalleCheckerTest {
                     }
 
                     linkCallDataMap.addCallData(fromApplication, toApplication, timeHistogramList);
-                    LinkData linkData = new LinkData(fromApplication, toApplication);
-                    linkData.setLinkCallDataMap(linkCallDataMap);
+                    LinkData linkData = LinkData.copyOf(fromApplication, toApplication, linkCallDataMap);
                     linkDataMap.addLinkData(linkData);
                 }
 

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateToCalleCheckerTest.java
@@ -65,8 +65,7 @@ public class SlowRateToCalleCheckerTest {
                     }
 
                     linkCallDataMap.addCallData(fromApplication, toApplication, timeHistogramList);
-                    LinkData linkData = new LinkData(fromApplication, toApplication);
-                    linkData.setLinkCallDataMap(linkCallDataMap);
+                    LinkData linkData = LinkData.copyOf(fromApplication, toApplication, linkCallDataMap);
                     linkDataMap.addLinkData(linkData);
                 }
 

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/TotalCountToCalleeCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/TotalCountToCalleeCheckerTest.java
@@ -65,8 +65,7 @@ public class TotalCountToCalleeCheckerTest {
                     }
 
                     linkCallDataMap.addCallData(fromApplication, toApplication, timeHistogramList);
-                    LinkData linkData = new LinkData(fromApplication, toApplication);
-                    linkData.setLinkCallDataMap(linkCallDataMap);
+                    LinkData linkData = LinkData.copyOf(fromApplication, toApplication, linkCallDataMap);
                     linkDataMap.addLinkData(linkData);
                 }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkMarker.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkMarker.java
@@ -47,8 +47,7 @@ public class VirtualLinkMarker {
         logger.debug("acceptApplicationList:{}", acceptApplicationList);
         for (AcceptApplication acceptApplication : acceptApplicationList) {
             // linkCallData needs to be modified - remove callHistogram on purpose
-            LinkData virtualLinkData = new LinkData(linkData.getFromApplication(), acceptApplication.getApplication());
-            virtualLinkData.setLinkCallDataMap(linkData.getLinkCallDataMap());
+            LinkData virtualLinkData = LinkData.copyOf(linkData.getFromApplication(), acceptApplication.getApplication(), linkData.getLinkCallDataMap());
             virtualLinkDataList.add(virtualLinkData);
             markVirtualLink(virtualLinkData);
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java
@@ -84,8 +84,7 @@ public class RpcCallProcessor implements LinkDataMapProcessor {
                     logger.debug("Application info replaced. {} {} => {}", direction, linkData, acceptApplicationList);
 
                     AcceptApplication first = acceptApplicationList.iterator().next();
-                    final LinkData acceptedLinkData = new LinkData(linkData.getFromApplication(), first.getApplication());
-                    acceptedLinkData.setLinkCallDataMap(linkData.getLinkCallDataMap());
+                    final LinkData acceptedLinkData = LinkData.copyOf(linkData.getFromApplication(), first.getApplication(), linkData.getLinkCallDataMap());
                     return Collections.singletonList(acceptedLinkData);
                 } else {
                     // special case - there are more than 2 nodes grouped by a single url
@@ -97,8 +96,7 @@ public class RpcCallProcessor implements LinkDataMapProcessor {
                     return Collections.singletonList(linkData);
                 } else {
                     final Application unknown = new Application(toApplication.getName(), ServiceType.UNKNOWN);
-                    final LinkData unknownLinkData = new LinkData(linkData.getFromApplication(), unknown);
-                    unknownLinkData.setLinkCallDataMap(linkData.getLinkCallDataMap());
+                    final LinkData unknownLinkData = LinkData.copyOf(linkData.getFromApplication(), unknown, linkData.getLinkCallDataMap());
                     return Collections.singletonList(unknownLinkData);
                 }
             }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkData.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkData.java
@@ -37,6 +37,11 @@ public class LinkData {
     private LinkCallDataMap linkCallDataMap;
     private final TimeWindowFunction timeWindow;
 
+    public static LinkData copyOf(Application fromApplication, Application toApplication, LinkCallDataMap linkCallDataMap) {
+        Objects.requireNonNull(linkCallDataMap, "linkCallDataMap");
+        return new LinkData(fromApplication, toApplication, TimeWindowFunction.identity(), linkCallDataMap);
+    }
+
     public LinkData(Application fromApplication, Application toApplication) {
         this(fromApplication, toApplication, TimeWindowFunction.identity());
     }
@@ -47,6 +52,14 @@ public class LinkData {
 
         this.timeWindow = Objects.requireNonNull(timeWindow, "timeWindow");
         this.linkCallDataMap = new LinkCallDataMap(timeWindow);
+    }
+
+    private LinkData(Application fromApplication, Application toApplication, TimeWindowFunction timeWindow, LinkCallDataMap linkCallDataMap) {
+        this.fromApplication = Objects.requireNonNull(fromApplication, "fromApplication");
+        this.toApplication = Objects.requireNonNull(toApplication, "toApplication");
+
+        this.timeWindow = Objects.requireNonNull(timeWindow, "timeWindow");
+        this.linkCallDataMap = Objects.requireNonNull(linkCallDataMap, "linkCallDataMap");
     }
 
     /**
@@ -66,17 +79,12 @@ public class LinkData {
         this.linkCallDataMap = new LinkCallDataMap(timeWindow);
     }
 
-
     public Application getFromApplication() {
         return this.fromApplication;
     }
 
     public Application getToApplication() {
         return this.toApplication;
-    }
-
-    public void setLinkCallDataMap(LinkCallDataMap linkCallDataMap) {
-        this.linkCallDataMap = linkCallDataMap;
     }
 
     public LinkCallDataMap getLinkCallDataMap() {


### PR DESCRIPTION
This pull request includes several changes aimed at improving the creation and management of `LinkData` objects across various classes and test files. The main change involves replacing the constructor and setter methods with a new static factory method `LinkData.copyOf`. This simplifies the creation of `LinkData` objects and ensures that all necessary fields are properly initialized.

### Introduction of `LinkData.copyOf` method:

* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkData.java`](diffhunk://#diff-19d8236941a2aac174642a84d0f2f67eb50e7a671424886babf675fd883b0727R40-R44): Added a new static factory method `LinkData.copyOf` to create `LinkData` objects, ensuring all required fields are initialized. [[1]](diffhunk://#diff-19d8236941a2aac174642a84d0f2f67eb50e7a671424886babf675fd883b0727R40-R44) [[2]](diffhunk://#diff-19d8236941a2aac174642a84d0f2f67eb50e7a671424886babf675fd883b0727R57-R64)

### Refactoring of `LinkData` creation in test files:

* [`batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountToCalleCheckerTest.java`](diffhunk://#diff-8d797b5bd0dbbde91b894b62d5ee04953749760f7830441ab2175227a824d07fL79-R79): Replaced the constructor and setter with `LinkData.copyOf` for creating `LinkData` objects.
* [`batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateToCalleCheckerTest.java`](diffhunk://#diff-1565965df12c1fb7e5a7ac317c2130060120f0ceb0744421531594523e5b611bL75-R75): Replaced the constructor and setter with `LinkData.copyOf` for creating `LinkData` objects.
* [`batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountToCalleCheckerTest.java`](diffhunk://#diff-a3161493868d1ae24ae02d2ca83a27a4236959df8a1c26b170666c67837ab064L68-R68): Replaced the constructor and setter with `LinkData.copyOf` for creating `LinkData` objects.
* [`batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateToCalleCheckerTest.java`](diffhunk://#diff-89426d43a92a708dfed90a9c0bcca3d53ec837e3a46ab9f5990cd55131287961L68-R68): Replaced the constructor and setter with `LinkData.copyOf` for creating `LinkData` objects.
* [`batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/TotalCountToCalleeCheckerTest.java`](diffhunk://#diff-5f4c783ca2a854d22d0dcbc499374f18934366652241f912b25314d831bb15d1L68-R68): Replaced the constructor and setter with `LinkData.copyOf` for creating `LinkData` objects.

### Refactoring of `LinkData` creation in main application code:

* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkMarker.java`](diffhunk://#diff-9d19e4cd9177769139314fed727ec7f4ad657975701e208da1d61abf875032efL50-R50): Replaced the constructor and setter with `LinkData.copyOf` for creating virtual `LinkData` objects.
* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java`](diffhunk://#diff-10e8402c782ebbd45ab5d34b1a1ac1e94421db5358929374a50c57119c1ac4d2L87-R87): Replaced the constructor and setter with `LinkData.copyOf` for creating `LinkData` objects in two different methods. [[1]](diffhunk://#diff-10e8402c782ebbd45ab5d34b1a1ac1e94421db5358929374a50c57119c1ac4d2L87-R87) [[2]](diffhunk://#diff-10e8402c782ebbd45ab5d34b1a1ac1e94421db5358929374a50c57119c1ac4d2L100-R99)

These changes improve the consistency and reliability of `LinkData` object creation, reducing the likelihood of errors due to uninitialized fields.