### PR TITLE
[#12434] Refactor ServerMap

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/Vertex.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/Vertex.java
@@ -1,0 +1,23 @@
+package com.navercorp.pinpoint.collector.applicationmap;
+
+import com.navercorp.pinpoint.common.trace.ServiceType;
+
+import java.util.Objects;
+
+public record Vertex(String applicationName, ServiceType serviceType) {
+
+    public Vertex(String applicationName, ServiceType serviceType) {
+        this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
+        this.serviceType = Objects.requireNonNull(serviceType, "serviceType");
+    }
+
+
+    public static Vertex of(String applicationName, ServiceType serviceType) {
+        return new Vertex(applicationName, serviceType);
+    }
+
+    @Override
+    public String toString() {
+        return applicationName + "/" + serviceType.getName() + ':' + serviceType.getCode();
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/HostApplicationMapDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/HostApplicationMapDao.java
@@ -16,11 +16,14 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.dao;
 
+import com.navercorp.pinpoint.collector.applicationmap.Vertex;
+
 /**
  * 
  * @author netspider
  * 
  */
 public interface HostApplicationMapDao {
-    void insert(long requestTime, String host, String bindApplicationName, short bindServiceType, String parentApplicationName, short parentServiceType);
+    void insert(long requestTime, String host, Vertex selfVertex, String parentApplicationName, short parentServiceType);
+
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/MapInLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/MapInLinkDao.java
@@ -16,8 +16,8 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.dao;
 
+import com.navercorp.pinpoint.collector.applicationmap.Vertex;
 import com.navercorp.pinpoint.collector.dao.CachedStatisticsDao;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 
 /**
  * 
@@ -25,6 +25,5 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
  * @author emeroad
  */
 public interface MapInLinkDao extends CachedStatisticsDao {
-    void inLink(long requestTime, String inApplicationName, ServiceType inServiceType,
-                String outApplicationName, ServiceType outServiceType, String outHost, int elapsed, boolean isError);
+    void inLink(long requestTime, Vertex inVertex, Vertex outVertex, String outHost, int elapsed, boolean isError);
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/MapOutLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/MapOutLinkDao.java
@@ -16,8 +16,8 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.dao;
 
+import com.navercorp.pinpoint.collector.applicationmap.Vertex;
 import com.navercorp.pinpoint.collector.dao.CachedStatisticsDao;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 
 /**
  * 
@@ -25,6 +25,6 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
  * @author emeroad
  */
 public interface MapOutLinkDao extends CachedStatisticsDao {
-    void outLink(long requestTime, String outApplicationName, ServiceType outServiceType, String outAgentId,
-                 String inApplicationName, ServiceType inServiceType, String inHost, int elapsed, boolean isError);
+    void outLink(long requestTime, Vertex outVertex, String outAgentId,
+                 Vertex inVertex, String inHost, int elapsed, boolean isError);
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/MapResponseTimeDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/MapResponseTimeDao.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.dao;
 
+import com.navercorp.pinpoint.collector.applicationmap.Vertex;
 import com.navercorp.pinpoint.collector.dao.CachedStatisticsDao;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
@@ -24,7 +25,7 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
  * @author jaehong.kim
  */
 public interface MapResponseTimeDao extends CachedStatisticsDao {
-    void received(long requestTime, String applicationName, ServiceType serviceType, String agentId, int elapsed, boolean isError);
+    void received(long requestTime, Vertex selfVertex, String agentId, int elapsed, boolean isError);
 
     void updatePing(long requestTime, String applicationName, ServiceType serviceType, String agentId, int elapsed, boolean isError);
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/LinkService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/LinkService.java
@@ -1,5 +1,6 @@
 package com.navercorp.pinpoint.collector.applicationmap.service;
 
+import com.navercorp.pinpoint.collector.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import jakarta.validation.constraints.NotBlank;
 
@@ -12,21 +13,18 @@ public interface LinkService {
      * The following message is generated for the in(MySQL) :<br/>
      * MySQL (MYSQL) <- emeroad-app (TOMCAT)[localhost:8080]
      *
-     * @param outApplicationName outApplicationName
-     * @param outServiceType     outServiceType
-     * @param inApplicationName  inApplicationName
-     * @param inServiceType      inServiceType
-     * @param inHost             inHost
-     * @param elapsed            elapsed
-     * @param isError            isError
+     * @param outVertex  outVertex
+     * @param outAgentId outAgentId
+     * @param inVertex   inVertex
+     * @param inHost     inHost
+     * @param elapsed    elapsed
+     * @param isError    isError
      */
     void updateOutLink(
             long requestTime,
-            @NotBlank String outApplicationName,
-            ServiceType outServiceType,
+            Vertex outVertex,
             @NotBlank String outAgentId,
-            @NotBlank String inApplicationName,
-            ServiceType inServiceType,
+            Vertex inVertex,
             String inHost,
             int elapsed, boolean isError
     );
@@ -38,28 +36,23 @@ public interface LinkService {
      * The following message is generated for the out(Tomcat) :<br/>
      * emeroad-app (TOMCAT) -> MySQL (MYSQL)[10.25.141.69:3306]
      *
-     * @param inApplicationName  inApplicationName
-     * @param inServiceType      inServiceType
-     * @param outApplicationName outApplicationName
-     * @param outServiceType     outServiceType
-     * @param outHost            outHost
-     * @param elapsed            elapsed
-     * @param isError            isError
+     * @param inVertex  inVertex
+     * @param outVertex outVertex
+     * @param outHost   outHost
+     * @param elapsed   elapsed
+     * @param isError   isError
      */
     void updateInLink(
             long requestTime,
-            @NotBlank String inApplicationName,
-            ServiceType inServiceType,
-            @NotBlank String outApplicationName,
-            ServiceType outServiceType,
+            Vertex inVertex,
+            Vertex outVertex,
             String outHost,
             int elapsed, boolean isError
     );
 
     void updateResponseTime(
             long requestTime,
-            @NotBlank String applicationName,
-            ServiceType serviceType,
+            Vertex appVertex,
             String agentId,
             int elapsed, boolean isError
     );

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/LinkServiceImpl.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/LinkServiceImpl.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.service;
 
+import com.navercorp.pinpoint.collector.applicationmap.Vertex;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapInLinkDao;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapOutLinkDao;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapResponseTimeDao;
@@ -44,41 +45,35 @@ public class LinkServiceImpl implements LinkService {
     @Override
     public void updateOutLink(
             long requestTime,
-            @NotBlank String outApplicationName,
-            ServiceType outServiceType,
+            Vertex outVertex,
             @NotBlank String outAgentId,
-            @NotBlank String inApplicationName,
-            ServiceType inServiceType,
+            Vertex inVertex,
             String inHost,
             int elapsed, boolean isError
     ) {
-        outLinkDao.outLink(requestTime, outApplicationName, outServiceType, outAgentId,
-                inApplicationName, inServiceType, inHost, elapsed, isError);
+        outLinkDao.outLink(requestTime, outVertex, outAgentId,
+                inVertex, inHost, elapsed, isError);
     }
 
     @Override
     public void updateInLink(
             long requestTime,
-            @NotBlank String inApplicationName,
-            ServiceType inServiceType,
-            @NotBlank String outApplicationName,
-            ServiceType outServiceType,
+            Vertex inVertex,
+            Vertex outVertex,
             String outHost,
             int elapsed, boolean isError
     ) {
-        inLinkDao.inLink(requestTime, inApplicationName, inServiceType,
-                outApplicationName, outServiceType, outHost, elapsed, isError);
+        inLinkDao.inLink(requestTime, inVertex, outVertex, outHost, elapsed, isError);
     }
 
     @Override
     public void updateResponseTime(
             long requestTime,
-            @NotBlank String applicationName,
-            ServiceType serviceType,
+            Vertex selfVertex,
             String agentId,
             int elapsed, boolean isError
     ) {
-        responseTimeDao.received(requestTime, applicationName, serviceType, agentId, elapsed, isError);
+        responseTimeDao.received(requestTime, selfVertex, agentId, elapsed, isError);
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/InLinkColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/InLinkColumnName.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.statistics;
 
+import com.navercorp.pinpoint.collector.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -34,14 +35,26 @@ public class InLinkColumnName implements ColumnName {
     private final String callHost;
     private final short columnSlotNumber;
 
+    public static ColumnName histogram(String outAgentId, Vertex inVertex, String callHost, short columnSlotNumber) {
+        return histogram(outAgentId, inVertex.serviceType(), inVertex.applicationName(), callHost, columnSlotNumber);
+    }
 
     public static ColumnName histogram(String outAgentId, ServiceType inServiceType, String inApplicationName, String callHost, short columnSlotNumber) {
         return new InLinkColumnName(outAgentId, inServiceType.getCode(), inApplicationName, callHost, columnSlotNumber);
     }
 
+    public static ColumnName sum(String outAgentId, Vertex inVertex, String callHost, ServiceType outServiceType) {
+        return sum(outAgentId, inVertex.serviceType(), inVertex.applicationName(), callHost, outServiceType);
+    }
+
     public static ColumnName sum(String outAgentId, ServiceType inServiceType, String inApplicationName, String callHost, ServiceType outServiceType) {
         final short slotTime = outServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
         return histogram(outAgentId, inServiceType, inApplicationName, callHost, slotTime);
+    }
+
+    public static ColumnName max(String outAgentId, Vertex inVertex, String callHost, ServiceType outServiceType) {
+        final short slotTime = outServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
+        return histogram(outAgentId, inVertex.serviceType(), inVertex.applicationName(), callHost, slotTime);
     }
 
     public static ColumnName max(String outAgentId, ServiceType inServiceType, String inApplicationName, String callHost, ServiceType outServiceType) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/LinkRowKey.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/LinkRowKey.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.statistics;
 
+import com.navercorp.pinpoint.collector.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.util.ApplicationMapStatisticsUtils;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
@@ -28,6 +29,10 @@ public class LinkRowKey implements RowKey {
     private final String applicationName;
     private final short serviceType;
     private final long rowTimeSlot;
+
+    public static RowKey of(Vertex vertex, long rowTimeSlot) {
+        return new LinkRowKey(vertex.applicationName(), vertex.serviceType().getCode(), rowTimeSlot);
+    }
 
     public static RowKey of(String applicationName, ServiceType serviceType, long rowTimeSlot) {
         return new LinkRowKey(applicationName, serviceType.getCode(), rowTimeSlot);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/OutLinkColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/OutLinkColumnName.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.statistics;
 
+import com.navercorp.pinpoint.collector.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.util.ApplicationMapStatisticsUtils;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
@@ -31,13 +32,25 @@ public class OutLinkColumnName implements ColumnName {
     private final String outHost;
     private final short columnSlotNumber;
 
+    public static ColumnName histogram(Vertex outVertex, String outHost, short columnSlotNumber) {
+        return histogram(outVertex.applicationName(), outVertex.serviceType(), outHost, columnSlotNumber);
+    }
+
     public static ColumnName histogram(String outApplicationName, ServiceType outServiceType, String outHost, short columnSlotNumber) {
         return new OutLinkColumnName(outApplicationName, outServiceType.getCode(), outHost, columnSlotNumber);
+    }
+
+    public static ColumnName sum(Vertex outVertex, String outHost, ServiceType inServiceType) {
+        return sum(outVertex.applicationName(), outVertex.serviceType(), outHost, inServiceType);
     }
 
     public static ColumnName sum(String outApplicationName, ServiceType outServiceType, String outHost, ServiceType inServiceType) {
         final short slotTime = inServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
         return histogram(outApplicationName, outServiceType, outHost, slotTime);
+    }
+
+    public static ColumnName max(Vertex outVertex, String outHost, ServiceType inServiceType) {
+        return max(outVertex.applicationName(), outVertex.serviceType(), outHost, inServiceType);
     }
 
     public static ColumnName max(String outApplicationName, ServiceType outServiceType, String outHost, ServiceType inServiceType) {

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDaoTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDaoTest.java
@@ -39,6 +39,7 @@ public class HbaseHostApplicationMapDaoTest {
         String parentApp = "parentApp";
         long statisticsRowSlot = timeSlot.getTimeSlot(System.currentTimeMillis());
         ServiceType standAlone = ServiceType.STAND_ALONE;
+
         byte[] parentApps = HbaseHostApplicationMapDao.createRowKey0(parentApp, standAlone.getCode(), statisticsRowSlot, null);
         logger.debug("rowKey size:{}", parentApps.length);
 


### PR DESCRIPTION
This pull request introduces a new `Vertex` class to simplify and standardize the representation of application and service type pairs across the codebase. It refactors multiple DAO interfaces and their implementations to use the `Vertex` class, replacing separate parameters for application names and service types. This improves code readability, reduces redundancy, and ensures consistency in handling application-service pairs.

### Refactoring to use `Vertex`:

* **Creation of `Vertex` class**: Introduced a new `Vertex` record in `collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/Vertex.java`. This class encapsulates `applicationName` and `serviceType` with validation and utility methods.

* **Refactored DAO interfaces**:
  - Updated `HostApplicationMapDao`, `MapInLinkDao`, `MapOutLinkDao`, and `MapResponseTimeDao` to replace separate parameters for application names and service types with the `Vertex` class. [[1]](diffhunk://#diff-130293c71e15114a35fd74ccde13979da547d328c81098707da679ea86e7b163R19-R28) [[2]](diffhunk://#diff-2ba6b27d38387b3d57533166eff1d4886f0a035cdc46db6a0ccf7bb5b2b49ac9R19-R28) [[3]](diffhunk://#diff-daabb1c363c1a021c28bab881dfff94cc3be344c1af33bdcf9d26c86e5ad8e26R19-R29) [[4]](diffhunk://#diff-ac777dbf6552460864a301bd44f9652eec42be1aeac1f77fc18c2f3ff6970044L27-R28)

* **Refactored HBase DAO implementations**:
  - Updated methods in `HbaseHostApplicationMapDao`, `HbaseMapInLinkDao`, `HbaseMapOutLinkDao`, and `HbaseMapResponseTimeDao` to use `Vertex` objects. This includes changes to method signatures, logging, row key creation, and column name generation. [[1]](diffhunk://#diff-67d647f20220b276cc88a58eac5ed57e1ad56d906395e43b74d5111517c21ab0L76-R105) [[2]](diffhunk://#diff-d76d17c39980e928a6f9a494cb5a559f60cd97ff34ab37514663f1858290dacfL69-R101) [[3]](diffhunk://#diff-4b07ea846dfc607b73cacf60ac8f045ab8ac879a205654de45731ec9f1d2db80L64-R91) [[4]](diffhunk://#diff-40d8993f9cc21b2e5126a8f739a0a4f28435a4ef3213fda8e4a18373681bf981L64-R86)

### Code consistency and cleanup:

* Removed redundant imports of `ServiceType` in files where `Vertex` replaced its usage. This ensures cleaner and more focused code. [[1]](diffhunk://#diff-ac777dbf6552460864a301bd44f9652eec42be1aeac1f77fc18c2f3ff6970044R19) [[2]](diffhunk://#diff-d76d17c39980e928a6f9a494cb5a559f60cd97ff34ab37514663f1858290dacfL29) [[3]](diffhunk://#diff-4b07ea846dfc607b73cacf60ac8f045ab8ac879a205654de45731ec9f1d2db80L28)

These changes streamline the handling of application-service pairs, making the codebase more maintainable and easier to extend in the future.