### PR TITLE
[#noissue] Refactor FilteredMap

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/ResponseTimeDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/ResponseTimeDataCollector.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.collector;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
@@ -65,7 +66,8 @@ public class ResponseTimeDataCollector extends DataCollector {
         }
 
         Range range = Range.between(timeSlotEndTime - slotInterval, timeSlotEndTime);
-        List<ResponseTime> responseTimes = responseDao.selectResponseTime(application, range);
+        TimeWindow timeWindow = new TimeWindow(range);
+        List<ResponseTime> responseTimes = responseDao.selectResponseTime(application, timeWindow);
 
         for (ResponseTime responseTime : responseTimes) {
             sum(responseTime.getAgentResponseHistogramList());

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountCheckerTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -46,7 +46,7 @@ public class ErrorCountCheckerTest {
         mockMapResponseDAO = new MapResponseDao() {
 
             @Override
-            public List<ResponseTime> selectResponseTime(Application application, Range range) {
+            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
                 long timeStamp = 1409814914298L;
                 ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
 

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateCheckerTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -46,7 +46,7 @@ public class ErrorRateCheckerTest {
         mockMapResponseDAO = new MapResponseDao() {
 
             @Override
-            public List<ResponseTime> selectResponseTime(Application application, Range range) {
+            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
                 long timeStamp = 1409814914298L;
                 ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
 

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ResponseCountCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ResponseCountCheckerTest.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.DataCollectorFactory;
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -48,7 +48,7 @@ public class ResponseCountCheckerTest {
         mockMapResponseDAO = new MapResponseDao() {
 
             @Override
-            public List<ResponseTime> selectResponseTime(Application application, Range range) {
+            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
                 long timeStamp = 1409814914298L;
                 ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
 

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountCheckerTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -46,7 +46,7 @@ public class SlowCountCheckerTest {
         mockMapResponseDAO = new MapResponseDao() {
 
             @Override
-            public List<ResponseTime> selectResponseTime(Application application, Range range) {
+            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
                 long timeStamp = 1409814914298L;
                 ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
                 TimeHistogram histogram;

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateCheckerTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -46,7 +46,7 @@ public class SlowRateCheckerTest {
         mockMapResponseDAO = new MapResponseDao() {
 
             @Override
-            public List<ResponseTime> selectResponseTime(Application application, Range range) {
+            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
                 long timeStamp = 1409814914298L;
                 ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilder.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.EmptyNodeHistogramFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.NodeHistogramAppender;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.NodeHistogramAppenderFactory;
@@ -48,6 +49,8 @@ public class ApplicationMapBuilder {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
+
+    private final TimeWindow timeWindow;
     private final Range range;
 
     private final NodeHistogramAppenderFactory nodeHistogramAppenderFactory;
@@ -56,9 +59,11 @@ public class ApplicationMapBuilder {
     private NodeHistogramFactory nodeHistogramFactory;
     private ServerGroupListFactory serverGroupListFactory;
 
-    public ApplicationMapBuilder(Range range, NodeHistogramAppenderFactory nodeHistogramAppenderFactory,
+    public ApplicationMapBuilder(TimeWindow timeWindow,
+                                 NodeHistogramAppenderFactory nodeHistogramAppenderFactory,
                                  ServerInfoAppenderFactory serverInfoAppenderFactory) {
-        this.range = Objects.requireNonNull(range, "range");
+        this.timeWindow = Objects.requireNonNull(timeWindow, "timeWindow");
+        this.range = timeWindow.getWindowRange();
         this.nodeHistogramAppenderFactory = Objects.requireNonNull(nodeHistogramAppenderFactory, "nodeHistogramAppenderFactory");
         this.serverInfoAppenderFactory = Objects.requireNonNull(serverInfoAppenderFactory, "serverInfoAppenderFactory");
     }
@@ -85,9 +90,9 @@ public class ApplicationMapBuilder {
         NodeHistogramAppender nodeHistogramAppender = nodeHistogramAppenderFactory.create(nodeHistogramFactory);
 
         LinkList emptyLinkList = LinkList.of();
-        nodeHistogramAppender.appendNodeHistogram(range, nodeList, emptyLinkList, timeoutMillis);
+        nodeHistogramAppender.appendNodeHistogram(timeWindow, nodeList, emptyLinkList, timeoutMillis);
 
-        return DefaultApplicationMap.build(nodeList, emptyLinkList, range);
+        return DefaultApplicationMap.build(nodeList, emptyLinkList, timeWindow.getWindowRange());
     }
 
     private NodeList getNodeList(Application application) {
@@ -118,7 +123,7 @@ public class ApplicationMapBuilder {
 
         NodeHistogramAppender nodeHistogramAppender = nodeHistogramAppenderFactory.create(nodeHistogramFactory);
         final TimeoutWatcher timeoutWatcher = new TimeoutWatcher(timeoutMillis);
-        nodeHistogramAppender.appendNodeHistogram(range, nodeList, linkList, timeoutWatcher.remainingTimeMillis());
+        nodeHistogramAppender.appendNodeHistogram(timeWindow, nodeList, linkList, timeoutWatcher.remainingTimeMillis());
 
         ServerGroupListFactory serverGroupListFactory = this.serverGroupListFactory;
         if (serverGroupListFactory == null) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderFactory.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.NodeHistogramAppenderFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.server.ServerInfoAppenderFactory;
 
@@ -37,7 +37,7 @@ public class ApplicationMapBuilderFactory {
         this.serverInfoAppenderFactory = serverInfoAppenderFactory;
     }
 
-    public ApplicationMapBuilder createApplicationMapBuilder(Range range) {
-        return new ApplicationMapBuilder(range, nodeHistogramAppenderFactory, serverInfoAppenderFactory);
+    public ApplicationMapBuilder createApplicationMapBuilder(TimeWindow timeWindow) {
+        return new ApplicationMapBuilder(timeWindow, nodeHistogramAppenderFactory, serverInfoAppenderFactory);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/DefaultNodeHistogramFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/DefaultNodeHistogramFactory.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.appender.histogram;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.WasNodeHistogramDataSource;
 import com.navercorp.pinpoint.web.applicationmap.histogram.AgentTimeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.AgentTimeHistogramBuilder;
@@ -52,8 +53,8 @@ public class DefaultNodeHistogramFactory implements NodeHistogramFactory {
     }
 
     @Override
-    public NodeHistogram createWasNodeHistogram(Application wasApplication, Range range) {
-        return wasNodeHistogramDataSource.createNodeHistogram(wasApplication, range);
+    public NodeHistogram createWasNodeHistogram(Application wasApplication, TimeWindow timeWindow) {
+        return wasNodeHistogramDataSource.createNodeHistogram(wasApplication, timeWindow);
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/EmptyNodeHistogramFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/EmptyNodeHistogramFactory.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.appender.histogram;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkList;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -27,8 +28,8 @@ import com.navercorp.pinpoint.web.vo.Application;
 public class EmptyNodeHistogramFactory implements NodeHistogramFactory {
 
     @Override
-    public NodeHistogram createWasNodeHistogram(Application wasApplication, Range range) {
-        return NodeHistogram.empty(wasApplication, range);
+    public NodeHistogram createWasNodeHistogram(Application wasApplication,  TimeWindow timeWindow) {
+        return NodeHistogram.empty(wasApplication, timeWindow.getWindowRange());
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/NodeHistogramAppender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/NodeHistogramAppender.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.appender.histogram;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkList;
 import com.navercorp.pinpoint.web.applicationmap.nodes.NodeList;
 
@@ -25,5 +25,5 @@ import com.navercorp.pinpoint.web.applicationmap.nodes.NodeList;
  */
 public interface NodeHistogramAppender {
 
-    void appendNodeHistogram(Range range, NodeList nodeList, LinkList linkList, long timeoutMillis);
+    void appendNodeHistogram(TimeWindow timeWindow, NodeList nodeList, LinkList linkList, long timeoutMillis);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/NodeHistogramFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/NodeHistogramFactory.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.appender.histogram;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkList;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -26,7 +27,7 @@ import com.navercorp.pinpoint.web.vo.Application;
  */
 public interface NodeHistogramFactory {
 
-    NodeHistogram createWasNodeHistogram(Application wasApplication, Range range);
+    NodeHistogram createWasNodeHistogram(Application wasApplication, TimeWindow timeWindow);
 
     NodeHistogram createTerminalNodeHistogram(Application terminalApplication, Range range, LinkList linkList);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/SimplifiedNodeHistogramFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/SimplifiedNodeHistogramFactory.java
@@ -1,6 +1,7 @@
 package com.navercorp.pinpoint.web.applicationmap.appender.histogram;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.WasNodeHistogramDataSource;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
@@ -30,8 +31,8 @@ public class SimplifiedNodeHistogramFactory implements NodeHistogramFactory {
     }
 
     @Override
-    public NodeHistogram createWasNodeHistogram(Application wasApplication, Range range) {
-        return wasNodeHistogramDataSource.createNodeHistogram(wasApplication, range);
+    public NodeHistogram createWasNodeHistogram(Application wasApplication, TimeWindow timeWindow) {
+        return wasNodeHistogramDataSource.createNodeHistogram(wasApplication, timeWindow);
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/MapResponseNodeHistogramDataSource.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/MapResponseNodeHistogramDataSource.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
 import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -37,10 +38,11 @@ public class MapResponseNodeHistogramDataSource implements WasNodeHistogramDataS
     }
 
     @Override
-    public NodeHistogram createNodeHistogram(Application application, Range range) {
-        List<ResponseTime> responseTimes = mapResponseDao.selectResponseTime(application, range);
+    public NodeHistogram createNodeHistogram(Application application, TimeWindow timeWindow) {
+        List<ResponseTime> responseTimes = mapResponseDao.selectResponseTime(application, timeWindow);
 
-        NodeHistogram.Builder builder = NodeHistogram.newBuilder(application, range);
+        Range windowRange = timeWindow.getWindowRange();
+        NodeHistogram.Builder builder = NodeHistogram.newBuilder(application, windowRange);
         builder.setResponseHistogram(responseTimes);
         return builder.build();
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/MapResponseSimplifiedNodeHistogramDataSource.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/MapResponseSimplifiedNodeHistogramDataSource.java
@@ -1,7 +1,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
 import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -19,10 +19,10 @@ public class MapResponseSimplifiedNodeHistogramDataSource implements WasNodeHist
     }
 
     @Override
-    public NodeHistogram createNodeHistogram(Application application, Range range) {
-        List<ResponseTime> responseTimes = mapResponseDao.selectResponseTime(application, range);
+    public NodeHistogram createNodeHistogram(Application application, TimeWindow timeWindow) {
+        List<ResponseTime> responseTimes = mapResponseDao.selectResponseTime(application, timeWindow);
 
-        NodeHistogram.Builder builder = NodeHistogram.newBuilder(application, range);
+        NodeHistogram.Builder builder = NodeHistogram.newBuilder(application, timeWindow.getWindowRange());
         builder.setApplicationHistogram(responseTimes);
         builder.setAgentHistogramMap(responseTimes);
         return builder.build();

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/ResponseHistogramsNodeHistogramDataSource.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/ResponseHistogramsNodeHistogramDataSource.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseHistograms;
@@ -37,10 +37,10 @@ public class ResponseHistogramsNodeHistogramDataSource implements WasNodeHistogr
     }
 
     @Override
-    public NodeHistogram createNodeHistogram(Application application, Range range) {
+    public NodeHistogram createNodeHistogram(Application application, TimeWindow timeWindow) {
         List<ResponseTime> responseTimes = responseHistograms.getResponseTimeList(application);
 
-        NodeHistogram.Builder builder = NodeHistogram.newBuilder(application, range);
+        NodeHistogram.Builder builder = NodeHistogram.newBuilder(application, timeWindow.getWindowRange());
         builder.setResponseHistogram(responseTimes);
         return builder.build();
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/WasNodeHistogramDataSource.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/WasNodeHistogramDataSource.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -27,5 +27,5 @@ import com.navercorp.pinpoint.web.vo.Application;
  */
 public interface WasNodeHistogramDataSource {
 
-    NodeHistogram createNodeHistogram(Application application, Range range);
+    NodeHistogram createNodeHistogram(Application application, TimeWindow timeWindow);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapHbaseConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapHbaseConfiguration.java
@@ -19,7 +19,6 @@ package com.navercorp.pinpoint.web.applicationmap.config;
 
 import com.navercorp.pinpoint.common.hbase.ConnectionFactoryBean;
 import com.navercorp.pinpoint.common.hbase.HbaseTemplate;
-import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.TableFactory;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.async.AsyncConnectionFactoryBean;
@@ -39,6 +38,7 @@ import com.navercorp.pinpoint.web.applicationmap.dao.hbase.HbaseMapInLinkDao;
 import com.navercorp.pinpoint.web.applicationmap.dao.hbase.HbaseMapOutLinkDao;
 import com.navercorp.pinpoint.web.applicationmap.dao.hbase.HbaseMapResponseTimeDao;
 import com.navercorp.pinpoint.web.applicationmap.dao.hbase.MapScanFactory;
+import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ResultExtractorFactory;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.RowMapperFactory;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.vo.RangeFactory;
@@ -57,6 +57,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.concurrent.ThreadPoolExecutorFactoryBean;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
@@ -131,14 +132,14 @@ public class MapHbaseConfiguration {
 
     @Bean
     public MapResponseDao mapResponseDao(@Qualifier("mapHbaseTemplate")
-                                                  HbaseTemplate hbaseTemplate,
+                                         HbaseTemplate hbaseTemplate,
                                          TableNameProvider tableNameProvider,
-                                         @Qualifier("responseTimeMapper")
-                                                  RowMapper<ResponseTime> responseTimeMapper,
+                                         @Qualifier("responseTimeResultExtract")
+                                         ResultExtractorFactory<List<ResponseTime>> resultExtractFactory,
                                          MapScanFactory mapScanFactory,
                                          @Qualifier("mapSelfRowKeyDistributor")
-                                                  RowKeyDistributorByHashPrefix rowKeyDistributor) {
-        return new HbaseMapResponseTimeDao(hbaseTemplate, tableNameProvider, responseTimeMapper, mapScanFactory, rowKeyDistributor);
+                                         RowKeyDistributorByHashPrefix rowKeyDistributor) {
+        return new HbaseMapResponseTimeDao(hbaseTemplate, tableNameProvider, resultExtractFactory, mapScanFactory, rowKeyDistributor);
     }
 
     @Bean

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapMapperConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapMapperConfiguration.java
@@ -1,12 +1,13 @@
 package com.navercorp.pinpoint.web.applicationmap.config;
 
 
-import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.InLinkMapper;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.LinkFilter;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.OutLinkMapper;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ResponseTimeMapper;
+import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ResponseTimeResultExtractor;
+import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ResultExtractorFactory;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.RowMapperFactory;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.component.ApplicationFactory;
@@ -16,13 +17,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+
 @Configuration
 public class MapMapperConfiguration {
 
     @Bean
     public RowMapperFactory<LinkDataMap> mapOutLinkMapper(ApplicationFactory applicationFactory,
                                                           @Qualifier("mapOutLinkRowKeyDistributor")
-                                         RowKeyDistributorByHashPrefix rowKeyDistributor) {
+                                                          RowKeyDistributorByHashPrefix rowKeyDistributor) {
         return (windowFunction) -> new OutLinkMapper(applicationFactory, rowKeyDistributor, LinkFilter::skip, windowFunction);
     }
 
@@ -35,9 +38,17 @@ public class MapMapperConfiguration {
     }
 
     @Bean
-    public RowMapper<ResponseTime> responseTimeMapper(ServiceTypeRegistryService registry,
+    public RowMapperFactory<ResponseTime> responseTimeMapper(ServiceTypeRegistryService registry,
                                                       @Qualifier("mapSelfRowKeyDistributor")
                                                       RowKeyDistributorByHashPrefix rowKeyDistributor) {
-        return new ResponseTimeMapper(registry, rowKeyDistributor);
+        return (windowFunction) -> new ResponseTimeMapper(registry, rowKeyDistributor, windowFunction);
     }
+
+    @Bean
+    public ResultExtractorFactory<List<ResponseTime>> responseTimeResultExtract(ServiceTypeRegistryService registry,
+                                                                                @Qualifier("mapSelfRowKeyDistributor")
+                                                      RowKeyDistributorByHashPrefix rowKeyDistributor) {
+        return (windowFunction) -> new ResponseTimeResultExtractor(registry, rowKeyDistributor, windowFunction);
+    }
+
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapHistogramController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapHistogramController.java
@@ -101,10 +101,11 @@ public class MapHistogramController {
             @Valid @ModelAttribute
             RangeForm rangeForm) {
         final Range range = toRange(rangeForm);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         final Application application = getApplication(appForm);
 
-        AgentHistogramList responseTimes = responseTimeHistogramService.selectResponseTimeHistogramData(application, range);
+        AgentHistogramList responseTimes = responseTimeHistogramService.selectResponseTimeHistogramData(application, timeWindow);
         return new ApplicationTimeHistogramViewModel(TimeHistogramFormat.V1, application, responseTimes);
     }
 
@@ -127,6 +128,7 @@ public class MapHistogramController {
             boolean useLoadHistogramFormat
     ) {
         final Range range = toRange(rangeForm);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         final Application application = getApplication(appForm);
 
@@ -135,7 +137,7 @@ public class MapHistogramController {
         final List<Application> toApplications =
                 mapApplicationPairsToApplications(applicationPairs.getToApplications());
         final ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption
-                .Builder(application, range, fromApplications, toApplications)
+                .Builder(application, timeWindow, fromApplications, toApplications)
                 .setUseStatisticsAgentState(useStatisticsAgentState)
                 .build();
         final NodeHistogramSummary nodeHistogramSummary = responseTimeHistogramService.selectNodeHistogramData(option);
@@ -167,6 +169,7 @@ public class MapHistogramController {
             boolean useLoadHistogramFormat
     ) {
         final Range range = toRange(rangeForm);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         if (fromApplicationNames.size() != fromServiceTypeCodes.size()) {
             throw new IllegalArgumentException(
@@ -182,7 +185,7 @@ public class MapHistogramController {
         final List<Application> fromApplications = toApplications(fromApplicationNames, fromServiceTypeCodes);
         final List<Application> toApplications = toApplications(toApplicationNames, toServiceTypeCodes);
         final ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption
-                .Builder(application, range, fromApplications, toApplications)
+                .Builder(application, timeWindow, fromApplications, toApplications)
                 .setUseStatisticsAgentState(useStatisticsAgentState)
                 .build();
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapResponseDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapResponseDao.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap.dao;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
 
@@ -29,6 +29,6 @@ import java.util.List;
  * 
  */
 public interface MapResponseDao {
-    List<ResponseTime> selectResponseTime(Application application, Range range);
+    List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ResultExtractorFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ResultExtractorFactory.java
@@ -1,0 +1,10 @@
+package com.navercorp.pinpoint.web.applicationmap.dao.mapper;
+
+import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
+
+@FunctionalInterface
+public interface ResultExtractorFactory<R> {
+
+    ResultsExtractor<R> newMapper(TimeWindowFunction timeWindow);
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImpl.java
@@ -182,7 +182,8 @@ public class FilteredMapServiceImpl implements FilteredMapService {
     }
 
     private ApplicationMap createMap(FilteredMapServiceOption option, FilteredMap filteredMap) {
-        final ApplicationMapBuilder applicationMapBuilder = applicationMapBuilderFactory.createApplicationMapBuilder(option.getRange());
+        TimeWindow timeWindow = new TimeWindow(option.getRange());
+        final ApplicationMapBuilder applicationMapBuilder = applicationMapBuilderFactory.createApplicationMapBuilder(timeWindow);
         final WasNodeHistogramDataSource wasNodeHistogramDataSource = new ResponseHistogramsNodeHistogramDataSource(filteredMap.getResponseHistograms());
         applicationMapBuilder.includeNodeHistogram(new DefaultNodeHistogramFactory(wasNodeHistogramDataSource));
         ServerGroupListDataSource serverGroupListDataSource = serverInstanceDatasourceService.getServerGroupListDataSource();

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceImpl.java
@@ -138,7 +138,7 @@ public class MapServiceImpl implements MapService {
     }
 
     private ApplicationMapBuilder createApplicationMapBuilder(MapServiceOption option) {
-        ApplicationMapBuilder builder = applicationMapBuilderFactory.createApplicationMapBuilder(option.getRange());
+        ApplicationMapBuilder builder = applicationMapBuilderFactory.createApplicationMapBuilder(option.getTimeWindow());
 
         final NodeHistogramFactory nodeHistogramFactory = newNodeHistogramFactory(option);
         builder.includeNodeHistogram(nodeHistogramFactory);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramService.java
@@ -17,7 +17,6 @@
 
 package com.navercorp.pinpoint.web.applicationmap.service;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkHistogramSummary;
 import com.navercorp.pinpoint.web.applicationmap.nodes.NodeHistogramSummary;
@@ -30,7 +29,7 @@ import com.navercorp.pinpoint.web.vo.Application;
  */
 public interface ResponseTimeHistogramService {
 
-    AgentHistogramList selectResponseTimeHistogramData(Application application, Range range);
+    AgentHistogramList selectResponseTimeHistogramData(Application application, TimeWindow timeWindow);
 
     NodeHistogramSummary selectNodeHistogramData(ResponseTimeHistogramServiceOption option);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImpl.java
@@ -98,8 +98,8 @@ public class ResponseTimeHistogramServiceImpl implements ResponseTimeHistogramSe
     }
 
     @Override
-    public AgentHistogramList selectResponseTimeHistogramData(Application application, Range range) {
-        List<ResponseTime> responseTimes = mapResponseDao.selectResponseTime(application, range);
+    public AgentHistogramList selectResponseTimeHistogramData(Application application, TimeWindow timeWindow) {
+        List<ResponseTime> responseTimes = mapResponseDao.selectResponseTime(application, timeWindow);
         return AgentHistogramList.newBuilder().build(application, responseTimes);
     }
 
@@ -127,7 +127,7 @@ public class ResponseTimeHistogramServiceImpl implements ResponseTimeHistogramSe
     private NodeHistogramSummary getUserNodeHistogramSummary(ResponseTimeHistogramServiceOption option) {
         Application application = option.getApplication();
         Range range = option.getRange();
-        TimeWindow timeWindow = new TimeWindow(range);
+        TimeWindow timeWindow = option.getTimeWindow();
         List<Application> destinationApplications = option.getToApplications();
 
         final ServerGroupListFactory serverGroupListFactory = createServerGroupListFactory(option.isUseStatisticsAgentState());
@@ -151,9 +151,10 @@ public class ResponseTimeHistogramServiceImpl implements ResponseTimeHistogramSe
     private NodeHistogramSummary getWasNodeHistogramSummary(ResponseTimeHistogramServiceOption option) {
         Application application = option.getApplication();
         Range range = option.getRange();
+        TimeWindow timeWindow = option.getTimeWindow();
 
         final NodeHistogramFactory nodeHistogramFactory = createNodeHistogramFactory();
-        NodeHistogram nodeHistogram = nodeHistogramFactory.createWasNodeHistogram(application, range);
+        NodeHistogram nodeHistogram = nodeHistogramFactory.createWasNodeHistogram(application, timeWindow);
 
         Node node = new Node(application);
         node.setNodeHistogram(nodeHistogram);
@@ -166,7 +167,7 @@ public class ResponseTimeHistogramServiceImpl implements ResponseTimeHistogramSe
     private NodeHistogramSummary getTerminalNodeHistogramSummary(ResponseTimeHistogramServiceOption option) {
         Application application = option.getApplication();
         Range range = option.getRange();
-        TimeWindow timeWindow = new TimeWindow(range);
+        TimeWindow timeWindow = option.getTimeWindow();
 
         ServiceType applicationServiceType = application.getServiceType();
 
@@ -198,7 +199,7 @@ public class ResponseTimeHistogramServiceImpl implements ResponseTimeHistogramSe
 
         Application application = option.getApplication();
         Range range = option.getRange();
-        TimeWindow timeWindow = new TimeWindow(range);
+        TimeWindow timeWindow = option.getTimeWindow();
 
         final ServerGroupListFactory serverGroupListFactory = createServerGroupListFactory(option.isUseStatisticsAgentState());
         List<Application> sourceApplications = option.getFromApplications();

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceOption.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceOption.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.applicationmap.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.vo.Application;
 
 import java.util.List;
@@ -28,14 +29,14 @@ import java.util.Objects;
  */
 public class ResponseTimeHistogramServiceOption {
     private final Application application;
-    private final Range range;
+    private final TimeWindow timeWindow;
     private final List<Application> fromApplications;
     private final List<Application> toApplications;
     private final boolean useStatisticsAgentState;
 
     private ResponseTimeHistogramServiceOption(Builder builder) {
         this.application = builder.application;
-        this.range = builder.range;
+        this.timeWindow = builder.timeWindow;
         this.fromApplications = builder.fromApplications;
         this.toApplications = builder.toApplications;
         this.useStatisticsAgentState = builder.useStatisticsAgentState;
@@ -46,7 +47,11 @@ public class ResponseTimeHistogramServiceOption {
     }
 
     public Range getRange() {
-        return range;
+        return timeWindow.getWindowRange();
+    }
+
+    public TimeWindow getTimeWindow() {
+        return timeWindow;
     }
 
     public List<Application> getFromApplications() {
@@ -64,7 +69,7 @@ public class ResponseTimeHistogramServiceOption {
     @Override
     public String toString() {
         return "ResponseTimeHistogramServiceOption{" + "application=" + application +
-                ", range=" + range +
+                ", timeWindow=" + timeWindow +
                 ", fromApplications=" + fromApplications +
                 ", toApplications=" + toApplications +
                 ", useStatisticsAgentState=" + useStatisticsAgentState +
@@ -73,15 +78,15 @@ public class ResponseTimeHistogramServiceOption {
 
     public static class Builder {
         private final Application application;
-        private final Range range;
+        private final TimeWindow timeWindow;
         private final List<Application> fromApplications;
         private final List<Application> toApplications;
 
         private boolean useStatisticsAgentState;
 
-        public Builder(Application application, Range range, List<Application> fromApplications, List<Application> toApplications) {
+        public Builder(Application application, TimeWindow timeWindow, List<Application> fromApplications, List<Application> toApplications) {
             this.application = Objects.requireNonNull(application, "application");
-            this.range = Objects.requireNonNull(range, "range");
+            this.timeWindow = Objects.requireNonNull(timeWindow, "timeWindow");
             this.fromApplications = Objects.requireNonNull(fromApplications, "fromApplications");
             this.toApplications = Objects.requireNonNull(toApplications, "toApplications");
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/util/CancellableHistogramFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/util/CancellableHistogramFactory.java
@@ -1,6 +1,7 @@
 package com.navercorp.pinpoint.web.applicationmap.util;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.NodeHistogramFactory;
 import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkList;
@@ -16,11 +17,11 @@ public class CancellableHistogramFactory implements NodeHistogramFactory {
         this.nodeHistogramFactory = Objects.requireNonNull(nodeHistogramFactory, "nodeHistogramFactory");
     }
 
-    public NodeHistogram createWasNodeHistogram(Application application, Range range) {
+    public NodeHistogram createWasNodeHistogram(Application application, TimeWindow timeWindow) {
         if (isCancel()) {
-            return nodeHistogramFactory.createEmptyNodeHistogram(application, range);
+            return nodeHistogramFactory.createEmptyNodeHistogram(application, timeWindow.getWindowRange());
         }
-        return nodeHistogramFactory.createWasNodeHistogram(application, range);
+        return nodeHistogramFactory.createWasNodeHistogram(application, timeWindow);
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentListController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentListController.java
@@ -1,6 +1,7 @@
 package com.navercorp.pinpoint.web.authorization.controller;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.applicationmap.nodes.NodeHistogramSummary;
@@ -119,9 +120,11 @@ public class AgentListController {
         final ApplicationAgentListQueryRule applicationAgentListQueryRule = ApplicationAgentListQueryRule.getByValue(query, ApplicationAgentListQueryRule.ALL);
         final long timestamp = System.currentTimeMillis();
         final Application application = createApplication(applicationName, serviceTypeCode, serviceTypeName);
+        Range between = Range.between(timestamp, timestamp);
+        TimeWindow timeWindow = new TimeWindow(between);
         final AgentsMapByHost list = this.applicationAgentInfoService.getAgentsListByApplicationName(
                 application,
-                Range.between(timestamp, timestamp),
+                timeWindow,
                 paramSortBy,
                 applicationAgentListQueryRule,
                 AgentInfoFilters.acceptAll()
@@ -141,9 +144,12 @@ public class AgentListController {
         final SortByAgentInfo.Rules paramSortBy = sortBy.orElse(DEFAULT_SORT_BY);
         final ApplicationAgentListQueryRule applicationAgentListQueryRule = ApplicationAgentListQueryRule.getByValue(query, ApplicationAgentListQueryRule.ACTIVE_STATUS);
         final Application application = createApplication(applicationName, serviceTypeCode, serviceTypeName);
+        Range between = Range.between(from, to);
+        TimeWindow timeWindow = new TimeWindow(between);
+
         final AgentsMapByHost list = this.applicationAgentInfoService.getAgentsListByApplicationName(
                 application,
-                Range.between(from, to),
+                timeWindow,
                 paramSortBy,
                 applicationAgentListQueryRule,
                 AgentInfoFilters.acceptAll()
@@ -170,6 +176,8 @@ public class AgentListController {
                     applicationName, serviceTypeCode, serviceTypeName, from, to, sortBy, String.valueOf(serverMapAgentListQueryRule)
             );
         }
+        Range between = Range.between(from, to);
+        TimeWindow timeWindow = new TimeWindow(between);
 
         final Application application = applicationFactory.createApplication(applicationName, serviceType.getCode());
 
@@ -178,7 +186,7 @@ public class AgentListController {
         final List<Application> toApplications =
                 pairsToList(applicationPairs.getToApplications());
         final ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption
-                .Builder(application, Range.between(from, to),
+                .Builder(application, timeWindow,
                 fromApplications, toApplications)
                 .build();
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ResponseTimeController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ResponseTimeController.java
@@ -90,9 +90,11 @@ public class ResponseTimeController {
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         Application application = createApplication(applicationName, serviceTypeCode, serviceTypeName);
 
-        ResponseTimeHistogramServiceOption option = createWasOptionBuilder(application, range)
+        ResponseTimeHistogramServiceOption option = createWasOptionBuilder(application, timeWindow)
                 .setUseStatisticsAgentState(false) //set useStatisticsAgentState to false for agent data
                 .build();
         NodeHistogramSummary nodeHistogramSummary = responseTimeHistogramService.selectNodeHistogramData(option);
@@ -109,9 +111,11 @@ public class ResponseTimeController {
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         Application application = createApplication(applicationName, serviceTypeCode, serviceTypeName);
 
-        ResponseTimeHistogramServiceOption option = createWasOptionBuilder(application, range)
+        ResponseTimeHistogramServiceOption option = createWasOptionBuilder(application, timeWindow)
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = responseTimeHistogramService.selectNodeHistogramData(option);
@@ -141,10 +145,12 @@ public class ResponseTimeController {
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         Application application = createApplication(applicationName, serviceTypeCode, serviceTypeName);
         TimeHistogramType timeHistogramType = TimeHistogramType.valueOf(type);
 
-        ResponseTimeHistogramServiceOption option = createWasOptionBuilder(application, range)
+        ResponseTimeHistogramServiceOption option = createWasOptionBuilder(application, timeWindow)
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = responseTimeHistogramService.selectNodeHistogramData(option);
@@ -163,20 +169,22 @@ public class ResponseTimeController {
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         Application application = createApplication(applicationName, serviceTypeCode, serviceTypeName);
 
-        ResponseTimeHistogramServiceOption option = createWasOptionBuilder(application, range)
+        ResponseTimeHistogramServiceOption option = createWasOptionBuilder(application, timeWindow)
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = responseTimeHistogramService.selectNodeHistogramData(option);
         return HistogramView.view(nodeHistogramSummary);
     }
 
-    private ResponseTimeHistogramServiceOption.Builder createWasOptionBuilder(Application application, Range range) {
+    private ResponseTimeHistogramServiceOption.Builder createWasOptionBuilder(Application application, TimeWindow timeWindow) {
         if (!application.getServiceType().isWas()) {
             throw new IllegalArgumentException("application is not WAS. application:" + application + ", serviceTypeCode:" + application.getServiceType());
         }
-        return new ResponseTimeHistogramServiceOption.Builder(application, range, Collections.emptyList(), Collections.emptyList());
+        return new ResponseTimeHistogramServiceOption.Builder(application, timeWindow, Collections.emptyList(), Collections.emptyList());
     }
 
     @PostMapping(value = "/getNode/serverHistogramData")
@@ -190,9 +198,11 @@ public class ResponseTimeController {
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         Application application = createApplication(applicationName, serviceTypeCode, serviceTypeName);
 
-        ResponseTimeHistogramServiceOption option = createOptionBuilder(application, range, applicationPairs)
+        ResponseTimeHistogramServiceOption option = createOptionBuilder(application, timeWindow, applicationPairs)
                 .setUseStatisticsAgentState(false) //set useStatisticsAgentState to false for agent data
                 .build();
         NodeHistogramSummary nodeHistogramSummary = responseTimeHistogramService.selectNodeHistogramData(option);
@@ -210,9 +220,11 @@ public class ResponseTimeController {
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         Application application = createApplication(applicationName, serviceTypeCode, serviceTypeName);
 
-        ResponseTimeHistogramServiceOption option = createOptionBuilder(application, range, applicationPairs)
+        ResponseTimeHistogramServiceOption option = createOptionBuilder(application, timeWindow, applicationPairs)
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = responseTimeHistogramService.selectNodeHistogramData(option);
@@ -232,10 +244,12 @@ public class ResponseTimeController {
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         Application application = createApplication(applicationName, serviceTypeCode, serviceTypeName);
         TimeHistogramType timeHistogramType = TimeHistogramType.valueOf(type);
 
-        ResponseTimeHistogramServiceOption option = createOptionBuilder(application, range, applicationPairs)
+        ResponseTimeHistogramServiceOption option = createOptionBuilder(application, timeWindow, applicationPairs)
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = responseTimeHistogramService.selectNodeHistogramData(option);
@@ -309,11 +323,11 @@ public class ResponseTimeController {
         return chartView(histogram, timeHistogramType);
     }
 
-    private ResponseTimeHistogramServiceOption.Builder createOptionBuilder(Application application, Range range,
+    private ResponseTimeHistogramServiceOption.Builder createOptionBuilder(Application application, TimeWindow timeWindow,
                                                                            ApplicationPairs applicationPairs) {
         List<Application> fromApplications = mapApplicationPairsToApplications(applicationPairs.getFromApplications());
         List<Application> toApplications = mapApplicationPairsToApplications(applicationPairs.getToApplications());
-        return new ResponseTimeHistogramServiceOption.Builder(application, range, fromApplications, toApplications);
+        return new ResponseTimeHistogramServiceOption.Builder(application, timeWindow, fromApplications, toApplications);
     }
 
     private List<Application> mapApplicationPairsToApplications(List<ApplicationPair> applicationPairs) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/ApdexScoreController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/ApdexScoreController.java
@@ -40,10 +40,11 @@ public class ApdexScoreController {
             @RequestParam("from") @PositiveOrZero long from,
             @RequestParam("to") @PositiveOrZero long to) {
         final Range range = Range.between(from, to);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         Application application = applicationFactory.createApplication(applicationName, serviceTypeCode);
 
-        return apdexScoreService.selectApdexScoreData(application, range);
+        return apdexScoreService.selectApdexScoreData(application, timeWindow);
     }
 
     @GetMapping(value = "/getApdexScore", params = "serviceTypeName")
@@ -53,10 +54,11 @@ public class ApdexScoreController {
             @RequestParam("from") @PositiveOrZero long from,
             @RequestParam("to") @PositiveOrZero long to) {
         final Range range = Range.between(from, to);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         Application application = applicationFactory.createApplicationByTypeName(applicationName, serviceTypeName);
 
-        return apdexScoreService.selectApdexScoreData(application, range);
+        return apdexScoreService.selectApdexScoreData(application, timeWindow);
     }
 
     @GetMapping(value = "/getApdexScore", params = {"agentId"})
@@ -67,10 +69,11 @@ public class ApdexScoreController {
             @RequestParam("from") @PositiveOrZero long from,
             @RequestParam("to") @PositiveOrZero long to) {
         final Range range = Range.between(from, to);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         Application application = applicationFactory.createApplication(applicationName, serviceTypeCode);
 
-        return apdexScoreService.selectApdexScoreData(application, agentId, range);
+        return apdexScoreService.selectApdexScoreData(application, agentId, timeWindow);
     }
 
     @GetMapping(value = "/getApdexScore", params = {"agentId", "serviceTypeName"})
@@ -81,10 +84,11 @@ public class ApdexScoreController {
             @RequestParam("from") @PositiveOrZero long from,
             @RequestParam("to") @PositiveOrZero long to) {
         final Range range = Range.between(from, to);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         Application application = applicationFactory.createApplicationByTypeName(applicationName, serviceTypeName);
 
-        return apdexScoreService.selectApdexScoreData(application, agentId, range);
+        return apdexScoreService.selectApdexScoreData(application, agentId, timeWindow);
     }
 
     @GetMapping(value = "/getApplicationStat/apdexScore/chart")

--- a/web/src/main/java/com/navercorp/pinpoint/web/realtime/AgentLookupServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/realtime/AgentLookupServiceImpl.java
@@ -17,6 +17,7 @@ package com.navercorp.pinpoint.web.realtime;
 
 import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.realtime.service.AgentLookupService;
 import com.navercorp.pinpoint.web.service.ApplicationAgentListService;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
@@ -46,8 +47,11 @@ class AgentLookupServiceImpl implements AgentLookupService {
     public List<ClusterKey> getRecentAgents(String applicationName) {
         long now = System.currentTimeMillis();
         long from = now - recentness.toMillis();
+        Range between = Range.between(from, now);
+        TimeWindow timeWindow = new TimeWindow(between);
+
         return intoClusterKeyList(this.applicationAgentListService.activeStatisticsAgentList(applicationName, null,
-                Range.between(from, now),
+                timeWindow,
                 ACTUAL_AGENT_INFO_PREDICATE
         ));
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.dao.AgentInfoDao;
 import com.navercorp.pinpoint.web.dao.AgentInfoQuery;
 import com.navercorp.pinpoint.web.dao.AgentLifeCycleDao;
@@ -151,15 +152,15 @@ public class AgentInfoServiceImpl implements AgentInfoService {
 
     private List<AgentInfo> getAgentInfoList(String applicationName, long timestamp, int durationHours, Predicate<AgentInfo> agentInfoFilter) {
         Range range = Range.between(timestamp - TimeUnit.HOURS.toMillis(durationHours), timestamp);
+        TimeWindow timeWindow = new TimeWindow(range);
         if (durationHours <= 0) {
             return applicationAgentListService.allAgentList(applicationName, null, range, agentInfoFilter.and(ACTUAL_AGENT_INFO_PREDICATE)).stream()
                     .map(AgentAndStatus::getAgentInfo)
                     .collect(Collectors.toList());
         }
-        List<AgentInfo> result = applicationAgentListService.activeStatusAgentList(applicationName, null, range, agentInfoFilter).stream()
+        return applicationAgentListService.activeStatusAgentList(applicationName, null, timeWindow, agentInfoFilter).stream()
                 .map(AgentAndStatus::getAgentInfo)
                 .collect(Collectors.toList());
-        return result;
     }
 
     private ApplicationAgentHostList.Builder newBuilder(int offset, int endIndex, int totalApplications) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApdexScoreService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApdexScoreService.java
@@ -1,6 +1,5 @@
 package com.navercorp.pinpoint.web.service;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.histogram.ApdexScore;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -8,9 +7,9 @@ import com.navercorp.pinpoint.web.vo.stat.chart.StatChart;
 
 public interface ApdexScoreService {
 
-    ApdexScore selectApdexScoreData(Application application, Range range);
+    ApdexScore selectApdexScoreData(Application application, TimeWindow timeWindow);
 
-    ApdexScore selectApdexScoreData(Application application, String agentId, Range range);
+    ApdexScore selectApdexScoreData(Application application, String agentId, TimeWindow timeWindow);
 
     StatChart<?> selectApplicationChart(Application application, TimeWindow timeWindow);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApdexScoreServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApdexScoreServiceImpl.java
@@ -1,6 +1,5 @@
 package com.navercorp.pinpoint.web.service;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
@@ -35,11 +34,11 @@ public class ApdexScoreServiceImpl implements ApdexScoreService {
     }
 
     @Override
-    public ApdexScore selectApdexScoreData(Application application, Range range) {
+    public ApdexScore selectApdexScoreData(Application application, TimeWindow timeWindow) {
         ServiceType applicationServiceType = application.getServiceType();
 
         if (applicationServiceType.isWas()) {
-            List<ResponseTime> responseTimeList = mapResponseDao.selectResponseTime(application, range);
+            List<ResponseTime> responseTimeList = mapResponseDao.selectResponseTime(application, timeWindow);
             Histogram applicationHistogram = createApplicationHistogram(responseTimeList, applicationServiceType);
 
             return ApdexScore.newApdexScore(applicationHistogram);
@@ -50,11 +49,11 @@ public class ApdexScoreServiceImpl implements ApdexScoreService {
     }
 
     @Override
-    public ApdexScore selectApdexScoreData(Application application, String agentId, Range range) {
+    public ApdexScore selectApdexScoreData(Application application, String agentId, TimeWindow timeWindow) {
         ServiceType applicationServiceType = application.getServiceType();
 
         if (applicationServiceType.isWas()) {
-            List<ResponseTime> responseTimeList = mapResponseDao.selectResponseTime(application, range);
+            List<ResponseTime> responseTimeList = mapResponseDao.selectResponseTime(application, timeWindow);
             Histogram agentHistogram = createAgentHistogram(responseTimeList, agentId, applicationServiceType);
 
             return ApdexScore.newApdexScore(agentHistogram);
@@ -86,8 +85,7 @@ public class ApdexScoreServiceImpl implements ApdexScoreService {
 
     @Override
     public StatChart<?> selectApplicationChart(Application application, TimeWindow timeWindow) {
-        Range range = timeWindow.getWindowRange();
-        List<ResponseTime> responseTimeList = mapResponseDao.selectResponseTime(application, range);
+        List<ResponseTime> responseTimeList = mapResponseDao.selectResponseTime(application, timeWindow);
         AgentTimeHistogram timeHistogram = createAgentTimeHistogram(application, timeWindow, responseTimeList);
 
         List<ApplicationStatPoint> applicationStatPoints = timeHistogram.getApplicationApdexScoreList(timeWindow);
@@ -97,8 +95,7 @@ public class ApdexScoreServiceImpl implements ApdexScoreService {
 
     @Override
     public StatChart<?> selectAgentChart(Application application, TimeWindow timeWindow, String agentId) {
-        Range range = timeWindow.getWindowRange();
-        List<ResponseTime> responseTimeList = mapResponseDao.selectResponseTime(application, range);
+        List<ResponseTime> responseTimeList = mapResponseDao.selectResponseTime(application, timeWindow);
         AgentTimeHistogram timeHistogram = createAgentTimeHistogram(application, timeWindow, responseTimeList);
 
         List<SampledApdexScore> sampledPoints = timeHistogram.getSampledAgentApdexScoreList(agentId);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentInfoMapService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentInfoMapService.java
@@ -1,6 +1,6 @@
 package com.navercorp.pinpoint.web.service;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilter;
 import com.navercorp.pinpoint.web.vo.tree.AgentsMapByHost;
@@ -9,7 +9,7 @@ import com.navercorp.pinpoint.web.vo.tree.SortByAgentInfo;
 public interface ApplicationAgentInfoMapService {
 
     AgentsMapByHost getAgentsListByApplicationName(Application application,
-                                                   Range range,
+                                                   TimeWindow timeWindow,
                                                    SortByAgentInfo.Rules sortBy,
                                                    ApplicationAgentListQueryRule applicationAgentListQueryRule,
                                                    AgentInfoFilter agentInfoPredicate);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentInfoMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentInfoMapServiceImpl.java
@@ -1,6 +1,7 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -30,14 +31,14 @@ public class ApplicationAgentInfoMapServiceImpl implements ApplicationAgentInfoM
 
     @Override
     public AgentsMapByHost getAgentsListByApplicationName(Application application,
-                                                          Range range,
+                                                          TimeWindow timeWindow,
                                                           SortByAgentInfo.Rules sortBy,
                                                           ApplicationAgentListQueryRule applicationAgentListQueryRule,
                                                           AgentInfoFilter agentInfoPredicate) {
         Objects.requireNonNull(agentInfoPredicate, "agentInfoPredicate");
         Objects.requireNonNull(application, "applicationName");
 
-        List<AgentAndStatus> agentInfoAndStatuses = getActivateAgentInfoList(application, range, applicationAgentListQueryRule, agentInfoPredicate);
+        List<AgentAndStatus> agentInfoAndStatuses = getActivateAgentInfoList(application, timeWindow, applicationAgentListQueryRule, agentInfoPredicate);
         if (agentInfoAndStatuses.isEmpty()) {
             logger.warn("agent list is empty for application:{}", application);
         }
@@ -60,16 +61,17 @@ public class ApplicationAgentInfoMapServiceImpl implements ApplicationAgentInfoM
     }
 
     private List<AgentAndStatus> getActivateAgentInfoList(Application application,
-                                                          Range range,
+                                                          TimeWindow timeWindow,
                                                           ApplicationAgentListQueryRule applicationAgentListQueryRule,
                                                           AgentInfoFilter agentInfoFilter) {
         final String applicationName = application.getName();
         final ServiceType serviceType = application.getServiceType();
+        final Range windowRange = timeWindow.getWindowRange();
         return switch (applicationAgentListQueryRule) {
-            case ACTIVE_STATUS -> applicationAgentListService.activeStatusAgentList(applicationName, serviceType, range, agentInfoFilter);
-            case ACTIVE_STATISTICS -> applicationAgentListService.activeStatisticsAgentList(applicationName, serviceType, range, agentInfoFilter);
-            case ACTIVE_ALL -> applicationAgentListService.activeAllAgentList(applicationName, serviceType, range, agentInfoFilter);
-            default -> applicationAgentListService.allAgentList(applicationName, serviceType, range, agentInfoFilter);
+            case ACTIVE_STATUS -> applicationAgentListService.activeStatusAgentList(applicationName, serviceType, timeWindow, agentInfoFilter);
+            case ACTIVE_STATISTICS -> applicationAgentListService.activeStatisticsAgentList(applicationName, serviceType, timeWindow, agentInfoFilter);
+            case ACTIVE_ALL -> applicationAgentListService.activeAllAgentList(applicationName, serviceType, timeWindow, agentInfoFilter);
+            default -> applicationAgentListService.allAgentList(applicationName, serviceType, windowRange, agentInfoFilter);
         };
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentListService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentListService.java
@@ -1,6 +1,7 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
@@ -15,11 +16,23 @@ public interface ApplicationAgentListService {
     String AGENT_INFO_NOT_FOUND_HOSTNAME = "!noAgentInfo";
     Predicate<AgentInfo> ACTUAL_AGENT_INFO_PREDICATE = agentInfo -> !AGENT_INFO_NOT_FOUND_HOSTNAME.equals(agentInfo.getHostName());
 
-    List<AgentAndStatus> allAgentList(String applicationName, @Nullable ServiceType serviceType, Range range, Predicate<AgentInfo> agentInfoPredicate);
+    List<AgentAndStatus> allAgentList(String applicationName,
+                                      @Nullable ServiceType serviceType,
+                                      Range range,
+                                      Predicate<AgentInfo> agentInfoPredicate);
 
-    List<AgentAndStatus> activeStatusAgentList(String applicationName, @Nullable ServiceType serviceType, Range range, Predicate<AgentInfo> agentInfoPredicate);
+    List<AgentAndStatus> activeStatusAgentList(String applicationName,
+                                               @Nullable ServiceType serviceType,
+                                               TimeWindow timeWindow,
+                                               Predicate<AgentInfo> agentInfoPredicate);
 
-    List<AgentAndStatus> activeStatisticsAgentList(String applicationName, @Nullable ServiceType serviceType, Range range, Predicate<AgentInfo> agentInfoPredicate);
+    List<AgentAndStatus> activeStatisticsAgentList(String applicationName,
+                                                   @Nullable ServiceType serviceType,
+                                                   TimeWindow timeWindow,
+                                                   Predicate<AgentInfo> agentInfoPredicate);
 
-    List<AgentAndStatus> activeAllAgentList(String applicationName, @Nullable ServiceType serviceType, Range range, Predicate<AgentInfo> agentInfoPredicate);
+    List<AgentAndStatus> activeAllAgentList(String applicationName,
+                                            @Nullable ServiceType serviceType,
+                                            TimeWindow timeWindow,
+                                            Predicate<AgentInfo> agentInfoPredicate);
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.web.applicationmap;
 import com.navercorp.pinpoint.common.server.bo.SimpleAgentKey;
 import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.DefaultNodeHistogramFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.NodeHistogramFactory;
@@ -106,7 +107,7 @@ public class ApplicationMapBuilderTest {
                 return List.of(responseTimeBuilder.build());
             }
         };
-        when(mapResponseDao.selectResponseTime(any(Application.class), any(Range.class))).thenAnswer(responseTimeAnswer);
+        when(mapResponseDao.selectResponseTime(any(Application.class), any(TimeWindow.class))).thenAnswer(responseTimeAnswer);
         when(responseHistograms.getResponseTimeList(any(Application.class))).thenAnswer(responseTimeAnswer);
 
         when(agentInfoService.getAgentsByApplicationName(anyString(), anyLong())).thenAnswer(new Answer<>() {
@@ -153,12 +154,14 @@ public class ApplicationMapBuilderTest {
     @Test
     public void testNoCallData() {
         Range range = Range.between(0, 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         Application application = ApplicationMapBuilderTestHelper.createApplicationFromDepth(0);
 
         ServerGroupListFactory serverGroupListFactory = new DefaultServerGroupListFactory(agentInfoServerGroupListDataSource);
 
-        ApplicationMapBuilder applicationMapBuilder = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(range, serialExecutor);
-        ApplicationMapBuilder applicationMapBuilder_parallelAppenders = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(range, parallelExecutor);
+        ApplicationMapBuilder applicationMapBuilder = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(timeWindow, serialExecutor);
+        ApplicationMapBuilder applicationMapBuilder_parallelAppenders = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(timeWindow, parallelExecutor);
         ApplicationMap applicationMap = applicationMapBuilder
                 .includeServerInfo(serverGroupListFactory)
                 .build(application, buildTimeoutMillis);
@@ -179,13 +182,15 @@ public class ApplicationMapBuilderTest {
     @Test
     public void testEmptyCallData() {
         Range range = Range.between(0, 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         LinkDataDuplexMap linkDataDuplexMap = new LinkDataDuplexMap();
 
         NodeHistogramFactory nodeHistogramFactory = new DefaultNodeHistogramFactory(mapResponseNodeHistogramDataSource);
         ServerGroupListFactory serverGroupListFactory = new DefaultServerGroupListFactory(agentInfoServerGroupListDataSource);
 
-        ApplicationMapBuilder applicationMapBuilder = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(range, serialExecutor);
-        ApplicationMapBuilder applicationMapBuilder_parallelAppenders = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(range, parallelExecutor);
+        ApplicationMapBuilder applicationMapBuilder = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(timeWindow, serialExecutor);
+        ApplicationMapBuilder applicationMapBuilder_parallelAppenders = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(timeWindow, parallelExecutor);
         ApplicationMap applicationMap = applicationMapBuilder
                 .includeNodeHistogram(nodeHistogramFactory)
                 .includeServerInfo(serverGroupListFactory)
@@ -209,13 +214,15 @@ public class ApplicationMapBuilderTest {
     @Test
     public void testEmptyCallDataSimplified() {
         Range range = Range.between(0, 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         LinkDataDuplexMap linkDataDuplexMap = new LinkDataDuplexMap();
 
         NodeHistogramFactory nodeHistogramFactory = new SimplifiedNodeHistogramFactory(mapResponseSimplifiedNodeHistogramDataSource);
         ServerGroupListFactory serverGroupListFactory = new DefaultServerGroupListFactory(agentInfoServerGroupListDataSource);
 
-        ApplicationMapBuilder applicationMapBuilder = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(range, serialExecutor);
-        ApplicationMapBuilder applicationMapBuilder_parallelAppenders = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(range, parallelExecutor);
+        ApplicationMapBuilder applicationMapBuilder = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(timeWindow, serialExecutor);
+        ApplicationMapBuilder applicationMapBuilder_parallelAppenders = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(timeWindow, parallelExecutor);
         ApplicationMap applicationMap = applicationMapBuilder
                 .includeNodeHistogram(nodeHistogramFactory)
                 .includeServerInfo(serverGroupListFactory)
@@ -351,6 +358,8 @@ public class ApplicationMapBuilderTest {
 
     private void runTest(int callerDepth, int calleeDepth) {
         Range range = Range.between(0, 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         int expectedNumNodes = ApplicationMapBuilderTestHelper.getExpectedNumNodes(calleeDepth, callerDepth);
         int expectedNumLinks = ApplicationMapBuilderTestHelper.getExpectedNumLinks(calleeDepth, callerDepth);
 
@@ -359,8 +368,8 @@ public class ApplicationMapBuilderTest {
         ServerGroupListFactory serverGroupListFactory = new DefaultServerGroupListFactory(agentInfoServerGroupListDataSource);
 
         LinkDataDuplexMap linkDataDuplexMap = ApplicationMapBuilderTestHelper.createLinkDataDuplexMap(calleeDepth, callerDepth);
-        ApplicationMapBuilder applicationMapBuilder = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(range, serialExecutor);
-        ApplicationMapBuilder applicationMapBuilder_parallelAppenders = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(range, parallelExecutor);
+        ApplicationMapBuilder applicationMapBuilder = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(timeWindow, serialExecutor);
+        ApplicationMapBuilder applicationMapBuilder_parallelAppenders = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(timeWindow, parallelExecutor);
 
         // test builder using MapResponseDao
         ApplicationMap applicationMap_MapResponseDao = applicationMapBuilder
@@ -403,6 +412,8 @@ public class ApplicationMapBuilderTest {
 
     private void runTestSimplified(int callerDepth, int calleeDepth) {
         Range range = Range.between(0, 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         int expectedNumNodes = ApplicationMapBuilderTestHelper.getExpectedNumNodes(calleeDepth, callerDepth);
         int expectedNumLinks = ApplicationMapBuilderTestHelper.getExpectedNumLinks(calleeDepth, callerDepth);
 
@@ -410,8 +421,8 @@ public class ApplicationMapBuilderTest {
         ServerGroupListFactory serverGroupListFactory = new DefaultServerGroupListFactory(agentInfoServerGroupListDataSource);
 
         LinkDataDuplexMap linkDataDuplexMap = ApplicationMapBuilderTestHelper.createLinkDataDuplexMap(calleeDepth, callerDepth);
-        ApplicationMapBuilder applicationMapBuilder = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(range, serialExecutor);
-        ApplicationMapBuilder applicationMapBuilder_parallelAppenders = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(range, parallelExecutor);
+        ApplicationMapBuilder applicationMapBuilder = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(timeWindow, serialExecutor);
+        ApplicationMapBuilder applicationMapBuilder_parallelAppenders = ApplicationMapBuilderTestHelper.createApplicationMapBuilder(timeWindow, parallelExecutor);
 
         // test builder using MapResponseDao
         ApplicationMap applicationMap_MapResponseDao = applicationMapBuilder

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTestHelper.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTestHelper.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.web.applicationmap;
 
-import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.NodeHistogramAppenderFactory;
@@ -43,10 +43,10 @@ public class ApplicationMapBuilderTestHelper {
     private static final ServiceType TERMINAL_TYPE = ServiceTypeFactory.of(2000, "TERMINAL", TERMINAL, INCLUDE_DESTINATION_ID);
     private static final ServiceType RPC_TYPE = ServiceTypeFactory.of(9000, "RPC", RECORD_STATISTICS);
 
-    public static ApplicationMapBuilder createApplicationMapBuilder(Range range, Executor executor) {
+    public static ApplicationMapBuilder createApplicationMapBuilder(TimeWindow timeWindow, Executor executor) {
         NodeHistogramAppenderFactory nodeHistogramAppenderFactory = new NodeHistogramAppenderFactory(executor);
         ServerInfoAppenderFactory serverInfoAppenderFactory = new ServerInfoAppenderFactory(executor);
-        return new ApplicationMapBuilder(range, nodeHistogramAppenderFactory, serverInfoAppenderFactory);
+        return new ApplicationMapBuilder(timeWindow, nodeHistogramAppenderFactory, serverInfoAppenderFactory);
     }
 
     public static int getExpectedNumNodes(int calleeDepth, int callerDepth) {

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/NodeHistogramAppenderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/NodeHistogramAppenderTest.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.appender.histogram;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
@@ -80,10 +81,12 @@ public class NodeHistogramAppenderTest {
     public void emptyNodeList() {
         // Given
         Range range = Range.between(0, 60 * 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         NodeList nodeList = NodeList.of();
         LinkList linkList = LinkList.of();
         // When
-        nodeHistogramAppender.appendNodeHistogram(range, nodeList, linkList, buildTimeoutMillis);
+        nodeHistogramAppender.appendNodeHistogram(timeWindow, nodeList, linkList, buildTimeoutMillis);
         // Then
         assertThat(nodeList.getNodeList()).isEmpty();
         verifyNoInteractions(wasNodeHistogramDataSource);
@@ -96,15 +99,16 @@ public class NodeHistogramAppenderTest {
     public void wasNode() {
         // Given
         Range range = Range.between(0, 60 * 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         LinkList linkList = LinkList.of();
         Node node = createNode("testApp", ServiceTypeFactory.of(1000, "WAS"));
         NodeList nodeList = NodeList.of(node);
 
         NodeHistogram nodeHistogram = NodeHistogram.empty(node.getApplication(), range);
-        when(wasNodeHistogramDataSource.createNodeHistogram(node.getApplication(), range)).thenReturn(nodeHistogram);
+        when(wasNodeHistogramDataSource.createNodeHistogram(node.getApplication(), timeWindow)).thenReturn(nodeHistogram);
         // When
-        nodeHistogramAppender.appendNodeHistogram(range, nodeList, linkList, buildTimeoutMillis);
+        nodeHistogramAppender.appendNodeHistogram(timeWindow, nodeList, linkList, buildTimeoutMillis);
         // Then
         Node actualNode = nodeList.getNodeList().iterator().next();
         Assertions.assertSame(nodeHistogram, actualNode.getNodeHistogram());
@@ -120,6 +124,7 @@ public class NodeHistogramAppenderTest {
     public void terminalNode() {
         // Given
         Range range = Range.between(0, 60 * 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         // fromNode : [testApp] test-app
         Node fromNode = createNode("testApp", ServiceTypeFactory.of(1000, "WAS"));
@@ -143,7 +148,7 @@ public class NodeHistogramAppenderTest {
         LinkList linkList = LinkList.of(link);
 
         // When
-        nodeHistogramAppender.appendNodeHistogram(range, nodeList, linkList, buildTimeoutMillis);
+        nodeHistogramAppender.appendNodeHistogram(timeWindow, nodeList, linkList, buildTimeoutMillis);
 
         // Then
         Node actualNode = nodeList.getNodeList().iterator().next();
@@ -173,6 +178,7 @@ public class NodeHistogramAppenderTest {
     public void terminalNode_multiple() {
         // Given
         Range range = Range.between(0, 60 * 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         // fromNode : [testApp] test-app
         Node fromNode = createNode("testApp", ServiceTypeFactory.of(1000, "WAS"));
@@ -195,7 +201,7 @@ public class NodeHistogramAppenderTest {
         LinkList linkList = LinkList.of(link);
 
         // When
-        nodeHistogramAppender.appendNodeHistogram(range, nodeList, linkList, buildTimeoutMillis);
+        nodeHistogramAppender.appendNodeHistogram(timeWindow, nodeList, linkList, buildTimeoutMillis);
 
         // Then
         Node actualNode = nodeList.getNodeList().iterator().next();
@@ -226,6 +232,8 @@ public class NodeHistogramAppenderTest {
     public void terminalNodes() {
         // Given
         Range range = Range.between(0, 60 * 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         NodeList.Builder nodeBuilder = NodeList.newBuilder();
         LinkList.Builder linkBuilder = LinkList.newBuilder();
 
@@ -259,7 +267,7 @@ public class NodeHistogramAppenderTest {
         LinkList linkList = linkBuilder.build();
 
         // When
-        nodeHistogramAppender.appendNodeHistogram(range, nodeList, linkList, buildTimeoutMillis);
+        nodeHistogramAppender.appendNodeHistogram(timeWindow, nodeList, linkList, buildTimeoutMillis);
 
         // Then
         // Database node
@@ -300,6 +308,8 @@ public class NodeHistogramAppenderTest {
     public void userNode() {
         // Given
         Range range = Range.between(0, 60 * 1000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         NodeList.Builder nodeBuilder = NodeList.newBuilder();
 
         // userNode : [userNode] user
@@ -325,7 +335,7 @@ public class NodeHistogramAppenderTest {
         LinkList linkList = LinkList.of(link);
 
         // When
-        nodeHistogramAppender.appendNodeHistogram(range, nodeList, linkList, buildTimeoutMillis);
+        nodeHistogramAppender.appendNodeHistogram(timeWindow, nodeList, linkList, buildTimeoutMillis);
 
         NodeHistogram nodeHistogram = userNode.getNodeHistogram();
         // verify application-level histogram

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ResponseTimeMapperTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ResponseTimeMapperTest.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.applicationmap.dao.mapper;
 
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
@@ -59,7 +60,8 @@ public class ResponseTimeMapperTest {
                 .setValue(valueArray)
                 .build();
 
-        ResponseTimeMapper responseTimeMapper = new ResponseTimeMapper(mock(ServiceTypeRegistryService.class), mock(RowKeyDistributorByHashPrefix.class));
+        ResponseTimeMapper responseTimeMapper = new ResponseTimeMapper(mock(ServiceTypeRegistryService.class),
+                mock(RowKeyDistributorByHashPrefix.class), TimeWindowFunction.identity());
         ResponseTime.Builder responseBuilder = ResponseTime.newBuilder("applicationName", ServiceType.STAND_ALONE, System.currentTimeMillis());
         responseTimeMapper.recordColumn(responseBuilder, mockCell);
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
@@ -91,11 +91,12 @@ public class ResponseTimeHistogramServiceImplTest {
         final Application nodeApplication = new Application("WAS", ServiceType.STAND_ALONE);
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
-        when(mapResponseDao.selectResponseTime(eq(nodeApplication), any(Range.class))).thenReturn(List.of());
+        when(mapResponseDao.selectResponseTime(eq(nodeApplication), any(TimeWindow.class))).thenReturn(List.of());
 
         //WAS node does not use fromApplications or toApplications to build nodeHistogramData
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(), List.of())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, timeWindow, List.of(), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
 
@@ -118,11 +119,12 @@ public class ResponseTimeHistogramServiceImplTest {
         final Application nodeApplication = new Application("WAS", ServiceType.STAND_ALONE);
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
-        when(mapResponseDao.selectResponseTime(eq(nodeApplication), any(Range.class))).thenReturn(List.of(createResponseTime(nodeApplication, timestamp)));
+        when(mapResponseDao.selectResponseTime(eq(nodeApplication), any(TimeWindow.class))).thenReturn(List.of(createResponseTime(nodeApplication, timestamp)));
 
         //WAS node does not use fromApplications or toApplications to build nodeHistogramData
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(), List.of())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, timeWindow, List.of(), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
 
@@ -159,12 +161,13 @@ public class ResponseTimeHistogramServiceImplTest {
 
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         //User node use toApplications(was1) to build histogramData
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), eq(LinkDataMapProcessor.NO_OP), any(LinkDataMapProcessor.class)))
                 .thenReturn(createCalleeLinkSelector(List.of(new LinkKey(nodeApplication, toApplication)), timestamp));
 
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(), List.of(toApplication))
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, timeWindow, List.of(), List.of(toApplication))
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -188,12 +191,13 @@ public class ResponseTimeHistogramServiceImplTest {
 
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), eq(LinkDataMapProcessor.NO_OP)))
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(was, nodeApplication)), timestamp));
 
         //UNKNOWN(TERMINAL, ALIAS) node use fromApplications to build nodeHistogramData
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was), List.of())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, timeWindow, List.of(was), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -220,6 +224,7 @@ public class ResponseTimeHistogramServiceImplTest {
 
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), eq(LinkDataMapProcessor.NO_OP)))
                 .thenReturn(createCallerLinkSelector(List.of(
@@ -228,7 +233,7 @@ public class ResponseTimeHistogramServiceImplTest {
                 ), timestamp));
 
         //UNKNOWN(TERMINAL, ALIAS) node use toApplications to build nodeHistogramData
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was1, was2), List.of())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, timeWindow, List.of(was1, was2), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -256,11 +261,12 @@ public class ResponseTimeHistogramServiceImplTest {
 
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), eq(LinkDataMapProcessor.NO_OP)))
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(was, nodeApplication)), timestamp));
 
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was), List.of())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, timeWindow, List.of(was), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -288,11 +294,12 @@ public class ResponseTimeHistogramServiceImplTest {
 
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), any(LinkDataMapProcessor.class)))
                 .thenReturn(createCallerLinkSelector(List.of(new LinkKey(was1, nodeApplication)), timestamp));
 
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was1, was2), List.of())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, timeWindow, List.of(was1, was2), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -320,13 +327,14 @@ public class ResponseTimeHistogramServiceImplTest {
 
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         //with no source Application do not scan
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), any(LinkDataMapProcessor.class)))
                 .thenThrow(new IllegalStateException("no scan for QUEUE node with empty sourceApplications"));
 
         //fromApplications out of Search range
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(), List.of())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, timeWindow, List.of(), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);
@@ -357,6 +365,7 @@ public class ResponseTimeHistogramServiceImplTest {
 
         final long timestamp = System.currentTimeMillis();
         final Range range = Range.between(timestamp, timestamp + 60000);
+        TimeWindow timeWindow = new TimeWindow(range);
 
         when(linkSelectorFactory.createLinkSelector(eq(LinkSelectorType.UNIDIRECTIONAL), any(LinkDataMapProcessor.class), any(LinkDataMapProcessor.class)))
                 .thenReturn(createCallerLinkSelector(List.of(
@@ -364,7 +373,7 @@ public class ResponseTimeHistogramServiceImplTest {
                 ), timestamp));
 
         //fromApplications out of Search range
-        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, range, List.of(was2), List.of())
+        ResponseTimeHistogramServiceOption option = new ResponseTimeHistogramServiceOption.Builder(nodeApplication, timeWindow, List.of(was2), List.of())
                 .setUseStatisticsAgentState(true)
                 .build();
         NodeHistogramSummary nodeHistogramSummary = service.selectNodeHistogramData(option);

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ApdexScoreServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ApdexScoreServiceImplTest.java
@@ -2,6 +2,7 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.DateTimeUtils;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
@@ -31,11 +32,13 @@ public class ApdexScoreServiceImplTest {
 
     private ApdexScoreServiceImpl apdexScoreService;
     private Range testRange;
+    private TimeWindow timeWindow;
 
     @BeforeEach
     public void mockResponseDao() {
         Instant endTimestamp = DateTimeUtils.epochMilli().truncatedTo(ChronoUnit.MINUTES);
         testRange = Range.between(endTimestamp.minus(Duration.ofMinutes(5)), endTimestamp);
+        timeWindow = new TimeWindow(testRange);
 
         List<ResponseTime> responseTimeList = new ArrayList<>(5);
         for (int i = 0; i < 5; i++) {
@@ -72,35 +75,35 @@ public class ApdexScoreServiceImplTest {
 
     @Test
     public void selectApplicationApdexScoreData() {
-        ApdexScore apdexScore = apdexScoreService.selectApdexScoreData(testApplication, testRange);
+        ApdexScore apdexScore = apdexScoreService.selectApdexScoreData(testApplication, timeWindow);
 
         assertThat(apdexScore.getApdexScore()).isGreaterThan(0);
     }
 
     @Test
     public void selectNonWasApplicationApexScoreData() {
-        ApdexScore apdexScore = apdexScoreService.selectApdexScoreData(new Application("nonWas", ServiceType.USER), testRange);
+        ApdexScore apdexScore = apdexScoreService.selectApdexScoreData(new Application("nonWas", ServiceType.USER), timeWindow);
 
         assertThat(apdexScore.getApdexScore()).isEqualTo(0);
     }
 
     @Test
     public void selectNonExistingApplicationApexScoreData() {
-        ApdexScore apdexScore = apdexScoreService.selectApdexScoreData(new Application("nonExisting", ServiceType.STAND_ALONE), testRange);
+        ApdexScore apdexScore = apdexScoreService.selectApdexScoreData(new Application("nonExisting", ServiceType.STAND_ALONE), timeWindow);
 
         assertThat(apdexScore.getApdexScore()).isEqualTo(0);
     }
 
     @Test
     public void selectAgentApexScoreData() {
-        ApdexScore apdexScore = apdexScoreService.selectApdexScoreData(testApplication, agentIdList.get(0), testRange);
+        ApdexScore apdexScore = apdexScoreService.selectApdexScoreData(testApplication, agentIdList.get(0), timeWindow);
 
         assertThat(apdexScore.getApdexScore()).isGreaterThan(0);
     }
 
     @Test
     public void selectNonExistingAgentApexScoreData() {
-        ApdexScore apdexScore = apdexScoreService.selectApdexScoreData(testApplication, "nonExistingAgentId", testRange);
+        ApdexScore apdexScore = apdexScoreService.selectApdexScoreData(testApplication, "nonExistingAgentId", timeWindow);
 
         assertThat(apdexScore.getApdexScore()).isEqualTo(0);
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ApplicationAgentListServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ApplicationAgentListServiceImplTest.java
@@ -2,6 +2,7 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
@@ -118,12 +119,13 @@ public class ApplicationAgentListServiceImplTest {
     @Test
     public void activeStatusAgentListTest() {
         Range range = Range.between(0, 60_000);
+        TimeWindow timeWindow = new TimeWindow(range);
         List<String> agentIds = List.of(testAgentId);
         when(applicationIndexDao.selectAgentIds(testApplicationName)).thenReturn(agentIds);
         when(agentInfoDao.getSimpleAgentInfos(agentIds, range.getTo())).thenReturn(List.of(testAgentInfo));
         when(agentLifeCycleDao.getAgentStatus(ArgumentMatchers.any())).thenReturn(List.of(Optional.of(testAgentStatus)));
 
-        List<AgentAndStatus> agentAndStatusList = applicationAgentListService.activeStatusAgentList(testApplicationName, testApplicationServiceType, range, AgentInfoFilters.acceptAll());
+        List<AgentAndStatus> agentAndStatusList = applicationAgentListService.activeStatusAgentList(testApplicationName, testApplicationServiceType, timeWindow, AgentInfoFilters.acceptAll());
 
         Assertions.assertThat(agentAndStatusList).hasSize(1);
         AgentAndStatus agentAndStatus = agentAndStatusList.get(0);
@@ -134,12 +136,14 @@ public class ApplicationAgentListServiceImplTest {
     @Test
     public void activeStatusAgentListTest2() {
         Range range = Range.between(0, 60_000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         List<String> agentIds = List.of(testAgentId);
         when(applicationIndexDao.selectAgentIds(testApplicationName)).thenReturn(agentIds);
         when(agentInfoDao.getSimpleAgentInfos(agentIds, range.getTo())).thenReturn(List.of(testAgentInfo));
         when(agentLifeCycleDao.getAgentStatus(ArgumentMatchers.any())).thenReturn(List.of(Optional.of(testAgentStatus)));
 
-        List<AgentAndStatus> agentAndStatusList = applicationAgentListService.activeStatusAgentList(testApplicationName, null, range, AgentInfoFilters.acceptAll());
+        List<AgentAndStatus> agentAndStatusList = applicationAgentListService.activeStatusAgentList(testApplicationName, null, timeWindow, AgentInfoFilters.acceptAll());
 
         Assertions.assertThat(agentAndStatusList).hasSize(1);
         AgentAndStatus agentAndStatus = agentAndStatusList.get(0);
@@ -150,11 +154,13 @@ public class ApplicationAgentListServiceImplTest {
     @Test
     public void activeResponseAgentListTest() {
         Range range = Range.between(0, 60_000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         List<String> agentIds = List.of(testAgentId);
-        when(mapResponseDao.selectResponseTime(testApplication, range)).thenReturn(List.of(testResponseTime));
+        when(mapResponseDao.selectResponseTime(testApplication, timeWindow)).thenReturn(List.of(testResponseTime));
         when(agentInfoDao.getSimpleAgentInfos(agentIds, range.getTo())).thenReturn(List.of(testAgentInfo));
 
-        List<AgentAndStatus> agentAndStatusList = applicationAgentListService.activeStatisticsAgentList(testApplicationName, testApplicationServiceType, range, AgentInfoFilters.acceptAll());
+        List<AgentAndStatus> agentAndStatusList = applicationAgentListService.activeStatisticsAgentList(testApplicationName, testApplicationServiceType, timeWindow, AgentInfoFilters.acceptAll());
 
         Assertions.assertThat(agentAndStatusList).hasSize(1);
         AgentAndStatus agentAndStatus = agentAndStatusList.get(0);
@@ -164,12 +170,14 @@ public class ApplicationAgentListServiceImplTest {
     @Test
     public void activeResponseAgentListTest2() {
         Range range = Range.between(0, 60_000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         List<String> agentIds = List.of(testAgentId);
         when(applicationIndexDao.selectApplicationName(testApplicationName)).thenReturn(List.of(testApplication));
-        when(mapResponseDao.selectResponseTime(testApplication, range)).thenReturn(List.of(testResponseTime));
+        when(mapResponseDao.selectResponseTime(testApplication, timeWindow)).thenReturn(List.of(testResponseTime));
         when(agentInfoDao.getSimpleAgentInfos(agentIds, range.getTo())).thenReturn(List.of(testAgentInfo));
 
-        List<AgentAndStatus> agentAndStatusList = applicationAgentListService.activeStatisticsAgentList(testApplicationName, null, range, AgentInfoFilters.acceptAll());
+        List<AgentAndStatus> agentAndStatusList = applicationAgentListService.activeStatisticsAgentList(testApplicationName, null, timeWindow, AgentInfoFilters.acceptAll());
 
         Assertions.assertThat(agentAndStatusList).hasSize(1);
         AgentAndStatus agentAndStatus = agentAndStatusList.get(0);
@@ -199,13 +207,15 @@ public class ApplicationAgentListServiceImplTest {
     @Test
     public void nullAgentInfoHandleTest2() {
         Range range = Range.between(0, 60_000);
+        TimeWindow timeWindow = new TimeWindow(range);
+
         List<String> agentIds = List.of(testAgentId);
-        when(mapResponseDao.selectResponseTime(testApplication, range)).thenReturn(List.of(testResponseTime));
+        when(mapResponseDao.selectResponseTime(testApplication, timeWindow)).thenReturn(List.of(testResponseTime));
         List<AgentInfo> nullAgentInfoList = new ArrayList<>();
         nullAgentInfoList.add(null);
         when(agentInfoDao.getSimpleAgentInfos(agentIds, range.getTo())).thenReturn(nullAgentInfoList);
 
-        List<AgentAndStatus> agentAndStatusList = applicationAgentListService.activeStatisticsAgentList(testApplicationName, testApplicationServiceType, range, AgentInfoFilters.acceptAll());
+        List<AgentAndStatus> agentAndStatusList = applicationAgentListService.activeStatisticsAgentList(testApplicationName, testApplicationServiceType, timeWindow, AgentInfoFilters.acceptAll());
 
         Assertions.assertThat(agentAndStatusList).hasSize(1);
         AgentAndStatus agentAndStatus = agentAndStatusList.get(0);


### PR DESCRIPTION
This pull request refactors the codebase to replace the use of `Range` with `TimeWindow` for time range management, improving clarity and consistency across the application. The changes affect both the core logic and associated test files.

### Core Logic Refactoring:
* **`ResponseTimeDataCollector`**: Replaced `Range` with `TimeWindow` in the `collect` method for better representation of time ranges. (`batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/ResponseTimeDataCollector.java`)
* **`ApplicationMapBuilder`**: Updated the constructor and methods to use `TimeWindow` instead of `Range`, ensuring consistent handling of time ranges throughout the application map building process. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilder.java`) [[1]](diffhunk://#diff-7105bb67aa47b306a56c96658af4d2b98e9066b0f6c419c551e79b5f212dbddcR52-R53) [[2]](diffhunk://#diff-7105bb67aa47b306a56c96658af4d2b98e9066b0f6c419c551e79b5f212dbddcL59-R66) [[3]](diffhunk://#diff-7105bb67aa47b306a56c96658af4d2b98e9066b0f6c419c551e79b5f212dbddcL88-R95) [[4]](diffhunk://#diff-7105bb67aa47b306a56c96658af4d2b98e9066b0f6c419c551e79b5f212dbddcL121-R126)
* **`DefaultNodeHistogramAppender`**: Refactored methods to accept `TimeWindow` instead of `Range`, aligning with the new time range abstraction. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/DefaultNodeHistogramAppender.java`) [[1]](diffhunk://#diff-be55c3910e8a30017f138675f86100bba66bdd2e76acf55e4a00a4b7856889bcL58-R59) [[2]](diffhunk://#diff-be55c3910e8a30017f138675f86100bba66bdd2e76acf55e4a00a4b7856889bcL67-R68) [[3]](diffhunk://#diff-be55c3910e8a30017f138675f86100bba66bdd2e76acf55e4a00a4b7856889bcL103-R124)
* **`DefaultNodeHistogramFactory`**: Updated the `createWasNodeHistogram` method to use `TimeWindow` for histogram creation. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/DefaultNodeHistogramFactory.java`)

### Test Updates:
* **Checker Tests**: Updated test cases in multiple checker test files (`ErrorCountCheckerTest`, `ErrorRateCheckerTest`, `ResponseCountCheckerTest`, `SlowCountCheckerTest`, `SlowRateCheckerTest`) to replace `Range` with `TimeWindow` in mock DAO methods and imports. [[1]](diffhunk://#diff-5eef0b896524c55f199719e811c1d0e1e1000fc19ebd4e344bbb5cccae28a14aL49-R49) [[2]](diffhunk://#diff-2a2d94e09d0292a282104da2f1a051a659e545a210e1d7c42e9e18e81c6802ebL49-R49) [[3]](diffhunk://#diff-0d55874c29eaa57389b7ca2ff279a548c5c32c0e41e9b27050962e0793e864afL51-R51) [[4]](diffhunk://#diff-d042221f4188804de913766609816608b2381c9a96ab6d9f380124c478acb2d3L49-R49) [[5]](diffhunk://#diff-b2c6eac16027222e65d42df91f53c247465ed591df5c1e1c0f53c3d8785d35d7L49-R49)

These changes streamline the codebase by unifying the representation of time ranges, reducing ambiguity, and improving maintainability.