### PR TITLE
[#noissue] Remove viewVersion from FilteredMap

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ApplicationMapStatisticsUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ApplicationMapStatisticsUtils.java
@@ -114,6 +114,10 @@ public class ApplicationMapStatisticsUtils {
         return BytesUtils.toStringAndRightTrim(bytes, 6, length);
     }
 
+    /**
+     * @deprecated Since 3.1.0. Use {@link UserNodeUtils#newUserNodeName(String, ServiceType)} instead.
+     */
+    @Deprecated
     public static String getDestApplicationNameFromColumnNameForUser(byte[] bytes, ServiceType destServiceType) {
         String destApplicationName = getDestApplicationNameFromColumnName(bytes);
         String destServiceTypeName = destServiceType.getName();

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/UserNodeUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/UserNodeUtils.java
@@ -1,0 +1,13 @@
+package com.navercorp.pinpoint.common.server.util;
+
+import com.navercorp.pinpoint.common.trace.ServiceType;
+
+public final class UserNodeUtils {
+
+    private UserNodeUtils() {
+    }
+
+    public static String newUserNodeName(String applicationName, ServiceType applicationServiceType) {
+        return applicationName + '_' + applicationServiceType.getName();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
@@ -96,7 +96,6 @@ public class FilteredMapController {
             @NullOrNotBlank String filterHint,
             @RequestParam(value = "limit", required = false, defaultValue = "10000")
             @PositiveOrZero int limitParam,
-            @RequestParam(value = "v", required = false, defaultValue = "0") int viewVersion,
             @RequestParam(value = "useStatisticsAgentState", defaultValue = "false", required = false)
             boolean useStatisticsAgentState,
             @RequestParam(value = "useLoadHistogramFormat", defaultValue = "false", required = false)
@@ -117,7 +116,7 @@ public class FilteredMapController {
         final Range scannerRange = Range.between(lastScanTime, rangeForm.getTo());
         logger.debug("originalRange: {}, scannerRange: {}", originalRange, scannerRange);
         final FilteredMapServiceOption option = new FilteredMapServiceOption
-                .Builder(limitedScanResult.scanData(), originalRange, xGroupUnit, yGroupUnit, filter, viewVersion)
+                .Builder(limitedScanResult.scanData(), originalRange, xGroupUnit, yGroupUnit, filter)
                 .setUseStatisticsAgentState(useStatisticsAgentState)
                 .build();
         final FilterMapWithScatter scatter = filteredMapService.selectApplicationMapWithScatterData(option);
@@ -152,7 +151,6 @@ public class FilteredMapController {
             @NullOrNotBlank String filterHint,
             @RequestParam(value = "limit", required = false, defaultValue = "10000")
             @PositiveOrZero int limitParam,
-            @RequestParam(value = "v", required = false, defaultValue = "0") int viewVersion,
             @RequestParam(value = "useStatisticsAgentState", defaultValue = "true", required = false) boolean useStatisticsAgentState) {
         final String applicationName = appForm.getApplicationName();
 
@@ -168,7 +166,7 @@ public class FilteredMapController {
         final Range scannerRange = Range.between(lastScanTime, range.getTo());
         logger.debug("originalRange:{} scannerRange:{} ", originalRange, scannerRange);
         final FilteredMapServiceOption option = new FilteredMapServiceOption
-                .Builder(limitedScanResult.scanData(), originalRange, xGroupUnit, yGroupUnit, filter, viewVersion)
+                .Builder(limitedScanResult.scanData(), originalRange, xGroupUnit, yGroupUnit, filter)
                 .setUseStatisticsAgentState(useStatisticsAgentState)
                 .build();
         final FilterMapWithScatter map = filteredMapService.selectApplicationMapWithScatterData(option);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/InLinkMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/InLinkMapper.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.buffer.FixedBuffer;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.util.CellUtils;
 import com.navercorp.pinpoint.common.server.util.ApplicationMapStatisticsUtils;
+import com.navercorp.pinpoint.common.server.util.UserNodeUtils;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.TimeUtils;
@@ -123,12 +124,13 @@ public class InLinkMapper implements RowMapper<LinkDataMap> {
     }
 
     private Application readOutApplication(byte[] qualifier, ServiceType outServiceType) {
-        short outServiceTypeCode = ApplicationMapStatisticsUtils.getDestServiceTypeFromColumnName(qualifier);
+        int outServiceTypeCode = ApplicationMapStatisticsUtils.getDestServiceTypeFromColumnName(qualifier);
         // Caller may be a user node, and user nodes may call nodes with the same application name but different service type.
         // To distinguish between these user nodes, append callee's service type to the application name.
         String outApplicationName;
         if (registry.findServiceType(outServiceTypeCode).isUser()) {
-            outApplicationName = ApplicationMapStatisticsUtils.getDestApplicationNameFromColumnNameForUser(qualifier, outServiceType);
+            String destApplicationName = ApplicationMapStatisticsUtils.getDestApplicationNameFromColumnName(qualifier);
+            outApplicationName = UserNodeUtils.newUserNodeName(destApplicationName, outServiceType);
         } else {
             outApplicationName = ApplicationMapStatisticsUtils.getDestApplicationNameFromColumnName(qualifier);
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImpl.java
@@ -131,7 +131,7 @@ public class FilteredMapServiceImpl implements FilteredMapService {
 
     public ApplicationMap selectApplicationMap(FilteredMapServiceOption option) {
         final List<List<SpanBo>> filterList = selectFilteredSpan(option.getTransactionIdList(), option.getFilter(), option.getColumnGetCount());
-        FilteredMapBuilder filteredMapBuilder = new FilteredMapBuilder(applicationFactory, registry, option.getOriginalRange(), option.getVersion());
+        FilteredMapBuilder filteredMapBuilder = new FilteredMapBuilder(applicationFactory, registry, option.getOriginalRange());
         filteredMapBuilder.serverMapDataFilter(serverMapDataFilter);
         filteredMapBuilder.addTransactions(filterList);
         FilteredMap filteredMap = filteredMapBuilder.build();
@@ -144,7 +144,7 @@ public class FilteredMapServiceImpl implements FilteredMapService {
         watch.start();
 
         final List<List<SpanBo>> filterList = selectFilteredSpan(option.getTransactionIdList(), option.getFilter(), option.getColumnGetCount());
-        FilteredMapBuilder filteredMapBuilder = new FilteredMapBuilder(applicationFactory, registry, option.getOriginalRange(), option.getVersion());
+        FilteredMapBuilder filteredMapBuilder = new FilteredMapBuilder(applicationFactory, registry, option.getOriginalRange());
         filteredMapBuilder.serverMapDataFilter(serverMapDataFilter);
         filteredMapBuilder.addTransactions(filterList);
         FilteredMap filteredMap = filteredMapBuilder.build();

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceOption.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceOption.java
@@ -37,7 +37,6 @@ public class FilteredMapServiceOption {
     private final int xGroupUnit;
     private final int yGroupUnit;
     private final Filter<List<SpanBo>> filter;
-    private final int version;
     private final boolean useStatisticsAgentState;
     private final ColumnGetCount columnGetCount;
 
@@ -48,7 +47,6 @@ public class FilteredMapServiceOption {
         this.xGroupUnit = builder.xGroupUnit;
         this.yGroupUnit = builder.yGroupUnit;
         this.filter = builder.filter;
-        this.version = builder.version;
         this.useStatisticsAgentState = builder.useStatisticsAgentState;
         this.columnGetCount = builder.columnGetCount;
     }
@@ -77,10 +75,6 @@ public class FilteredMapServiceOption {
         return filter;
     }
 
-    public int getVersion() {
-        return version;
-    }
-
     public boolean isUseStatisticsAgentState() {
         return useStatisticsAgentState;
     }
@@ -98,7 +92,6 @@ public class FilteredMapServiceOption {
                 ", xGroupUnit=" + xGroupUnit +
                 ", yGroupUnit=" + yGroupUnit +
                 ", filter=" + filter +
-                ", version=" + version +
                 ", useStatisticsAgentState=" + useStatisticsAgentState +
                 '}';
     }
@@ -109,27 +102,24 @@ public class FilteredMapServiceOption {
         private int xGroupUnit;
         private int yGroupUnit;
         private final Filter<List<SpanBo>> filter;
-        private final int version;
         private ColumnGetCount columnGetCount;
 
         private boolean useStatisticsAgentState;
 
-        public Builder(TransactionId transactionId, int version, ColumnGetCount columnGetCount) {
+        public Builder(TransactionId transactionId, ColumnGetCount columnGetCount) {
             Objects.requireNonNull(transactionId, "transactionId");
             this.transactionIdList = Collections.singletonList(transactionId);
-            this.version = version;
             this.columnGetCount = columnGetCount;
             this.originalRange = Range.between(-1, -1);
             this.filter = Filter.acceptAllFilter();
         }
 
-        public Builder(List<TransactionId> transactionIdList, Range originalRange, int xGroupUnit, int yGroupUnit, Filter<List<SpanBo>> filter, int version) {
+        public Builder(List<TransactionId> transactionIdList, Range originalRange, int xGroupUnit, int yGroupUnit, Filter<List<SpanBo>> filter) {
             this.transactionIdList = Objects.requireNonNull(transactionIdList, "transactionIdList");
             this.filter = Objects.requireNonNull(filter, "filter");
             this.originalRange = originalRange;
             this.xGroupUnit = xGroupUnit;
             this.yGroupUnit = yGroupUnit;
-            this.version = version;
         }
 
         public Builder setUseStatisticsAgentState(boolean useStatisticsAgentState) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/BusinessTransactionController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/BusinessTransactionController.java
@@ -106,14 +106,13 @@ public class BusinessTransactionController {
             long focusTimestamp,
             @RequestParam(value = "agentId", required = false) String agentId,
             @RequestParam(value = "spanId", required = false, defaultValue = DEFAULT_SPAN_ID) long spanId,
-            @RequestParam(value = "v", required = false, defaultValue = "0") int viewVersion,
             @RequestParam(value = "useStatisticsAgentState", required = false, defaultValue = "false")
             boolean useStatisticsAgentState,
             @RequestParam(value = "useLoadHistogramFormat", required = false, defaultValue = "false")
             boolean useLoadHistogramFormat
     ) {
-        logger.debug("GET /transactionInfo params {traceId={}, focusTimestamp={}, agentId={}, spanId={}, v={}}",
-                traceId, focusTimestamp, agentId, spanId, viewVersion);
+        logger.debug("GET /transactionInfo params {traceId={}, focusTimestamp={}, agentId={}, spanId={}}",
+                traceId, focusTimestamp, agentId, spanId);
         final TransactionId transactionId = TransactionIdUtils.parseTransactionId(traceId);
         final ColumnGetCount columnGetCount = ColumnGetCount.of(callstackSelectSpansLimit);
 
@@ -124,7 +123,7 @@ public class BusinessTransactionController {
 
         // application map
         final FilteredMapServiceOption.Builder optionBuilder =
-                new FilteredMapServiceOption.Builder(transactionId, viewVersion, columnGetCount);
+                new FilteredMapServiceOption.Builder(transactionId, columnGetCount);
         final FilteredMapServiceOption option =
                 optionBuilder.setUseStatisticsAgentState(useStatisticsAgentState).build();
         final ApplicationMap map = filteredMapService.selectApplicationMap(option);

--- a/web/src/test/java/com/navercorp/pinpoint/web/TestTraceUtils.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/TestTraceUtils.java
@@ -26,6 +26,7 @@ import com.navercorp.pinpoint.web.util.ServiceTypeRegistryMockFactory;
 import org.assertj.core.matcher.AssertionMatcher;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -45,8 +46,11 @@ public class TestTraceUtils {
     public static final String UNKNOWN_TYPE_NAME = ServiceType.UNKNOWN.getName();
     public static final short USER_TYPE_CODE = ServiceType.USER.getCode();
     public static final String USER_TYPE_NAME = ServiceType.USER.getName();
-    public static final short TEST_STAND_ALONE_TYPE_CODE = ServiceType.TEST_STAND_ALONE.getCode();
-    public static final String TEST_STAND_ALONE_TYPE_NAME = ServiceType.TEST_STAND_ALONE.getName();
+
+    public static final ServiceType TEST_STAND_ALONE_TYPE = ServiceType.TEST_STAND_ALONE;
+    public static final short TEST_STAND_ALONE_TYPE_CODE = TEST_STAND_ALONE_TYPE.getCode();
+    public static final String TEST_STAND_ALONE_TYPE_NAME = TEST_STAND_ALONE_TYPE.getName();
+
     public static final short TOMCAT_TYPE_CODE = 1010;
     public static final String TOMCAT_TYPE_NAME = "TOMCAT";
     public static final short RPC_TYPE_CODE = 9999;
@@ -111,6 +115,7 @@ public class TestTraceUtils {
         private int elapsed;
         private int errorCode;
         private SpanBo parentSpan;
+        private ServiceType serviceType = TEST_STAND_ALONE_TYPE;
 
         public SpanBuilder(String applicationName, String agentId) {
             this(0, applicationName, agentId);
@@ -118,7 +123,7 @@ public class TestTraceUtils {
 
         public SpanBuilder(int version, String applicationName, String agentId) {
             this.version = version;
-            this.applicationName = applicationName;
+            this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
             this.agentId = agentId;
         }
 
@@ -151,7 +156,13 @@ public class TestTraceUtils {
         }
 
         public SpanBuilder parentSpan(SpanBo parentSpan) {
-            this.parentSpan = parentSpan;
+            this.parentSpan = Objects.requireNonNull(parentSpan, "parentSpan");
+            return this;
+        }
+
+        public SpanBuilder serviceType(ServiceType serviceType) {
+            Objects.requireNonNull(serviceType, "serviceType");
+            this.serviceType = serviceType;
             return this;
         }
 
@@ -165,8 +176,8 @@ public class TestTraceUtils {
                 spanId = random.nextLong();
             }
             spanBo.setSpanId(spanId);
-            spanBo.setServiceType(ServiceType.TEST_STAND_ALONE.getCode());
-            spanBo.setApplicationServiceType(ServiceType.TEST_STAND_ALONE.getCode());
+            spanBo.setServiceType(serviceType.getCode());
+            spanBo.setApplicationServiceType(serviceType.getCode());
             spanBo.setStartTime(startTime);
             spanBo.setCollectorAcceptTime(collectorAcceptTime);
             spanBo.setElapsed(elapsed);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilderTest.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.web.applicationmap.map;
 
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.util.UserNodeUtils;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
@@ -51,8 +52,6 @@ public class FilteredMapBuilderTest {
 
     private static final Random RANDOM = new Random();
 
-    private static final int VERSION = 0;
-
     // Mocked
     private final ServiceTypeRegistryService registry = TestTraceUtils.mockServiceTypeRegistryService();
 
@@ -70,7 +69,7 @@ public class FilteredMapBuilderTest {
     public void twoTier() {
         // Given
         final Range range = Range.between(1, 200000);
-        final FilteredMapBuilder builder = new FilteredMapBuilder(applicationFactory, registry, range, VERSION);
+        final FilteredMapBuilder builder = new FilteredMapBuilder(applicationFactory, registry, range);
 
         // root app span
         long rootSpanId = RANDOM.nextLong();
@@ -114,7 +113,7 @@ public class FilteredMapBuilderTest {
         LinkDataDuplexMap linkDataDuplexMap = filteredMap.getLinkDataDuplexMap();
         LinkDataMap sourceLinkDataMap = linkDataDuplexMap.getSourceLinkDataMap();
         assertSourceLinkData(sourceLinkDataMap,
-                "ROOT_APP", registry.findServiceType(TestTraceUtils.USER_TYPE_CODE),
+                newUserNode("ROOT_APP"), registry.findServiceType(TestTraceUtils.USER_TYPE_CODE),
                 "ROOT_APP", registry.findServiceType(TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE));
         assertSourceLinkData(sourceLinkDataMap,
                 "ROOT_APP", registry.findServiceType(TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE),
@@ -124,7 +123,7 @@ public class FilteredMapBuilderTest {
                 "CacheName", registry.findServiceType(TestTraceUtils.CACHE_TYPE_CODE));
         LinkDataMap targetLinkDataMap = linkDataDuplexMap.getTargetLinkDataMap();
         assertTargetLinkData(targetLinkDataMap,
-                "ROOT_APP", registry.findServiceType(TestTraceUtils.USER_TYPE_CODE),
+                newUserNode("ROOT_APP"), registry.findServiceType(TestTraceUtils.USER_TYPE_CODE),
                 "ROOT_APP", registry.findServiceType(TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE));
         assertTargetLinkData(targetLinkDataMap,
                 "ROOT_APP", registry.findServiceType(TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE),
@@ -140,6 +139,10 @@ public class FilteredMapBuilderTest {
         List<ResponseTime> appAResponseTimes = responseHistograms.getResponseTimeList(applicationA);
 
         assertThat(appAResponseTimes).hasSize(1);
+    }
+
+    private String newUserNode(String nodeName) {
+        return UserNodeUtils.newUserNodeName(nodeName, TestTraceUtils.TEST_STAND_ALONE_TYPE);
     }
 
     private void assertSourceLinkData(LinkDataMap sourceLinkDataMap, String fromApplicationName, ServiceType fromServiceType, String toApplicationName, ServiceType toServiceType) {

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImplTest.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.web.applicationmap.service;
 
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.util.UserNodeUtils;
 import com.navercorp.pinpoint.common.server.util.json.JsonField;
 import com.navercorp.pinpoint.common.server.util.json.JsonFields;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
@@ -158,7 +159,6 @@ public class FilteredMapServiceImplTest {
     public void twoTier() {
         // Given
         Range originalRange = Range.between(1000, 2000);
-        Range scanRange = Range.between(1000, 2000);
         final TimeWindow timeWindow = new TimeWindow(originalRange, TimeWindowDownSampler.SAMPLER);
 
         // root app span
@@ -198,7 +198,7 @@ public class FilteredMapServiceImplTest {
         when(traceDao.selectAllSpans(anyList(), isNull())).thenReturn(List.of(List.of(rootSpan, appASpan)));
 
         // When
-        final FilteredMapServiceOption option = new FilteredMapServiceOption.Builder(Collections.emptyList(), originalRange, 1, 1, Filter.acceptAllFilter(), 0).build();
+        final FilteredMapServiceOption option = new FilteredMapServiceOption.Builder(Collections.emptyList(), originalRange, 1, 1, Filter.acceptAllFilter()).build();
         FilterMapWithScatter filterMapWithScatter = filteredMapService.selectApplicationMapWithScatterData(option);
         ApplicationMap applicationMap = filterMapWithScatter.getApplicationMap();
 
@@ -207,7 +207,7 @@ public class FilteredMapServiceImplTest {
         assertThat(nodes).hasSize(4);
         for (Node node : nodes) {
             Application application = node.getApplication();
-            if (application.getName().equals("ROOT_APP") && application.getServiceType().getCode() == TestTraceUtils.USER_TYPE_CODE) {
+            if (application.getName().equals(UserNodeUtils.newUserNodeName("ROOT_APP", ServiceType.TEST_STAND_ALONE)) && application.getServiceType().getCode() == TestTraceUtils.USER_TYPE_CODE) {
                 // USER node
                 NodeHistogram nodeHistogram = node.getNodeHistogram();
                 // histogram
@@ -290,7 +290,7 @@ public class FilteredMapServiceImplTest {
         for (Link link : links) {
             Application fromApplication = link.getFrom().getApplication();
             Application toApplication = link.getTo().getApplication();
-            if ((fromApplication.getName().equals("ROOT_APP") && fromApplication.getServiceType().getCode() == TestTraceUtils.USER_TYPE_CODE) &&
+            if ((fromApplication.getName().equals(UserNodeUtils.newUserNodeName("ROOT_APP", ServiceType.TEST_STAND_ALONE)) && fromApplication.getServiceType().getCode() == TestTraceUtils.USER_TYPE_CODE) &&
                     (toApplication.getName().equals("ROOT_APP") && toApplication.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE)) {
                 // histogram
                 Histogram histogram = link.getHistogram();


### PR DESCRIPTION
This pull request introduces several changes aimed at improving code clarity, reducing complexity, and deprecating outdated methods. The most significant updates include the removal of the `viewVersion` parameter across multiple classes, the introduction of the `UserNodeUtils` utility class, and the refactoring of methods to use this new utility. These changes help streamline the codebase and enhance maintainability.

### Deprecation and New Utility Introduction:
* Added the `UserNodeUtils` utility class with a `newUserNodeName` method to generate user node names by combining application name and service type. This replaces the older logic scattered across the codebase. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/UserNodeUtils.java`)
* Deprecated the `getDestApplicationNameFromColumnNameForUser` method in `ApplicationMapStatisticsUtils` and recommended using `UserNodeUtils#newUserNodeName` instead. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ApplicationMapStatisticsUtils.java`)

### Removal of `viewVersion` Parameter:
* Removed the `viewVersion` parameter from `FilteredMapServiceOption`, its builder, and all related method calls, simplifying the logic for handling application maps. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceOption.java`) [[1]](diffhunk://#diff-49358faa30794f09d9e3658b4a76b1247ee2931ade45a51492cf8d181ec0d7f5L40) [[2]](diffhunk://#diff-49358faa30794f09d9e3658b4a76b1247ee2931ade45a51492cf8d181ec0d7f5L112-L132)
* Updated constructors and methods in `FilteredMapBuilder` to no longer require the `version` parameter, removing unnecessary complexity. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java`) [[1]](diffhunk://#diff-391cf5eafd5e0eacd7297befcb97d98db7c673b97b531f06730616b7b4a0138aL66-L67) [[2]](diffhunk://#diff-391cf5eafd5e0eacd7297befcb97d98db7c673b97b531f06730616b7b4a0138aL81-L86)
* Eliminated the `viewVersion` parameter from request mappings in `FilteredMapController` and `BusinessTransactionController`, reducing unused code. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java`, `web/src/main/java/com/navercorp/pinpoint/web/controller/BusinessTransactionController.java`) [[1]](diffhunk://#diff-d3a358a0cdba7441ba63fb562da9330ee7ffa2ceb86c5feb474e38cf48f35461L99) [[2]](diffhunk://#diff-452f8d38c30949007e220439a123691c6778be673bab3ae341642bf4580cbd6cL109-R115)

### Refactoring to Use `UserNodeUtils`:
* Updated the `InLinkMapper` class to use `UserNodeUtils.newUserNodeName` for creating user node names, replacing the older logic. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/InLinkMapper.java`)
* Refactored the `createParentApplication` method in `FilteredMapBuilder` to use the new `newUserNodeName` helper method, consolidating user node name creation logic. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java`)

These changes collectively improve the maintainability and readability of the codebase while ensuring a smoother transition to the new utility methods.