### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
@@ -129,7 +129,7 @@ public class FilteredMapController {
         return new FilterMapView(applicationMapView, scatterDataMapView, lastScanTime);
     }
 
-    @GetMapping(value = "/filterServer")
+    @GetMapping(value = "/filterServerMap")
     public FilterMapViewV3 getFilterServer(
             @Valid @ModelAttribute
             ApplicationForm appForm,

--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/SpanFilters.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/SpanFilters.java
@@ -3,7 +3,7 @@ package com.navercorp.pinpoint.web.calltree.span;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.util.StringUtils;
-import com.navercorp.pinpoint.web.controller.BusinessTransactionController;
+import com.navercorp.pinpoint.web.controller.TransactionController;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,8 +12,8 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 public class SpanFilters {
-    private static final long DEFAULT_FOCUS_TIMESTAMP = Long.parseLong(BusinessTransactionController.DEFAULT_FOCUS_TIMESTAMP);
-    private static final long DEFAULT_SPAN_ID = Long.parseLong(BusinessTransactionController.DEFAULT_SPAN_ID);
+    private static final long DEFAULT_FOCUS_TIMESTAMP = Long.parseLong(TransactionController.DEFAULT_FOCUS_TIMESTAMP);
+    private static final long DEFAULT_SPAN_ID = Long.parseLong(TransactionController.DEFAULT_SPAN_ID);
 
 
     public static Predicate<SpanBo> spanFilter(long spanId, String agentId, long focusTimestamp) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/TransactionController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/TransactionController.java
@@ -64,9 +64,9 @@ import java.util.function.Predicate;
  * @author Taejin Koo
  */
 @RestController
-@RequestMapping(path = {"/api", "/api/trace"})
+@RequestMapping(path = {"/api", "/api/transaction"})
 @Validated
-public class BusinessTransactionController {
+public class TransactionController {
     private final Logger logger = LogManager.getLogger(this.getClass());
 
     public static final String DEFAULT_FOCUS_TIMESTAMP = "0";
@@ -83,11 +83,11 @@ public class BusinessTransactionController {
     private int callstackSelectSpansLimit;
 
 
-    public BusinessTransactionController(SpanService spanService,
-                                         TransactionInfoService transactionInfoService,
-                                         FilteredMapService filteredMapService,
-                                         HyperLinkFactory hyperLinkFactory,
-                                         LogLinkBuilder logLinkBuilder) {
+    public TransactionController(SpanService spanService,
+                                 TransactionInfoService transactionInfoService,
+                                 FilteredMapService filteredMapService,
+                                 HyperLinkFactory hyperLinkFactory,
+                                 LogLinkBuilder logLinkBuilder) {
         this.spanService = Objects.requireNonNull(spanService, "spanService");
         this.transactionInfoService = Objects.requireNonNull(transactionInfoService, "transactionInfoService");
         this.filteredMapService = Objects.requireNonNull(filteredMapService, "filteredMapService");
@@ -95,7 +95,7 @@ public class BusinessTransactionController {
         this.logLinkBuilder = Objects.requireNonNull(logLinkBuilder, "logLinkBuilder");
     }
 
-    @GetMapping(value = "/transaction")
+    @GetMapping(value = "/trace")
     public TransactionInfoViewModel getTrace(
             @RequestParam("traceId") @NotBlank String traceId,
             @RequestParam(value = "focusTimestamp", required = false, defaultValue = DEFAULT_FOCUS_TIMESTAMP)


### PR DESCRIPTION
This pull request introduces several changes to improve the naming consistency and clarity of the codebase, particularly around transaction-related components. The main updates include renaming the `BusinessTransactionController` to `TransactionController`, updating related references throughout the code, and refining endpoint paths for better alignment with their functionality.

### Controller Renaming and Refactoring:

* Renamed the `BusinessTransactionController` to `TransactionController` for better alignment with its purpose. This includes updating the class name, constructor, and static constants. (`web/src/main/java/com/navercorp/pinpoint/web/controller/TransactionController.java`) [[1]](diffhunk://#diff-e1dd69763659b859e78de47ce857f6e186b1fc816175373245548f32cb8c052aL67-R69) [[2]](diffhunk://#diff-e1dd69763659b859e78de47ce857f6e186b1fc816175373245548f32cb8c052aL86-R86)
* Updated the `@RequestMapping` path from `"/api/trace"` to `"/api/transaction"` to reflect the new naming convention. (`web/src/main/java/com/navercorp/pinpoint/web/controller/TransactionController.java`)

### Endpoint and Method Updates:

* Changed the `@GetMapping` value for the `getTrace` method from `"/transaction"` to `"/trace"` to better describe its functionality. (`web/src/main/java/com/navercorp/pinpoint/web/controller/TransactionController.java`)
* Updated the `@GetMapping` value for the `getFilterServer` method from `"/filterServer"` to `"/filterServerMap"` for improved clarity. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java`)

### Dependency and Reference Updates:

* Updated references to `BusinessTransactionController` in `SpanFilters` to use the new `TransactionController` class. This includes changes to static constants like `DEFAULT_FOCUS_TIMESTAMP` and `DEFAULT_SPAN_ID`. (`web/src/main/java/com/navercorp/pinpoint/web/calltree/span/SpanFilters.java`) [[1]](diffhunk://#diff-b55708180e4f6ce43d8ce20474fac38a5a76589a36abca5693d6def765819975L6-R6) [[2]](diffhunk://#diff-b55708180e4f6ce43d8ce20474fac38a5a76589a36abca5693d6def765819975L15-R16)