### PR TITLE
[#noissue] Extract HistogramFormat in Link

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogram.java
@@ -16,8 +16,6 @@
 
 package com.navercorp.pinpoint.web.applicationmap.histogram;
 
-import com.navercorp.pinpoint.web.applicationmap.view.TimeHistogramBuilder;
-import com.navercorp.pinpoint.web.applicationmap.view.TimeHistogramViewModel;
 import com.navercorp.pinpoint.web.vo.Application;
 
 import java.util.Collections;
@@ -40,9 +38,8 @@ public class ApplicationTimeHistogram {
         this.histogramList = Objects.requireNonNull(histogramList, "histogramList");
     }
 
-    public List<TimeHistogramViewModel> createViewModel(TimeHistogramFormat timeHistogramFormat) {
-        TimeHistogramBuilder builder = new TimeHistogramBuilder(timeHistogramFormat);
-        return builder.build(application, histogramList);
+    public Application getApplication() {
+        return application;
     }
 
     public List<TimeHistogram> getHistogramList() {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/NodeHistogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/NodeHistogram.java
@@ -107,7 +107,7 @@ public class NodeHistogram {
 
     public Map<String, ResponseTimeStatics> getAgentResponseStatisticsMap() {
         if (agentHistogramMap == null) {
-            return null;
+            return Map.of();
         }
         Map<String, ResponseTimeStatics> map = new HashMap<>(agentHistogramMap.size());
         agentHistogramMap.forEach((agentId, histogram) ->

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/Link.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/Link.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.web.applicationmap.link;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.navercorp.pinpoint.common.server.util.json.JsonFields;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.histogram.AgentTimeHistogram;
@@ -25,18 +24,14 @@ import com.navercorp.pinpoint.web.applicationmap.histogram.AgentTimeHistogramBui
 import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationTimeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationTimeHistogramBuilder;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
-import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.AgentHistogramList;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkCallData;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkCallDataMap;
-import com.navercorp.pinpoint.web.applicationmap.view.TimeHistogramViewModel;
-import com.navercorp.pinpoint.web.view.id.AgentNameView;
 import com.navercorp.pinpoint.web.vo.Application;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -157,29 +152,21 @@ public class Link {
         return outLinkList.mergeHistogram(toNode.getServiceType());
     }
 
-    public List<TimeHistogramViewModel> getLinkApplicationTimeSeriesHistogram(TimeHistogramFormat format) {
+    public ApplicationTimeHistogram getLinkApplicationTimeSeriesHistogram() {
         if (direction == LinkDirection.IN_LINK) {
-            return getSourceApplicationTimeSeriesHistogram(format);
+            return getSourceApplicationTimeSeriesHistogramData();
         } else {
-            return getTargetApplicationTimeSeriesHistogram(format);
+            return getTargetApplicationTimeSeriesHistogramData();
         }
     }
 
-    public List<TimeHistogramViewModel> getSourceApplicationTimeSeriesHistogram(TimeHistogramFormat format) {
-        ApplicationTimeHistogram histogramData = getSourceApplicationTimeSeriesHistogramData();
-        return histogramData.createViewModel(format);
-    }
 
-    private ApplicationTimeHistogram getSourceApplicationTimeSeriesHistogramData() {
+    public ApplicationTimeHistogram getSourceApplicationTimeSeriesHistogramData() {
         // we need Target (to)'s time since time in link is RPC-based
         ApplicationTimeHistogramBuilder builder = new ApplicationTimeHistogramBuilder(toNode.getApplication(), range);
         return builder.build(inLink.getLinkDataList());
     }
 
-    public List<TimeHistogramViewModel> getTargetApplicationTimeSeriesHistogram(TimeHistogramFormat format) {
-        ApplicationTimeHistogram targetApplicationTimeHistogramData = getTargetApplicationTimeSeriesHistogramData();
-        return targetApplicationTimeHistogramData.createViewModel(format);
-    }
 
     public ApplicationTimeHistogram getTargetApplicationTimeSeriesHistogramData() {
         // we need Target (to)'s time since time in link is RPC-based
@@ -203,12 +190,10 @@ public class Link {
         this.outLink.addLinkDataMap(outLinkCallDataMap);
     }
 
-    public JsonFields<AgentNameView, List<TimeHistogramViewModel>> getSourceAgentTimeSeriesHistogram(TimeHistogramFormat format) {
+    public AgentTimeHistogram getSourceAgentTimeSeriesHistogram() {
         // we need Target (to)'s time since time in link is RPC-based
         AgentTimeHistogramBuilder builder = new AgentTimeHistogramBuilder(toNode.getApplication(), range);
-        AgentTimeHistogram applicationTimeSeriesHistogram = builder.buildSource(inLink);
-
-        return applicationTimeSeriesHistogram.createViewModel(format);
+        return builder.buildSource(inLink);
     }
 
     public AgentTimeHistogram getTargetAgentTimeHistogram() {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkHistogramSummaryView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkHistogramSummaryView.java
@@ -27,6 +27,7 @@ public class LinkHistogramSummaryView {
 
     public List<TimeHistogramViewModel> getTimeSeriesHistogram() {
         ApplicationTimeHistogram histogram = linkHistogramSummary.getLinkApplicationTimeHistogram();
-        return histogram.createViewModel(format);
+        TimeHistogramBuilder builder = new TimeHistogramBuilder(format);
+        return builder.build(histogram);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.navercorp.pinpoint.common.server.util.json.JsonFields;
+import com.navercorp.pinpoint.web.applicationmap.histogram.AgentTimeHistogram;
+import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationTimeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
 import com.navercorp.pinpoint.web.applicationmap.link.Link;
@@ -158,9 +160,11 @@ public class LinkView {
         }
 
         private void writeTimeSeriesHistogram(Link link, TimeHistogramFormat format, JsonGenerator jgen) throws IOException {
-            List<TimeHistogramViewModel> sourceApplicationTimeSeriesHistogram = link.getLinkApplicationTimeSeriesHistogram(format);
+            ApplicationTimeHistogram linkApplicationTimeSeriesHistogram = link.getLinkApplicationTimeSeriesHistogram();
+            TimeHistogramBuilder builder = new TimeHistogramBuilder(format);
+            List<TimeHistogramViewModel> sourceApplicationHistogram = builder.build(linkApplicationTimeSeriesHistogram);
             jgen.writeFieldName("timeSeriesHistogram");
-            jgen.writeObject(sourceApplicationTimeSeriesHistogram);
+            jgen.writeObject(sourceApplicationHistogram);
         }
 
         private void writeAgentResponseStatistics(String fieldName, Collection<AgentHistogram> agentHistogramList, JsonGenerator jgen) throws IOException {
@@ -186,8 +190,8 @@ public class LinkView {
         private void writeSourceAgentTimeSeriesHistogram(LinkView linkView, JsonGenerator jgen) throws IOException {
             Link link = linkView.getLink();
             TimeHistogramFormat format = linkView.getFormat();
-            JsonFields<AgentNameView, List<TimeHistogramViewModel>> sourceAgentTimeSeriesHistogram = link.getSourceAgentTimeSeriesHistogram(format);
-//        sourceAgentTimeSeriesHistogram.setFieldName("sourceTimeSeriesHistogram");
+            AgentTimeHistogram agentTimeHistogram = link.getSourceAgentTimeSeriesHistogram();
+            JsonFields<AgentNameView, List<TimeHistogramViewModel>> sourceAgentTimeSeriesHistogram = agentTimeHistogram.createViewModel(format);
             jgen.writeFieldName("sourceTimeSeriesHistogram");
             jgen.writeObject(sourceAgentTimeSeriesHistogram);
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeHistogramSummaryView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeHistogramSummaryView.java
@@ -63,7 +63,8 @@ public class NodeHistogramSummaryView {
         if (applicationTimeHistogram == null) {
             return List.of();
         }
-        return applicationTimeHistogram.createViewModel(format);
+        TimeHistogramBuilder builder = new TimeHistogramBuilder(format);
+        return builder.build(applicationTimeHistogram);
     }
 
     public JsonFields<AgentNameView, List<TimeHistogramViewModel>> getAgentTimeSeriesHistogram() {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
@@ -203,7 +203,8 @@ public class NodeView {
                     final TimeHistogramFormat format = nodeView.getFormat();
 
                     ApplicationTimeHistogram applicationTimeHistogram = nodeHistogram.getApplicationTimeHistogram();
-                    List<TimeHistogramViewModel> applicationTimeSeriesHistogram = applicationTimeHistogram.createViewModel(format);
+                    TimeHistogramBuilder builder = new TimeHistogramBuilder(format);
+                    List<TimeHistogramViewModel> applicationTimeSeriesHistogram = builder.build(applicationTimeHistogram);
                     if (applicationTimeSeriesHistogram == null) {
                         JacksonWriterUtils.writeEmptyArray(jgen, "timeSeriesHistogram");
                     } else {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/TimeHistogramBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/TimeHistogramBuilder.java
@@ -1,5 +1,6 @@
 package com.navercorp.pinpoint.web.applicationmap.view;
 
+import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationTimeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -21,5 +22,11 @@ public class TimeHistogramBuilder {
             case V2 -> new LoadTimeViewModelBuilder(histogramList).build();
             case V3 -> new TimeseriesHistogramViewModelBuilder(application, histogramList).build();
         };
+    }
+
+    public List<TimeHistogramViewModel> build(ApplicationTimeHistogram histogram) {
+        Objects.requireNonNull(histogram, "histogram");
+
+        return build(histogram.getApplication(), histogram.getHistogramList());
     }
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogramTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogramTest.java
@@ -60,7 +60,7 @@ public class AgentTimeHistogramTest {
         List<ResponseTime> responseHistogramList = createResponseTime(app, "test1", "test2");
         AgentTimeHistogram histogram = builder.build(responseHistogramList);
 
-        JsonFields<AgentNameView, List<TimeHistogramViewModel>> viewModel = histogram.createViewModel(TimeHistogramFormat.V1);
+        JsonFields<AgentNameView, List<TimeHistogramViewModel>> viewModel = histogram.createViewModel(TimeHistogramFormat.V3);
         logger.debug("{}", viewModel);
 
         String json = mapper.writeValueAsString(viewModel);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogramTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogramTest.java
@@ -25,6 +25,7 @@ import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkKey;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkCallData;
+import com.navercorp.pinpoint.web.applicationmap.view.TimeHistogramBuilder;
 import com.navercorp.pinpoint.web.applicationmap.view.TimeHistogramViewModel;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
@@ -53,7 +54,8 @@ public class ApplicationTimeHistogramTest {
         List<ResponseTime> responseHistogramList = createResponseTime(app);
         ApplicationTimeHistogram histogram = builder.build(responseHistogramList);
 
-        List<TimeHistogramViewModel> viewModel = histogram.createViewModel(TimeHistogramFormat.V1);
+        TimeHistogramBuilder builder1 = new TimeHistogramBuilder(TimeHistogramFormat.V3);
+        List<TimeHistogramViewModel> viewModel = builder1.build(histogram);
         logger.debug("{}", viewModel);
         ObjectWriter writer = mapper.writer();
         String s = writer.writeValueAsString(viewModel);
@@ -87,7 +89,8 @@ public class ApplicationTimeHistogramTest {
 
         ApplicationTimeHistogram histogram = builder.build(responseHistogramList);
 
-        List<TimeHistogramViewModel> viewModelList = histogram.createViewModel(TimeHistogramFormat.V2);
+        TimeHistogramBuilder histogramBuilder = new TimeHistogramBuilder(TimeHistogramFormat.V3);
+        List<TimeHistogramViewModel> viewModelList = histogramBuilder.build(histogram);
         logger.debug("{}", viewModelList);
     }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/view/LinkViewTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/view/LinkViewTest.java
@@ -47,7 +47,7 @@ public class LinkViewTest {
 
     @Test
     public void testSerializeV1() throws JsonProcessingException {
-        TimeHistogramFormat version = TimeHistogramFormat.V1;
+        TimeHistogramFormat version = TimeHistogramFormat.V3;
         LinkView linkView = newLinkView(version);
 
         ObjectWriter objectWriter = MAPPER.writerWithDefaultPrettyPrinter();
@@ -58,7 +58,7 @@ public class LinkViewTest {
 
     @Test
     public void testSerializeV2() throws JsonProcessingException {
-        TimeHistogramFormat version = TimeHistogramFormat.V2;
+        TimeHistogramFormat version = TimeHistogramFormat.V3;
         LinkView linkView = newLinkView(version);
 
         ObjectWriter objectWriter = MAPPER.writerWithDefaultPrettyPrinter();


### PR DESCRIPTION
This pull request refactors how `TimeHistogramViewModel` objects are created by removing the `createViewModel` methods from histogram classes and centralizing the logic in the `TimeHistogramBuilder` class. It also updates the codebase to use the new `TimeHistogramBuilder` approach consistently across all relevant components and tests.

### Refactoring and Code Simplification:
* Removed the `createViewModel` methods from `ApplicationTimeHistogram` and `AgentTimeHistogram` classes, and introduced a new `build` method in `TimeHistogramBuilder` to handle the creation of `TimeHistogramViewModel` objects. (`[[1]](diffhunk://#diff-0853178934b25eb0f0aae7bdbcd3d3b3667133360556fa485b8fcd180b968940L43-R42)`, `[[2]](diffhunk://#diff-382ee40347acc7118a25c093dd4f1a4bbb9926b7ed06845106a10477baa64267L206-R196)`, `[[3]](diffhunk://#diff-83d23c9089f0726c0cafc0e8eb35e8fd17b5c6cf16d0a81fd8d74f4d2e86d82cR26-R31)`)
* Updated all usages of the removed `createViewModel` methods to leverage the `TimeHistogramBuilder` class instead. (`[[1]](diffhunk://#diff-1021f6fd4dd6100beacb7bfcd2bdb5fc33b12b5580d9e1274e334d8a5a55df53L30-R31)`, `[[2]](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dL161-R167)`, `[[3]](diffhunk://#diff-4f258a718f20ea3bce74c9f3e9ab8bda7ca1c9781973a5c97374cfccfa18a1e4L66-R67)`, `[[4]](diffhunk://#diff-283e153fc2bfe9495312ec388b0570be6d8dfdcb230261ad8429607a4fdc0cc9L206-R207)`)

### Dependency Cleanup:
* Removed unused imports related to the removed `createViewModel` methods from various files, including `Link.java` and `ApplicationTimeHistogram.java`. (`[[1]](diffhunk://#diff-0853178934b25eb0f0aae7bdbcd3d3b3667133360556fa485b8fcd180b968940L19-L20)`, `[[2]](diffhunk://#diff-382ee40347acc7118a25c093dd4f1a4bbb9926b7ed06845106a10477baa64267L20-L39)`)

### Test Updates:
* Updated test cases to use the new `TimeHistogramBuilder` for creating `TimeHistogramViewModel` objects. (`[[1]](diffhunk://#diff-eb1e8d3969face944f05154b85bfe10129e5426695d331d9dce63b8141c3ef3fL63-R63)`, `[[2]](diffhunk://#diff-061065b16eb7a379122d59901123c3e61d90da40db63de57e66744fcbe61cd8aL56-R58)`, `[[3]](diffhunk://#diff-061065b16eb7a379122d59901123c3e61d90da40db63de57e66744fcbe61cd8aL90-R93)`)
* Changed the default `TimeHistogramFormat` used in tests from `V1` to `V3` to align with the updated implementation. (`[web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImplTest.javaL113-R114](diffhunk://#diff-bd921a1834dccb93fa4c3c85a81ed5e13dee2ee980b08f4fb565a4690b7f8385L113-R114)`)

### API Changes:
* Simplified the API for accessing histogram data in the `Link` and `NodeHistogramSummaryView` classes by removing format-specific methods and exposing raw histogram data. (`[[1]](diffhunk://#diff-382ee40347acc7118a25c093dd4f1a4bbb9926b7ed06845106a10477baa64267L160-L182)`, `[[2]](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dL189-R194)`)