### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkHandler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkHandler.java
@@ -59,7 +59,7 @@ public class VirtualLinkHandler {
             return linkDataDuplexMap;
         }
         logger.debug("Virtual link size : {}", virtualLinkDataSet.size());
-        List<Application> unpopulatedEmulatedNodes = getUnpopulatedEmulatedNodes(linkDataDuplexMap.getTargetLinkDataMap(), virtualLinkDataSet);
+        Collection<Application> unpopulatedEmulatedNodes = getUnpopulatedEmulatedNodes(linkDataDuplexMap.getTargetLinkDataMap(), virtualLinkDataSet);
         if (unpopulatedEmulatedNodes.isEmpty()) {
             logger.debug("unpopulated emulated node not found");
         } else {
@@ -75,7 +75,7 @@ public class VirtualLinkHandler {
         return linkDataDuplexMap;
     }
 
-    private List<Application> getUnpopulatedEmulatedNodes(LinkDataMap targetLinkDataMap, Set<LinkData> virtualLinkDataSet) {
+    private Collection<Application> getUnpopulatedEmulatedNodes(LinkDataMap targetLinkDataMap, Set<LinkData> virtualLinkDataSet) {
         Set<Application> unpopulatedEmulatedNodes = new HashSet<>();
         for (LinkData virtualLinkData : virtualLinkDataSet) {
             Application toApplication = virtualLinkData.getToApplication();
@@ -83,7 +83,7 @@ public class VirtualLinkHandler {
                 unpopulatedEmulatedNodes.add(toApplication);
             }
         }
-        return new ArrayList<>(unpopulatedEmulatedNodes);
+        return unpopulatedEmulatedNodes;
     }
 
     private Collection<LinkData> getEmulatedNodeInLinkData(LinkVisitChecker linkVisitChecker, Application emulatedNode, TimeWindow timeWindow) {
@@ -95,12 +95,16 @@ public class VirtualLinkHandler {
             Application fromApplication = inLinkData.getFromApplication();
             // filter callee link data from non-WAS nodes
             if (!fromApplication.getServiceType().isWas()) {
-                logger.trace("filtered {} as {} is not a WAS node", inLinkData, fromApplication);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("filtered {} as {} is not a WAS node", inLinkData, fromApplication);
+                }
                 continue;
             }
             // filter callee link data from nodes that haven't been visited as we don't need them
             if (!linkVisitChecker.isVisitedOut(fromApplication)) {
-                logger.trace("filtered {} as {} is not in scope of the current server map", inLinkData, fromApplication);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("filtered {} as {} is not in scope of the current server map", inLinkData, fromApplication);
+                }
                 continue;
             }
             logger.debug("emulated node [{}] inLink LinkData:{}", emulatedNode, inLinkData);

--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/CallTreeIterator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/CallTreeIterator.java
@@ -245,7 +245,7 @@ public class CallTreeIterator implements Iterator<CallTreeNode> {
     }
 
     public List<Align> values() {
-        List<Align> values = new ArrayList<>();
+        List<Align> values = new ArrayList<>(nodes.size());
         for (CallTreeNode node : nodes) {
             values.add(node.getAlign());
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/MetaSpanCallTreeFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/MetaSpanCallTreeFactory.java
@@ -49,14 +49,14 @@ public class MetaSpanCallTreeFactory {
         rootSpan.setStartTime(startTimeMillis);
         rootSpan.setServiceType(ServiceType.UNKNOWN.getCode());
 
-        List<AnnotationBo> annotations = new ArrayList<>();
         ApiMetaDataBo apiMetaData = new ApiMetaDataBo(UNKNOWN_AGENT_ID, AGENT_START_TIME, 0, LineNumber.NO_LINE_NUMBER,
                 MethodTypeEnum.WEB_REQUEST, "Unknown");
-
         final AnnotationBo apiMetaDataAnnotation = AnnotationBo.of(AnnotationKey.API_METADATA.getCode(), apiMetaData);
-        annotations.add(apiMetaDataAnnotation);
 
         final AnnotationBo argumentAnnotation = AnnotationBo.of(AnnotationKeyUtils.getArgs(0).getCode(), "No Agent Data");
+
+        List<AnnotationBo> annotations = new ArrayList<>();
+        annotations.add(apiMetaDataAnnotation);
         annotations.add(argumentAnnotation);
         rootSpan.setAnnotationBoList(annotations);
 
@@ -74,18 +74,16 @@ public class MetaSpanCallTreeFactory {
         rootSpan.setApplicationName("CORRUPTED");
         rootSpan.setServiceType(ServiceType.UNKNOWN.getCode());
 
-        List<AnnotationBo> annotations = new ArrayList<>();
-
         ApiMetaDataBo apiMetaData = new ApiMetaDataBo(CORRUPTED_AGENT_ID, AGENT_START_TIME, 0, LineNumber.NO_LINE_NUMBER,
                 MethodTypeEnum.CORRUPTED, "...");
-
         final AnnotationBo apiMetaDataAnnotation = AnnotationBo.of(AnnotationKey.API_METADATA.getCode(), apiMetaData);
-        annotations.add(apiMetaDataAnnotation);
-
 
         int key = AnnotationKeyUtils.getArgs(0).getCode();
         String errorMessage = getErrorMessage(title, startTimeMillis);
         final AnnotationBo argumentAnnotation = AnnotationBo.of(key, errorMessage);
+
+        List<AnnotationBo> annotations = new ArrayList<>();
+        annotations.add(apiMetaDataAnnotation);
         annotations.add(argumentAnnotation);
         rootSpan.setAnnotationBoList(annotations);
         return new MetaSpanCallTree(new SpanAlign(rootSpan, true));

--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/Node.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/Node.java
@@ -138,7 +138,7 @@ public class Node {
             return Collections.emptyList();
         }
 
-        List<Align> alignList = new ArrayList<>();
+        List<Align> alignList = new ArrayList<>(spanEventBoList.size());
         for (SpanEventBo spanEventBo : spanEventBoList) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Populate spanEvent{seq={}, depth={}, event={}}", spanEventBo.getSequence(), spanEventBo.getDepth(), spanEventBo);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ProxyRequestTypeRegistryServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ProxyRequestTypeRegistryServiceImpl.java
@@ -75,7 +75,7 @@ public class ProxyRequestTypeRegistryServiceImpl implements ProxyRequestTypeRegi
     public void init() {
         final ClassLoader classLoader = ClassUtils.getDefaultClassLoader();
         final ServiceLoader<ProxyRequestMetadataProvider> serviceLoader = ServiceLoader.load(ProxyRequestMetadataProvider.class, classLoader);
-        final List<ProxyRequestType> proxyRequestTypeList = new ArrayList<ProxyRequestType>();
+        final List<ProxyRequestType> proxyRequestTypeList = new ArrayList<>();
         for (ProxyRequestMetadataProvider provider : serviceLoader) {
             final ProxyRequestMetadataSetupContext context = new ProxyRequestMetadataSetupContext() {
                 @Override


### PR DESCRIPTION
This pull request focuses on improving code efficiency, readability, and logging throughout the `web` module. The most significant changes include optimizing the initialization of collections, enhancing logging for debugging, and improving consistency in method return types.

### Code efficiency improvements:
* Updated the initialization of `ArrayList` instances to include initial capacity where applicable, improving memory allocation efficiency in `CallTreeIterator`, `Node`, and `MetaSpanCallTreeFactory`. (`[[1]](diffhunk://#diff-eb3a3e58cc17eeca043134aebe7207eee60f725b5e5d6d30cf189304e0672e39L248-R248)`, `[[2]](diffhunk://#diff-90618b20ad38a7a731382592e26581870901eda13a5e43700a62d148c712502bL141-R141)`, `[[3]](diffhunk://#diff-7fc61eafdca60bd93e071196758b677a2102b10cb460bb11abcf02e003c332afL52-R59)`, `[[4]](diffhunk://#diff-7fc61eafdca60bd93e071196758b677a2102b10cb460bb11abcf02e003c332afL77-R86)`)
* Simplified the instantiation of `ArrayList` by removing redundant type arguments in `ProxyRequestTypeRegistryServiceImpl`. (`[web/src/main/java/com/navercorp/pinpoint/web/service/ProxyRequestTypeRegistryServiceImpl.javaL78-R78](diffhunk://#diff-bdc7a6f08ff84d6c2b1f1e6772a35b065cdb71bf23ad9b916234d41780291e0aL78-R78)`)

### Method return type consistency:
* Changed the return type of `getUnpopulatedEmulatedNodes` from `List` to `Collection` in `VirtualLinkHandler` to better reflect the method's implementation and usage. (`[[1]](diffhunk://#diff-a7126b4b2e85315a3bad368e2fdf2a44e7d859984c3ef004816fd3da987426c2L62-R62)`, `[[2]](diffhunk://#diff-a7126b4b2e85315a3bad368e2fdf2a44e7d859984c3ef004816fd3da987426c2L78-R86)`)

### Logging enhancements:
* Added conditional checks for `logger.isTraceEnabled()` before trace-level logging in `VirtualLinkHandler` to avoid unnecessary string concatenation when trace logging is disabled. (`[web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkHandler.javaR98-R107](diffhunk://#diff-a7126b4b2e85315a3bad368e2fdf2a44e7d859984c3ef004816fd3da987426c2R98-R107)`)