### PR TITLE
[#12606] Fix NPE of kafka stream acceptorHost is null

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.java
@@ -216,7 +216,11 @@ public class HbaseTraceService implements TraceService {
             if (spanServiceType.isQueue()) {
                 if (!selfVertex.serviceType().isQueue() && !parentVertex.serviceType().isQueue()) {
                     // emulate virtual queue node's accept Span and record it's acceptor host
-                    final Vertex queueAcceptVertex = Vertex.of(span.getAcceptorHost(), spanServiceType);
+                    String applicationName = span.getAcceptorHost();
+                    if(applicationName == null) {
+                        applicationName = span.getRemoteAddr();
+                    }
+                    final Vertex queueAcceptVertex = Vertex.of(applicationName, spanServiceType);
 
                     if (logger.isDebugEnabled()) {
                         logger.debug("[Bind] child-queue {}/{} <- {}", queueAcceptVertex, span.getRemoteAddr(), parentVertex);


### PR DESCRIPTION
#12606 

Collector error logs
~~~
java.lang.NullPointerException: bindApplicationName
	at java.base/java.util.Objects.requireNonNull(Objects.java:235) ~[?:?]
	at com.navercorp.pinpoint.collector.applicationmap.dao.hbase.HbaseHostApplicationMapDao.insert(HbaseHostApplicationMapDao.java:79) ~[pinpoint-collector-3.1.0-SNAPSHOT.jar!/:3.1.0-SNAPSHOT]
	at com.navercorp.pinpoint.collector.service.HbaseTraceService.insertSpanStat(HbaseTraceService.java:201) ~[pinpoint-collector-3.1.0-SNAPSHOT.jar!/:3.1.0-SNAPSHOT]
	at com.navercorp.pinpoint.collector.service.HbaseTraceService.insertSpan(HbaseTraceService.java:111) ~[pinpoint-collector-3.1.0-SNAPSHOT.jar!/:3.1.0-SNAPSHOT]
	at jdk.internal.reflect.GeneratedMethodAccessor40.invoke(Unknown Source) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
~~~