### PR TITLE
[#noissue] Optimize TagUtils

### DIFF
--- a/metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/util/TagUtils.java
+++ b/metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/util/TagUtils.java
@@ -24,8 +24,8 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * @author Hyunjoon Cho
@@ -40,10 +40,10 @@ public class TagUtils {
 
     public static List<Tag> parseTags(List<String> tags) {
         if (CollectionUtils.isEmpty(tags)) {
-            return new ArrayList<>();
+            return List.of();
         }
 
-        List<Tag> tagList = new ArrayList<>();
+        List<Tag> tagList = new ArrayList<>(tags.size());
         for (String tagString : tags) {
             Tag tag = parseTag(tagString);
             tagList.add(tag);
@@ -53,12 +53,12 @@ public class TagUtils {
 
     public static List<Tag> parseTags(String tagStrings) {
         if (tagStrings == null || tagStrings.contains("null")) {
-            return new ArrayList<>();
+            return List.of();
         }
 
-        List<Tag> tagList = new ArrayList<>();
-
         String[] tagStrArray = parseMultiValueFieldList(tagStrings);
+
+        List<Tag> tagList = new ArrayList<>(tagStrArray.length);
         for (String tagString : tagStrArray) {
             Tag tag = parseTag(tagString);
             tagList.add(tag);
@@ -94,8 +94,10 @@ public class TagUtils {
     }
 
     public static String toTagString(List<Tag> tagList) {
-        return tagList.stream()
-                .map(Tag::toString)
-                .collect(Collectors.joining(","));
+        StringJoiner joiner = new StringJoiner(",");
+        for (Tag tag : tagList) {
+            joiner.add(tag.toString());
+        }
+        return joiner.toString();
     }
 }


### PR DESCRIPTION
This pull request refactors the handling of JSON and tag processing in the `MultiValueTagTypeHandler` and `TagUtils` classes to improve performance and simplify code. The most important changes include replacing `ObjectMapper` with `ObjectReader` for JSON deserialization, optimizing list initialization, and replacing `Stream`-based operations with more efficient alternatives.

### Refactoring JSON handling:

* Replaced `ObjectMapper` with `ObjectReader` in `MultiValueTagTypeHandler` for deserializing lists of strings, reducing overhead and improving performance. (`[[1]](diffhunk://#diff-cec10858ce67887378c3949a9d50d4feab3501b3cb74236188936e6cd5a85215L20-R21)`, `[[2]](diffhunk://#diff-cec10858ce67887378c3949a9d50d4feab3501b3cb74236188936e6cd5a85215L33-R39)`, `[[3]](diffhunk://#diff-cec10858ce67887378c3949a9d50d4feab3501b3cb74236188936e6cd5a85215L57-R56)`)

### Optimizations in `TagUtils`:

* Updated list initialization in `parseTags` methods to preallocate size based on input, reducing resizing overhead. (`[[1]](diffhunk://#diff-1a3f6e4c9869d0d5d712aee2bd861de42f8509fb78e65061f84dcc61b83007a0L46-R46)`, `[[2]](diffhunk://#diff-1a3f6e4c9869d0d5d712aee2bd861de42f8509fb78e65061f84dcc61b83007a0L59-R61)`)
* Replaced `Stream`-based operations with a `StringJoiner` in `toTagString`, improving efficiency for converting a list of tags to a string. (`[metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/util/TagUtils.javaL97-R101](diffhunk://#diff-1a3f6e4c9869d0d5d712aee2bd861de42f8509fb78e65061f84dcc61b83007a0L97-R101)`)