### PR TITLE
[#nouissue] Refactor timestamp handling

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilder.java
@@ -82,7 +82,7 @@ public class ApplicationMapBuilder {
 
         Node node = new Node(application);
         if (serverGroupListFactory != null) {
-            ServerGroupList runningInstances = serverGroupListFactory.createWasNodeInstanceList(node, range.getToInstant());
+            ServerGroupList runningInstances = serverGroupListFactory.createWasNodeInstanceList(node, range.getTo());
             if (runningInstances.getInstanceCount() > 0) {
                 node.setServerGroupList(runningInstances);
                 nodeList.addNode(node);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/DefaultServerGroupListFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/DefaultServerGroupListFactory.java
@@ -16,15 +16,14 @@
 
 package com.navercorp.pinpoint.web.applicationmap.appender.server;
 
+import com.navercorp.pinpoint.web.applicationmap.appender.server.datasource.ServerGroupListDataSource;
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.nodes.ServerBuilder;
 import com.navercorp.pinpoint.web.applicationmap.nodes.ServerGroupList;
-import com.navercorp.pinpoint.web.applicationmap.appender.server.datasource.ServerGroupListDataSource;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataDuplexMap;
 import com.navercorp.pinpoint.web.vo.Application;
 
-import java.time.Instant;
 import java.util.Objects;
 
 /**
@@ -39,7 +38,7 @@ public class DefaultServerGroupListFactory implements ServerGroupListFactory {
     }
 
     @Override
-    public ServerGroupList createWasNodeInstanceList(Node wasNode, Instant timestamp) {
+    public ServerGroupList createWasNodeInstanceList(Node wasNode, long timestamp) {
         return serverGroupListDataSource.createServerGroupList(wasNode, timestamp);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/DefaultServerInfoAppender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/DefaultServerInfoAppender.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.util.CollectionUtils;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -105,7 +104,7 @@ public class DefaultServerInfoAppender implements ServerInfoAppender {
             return CompletableFuture.supplyAsync(new Supplier<>() {
                 @Override
                 public ServerGroupList get() {
-                    final Instant to = range.getToInstant();
+                    final long to = range.getTo();
                     return serverGroupListFactory.createWasNodeInstanceList(node, to);
                 }
             }, executor);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/EmptyServerGroupListFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/EmptyServerGroupListFactory.java
@@ -20,15 +20,13 @@ import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.nodes.ServerGroupList;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataDuplexMap;
 
-import java.time.Instant;
-
 /**
  * @author HyunGil Jeong
  */
 public class EmptyServerGroupListFactory implements ServerGroupListFactory {
 
     @Override
-    public ServerGroupList createWasNodeInstanceList(Node wasNode, Instant timestamp) {
+    public ServerGroupList createWasNodeInstanceList(Node wasNode, long timestamp) {
         return ServerGroupList.empty();
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/ServerGroupListFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/ServerGroupListFactory.java
@@ -20,14 +20,12 @@ import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.nodes.ServerGroupList;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataDuplexMap;
 
-import java.time.Instant;
-
 /**
  * @author HyunGil Jeong
  */
 public interface ServerGroupListFactory {
 
-    ServerGroupList createWasNodeInstanceList(Node wasNode, Instant timestamp);
+    ServerGroupList createWasNodeInstanceList(Node wasNode, long timestamp);
 
     ServerGroupList createTerminalNodeInstanceList(Node terminalNode, LinkDataDuplexMap linkDataDuplexMap);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/StatisticsServerGroupListFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/StatisticsServerGroupListFactory.java
@@ -27,7 +27,6 @@ import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
 
-import java.time.Instant;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -43,7 +42,7 @@ public class StatisticsServerGroupListFactory implements ServerGroupListFactory 
     }
 
     @Override
-    public ServerGroupList createWasNodeInstanceList(Node wasNode, Instant timestamp) {
+    public ServerGroupList createWasNodeInstanceList(Node wasNode, long timestamp) {
         ServerGroupList serverGroupList = createWasNodeInstanceListFromHistogram(wasNode, timestamp);
         if (serverGroupList.getServerGroupList().isEmpty()) {
             // When there is no transaction information, agentInfo information is used.
@@ -52,9 +51,9 @@ public class StatisticsServerGroupListFactory implements ServerGroupListFactory 
         return serverGroupList;
     }
 
-    ServerGroupList createWasNodeInstanceListFromHistogram(Node wasNode, Instant timestamp) {
+    ServerGroupList createWasNodeInstanceListFromHistogram(Node wasNode, long timestamp) {
         Objects.requireNonNull(wasNode, "wasNode");
-        if (timestamp.toEpochMilli() < 0) {
+        if (timestamp < 0) {
             return ServerGroupList.empty();
         }
 
@@ -76,7 +75,7 @@ public class StatisticsServerGroupListFactory implements ServerGroupListFactory 
         return builder.build();
     }
 
-    ServerGroupList createWasNodeInstanceListFromAgentInfo(Node wasNode, Instant timestamp) {
+    ServerGroupList createWasNodeInstanceListFromAgentInfo(Node wasNode, long timestamp) {
         return serverGroupListDataSource.createServerGroupList(wasNode, timestamp);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/datasource/AgentInfoServerGroupListDataSource.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/datasource/AgentInfoServerGroupListDataSource.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.util.CollectionUtils;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -59,15 +58,14 @@ public class AgentInfoServerGroupListDataSource implements ServerGroupListDataSo
         this.hyperLinkFactory = Objects.requireNonNull(hyperLinkFactory, "hyperLinkFactory");
     }
 
-    public ServerGroupList createServerGroupList(Node node, Instant timestamp) {
+    public ServerGroupList createServerGroupList(Node node, long timestamp) {
         Objects.requireNonNull(node, "node");
-        Objects.requireNonNull(timestamp, "timestamp");
-        if (timestamp.toEpochMilli() < 0) {
+        if (timestamp < 0) {
             return ServerGroupList.empty();
         }
 
         Application application = node.getApplication();
-        Set<AgentInfo> agentInfos = agentInfoService.getAgentsByApplicationNameWithoutStatus(application.getName(), timestamp.toEpochMilli());
+        Set<AgentInfo> agentInfos = agentInfoService.getAgentsByApplicationNameWithoutStatus(application.getName(), timestamp);
         if (CollectionUtils.isEmpty(agentInfos)) {
             logger.warn("agentInfo not found. application:{}", application);
             return ServerGroupList.empty();
@@ -87,7 +85,7 @@ public class AgentInfoServerGroupListDataSource implements ServerGroupListDataSo
     }
 
     // TODO Change to list of filters?
-    private Set<AgentInfo> filterAgentInfos(Set<AgentInfo> agentInfos, Instant timestamp, Node node) {
+    private Set<AgentInfo> filterAgentInfos(Set<AgentInfo> agentInfos, long timestamp, Node node) {
 
         final Map<String, Histogram> agentHistogramMap = getAgentHistogramMap(node);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/datasource/ServerGroupListDataSource.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/datasource/ServerGroupListDataSource.java
@@ -19,8 +19,6 @@ package com.navercorp.pinpoint.web.applicationmap.appender.server.datasource;
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.nodes.ServerGroupList;
 
-import java.time.Instant;
-
 /**
  * @author emeroad
  * @author minwoo.jung
@@ -28,5 +26,5 @@ import java.time.Instant;
  */
 public interface ServerGroupListDataSource {
 
-    ServerGroupList createServerGroupList(Node node, Instant timestamp);
+    ServerGroupList createServerGroupList(Node node, long timestamp);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImpl.java
@@ -155,7 +155,7 @@ public class ResponseTimeHistogramServiceImpl implements ResponseTimeHistogramSe
         NodeHistogram nodeHistogram = nodeHistogramFactory.createWasNodeHistogram(application, range);
         node.setNodeHistogram(nodeHistogram);
         final ServerGroupListFactory serverGroupListFactory = createServerGroupListFactory(option.isUseStatisticsAgentState());
-        ServerGroupList serverGroupList = serverGroupListFactory.createWasNodeInstanceList(node, range.getToInstant());
+        ServerGroupList serverGroupList = serverGroupListFactory.createWasNodeInstanceList(node, range.getTo());
         return new NodeHistogramSummary(application, serverGroupList, nodeHistogram);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
@@ -47,7 +47,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -194,7 +193,7 @@ public class AgentInfoServiceImpl implements AgentInfoService {
     private List<AgentAndStatus> getAgentAndStatuses(List<AgentInfo> agentInfoList, long timestamp) {
         List<AgentAndStatus> result = new ArrayList<>(agentInfoList.size());
 
-        AgentStatusQuery query = AgentStatusQuery.buildQuery(agentInfoList, Instant.ofEpochMilli(timestamp));
+        AgentStatusQuery query = AgentStatusQuery.buildQuery(agentInfoList, timestamp);
         List<Optional<AgentStatus>> agentStatus = this.agentLifeCycleDao.getAgentStatus(query);
         for (int i = 0; i < agentStatus.size(); i++) {
             Optional<AgentStatus> status = agentStatus.get(i);
@@ -231,7 +230,7 @@ public class AgentInfoServiceImpl implements AgentInfoService {
 
         List<DetailedAgentAndStatus> result = new ArrayList<>(agentInfos.size());
 
-        AgentStatusQuery query = AgentStatusQuery.buildGenericQuery(agentInfos, DetailedAgentInfo::getAgentInfo, Instant.ofEpochMilli(timestamp));
+        AgentStatusQuery query = AgentStatusQuery.buildGenericQuery(agentInfos, DetailedAgentInfo::getAgentInfo, timestamp);
         List<Optional<AgentStatus>> agentStatus = this.agentLifeCycleDao.getAgentStatus(query);
 
         for (int i = 0; i < agentStatus.size(); i++) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentListServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentListServiceImpl.java
@@ -21,7 +21,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -101,7 +100,7 @@ public class ApplicationAgentListServiceImpl implements ApplicationAgentListServ
     private List<AgentAndStatus> getAgentAndStatuses(List<AgentInfo> agentInfoList, Range range) {
         List<AgentAndStatus> agentAndStatusList = new ArrayList<>(agentInfoList.size());
 
-        AgentStatusQuery query = AgentStatusQuery.buildQuery(agentInfoList, Instant.ofEpochMilli(range.getTo()));
+        AgentStatusQuery query = AgentStatusQuery.buildQuery(agentInfoList, range.getTo());
         List<Optional<AgentStatus>> agentStatus = this.agentLifeCycleDao.getAgentStatus(query);
         for (int i = 0; i < agentStatus.size(); i++) {
             Optional<AgentStatus> status = agentStatus.get(i);

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/agent/AgentStatusQuery.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/agent/AgentStatusQuery.java
@@ -2,7 +2,6 @@ package com.navercorp.pinpoint.web.vo.agent;
 
 import com.navercorp.pinpoint.common.server.bo.SimpleAgentKey;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -11,11 +10,11 @@ import java.util.function.Function;
 
 public class AgentStatusQuery {
     private final List<SimpleAgentKey> agentKeyList;
-    private final Instant queryTimestamp;
+    private final long queryTimestamp;
 
-    private AgentStatusQuery(List<SimpleAgentKey> agentKeyList, Instant queryTimestamp) {
+    private AgentStatusQuery(List<SimpleAgentKey> agentKeyList, long queryTimestamp) {
         this.agentKeyList = Objects.requireNonNull(agentKeyList, "agentStatusKeys");
-        this.queryTimestamp = Objects.requireNonNull(queryTimestamp, "queryTimestamp");
+        this.queryTimestamp = queryTimestamp;
     }
 
     public List<SimpleAgentKey> getAgentKeys() {
@@ -23,7 +22,7 @@ public class AgentStatusQuery {
     }
 
     public long getQueryTimestamp() {
-        return queryTimestamp.toEpochMilli();
+        return queryTimestamp;
     }
 
     public static Builder newBuilder() {
@@ -47,16 +46,16 @@ public class AgentStatusQuery {
             this.agentKeyList.add(agentKey);
         }
 
-        public AgentStatusQuery build(Instant queryTimestamp) {
+        public AgentStatusQuery build(long queryTimestamp) {
             return new AgentStatusQuery(new ArrayList<>(agentKeyList), queryTimestamp);
         }
     }
 
-    public static AgentStatusQuery buildQuery(Collection<AgentInfo> agentInfos, Instant timestamp) {
+    public static AgentStatusQuery buildQuery(Collection<AgentInfo> agentInfos, long timestamp) {
         return buildQuery(agentInfos, AgentStatusQuery::apply, timestamp);
     }
 
-    public static <T> AgentStatusQuery buildGenericQuery(Collection<T> agentInfos, Function<T, AgentInfo> agentInfoFunction, Instant timestamp) {
+    public static <T> AgentStatusQuery buildGenericQuery(Collection<T> agentInfos, Function<T, AgentInfo> agentInfoFunction, long timestamp) {
         return buildQuery(agentInfos, agentInfoFunction.andThen(AgentStatusQuery::apply), timestamp);
     }
 
@@ -67,7 +66,7 @@ public class AgentStatusQuery {
         return new SimpleAgentKey(agentInfo.getAgentId(), agentInfo.getStartTimestamp());
     }
 
-    public static <T> AgentStatusQuery buildQuery(Collection<T> agentInfos, Function<T, SimpleAgentKey> transform, Instant timestamp) {
+    public static <T> AgentStatusQuery buildQuery(Collection<T> agentInfos, Function<T, SimpleAgentKey> transform, long timestamp) {
         AgentStatusQuery.Builder builder = AgentStatusQuery.newBuilder();
         for (T agentInfo : agentInfos) {
             SimpleAgentKey apply = transform.apply(agentInfo);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/appender/server/ServerInfoAppenderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/appender/server/ServerInfoAppenderTest.java
@@ -108,7 +108,7 @@ public class ServerInfoAppenderTest {
         nodeList.addNode(wasNode);
 
         ServerGroupList serverGroupList = ServerGroupList.empty();
-        when(serverGroupListDataSource.createServerGroupList(wasNode, range.getToInstant())).thenReturn(serverGroupList);
+        when(serverGroupListDataSource.createServerGroupList(wasNode, range.getTo())).thenReturn(serverGroupList);
         // When
         serverInfoAppender.appendServerInfo(range, nodeList, linkDataDuplexMap, timeoutMillis);
         // Then
@@ -129,9 +129,9 @@ public class ServerInfoAppenderTest {
         nodeList.addNode(wasNode2);
 
         ServerGroupList serverGroupList1 = ServerGroupList.empty();
-        when(serverGroupListDataSource.createServerGroupList(wasNode1, range.getToInstant())).thenReturn(serverGroupList1);
+        when(serverGroupListDataSource.createServerGroupList(wasNode1, range.getTo())).thenReturn(serverGroupList1);
         ServerGroupList serverGroupList2 = ServerGroupList.empty();
-        when(serverGroupListDataSource.createServerGroupList(wasNode2, range.getToInstant())).thenReturn(serverGroupList2);
+        when(serverGroupListDataSource.createServerGroupList(wasNode2, range.getTo())).thenReturn(serverGroupList2);
         // When
         serverInfoAppender.appendServerInfo(range, nodeList, linkDataDuplexMap, timeoutMillis);
         // Then

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
@@ -49,8 +49,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -76,7 +74,7 @@ public class ResponseTimeHistogramServiceImplTest {
 
         when(serverInstanceDatasourceService.getServerGroupListDataSource()).thenReturn(new ServerGroupListDataSource() {
             @Override
-            public ServerGroupList createServerGroupList(Node node, Instant timestamp) {
+            public ServerGroupList createServerGroupList(Node node, long timestamp) {
                 return ServerGroupList.empty();
             }
         });
@@ -93,10 +91,10 @@ public class ResponseTimeHistogramServiceImplTest {
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
 
-        when(mapResponseDao.selectResponseTime(eq(nodeApplication), any(Range.class))).thenReturn(Collections.emptyList());
+        when(mapResponseDao.selectResponseTime(eq(nodeApplication), any(Range.class))).thenReturn(List.of());
 
         //WAS node does not use fromApplications or toApplications to build nodeHistogramData
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, Collections.emptyList(), Collections.emptyList())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
 
@@ -123,7 +121,7 @@ public class ResponseTimeHistogramServiceImplTest {
         when(mapResponseDao.selectResponseTime(eq(nodeApplication), any(Range.class))).thenReturn(List.of(createResponseTime(nodeApplication, timestamp)));
 
         //WAS node does not use fromApplications or toApplications to build nodeHistogramData
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, Collections.emptyList(), Collections.emptyList())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
 
@@ -165,7 +163,7 @@ public class ResponseTimeHistogramServiceImplTest {
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), eq(LinkDataMapProcessor.NO_OP), any(LinkDataMapProcessor.class)))
                 .thenReturn(createCalleeLinkSelector(List.of(new LinkKey(nodeApplication, toApplication)), timestamp));
 
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, Collections.emptyList(), List.of(toApplication))
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(), List.of(toApplication))
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -194,7 +192,7 @@ public class ResponseTimeHistogramServiceImplTest {
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(was, nodeApplication)), timestamp));
 
         //UNKNOWN(TERMINAL, ALIAS) node use fromApplications to build nodeHistogramData
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was), Collections.emptyList())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -229,7 +227,7 @@ public class ResponseTimeHistogramServiceImplTest {
                 ), timestamp));
 
         //UNKNOWN(TERMINAL, ALIAS) node use toApplications to build nodeHistogramData
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was1, was2), Collections.emptyList())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was1, was2), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -261,7 +259,7 @@ public class ResponseTimeHistogramServiceImplTest {
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), eq(LinkDataMapProcessor.NO_OP)))
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(was, nodeApplication)), timestamp));
 
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was), Collections.emptyList())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -293,7 +291,7 @@ public class ResponseTimeHistogramServiceImplTest {
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), any(LinkDataMapProcessor.class)))
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(was1, nodeApplication)), timestamp));
 
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was1, was2), Collections.emptyList())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was1, was2), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -327,7 +325,7 @@ public class ResponseTimeHistogramServiceImplTest {
                 .thenThrow(new IllegalStateException("no scan for QUEUE node with empty sourceApplications"));
 
         //fromApplications out of Search range
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, Collections.emptyList(), Collections.emptyList())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -365,7 +363,7 @@ public class ResponseTimeHistogramServiceImplTest {
                 ), timestamp));
 
         //fromApplications out of Search range
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was2), Collections.emptyList())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was2), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);

--- a/web/src/test/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentLifeCycleDaoTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentLifeCycleDaoTest.java
@@ -36,7 +36,6 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -162,7 +161,7 @@ public class HbaseAgentLifeCycleDaoTest {
         AgentInfo nullAgentInfo = null;
         List<AgentInfo> givenAgentInfos = Arrays.asList(nonNullAgentInfo, nullAgentInfo, nonNullAgentInfo, nullAgentInfo);
         // When
-        AgentStatusQuery query = AgentStatusQuery.buildQuery(givenAgentInfos, Instant.ofEpochMilli(expectedTimestamp));
+        AgentStatusQuery query = AgentStatusQuery.buildQuery(givenAgentInfos, expectedTimestamp);
         List<Optional<AgentStatus>> agentStatus = this.agentLifeCycleDao.getAgentStatus(query);
 
         // Then
@@ -178,7 +177,7 @@ public class HbaseAgentLifeCycleDaoTest {
     public void populateAgentStatus_should_not_crash_with_invalid_inputs() {
         this.agentLifeCycleDao.getAgentStatus(null, 1000, 1000L);
         AgentStatusQuery.Builder builder = AgentStatusQuery.newBuilder();
-        AgentStatusQuery query = builder.build(Instant.ofEpochMilli(1000));
+        AgentStatusQuery query = builder.build(1000);
         this.agentLifeCycleDao.getAgentStatus(query);
     }
 


### PR DESCRIPTION
This pull request includes several changes to the `pinpoint` project, focusing on replacing the use of `Instant` with `long` for timestamp handling across various classes and methods. This change aims to simplify the timestamp management and improve consistency throughout the codebase. The most important changes include modifications to method signatures, imports, and related test cases.

### Timestamp handling updates:

* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilder.java`](diffhunk://#diff-7105bb67aa47b306a56c96658af4d2b98e9066b0f6c419c551e79b5f212dbddcL85-R85): Updated `createWasNodeInstanceList` method to use `long` instead of `Instant` for the timestamp parameter.
* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/DefaultServerGroupListFactory.java`](diffhunk://#diff-14b6b115f41987ba750670371d239707c91e4aa5aefebf29f2f04e6a04a9a8deR19-L27): Changed the method signature of `createWasNodeInstanceList` to accept `long` instead of `Instant` for the timestamp. [[1]](diffhunk://#diff-14b6b115f41987ba750670371d239707c91e4aa5aefebf29f2f04e6a04a9a8deR19-L27) [[2]](diffhunk://#diff-14b6b115f41987ba750670371d239707c91e4aa5aefebf29f2f04e6a04a9a8deL42-R41)
* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/StatisticsServerGroupListFactory.java`](diffhunk://#diff-c791e0737f59e001c7c8b138b0789cbd2132ee127ebae31d6cf36831acd0180dL46-R45): Modified the method signatures to use `long` for timestamp parameters. [[1]](diffhunk://#diff-c791e0737f59e001c7c8b138b0789cbd2132ee127ebae31d6cf36831acd0180dL46-R45) [[2]](diffhunk://#diff-c791e0737f59e001c7c8b138b0789cbd2132ee127ebae31d6cf36831acd0180dL55-R56) [[3]](diffhunk://#diff-c791e0737f59e001c7c8b138b0789cbd2132ee127ebae31d6cf36831acd0180dL79-R78)
* [`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/datasource/AgentInfoServerGroupListDataSource.java`](diffhunk://#diff-25617e0baac539c8c92da6d22ee66b7879961dd59785ac40d6435520b49826b0L62-R68): Updated methods to use `long` for timestamp parameters. [[1]](diffhunk://#diff-25617e0baac539c8c92da6d22ee66b7879961dd59785ac40d6435520b49826b0L62-R68) [[2]](diffhunk://#diff-25617e0baac539c8c92da6d22ee66b7879961dd59785ac40d6435520b49826b0L90-R88)
* [`web/src/main/java/com/navercorp/pinpoint/web/vo/agent/AgentStatusQuery.java`](diffhunk://#diff-7220a22051cffd62c0da20411c57dda4746fdd9d477298091002e89b581b28a3L14-R25): Refactored the class to use `long` instead of `Instant` for query timestamps. [[1]](diffhunk://#diff-7220a22051cffd62c0da20411c57dda4746fdd9d477298091002e89b581b28a3L14-R25) [[2]](diffhunk://#diff-7220a22051cffd62c0da20411c57dda4746fdd9d477298091002e89b581b28a3L50-R58) [[3]](diffhunk://#diff-7220a22051cffd62c0da20411c57dda4746fdd9d477298091002e89b581b28a3L70-R69)

These changes ensure that timestamp handling is consistent and simplified across the codebase, reducing the complexity of managing time-related data.