### PR TITLE
[#noissue] Refactor FilteredMap

### DIFF
--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ApdexScoreCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ApdexScoreCheckerTest.java
@@ -44,7 +44,7 @@ public class ApdexScoreCheckerTest {
     public static void before() {
         mockMapResponseDAO = (application, range) -> {
             long timeStamp = 1409814914298L;
-            ResponseTime responseTime = new ResponseTime(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
+            ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
 
             for (int i=0 ; i < 5; i++) {
                 for (int j=0 ; j < 5; j++) {
@@ -59,7 +59,7 @@ public class ApdexScoreCheckerTest {
                 timeStamp += 1;
             }
 
-            return List.of(responseTime);
+            return List.of(responseTime.build());
         };
     }
 

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountCheckerTest.java
@@ -48,7 +48,7 @@ public class ErrorCountCheckerTest {
             @Override
             public List<ResponseTime> selectResponseTime(Application application, Range range) {
                 long timeStamp = 1409814914298L;
-                ResponseTime responseTime = new ResponseTime(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
+                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
 
                 TimeHistogram histogram;
                 for (int i = 0; i < 5; i++) {
@@ -65,7 +65,7 @@ public class ErrorCountCheckerTest {
                     timeStamp += 1;
                 }
 
-                return List.of(responseTime);
+                return List.of(responseTime.build());
             }
         };
     }

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateCheckerTest.java
@@ -48,7 +48,7 @@ public class ErrorRateCheckerTest {
             @Override
             public List<ResponseTime> selectResponseTime(Application application, Range range) {
                 long timeStamp = 1409814914298L;
-                ResponseTime responseTime = new ResponseTime(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
+                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
 
                 TimeHistogram histogram;
                 for (int i = 0; i < 5; i++) {
@@ -65,7 +65,7 @@ public class ErrorRateCheckerTest {
                     timeStamp += 1;
                 }
 
-                return List.of(responseTime);
+                return List.of(responseTime.build());
             }
         };
     }

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ResponseCountCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ResponseCountCheckerTest.java
@@ -50,7 +50,7 @@ public class ResponseCountCheckerTest {
             @Override
             public List<ResponseTime> selectResponseTime(Application application, Range range) {
                 long timeStamp = 1409814914298L;
-                ResponseTime responseTime = new ResponseTime(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
+                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
 
                 TimeHistogram histogram;
                 for (int i = 0; i < 5; i++) {
@@ -67,7 +67,7 @@ public class ResponseCountCheckerTest {
                     timeStamp += 1;
                 }
 
-                return List.of(responseTime);
+                return List.of(responseTime.build());
             }
         };
     }

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountCheckerTest.java
@@ -48,7 +48,7 @@ public class SlowCountCheckerTest {
             @Override
             public List<ResponseTime> selectResponseTime(Application application, Range range) {
                 long timeStamp = 1409814914298L;
-                ResponseTime responseTime = new ResponseTime(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
+                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
                 TimeHistogram histogram;
                 for (int i = 0; i < 5; i++) {
                     for (int j = 0; j < 5; j++) {
@@ -64,7 +64,7 @@ public class SlowCountCheckerTest {
                     timeStamp += 1;
                 }
 
-                return List.of(responseTime);
+                return List.of(responseTime.build());
             }
         };
     }

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateCheckerTest.java
@@ -48,7 +48,7 @@ public class SlowRateCheckerTest {
             @Override
             public List<ResponseTime> selectResponseTime(Application application, Range range) {
                 long timeStamp = 1409814914298L;
-                ResponseTime responseTime = new ResponseTime(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
+                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
 
                 TimeHistogram histogram;
                 for (int i = 0; i < 5; i++) {
@@ -65,7 +65,7 @@ public class SlowRateCheckerTest {
                     timeStamp += 1;
                 }
 
-                return List.of(responseTime);
+                return List.of(responseTime.build());
             }
         };
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java
@@ -20,9 +20,7 @@ package com.navercorp.pinpoint.web.applicationmap.map;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.util.UserNodeUtils;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
-import com.navercorp.pinpoint.common.timeseries.window.TimeWindowDownSampler;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -77,14 +75,13 @@ public class FilteredMapBuilder {
 
     private final Map<String, Application> applicationHashMap = new HashMap<>();
 
-    public FilteredMapBuilder(ApplicationFactory applicationFactory, ServiceTypeRegistryService registry, Range range) {
+    public FilteredMapBuilder(ApplicationFactory applicationFactory, ServiceTypeRegistryService registry, TimeWindow timeWindow) {
         this.applicationFactory = Objects.requireNonNull(applicationFactory, "applicationFactory");
         this.registry = Objects.requireNonNull(registry, "registry");
 
-        Objects.requireNonNull(range, "range");
-        this.timeWindow = new TimeWindow(range, TimeWindowDownSampler.SAMPLER);
+        this.timeWindow = Objects.requireNonNull(timeWindow, "timeWindow");
         this.linkDataDuplexMap = new LinkDataDuplexMap();
-        this.responseHistogramsBuilder = new ResponseHistograms.Builder(range);
+        this.responseHistogramsBuilder = new ResponseHistograms.Builder(timeWindow);
         this.dotExtractor = new DotExtractor();
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImpl.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.hbase.bo.ColumnGetCount;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMap;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMapBuilder;
@@ -131,7 +132,9 @@ public class FilteredMapServiceImpl implements FilteredMapService {
 
     public ApplicationMap selectApplicationMap(FilteredMapServiceOption option) {
         final List<List<SpanBo>> filterList = selectFilteredSpan(option.getTransactionIdList(), option.getFilter(), option.getColumnGetCount());
-        FilteredMapBuilder filteredMapBuilder = new FilteredMapBuilder(applicationFactory, registry, option.getRange());
+        TimeWindow timeWindow = new TimeWindow(option.getRange());
+
+        FilteredMapBuilder filteredMapBuilder = new FilteredMapBuilder(applicationFactory, registry, timeWindow);
         filteredMapBuilder.serverMapDataFilter(serverMapDataFilter);
         filteredMapBuilder.addTransactions(filterList);
         FilteredMap filteredMap = filteredMapBuilder.build();
@@ -145,7 +148,9 @@ public class FilteredMapServiceImpl implements FilteredMapService {
 
         final List<List<SpanBo>> filterList = selectFilteredSpan(option.getTransactionIdList(), option.getFilter(), option.getColumnGetCount());
         Range scanRange = option.getRange();
-        FilteredMapBuilder filteredMapBuilder = new FilteredMapBuilder(applicationFactory, registry, scanRange);
+        TimeWindow timeWindow = new TimeWindow(scanRange);
+
+        FilteredMapBuilder filteredMapBuilder = new FilteredMapBuilder(applicationFactory, registry, timeWindow);
         filteredMapBuilder.serverMapDataFilter(serverMapDataFilter);
         filteredMapBuilder.addTransactions(filterList);
         FilteredMap filteredMap = filteredMapBuilder.build();

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
@@ -101,9 +101,9 @@ public class ApplicationMapBuilderTest {
                 String applicationName = application.getName();
                 ServiceType applicationServiceType = application.getServiceType();
                 int depth = ApplicationMapBuilderTestHelper.getDepthFromApplicationName(applicationName);
-                ResponseTime responseTime = new ResponseTime(application.getName(), application.getServiceType(), timestamp);
-                responseTime.addResponseTime(ApplicationMapBuilderTestHelper.createAgentIdFromDepth(depth), applicationServiceType.getHistogramSchema().getNormalSlot().getSlotTime(), 1);
-                return List.of(responseTime);
+                ResponseTime.Builder responseTimeBuilder = ResponseTime.newBuilder(application.getName(), application.getServiceType(), timestamp);
+                responseTimeBuilder.addResponseTime(ApplicationMapBuilderTestHelper.createAgentIdFromDepth(depth), applicationServiceType.getHistogramSchema().getNormalSlot().getSlotTime(), 1);
+                return List.of(responseTimeBuilder.build());
             }
         };
         when(mapResponseDao.selectResponseTime(any(Application.class), any(Range.class))).thenAnswer(responseTimeAnswer);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ResponseTimeMapperTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ResponseTimeMapperTest.java
@@ -60,9 +60,10 @@ public class ResponseTimeMapperTest {
                 .build();
 
         ResponseTimeMapper responseTimeMapper = new ResponseTimeMapper(mock(ServiceTypeRegistryService.class), mock(RowKeyDistributorByHashPrefix.class));
-        ResponseTime responseTime = new ResponseTime("applicationName", ServiceType.STAND_ALONE, System.currentTimeMillis());
-        responseTimeMapper.recordColumn(responseTime, mockCell);
+        ResponseTime.Builder responseBuilder = ResponseTime.newBuilder("applicationName", ServiceType.STAND_ALONE, System.currentTimeMillis());
+        responseTimeMapper.recordColumn(responseBuilder, mockCell);
 
+        ResponseTime responseTime = responseBuilder.build();
         Histogram agentHistogram = responseTime.findHistogram("agent");
 
         assertThat(agentHistogram)

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogramTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogramTest.java
@@ -107,19 +107,19 @@ public class AgentTimeHistogramTest {
 
     private List<ResponseTime> createResponseTime(Application app, String agentName1, String agentName2) {
 
-        ResponseTime one = new ResponseTime(app.getName(), app.getServiceType(), 0);
+        ResponseTime.Builder one = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 0);
         one.addResponseTime(agentName1, (short) 1000, 1);
 
-        ResponseTime two = new ResponseTime(app.getName(), app.getServiceType(), 1000 * 60);
+        ResponseTime.Builder two = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 1000 * 60);
         two.addResponseTime(agentName1, (short) 3000, 1);
 
-        ResponseTime three = new ResponseTime(app.getName(), app.getServiceType(), 0);
+        ResponseTime.Builder three = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 0);
         three.addResponseTime(agentName2, (short) 1000, 1);
 
-        ResponseTime four = new ResponseTime(app.getName(), app.getServiceType(), 1000 * 60);
+        ResponseTime.Builder four = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 1000 * 60);
         four.addResponseTime(agentName2, (short) 3000, 1);
 
-        return List.of(one, two, three, four);
+        return List.of(one.build(), two.build(), three.build(), four.build());
     }
 
     @Test

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogramTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogramTest.java
@@ -65,13 +65,13 @@ public class ApplicationTimeHistogramTest {
 
     private List<ResponseTime> createResponseTime(Application app) {
 
-        ResponseTime one = new ResponseTime(app.getName(), app.getServiceType(), 0);
+        ResponseTime.Builder one = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 0);
         one.addResponseTime("test", (short) 1000, 1);
 
-        ResponseTime two = new ResponseTime(app.getName(), app.getServiceType(), 1000 * 60);
+        ResponseTime.Builder two = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 1000 * 60);
         two.addResponseTime("test", (short) 3000, 1);
 
-        return List.of(one, two);
+        return List.of(one.build(), two.build());
     }
 
     @Test
@@ -82,10 +82,10 @@ public class ApplicationTimeHistogramTest {
 
         ApplicationTimeHistogramBuilder builder = new ApplicationTimeHistogramBuilder(app, range);
 
-        ResponseTime responseTime = new ResponseTime(app.getName(), app.getServiceType(), timestamp);
+        ResponseTime.Builder responseTime = new ResponseTime.Builder(app.getName(), app.getServiceType(), timestamp);
         responseTime.addResponseTime("test", (short) 1000, 1);
 
-        List<ResponseTime> responseHistogramList = List.of(responseTime);
+        List<ResponseTime> responseHistogramList = List.of(responseTime.build());
 
         ApplicationTimeHistogram histogram = builder.build(responseHistogramList);
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilderTest.java
@@ -71,7 +71,7 @@ public class FilteredMapBuilderTest {
         // Given
         final Range range = Range.between(1, 200000);
         TimeWindow timeWindow = new TimeWindow(range);
-        final FilteredMapBuilder builder = new FilteredMapBuilder(applicationFactory, registry, timeWindow.getWindowRange());
+        final FilteredMapBuilder builder = new FilteredMapBuilder(applicationFactory, registry, timeWindow);
 
         // root app span
         long rootSpanId = RANDOM.nextLong();

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImplTest.java
@@ -24,7 +24,6 @@ import com.navercorp.pinpoint.common.server.util.json.JsonField;
 import com.navercorp.pinpoint.common.server.util.json.JsonFields;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
-import com.navercorp.pinpoint.common.timeseries.window.TimeWindowDownSampler;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -160,8 +159,7 @@ public class FilteredMapServiceImplTest {
     public void twoTier() {
         // Given
         Range originalRange = Range.between(1000, 2000);
-        final TimeWindow timeWindow = new TimeWindow(originalRange, TimeWindowDownSampler.SAMPLER);
-
+        final TimeWindow timeWindow = new TimeWindow(originalRange);
         // root app span
         long rootSpanId = RANDOM.nextLong();
         long rootSpanStartTime = 1000L;

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
@@ -136,15 +136,15 @@ public class ResponseTimeHistogramServiceImplTest {
     }
 
     private ResponseTime createResponseTime(Application application, long timestamp) {
-        ResponseTime responseTime = new ResponseTime(application.getName(), application.getServiceType(), timestamp);
+        ResponseTime.Builder responseTimeBuilder = ResponseTime.newBuilder(application.getName(), application.getServiceType(), timestamp);
         HistogramSchema schema = application.getServiceType().getHistogramSchema();
-        responseTime.addResponseTime("agentId", schema.getFastSlot().getSlotTime(), 1L);
-        responseTime.addResponseTime("agentId", schema.getNormalSlot().getSlotTime(), 2L);
-        responseTime.addResponseTime("agentId", schema.getSlowSlot().getSlotTime(), 3L);
-        responseTime.addResponseTime("agentId", schema.getErrorSlot().getSlotTime(), 4L);
-        responseTime.addResponseTime("agentId", schema.getSumStatSlot().getSlotTime(), 1000L);
-        responseTime.addResponseTime("agentId", schema.getMaxStatSlot().getSlotTime(), 2000L);
-        return responseTime;
+        responseTimeBuilder.addResponseTime("agentId", schema.getFastSlot().getSlotTime(), 1L);
+        responseTimeBuilder.addResponseTime("agentId", schema.getNormalSlot().getSlotTime(), 2L);
+        responseTimeBuilder.addResponseTime("agentId", schema.getSlowSlot().getSlotTime(), 3L);
+        responseTimeBuilder.addResponseTime("agentId", schema.getErrorSlot().getSlotTime(), 4L);
+        responseTimeBuilder.addResponseTime("agentId", schema.getSumStatSlot().getSlotTime(), 1000L);
+        responseTimeBuilder.addResponseTime("agentId", schema.getMaxStatSlot().getSlotTime(), 2000L);
+        return responseTimeBuilder.build();
     }
 
     /**

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ApdexScoreServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ApdexScoreServiceImplTest.java
@@ -51,11 +51,11 @@ public class ApdexScoreServiceImplTest {
     }
 
     private ResponseTime createResponseTime(long timeStamp) {
-        ResponseTime responseTime = new ResponseTime(testApplication.getName(), testApplication.getServiceType(), timeStamp);
+        ResponseTime.Builder responseTimeBuilder = ResponseTime.newBuilder(testApplication.getName(), testApplication.getServiceType(), timeStamp);
         for (String agentId : agentIdList) {
-            responseTime.addResponseTime(agentId, createTestHistogram(1, 2, 3, 4, 5));
+            responseTimeBuilder.addResponseTime(agentId, createTestHistogram(1, 2, 3, 4, 5));
         }
-        return responseTime;
+        return responseTimeBuilder.build();
     }
 
     private Histogram createTestHistogram(long fast, long normal, long slow, long verySlow, long error) {

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ApplicationAgentListServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ApplicationAgentListServiceImplTest.java
@@ -76,9 +76,10 @@ public class ApplicationAgentListServiceImplTest {
 
         testAgentStatus = new AgentStatus(testAgentId, AgentLifeCycleState.RUNNING, 2000);
 
-        testResponseTime = new ResponseTime(testApplicationName, ServiceType.TEST, 3000);
+        ResponseTime.Builder builder = ResponseTime.newBuilder(testApplicationName, ServiceType.TEST, 3000);
         HistogramSlot testServicePingSlot = ServiceType.TEST.getHistogramSchema().getPingSlot();
-        testResponseTime.addResponseTime(testAgentId, testServicePingSlot.getSlotTime(), 1);
+        builder.addResponseTime(testAgentId, testServicePingSlot.getSlotTime(), 1);
+        this.testResponseTime = builder.build();
 
         LegacyAgentCompatibility legacyAgentCompatibility = mock(LegacyAgentCompatibility.class);
         lenient().when(legacyAgentCompatibility.isLegacyAgent(ArgumentMatchers.anyShort(), ArgumentMatchers.any())).thenReturn(false);

--- a/web/src/test/java/com/navercorp/pinpoint/web/vo/ResponseHistogramsTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/vo/ResponseHistogramsTest.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.vo;
 
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.TestTraceUtils;
@@ -41,11 +42,13 @@ public class ResponseHistogramsTest {
     public void empty() {
         // Given
         final Range range = Range.between(1, 200000);
+        final TimeWindow timeWindow = new TimeWindow(range);
+
         final String applicationName = "TEST_APP";
         final ServiceType serviceType = registry.findServiceType(TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE);
         final Application application = new Application(applicationName, serviceType);
 
-        ResponseHistograms.Builder builder = new ResponseHistograms.Builder(range);
+        ResponseHistograms.Builder builder = new ResponseHistograms.Builder(timeWindow);
         ResponseHistograms responseHistograms = builder.build();
 
         // When
@@ -59,12 +62,14 @@ public class ResponseHistogramsTest {
     public void nonExistentApplication() {
         // Given
         final Range range = Range.between(1, 200000);
+        final TimeWindow timeWindow = new TimeWindow(range);
+
         final String applicationName = "TEST_APP";
         final ServiceType serviceType = registry.findServiceType(TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE);
         final Application application = new Application(applicationName, serviceType);
         SpanBo fastSpan = new TestTraceUtils.SpanBuilder(applicationName, "test-app").elapsed(500).build();
 
-        ResponseHistograms.Builder builder = new ResponseHistograms.Builder(range);
+        ResponseHistograms.Builder builder = new ResponseHistograms.Builder(timeWindow);
         List<Long> timeslotIterator = builder.getWindow().getTimeseriesWindows();
         long timeslot = timeslotIterator.get(0);
         builder.addHistogram(application, fastSpan, timeslot);
@@ -84,6 +89,7 @@ public class ResponseHistogramsTest {
     public void timeslots() {
         // Given
         final Range range = Range.between(1, 200000);
+        final TimeWindow timeWindow = new TimeWindow(range);
         final String applicationName = "TEST_APP";
         final ServiceType serviceType = registry.findServiceType(TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE);
         final Application application = new Application(applicationName, serviceType);
@@ -94,7 +100,7 @@ public class ResponseHistogramsTest {
         SpanBo verySlowSpan = new TestTraceUtils.SpanBuilder(applicationName, "test-app").elapsed(5500).build();
         SpanBo errorSpan = new TestTraceUtils.SpanBuilder(applicationName, "test-app").elapsed(500).errorCode(1).build();
 
-        ResponseHistograms.Builder builder = new ResponseHistograms.Builder(range);
+        ResponseHistograms.Builder builder = new ResponseHistograms.Builder(timeWindow);
         Iterator<Long> timeslotIterator = builder.getWindow().getTimeseriesWindows().iterator();
         long timeslot1 = timeslotIterator.next();
         long timeslot2 = timeslotIterator.next();
@@ -145,6 +151,7 @@ public class ResponseHistogramsTest {
     public void multipleAgents() {
         // Given
         final Range range = Range.between(1, 200000);
+        final TimeWindow timeWindow = new TimeWindow(range);
         final String applicationName = "TEST_APP";
         final ServiceType serviceType = registry.findServiceType(TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE);
         final Application application = new Application(applicationName, serviceType);
@@ -160,7 +167,7 @@ public class ResponseHistogramsTest {
         SpanBo verySlowSpan = new TestTraceUtils.SpanBuilder(applicationName, verySlowAgentId).elapsed(5500).build();
         SpanBo errorSpan = new TestTraceUtils.SpanBuilder(applicationName, errorAgentId).elapsed(500).errorCode(1).build();
 
-        ResponseHistograms.Builder builder = new ResponseHistograms.Builder(range);
+        ResponseHistograms.Builder builder = new ResponseHistograms.Builder(timeWindow);
         long timeslot = builder.getWindow().getTimeseriesWindows().get(0);
         builder.addHistogram(application, fastSpan, timeslot);
         builder.addHistogram(application, normalSpan, timeslot);
@@ -194,6 +201,7 @@ public class ResponseHistogramsTest {
     public void multipleApplications() {
         // Given
         final Range range = Range.between(1, 200000);
+        final TimeWindow timeWindow = new TimeWindow(range);
         final String appAName = "APP_A";
         final ServiceType appAServiceType = registry.findServiceType(TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE);
         final Application appA = new Application(appAName, appAServiceType);
@@ -206,7 +214,7 @@ public class ResponseHistogramsTest {
         SpanBo appASpan = new TestTraceUtils.SpanBuilder(appAName, appAAgentId).elapsed(500).build();
         SpanBo appBSpan = new TestTraceUtils.SpanBuilder(appBName, appBAgentId).elapsed(1500).build();
 
-        ResponseHistograms.Builder builder = new ResponseHistograms.Builder(range);
+        ResponseHistograms.Builder builder = new ResponseHistograms.Builder(timeWindow);
         List<Long> timeslotIterator = builder.getWindow().getTimeseriesWindows();
         long timeslot = timeslotIterator.get(0);
 


### PR DESCRIPTION
This pull request refactors the handling of time ranges in the application map and response histogram components by replacing the `Range` and `TimeWindowDownSampler` classes with the `TimeWindow` class. The changes improve consistency and simplify the codebase. Additionally, a helper method for error determination was introduced in the `ResponseHistograms.Builder` class.

### Refactoring to use `TimeWindow`:

* **Replaced `Range` and `TimeWindowDownSampler` with `TimeWindow` in constructors and methods:**
  - Updated the `FilteredMapBuilder` constructor to accept a `TimeWindow` object instead of a `Range` and removed the use of `TimeWindowDownSampler`. (`FilteredMapBuilder.java`, [web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.javaL80-R84](diffhunk://#diff-391cf5eafd5e0eacd7297befcb97d98db7c673b97b531f06730616b7b4a0138aL80-R84))
  - Adjusted the `ResponseHistograms.Builder` constructor to use a `TimeWindow` object instead of a `Range`. (`ResponseHistograms.java`, [web/src/main/java/com/navercorp/pinpoint/web/vo/ResponseHistograms.javaL55-R57](diffhunk://#diff-9253bbcbe7c703cf91ce6694a6808c95f248d61de6f32b29b46c51c11e711bdaL55-R57))
  - Updated method calls in `FilteredMapServiceImpl` to construct and pass a `TimeWindow` object instead of a `Range`. (`FilteredMapServiceImpl.java`, [[1]](diffhunk://#diff-154c8813f020a7214570caaef085d59e121e0f171eaeb3310343627782747fb2L134-R137) [[2]](diffhunk://#diff-154c8813f020a7214570caaef085d59e121e0f171eaeb3310343627782747fb2L148-R153)

* **Updated test cases to align with `TimeWindow` changes:**
  - Modified test cases in `FilteredMapBuilderTest`, `FilteredMapServiceImplTest`, and `ResponseHistogramsTest` to use `TimeWindow` objects instead of `Range`. (`FilteredMapBuilderTest.java`, [[1]](diffhunk://#diff-07b786e702e603b7d30e07d029620712ba3aa2f92dc3ca9e7b8440996f08294eL74-R74); `FilteredMapServiceImplTest.java`, [[2]](diffhunk://#diff-bd921a1834dccb93fa4c3c85a81ed5e13dee2ee980b08f4fb565a4690b7f8385L163-R162); `ResponseHistogramsTest.java`, [[3]](diffhunk://#diff-9eb591a1c974dd1fcb64e942b3acaed9ef1b6da586e8277513bd389aab822313R45-R51) [[4]](diffhunk://#diff-9eb591a1c974dd1fcb64e942b3acaed9ef1b6da586e8277513bd389aab822313R65-R72) [[5]](diffhunk://#diff-9eb591a1c974dd1fcb64e942b3acaed9ef1b6da586e8277513bd389aab822313L97-R103) [[6]](diffhunk://#diff-9eb591a1c974dd1fcb64e942b3acaed9ef1b6da586e8277513bd389aab822313L163-R170)

### Code simplification:

* **Introduced `isError` helper method:**
  - Added a private `isError` method in `ResponseHistograms.Builder` to encapsulate the logic for determining whether a `SpanBo` object represents an error. This improves readability and reusability. (`ResponseHistograms.java`, [web/src/main/java/com/navercorp/pinpoint/web/vo/ResponseHistograms.javaL71-R80](diffhunk://#diff-9253bbcbe7c703cf91ce6694a6808c95f248d61de6f32b29b46c51c11e711bdaL71-R80))

These changes collectively improve the maintainability and clarity of the codebase, ensuring better handling of time-related data and reducing redundancy.