### PR TITLE
[#noissue] Refactor JacksonSerde

### DIFF
--- a/channel/src/main/java/com/navercorp/pinpoint/channel/ChannelSpringConfig.java
+++ b/channel/src/main/java/com/navercorp/pinpoint/channel/ChannelSpringConfig.java
@@ -15,6 +15,10 @@
  */
 package com.navercorp.pinpoint.channel;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.channel.serde.JacksonSerdeFactory;
+import com.navercorp.pinpoint.channel.serde.JsonSerdeFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,8 +31,18 @@ import java.util.List;
 public class ChannelSpringConfig {
 
     @Bean
-    ChannelProviderRepository channelProviderRepository(List<ChannelProviderRegistry> registries) {
+    @ConditionalOnMissingBean(ObjectMapper.class)
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Bean
+    public ChannelProviderRepository channelProviderRepository(List<ChannelProviderRegistry> registries) {
         return new ChannelProviderRepository(registries);
     }
 
+    @Bean
+    public JsonSerdeFactory jsonSerdeFactory(ObjectMapper objectMapper) {
+        return new JacksonSerdeFactory(objectMapper);
+    }
 }

--- a/channel/src/main/java/com/navercorp/pinpoint/channel/serde/JacksonSerde.java
+++ b/channel/src/main/java/com/navercorp/pinpoint/channel/serde/JacksonSerde.java
@@ -15,8 +15,8 @@
  */
 package com.navercorp.pinpoint.channel.serde;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import jakarta.annotation.Nonnull;
 
 import java.io.IOException;
@@ -27,38 +27,25 @@ import java.util.Objects;
 /**
  * @author youngjin.kim2
  */
-public class JacksonSerde<T> implements Serde<T> {
+class JacksonSerde<T> implements Serde<T> {
 
-    private final ObjectMapper objectMapper;
-    private final JavaType javaType;
+    private final ObjectReader reader;
+    private final ObjectWriter writer;
 
-    public JacksonSerde(ObjectMapper objectMapper, JavaType javaType) {
-        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
-        this.javaType = Objects.requireNonNull(javaType, "javaType");
-    }
-
-    public static <T> Serde<T> byClass(ObjectMapper objectMapper, Class<T> clazz) {
-        return new JacksonSerde<>(objectMapper, objectMapper.constructType(clazz));
-    }
-
-    public static <T> Serde<T> byParameterized(
-            ObjectMapper objectMapper,
-            Class<?> parameterized,
-            Class<?> ...parameterizedClasses
-    ) {
-        JavaType type = objectMapper.getTypeFactory().constructParametricType(parameterized, parameterizedClasses);
-        return new JacksonSerde<>(objectMapper, type);
+    public JacksonSerde(ObjectReader reader, ObjectWriter writer) {
+        this.reader = Objects.requireNonNull(reader, "reader");
+        this.writer = Objects.requireNonNull(writer, "writer");
     }
 
     @Override
     @Nonnull
     public T deserialize(@Nonnull InputStream inputStream) throws IOException {
-        return this.objectMapper.readValue(inputStream, this.javaType);
+        return reader.readValue(inputStream);
     }
 
     @Override
     public void serialize(@Nonnull T object, @Nonnull OutputStream outputStream) throws IOException {
-        this.objectMapper.writeValue(outputStream, object);
+        this.writer.writeValue(outputStream, object);
     }
 
 }

--- a/channel/src/main/java/com/navercorp/pinpoint/channel/serde/JacksonSerdeFactory.java
+++ b/channel/src/main/java/com/navercorp/pinpoint/channel/serde/JacksonSerdeFactory.java
@@ -1,0 +1,40 @@
+package com.navercorp.pinpoint.channel.serde;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class JacksonSerdeFactory implements JsonSerdeFactory {
+
+    private final ObjectMapper objectMapper;
+
+    public JacksonSerdeFactory(ObjectMapper objectMapper) {
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    }
+
+    @Override
+    public <T> Serde<T> byClass(Class<T> clazz) {
+        JavaType javaType = objectMapper.constructType(clazz);
+        ObjectReader reader = objectMapper.readerFor(javaType);
+        ObjectWriter writer = objectMapper.writerFor(javaType);
+        return new JacksonSerde<>(reader, writer);
+    }
+
+    @Override
+    public <T> Serde<T> byParameterized(
+            Class<?> parameterized,
+            Class<?>... parameterizedClasses
+    ) {
+        JavaType type = objectMapper.getTypeFactory().constructParametricType(parameterized, parameterizedClasses);
+        ObjectReader reader = objectMapper.readerFor(type);
+        ObjectWriter writer = objectMapper.writerFor(type);
+        return new JacksonSerde<>(reader, writer);
+    }
+
+
+}

--- a/channel/src/main/java/com/navercorp/pinpoint/channel/serde/JsonSerdeFactory.java
+++ b/channel/src/main/java/com/navercorp/pinpoint/channel/serde/JsonSerdeFactory.java
@@ -1,0 +1,10 @@
+package com.navercorp.pinpoint.channel.serde;
+
+public interface JsonSerdeFactory {
+    <T> Serde<T> byClass(Class<T> clazz);
+
+    <T> Serde<T> byParameterized(
+            Class<?> parameterized,
+            Class<?>... parameterizedClasses
+    );
+}

--- a/channel/src/test/java/com/navercorp/pinpoint/channel/ChannelSpringConfigTest.java
+++ b/channel/src/test/java/com/navercorp/pinpoint/channel/ChannelSpringConfigTest.java
@@ -38,3 +38,5 @@ public class ChannelSpringConfigTest {
     }
 
 }
+
+

--- a/channel/src/test/java/com/navercorp/pinpoint/channel/serde/JacksonSerdeTest.java
+++ b/channel/src/test/java/com/navercorp/pinpoint/channel/serde/JacksonSerdeTest.java
@@ -17,6 +17,8 @@ package com.navercorp.pinpoint.channel.serde;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class JacksonSerdeTest {
 
+    ObjectMapper objectMapper = new ObjectMapper();
     Random random = new Random();
 
     @Test
@@ -51,7 +54,7 @@ public class JacksonSerdeTest {
         assertThat(result.getBar().getBar()).isEqualTo("Hello");
     }
 
-    private static Foo<Foo<String>> makeFooFooString(int p0, int p1, String p2) {
+    private Foo<Foo<String>> makeFooFooString(int p0, int p1, String p2) {
         Foo<Foo<String>> target = new Foo<>();
         target.setFoo(p0);
         target.setBar(new Foo<>());
@@ -60,12 +63,15 @@ public class JacksonSerdeTest {
         return target;
     }
 
-    private static Serde<Foo<Foo<String>>> getSerde() {
-        ObjectMapper objectMapper = new ObjectMapper();
+    private Serde<Foo<Foo<String>>> getSerde() {
+
         TypeFactory typeFactory = objectMapper.getTypeFactory();
         JavaType t1 = typeFactory.constructParametricType(Foo.class, String.class);
         JavaType t2 = typeFactory.constructParametricType(Foo.class, t1);
-        return new JacksonSerde<>(objectMapper, t2);
+
+        ObjectReader reader = objectMapper.readerFor(t2);
+        ObjectWriter writer = objectMapper.writerFor(t2);
+        return new JacksonSerde<>(reader, writer);
     }
 
     private static class Foo<T> {

--- a/channel/src/test/java/com/navercorp/pinpoint/channel/service/ChannelServiceProtocolTest.java
+++ b/channel/src/test/java/com/navercorp/pinpoint/channel/service/ChannelServiceProtocolTest.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.channel.ChannelProviderRegistry;
 import com.navercorp.pinpoint.channel.ChannelProviderRepository;
 import com.navercorp.pinpoint.channel.MemoryChannelProvider;
-import com.navercorp.pinpoint.channel.serde.JacksonSerde;
+import com.navercorp.pinpoint.channel.serde.JacksonSerdeFactory;
+import com.navercorp.pinpoint.channel.serde.JsonSerdeFactory;
 import com.navercorp.pinpoint.channel.service.client.ChannelServiceClient;
 import com.navercorp.pinpoint.channel.service.client.MonoChannelServiceClient;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author youngjin.kim2
  */
 public class ChannelServiceProtocolTest {
+    JsonSerdeFactory factory = new JacksonSerdeFactory(new ObjectMapper());
 
     @Test
     public void shouldThrowWithWrongSerde() {
@@ -41,12 +43,11 @@ public class ChannelServiceProtocolTest {
                 ChannelProviderRegistry.of("mem", new MemoryChannelProvider())
         ));
 
-        ObjectMapper objectMapper = new ObjectMapper();
         MonoChannelServiceProtocol<Foo, Bar> protocol = ChannelServiceProtocol.<Foo, Bar>builder()
-                .setDemandSerde(JacksonSerde.byParameterized(objectMapper, Bar.class))
+                .setDemandSerde(factory.byParameterized(Bar.class))
                 .setDemandPubChannelURIProvider(el -> URI.create("mem:demand"))
                 .setDemandSubChannelURI(URI.create("mem:demand"))
-                .setSupplySerde(JacksonSerde.byClass(objectMapper, Bar.class))
+                .setSupplySerde(factory.byClass(Bar.class))
                 .setSupplyChannelURIProvider(el -> URI.create("mem:supply"))
                 .setRequestTimeout(Duration.ofSeconds(1))
                 .buildMono();

--- a/channel/src/test/java/com/navercorp/pinpoint/channel/service/FluxChannelServiceTest.java
+++ b/channel/src/test/java/com/navercorp/pinpoint/channel/service/FluxChannelServiceTest.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.channel.ChannelProviderRegistry;
 import com.navercorp.pinpoint.channel.ChannelProviderRepository;
 import com.navercorp.pinpoint.channel.MemoryChannelProvider;
-import com.navercorp.pinpoint.channel.serde.JacksonSerde;
+import com.navercorp.pinpoint.channel.serde.JacksonSerdeFactory;
+import com.navercorp.pinpoint.channel.serde.JsonSerdeFactory;
 import com.navercorp.pinpoint.channel.service.client.ChannelServiceClient;
 import com.navercorp.pinpoint.channel.service.client.ChannelState;
 import com.navercorp.pinpoint.channel.service.server.ChannelServiceServer;
@@ -39,6 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class FluxChannelServiceTest {
 
+    JsonSerdeFactory factory = new JacksonSerdeFactory(new ObjectMapper());
+
     @Test
     @DisplayName("basic flux service scenario")
     public void testBasicFluxScenario() {
@@ -54,13 +57,12 @@ public class FluxChannelServiceTest {
         assertThat(response).hasSameElementsAs(List.of("Foo", "Bar", "Hello", "World"));
     }
 
-    private static FluxChannelServiceProtocol<String, String> defineProtocol() {
-        ObjectMapper objectMapper = new ObjectMapper();
+    private FluxChannelServiceProtocol<String, String> defineProtocol() {
         return ChannelServiceProtocol.<String, String>builder()
-                .setDemandSerde(JacksonSerde.byClass(objectMapper, String.class))
+                .setDemandSerde(factory.byClass(String.class))
                 .setDemandPubChannelURIProvider(d -> URI.create("mem:split:demand"))
                 .setDemandSubChannelURI(URI.create("mem:split:demand"))
-                .setSupplySerde(JacksonSerde.byClass(objectMapper, String.class))
+                .setSupplySerde(factory.byClass(String.class))
                 .setSupplyChannelURIProvider(d -> URI.create("mem:split:supply"))
                 .setDemandInterval(Duration.ZERO)
                 .setBufferSize(4)

--- a/log/log-common/src/main/java/com/navercorp/pinpoint/log/LogServiceProtocolConfig.java
+++ b/log/log-common/src/main/java/com/navercorp/pinpoint/log/LogServiceProtocolConfig.java
@@ -15,11 +15,10 @@
  */
 package com.navercorp.pinpoint.log;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.channel.ChannelSpringConfig;
 import com.navercorp.pinpoint.channel.redis.pubsub.RedisPubSubConfig;
 import com.navercorp.pinpoint.channel.redis.stream.RedisStreamConfig;
-import com.navercorp.pinpoint.channel.serde.JacksonSerde;
+import com.navercorp.pinpoint.channel.serde.JsonSerdeFactory;
 import com.navercorp.pinpoint.channel.service.ChannelServiceProtocol;
 import com.navercorp.pinpoint.channel.service.FluxChannelServiceProtocol;
 import com.navercorp.pinpoint.channel.service.client.ChannelState;
@@ -40,12 +39,12 @@ import java.time.Duration;
 public class LogServiceProtocolConfig {
 
     @Bean
-    FluxChannelServiceProtocol<FileKey, LogPile> logProtocol(ObjectMapper objectMapper) {
+    FluxChannelServiceProtocol<FileKey, LogPile> logProtocol(JsonSerdeFactory factory) {
         return ChannelServiceProtocol.<FileKey, LogPile>builder()
-                .setDemandSerde(JacksonSerde.byClass(objectMapper, FileKey.class))
+                .setDemandSerde(factory.byClass(FileKey.class))
                 .setDemandPubChannelURIProvider(demand -> URI.create("pubsub:log:demand:" + demand))
                 .setDemandSubChannelURI(URI.create("pubsub:log:demand:*"))
-                .setSupplySerde(JacksonSerde.byClass(objectMapper, LogPile.class))
+                .setSupplySerde(factory.byClass(LogPile.class))
                 .setSupplyChannelURIProvider(demand -> URI.create("stream:log:supply:" + demand))
                 .setDemandInterval(Duration.ofSeconds(5))
                 .setBufferSize(4)

--- a/log/log-web/src/main/java/com/navercorp/pinpoint/log/web/websocket/LogWebSocketConfig.java
+++ b/log/log-web/src/main/java/com/navercorp/pinpoint/log/web/websocket/LogWebSocketConfig.java
@@ -15,8 +15,7 @@
  */
 package com.navercorp.pinpoint.log.web.websocket;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.navercorp.pinpoint.channel.serde.JacksonSerde;
+import com.navercorp.pinpoint.channel.serde.JsonSerdeFactory;
 import com.navercorp.pinpoint.log.web.service.LiveTailService;
 import com.navercorp.pinpoint.log.web.service.LogServiceConfig;
 import com.navercorp.pinpoint.log.web.vo.LiveTailBatch;
@@ -37,11 +36,11 @@ public class LogWebSocketConfig {
     @Bean
     PinpointWebSocketHandler logWebSocketHandler(
             LiveTailService liveTailService,
-            ObjectMapper objectMapper
+            JsonSerdeFactory factory
     ) {
         return new LogWebSocketHandler(
                 liveTailService,
-                JacksonSerde.byParameterized(objectMapper, List.class, LiveTailBatch.class)
+                factory.byParameterized(List.class, LiveTailBatch.class)
         );
     }
 

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/config/ATCServiceProtocolConfig.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/config/ATCServiceProtocolConfig.java
@@ -15,11 +15,10 @@
  */
 package com.navercorp.pinpoint.realtime.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.channel.ChannelSpringConfig;
 import com.navercorp.pinpoint.channel.redis.pubsub.RedisPubSubConfig;
 import com.navercorp.pinpoint.channel.redis.pubsub.RedisPubSubConstants;
-import com.navercorp.pinpoint.channel.serde.JacksonSerde;
+import com.navercorp.pinpoint.channel.serde.JsonSerdeFactory;
 import com.navercorp.pinpoint.channel.service.ChannelServiceProtocol;
 import com.navercorp.pinpoint.channel.service.FluxChannelServiceProtocol;
 import com.navercorp.pinpoint.channel.service.client.ChannelState;
@@ -40,12 +39,12 @@ import java.time.Duration;
 public class ATCServiceProtocolConfig {
 
     @Bean
-    FluxChannelServiceProtocol<ATCDemand, ATCSupply> atcProtocol(ObjectMapper objectMapper) {
+    FluxChannelServiceProtocol<ATCDemand, ATCSupply> atcProtocol(JsonSerdeFactory factory) {
         return ChannelServiceProtocol.<ATCDemand, ATCSupply>builder()
-                .setDemandSerde(JacksonSerde.byClass(objectMapper, ATCDemand.class))
+                .setDemandSerde(factory.byClass(ATCDemand.class))
                 .setDemandPubChannelURIProvider(demand -> URI.create(RedisPubSubConstants.SCHEME + ":demand:atc-2"))
                 .setDemandSubChannelURI(URI.create(RedisPubSubConstants.SCHEME + ":demand:atc-2"))
-                .setSupplySerde(JacksonSerde.byClass(objectMapper, ATCSupply.class))
+                .setSupplySerde(factory.byClass(ATCSupply.class))
                 .setSupplyChannelURIProvider(ATCServiceProtocolConfig::getATCSupplyChannelURI)
                 .setDemandInterval(Duration.ofSeconds(5))
                 .setBufferSize(4)

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/config/ATDServiceProtocolConfig.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/config/ATDServiceProtocolConfig.java
@@ -15,16 +15,13 @@
  */
 package com.navercorp.pinpoint.realtime.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.navercorp.pinpoint.channel.redis.pubsub.RedisPubSubConfig;
 import com.navercorp.pinpoint.channel.redis.pubsub.RedisPubSubConstants;
-import com.navercorp.pinpoint.channel.serde.JacksonSerde;
+import com.navercorp.pinpoint.channel.serde.JsonSerdeFactory;
 import com.navercorp.pinpoint.channel.service.ChannelServiceProtocol;
 import com.navercorp.pinpoint.channel.service.MonoChannelServiceProtocol;
 import com.navercorp.pinpoint.realtime.dto.ATDDemand;
 import com.navercorp.pinpoint.realtime.dto.ATDSupply;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -42,15 +39,13 @@ public class ATDServiceProtocolConfig {
 
     @Bean
     MonoChannelServiceProtocol<ATDDemand, ATDSupply> atdProtocol(
-            ObjectMapper objectMapper,
-            @Qualifier("clusterKeyDeserializer") SimpleModule clusterKeyJacksonModule
+            JsonSerdeFactory factory
     ) {
-        objectMapper.registerModule(clusterKeyJacksonModule);
         return ChannelServiceProtocol.<ATDDemand, ATDSupply>builder()
-                .setDemandSerde(JacksonSerde.byClass(objectMapper, ATDDemand.class))
+                .setDemandSerde(factory.byClass(ATDDemand.class))
                 .setDemandPubChannelURIProvider(demand -> URI.create(RedisPubSubConstants.SCHEME + ":demand:atd-2"))
                 .setDemandSubChannelURI(URI.create(RedisPubSubConstants.SCHEME + ":demand:atd-2"))
-                .setSupplySerde(JacksonSerde.byClass(objectMapper, ATDSupply.class))
+                .setSupplySerde(factory.byClass(ATDSupply.class))
                 .setSupplyChannelURIProvider(
                         demand -> URI.create(RedisPubSubConstants.SCHEME + ":supply:atd-2:" + demand.getId()))
                 .setRequestTimeout(Duration.ofSeconds(3))

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/serde/ClusterKeyDeserializer.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/serde/ClusterKeyDeserializer.java
@@ -16,11 +16,9 @@
 package com.navercorp.pinpoint.realtime.serde;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.node.LongNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
 
 import java.io.IOException;
@@ -36,10 +34,11 @@ public class ClusterKeyDeserializer extends StdDeserializer<ClusterKey> {
 
     @Override
     public ClusterKey deserialize(JsonParser parser, DeserializationContext ctx) throws IOException {
-        TreeNode root = parser.readValueAsTree();
-        String applicationName = ((TextNode) root.get("applicationName")).asText();
-        String agentId = ((TextNode) root.get("agentId")).asText();
-        long startTimestamp = ((LongNode) root.get("startTimestamp")).asLong();
+        JsonNode clusterNode = parser.readValueAsTree();
+
+        String applicationName = clusterNode.get("applicationName").asText();
+        String agentId = clusterNode.get("agentId").asText();
+        long startTimestamp = clusterNode.get("startTimestamp").asLong();
         return new ClusterKey(applicationName, agentId, startTimestamp);
     }
 

--- a/realtime/realtime-common/src/test/java/com/navercorp/pinpoint/realtime/serde/ClusterTest.java
+++ b/realtime/realtime-common/src/test/java/com/navercorp/pinpoint/realtime/serde/ClusterTest.java
@@ -1,0 +1,42 @@
+package com.navercorp.pinpoint.realtime.serde;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ClusterTest {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void deserialize() throws IOException {
+
+        Map<String, Object> clusterKeyMap = Map.of(
+                "applicationName", "app1",
+                "agentId", "agentId1",
+                "startTimestamp", 1234L
+        );
+
+        String json = mapper.writeValueAsString(clusterKeyMap);
+
+        JsonFactory factory = mapper.getFactory();
+        JsonParser parser = factory.createParser(json);
+        parser.nextToken();
+
+        ClusterKeyDeserializer deserializer = new ClusterKeyDeserializer();
+        ClusterKey clusterKey = deserializer.deserialize(parser, null);
+
+        assertNotNull(clusterKey);
+        assertEquals("app1", clusterKey.getApplicationName());
+        assertEquals("agentId1", clusterKey.getAgentId());
+        assertEquals(1234, clusterKey.getStartTimestamp());
+    }
+}

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/WebActiveThreadCountConfig.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/WebActiveThreadCountConfig.java
@@ -15,7 +15,9 @@
  */
 package com.navercorp.pinpoint.web.realtime.activethread.count;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.channel.serde.JsonSerdeFactory;
+import com.navercorp.pinpoint.channel.serde.Serde;
+import com.navercorp.pinpoint.web.realtime.activethread.count.dto.ActiveThreadCountResponse;
 import com.navercorp.pinpoint.web.realtime.activethread.count.service.ActiveThreadCountService;
 import com.navercorp.pinpoint.web.realtime.activethread.count.service.ActiveThreadCountWebServiceConfig;
 import com.navercorp.pinpoint.web.realtime.activethread.count.websocket.RedisActiveThreadCountWebSocketHandler;
@@ -31,11 +33,12 @@ import org.springframework.context.annotation.Import;
 public class WebActiveThreadCountConfig {
 
     @Bean
-    RedisActiveThreadCountWebSocketHandler redisActiveThreadCountWebSocketHandler(
+    public RedisActiveThreadCountWebSocketHandler redisActiveThreadCountWebSocketHandler(
             ActiveThreadCountService service,
-            ObjectMapper objectMapper
+            JsonSerdeFactory factory
     ) {
-        return new RedisActiveThreadCountWebSocketHandler(service, objectMapper);
+        Serde<ActiveThreadCountResponse> responseSerde = factory.byClass(ActiveThreadCountResponse.class);
+        return new RedisActiveThreadCountWebSocketHandler(service, responseSerde);
     }
 
 }

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/websocket/RedisActiveThreadCountWebSocketHandler.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/websocket/RedisActiveThreadCountWebSocketHandler.java
@@ -15,8 +15,6 @@
  */
 package com.navercorp.pinpoint.web.realtime.activethread.count.websocket;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.navercorp.pinpoint.channel.serde.JacksonSerde;
 import com.navercorp.pinpoint.web.realtime.activethread.count.dto.ActiveThreadCountResponse;
 import com.navercorp.pinpoint.web.realtime.activethread.count.service.ActiveThreadCountService;
 import org.apache.logging.log4j.LogManager;
@@ -44,10 +42,10 @@ public class RedisActiveThreadCountWebSocketHandler {
 
     public RedisActiveThreadCountWebSocketHandler(
             ActiveThreadCountService atcSessionFactory,
-            ObjectMapper objectMapper
+            Serializer<ActiveThreadCountResponse> responseSerializer
     ) {
         this.atcService = Objects.requireNonNull(atcSessionFactory, "atcSessionFactory");
-        this.responseSerializer = JacksonSerde.byClass(objectMapper, ActiveThreadCountResponse.class);
+        this.responseSerializer = Objects.requireNonNull(responseSerializer, "responseSerializer");
     }
 
     public void afterConnectionEstablished(@NonNull WebSocketSession session) {


### PR DESCRIPTION
This pull request introduces significant improvements to the serialization and deserialization (serde) infrastructure, replacing the direct use of `ObjectMapper` with a new `JsonSerdeFactory` abstraction. This change enhances modularity, testability, and reusability across the codebase. Key changes include the introduction of `JacksonSerdeFactory` and `JsonSerdeFactory` interfaces, refactoring of the `JacksonSerde` class, and updates to tests and configurations to use the new factory-based approach.

### Serialization/Deserialization Refactor:

* **Introduction of `JsonSerdeFactory` and `JacksonSerdeFactory`:**
  - Added `JsonSerdeFactory` interface to define a contract for serde creation. (`channel/src/main/java/com/navercorp/pinpoint/channel/serde/JsonSerdeFactory.java`)
  - Implemented `JacksonSerdeFactory` to encapsulate `ObjectMapper` logic and provide `Serde` instances using `ObjectReader` and `ObjectWriter` for improved performance. (`channel/src/main/java/com/navercorp/pinpoint/channel/serde/JacksonSerdeFactory.java`)

* **Refactoring of `JacksonSerde`:**
  - Replaced `ObjectMapper` and `JavaType` with `ObjectReader` and `ObjectWriter` for serialization and deserialization. This simplifies the serde logic and improves performance. (`channel/src/main/java/com/navercorp/pinpoint/channel/serde/JacksonSerde.java`) [[1]](diffhunk://#diff-7fbef4e05f7716be4c0a47144a6eaedc0bc519f938dfd825548dbcc080f002d0L18-R19) [[2]](diffhunk://#diff-7fbef4e05f7716be4c0a47144a6eaedc0bc519f938dfd825548dbcc080f002d0L32-R48)

### Dependency Injection and Configuration Updates:

* **Spring Configuration Updates:**
  - Added a new `ObjectMapper` bean with `@ConditionalOnMissingBean` to ensure flexibility in Spring-managed environments. (`channel/src/main/java/com/navercorp/pinpoint/channel/ChannelSpringConfig.java`) [[1]](diffhunk://#diff-96e375936706a5b709230cf1538fbc7adb310f6e1ffe1cbc8869b33fe96ffd1dR18-R21) [[2]](diffhunk://#diff-96e375936706a5b709230cf1538fbc7adb310f6e1ffe1cbc8869b33fe96ffd1dL30-R47)
  - Introduced a `JsonSerdeFactory` bean to provide serde instances throughout the application.

### Test Suite Updates:

* **Test Refactoring:**
  - Updated test cases to use `JacksonSerdeFactory` instead of directly instantiating `ObjectMapper` or `JacksonSerde`. This ensures consistency with the new factory-based approach. (`channel/src/test/java/com/navercorp/pinpoint/channel/serde/JacksonSerdeTest.java`, `channel/src/test/java/com/navercorp/pinpoint/channel/service/ChannelServiceProtocolTest.java`, etc.) [[1]](diffhunk://#diff-447c49a5964db4e7b8b0822093711b05de67bdffe1643083b2f83ebab2892e13L63-R74) [[2]](diffhunk://#diff-62d60270914acb06ca9c35170ffc95926ac14d384010580111b900a45c0f6fc0R38-R50) [[3]](diffhunk://#diff-eec278891e39917c12bd660ea33d5bed1a285a35c50adbb4480ca57ec009160dL57-R65) [[4]](diffhunk://#diff-bcffe2d179628409dcd59e3795c15f9e5c0b0abebd5c2ca6526d1c9b9a18c9cdL87-R100)

### Application-Level Integration:

* **Protocol Configurations:**
  - Updated various protocol configurations to use `JsonSerdeFactory` for serde creation, improving modularity and reducing boilerplate code. Examples include `LogServiceProtocolConfig`, `LogWebSocketConfig`, and `ATCServiceProtocolConfig`. [[1]](diffhunk://#diff-94d0daed6a077ed438eb525e8b675d8dea46f0cb208d582925aa27adbcab4c35L43-R47) [[2]](diffhunk://#diff-5e86ce2f3aaef7a8b2f86668a9ffba3453d2f57c0a8760315537b6c11a7e6b4aL40-R43) [[3]](diffhunk://#diff-8fedb3d12baa8a5e07368702f539fc4e1c4c1873aa8f43d309f78edab67307a4L18-R21) 

These changes collectively modernize the serde infrastructure, making it more robust and maintainable while improving the overall developer experience.