### PR TITLE
[#noissue] Reduced memory usage in ResponseTime

### DIFF
--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ApdexScoreCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ApdexScoreCheckerTest.java
@@ -16,6 +16,7 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
@@ -42,24 +43,27 @@ public class ApdexScoreCheckerTest {
 
     @BeforeAll
     public static void before() {
-        mockMapResponseDAO = (application, range) -> {
-            long timeStamp = 1409814914298L;
-            ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
+        mockMapResponseDAO = new MapResponseDao() {
+            @Override
+            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
+                long timeStamp = 1409814914298L;
+                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
 
-            for (int i=0 ; i < 5; i++) {
-                for (int j=0 ; j < 5; j++) {
-                    TimeHistogram histogram = new TimeHistogram(ServiceType.STAND_ALONE, timeStamp);
-                    histogram.addCallCountByElapsedTime(1000, false);
-                    histogram.addCallCountByElapsedTime(1000, false);
-                    histogram.addCallCountByElapsedTime(1000, false);
-                    histogram.addCallCountByElapsedTime(1000, false);
-                    histogram.addCallCountByElapsedTime(6000, false);
-                    responseTime.addResponseTime("agent_" + i + "_" + j, histogram);
+                for (int i = 0; i < 5; i++) {
+                    for (int j = 0; j < 5; j++) {
+                        TimeHistogram histogram = new TimeHistogram(ServiceType.STAND_ALONE, timeStamp);
+                        histogram.addCallCountByElapsedTime(1000, false);
+                        histogram.addCallCountByElapsedTime(1000, false);
+                        histogram.addCallCountByElapsedTime(1000, false);
+                        histogram.addCallCountByElapsedTime(1000, false);
+                        histogram.addCallCountByElapsedTime(6000, false);
+                        responseTime.addResponseTime("agent_" + i + "_" + j, histogram);
+                    }
+                    timeStamp += 1;
                 }
-                timeStamp += 1;
-            }
 
-            return List.of(responseTime.build());
+                return List.of(responseTime.build());
+            }
         };
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/MapApplicationResponseNodeHistogramDataSource.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/MapApplicationResponseNodeHistogramDataSource.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource;
+
+import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
+import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
+import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationHistogram;
+import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationTimeHistogram;
+import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
+import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
+import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
+import com.navercorp.pinpoint.web.vo.Application;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ */
+public class MapApplicationResponseNodeHistogramDataSource implements WasNodeHistogramDataSource {
+
+    private final MapResponseDao mapResponseDao;
+
+    public MapApplicationResponseNodeHistogramDataSource(MapResponseDao mapResponseDao) {
+        this.mapResponseDao = Objects.requireNonNull(mapResponseDao, "mapResponseDao");
+    }
+
+    @Override
+    public NodeHistogram createNodeHistogram(Application application, TimeWindow timeWindow) {
+        ApplicationHistogram applicationHistogram = mapResponseDao.selectApplicationResponseTime(application, timeWindow);
+
+        List<TimeHistogram> histogram = applicationHistogram.getApplicationHistograms();
+        ApplicationTimeHistogram applicationTimeHistogram = new ApplicationTimeHistogram(application, histogram);
+
+        Range windowRange = timeWindow.getWindowRange();
+        NodeHistogram.Builder builder = NodeHistogram.newBuilder(application, windowRange);
+        builder.setApplicationTimeHistogram(applicationTimeHistogram);
+
+        Histogram appHistogram = getHistogram(application, applicationTimeHistogram);
+        builder.setApplicationHistogram(appHistogram);
+
+        Map<String, Histogram> agentMap = getAgentIdMap(application, applicationHistogram.getAgentIds());
+        builder.setAgentHistogramMap(agentMap);
+        return builder.build();
+    }
+
+    private Histogram getHistogram(Application application, ApplicationTimeHistogram applicationTimeHistogram) {
+        Histogram histogram = new Histogram(application.getServiceType());
+        applicationTimeHistogram.getHistogramList().forEach(histogram::add);
+        return histogram;
+    }
+
+    private Map<String, Histogram> getAgentIdMap(Application application, Set<String> agentIds) {
+        Map<String, Histogram> agentMap = new HashMap<>();
+        Histogram emptyHistogram = new Histogram(application.getServiceType());
+        for (String agentId : agentIds) {
+            agentMap.put(agentId, emptyHistogram);
+        }
+        return agentMap;
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapHbaseConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapHbaseConfiguration.java
@@ -40,6 +40,7 @@ import com.navercorp.pinpoint.web.applicationmap.dao.hbase.HbaseMapResponseTimeD
 import com.navercorp.pinpoint.web.applicationmap.dao.hbase.MapScanFactory;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ResultExtractorFactory;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.RowMapperFactory;
+import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationHistogram;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.vo.RangeFactory;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
@@ -134,12 +135,14 @@ public class MapHbaseConfiguration {
     public MapResponseDao mapResponseDao(@Qualifier("mapHbaseTemplate")
                                          HbaseTemplate hbaseTemplate,
                                          TableNameProvider tableNameProvider,
-                                         @Qualifier("responseTimeResultExtract")
+                                         @Qualifier("responseTimeResultExtractor")
                                          ResultExtractorFactory<List<ResponseTime>> resultExtractFactory,
+                                         @Qualifier("applicationResponseTimeResultExtractor")
+                                         ResultExtractorFactory<ApplicationHistogram> applicationHistogramResultExtractor,
                                          MapScanFactory mapScanFactory,
                                          @Qualifier("mapSelfRowKeyDistributor")
                                          RowKeyDistributorByHashPrefix rowKeyDistributor) {
-        return new HbaseMapResponseTimeDao(hbaseTemplate, tableNameProvider, resultExtractFactory, mapScanFactory, rowKeyDistributor);
+        return new HbaseMapResponseTimeDao(hbaseTemplate, tableNameProvider, resultExtractFactory, applicationHistogramResultExtractor, mapScanFactory, rowKeyDistributor);
     }
 
     @Bean

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapMapperConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapMapperConfiguration.java
@@ -2,6 +2,7 @@ package com.navercorp.pinpoint.web.applicationmap.config;
 
 
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
+import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ApplicationResponseTimeResultExtractor;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.InLinkMapper;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.LinkFilter;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.OutLinkMapper;
@@ -9,6 +10,7 @@ import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ResponseTimeMapper;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ResponseTimeResultExtractor;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ResultExtractorFactory;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.RowMapperFactory;
+import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationHistogram;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
@@ -45,10 +47,17 @@ public class MapMapperConfiguration {
     }
 
     @Bean
-    public ResultExtractorFactory<List<ResponseTime>> responseTimeResultExtract(ServiceTypeRegistryService registry,
+    public ResultExtractorFactory<List<ResponseTime>> responseTimeResultExtractor(ServiceTypeRegistryService registry,
                                                                                 @Qualifier("mapSelfRowKeyDistributor")
                                                       RowKeyDistributorByHashPrefix rowKeyDistributor) {
         return (windowFunction) -> new ResponseTimeResultExtractor(registry, rowKeyDistributor, windowFunction);
+    }
+
+    @Bean
+    public ResultExtractorFactory<ApplicationHistogram> applicationResponseTimeResultExtractor(ServiceTypeRegistryService registry,
+                                                                                @Qualifier("mapSelfRowKeyDistributor")
+                                                                                RowKeyDistributorByHashPrefix rowKeyDistributor) {
+        return (windowFunction) -> new ApplicationResponseTimeResultExtractor(registry, rowKeyDistributor, windowFunction);
     }
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapResponseDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapResponseDao.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.dao;
 
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
+import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
 
@@ -31,4 +32,7 @@ import java.util.List;
 public interface MapResponseDao {
     List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow);
 
+    default ApplicationHistogram selectApplicationResponseTime(Application application, TimeWindow timeWindow) {
+        return null;
+    }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ApplicationResponseTimeResultExtractor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ApplicationResponseTimeResultExtractor.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.dao.mapper;
+
+import com.navercorp.pinpoint.common.buffer.Buffer;
+import com.navercorp.pinpoint.common.buffer.FixedBuffer;
+import com.navercorp.pinpoint.common.hbase.HbaseTables;
+import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
+import com.navercorp.pinpoint.common.hbase.util.CellUtils;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.util.BytesUtils;
+import com.navercorp.pinpoint.common.util.TimeUtils;
+import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
+import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationHistogram;
+import com.sematext.hbase.wd.RowKeyDistributorByHashPrefix;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+
+
+/**
+ * @author emeroad
+ */
+public class ApplicationResponseTimeResultExtractor implements ResultsExtractor<ApplicationHistogram> {
+
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    private final ServiceTypeRegistryService registry;
+
+    private final RowKeyDistributorByHashPrefix rowKeyDistributor;
+
+    private final TimeWindowFunction timeWindowFunction;
+
+
+    public ApplicationResponseTimeResultExtractor(ServiceTypeRegistryService registry,
+                                                  RowKeyDistributorByHashPrefix rowKeyDistributor,
+                                                  TimeWindowFunction timeWindowFunction) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+        this.rowKeyDistributor = Objects.requireNonNull(rowKeyDistributor, "rowKeyDistributor");
+        this.timeWindowFunction = Objects.requireNonNull(timeWindowFunction, "timeWindowFunction");
+    }
+
+    public ApplicationHistogram extractData(ResultScanner results) throws Exception {
+        ApplicationHistogram.Builder builder = null;
+        for (Result result : results) {
+            builder = this.mapRow(builder, result);
+        }
+        if (builder == null) {
+            return null;
+        }
+        return builder.build();
+    }
+
+
+    private ApplicationHistogram.Builder mapRow(ApplicationHistogram.Builder builder, Result result) {
+        if (result.isEmpty()) {
+            return null;
+        }
+
+        final byte[] rowKey = getOriginalKey(result.getRow());
+
+        Record record = createResponseTimeBuilder(rowKey);
+        if (builder == null) {
+            builder = ApplicationHistogram.newBuilder(record.applicationName(), record.serviceType());
+        } else {
+            if (!builder.getApplicationName().equals(record.applicationName())) {
+                throw new IllegalArgumentException("applicationName must match");
+            }
+            if (!builder.getApplicationServiceType().equals(record.serviceType())) {
+                throw new IllegalArgumentException("serviceType must match");
+            }
+        }
+        for (Cell cell : result.rawCells()) {
+            if (CellUtil.matchingFamily(cell, HbaseTables.MAP_STATISTICS_SELF_VER2_COUNTER.getName())) {
+                recordColumn(builder, record.timestamp(), cell);
+            }
+
+            if (logger.isTraceEnabled()) {
+                String columnFamily = Bytes.toString(cell.getFamilyArray(), cell.getFamilyOffset(), cell.getFamilyLength());
+                logger.trace("unknown column family:{}", columnFamily);
+            }
+        }
+        return builder;
+    }
+
+    void recordColumn(ApplicationHistogram.Builder responseTimeBuilder, long timestamp, Cell cell) {
+
+        final byte[] qArray = cell.getQualifierArray();
+        final int qOffset = cell.getQualifierOffset();
+        final short slotNumber = Bytes.toShort(qArray, qOffset);
+
+        // agentId should be added as data.
+        String agentId = Bytes.toString(qArray, qOffset + BytesUtils.SHORT_BYTE_LENGTH, cell.getQualifierLength() - BytesUtils.SHORT_BYTE_LENGTH);
+        long count = CellUtils.valueToLong(cell);
+
+        responseTimeBuilder.addResponseTime(agentId, timestamp, slotNumber, count);
+    }
+
+    private Record createResponseTimeBuilder(byte[] rowKey) {
+        final Buffer row = new FixedBuffer(rowKey);
+        final String applicationName = row.read2PrefixedString();
+        final short serviceTypeCode = row.readShort();
+        final long timestamp = timeWindowFunction.refineTimestamp(TimeUtils.recoveryTimeMillis(row.readLong()));
+        final ServiceType serviceType = registry.findServiceType(serviceTypeCode);
+
+        return new Record(applicationName, serviceType, timestamp);
+    }
+
+    private record Record(
+            String applicationName,
+            ServiceType serviceType,
+            long timestamp
+    ) {}
+
+    private byte[] getOriginalKey(byte[] rowKey) {
+        return rowKeyDistributor.getOriginalKey(rowKey);
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationHistogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationHistogram.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.histogram;
+
+import com.navercorp.pinpoint.common.trace.ServiceType;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author emeroad
+ */
+public class ApplicationHistogram {
+    // rowKey
+    private final String applicationName;
+    private final ServiceType applicationServiceType;
+    // agentId is the key
+    private final List<TimeHistogram> histograms;
+    private final Set<String> agentIdMap;
+
+
+    ApplicationHistogram(String applicationName,
+                         ServiceType applicationServiceType,
+                         List<TimeHistogram> histograms,
+                         Set<String> agentIdMap) {
+        this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
+        this.applicationServiceType = Objects.requireNonNull(applicationServiceType, "applicationServiceType");
+        this.histograms = Objects.requireNonNull(histograms, "histograms");
+        this.agentIdMap = Objects.requireNonNull(agentIdMap, "agentIdMap");
+    }
+
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public int getApplicationServiceType() {
+        return applicationServiceType.getCode();
+    }
+
+    public Set<String> getAgentIds() {
+        return agentIdMap;
+    }
+
+
+    public List<TimeHistogram> getApplicationHistograms() {
+        return histograms;
+    }
+
+    @Override
+    public String toString() {
+        return "ApplicationHistogram{" +
+                "applicationName='" + applicationName + '\'' +
+                ", applicationServiceType=" + applicationServiceType +
+                ", histograms=" + histograms +
+                ", agentIdMap=" + agentIdMap +
+                '}';
+    }
+
+    public static Builder newBuilder(String applicationName, ServiceType applicationServiceType) {
+        return new Builder(applicationName, applicationServiceType);
+    }
+
+    public static class Builder {
+
+        private final Map<Long, TimeHistogram> histogramMap;
+        // agentId is the key
+        private final Set<String> agentIdMap;
+
+        private final String applicationName;
+        private final ServiceType applicationServiceType;
+
+        Builder(String applicationName, ServiceType applicationServiceType) {
+            this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
+            this.applicationServiceType = Objects.requireNonNull(applicationServiceType, "applicationServiceType");
+            this.histogramMap = new HashMap<>();
+            this.agentIdMap = new HashSet<>();
+        }
+
+        public String getApplicationName() {
+            return applicationName;
+        }
+
+        public ServiceType getApplicationServiceType() {
+            return applicationServiceType;
+        }
+
+        public void addResponseTime(String agentId, long timeStamp, short slotNumber, long count) {
+            this.agentIdMap.add(agentId);
+            TimeHistogram timeHistogram = getTimeHistogram(timeStamp);
+            timeHistogram.addCallCount(slotNumber, count);
+        }
+
+        private TimeHistogram getTimeHistogram(long timeStamp) {
+            return this.histogramMap.computeIfAbsent(timeStamp, k -> new TimeHistogram(applicationServiceType, timeStamp));
+        }
+
+
+        public void addResponseTime(String agentId, long timestamp, Histogram copyHistogram) {
+            Objects.requireNonNull(agentId, "agentId");
+            Objects.requireNonNull(copyHistogram, "copyHistogram");
+
+            this.agentIdMap.add(agentId);
+            TimeHistogram histogram = getTimeHistogram(timestamp);
+            histogram.add(copyHistogram);
+        }
+
+        public void addResponseTime(String agentId, long timestamp, int elapsedTime, boolean error) {
+            Objects.requireNonNull(agentId, "agentId");
+
+            this.agentIdMap.add(agentId);
+
+            TimeHistogram histogram = getTimeHistogram(timestamp);
+            histogram.addCallCountByElapsedTime(elapsedTime, error);
+        }
+
+        public ApplicationHistogram build() {
+            List<TimeHistogram> list = new ArrayList<>(this.histogramMap.values());
+            list.sort(Comparator.comparing(TimeHistogram::getTimeStamp));
+            return new ApplicationHistogram(applicationName, applicationServiceType, list, this.agentIdMap);
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/NodeHistogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/NodeHistogram.java
@@ -154,29 +154,21 @@ public class NodeHistogram {
         final Application application;
         final Range range;
 
-        // ApplicationLevelHistogram
-        Histogram applicationHistogram;
-
+        AgentTimeHistogram agentTimeHistogram;
         // key is agentId
         Map<String, Histogram> agentHistogramMap = Collections.emptyMap();
 
+        // ApplicationLevelHistogram
+        Histogram applicationHistogram;
         ApplicationTimeHistogram applicationTimeHistogram;
 
-        AgentTimeHistogram agentTimeHistogram;
 
         Builder(Application application, Range range) {
             this.application = Objects.requireNonNull(application, "application");
             this.range = Objects.requireNonNull(range, "range");
         }
 
-        public void setApplicationTimeHistogram(ApplicationTimeHistogram applicationTimeHistogram) {
-            this.applicationTimeHistogram = applicationTimeHistogram;
-        }
-
-        public void setApplicationHistogram(Histogram applicationHistogram) {
-            this.applicationHistogram = Objects.requireNonNull(applicationHistogram, "applicationHistogram");
-        }
-
+        // agent -----------------
         public void setAgentTimeHistogram(AgentTimeHistogram agentTimeHistogram) {
             this.agentTimeHistogram = agentTimeHistogram;
         }
@@ -185,29 +177,43 @@ public class NodeHistogram {
             this.agentHistogramMap = agentHistogramMap;
         }
 
-        public void setApplicationHistogram(List<ResponseTime> responseTimeList) {
-            Objects.requireNonNull(responseTimeList, "responseTimeList");
-            this.applicationHistogram = createApplicationLevelResponseTime(responseTimeList);
-        }
-
         public void setAgentHistogramMap(List<ResponseTime> responseTimeList) {
             Objects.requireNonNull(responseTimeList, "responseTimeList");
             this.agentHistogramMap = createAgentLevelResponseTime(responseTimeList);
         }
 
+        // application ----------------
+
+        public void setApplicationHistogram(Histogram applicationHistogram) {
+            this.applicationHistogram = Objects.requireNonNull(applicationHistogram, "applicationHistogram");
+        }
+
+        public void setApplicationHistogram(List<ResponseTime> responseTimeList) {
+            Objects.requireNonNull(responseTimeList, "responseTimeList");
+            this.applicationHistogram = createApplicationLevelResponseTime(responseTimeList);
+        }
+
+        public void setApplicationTimeHistogram(ApplicationTimeHistogram applicationTimeHistogram) {
+            this.applicationTimeHistogram = applicationTimeHistogram;
+        }
+
+        public void setApplicationResponseHistogram(List<ResponseTime> responseHistogramList) {
+            this.applicationTimeHistogram = createApplicationLevelTimeSeriesResponseTime(responseHistogramList);
+            this.applicationHistogram = createApplicationLevelResponseTime(responseHistogramList);
+        }
+
+        // all ----
         public void setResponseHistogram(List<ResponseTime> responseHistogramList) {
             this.agentTimeHistogram = createAgentLevelTimeSeriesResponseTime(responseHistogramList);
             this.agentHistogramMap = createAgentLevelResponseTime(responseHistogramList);
 
-            this.applicationTimeHistogram = createApplicationLevelTimeSeriesResponseTime(responseHistogramList);
-            this.applicationHistogram = createApplicationLevelResponseTime(responseHistogramList);
+            setApplicationResponseHistogram(responseHistogramList);
         }
 
         private ApplicationTimeHistogram createApplicationLevelTimeSeriesResponseTime(List<ResponseTime> responseHistogramList) {
             ApplicationTimeHistogramBuilder builder = new ApplicationTimeHistogramBuilder(application, range);
             return builder.build(responseHistogramList);
         }
-
 
         private AgentTimeHistogram createAgentLevelTimeSeriesResponseTime(List<ResponseTime> responseHistogramList) {
             AgentTimeHistogramBuilder builder = new AgentTimeHistogramBuilder(application, range);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceImpl.java
@@ -24,8 +24,9 @@ import com.navercorp.pinpoint.web.applicationmap.ApplicationMapBuilderFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.DefaultNodeHistogramFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.NodeHistogramFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.SimplifiedNodeHistogramFactory;
-import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.MapResponseNodeHistogramDataSource;
+import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.MapApplicationResponseNodeHistogramDataSource;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.MapResponseSimplifiedNodeHistogramDataSource;
+import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.WasNodeHistogramDataSource;
 import com.navercorp.pinpoint.web.applicationmap.appender.server.DefaultServerGroupListFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.server.ServerGroupListFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.server.StatisticsServerGroupListFactory;
@@ -97,7 +98,7 @@ public class MapServiceImpl implements MapService {
         logger.debug("SelectApplicationMap");
 
         StopWatch watch = new StopWatch("ApplicationMap");
-        watch.start("ApplicationMap Hbase Io Fetch(Out,In) Time");
+        watch.start("ApplicationMap Link Fetch(Out,In) Time");
 
         final SearchOption searchOption = option.getSearchOption();
         LinkSelectorType linkSelectorType = searchOption.getLinkSelectorType();
@@ -150,9 +151,11 @@ public class MapServiceImpl implements MapService {
 
     private NodeHistogramFactory newNodeHistogramFactory(MapServiceOption option) {
         if (option.isSimpleResponseHistogram()) {
-            return new SimplifiedNodeHistogramFactory(new MapResponseSimplifiedNodeHistogramDataSource(mapResponseDao));
+            WasNodeHistogramDataSource dataSource = new MapResponseSimplifiedNodeHistogramDataSource(mapResponseDao);
+            return new SimplifiedNodeHistogramFactory(dataSource);
         } else {
-            return new DefaultNodeHistogramFactory(new MapResponseNodeHistogramDataSource(mapResponseDao));
+            WasNodeHistogramDataSource dataSource = new MapApplicationResponseNodeHistogramDataSource(mapResponseDao);
+            return new DefaultNodeHistogramFactory(dataSource);
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new feature for handling application-level response time histograms. It involves adding a new `ApplicationHistogram` data structure and integrating it into the existing system. The changes include updates to data access objects, configuration files, and the addition of a new mapper class for extracting histogram data. Below are the key changes grouped by theme:

### New Feature: Application-Level Response Time Histogram
* **Addition of `ApplicationHistogram` Support**: Introduced the `ApplicationHistogram` class to represent application-level response time histograms. This includes adding a new method `selectApplicationResponseTime` to the `MapResponseDao` interface and its implementation in `HbaseMapResponseTimeDao`. [[1]](diffhunk://#diff-51b8ca39ea5066a374e18b76f5b8ed5b60f7e6e172ca0ebcadbfb6a62d2fa356R35) [[2]](diffhunk://#diff-f0573e9902ac6c82e5d66f153f0a1690458cc4132d1df9bb72e9bf7ed303072cR102-R123)

* **New Mapper for Histogram Extraction**: Added the `ApplicationResponseTimeResultExtractor` class to extract histogram data from HBase. This mapper processes HBase rows to build `ApplicationHistogram` objects.

### Configuration Updates
* **Dependency Injection for Histogram Extractor**: Updated the `MapHbaseConfiguration` and `MapMapperConfiguration` to include beans for the new `ApplicationResponseTimeResultExtractor` and its factory. These changes ensure the new feature is properly wired into the application. [[1]](diffhunk://#diff-a96a2c5f31c389a4beaa10d2fe7cd39bcca806b0b1b4c33eb87bf4a6ee7cd75eL137-R145) [[2]](diffhunk://#diff-17856bf858d8167b0fe77ba7bd516cc06ed33bd43efb7e57a590453825191591L48-R62)

### Test Enhancements
* **Test Updates for `ErrorCountCheckerTest`**: Added a stub implementation for the new `selectApplicationResponseTime` method in the `ErrorCountCheckerTest` class to support testing.

### New Data Source
* **`MapApplicationResponseNodeHistogramDataSource` Implementation**: Added a new data source class to create `NodeHistogram` objects using the `ApplicationHistogram` data. This class integrates with the `MapResponseDao` to fetch and process histogram data.

These changes collectively enable the application to handle and process application-level response time histograms, enhancing its analytical capabilities.