### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilder.java
@@ -99,9 +99,10 @@ public class ApplicationMapBuilder {
         if (serverGroupListFactory == null) {
             return NodeList.of();
         }
-        Node node = new Node(application);
-        ServerGroupList runningInstances = serverGroupListFactory.createWasNodeInstanceList(node, range.getTo());
+        Node query = new Node(application);
+        ServerGroupList runningInstances = serverGroupListFactory.createWasNodeInstanceList(query, range.getTo());
         if (runningInstances.hasServerInstance()) {
+            Node node = new Node(application);
             node.setServerGroupList(runningInstances);
             return NodeList.of(node);
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/DefaultServerInfoAppender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/DefaultServerInfoAppender.java
@@ -44,8 +44,6 @@ public class DefaultServerInfoAppender implements ServerInfoAppender {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
-    private static final ServerGroupList EMPTY = ServerGroupList.empty();
-
     private final ServerGroupListFactory serverGroupListFactory;
 
     private final Executor executor;
@@ -141,16 +139,13 @@ public class DefaultServerInfoAppender implements ServerInfoAppender {
 
     private void bind(List<ServerGroupRequest> serverGroupRequest) {
         for (ServerGroupRequest pair : serverGroupRequest) {
-            Node node = pair.node();
             CompletableFuture<ServerGroupList> future = pair.future();
             try {
-                ServerGroupList serverGroupList = future.getNow(EMPTY);
-                if (serverGroupList == EMPTY) {
-                    serverGroupList = serverGroupListFactory.createEmptyNodeInstanceList();
-                }
+                ServerGroupList serverGroupList = future.getNow(ServerGroupList.empty());
+                Node node = pair.node();
                 node.setServerGroupList(serverGroupList);
             } catch (Throwable th) {
-                logger.warn("Failed to get server info for node {}", node);
+                logger.warn("Failed to get server info for node {}", pair.node());
                 throw new RuntimeException("Unexpected error", th);
             }
         }


### PR DESCRIPTION
This pull request includes changes to improve the handling of `Node` and `ServerGroupList` objects in the application map builder and server info appender. The updates aim to enhance clarity and reduce unnecessary code duplication.

### Improvements to `Node` handling:

* Refactored the `getNodeList` method in `ApplicationMapBuilder` to use a separate `query` object for creating the `ServerGroupList`, improving clarity by distinguishing between the query node and the resulting node. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilder.java`, [web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilder.javaL102-R105](diffhunk://#diff-7105bb67aa47b306a56c96658af4d2b98e9066b0f6c419c551e79b5f212dbddcL102-R105))

### Simplification of `ServerGroupList` usage:

* Removed the redundant `EMPTY` constant in `DefaultServerInfoAppender`, replacing its usage with the static method `ServerGroupList.empty()` for consistency and simplicity. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/DefaultServerInfoAppender.java`, [[1]](diffhunk://#diff-284651c342c7aecb97f58c23c018333d129d31e0b3ff45ce65e80949a9456e52L47-L48) [[2]](diffhunk://#diff-284651c342c7aecb97f58c23c018333d129d31e0b3ff45ce65e80949a9456e52L144-R148)