### PR TITLE
[#12617] Add server.port to PinpointSpringBanner

### DIFF
--- a/collector/src/main/resources/pinpoint-collector-root.properties
+++ b/collector/src/main/resources/pinpoint-collector-root.properties
@@ -90,6 +90,7 @@ collector.application.uid.cache.recordStats=false
 # Pinpoint banner mode : OFF, CONSOLE, LOG
 pinpoint.banner.mode=console
 pinpoint.banner.configs=spring.active.profile,\
+                        server.port,\
                         pinpoint.zookeeper.address,\
                         collector.receiver.grpc.agent.enable,\
                         collector.receiver.grpc.agent.bindaddress.ip,\

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -107,6 +107,7 @@ pinpoint.web.application.uid.enable=false
 # Pinpoint banner mode : OFF, CONSOLE, LOG
 pinpoint.banner.mode=console
 pinpoint.banner.configs=spring.active.profile,\
+                        server.port,\
                         pinpoint.zookeeper.address,\
                         spring.datasource.hikari.jdbc-url,\
                         spring.meta-datasource.hikari.jdbc-url,\


### PR DESCRIPTION
This pull request updates configuration files to include `server.port` in the `pinpoint.banner.configs` property, improving the visibility of server port settings in both the collector and web modules.

Configuration updates:

* [`collector/src/main/resources/pinpoint-collector-root.properties`](diffhunk://#diff-1dcf31a1cf7f6c97c78434f660ba8086e56a737bc1da37f3c120fd35951f3112R93): Added `server.port` to the `pinpoint.banner.configs` property to enhance configuration clarity for the collector module.
* [`web/src/main/resources/pinpoint-web-root.properties`](diffhunk://#diff-c03bc17fc54b79933f6832f97a718e5b9e4f557abd75c2610ba3e6a68a541c66R110): Added `server.port` to the `pinpoint.banner.configs` property to enhance configuration clarity for the web module.