### PR TITLE
[#noissue] Cleanup down sampling 

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/MapOutLinkDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/MapOutLinkDataCollector.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.collector;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapOutLinkDao;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
@@ -60,7 +61,8 @@ public class MapOutLinkDataCollector extends DataCollector {
         }
 
         Range between = Range.between(timeSlotEndTime - slotInterval, timeSlotEndTime);
-        LinkDataMap outLinkDataMap = mapOutLinkDao.selectOutLink(application, between, false);
+        TimeWindow timeWindow = new TimeWindow(between);
+        LinkDataMap outLinkDataMap = mapOutLinkDao.selectOutLink(application, timeWindow, false);
 
         for (LinkData linkData : outLinkDataMap.getLinkDataList()) {
             LinkCallDataMap linkCallDataMap = linkData.getLinkCallDataMap();

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountToCalleCheckerTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.MapOutLinkDataCollector;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -53,7 +53,7 @@ public class ErrorCountToCalleCheckerTest {
         dao = new MapOutLinkDao() {
 
             @Override
-            public LinkDataMap selectOutLink(Application outApplication, Range range, boolean timeAggregated) {
+            public LinkDataMap selectOutLink(Application outApplication, TimeWindow timeWindow, boolean timeAggregated) {
                 long timeStamp = 1409814914298L;
                 LinkDataMap linkDataMap = new LinkDataMap();
                 Application fromApplication = new Application(FROM_SERVICE_NAME, ServiceType.STAND_ALONE);

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateToCalleCheckerTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.MapOutLinkDataCollector;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -50,7 +50,7 @@ public class ErrorRateToCalleCheckerTest {
         dao = new MapOutLinkDao() {
 
             @Override
-            public LinkDataMap selectOutLink(Application outApplication, Range range, boolean timeAggregated) {
+            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range, boolean timeAggregated) {
                 long timeStamp = 1409814914298L;
                 LinkDataMap linkDataMap = new LinkDataMap();
                 Application fromApplication = new Application(FROM_SERVICE_NAME, ServiceType.STAND_ALONE);

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountToCalleCheckerTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.MapOutLinkDataCollector;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -49,7 +49,7 @@ public class SlowCountToCalleCheckerTest {
         dao = new MapOutLinkDao() {
 
             @Override
-            public LinkDataMap selectOutLink(Application outApplication, Range range, boolean timeAggregated) {
+            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range, boolean timeAggregated) {
                 long timeStamp = 1409814914298L;
                 LinkDataMap linkDataMap = new LinkDataMap();
                 Application fromApplication = new Application(FROM_SERVICE_NAME, ServiceType.STAND_ALONE);

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateToCalleCheckerTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.MapOutLinkDataCollector;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -49,7 +49,7 @@ public class SlowRateToCalleCheckerTest {
         dao = new MapOutLinkDao() {
 
             @Override
-            public LinkDataMap selectOutLink(Application outApplication, Range range, boolean timeAggregated) {
+            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range, boolean timeAggregated) {
                 long timeStamp = 1409814914298L;
                 LinkDataMap linkDataMap = new LinkDataMap();
                 Application fromApplication = new Application(FROM_SERVICE_NAME, ServiceType.STAND_ALONE);

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/TotalCountToCalleeCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/TotalCountToCalleeCheckerTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.MapOutLinkDataCollector;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -49,7 +49,7 @@ public class TotalCountToCalleeCheckerTest {
         dao = new MapOutLinkDao() {
 
             @Override
-            public LinkDataMap selectOutLink(Application outApplication, Range range, boolean timeAggregated) {
+            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range, boolean timeAggregated) {
                 long timeStamp = 1409814914298L;
                 LinkDataMap linkDataMap = new LinkDataMap();
                 Application fromApplication = new Application(FROM_SERVICE_NAME, ServiceType.STAND_ALONE);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java
@@ -102,7 +102,7 @@ public class MapController {
             @RequestParam(value = "useStatisticsAgentState", defaultValue = "false", required = false)
             boolean useStatisticsAgentState
     ) {
-        final Range range = toRange(rangeForm);
+        final TimeWindow timeWindow = newTimeWindow(rangeForm);
 
         final SearchOption searchOption = searchOptionBuilder()
                 .build(depthForm.getCallerRange(), depthForm.getCalleeRange(), bidirectional, wasOnly);
@@ -110,14 +110,13 @@ public class MapController {
         final Application application = getApplication(appForm);
 
         final MapServiceOption option = new MapServiceOption
-                .Builder(application, range, searchOption)
+                .Builder(application, timeWindow, searchOption)
                 .setUseStatisticsAgentState(useStatisticsAgentState)
                 .build();
 
         logger.info("Select applicationMap {}. option={}", TimeHistogramFormat.V3, option);
         final ApplicationMap map = this.mapService.selectApplicationMap(option);
 
-        TimeWindow timeWindow = new TimeWindow(range);
         return new MapViewV3(map, timeWindow, MapViews.ofBasic(), hyperLinkFactory);
     }
 
@@ -143,14 +142,14 @@ public class MapController {
             @RequestParam(value = "useLoadHistogramFormat", defaultValue = "false", required = false)
             boolean useLoadHistogramFormat
     ) {
-        final Range range = toRange(rangeForm);
+        final TimeWindow timeWindow = newTimeWindow(rangeForm);
 
         final SearchOption searchOption = searchOptionBuilder()
                 .build(depthForm.getCallerRange(), depthForm.getCalleeRange(), bidirectional, wasOnly);
         final Application application = getApplication(appForm);
 
         final MapServiceOption option = new MapServiceOption
-                .Builder(application, range, searchOption)
+                .Builder(application, timeWindow, searchOption)
                 .setUseStatisticsAgentState(useStatisticsAgentState)
                 .build();
 
@@ -174,14 +173,14 @@ public class MapController {
             @RequestParam(value = "wasOnly", defaultValue = "false", required = false) boolean wasOnly,
             @RequestParam(value = "useStatisticsAgentState", defaultValue = "false", required = false)
             boolean useStatisticsAgentState) {
-        final Range range = toRange(rangeForm);
+        final TimeWindow timeWindow = newTimeWindow(rangeForm);
 
         final Application application = getApplication(appForm);
         SearchOption searchOption = searchOptionBuilder()
                 .build(depthForm.getCallerRange(), depthForm.getCalleeRange(), bidirectional, wasOnly);
 
         final MapServiceOption option = new MapServiceOption
-                .Builder(application, range, searchOption)
+                .Builder(application, timeWindow, searchOption)
                 .setSimpleResponseHistogram(true)
                 .setUseStatisticsAgentState(useStatisticsAgentState)
                 .build();
@@ -196,9 +195,9 @@ public class MapController {
         return applicationValidator.newApplication(appForm.getApplicationName(), appForm.getServiceTypeCode(), appForm.getServiceTypeName());
     }
 
-    private Range toRange(RangeForm rangeForm) {
+    private TimeWindow newTimeWindow(RangeForm rangeForm) {
         Range between = Range.between(rangeForm.getFrom(), rangeForm.getTo());
         this.rangeValidator.validate(between);
-        return between;
+        return new TimeWindow(between);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapHistogramController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapHistogramController.java
@@ -20,6 +20,7 @@ package com.navercorp.pinpoint.web.applicationmap.controller;
 import com.navercorp.pinpoint.common.timeseries.time.ForwardRangeValidator;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.time.RangeValidator;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.controller.form.ApplicationForm;
 import com.navercorp.pinpoint.web.applicationmap.controller.form.RangeForm;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
@@ -230,11 +231,12 @@ public class MapHistogramController {
     ) {
         final Range range = toRange(rangeForm);
         this.rangeValidator.validate(range);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         final Application fromApplication = this.createApplication(fromApplicationName, fromServiceTypeCode);
         final Application toApplication = this.createApplication(toApplicationName, toServiceTypeCode);
         final LinkHistogramSummary linkHistogramSummary =
-                responseTimeHistogramService.selectLinkHistogramData(fromApplication, toApplication, range);
+                responseTimeHistogramService.selectLinkHistogramData(fromApplication, toApplication, timeWindow);
 
         TimeHistogramFormat format = TimeHistogramFormat.format(useLoadHistogramFormat);
         return new LinkHistogramSummaryView(linkHistogramSummary, format);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapInLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapInLinkDao.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.dao;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -27,6 +27,6 @@ import com.navercorp.pinpoint.web.vo.Application;
  * 
  */
 public interface MapInLinkDao {
-    LinkDataMap selectInLink(Application inApplication, Range range, boolean timeAggregated);
+    LinkDataMap selectInLink(Application inApplication, TimeWindow timeWindow, boolean timeAggregated);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapOutLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapOutLinkDao.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.dao;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -27,6 +27,6 @@ import com.navercorp.pinpoint.web.vo.Application;
  * 
  */
 public interface MapOutLinkDao {
-   LinkDataMap selectOutLink(Application outApplication, Range range, boolean timeAggregated);
+   LinkDataMap selectOutLink(Application outApplication, TimeWindow timeWindow, boolean timeAggregated);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java
@@ -23,9 +23,7 @@ import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
-import com.navercorp.pinpoint.common.timeseries.window.TimeWindowDownSampler;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapInLinkDao;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.LinkTimeWindowReducer;
@@ -81,17 +79,15 @@ public class HbaseMapInLinkDao implements MapInLinkDao {
     }
 
     @Override
-    public LinkDataMap selectInLink(Application inApplication, Range range, boolean timeAggregated) {
+    public LinkDataMap selectInLink(Application inApplication, TimeWindow timeWindow, boolean timeAggregated) {
         Objects.requireNonNull(inApplication, "inApplication");
-        Objects.requireNonNull(range, "range");
-
-        final TimeWindow timeWindow = new TimeWindow(range, TimeWindowDownSampler.SAMPLER);
+        Objects.requireNonNull(timeWindow, "timeWindow");
 
         TimeWindowFunction mapperWindow = newTimeWindow(timeAggregated);
         RowMapper<LinkDataMap> rowMapper = this.inLinkMapperFactory.newMapper(mapperWindow);
         ResultsExtractor<LinkDataMap> resultExtractor = new RowMapReduceResultExtractor<>(rowMapper, new LinkTimeWindowReducer(timeWindow));
 
-        final Scan scan = scanFactory.createScan("MapInLinkScan", inApplication, range, DESCRIPTOR.getName());
+        final Scan scan = scanFactory.createScan("MapInLinkScan", inApplication, timeWindow.getWindowRange(), DESCRIPTOR.getName());
 
         return selectInLink(scan, DESCRIPTOR.getTable(), resultExtractor, MAP_STATISTICS_CALLER_VER2_NUM_PARTITIONS);
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -23,9 +23,7 @@ import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
-import com.navercorp.pinpoint.common.timeseries.window.TimeWindowDownSampler;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapOutLinkDao;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.LinkTimeWindowReducer;
@@ -81,16 +79,14 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
     }
 
     @Override
-    public LinkDataMap selectOutLink(Application outApplication, Range range, boolean timeAggregated) {
-
-        final TimeWindow timeWindow = new TimeWindow(range, TimeWindowDownSampler.SAMPLER);
+    public LinkDataMap selectOutLink(Application outApplication, TimeWindow timeWindow, boolean timeAggregated) {
 
         TimeWindowFunction mapperWindow = newTimeWindow(timeAggregated);
         RowMapper<LinkDataMap> rowMapper = this.outMapperFactory.newMapper(mapperWindow);
 
         ResultsExtractor<LinkDataMap> resultExtractor = new RowMapReduceResultExtractor<>(rowMapper, new LinkTimeWindowReducer(timeWindow));
 
-        final Scan scan = scanFactory.createScan("MapOutLinkScan", outApplication, range, DESCRIPTOR.getName());
+        final Scan scan = scanFactory.createScan("MapOutLinkScan", outApplication, timeWindow.getWindowRange(), DESCRIPTOR.getName());
         return selectOutLink(scan, DESCRIPTOR.getTable(), resultExtractor, MAP_STATISTICS_CALLEE_VER2_NUM_PARTITIONS);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/BidirectionalLinkSelector.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/BidirectionalLinkSelector.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataDuplexMap;
 import com.navercorp.pinpoint.web.applicationmap.service.SearchDepth;
 import com.navercorp.pinpoint.web.security.ServerMapDataFilter;
@@ -59,19 +59,19 @@ public class BidirectionalLinkSelector implements LinkSelector {
     }
 
     @Override
-    public LinkDataDuplexMap select(List<Application> sourceApplications, Range range, int outSearchDepth, int inSearchDepth) {
-        return select(sourceApplications, range, outSearchDepth, inSearchDepth, false);
+    public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth) {
+        return select(sourceApplications, timeWindow, outSearchDepth, inSearchDepth, false);
     }
 
     @Override
-    public LinkDataDuplexMap select(List<Application> sourceApplications, Range range, int outSearchDepth, int inSearchDepth, boolean timeAggregated) {
+    public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth, boolean timeAggregated) {
         logger.debug("Creating link data map for {}", sourceApplications);
         final SearchDepth outDepth = new SearchDepth(outSearchDepth);
         final SearchDepth inDepth = new SearchDepth(inSearchDepth);
 
         LinkDataDuplexMap linkDataDuplexMap = new LinkDataDuplexMap();
         List<Application> applications = filterApplications(sourceApplications);
-        LinkSelectContext linkSelectContext = new LinkSelectContext(range, outDepth, inDepth, linkVisitChecker, timeAggregated);
+        LinkSelectContext linkSelectContext = new LinkSelectContext(timeWindow, outDepth, inDepth, linkVisitChecker, timeAggregated);
 
         while (!applications.isEmpty()) {
 
@@ -85,7 +85,7 @@ public class BidirectionalLinkSelector implements LinkSelector {
             applications = filterApplications(nextApplications);
             linkSelectContext = linkSelectContext.advance();
         }
-        return virtualLinkHandler.processVirtualLinks(linkDataDuplexMap, linkVisitChecker, range);
+        return virtualLinkHandler.processVirtualLinks(linkDataDuplexMap, linkVisitChecker, timeWindow);
     }
 
     private List<Application> filterApplications(List<Application> applications) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelectContext.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelectContext.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.service.SearchDepth;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -38,7 +38,7 @@ public class LinkSelectContext {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
-    private final Range range;
+    private final TimeWindow timeWindow;
     private final SearchDepth outDepth;
     private final SearchDepth inDepth;
 
@@ -47,17 +47,17 @@ public class LinkSelectContext {
 
     private final Set<Application> nextApplications = ConcurrentHashMap.newKeySet();
 
-    public LinkSelectContext(Range range, SearchDepth outDepth, SearchDepth inDepth,
+    public LinkSelectContext(TimeWindow timeWindow, SearchDepth outDepth, SearchDepth inDepth,
                              LinkVisitChecker linkVisitChecker, boolean timeAggregated) {
-        this.range = Objects.requireNonNull(range, "range");
+        this.timeWindow = Objects.requireNonNull(timeWindow, "timeWindow");
         this.outDepth = Objects.requireNonNull(outDepth, "outDepth");
         this.inDepth = Objects.requireNonNull(inDepth, "inDepth");
         this.linkVisitChecker = Objects.requireNonNull(linkVisitChecker, "linkVisitChecker");
         this.timeAggregated = timeAggregated;
     }
 
-    public Range getRange() {
-        return range;
+    public TimeWindow getTimeWindow() {
+        return timeWindow;
     }
 
     public int getOutDepth() {
@@ -106,6 +106,6 @@ public class LinkSelectContext {
     public LinkSelectContext advance() {
         SearchDepth nextOutDepth = outDepth.nextDepth();
         SearchDepth nextInDepth = inDepth.nextDepth();
-        return new LinkSelectContext(range, nextOutDepth, nextInDepth, linkVisitChecker, timeAggregated);
+        return new LinkSelectContext(timeWindow, nextOutDepth, nextInDepth, linkVisitChecker, timeAggregated);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelector.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelector.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataDuplexMap;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -27,7 +27,7 @@ import java.util.List;
  * @author emeroad
  */
 public interface LinkSelector {
-    LinkDataDuplexMap select(List<Application> sourceApplications, Range range, int outSearchDepth, int inSearchDepth);
+    LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth);
 
-    LinkDataDuplexMap select(List<Application> sourceApplications, Range range, int outSearchDepth, int inSearchDepth, boolean timeAggregated);
+    LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth, boolean timeAggregated);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/UnidirectionalLinkSelector.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/UnidirectionalLinkSelector.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataDuplexMap;
 import com.navercorp.pinpoint.web.applicationmap.service.SearchDepth;
@@ -56,12 +56,12 @@ public class UnidirectionalLinkSelector implements LinkSelector {
     }
 
     @Override
-    public LinkDataDuplexMap select(List<Application> sourceApplications, Range range, int outSearchDepth, int inSearchDepth) {
-        return select(sourceApplications, range, outSearchDepth, inSearchDepth, false);
+    public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth) {
+        return select(sourceApplications, timeWindow, outSearchDepth, inSearchDepth, false);
     }
 
     @Override
-    public LinkDataDuplexMap select(List<Application> sourceApplications, Range range, int outSearchDepth, int inSearchDepth, boolean timeAggregated) {
+    public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth, boolean timeAggregated) {
         logger.debug("Creating link data map for {}", sourceApplications);
         final SearchDepth outDepth = new SearchDepth(outSearchDepth);
         final SearchDepth inDepth = new SearchDepth(inSearchDepth);
@@ -70,9 +70,9 @@ public class UnidirectionalLinkSelector implements LinkSelector {
         List<Application> applications = filterApplications(sourceApplications);
 
         List<Application> outboundApplications = Collections.unmodifiableList(applications);
-        LinkSelectContext outboundLinkSelectContext = new LinkSelectContext(range, outDepth, new SearchDepth(0), linkVisitChecker, timeAggregated);
+        LinkSelectContext outboundLinkSelectContext = new LinkSelectContext(timeWindow, outDepth, new SearchDepth(0), linkVisitChecker, timeAggregated);
         List<Application> inboundApplications = Collections.unmodifiableList(applications);
-        LinkSelectContext inboundLinkSelectContext = new LinkSelectContext(range, new SearchDepth(0), inDepth, linkVisitChecker, timeAggregated);
+        LinkSelectContext inboundLinkSelectContext = new LinkSelectContext(timeWindow, new SearchDepth(0), inDepth, linkVisitChecker, timeAggregated);
 
         while (!outboundApplications.isEmpty() || !inboundApplications.isEmpty()) {
 
@@ -93,7 +93,7 @@ public class UnidirectionalLinkSelector implements LinkSelector {
             outboundLinkSelectContext = outboundLinkSelectContext.advance();
             inboundLinkSelectContext = inboundLinkSelectContext.advance();
         }
-        return virtualLinkHandler.processVirtualLinks(linkDataDuplexMap, linkVisitChecker, range);
+        return virtualLinkHandler.processVirtualLinks(linkDataDuplexMap, linkVisitChecker, timeWindow);
     }
 
     private List<Application> filterApplications(List<Application> applications) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkHandler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkHandler.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkKey;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkCallData;
@@ -53,7 +53,7 @@ public class VirtualLinkHandler {
         this.virtualLinkMarker = Objects.requireNonNull(virtualLinkMarker, "virtualLinkMarker");
     }
 
-    public LinkDataDuplexMap processVirtualLinks(LinkDataDuplexMap linkDataDuplexMap, LinkVisitChecker linkVisitChecker, Range range) {
+    public LinkDataDuplexMap processVirtualLinks(LinkDataDuplexMap linkDataDuplexMap, LinkVisitChecker linkVisitChecker, TimeWindow timeWindow) {
         Set<LinkData> virtualLinkDataSet = virtualLinkMarker.getVirtualLinkData();
         if (virtualLinkDataSet.isEmpty()) {
             return linkDataDuplexMap;
@@ -65,7 +65,7 @@ public class VirtualLinkHandler {
         } else {
             logger.info("unpopulated emulated nodes : {}", unpopulatedEmulatedNodes);
             for (Application unpopulatedEmulatedNode : unpopulatedEmulatedNodes) {
-                for (LinkData emulatedNodeInLinkData : getEmulatedNodeInLinkData(linkVisitChecker, unpopulatedEmulatedNode, range)) {
+                for (LinkData emulatedNodeInLinkData : getEmulatedNodeInLinkData(linkVisitChecker, unpopulatedEmulatedNode, timeWindow)) {
                     linkDataDuplexMap.addTargetLinkData(emulatedNodeInLinkData);
                 }
             }
@@ -86,8 +86,8 @@ public class VirtualLinkHandler {
         return new ArrayList<>(unpopulatedEmulatedNodes);
     }
 
-    private Collection<LinkData> getEmulatedNodeInLinkData(LinkVisitChecker linkVisitChecker, Application emulatedNode, Range range) {
-        LinkDataMap inLinkDataMap = linkDataMapService.selectInLinkDataMap(emulatedNode, range, false);
+    private Collection<LinkData> getEmulatedNodeInLinkData(LinkVisitChecker linkVisitChecker, Application emulatedNode, TimeWindow timeWindow) {
+        LinkDataMap inLinkDataMap = linkDataMapService.selectInLinkDataMap(emulatedNode, timeWindow, false);
         logger.debug("emulated node [{}] in LinkDataMap:{}", emulatedNode, inLinkDataMap);
 
         LinkDataMap filteredInLinkDataMap = new LinkDataMap();

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/ApplicationFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/ApplicationFilter.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
@@ -37,7 +37,7 @@ public class ApplicationFilter implements LinkDataMapProcessor {
     }
 
     @Override
-    public LinkDataMap processLinkDataMap(LinkDirection linkDirection, LinkDataMap linkDataMap, Range range) {
+    public LinkDataMap processLinkDataMap(LinkDirection linkDirection, LinkDataMap linkDataMap, TimeWindow timeWindow) {
         Objects.requireNonNull(linkDataMap, "linkDataMap");
 
         final LinkDataMap filteredLinkDataMap = new LinkDataMap();

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/ApplicationLimiterProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/ApplicationLimiterProcessor.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
@@ -54,7 +54,7 @@ public class ApplicationLimiterProcessor implements LinkDataMapProcessor {
 
 
     @Override
-    public LinkDataMap processLinkDataMap(LinkDirection direction, LinkDataMap linkDataMap, Range range) {
+    public LinkDataMap processLinkDataMap(LinkDirection direction, LinkDataMap linkDataMap, TimeWindow timeWindow) {
         final int linkSize = linkDataMap.size();
         final int remain = remain(linkSize);
         if (remain == EMPTY) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/DestinationApplicationFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/DestinationApplicationFilter.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
@@ -45,7 +45,7 @@ public class DestinationApplicationFilter implements LinkDataMapProcessor {
     }
 
     @Override
-    public LinkDataMap processLinkDataMap(LinkDirection linkDirection, LinkDataMap linkDataMap, Range range) {
+    public LinkDataMap processLinkDataMap(LinkDirection linkDirection, LinkDataMap linkDataMap, TimeWindow timeWindow) {
         final LinkDataMap filteredLinkDataMap = new LinkDataMap();
         for (LinkData linkData : linkDataMap.getLinkDataList()) {
             if (accept(linkData)) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/LinkDataMapProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/LinkDataMapProcessor.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 
@@ -26,11 +26,11 @@ import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
  */
 public interface LinkDataMapProcessor {
 
-    LinkDataMap processLinkDataMap(LinkDirection direction, LinkDataMap linkDataMap, Range range);
+    LinkDataMap processLinkDataMap(LinkDirection direction, LinkDataMap linkDataMap, TimeWindow timeWindow);
 
     LinkDataMapProcessor NO_OP = new LinkDataMapProcessor() {
         @Override
-        public LinkDataMap processLinkDataMap(LinkDirection direction, LinkDataMap linkDataMap, Range range) {
+        public LinkDataMap processLinkDataMap(LinkDirection direction, LinkDataMap linkDataMap, TimeWindow timeWindow) {
             return linkDataMap;
         }
     };

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/LinkDataMapProcessors.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/LinkDataMapProcessors.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 
@@ -38,10 +38,10 @@ public class LinkDataMapProcessors implements LinkDataMapProcessor {
     }
 
     @Override
-    public LinkDataMap processLinkDataMap(LinkDirection linkDirection, LinkDataMap linkDataMap, Range range) {
+    public LinkDataMap processLinkDataMap(LinkDirection linkDirection, LinkDataMap linkDataMap, TimeWindow timeWindow) {
         LinkDataMap processedLinkDataMap = linkDataMap;
         for (LinkDataMapProcessor linkDataMapProcessor : linkDataMapProcessors) {
-            processedLinkDataMap = linkDataMapProcessor.processLinkDataMap(linkDirection, processedLinkDataMap, range);
+            processedLinkDataMap = linkDataMapProcessor.processLinkDataMap(linkDirection, processedLinkDataMap, timeWindow);
         }
         return processedLinkDataMap;
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
@@ -61,23 +62,23 @@ public class RpcCallProcessor implements LinkDataMapProcessor {
     }
 
     @Override
-    public LinkDataMap processLinkDataMap(LinkDirection direction, LinkDataMap linkDataMap, Range range) {
+    public LinkDataMap processLinkDataMap(LinkDirection direction, LinkDataMap linkDataMap, TimeWindow timeWindow) {
         final LinkDataMap replacedLinkDataMap = new LinkDataMap();
         for (LinkData linkData : linkDataMap.getLinkDataList()) {
-            final List<LinkData> replacedLinkDatas = replaceLinkData(direction, linkData, range);
+            final List<LinkData> replacedLinkDatas = replaceLinkData(direction, linkData, timeWindow);
             for (LinkData replacedLinkData : replacedLinkDatas)
                 replacedLinkDataMap.addLinkData(replacedLinkData);
         }
         return replacedLinkDataMap;
     }
 
-    private List<LinkData> replaceLinkData(LinkDirection direction, LinkData linkData, Range range) {
+    private List<LinkData> replaceLinkData(LinkDirection direction, LinkData linkData, TimeWindow timeWindow) {
         final Application toApplication = linkData.getToApplication();
         if (toApplication.getServiceType().isRpcClient() || toApplication.getServiceType().isQueue()) {
             // rpc client's destination could have an agent installed in which case the link data must be replaced to point
             // to the destination application.
-            logger.debug("Finding {} accept applications for {}, {}", direction, toApplication, range);
-            final Set<AcceptApplication> acceptApplicationList = findAcceptApplications(linkData.getFromApplication(), toApplication.getName(), range);
+            logger.debug("Finding {} accept applications for {}, {}", direction, toApplication, timeWindow.getWindowRange());
+            final Set<AcceptApplication> acceptApplicationList = findAcceptApplications(linkData.getFromApplication(), toApplication.getName(), timeWindow.getWindowRange());
             logger.debug("Found {} accept applications: {}", direction, acceptApplicationList);
             if (CollectionUtils.hasLength(acceptApplicationList)) {
                 if (acceptApplicationList.size() == 1) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/SourceApplicationFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/SourceApplicationFilter.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
@@ -47,7 +47,7 @@ public class SourceApplicationFilter implements LinkDataMapProcessor {
     }
 
     @Override
-    public LinkDataMap processLinkDataMap(LinkDirection linkDirection, LinkDataMap linkDataMap, Range range) {
+    public LinkDataMap processLinkDataMap(LinkDirection linkDirection, LinkDataMap linkDataMap, TimeWindow timeWindow) {
         final LinkDataMap filteredLinkDataMap = new LinkDataMap();
         for (LinkData linkData : linkDataMap.getLinkDataList()) {
             if (accept(linkData)) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/WasOnlyProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/WasOnlyProcessor.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
@@ -35,7 +35,7 @@ public class WasOnlyProcessor implements LinkDataMapProcessor {
     private final Logger logger = LogManager.getLogger(this.getClass());
 
     @Override
-    public LinkDataMap processLinkDataMap(LinkDirection linkDirection, LinkDataMap linkDataMap, Range range) {
+    public LinkDataMap processLinkDataMap(LinkDirection linkDirection, LinkDataMap linkDataMap, TimeWindow timeWindow) {
         final LinkDataMap filteredLinkDataMap = new LinkDataMap();
         for (LinkData linkData : linkDataMap.getLinkDataList()) {
             if (accept(linkData)) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/LinkDataMapService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/LinkDataMapService.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.service;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -26,7 +26,7 @@ import com.navercorp.pinpoint.web.vo.Application;
  */
 public interface LinkDataMapService {
 
-    LinkDataMap selectOutLinkDataMap(Application outApplication, Range range, boolean timeAggregated);
+    LinkDataMap selectOutLinkDataMap(Application outApplication, TimeWindow timeWindow, boolean timeAggregated);
 
-    LinkDataMap selectInLinkDataMap(Application inApplication, Range range, boolean timeAggregated);
+    LinkDataMap selectInLinkDataMap(Application inApplication, TimeWindow timeWindow, boolean timeAggregated);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/LinkDataMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/LinkDataMapServiceImpl.java
@@ -17,7 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.service;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapInLinkDao;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapOutLinkDao;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
@@ -42,12 +42,12 @@ public class LinkDataMapServiceImpl implements LinkDataMapService {
     }
 
     @Override
-    public LinkDataMap selectOutLinkDataMap(Application outApplication, Range range, boolean timeAggregated) {
-        return mapOutLinkDao.selectOutLink(outApplication, range, timeAggregated);
+    public LinkDataMap selectOutLinkDataMap(Application outApplication, TimeWindow timeWindow, boolean timeAggregated) {
+        return mapOutLinkDao.selectOutLink(outApplication, timeWindow, timeAggregated);
     }
 
     @Override
-    public LinkDataMap selectInLinkDataMap(Application inApplication, Range range, boolean timeAggregated) {
-        return mapInLinkDao.selectInLink(inApplication, range, timeAggregated);
+    public LinkDataMap selectInLinkDataMap(Application inApplication, TimeWindow timeWindow, boolean timeAggregated) {
+        return mapInLinkDao.selectInLink(inApplication, timeWindow, timeAggregated);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceImpl.java
@@ -17,6 +17,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.service;
 
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMap;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMapBuilder;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMapBuilderFactory;
@@ -110,7 +111,9 @@ public class MapServiceImpl implements MapService {
         }
         LinkDataMapProcessor inLinkProcessor = LinkDataMapProcessor.NO_OP;
         LinkSelector linkSelector = linkSelectorFactory.createLinkSelector(linkSelectorType, outLinkProcessor, inLinkProcessor);
-        LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(Collections.singletonList(option.getSourceApplication()), option.getRange(), outSearchDepth, inSearchDepth, timeAggregate);
+
+        TimeWindow timeWindow = option.getTimeWindow();
+        LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(Collections.singletonList(option.getSourceApplication()), timeWindow, outSearchDepth, inSearchDepth, timeAggregate);
         watch.stop();
 
         if (linkDataLimiter.excess(linkDataDuplexMap.getTotalCount())) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceOption.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceOption.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.applicationmap.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.SearchOption;
 
@@ -28,7 +29,7 @@ import java.util.Objects;
  */
 public class MapServiceOption {
     private final Application sourceApplication;
-    private final Range range;
+    private final TimeWindow timeWindow;
     private final SearchOption searchOption;
 
     private final boolean simpleResponseHistogram;
@@ -36,7 +37,7 @@ public class MapServiceOption {
 
     private MapServiceOption(Builder builder) {
         this.sourceApplication = builder.sourceApplication;
-        this.range = builder.range;
+        this.timeWindow = builder.timeWindow;
         this.searchOption = builder.searchOption;
         this.simpleResponseHistogram = builder.simpleResponseHistogram;
         this.useStatisticsAgentState = builder.useStatisticsAgentState;
@@ -47,7 +48,11 @@ public class MapServiceOption {
     }
 
     public Range getRange() {
-        return range;
+        return timeWindow.getWindowRange();
+    }
+
+    public TimeWindow getTimeWindow() {
+        return timeWindow;
     }
 
     public SearchOption getSearchOption() {
@@ -66,7 +71,7 @@ public class MapServiceOption {
     public String toString() {
         return "MapServiceOption{" +
                 "sourceApplication=" + sourceApplication +
-                ", range=" + range +
+                ", timeWindow=" + timeWindow +
                 ", searchOption=" + searchOption +
                 ", simpleResponseHistogram=" + simpleResponseHistogram +
                 ", useStatisticsAgentState=" + useStatisticsAgentState +
@@ -75,16 +80,16 @@ public class MapServiceOption {
 
     public static class Builder {
         private final Application sourceApplication;
-        private final Range range;
+        private final TimeWindow timeWindow;
         private final SearchOption searchOption;
 
         private boolean simpleResponseHistogram;
         // option
         private boolean useStatisticsAgentState;
 
-        public Builder(Application sourceApplication, Range range, SearchOption searchOption) {
+        public Builder(Application sourceApplication, TimeWindow timeWindow, SearchOption searchOption) {
             this.sourceApplication = Objects.requireNonNull(sourceApplication, "sourceApplication");
-            this.range = Objects.requireNonNull(range,"range");
+            this.timeWindow = Objects.requireNonNull(timeWindow, "timeWindow");
             this.searchOption = Objects.requireNonNull(searchOption, "searchOption");
         }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramService.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.applicationmap.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkHistogramSummary;
 import com.navercorp.pinpoint.web.applicationmap.nodes.NodeHistogramSummary;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.AgentHistogramList;
@@ -33,5 +34,5 @@ public interface ResponseTimeHistogramService {
 
     NodeHistogramSummary selectNodeHistogramData(ResponseTimeHistogramServiceOption option);
 
-    LinkHistogramSummary selectLinkHistogramData(Application fromApplication, Application toApplication, Range range);
+    LinkHistogramSummary selectLinkHistogramData(Application fromApplication, Application toApplication, TimeWindow range);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ResponseTimeController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ResponseTimeController.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.web.authorization.controller;
 import com.navercorp.pinpoint.common.timeseries.time.ForwardRangeValidator;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.time.RangeValidator;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationTimeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
@@ -262,12 +263,13 @@ public class ResponseTimeController {
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
+        final TimeWindow timeWindow = new TimeWindow(range);
 
         Application fromApplication = createApplication(fromApplicationName, fromServiceTypeCode, fromServiceTypeName);
         Application toApplication = createApplication(toApplicationName, toServiceTypeCode, toServiceTypeName);
 
         LinkHistogramSummary linkHistogramSummary =
-                responseTimeHistogramService.selectLinkHistogramData(fromApplication, toApplication, range);
+                responseTimeHistogramService.selectLinkHistogramData(fromApplication, toApplication, timeWindow);
 
         return newHistogramView(linkHistogramSummary);
     }
@@ -293,13 +295,14 @@ public class ResponseTimeController {
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
+        final TimeWindow timeWindow = new TimeWindow(range);
 
         Application fromApplication = createApplication(fromApplicationName, fromServiceTypeCode, fromServiceTypeName);
         Application toApplication = createApplication(toApplicationName, toServiceTypeCode, toServiceTypeName);
         TimeHistogramType timeHistogramType = TimeHistogramType.valueOf(type);
 
         LinkHistogramSummary linkHistogramSummary =
-                responseTimeHistogramService.selectLinkHistogramData(fromApplication, toApplication, range);
+                responseTimeHistogramService.selectLinkHistogramData(fromApplication, toApplication, timeWindow);
 
         ApplicationTimeHistogram histogram = linkHistogramSummary.getLinkApplicationTimeHistogram();
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/BidirectionalLinkSelectorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/BidirectionalLinkSelectorTest.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.applicationmap.map;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkKey;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
@@ -76,7 +77,7 @@ public class BidirectionalLinkSelectorTest extends LinkSelectorTestBase {
         LinkDataMap link_OUT_IN_to_OUT = new LinkDataMap();
         link_OUT_IN_to_OUT.addLinkData(APP_OUT_IN, "agentOutIn", APP_OUT, "agentOut", 1000, ServiceType.STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount);
 
-        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(Range.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
+        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
             @Override
             public LinkDataMap answer(InvocationOnMock invocation) throws Throwable {
                 Application callerApplication = invocation.getArgument(0);
@@ -97,7 +98,7 @@ public class BidirectionalLinkSelectorTest extends LinkSelectorTestBase {
                 return newEmptyLinkDataMap();
             }
         });
-        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(Range.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
+        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
             @Override
             public LinkDataMap answer(InvocationOnMock invocation) throws Throwable {
                 Application calleeApplication = invocation.getArgument(0);
@@ -121,7 +122,7 @@ public class BidirectionalLinkSelectorTest extends LinkSelectorTestBase {
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(Set.of());
 
         LinkSelector linkSelector = linkSelectorFactory.createLinkSelector(getLinkSelectorType());
-        LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(List.of(APP_A), range, 2, 2);
+        LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(List.of(APP_A), timeWindow, 2, 2);
 
         // APP_IN_IN -> APP_IN (callee)
         LinkKey linkKey_IN_IN_to_IN = new LinkKey(APP_IN_IN, APP_IN);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilderTest.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.util.UserNodeUtils;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.TestTraceUtils;
@@ -69,7 +70,8 @@ public class FilteredMapBuilderTest {
     public void twoTier() {
         // Given
         final Range range = Range.between(1, 200000);
-        final FilteredMapBuilder builder = new FilteredMapBuilder(applicationFactory, registry, range);
+        TimeWindow timeWindow = new TimeWindow(range);
+        final FilteredMapBuilder builder = new FilteredMapBuilder(applicationFactory, registry, timeWindow.getWindowRange());
 
         // root app span
         long rootSpanId = RANDOM.nextLong();

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/UnidirectionalLinkSelectorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/UnidirectionalLinkSelectorTest.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.applicationmap.map;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkKey;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
@@ -76,7 +77,7 @@ public class UnidirectionalLinkSelectorTest extends LinkSelectorTestBase {
         LinkDataMap link_OUT_IN_to_OUT = new LinkDataMap();
         link_OUT_IN_to_OUT.addLinkData(APP_OUT_IN, "agentOutIn", APP_OUT, "agentOut", 1000, ServiceType.STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount);
 
-        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(Range.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
+        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
             @Override
             public LinkDataMap answer(InvocationOnMock invocation) throws Throwable {
                 Application callerApplication = invocation.getArgument(0);
@@ -97,7 +98,7 @@ public class UnidirectionalLinkSelectorTest extends LinkSelectorTestBase {
                 return newEmptyLinkDataMap();
             }
         });
-        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(Range.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
+        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
             @Override
             public LinkDataMap answer(InvocationOnMock invocation) throws Throwable {
                 Application calleeApplication = invocation.getArgument(0);
@@ -121,7 +122,7 @@ public class UnidirectionalLinkSelectorTest extends LinkSelectorTestBase {
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(Set.of());
 
         LinkSelector linkSelector = linkSelectorFactory.createLinkSelector(getLinkSelectorType());
-        LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(List.of(APP_A), range, 2, 2);
+        LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(List.of(APP_A), timeWindow, 2, 2);
 
         // APP_IN_IN -> APP_IN -> APP_A(selected) -> APP_OUT -> APP_OUT_OUT
         //                 |-> APP_IN_OUT   APP_OUT_IN -^

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/processor/ApplicationLimiterProcessorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/processor/ApplicationLimiterProcessorTest.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
@@ -31,6 +32,7 @@ class ApplicationLimiterProcessorTest {
     Application application1 = new Application("test1", ServiceType.TEST);
     Application application2 = new Application("test2", ServiceType.TEST);
     Range between = Range.between(10, 100);
+    final TimeWindow timeWindow = new TimeWindow(between);
 
     @Test
     void limitReached() {
@@ -39,14 +41,14 @@ class ApplicationLimiterProcessorTest {
         LinkDataMap linkDataMap = new LinkDataMap();
         linkDataMap.addLinkData(new LinkData(application1, application1));
 
-        processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, between);
+        processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
         Assertions.assertFalse(processor.limitReached());
 
-        processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, between);
+        processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
         Assertions.assertFalse(processor.limitReached());
 
 
-        processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, between);
+        processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
         Assertions.assertTrue(processor.limitReached());
     }
 
@@ -58,17 +60,17 @@ class ApplicationLimiterProcessorTest {
         LinkDataMap linkDataMap = new LinkDataMap();
         linkDataMap.addLinkData(new LinkData(application1, application1));
 
-        processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, between);
+        processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
         Assertions.assertFalse(processor.limitReached());
 
         LinkDataMap linkDataMap2 = new LinkDataMap();
         linkDataMap2.addLinkData(new LinkData(application1, application1));
         linkDataMap2.addLinkData(new LinkData(application2, application2));
-        LinkDataMap replaceLink = processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap2, between);
+        LinkDataMap replaceLink = processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap2, timeWindow);
         Assertions.assertTrue(processor.limitReached());
         Assertions.assertEquals(1, replaceLink.size());
 
-        processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, between);
+        processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
         Assertions.assertTrue(processor.limitReached());
     }
 
@@ -79,11 +81,11 @@ class ApplicationLimiterProcessorTest {
         LinkDataMap linkDataMap = new LinkDataMap();
         linkDataMap.addLinkData(new LinkData(application1, application1));
 
-        LinkDataMap result = processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, between);
+        LinkDataMap result = processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
         Assertions.assertSame(linkDataMap, result);
 
         linkDataMap.addLinkData(new LinkData(application2, application2));
-        LinkDataMap result2 = processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, between);
+        LinkDataMap result2 = processor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
         Assertions.assertNotSame(linkDataMap, result2);
     }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessorTest.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkKey;
@@ -49,7 +50,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class RpcCallProcessorTest {
 
-    private final Range testRange = Range.between(System.currentTimeMillis(), System.currentTimeMillis());
+    private final TimeWindow timeWindow = new TimeWindow(Range.between(1000 * 60, 1000 * 60));
+    private final Range testRange = timeWindow.getWindowRange();
 
     @Mock
     private HostApplicationMapDao hostApplicationMapDao;
@@ -70,7 +72,7 @@ public class RpcCallProcessorTest {
         // When
         VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
         RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
-        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.OUT_LINK, linkDataMap, testRange);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.OUT_LINK, linkDataMap, timeWindow);
 
         // Then
         LinkKey linkKey = new LinkKey(fromApplication, toApplication);
@@ -100,7 +102,7 @@ public class RpcCallProcessorTest {
         // When
         VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
         RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
-        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, testRange);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         LinkKey originalLinkKey = new LinkKey(fromApplication, toApplication);
@@ -139,7 +141,7 @@ public class RpcCallProcessorTest {
         // When
         VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
         RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
-        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, testRange);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         LinkKey originalLinkKey = new LinkKey(fromApplication, toApplication);
@@ -181,7 +183,7 @@ public class RpcCallProcessorTest {
         // When
         VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
         RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
-        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, testRange);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         LinkKey originalLinkKey = new LinkKey(fromApplication, toApplication);
@@ -214,7 +216,7 @@ public class RpcCallProcessorTest {
         // When
         VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
         RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
-        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, testRange);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         LinkKey linkKey = new LinkKey(fromApplication, toApplication);
@@ -253,7 +255,7 @@ public class RpcCallProcessorTest {
         // When
         VirtualLinkMarker virtualLinkMarker = new VirtualLinkMarker();
         RpcCallProcessor rpcCallProcessor = new RpcCallProcessor(hostApplicationMapDao, virtualLinkMarker);
-        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, testRange);
+        LinkDataMap replacedLinkDataMap = rpcCallProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         LinkKey originalLinkKey = new LinkKey(fromApplication, toApplication);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/processor/WasOnlyProcessorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/processor/WasOnlyProcessorTest.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
 import com.navercorp.pinpoint.common.trace.ServiceTypeProperty;
@@ -35,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class WasOnlyProcessorTest {
 
     private final Range testRange = Range.between(System.currentTimeMillis(), System.currentTimeMillis());
+    private final TimeWindow timeWindow = new TimeWindow(testRange);
 
     @Test
     public void shouldFilterLinksToTerminalNodes() {
@@ -48,7 +50,7 @@ public class WasOnlyProcessorTest {
 
         // When
         WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
-        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, testRange);
+        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         assertThat(filteredLinkDataMap.getLinkDataList()).isEmpty();
@@ -65,7 +67,7 @@ public class WasOnlyProcessorTest {
 
         // When
         WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
-        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, testRange);
+        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         assertThat(filteredLinkDataMap.getLinkDataList()).isEmpty();
@@ -82,7 +84,7 @@ public class WasOnlyProcessorTest {
 
         // When
         WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
-        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, testRange);
+        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         assertThat(filteredLinkDataMap.getLinkDataList()).isNotEmpty();
@@ -99,7 +101,7 @@ public class WasOnlyProcessorTest {
 
         // When
         WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
-        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, testRange);
+        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         assertThat(filteredLinkDataMap.getLinkDataList()).isNotEmpty();

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.applicationmap.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -387,12 +388,13 @@ public class ResponseTimeHistogramServiceImplTest {
         final Application toApplication = new Application("WAS", ServiceType.STAND_ALONE);
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        final TimeWindow timeWindow = new TimeWindow(range);
 
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), eq(LinkDataMapProcessor.NO_OP), any(LinkDataMapProcessor.class)))
                 .thenReturn(createCalleeLinkSelector(List.of(new LinkKey(fromApplication, toApplication)), timestamp));
 
-        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, range);
+        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, timeWindow);
         Histogram histogram = linkHistogramSummary.getHistogram();
 
         logger.debug(linkHistogramSummary);
@@ -412,11 +414,12 @@ public class ResponseTimeHistogramServiceImplTest {
         final Application toApplication = new Application("was2", ServiceType.STAND_ALONE);
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        final TimeWindow timeWindow = new TimeWindow(range);
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), eq(LinkDataMapProcessor.NO_OP)))
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(fromApplication, toApplication)), timestamp));
 
-        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, range);
+        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, timeWindow);
         Histogram histogram = linkHistogramSummary.getHistogram();
 
         logger.debug(linkHistogramSummary);
@@ -436,11 +439,12 @@ public class ResponseTimeHistogramServiceImplTest {
         final Application toApplication = new Application("unknown", ServiceType.UNKNOWN);
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        final TimeWindow timeWindow = new TimeWindow(range);
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), eq(LinkDataMapProcessor.NO_OP)))
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(fromApplication, toApplication)), timestamp));
 
-        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, range);
+        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, timeWindow);
         Histogram histogram = linkHistogramSummary.getHistogram();
 
         logger.debug(linkHistogramSummary);
@@ -462,11 +466,12 @@ public class ResponseTimeHistogramServiceImplTest {
         final Application toApplication = new Application("cache", cacheServiceType);
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        final TimeWindow timeWindow = new TimeWindow(range);
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), eq(LinkDataMapProcessor.NO_OP)))
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(fromApplication, toApplication)), timestamp));
 
-        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, range);
+        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, timeWindow);
         Histogram histogram = linkHistogramSummary.getHistogram();
 
         logger.debug(linkHistogramSummary);
@@ -488,11 +493,12 @@ public class ResponseTimeHistogramServiceImplTest {
         final Application toApplication = new Application("queue", queueServiceType);
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        final TimeWindow timeWindow = new TimeWindow(range);
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), any(LinkDataMapProcessor.class)))
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(fromApplication, toApplication)), timestamp));
 
-        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, range);
+        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, timeWindow);
         Histogram histogram = linkHistogramSummary.getHistogram();
 
         logger.debug(linkHistogramSummary);
@@ -514,11 +520,12 @@ public class ResponseTimeHistogramServiceImplTest {
         final Application toApplication = new Application("was", ServiceType.STAND_ALONE);
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        final TimeWindow timeWindow = new TimeWindow(range);
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), any(LinkDataMapProcessor.class)))
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(fromApplication, toApplication)), timestamp));
 
-        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, range);
+        LinkHistogramSummary linkHistogramSummary = service.selectLinkHistogramData(fromApplication, toApplication, timeWindow);
         Histogram histogram = linkHistogramSummary.getHistogram();
 
         logger.debug(linkHistogramSummary);
@@ -530,7 +537,7 @@ public class ResponseTimeHistogramServiceImplTest {
     private LinkSelector createCallerLinkSelector(List<LinkKey> linkKeys, long timestamp) {
         return new LinkSelector() {
             @Override
-            public LinkDataDuplexMap select(List<Application> sourceApplications, Range range, int callerSearchDepth, int calleeSearchDepth) {
+            public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int callerSearchDepth, int calleeSearchDepth) {
                 if (calleeSearchDepth > 0) {
                     throw new IllegalArgumentException("use UNIDIRECTIONAL link selector only. calleeSearchDepth: " + calleeSearchDepth);
                 }
@@ -543,11 +550,11 @@ public class ResponseTimeHistogramServiceImplTest {
             }
 
             @Override
-            public LinkDataDuplexMap select(List<Application> sourceApplications, Range range, int callerSearchDepth, int calleeSearchDepth, boolean timeAggregated) {
+            public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int callerSearchDepth, int calleeSearchDepth, boolean timeAggregated) {
                 if (timeAggregated) {
                     throw new IllegalArgumentException("link histogram data require timeSeries data");
                 }
-                return select(sourceApplications, range, callerSearchDepth, calleeSearchDepth);
+                return select(sourceApplications, timeWindow, callerSearchDepth, calleeSearchDepth);
             }
         };
     }
@@ -555,7 +562,7 @@ public class ResponseTimeHistogramServiceImplTest {
     private LinkSelector createCalleeLinkSelector(List<LinkKey> linkKeys, long timestamp) {
         return new LinkSelector() {
             @Override
-            public LinkDataDuplexMap select(List<Application> sourceApplications, Range range, int callerSearchDepth, int calleeSearchDepth) {
+            public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int callerSearchDepth, int calleeSearchDepth) {
                 if (callerSearchDepth > 0) {
                     throw new IllegalArgumentException("use UNIDIRECTIONAL link selector only. callerSearchDepth: " + callerSearchDepth);
                 }
@@ -568,11 +575,11 @@ public class ResponseTimeHistogramServiceImplTest {
             }
 
             @Override
-            public LinkDataDuplexMap select(List<Application> sourceApplications, Range range, int callerSearchDepth, int calleeSearchDepth, boolean timeAggregated) {
+            public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int callerSearchDepth, int calleeSearchDepth, boolean timeAggregated) {
                 if (timeAggregated) {
                     throw new IllegalArgumentException("link histogram data require timeSeries data");
                 }
-                return select(sourceApplications, range, callerSearchDepth, calleeSearchDepth);
+                return select(sourceApplications, timeWindow, callerSearchDepth, calleeSearchDepth);
             }
         };
     }


### PR DESCRIPTION
This pull request refactors the codebase to replace the use of the `Range` class with the `TimeWindow` class across multiple files. This change standardizes time range handling and simplifies the API for interacting with time-based data. The updates affect both the main application logic and its corresponding test cases.

### Key Changes:

#### Replacement of `Range` with `TimeWindow`:
* Updated the `MapOutLinkDataCollector` and `MapController` to use `TimeWindow` instead of `Range` for handling time ranges (`batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/MapOutLinkDataCollector.java`, `web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java`). [[1]](diffhunk://#diff-55bae80948938d4edcdc1a23f1a8de66e0badb7a29dc5588cef2dc7f64ce671fL63-R65) [[2]](diffhunk://#diff-ac916486b6086ae6f8151796efc30db2d5bf67f063407946da563a6d83e974e1L105-L120) [[3]](diffhunk://#diff-ac916486b6086ae6f8151796efc30db2d5bf67f063407946da563a6d83e974e1L146-R152) [[4]](diffhunk://#diff-ac916486b6086ae6f8151796efc30db2d5bf67f063407946da563a6d83e974e1L177-R183) [[5]](diffhunk://#diff-ac916486b6086ae6f8151796efc30db2d5bf67f063407946da563a6d83e974e1L199-R201)
* Adjusted DAO interfaces (`MapInLinkDao`, `MapOutLinkDao`) and their HBase implementations to accept `TimeWindow` instead of `Range` (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapInLinkDao.java`, `web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapOutLinkDao.java`, `web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java`, `web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java`). [[1]](diffhunk://#diff-db0a4789125271c239e23bb62975ee0bbe46654a5462712f82180af57b43ff09L30-R30) [[2]](diffhunk://#diff-5c5bdb9956076855991561fe63dfaf5bc51f534bc91b4be0a6a7a9e9cb5c0b09L30-R30) [[3]](diffhunk://#diff-6d29fe1aaae0f5e05fbae2922b440299771bfdcd4a9a88f9ab7231b078c7a074L84-R90) F89077ebL81R79)

#### Test Updates:
* Updated test cases for alarm checkers to reflect the `TimeWindow` changes, ensuring compatibility with the modified DAO interfaces (`batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/*`). [[1]](diffhunk://#diff-8d797b5bd0dbbde91b894b62d5ee04953749760f7830441ab2175227a824d07fL56-R56) [[2]](diffhunk://#diff-1565965df12c1fb7e5a7ac317c2130060120f0ceb0744421531594523e5b611bL53-R53) [[3]](diffhunk://#diff-a3161493868d1ae24ae02d2ca83a27a4236959df8a1c26b170666c67837ab064L52-R52) [[4]](diffhunk://#diff-89426d43a92a708dfed90a9c0bcca3d53ec837e3a46ab9f5990cd55131287961L52-R52) [[5]](diffhunk://#diff-5f4c783ca2a854d22d0dcbc499374f18934366652241f912b25314d831bb15d1L52-R52)

#### Import Adjustments:
* Replaced imports of `Range` with `TimeWindow` in all affected files to align with the new implementation. [[1]](diffhunk://#diff-55bae80948938d4edcdc1a23f1a8de66e0badb7a29dc5588cef2dc7f64ce671fR20) [[2]](diffhunk://#diff-8d797b5bd0dbbde91b894b62d5ee04953749760f7830441ab2175227a824d07fL20-R20) [[3]](diffhunk://#diff-1565965df12c1fb7e5a7ac317c2130060120f0ceb0744421531594523e5b611bL20-R20) [[4]](diffhunk://#diff-a3161493868d1ae24ae02d2ca83a27a4236959df8a1c26b170666c67837ab064L20-R20) [[5]](diffhunk://#diff-89426d43a92a708dfed90a9c0bcca3d53ec837e3a46ab9f5990cd55131287961L20-R20) [[6]](diffhunk://#diff-5f4c783ca2a854d22d0dcbc499374f18934366652241f912b25314d831bb15d1L20-R20) [[7]](diffhunk://#diff-0dd263a724a6f99cd27b0f1639f34ed293abcd972de2701e3810559defdbb8baR23) [[8]](diffhunk://#diff-db0a4789125271c239e23bb62975ee0bbe46654a5462712f82180af57b43ff09L19-R19) [[9]](diffhunk://#diff-5c5bdb9956076855991561fe63dfaf5bc51f534bc91b4be0a6a7a9e9cb5c0b09L19-R19)

These changes improve the consistency of time range handling across the codebase, making it easier to maintain and extend in the future.