### PR TITLE
[#noissue] Refactor iterator in JsonFields to use Iterators.forArray

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/json/JsonFields.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/json/JsonFields.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.Iterators;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -42,7 +43,7 @@ public class JsonFields<K, V> implements Iterable<JsonField<K, V>>, RandomAccess
 
     @Override
     public Iterator<JsonField<K, V>> iterator() {
-        return stream().iterator();
+        return Iterators.forArray(fields);
     }
 
     public Stream<JsonField<K, V>> stream() {

--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/NodeList.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/NodeList.java
@@ -5,13 +5,13 @@ import com.navercorp.pinpoint.common.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 public class NodeList implements Iterable<Node> {
 
@@ -23,15 +23,17 @@ public class NodeList implements Iterable<Node> {
     public static NodeList newNodeList(List<SpanBo> spans) {
         Objects.requireNonNull(spans, "spans");
 
-        List<Node> list = spans.stream()
-                .map(Node::toNode)
-                .sorted(STARTTIME_COMPARATOR)
-                .collect(Collectors.toList());
+        List<Node> list = new ArrayList<>(spans.size());
+        for (SpanBo span : spans) {
+            Node node = Node.toNode(span);
+            list.add(node);
+        }
+        list.sort(STARTTIME_COMPARATOR);
         return new NodeList(list);
     }
 
     public NodeList() {
-        this.nodeList = new ArrayList<>();
+        this.nodeList = Collections.emptyList();
     }
 
     public NodeList(List<Node> nodeList) {
@@ -72,14 +74,18 @@ public class NodeList implements Iterable<Node> {
 
 
     public NodeList filter(Predicate<Node> filter) {
+        Objects.requireNonNull(filter, "filter");
+
         if (CollectionUtils.isEmpty(nodeList)) {
             return new NodeList();
         }
-        Objects.requireNonNull(filter, "filter");
 
-        List<Node> list = nodeList.stream()
-                .filter(filter)
-                .collect(Collectors.toList());
+        List<Node> list = new ArrayList<>();
+        for (Node node : nodeList) {
+            if (filter.test(node)) {
+                list.add(node);
+            }
+        }
         return new NodeList(list);
     }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/calltree/span/NodeListTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/calltree/span/NodeListTest.java
@@ -1,0 +1,19 @@
+package com.navercorp.pinpoint.web.calltree.span;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+
+class NodeListTest {
+
+    @Test
+    void remove() {
+        Node node = mock(Node.class);
+
+        NodeList nodes = new NodeList();
+        nodes.remove(node);
+
+        Assertions.assertTrue(nodes.isEmpty());
+    }
+}


### PR DESCRIPTION
This pull request updates the `JsonFields` class to improve iterator performance by replacing the stream-based iterator with an array-based iterator.

Performance improvement:

* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/json/JsonFields.java`](diffhunk://#diff-a696fe156632a210dbea72bf06217320b7cf4884dd05b07c0007089a65b891d9L45-R46): Replaced the `iterator` method's implementation to use `Iterators.forArray(fields)` instead of `stream().iterator()` for better performance. This change leverages Guava's `Iterators` utility.
* [`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/json/JsonFields.java`](diffhunk://#diff-a696fe156632a210dbea72bf06217320b7cf4884dd05b07c0007089a65b891d9R7): Added an import for `com.google.common.collect.Iterators` to support the new iterator implementation.