### PR TITLE
[#12622] Refactor SQL comment handling to unify readComment

### DIFF
--- a/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/sql/DefaultSqlNormalizer.java
+++ b/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/sql/DefaultSqlNormalizer.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Queue;
 
 import static com.navercorp.pinpoint.common.profiler.sql.ParserContext.lookAhead1;
+import static com.navercorp.pinpoint.common.profiler.sql.ParserContext.readComment;
 import static com.navercorp.pinpoint.common.profiler.sql.ParserContext.readLine;
-import static com.navercorp.pinpoint.common.profiler.sql.ParserContext.readMultiLineComment;
 import static com.navercorp.pinpoint.common.profiler.sql.Tokens.NEXT_TOKEN_NOT_EXIST;
 import static com.navercorp.pinpoint.common.profiler.sql.Tokens.NUMBER_REPLACE;
 import static com.navercorp.pinpoint.common.profiler.sql.Tokens.SYMBOL_REPLACE;
@@ -70,7 +70,7 @@ public class DefaultSqlNormalizer implements SqlNormalizer {
                     int lookAhead1Char = lookAhead1(sql, i);
                     // multi line comment and oracle hint /*+ */
                     if (lookAhead1Char == '*') {
-                        i = readMultiLineComment("/*", i, sql, normalized);
+                        i = readComment("/*", "*/", i, sql, normalized);
                         break;
                         // single line comment
                     } else if (lookAhead1Char == '/') {
@@ -238,7 +238,7 @@ public class DefaultSqlNormalizer implements SqlNormalizer {
                     int lookAhead1Char = lookAhead1(sql, i);
                     // multi line comment and oracle hint /*+ */
                     if (lookAhead1Char == '*') {
-                        i = readMultiLineComment("/*", i, sql, result);
+                        i = readComment("/*", "*/", i, sql, result);
                         // single line comment
                     } else if (lookAhead1Char == '/') {
                         i = readLine("//", i, sql, result);

--- a/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/sql/DefaultSqlNormalizerTest.java
+++ b/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/sql/DefaultSqlNormalizerTest.java
@@ -307,13 +307,13 @@ public class DefaultSqlNormalizerTest {
         Assertions.assertEquals(result2, result1);
 
         sql1 = "//comment\nselect * from table id = ?;";
-        sql2 = "\nselect * from table id = ?;";
+        sql2 = "select * from table id = ?;";
         result1 = sut.normalizeSql(sql1).getNormalizedSql();
         result2 = sut.normalizeSql(sql2).getNormalizedSql();
         Assertions.assertEquals(result2, result1);
 
         sql1 = "--comment\nselect * from table id = ?;";
-        sql2 = "\nselect * from table id = ?;";
+        sql2 = "select * from table id = ?;";
         result1 = sut.normalizeSql(sql1).getNormalizedSql();
         result2 = sut.normalizeSql(sql2).getNormalizedSql();
         Assertions.assertEquals(result2, result1);


### PR DESCRIPTION
This pull request refactors the SQL comment parsing logic in the `DefaultSqlNormalizer` and `ParserContext` classes to simplify and consolidate the handling of comments. It replaces multiple specialized methods with a single, more generic `readComment` method. Additionally, related test cases in `DefaultSqlNormalizerTest` have been updated to reflect the changes.

### Refactoring of comment parsing logic:

* Consolidated multiple methods for handling comments (e.g., `readMultiLineComment`, `skipComment`, `readLine`) into a single method, `readComment`, which supports both single-line and multi-line comments. (`ParserContext.java`, [[1]](diffhunk://#diff-882dccd9b440b688603b91933bb367a25d4cd42a6d9e5c895fb336704372268cL219-L246) [[2]](diffhunk://#diff-882dccd9b440b688603b91933bb367a25d4cd42a6d9e5c895fb336704372268cL284-R309)
* Updated the `combineOutputParams` and `combineBindValues` methods in `DefaultSqlNormalizer` to use the new `readComment` method for parsing multi-line comments. (`DefaultSqlNormalizer.java`, [[1]](diffhunk://#diff-cd67351ca6866e1f0d29d266e7af9796513e31d163ab72010aa7e14cf65c4e09L73-R73) [[2]](diffhunk://#diff-cd67351ca6866e1f0d29d266e7af9796513e31d163ab72010aa7e14cf65c4e09L241-R241)

### Test updates:

* Adjusted test cases in `DefaultSqlNormalizerTest` to account for the updated comment normalization logic. Single-line comments now normalize to exclude the newline character at the start of the resulting SQL. (`DefaultSqlNormalizerTest.java`, [commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/sql/DefaultSqlNormalizerTest.javaL310-R316](diffhunk://#diff-e8b2b3ce30905f13f49d01c7d7165fae809b3313947ab86290b64e967a2fc1dbL310-R316))