### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/CallTreeIterator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/CallTreeIterator.java
@@ -25,7 +25,7 @@ import java.util.List;
  */
 public class CallTreeIterator implements Iterator<CallTreeNode> {
 
-    private List<CallTreeNode> nodes = new ArrayList<>();
+    private final List<CallTreeNode> nodes = new ArrayList<>();
     private int index = -1;
 
     public CallTreeIterator(final CallTreeNode root) {
@@ -79,7 +79,7 @@ public class CallTreeIterator implements Iterator<CallTreeNode> {
         index++;
 
         final Align align = node.getAlign();
-        if(align.isMeta()) {
+        if (align.isMeta()) {
             align.setGap(0);
             align.setDepth(node.getDepth());
             align.setExecutionMilliseconds(0);

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/tree/SimpleTreeView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/tree/SimpleTreeView.java
@@ -1,6 +1,7 @@
 package com.navercorp.pinpoint.web.view.tree;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.Iterators;
 
 import java.util.Iterator;
 import java.util.List;
@@ -27,9 +28,7 @@ public class SimpleTreeView<I, C> implements TreeView<TreeNode<C>> {
 
     @Override
     public Iterator<TreeNode<C>> nodes() {
-        return nodeList.stream()
-                .map(this::toTreeNode)
-                .iterator();
+        return Iterators.transform(nodeList.iterator(), this::toTreeNode);
     }
 
     private TreeNode<C> toTreeNode(I item) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/tree/StaticTreeView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/tree/StaticTreeView.java
@@ -19,7 +19,7 @@ public class StaticTreeView<C> implements TreeView<C> {
     @JsonValue
     @JsonUnwrapped
     public Iterator<C> nodes() {
-        return nodeList.stream().iterator();
+        return nodeList.iterator();
     }
 
     @Override


### PR DESCRIPTION
This pull request introduces improvements to the immutability of data structures, optimizes iteration logic, and simplifies code in the `web` module. The key changes include making the `nodes` list in `CallTreeIterator` immutable, replacing stream-based iteration with Guava's `Iterators.transform` in `SimpleTreeView`, and simplifying iteration in `StaticTreeView`.

### Improvements to immutability:
* [`web/src/main/java/com/navercorp/pinpoint/web/calltree/span/CallTreeIterator.java`](diffhunk://#diff-eb3a3e58cc17eeca043134aebe7207eee60f725b5e5d6d30cf189304e0672e39L28-R28): Changed the `nodes` list to be `final` to ensure it cannot be reassigned, improving immutability.

### Iteration optimizations:
* [`web/src/main/java/com/navercorp/pinpoint/web/view/tree/SimpleTreeView.java`](diffhunk://#diff-cccec2b917ff3e02d4e60516fabea386048941c3f91bc0abbedd4824b53f3e82L30-R31): Replaced the use of `Stream` with Guava's `Iterators.transform` for transforming `nodeList` into `TreeNode` objects, reducing overhead.
* [`web/src/main/java/com/navercorp/pinpoint/web/view/tree/StaticTreeView.java`](diffhunk://#diff-d7b90af3e9dab319e46f5a254446676f20c88e2495f188e894397d7b3b3429b5L22-R22): Simplified iteration by directly returning the iterator from `nodeList` instead of using `Stream`.

### Dependency updates:
* [`web/src/main/java/com/navercorp/pinpoint/web/view/tree/SimpleTreeView.java`](diffhunk://#diff-cccec2b917ff3e02d4e60516fabea386048941c3f91bc0abbedd4824b53f3e82R4): Added an import for `com.google.common.collect.Iterators` to support the use of `Iterators.transform`.