### PR TITLE
[#12434] Change Queue Link to application stats

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapInLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapInLinkDao.java
@@ -72,7 +72,7 @@ public class HbaseMapInLinkDao implements MapInLinkDao {
         Objects.requireNonNull(outApplicationName, "outApplicationName");
 
         if (logger.isDebugEnabled()) {
-            logger.debug("[InLink] {} ({}) <- {} ({})[{}]",
+            logger.debug("[InLink] {}/{} <- {}/{}/{}",
                     inApplicationName, inServiceType, outApplicationName, outServiceType, outHost);
         }
 
@@ -81,7 +81,7 @@ public class HbaseMapInLinkDao implements MapInLinkDao {
 
         // TODO callee, caller parameter normalization
         if (ignoreStatFilter.filter(inServiceType, outHost)) {
-            logger.debug("[Ignore-InLink] {} ({}) <- {} ({})[{}]",
+            logger.debug("[Ignore-InLink] {}/{} <- {}/{}/{}",
                     inApplicationName, inServiceType, outApplicationName, outServiceType, outHost);
             return;
         }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -68,7 +68,7 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
 
 
         if (logger.isDebugEnabled()) {
-            logger.debug("[OutLink] {} ({}) {} -> {} ({})[{}]", outApplicationName, outServiceType, outAgentId,
+            logger.debug("[OutLink] {}/{}/{} -> {}/{}/{}", outApplicationName, outServiceType, outAgentId,
                     inApplicationName, inServiceType, inHost);
         }
 


### PR DESCRIPTION
This pull request includes changes to improve logging consistency and introduce a new constant for queue merging in the `collector` module. The most important changes involve formatting updates to debug logs for better readability and the addition of the `MERGE_QUEUE` constant to enhance queue-related functionality.

### Logging Improvements:
* Updated debug log formats in `HbaseMapInLinkDao.java` and `HbaseMapOutLinkDao.java` to use consistent `{}/{}/...` patterns for better readability and uniformity. (`[[1]](diffhunk://#diff-d76d17c39980e928a6f9a494cb5a559f60cd97ff34ab37514663f1858290dacfL75-R75)`, `[[2]](diffhunk://#diff-d76d17c39980e928a6f9a494cb5a559f60cd97ff34ab37514663f1858290dacfL84-R84)`, `[[3]](diffhunk://#diff-4b07ea846dfc607b73cacf60ac8f045ab8ac879a205654de45731ec9f1d2db80L71-R71)`)
* Enhanced debug logs in `HbaseTraceService.java` to provide clearer information about virtual queue nodes and child-span updates. (`[[1]](diffhunk://#diff-1804eec889f0788f4f718d027f1a4d0988cbd7246263101baa7743b42a8dbb68L171-R179)`, `[[2]](diffhunk://#diff-1804eec889f0788f4f718d027f1a4d0988cbd7246263101baa7743b42a8dbb68R206-R226)`)
* Improved error logging in `insertSpanEventList` method to include detailed span application and event application information. (`[collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.javaL272-R288](diffhunk://#diff-1804eec889f0788f4f718d027f1a4d0988cbd7246263101baa7743b42a8dbb68L272-R288)`)

### Queue Functionality Enhancements:
* Added `MERGE_QUEUE` constant in `HbaseTraceService.java` for improved handling of queue-related operations. (`[collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.javaR53](diffhunk://#diff-1804eec889f0788f4f718d027f1a4d0988cbd7246263101baa7743b42a8dbb68R53)`)
* Integrated `MERGE_QUEUE` into span and link updates to support virtual queue node creation and emulation. (`[[1]](diffhunk://#diff-1804eec889f0788f4f718d027f1a4d0988cbd7246263101baa7743b42a8dbb68L171-R179)`, `[[2]](diffhunk://#diff-1804eec889f0788f4f718d027f1a4d0988cbd7246263101baa7743b42a8dbb68R206-R226)`)