### PR TITLE
[#12622] Refactor skipLine by merging with readLine

### DIFF
--- a/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/sql/ParserContext.java
+++ b/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/sql/ParserContext.java
@@ -52,7 +52,7 @@ public class ParserContext {
                     } else if (lookAhead1Char == '/') {
                         if (removeComments) {
                             this.parameter.touch();
-                            i = skipLine("//", i, normalized);
+                            i = skipLine("//", i);
                         } else {
                             i = readLine("//", i, normalized);
                         }
@@ -69,7 +69,7 @@ public class ParserContext {
                     if (lookAhead1(i) == '-') {
                         if (removeComments) {
                             this.parameter.touch();
-                            i = skipLine("--", i, normalized);
+                            i = skipLine("--", i);
                         } else {
                             i = readLine("--", i, normalized);
                         }
@@ -261,7 +261,7 @@ public class ParserContext {
         return i;
     }
 
-    private int skipLine(String first, int index, StringBuilder normalized) {
+    private int skipLine(String first, int index) {
         return readComment(first, "\n", index, this.sql, null);
     }
 


### PR DESCRIPTION
Related issue: #12622.

This pull request refactors the `ParserContext` class in the `commons-profiler` module to streamline comment handling in SQL parsing. The main changes involve simplifying the `skipLine` method by delegating its functionality to the `readLine` method and updating the related method calls accordingly.

### Refactoring of `skipLine` method:

* Removed the original implementation of `skipLine` and replaced it with a call to `readLine`, passing `null` for the `normalized` parameter when comments are being skipped. (`[commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/sql/ParserContext.javaL284-R285](diffhunk://#diff-882dccd9b440b688603b91933bb367a25d4cd42a6d9e5c895fb336704372268cL284-R285)`)

### Updates to method calls:

* Updated calls to `skipLine` in the `parse` method to remove the `normalized` parameter, aligning with the refactored `skipLine` signature. (`[[1]](diffhunk://#diff-882dccd9b440b688603b91933bb367a25d4cd42a6d9e5c895fb336704372268cL55-R55)`, `[[2]](diffhunk://#diff-882dccd9b440b688603b91933bb367a25d4cd42a6d9e5c895fb336704372268cL72-R72)`)

### Enhancement in `readLine`:

* Adjusted the `readLine` method to append content to the `normalized` parameter only if it is not `null`, ensuring compatibility with the refactored `skipLine` method. (`[commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/sql/ParserContext.javaR305-R307](diffhunk://#diff-882dccd9b440b688603b91933bb367a25d4cd42a6d9e5c895fb336704372268cR305-R307)`)