### PR TITLE
[#noissue] Remove unused TimeHistogramFormat in Link

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/Link.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/Link.java
@@ -65,7 +65,6 @@ public class Link {
     private final LinkCallDataMap outLink = new LinkCallDataMap();
 
     private Histogram linkHistogram;
-    private TimeHistogramFormat timeHistogramFormat = TimeHistogramFormat.V1;
 
     public Link(LinkDirection direction, Node fromNode, Node toNode, Range range) {
         this.direction = Objects.requireNonNull(direction, "direction");
@@ -107,10 +106,6 @@ public class Link {
         return LinkName.of(fromNode.getApplication(), toNode.getApplication());
     }
 
-
-    public void setTimeHistogramFormat(TimeHistogramFormat timeHistogramFormat) {
-        this.timeHistogramFormat = timeHistogramFormat;
-    }
 
     public LinkCallDataMap getInLink() {
         return inLink;
@@ -208,12 +203,12 @@ public class Link {
         this.outLink.addLinkDataMap(outLinkCallDataMap);
     }
 
-    public JsonFields<AgentNameView, List<TimeHistogramViewModel>> getSourceAgentTimeSeriesHistogram() {
+    public JsonFields<AgentNameView, List<TimeHistogramViewModel>> getSourceAgentTimeSeriesHistogram(TimeHistogramFormat format) {
         // we need Target (to)'s time since time in link is RPC-based
         AgentTimeHistogramBuilder builder = new AgentTimeHistogramBuilder(toNode.getApplication(), range);
         AgentTimeHistogram applicationTimeSeriesHistogram = builder.buildSource(inLink);
 
-        return applicationTimeSeriesHistogram.createViewModel(timeHistogramFormat);
+        return applicationTimeSeriesHistogram.createViewModel(format);
     }
 
     public AgentTimeHistogram getTargetAgentTimeHistogram() {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
@@ -99,7 +99,7 @@ public class LinkView {
                 // data showing how agents call each of their respective links
                 writeAgentHistogram("sourceHistogram", link.getSourceList(), jgen);
                 writeAgentHistogram("targetHistogram", link.getTargetList(), jgen);
-                writeSourceAgentTimeSeriesHistogram(link, jgen);
+                writeSourceAgentTimeSeriesHistogram(linkView, jgen);
                 writeAgentResponseStatistics("sourceResponseStatistics", link.getSourceList(), jgen);
                 writeAgentResponseStatistics("targetResponseStatistics", link.getTargetList(), jgen);
             }
@@ -180,8 +180,10 @@ public class LinkView {
             jgen.writeEndObject();
         }
 
-        private void writeSourceAgentTimeSeriesHistogram(Link link, JsonGenerator jgen) throws IOException {
-            JsonFields<AgentNameView, List<TimeHistogramViewModel>> sourceAgentTimeSeriesHistogram = link.getSourceAgentTimeSeriesHistogram();
+        private void writeSourceAgentTimeSeriesHistogram(LinkView linkView, JsonGenerator jgen) throws IOException {
+            Link link = linkView.getLink();
+            TimeHistogramFormat format = linkView.getFormat();
+            JsonFields<AgentNameView, List<TimeHistogramViewModel>> sourceAgentTimeSeriesHistogram = link.getSourceAgentTimeSeriesHistogram(format);
 //        sourceAgentTimeSeriesHistogram.setFieldName("sourceTimeSeriesHistogram");
             jgen.writeFieldName("sourceTimeSeriesHistogram");
             jgen.writeObject(sourceAgentTimeSeriesHistogram);


### PR DESCRIPTION
This pull request includes changes to the `Link` and `LinkView` classes to improve the handling of the `TimeHistogramFormat` parameter. The most significant changes include removing the `timeHistogramFormat` instance variable from the `Link` class and modifying methods to accept `TimeHistogramFormat` as a parameter.

Improvements to `Link` class:

* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/Link.java`](diffhunk://#diff-382ee40347acc7118a25c093dd4f1a4bbb9926b7ed06845106a10477baa64267L68): Removed the `timeHistogramFormat` instance variable and the associated setter method. Modified the `getSourceAgentTimeSeriesHistogram` method to accept `TimeHistogramFormat` as a parameter. [[1]](diffhunk://#diff-382ee40347acc7118a25c093dd4f1a4bbb9926b7ed06845106a10477baa64267L68) [[2]](diffhunk://#diff-382ee40347acc7118a25c093dd4f1a4bbb9926b7ed06845106a10477baa64267L111-L114) [[3]](diffhunk://#diff-382ee40347acc7118a25c093dd4f1a4bbb9926b7ed06845106a10477baa64267L211-R211)

Improvements to `LinkView` class:

* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java`](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dL102-R102): Updated the `serialize` method to pass `LinkView` instead of `Link` to the `writeSourceAgentTimeSeriesHistogram` method. Modified the `writeSourceAgentTimeSeriesHistogram` method to use the `TimeHistogramFormat` from `LinkView`. [[1]](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dL102-R102) [[2]](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dL183-R186)