### PR TITLE
[#noissue] Refactor ResponseTimeViewModelBuilder

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogramBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogramBuilder.java
@@ -19,7 +19,6 @@ package com.navercorp.pinpoint.web.applicationmap.histogram;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowDownSampler;
-import com.navercorp.pinpoint.common.trace.SlotType;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.AgentHistogram;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.AgentHistogramList;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkCallDataMap;
@@ -100,11 +99,6 @@ public class AgentTimeHistogramBuilder {
         }
 
         return resultAgentHistogramList;
-    }
-
-
-    public long getCount(TimeHistogram timeHistogram, SlotType slotType) {
-        return timeHistogram.getCount(slotType);
     }
 
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/Histogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/Histogram.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.common.trace.SlotType;
 import com.navercorp.pinpoint.web.view.HistogramSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -198,7 +197,7 @@ public class Histogram implements StatisticsHistogram {
     }
 
     public long getTotalCount() {
-        return errorCount + fastCount + fastErrorCount + normalCount + normalErrorCount + slowCount + slowErrorCount + verySlowCount + verySlowErrorCount;
+        return getSuccessCount() + getTotalErrorCount();
     }
 
     public long getSuccessCount() {
@@ -216,27 +215,6 @@ public class Histogram implements StatisticsHistogram {
     public long getAvgElapsed() {
         final long totalCount = getTotalCount();
         return totalCount > 0 ? sumElapsed / totalCount : 0L;
-    }
-
-    public long getCount(SlotType slotType) {
-        Objects.requireNonNull(slotType, "slotType");
-
-        return switch (slotType) {
-            case FAST -> fastCount;
-            case FAST_ERROR -> fastErrorCount;
-            case NORMAL -> normalCount;
-            case NORMAL_ERROR -> normalErrorCount;
-            case SLOW -> slowCount;
-            case SLOW_ERROR -> slowErrorCount;
-            case VERY_SLOW -> verySlowCount;
-            case VERY_SLOW_ERROR -> verySlowErrorCount;
-            case ERROR ->
-                // for backward compatibility.
-                    errorCount + fastErrorCount + normalErrorCount + slowErrorCount + verySlowErrorCount;
-            case SUM_STAT -> sumElapsed;
-            case MAX_STAT -> maxElapsed;
-            case PING -> pingCount;
-        };
     }
 
     public void addAll(final Collection<? extends Histogram> histograms) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ResponseTimeViewModelBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ResponseTimeViewModelBuilder.java
@@ -2,7 +2,7 @@ package com.navercorp.pinpoint.web.applicationmap.view;
 
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.common.trace.SlotType;
+import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseTimeStatics;
@@ -10,6 +10,7 @@ import com.navercorp.pinpoint.web.vo.ResponseTimeStatics;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.ToLongFunction;
 
 public class ResponseTimeViewModelBuilder {
     private final Application application;
@@ -25,53 +26,29 @@ public class ResponseTimeViewModelBuilder {
         ServiceType serviceType = application.getServiceType();
         HistogramSchema schema = serviceType.getHistogramSchema();
 
-        result.add(new ResponseTimeViewModel(schema.getFastSlot().getSlotName(), getColumnValue(histogramList, SlotType.FAST)));
-        result.add(new ResponseTimeViewModel(schema.getNormalSlot().getSlotName(), getColumnValue(histogramList, SlotType.NORMAL)));
-        result.add(new ResponseTimeViewModel(schema.getSlowSlot().getSlotName(), getColumnValue(histogramList, SlotType.SLOW)));
-        result.add(new ResponseTimeViewModel(schema.getVerySlowSlot().getSlotName(), getColumnValue(histogramList, SlotType.VERY_SLOW)));
-        result.add(new ResponseTimeViewModel(schema.getErrorSlot().getSlotName(), getColumnValue(histogramList, SlotType.ERROR)));
-        result.add(new ResponseTimeViewModel(ResponseTimeStatics.AVG_ELAPSED_TIME, getAvgValue(histogramList)));
-        result.add(new ResponseTimeViewModel(ResponseTimeStatics.MAX_ELAPSED_TIME, getColumnValue(histogramList, SlotType.MAX_STAT)));
-        result.add(new ResponseTimeViewModel(ResponseTimeStatics.SUM_ELAPSED_TIME, getColumnValue(histogramList, SlotType.SUM_STAT)));
-        result.add(new ResponseTimeViewModel(ResponseTimeStatics.TOTAL_COUNT, getTotalCount(histogramList)));
+        result.add(new ResponseTimeViewModel(schema.getFastSlot().getSlotName(), getColumnValue(histogramList, Histogram::getFastCount)));
+        result.add(new ResponseTimeViewModel(schema.getNormalSlot().getSlotName(), getColumnValue(histogramList, Histogram::getNormalCount)));
+        result.add(new ResponseTimeViewModel(schema.getSlowSlot().getSlotName(), getColumnValue(histogramList, Histogram::getSlowCount)));
+        result.add(new ResponseTimeViewModel(schema.getVerySlowSlot().getSlotName(), getColumnValue(histogramList, Histogram::getVerySlowCount)));
+        result.add(new ResponseTimeViewModel(schema.getErrorSlot().getSlotName(), getColumnValue(histogramList, Histogram::getTotalErrorCount)));
+
+        result.add(new ResponseTimeViewModel(ResponseTimeStatics.AVG_ELAPSED_TIME, getColumnValue(histogramList, Histogram::getAvgElapsed)));
+        result.add(new ResponseTimeViewModel(ResponseTimeStatics.MAX_ELAPSED_TIME, getColumnValue(histogramList, Histogram::getMaxElapsed)));
+        result.add(new ResponseTimeViewModel(ResponseTimeStatics.SUM_ELAPSED_TIME, getColumnValue(histogramList, Histogram::getSumElapsed)));
+        result.add(new ResponseTimeViewModel(ResponseTimeStatics.TOTAL_COUNT, getColumnValue(histogramList, Histogram::getTotalCount)));
 
         return result;
     }
 
-    private List<TimeCount> getColumnValue(List<TimeHistogram> histogramList, SlotType slotType) {
+    private List<TimeCount> getColumnValue(List<TimeHistogram> histogramList, ToLongFunction<TimeHistogram> function) {
         List<TimeCount> result = new ArrayList<>(histogramList.size());
         for (TimeHistogram timeHistogram : histogramList) {
             final long timeStamp = timeHistogram.getTimeStamp();
-            TimeCount TimeCount = new TimeCount(timeStamp, getCount(timeHistogram, slotType));
+            final long count = function.applyAsLong(timeHistogram);
+            TimeCount TimeCount = new TimeCount(timeStamp, count);
             result.add(TimeCount);
         }
         return result;
     }
 
-    private List<TimeCount> getAvgValue(List<TimeHistogram> histogramList) {
-        List<TimeCount> result = new ArrayList<>(histogramList.size());
-        for (TimeHistogram timeHistogram : histogramList) {
-            final long timeStamp = timeHistogram.getTimeStamp();
-            final long totalCount = timeHistogram.getTotalCount();
-            final long sumElapsed = getCount(timeHistogram, SlotType.SUM_STAT);
-            final long avgElapsed = totalCount > 0 ? sumElapsed / totalCount : 0L;
-
-            result.add(new TimeCount(timeStamp, avgElapsed));
-        }
-        return result;
-    }
-
-    private List<TimeCount> getTotalCount(List<TimeHistogram> histogramList) {
-        List<TimeCount> result = new ArrayList<>(histogramList.size());
-        for (TimeHistogram timeHistogram : histogramList) {
-            final long timeStamp = timeHistogram.getTimeStamp();
-            final long totalCount = timeHistogram.getTotalCount();
-            result.add(new TimeCount(timeStamp, totalCount));
-        }
-        return result;
-    }
-
-    private long getCount(TimeHistogram timeHistogram, SlotType slotType) {
-        return timeHistogram.getCount(slotType);
-    }
 }


### PR DESCRIPTION
This pull request includes several changes to the histogram-related classes in the `web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram` package. The changes primarily focus on removing the `SlotType` class usage and replacing it with more direct method calls. Additionally, some refactoring has been done to simplify the code and improve readability.

Refactoring and simplification:

* Removed the `getCount` method from `AgentTimeHistogramBuilder` and `Histogram` classes, which used `SlotType` to determine counts. [[1]](diffhunk://#diff-ebd1826dd2f87e5ef6e9b97802b498f67abe764e307cf6c533c05ceb3918d9e6L106-L110) [[2]](diffhunk://#diff-b6796c0a6da03afccc24ff7d41ca98444feb14dbe1cc93c4fe7e4a5bee1dca46L221-L241)
* Replaced `SlotType` usage with direct method references in `ResponseTimeViewModelBuilder`.

Code cleanup:

* Removed unused imports of `SlotType` from `AgentTimeHistogramBuilder`, `Histogram`, and `ResponseTimeViewModelBuilder` classes. [[1]](diffhunk://#diff-ebd1826dd2f87e5ef6e9b97802b498f67abe764e307cf6c533c05ceb3918d9e6L22) [[2]](diffhunk://#diff-b6796c0a6da03afccc24ff7d41ca98444feb14dbe1cc93c4fe7e4a5bee1dca46L23) [[3]](diffhunk://#diff-1f8a4faf05786e7f3c30327a0d9aa863f572a526b354424db54f02656df1a969L5-R13)

These changes help streamline the codebase by removing an unnecessary level of abstraction and making the code more straightforward.