### PR TITLE
[#noissue] Remove deprecated API in HeatMapService

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/ApplicationTraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/ApplicationTraceIndexDao.java
@@ -41,10 +41,6 @@ public interface ApplicationTraceIndexDao {
 
     LimitedScanResult<List<TransactionId>> scanTraceIndex(String applicationName, DragArea dragArea, int limit);
 
-
-    @Deprecated
-    LimitedScanResult<List<Dot>> scanScatterData(String applicationName, DragAreaQuery dragAreaQuery, int limit);
-
     LimitedScanResult<List<DotMetaData>> scanScatterDataV2(String applicationName, DragAreaQuery dragAreaQuery, int limit);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseApplicationTraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseApplicationTraceIndexDao.java
@@ -33,7 +33,6 @@ import com.navercorp.pinpoint.common.util.TimeUtils;
 import com.navercorp.pinpoint.web.config.ScatterChartProperties;
 import com.navercorp.pinpoint.web.dao.ApplicationTraceIndexDao;
 import com.navercorp.pinpoint.web.mapper.TraceIndexMetaScatterMapper;
-import com.navercorp.pinpoint.web.mapper.TraceIndexScatterMapper;
 import com.navercorp.pinpoint.web.mapper.TransactionIdMapper;
 import com.navercorp.pinpoint.web.scatter.DragArea;
 import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
@@ -280,19 +279,6 @@ public class HbaseApplicationTraceIndexDao implements ApplicationTraceIndexDao {
         final long lastTime = getLastTime(range, limit, lastRowAccessor, transactionIdSum);
 
         return new LimitedScanResult<>(lastTime, transactionIdSum);
-    }
-
-    @Deprecated
-    @Override
-    public LimitedScanResult<List<Dot>> scanScatterData(String applicationName, DragAreaQuery dragAreaQuery, int limit) {
-        Objects.requireNonNull(applicationName, "applicationName");
-        Objects.requireNonNull(dragAreaQuery, "dragAreaQuery");
-
-        Predicate<Dot> filter = buildDotPredicate(dragAreaQuery);
-
-        RowMapper<List<Dot>> mapper = new TraceIndexScatterMapper(filter);
-
-        return scanScatterData0(applicationName, dragAreaQuery, limit, false, mapper);
     }
 
     private Predicate<Dot> buildDotPredicate(DragAreaQuery dragAreaQuery) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapService.java
@@ -1,6 +1,5 @@
 package com.navercorp.pinpoint.web.service;
 
-import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
 import com.navercorp.pinpoint.web.scatter.heatmap.HeatMap;
@@ -10,9 +9,6 @@ import com.navercorp.pinpoint.web.vo.scatter.DotMetaData;
 import java.util.List;
 
 public interface HeatMapService {
-
-    @Deprecated
-    LimitedScanResult<List<SpanBo>> dragScatterData(String applicationName, DragAreaQuery dragAreaquery, int limit);
 
     LimitedScanResult<List<DotMetaData>> dragScatterDataV2(String applicationName, DragAreaQuery dragAreaquery, int limit);
 


### PR DESCRIPTION
This pull request focuses on removing deprecated methods and improving compatibility handling in the `HeatMapServiceImpl` class. The most significant changes include the removal of outdated methods from multiple interfaces and classes, the introduction of a compatibility filtering mechanism for legacy data, and the replacement of stream-based operations with iterative approaches for better clarity and control.

### Removal of deprecated methods:

* Removed the `scanScatterData` method from the `ApplicationTraceIndexDao` interface and its implementation in `HbaseApplicationTraceIndexDao`. This method was marked as deprecated and is no longer needed. [[1]](diffhunk://#diff-fff68d60d2cdc2a35bc9df144d6952b8ef0a135b5749c7428f75abc24164741cL44-L47) [[2]](diffhunk://#diff-8cc454aac6e5632f331fb44261c836529e35a9b92f21ac2452bc277fc110db2eL285-L297)
* Removed the `dragScatterData` method from the `HeatMapService` interface and its implementation in `HeatMapServiceImpl`. This method was replaced by `dragScatterDataV2`. [[1]](diffhunk://#diff-e027f01795987cea69b16739f58412fbbb4fcd285a0fcc9dd4b9b04c3c4ea658L14-L16) [[2]](diffhunk://#diff-a8a37dc437863bfbbd4eaf31b245a56171fd2d0dba7501770aacf29c7e7abadcL49-L68)

### Compatibility handling improvements:

* Introduced a new `legacyTablePredicate` in `HeatMapServiceImpl` to identify legacy data based on specific conditions. This predicate is used to filter and process legacy data for compatibility. [[1]](diffhunk://#diff-a8a37dc437863bfbbd4eaf31b245a56171fd2d0dba7501770aacf29c7e7abadcL29-R41) [[2]](diffhunk://#diff-a8a37dc437863bfbbd4eaf31b245a56171fd2d0dba7501770aacf29c7e7abadcL77-R86)
* Replaced the `legacyCompatibilityCheck` method with `hasOldVersion` and `filterCompatibility` methods to streamline compatibility checks and filtering logic. [[1]](diffhunk://#diff-a8a37dc437863bfbbd4eaf31b245a56171fd2d0dba7501770aacf29c7e7abadcL77-R86) [[2]](diffhunk://#diff-a8a37dc437863bfbbd4eaf31b245a56171fd2d0dba7501770aacf29c7e7abadcL134-R127)

### Code simplification:

* Replaced stream-based operations with explicit for-loops in methods like `filterLegacyTablePredicate` and `buildQuery` to improve readability and maintainability. [[1]](diffhunk://#diff-a8a37dc437863bfbbd4eaf31b245a56171fd2d0dba7501770aacf29c7e7abadcL134-R127) [[2]](diffhunk://#diff-a8a37dc437863bfbbd4eaf31b245a56171fd2d0dba7501770aacf29c7e7abadcL167-R159)