### PR TITLE
[#noissue] Improve empty list handling in NodeList

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/NodeList.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/NodeList.java
@@ -18,25 +18,33 @@ public class NodeList implements Iterable<Node> {
     private final static Comparator<Node> STARTTIME_COMPARATOR
             = Comparator.comparingLong((Node node) -> node.getSpanBo().getStartTime());
 
+    public static final NodeList EMPTY = new NodeList(Collections.emptyList());
+
     private final List<Node> nodeList;
 
     public static NodeList newNodeList(List<SpanBo> spans) {
         Objects.requireNonNull(spans, "spans");
+        if (spans.isEmpty()) {
+            return EMPTY;
+        }
 
         List<Node> list = new ArrayList<>(spans.size());
         for (SpanBo span : spans) {
-            Node node = Node.toNode(span);
-            list.add(node);
+            list.add(Node.toNode(span));
         }
         list.sort(STARTTIME_COMPARATOR);
         return new NodeList(list);
     }
 
-    public NodeList() {
-        this.nodeList = Collections.emptyList();
+    public static NodeList of(List<Node> nodeList) {
+        Objects.requireNonNull(nodeList, "nodeList");
+        if (CollectionUtils.isEmpty(nodeList)) {
+            return EMPTY;
+        }
+        return new NodeList(nodeList);
     }
 
-    public NodeList(List<Node> nodeList) {
+    private NodeList(List<Node> nodeList) {
         this.nodeList = Objects.requireNonNull(nodeList, "nodeList");
     }
 
@@ -75,9 +83,8 @@ public class NodeList implements Iterable<Node> {
 
     public NodeList filter(Predicate<Node> filter) {
         Objects.requireNonNull(filter, "filter");
-
-        if (CollectionUtils.isEmpty(nodeList)) {
-            return new NodeList();
+        if (nodeList.isEmpty()) {
+            return EMPTY;
         }
 
         List<Node> list = new ArrayList<>();
@@ -86,7 +93,7 @@ public class NodeList implements Iterable<Node> {
                 list.add(node);
             }
         }
-        return new NodeList(list);
+        return NodeList.of(list);
     }
 
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/SpanAligner.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/SpanAligner.java
@@ -19,8 +19,8 @@ package com.navercorp.pinpoint.web.calltree.span;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Objects;
@@ -259,7 +259,7 @@ public class SpanAligner {
 
         // find root
         final NodeList rootNodeList = nodeList.filter(NodeList.rootFilter());
-        if (rootNodeList.size() >= 1) {
+        if (!rootNodeList.isEmpty()) {
             return selectInRootNodeList(rootNodeList, true);
         }
 
@@ -306,7 +306,7 @@ public class SpanAligner {
 
         // find focus
         final NodeList focusNodeList = topNodeList.filter(this.focusFilter);
-        if (focusNodeList.size() >= 1) {
+        if (!focusNodeList.isEmpty()) {
             return selectInFocusNodeList(focusNodeList, topNodeList);
         }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/calltree/span/NodeListTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/calltree/span/NodeListTest.java
@@ -3,6 +3,9 @@ package com.navercorp.pinpoint.web.calltree.span;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.mockito.Mockito.mock;
 
 class NodeListTest {
@@ -11,7 +14,10 @@ class NodeListTest {
     void remove() {
         Node node = mock(Node.class);
 
-        NodeList nodes = new NodeList();
+        List<Node> nodeList = new ArrayList<>();
+        nodeList.add(node);
+
+        NodeList nodes = NodeList.of(nodeList);
         nodes.remove(node);
 
         Assertions.assertTrue(nodes.isEmpty());


### PR DESCRIPTION
This pull request refactors the `NodeList` class to improve immutability and simplify its usage, updates related logic in `SpanAligner`, and adjusts the corresponding test cases. It also includes a minor import reordering in `SpanAligner`.

### Refactoring of `NodeList`:

* Introduced a static `EMPTY` instance of `NodeList` for representing empty lists, replacing direct instantiation with `Collections.emptyList()` in multiple places. (`[[1]](diffhunk://#diff-e7ca746e462e44b26eed06f0a8f7a43462408ff0c28c6697f28b95b16dc714fcR21-R47)`, `[[2]](diffhunk://#diff-e7ca746e462e44b26eed06f0a8f7a43462408ff0c28c6697f28b95b16dc714fcL78-R87)`)
* Added a new static factory method `NodeList.of()` to create `NodeList` instances, ensuring null checks and reusing the `EMPTY` instance when applicable. (`[web/src/main/java/com/navercorp/pinpoint/web/calltree/span/NodeList.javaR21-R47](diffhunk://#diff-e7ca746e462e44b26eed06f0a8f7a43462408ff0c28c6697f28b95b16dc714fcR21-R47)`)
* Made the constructor of `NodeList` private to enforce the use of static factory methods for instance creation. (`[web/src/main/java/com/navercorp/pinpoint/web/calltree/span/NodeList.javaR21-R47](diffhunk://#diff-e7ca746e462e44b26eed06f0a8f7a43462408ff0c28c6697f28b95b16dc714fcR21-R47)`)
* Updated the `filter` method to use the new `NodeList.of()` factory method for creating filtered lists. (`[web/src/main/java/com/navercorp/pinpoint/web/calltree/span/NodeList.javaL89-R96](diffhunk://#diff-e7ca746e462e44b26eed06f0a8f7a43462408ff0c28c6697f28b95b16dc714fcL89-R96)`)

### Updates in `SpanAligner`:

* Replaced checks for `size() >= 1` with `isEmpty()` for clarity and consistency with the updated `NodeList` API. (`[[1]](diffhunk://#diff-bea7576f0b3d81a721b9e335e448e792ac0ea3d26ab8101356e7feae57cbf335L262-R262)`, `[[2]](diffhunk://#diff-bea7576f0b3d81a721b9e335e448e792ac0ea3d26ab8101356e7feae57cbf335L309-R309)`)

### Test case adjustments:

* Updated the `NodeListTest` to use the new `NodeList.of()` method instead of directly instantiating `NodeList`. (`[web/src/test/java/com/navercorp/pinpoint/web/calltree/span/NodeListTest.javaL14-R20](diffhunk://#diff-298f0446ed14f298e79707ef0776296afc843fef0f3e94bf18810a74aa29f482L14-R20)`)

### Miscellaneous:

* Reordered imports in `SpanAligner` to adhere to standard conventions. (`[web/src/main/java/com/navercorp/pinpoint/web/calltree/span/SpanAligner.javaL22-R23](diffhunk://#diff-bea7576f0b3d81a721b9e335e448e792ac0ea3d26ab8101356e7feae57cbf335L22-R23)`)