### PR TITLE
[#noissue] Cleanup TimeCount

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ResponseTimeViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ResponseTimeViewModel.java
@@ -17,11 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.view;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
@@ -46,16 +42,6 @@ public class ResponseTimeViewModel implements TimeHistogramViewModel {
     @JsonProperty("values")
     public List<TimeCount> getColumnValue() {
         return columnValue;
-    }
-
-    public static class TimeCountSerializer extends JsonSerializer<TimeCount> {
-        @Override
-        public void serialize(TimeCount count, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-            jgen.writeStartArray();
-            jgen.writeNumber(count.time());
-            jgen.writeNumber(count.count());
-            jgen.writeEndArray();
-        }
     }
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/TimeCount.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/TimeCount.java
@@ -1,7 +1,22 @@
 package com.navercorp.pinpoint.web.applicationmap.view;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-@JsonSerialize(using = ResponseTimeViewModel.TimeCountSerializer.class)
+import java.io.IOException;
+
+@JsonSerialize(using = TimeCount.TimeCountSerializer.class)
 public record TimeCount(long time, long count) {
+
+    public static class TimeCountSerializer extends JsonSerializer<TimeCount> {
+        @Override
+        public void serialize(TimeCount count, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+            jgen.writeStartArray();
+            jgen.writeNumber(count.time());
+            jgen.writeNumber(count.count());
+            jgen.writeEndArray();
+        }
+    }
 }


### PR DESCRIPTION
This pull request includes changes to the `ResponseTimeViewModel` and `TimeCount` classes in the `web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view` directory. The main focus of these changes is to move the `TimeCountSerializer` class from `ResponseTimeViewModel` to `TimeCount`.

Codebase refactoring:

* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ResponseTimeViewModel.java`](diffhunk://#diff-0583550101538bae322268a6f4ca803988fff9722460b572283e58e4b9f951ebL20-L24): Removed the `TimeCountSerializer` class and its associated imports. [[1]](diffhunk://#diff-0583550101538bae322268a6f4ca803988fff9722460b572283e58e4b9f951ebL20-L24) [[2]](diffhunk://#diff-0583550101538bae322268a6f4ca803988fff9722460b572283e58e4b9f951ebL51-L60)
* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/TimeCount.java`](diffhunk://#diff-179ea0f9c17798b60b1275659df2fb40bc7e534e600185576ddb14f5835ffc0cR3-R21): Added the `TimeCountSerializer` class and its associated imports, and updated the `@JsonSerialize` annotation to use the new location of `TimeCountSerializer`.