### PR TITLE
[#noissue] Refactor SystemMetric

### DIFF
--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/model/TelegrafMetric.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/model/TelegrafMetric.java
@@ -38,47 +38,17 @@ public class TelegrafMetric {
 
     }
 
-    public static class Field {
-        private final String name;
-        private final double value;
+    public record Field(String name, double value) {
+            public Field(String name, double value) {
+                this.name = Objects.requireNonNull(name, "name");
+                this.value = value;
+            }
 
-        public Field(String name, double value) {
-            this.name = Objects.requireNonNull(name, "name");
-            this.value = value;
+            @Override
+            public String toString() {
+                return name + "=" + value;
+            }
         }
-
-        public String getName() {
-            return name;
-        }
-
-        public double getValue() {
-            return value;
-        }
-
-        @Override
-        public String toString() {
-            return name + "=" + value;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Field field = (Field) o;
-
-            if (Double.compare(field.value, value) != 0) return false;
-            return name.equals(field.name);
-        }
-
-        @Override
-        public int hashCode() {
-            int result;
-            result = name.hashCode();
-            result = 31 * result + Double.hashCode(value);
-            return result;
-        }
-    }
 
 
     public List<Field> getFields() {

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricDataTypeService.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricDataTypeService.java
@@ -16,12 +16,12 @@
 
 package com.navercorp.pinpoint.metric.collector.service;
 
-import com.navercorp.pinpoint.metric.common.model.SystemMetric;
+import com.navercorp.pinpoint.metric.common.model.DoubleMetric;
 
 /**
  * @author minwoo.jung
  */
 public interface SystemMetricDataTypeService {
 
-    void saveMetricDataType(SystemMetric systemMetric);
+    void saveMetricDataType(DoubleMetric systemMetric);
 }

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricDataTypeServiceImpl.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricDataTypeServiceImpl.java
@@ -21,7 +21,6 @@ import com.navercorp.pinpoint.metric.common.model.DoubleMetric;
 import com.navercorp.pinpoint.metric.common.model.MetricData;
 import com.navercorp.pinpoint.metric.common.model.MetricDataName;
 import com.navercorp.pinpoint.metric.common.model.MetricDataType;
-import com.navercorp.pinpoint.metric.common.model.SystemMetric;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -43,7 +42,7 @@ public class SystemMetricDataTypeServiceImpl implements SystemMetricDataTypeServ
     }
 
     @Override
-    public void saveMetricDataType(SystemMetric systemMetric) {
+    public void saveMetricDataType(DoubleMetric systemMetric) {
         MetricDataName metricDataName = new MetricDataName(systemMetric.getMetricName(), systemMetric.getFieldName());
         MetricData metricData = metricDataTypeCache.getMetricDataType(metricDataName);
 
@@ -52,12 +51,9 @@ public class SystemMetricDataTypeServiceImpl implements SystemMetricDataTypeServ
             return;
         }
 
-        if (systemMetric instanceof DoubleMetric) {
-            long saveTime = DateTimeUtils.previousOrSameSundayToMillis();
-            MetricData metric = new MetricData(systemMetric.getMetricName(), systemMetric.getFieldName(), MetricDataType.DOUBLE, saveTime);
-            metricDataTypeCache.saveMetricDataType(metricDataName, metric);
-        } else {
-            logger.error("can not find metric data type.  systemMetric : {}", systemMetric);
-        }
+        long saveTime = DateTimeUtils.previousOrSameSundayToMillis();
+        MetricData metric = new MetricData(systemMetric.getMetricName(), systemMetric.getFieldName(), MetricDataType.DOUBLE, saveTime);
+        metricDataTypeCache.saveMetricDataType(metricDataName, metric);
+
     }
 }

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricService.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricService.java
@@ -17,14 +17,12 @@
 package com.navercorp.pinpoint.metric.collector.service;
 
 import com.navercorp.pinpoint.metric.collector.dao.SystemMetricDao;
-
 import com.navercorp.pinpoint.metric.common.model.DoubleMetric;
 import com.navercorp.pinpoint.metric.common.model.Metrics;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * @author Hyunjoon Cho
@@ -37,16 +35,10 @@ public class SystemMetricService {
         this.systemMetricDoubleDao = Objects.requireNonNull(systemMetricDoubleDao, "systemMetricDoubleDao");
     }
 
-    public void insert(Metrics systemMetrics) {
-        Objects.requireNonNull(systemMetrics, "systemMetrics");
-        List<DoubleMetric> doubleMetrics = filterDoubleCounter(systemMetrics);
-        systemMetricDoubleDao.insert(systemMetrics.getTenantId(), systemMetrics.getHostGroupName(), systemMetrics.getHostName(), doubleMetrics);
+    public void insert(Metrics metrics) {
+        Objects.requireNonNull(metrics, "metrics");
+        List<DoubleMetric> doubleMetrics = metrics.getMetrics();
+        systemMetricDoubleDao.insert(metrics.getTenantId(), metrics.getHostGroupName(), metrics.getHostName(), doubleMetrics);
     }
 
-    public List<DoubleMetric> filterDoubleCounter(Metrics systemMetrics) {
-        return systemMetrics.stream()
-                .filter(DoubleMetric.class::isInstance)
-                .map(DoubleMetric.class::cast)
-                .collect(Collectors.toList());
-    }
 }

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/DoubleMetric.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/DoubleMetric.java
@@ -16,14 +16,13 @@ public class DoubleMetric extends SystemMetric {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("DoubleMetric{");
-        sb.append("metric=").append(metricName);
-        sb.append(", host=").append(hostName);
-        sb.append(", field=").append(fieldName);
-        sb.append(", value=").append(fieldValue);
-        sb.append(", tags=").append(tags);
-        sb.append(", eventTime=").append(eventTime);
-        sb.append('}');
-        return sb.toString();
+        return "DoubleMetric{" +
+                "metric=" + metricName +
+                ", host=" + hostName +
+                ", field=" + fieldName +
+                ", value=" + fieldValue +
+                ", tags=" + tags +
+                ", eventTime=" + eventTime +
+                '}';
     }
 }

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/MetricDataName.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/MetricDataName.java
@@ -19,8 +19,6 @@ package com.navercorp.pinpoint.metric.common.model;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 import com.navercorp.pinpoint.common.timeseries.time.DateTimeUtils;
 
-import java.util.Objects;
-
 /**
  * @author minwoo.jung
  */
@@ -50,15 +48,18 @@ public class MetricDataName {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+
         MetricDataName that = (MetricDataName) o;
         return saveTime == that.saveTime && fieldName.equals(that.fieldName) && metricName.equals(that.metricName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fieldName, metricName, saveTime);
+        int result = fieldName.hashCode();
+        result = 31 * result + metricName.hashCode();
+        result = 31 * result + Long.hashCode(saveTime);
+        return result;
     }
 
     public static long createSaveTime() {

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/MetricTagKey.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/MetricTagKey.java
@@ -18,8 +18,6 @@ package com.navercorp.pinpoint.metric.common.model;
 
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 
-import java.util.Objects;
-
 /**
  * @author minwoo.jung
  */
@@ -67,15 +65,21 @@ public class MetricTagKey {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+
         MetricTagKey that = (MetricTagKey) o;
         return saveTime == that.saveTime && tenantId.equals(that.tenantId) && hostGroupName.equals(that.hostGroupName) && hostName.equals(that.hostName) && metricName.equals(that.metricName) && fieldName.equals(that.fieldName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tenantId, hostGroupName, hostName, metricName, fieldName, saveTime);
+        int result = tenantId.hashCode();
+        result = 31 * result + hostGroupName.hashCode();
+        result = 31 * result + hostName.hashCode();
+        result = 31 * result + metricName.hashCode();
+        result = 31 * result + fieldName.hashCode();
+        result = 31 * result + Long.hashCode(saveTime);
+        return result;
     }
 
     @Override

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/Metrics.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/Metrics.java
@@ -6,17 +6,16 @@ import jakarta.validation.Valid;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 
-public class Metrics implements Iterable<SystemMetric> {
+public class Metrics implements Iterable<DoubleMetric> {
     private final String tenantId;
     private final String hostGroupName;
     private final String hostName;
 
     @Valid
-    private final List<SystemMetric> metrics;
+    private final List<DoubleMetric> metrics;
 
-    public Metrics(String tenantId, String hostGroupName, String hostName, List<SystemMetric> metrics) {
+    public Metrics(String tenantId, String hostGroupName, String hostName, List<DoubleMetric> metrics) {
         this.tenantId = Objects.requireNonNull(tenantId, "tenantId");
         this.hostGroupName = Objects.requireNonNull(hostGroupName, "hostGroupName");
         this.hostName = Objects.requireNonNull(hostName, "hostName");
@@ -35,17 +34,13 @@ public class Metrics implements Iterable<SystemMetric> {
         return tenantId;
     }
 
-    public List<SystemMetric> getMetrics() {
+    public List<DoubleMetric> getMetrics() {
         return metrics;
     }
 
     @Override
-    public Iterator<SystemMetric> iterator() {
+    public Iterator<DoubleMetric> iterator() {
         return metrics.iterator();
-    }
-
-    public Stream<SystemMetric> stream() {
-        return metrics.stream();
     }
 
     public int size() {

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/SystemMetric.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/SystemMetric.java
@@ -74,13 +74,12 @@ public class SystemMetric {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("SystemMetric{");
-        sb.append("metric=").append(metricName);
-        sb.append(", host=").append(hostName);
-        sb.append(", field=").append(fieldName);
-        sb.append(", tags=").append(tags);
-        sb.append(", eventTime=").append(eventTime);
-        sb.append('}');
-        return sb.toString();
+        return "SystemMetric{" +
+                "metric=" + metricName +
+                ", host=" + hostName +
+                ", field=" + fieldName +
+                ", tags=" + tags +
+                ", eventTime=" + eventTime +
+                '}';
     }
 }

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/service/SystemMetricDataServiceImpl.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/service/SystemMetricDataServiceImpl.java
@@ -38,7 +38,7 @@ import com.navercorp.pinpoint.metric.web.model.MetricValue;
 import com.navercorp.pinpoint.metric.web.model.MetricValueGroup;
 import com.navercorp.pinpoint.metric.web.model.SystemMetricData;
 import com.navercorp.pinpoint.metric.web.model.basic.metric.group.GroupingRule;
-import org.apache.commons.lang3.time.StopWatch;
+import com.navercorp.pinpoint.metric.web.util.TagListUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -212,13 +212,7 @@ public class SystemMetricDataServiceImpl implements SystemMetricDataService {
         List<Tag> tagList1 = tagGroup1.tagList();
         List<Tag> tagList2 = tagGroup2.tagList();
 
-        if (tagList1.size() == tagList2.size()) {
-            if (tagList1.containsAll(tagList2)) {
-                return true;
-            }
-        }
-
-        return false;
+        return TagListUtils.containsAll(tagList1, tagList2);
     }
 
     private record TagGroup(List<Tag> tagList) {

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/service/SystemMetricHostInfoServiceImpl.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/service/SystemMetricHostInfoServiceImpl.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.metric.web.mapping.Field;
 import com.navercorp.pinpoint.metric.web.model.MetricDataSearchKey;
 import com.navercorp.pinpoint.metric.web.model.MetricInfo;
 import com.navercorp.pinpoint.metric.web.model.basic.metric.group.MatchingRule;
+import com.navercorp.pinpoint.metric.web.util.TagListUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -144,10 +145,7 @@ public class SystemMetricHostInfoServiceImpl implements SystemMetricHostInfoServ
 
         for (MetricTag metricTag : metricTagList) {
             List<Tag> collectedTagList = metricTag.getTags();
-            if (tagList.size() != collectedTagList.size()) {
-                continue;
-            }
-            if (collectedTagList.containsAll(tagList)) {
+            if (TagListUtils.containsAll(collectedTagList, tagList)) {
                 exactMetricTagList.add(metricTag.copy());
             }
         }

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/util/TagListUtils.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/util/TagListUtils.java
@@ -1,0 +1,16 @@
+package com.navercorp.pinpoint.metric.web.util;
+
+import com.navercorp.pinpoint.metric.common.model.Tag;
+
+import java.util.List;
+
+public class TagListUtils {
+
+    public static boolean containsAll(List<Tag> list1, List<Tag> list2) {
+        if (list1.size() != list2.size()) {
+            return false;
+        }
+
+        return list1.containsAll(list2);
+    }
+}

--- a/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/collector/controller/TelegrafMetricControllerTest.java
+++ b/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/collector/controller/TelegrafMetricControllerTest.java
@@ -1,0 +1,23 @@
+package com.navercorp.pinpoint.metric.collector.controller;
+
+import com.navercorp.pinpoint.metric.common.model.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TelegrafMetricControllerTest {
+
+    @Test
+    void filterTag() {
+        List<Tag> tags = List.of(
+                new Tag("tag1", "value1"),
+                new Tag("host", "host1")
+        );
+        List<Tag> tags1 = TelegrafMetricController.filterTag(tags, new String[]{"host"});
+        assertThat(tags1)
+                .hasSize(1)
+                .containsExactly(new Tag("tag1", "value1"));
+    }
+}

--- a/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricDataTypeServiceImplTest.java
+++ b/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricDataTypeServiceImplTest.java
@@ -4,7 +4,6 @@ import com.navercorp.pinpoint.metric.common.model.DoubleMetric;
 import com.navercorp.pinpoint.metric.common.model.MetricData;
 import com.navercorp.pinpoint.metric.common.model.MetricDataName;
 import com.navercorp.pinpoint.metric.common.model.MetricDataType;
-import com.navercorp.pinpoint.metric.common.model.SystemMetric;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -31,7 +30,7 @@ public class SystemMetricDataTypeServiceImplTest {
         MetricData metricData = new MetricData("metricName", "fieldName", MetricDataType.DOUBLE, metricDataName.getSaveTime());
         when(metricDataTypeCache.getMetricDataType(any(MetricDataName.class))).thenReturn(metricData);
 
-        SystemMetric systemMetric = new DoubleMetric("metricName", "hostName", "fieldName", 0, List.of(), Long.MAX_VALUE);
+        DoubleMetric systemMetric = new DoubleMetric("metricName", "hostName", "fieldName", 0, List.of(), Long.MAX_VALUE);
         systemMetricDataTypeService.saveMetricDataType(systemMetric);
 
         verify(metricDataTypeCache, never()).saveMetricDataType(any(MetricDataName.class), any(MetricData.class));
@@ -43,7 +42,7 @@ public class SystemMetricDataTypeServiceImplTest {
         SystemMetricDataTypeService systemMetricDataTypeService = new SystemMetricDataTypeServiceImpl(metricDataTypeCache);
         when(metricDataTypeCache.getMetricDataType(any(MetricDataName.class))).thenReturn(null);
 
-        SystemMetric systemMetric = new DoubleMetric("metricName", "hostName", "fieldName", 0, List.of(), Long.MAX_VALUE);
+        DoubleMetric systemMetric = new DoubleMetric("metricName", "hostName", "fieldName", 0, List.of(), Long.MAX_VALUE);
         systemMetricDataTypeService.saveMetricDataType(systemMetric);
 
         MetricDataName metricDataName = new MetricDataName(systemMetric.getMetricName(), systemMetric.getFieldName());
@@ -57,7 +56,7 @@ public class SystemMetricDataTypeServiceImplTest {
         SystemMetricDataTypeService systemMetricDataTypeService = new SystemMetricDataTypeServiceImpl(metricDataTypeCache);
         when(metricDataTypeCache.getMetricDataType(any(MetricDataName.class))).thenReturn(null);
 
-        SystemMetric systemMetric = new DoubleMetric("metricName", "hostName", "fieldName", 0, List.of(), Long.MAX_VALUE);
+        DoubleMetric systemMetric = new DoubleMetric("metricName", "hostName", "fieldName", 0, List.of(), Long.MAX_VALUE);
         systemMetricDataTypeService.saveMetricDataType(systemMetric);
 
         MetricDataName metricDataName = new MetricDataName(systemMetric.getMetricName(), systemMetric.getFieldName());
@@ -65,17 +64,4 @@ public class SystemMetricDataTypeServiceImplTest {
         verify(metricDataTypeCache).saveMetricDataType(metricDataName, metricData);
     }
 
-    @Test
-    public void saveMetricDataType4Test() {
-        MetricDataTypeCache metricDataTypeCache = mock(MetricDataTypeCache.class);
-        SystemMetricDataTypeService systemMetricDataTypeService = new SystemMetricDataTypeServiceImpl(metricDataTypeCache);
-        when(metricDataTypeCache.getMetricDataType(any(MetricDataName.class))).thenReturn(null);
-
-        SystemMetric systemMetric = new SystemMetric("metricName", "fieldName", "hostName", List.of(), Long.MAX_VALUE);
-        systemMetricDataTypeService.saveMetricDataType(systemMetric);
-
-        MetricDataName metricDataName = new MetricDataName(systemMetric.getMetricName(), systemMetric.getFieldName());
-        MetricData metricData = new MetricData("metricName", "fieldName", MetricDataType.LONG, metricDataName.getSaveTime());
-        verify(metricDataTypeCache, never()).saveMetricDataType(any(MetricDataName.class), any(MetricData.class));
-    }
 }

--- a/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricFilterTest.java
+++ b/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricFilterTest.java
@@ -19,8 +19,6 @@ package com.navercorp.pinpoint.metric.collector.service;
 import com.navercorp.pinpoint.metric.collector.dao.pinot.PinotSystemMetricDoubleDao;
 import com.navercorp.pinpoint.metric.common.model.DoubleMetric;
 import com.navercorp.pinpoint.metric.common.model.Metrics;
-import com.navercorp.pinpoint.metric.common.model.SystemMetric;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -37,33 +35,25 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @ExtendWith(MockitoExtension.class)
 public class SystemMetricFilterTest {
-    private final Random random = new Random(System.currentTimeMillis());
-
-    private SystemMetricService systemMetricService;
+    private final Random random = new Random();
 
     @Mock
     private DoubleMetric doubleMetric;
     @Mock
     private PinotSystemMetricDoubleDao doubleDao;
 
-    @BeforeEach
-    public void beforeEach() {
-        systemMetricService = new SystemMetricService(doubleDao);
-    }
-
     @Test
     public void testFilter() {
-        int longCount = random.nextInt(100);
         int doubleCount = random.nextInt(100);
-        Metrics systemMetrics = createList(longCount, doubleCount);
+        Metrics systemMetrics = createList(doubleCount);
 
-        List<DoubleMetric> doubleMetricList = systemMetricService.filterDoubleCounter(systemMetrics);
+        List<DoubleMetric> doubleMetricList = systemMetrics.getMetrics();
 
         assertThat(doubleMetricList).hasSize(doubleCount);
     }
 
-    private Metrics createList(int longCount, int doubleCount) {
-        List<SystemMetric> systemMetricList = new ArrayList<>();
+    private Metrics createList(int doubleCount) {
+        List<DoubleMetric> systemMetricList = new ArrayList<>();
 
         for (int i = 0; i < doubleCount; i++) {
             systemMetricList.add(doubleMetric);

--- a/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricTagServiceImplTest.java
+++ b/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricTagServiceImplTest.java
@@ -131,19 +131,19 @@ public class SystemMetricTagServiceImplTest {
         );
 
         MetricTagCollection metricTagCollection = systemMetricTagService.createMetricTagCollection(tenantId, applicationName, hostName, metricName, fieldName, tagList, saveTime);
-        Assertions.assertEquals(metricTagCollection.getHostGroupName(), applicationName);
-        Assertions.assertEquals(metricTagCollection.getHostName(), hostName);
-        Assertions.assertEquals(metricTagCollection.getMetricName(), metricName);
-        Assertions.assertEquals(metricTagCollection.getFieldName(), fieldName);
+        Assertions.assertEquals(applicationName, metricTagCollection.getHostGroupName());
+        Assertions.assertEquals(hostName, metricTagCollection.getHostName());
+        Assertions.assertEquals(metricName, metricTagCollection.getMetricName());
+        Assertions.assertEquals(fieldName, metricTagCollection.getFieldName());
 
         List<MetricTag> metricTagList = metricTagCollection.getMetricTagList();
 
         assertThat(metricTagList).hasSize(1);
         MetricTag metricTag = metricTagList.get(0);
-        Assertions.assertEquals(metricTag.getHostGroupName(), applicationName);
-        Assertions.assertEquals(metricTag.getHostName(), hostName);
-        Assertions.assertEquals(metricTag.getMetricName(), metricName);
-        Assertions.assertEquals(metricTag.getFieldName(), fieldName);
+        Assertions.assertEquals(applicationName, metricTag.getHostGroupName());
+        Assertions.assertEquals(hostName, metricTag.getHostName());
+        Assertions.assertEquals(metricName, metricTag.getMetricName());
+        Assertions.assertEquals(fieldName, metricTag.getFieldName());
 
         List<Tag> tags = metricTag.getTags();
 
@@ -188,10 +188,10 @@ public class SystemMetricTagServiceImplTest {
         MetricTagCollection mtc = new MetricTagCollection(tenantId, applicationName, hostName, metricName, fieldName, metricTagList);
         MetricTagCollection metricTagCollection = systemMetricTagService.createMetricTagCollection(mtc, tagList4, saveTime);
 
-        Assertions.assertEquals(metricTagCollection.getHostGroupName(), applicationName);
-        Assertions.assertEquals(metricTagCollection.getHostName(), hostName);
-        Assertions.assertEquals(metricTagCollection.getMetricName(), metricName);
-        Assertions.assertEquals(metricTagCollection.getFieldName(), fieldName);
+        Assertions.assertEquals(applicationName, metricTagCollection.getHostGroupName());
+        Assertions.assertEquals(hostName, metricTagCollection.getHostName());
+        Assertions.assertEquals(metricName, metricTagCollection.getMetricName());
+        Assertions.assertEquals(fieldName, metricTagCollection.getFieldName());
 
         List<MetricTag> mtList = metricTagCollection.getMetricTagList();
         assertThat(mtList).hasSize(4);

--- a/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/common/model/validation/TelegrafMetricsValidatorTest.java
+++ b/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/common/model/validation/TelegrafMetricsValidatorTest.java
@@ -1,7 +1,7 @@
 package com.navercorp.pinpoint.metric.common.model.validation;
 
+import com.navercorp.pinpoint.metric.common.model.DoubleMetric;
 import com.navercorp.pinpoint.metric.common.model.Metrics;
-import com.navercorp.pinpoint.metric.common.model.SystemMetric;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validation;
@@ -25,7 +25,7 @@ public class TelegrafMetricsValidatorTest {
         ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
         final Validator validator = validatorFactory.getValidator();
 
-        SystemMetric systemMetric = new SystemMetric("", "fieldname", "hostName", Collections.emptyList(), System.currentTimeMillis());
+        DoubleMetric systemMetric = new DoubleMetric("", "fieldname", "hostName", 0, Collections.emptyList(), System.currentTimeMillis());
         Metrics metrics = new Metrics("tenantId", "hostGroupName", "hostName", List.of(systemMetric));
 
         Set<ConstraintViolation<Metrics>> result = validator.validate(metrics);

--- a/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/web/util/TagListUtilsTest.java
+++ b/metric-module/metric/src/test/java/com/navercorp/pinpoint/metric/web/util/TagListUtilsTest.java
@@ -1,0 +1,56 @@
+package com.navercorp.pinpoint.metric.web.util;
+
+import com.navercorp.pinpoint.metric.common.model.Tag;
+import org.apache.commons.collections4.CollectionUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class TagListUtilsTest {
+
+
+    @Test
+    void isEqualsUtils_same() {
+        Tag t1 = new Tag("key1", "value");
+        Tag t2 = new Tag("key2", "value");
+        List<Tag> tags1 = List.of(t1, t2);
+        List<Tag> tags2 = List.of(t2, t1);
+
+        Assertions.assertTrue(TagListUtils.containsAll(tags1, tags2));
+        Assertions.assertTrue(isEqualsUtils(tags1, tags2));
+    }
+
+    @Test
+    void isEquals_cardinality() {
+        Tag t1 = new Tag("key1", "value");
+        Tag t2 = new Tag("key2", "value");
+        List<Tag> tags1 = List.of(t1, t2, t2);
+        List<Tag> tags2 = List.of(t2, t1, t1);
+
+        Assertions.assertTrue(TagListUtils.containsAll(tags1, tags2));
+        Assertions.assertTrue(isEqualsUtils(tags1, tags2));
+    }
+
+    @Test
+    @Disabled
+    void isEquals_containsall() {
+        Tag t1 = new Tag("key1", "value");
+        Tag t2 = new Tag("key2", "value");
+        List<Tag> tags1 = List.of(t1, t2);
+        List<Tag> tags2 = List.of(t2, t1, t1);
+
+        Assertions.assertFalse(TagListUtils.containsAll(tags1, tags2));
+        // list.size() != list2.size() issue
+        Assertions.assertFalse(isEqualsUtils(tags1, tags2));
+    }
+
+    boolean isEqualsUtils(List<Tag> tagList1, List<Tag> tagList2) {
+        // same cardinalities
+//        return CollectionUtils.isEqualCollection(tagList1, tagList2);
+        // sub set
+//        return CollectionUtils.isSubCollection(tagList1, tagList2);
+        return CollectionUtils.containsAll(tagList1, tagList2);
+    }
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `TelegrafMetricController` and related classes to improve performance, simplify code, and enhance maintainability. Key updates include replacing `SystemMetric` with `DoubleMetric` as the primary metric type, refactoring stream-based operations into iterative ones, and optimizing tag handling. Additionally, the code now uses Java `record` for the `Field` class and includes other minor improvements.

### Metric Type Refactoring:
* Replaced `SystemMetric` with `DoubleMetric` as the primary metric type across the codebase, including updates to `SystemMetricDataTypeService` and `SystemMetricService` to reflect this change. (`[[1]](diffhunk://#diff-e88561a7bde1943722d053bfd071588018635fc24957d5d5e35a9da7c759ca76L19-R26)`, `[[2]](diffhunk://#diff-0aa169ac74a4ef8f0fad824cd3e4fe1c44e480e4f71f6f0f1edbe8be7cbbb087L46-R45)`, `[[3]](diffhunk://#diff-36c04304b7988c3f13eca7f836d3a2ec727d4592ad4f076297c4592dfcbb74fcL40-L51)`)

### Code Simplification:
* Refactored stream-based operations in `TelegrafMetricController` to use explicit loops, improving readability and performance. (`[[1]](diffhunk://#diff-5f2301a141d9218033478e4343a83338079876c26865ea03dc08dec7a5d24142L117-R135)`, `[[2]](diffhunk://#diff-5f2301a141d9218033478e4343a83338079876c26865ea03dc08dec7a5d24142L136-R177)`)
* Converted the `Field` class to a Java `record`, reducing boilerplate code for getters, `equals`, `hashCode`, and `toString` methods. (`[metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/model/TelegrafMetric.javaL41-L80](diffhunk://#diff-b52e7de83b15b0ff4a4819a0feba0fe76e6803e86043530e4f408cdb45c0fb3eL41-L80)`)

### Tag Handling Improvements:
* Optimized tag filtering by replacing `List<String>` with a `String[]` and using `ArrayUtils.contains` for better performance. (`[[1]](diffhunk://#diff-5f2301a141d9218033478e4343a83338079876c26865ea03dc08dec7a5d24142L61-R60)`, `[[2]](diffhunk://#diff-5f2301a141d9218033478e4343a83338079876c26865ea03dc08dec7a5d24142L136-R177)`)
* Updated tag comparison logic in `SystemMetricTagServiceImpl` to use `TagListUtils.containsAll` for more reliable comparisons. (`[metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/service/SystemMetricTagServiceImpl.javaL55-R99](diffhunk://#diff-a01a9ea78c344593a23eecd23e0160fc9bd34677194a22beb300d39f4a76a340L55-R99)`)

### Null Handling and Logging:
* Added a null check for the `hostName` in `saveSystemMetric` to handle invalid input gracefully and log the issue. (`[metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/controller/TelegrafMetricController.javaR85-R90](diffhunk://#diff-5f2301a141d9218033478e4343a83338079876c26865ea03dc08dec7a5d24142R85-R90)`)
* Changed the `getHost` method to return `null` instead of an empty string when no host tag is found. (`[metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/collector/controller/TelegrafMetricController.javaL104-R109](diffhunk://#diff-5f2301a141d9218033478e4343a83338079876c26865ea03dc08dec7a5d24142L104-R109)`)

### Minor Improvements:
* Simplified `toString` methods for `DoubleMetric` and `MetricDataName` for better readability. (`[[1]](diffhunk://#diff-c3a7c9732bff4d6dba8d439feb2d6ed461b549733f361e7fe8a74fa1d03d193dL19-R26)`, `[[2]](diffhunk://#diff-18c3819e3e3a4e67b072253519f4ed9f23d13cbb13d1de8ef50d249c62202918L53-R62)`)