### PR TITLE
[#noissue] Fix ArrayIndexOutOfBoundsException message in BytesUtils

### DIFF
--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.java
@@ -544,4 +544,12 @@ public class BytesUtilsTest {
         Assertions.assertThrows(ArrayIndexOutOfBoundsException.class, () -> BytesUtils.checkFromIndexSize(0, -1, 0));
         Assertions.assertThrows(ArrayIndexOutOfBoundsException.class, () -> BytesUtils.checkFromIndexSize(0, 0, -1));
     }
+
+    @Test
+    public void checkBounds_exceptionMessage() {
+        ArrayIndexOutOfBoundsException error = Assertions.assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+            BytesUtils.checkFromIndexSize(1, 4, 0);
+        });
+        assertEquals("Out of range 5", error.getMessage());
+    }
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java
@@ -399,7 +399,7 @@ public final class BytesUtils {
             throwArrayIndexOutOfBoundsException(fromIndex, size, length);
         }
         if (fromIndex > length - size) {
-            throw new ArrayIndexOutOfBoundsException("Out of range " + fromIndex + size);
+            throw new ArrayIndexOutOfBoundsException("Out of range " + (fromIndex + size));
         }
     }
 


### PR DESCRIPTION
This pull request updates the `BytesUtils` utility class and its corresponding test suite to improve exception handling and validation messages. The changes ensure that the exception message for out-of-range errors provides accurate information and adds a test case to verify this behavior.

### Improvements to exception handling:

* [`commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java`](diffhunk://#diff-7ef761358947bcfc5f43ab6e136ff008a2d69a1da0fbc7b8dfdd59451fc6cbdfL402-R402): Corrected the exception message in the `checkFromIndexSize` method to accurately reflect the out-of-range index by using `(fromIndex + size)` instead of `fromIndex + size`.

### Enhancements to test coverage:

* [`commons-buffer/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.java`](diffhunk://#diff-d8b6c643a0e840b66ca4be6a6bf030d4177b52d7eac8f3f81150e0df9c709ddfR547-R554): Added a new test case, `checkBounds_exceptionMessage`, to validate the updated exception message for out-of-range errors in the `checkFromIndexSize` method.