### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/agent-module/plugins/jtds/src/main/java/com/navercorp/pinpoint/plugin/jdbc/jtds/JtdsJdbcUrlParser.java
+++ b/agent-module/plugins/jtds/src/main/java/com/navercorp/pinpoint/plugin/jdbc/jtds/JtdsJdbcUrlParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ public class JtdsJdbcUrlParser implements JdbcUrlParserV2 {
         final int databaseIdIndex = hostAndPortAndDataBaseString.indexOf('/');
         if (databaseIdIndex != -1) {
             hostAndPortString = hostAndPortAndDataBaseString.substring(0, databaseIdIndex);
-            databaseId = hostAndPortAndDataBaseString.substring(databaseIdIndex + 1, hostAndPortAndDataBaseString.length());
+            databaseId = hostAndPortAndDataBaseString.substring(databaseIdIndex + 1);
         } else {
             hostAndPortString = hostAndPortAndDataBaseString;
         }

--- a/agent-module/plugins/spring-boot/src/main/java/com/navercorp/pinpoint/plugin/spring/boot/interceptor/LauncherLaunchInterceptor.java
+++ b/agent-module/plugins/spring-boot/src/main/java/com/navercorp/pinpoint/plugin/spring/boot/interceptor/LauncherLaunchInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,9 +145,7 @@ public class LauncherLaunchInterceptor implements AroundInterceptor {
             return extractNameFromFile(uri);
         }
         String rootJarFileUri = extractNameFromFile(uri.substring(0, rootJarEndIndex));
-        StringBuilder sb = new StringBuilder(rootJarFileUri);
-        sb.append(uri.substring(rootJarEndIndex));
-        return sb.toString();
+        return rootJarFileUri + uri.substring(rootJarEndIndex);
     }
 
 }

--- a/otlpmetric/otlpmetric-collector/src/main/java/com/navercorp/pinpoint/otlp/collector/model/SortKeyUtils.java
+++ b/otlpmetric/otlpmetric-collector/src/main/java/com/navercorp/pinpoint/otlp/collector/model/SortKeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,10 @@ package com.navercorp.pinpoint.otlp.collector.model;
 public class SortKeyUtils {
 
     public static String generateKey(String applicationName, String metricGroupName, String metricName) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(applicationName);
-        sb.append("#");
-        sb.append(metricGroupName);
-        sb.append("#");
-        sb.append(metricName);
-        return sb.toString();
+        return applicationName +
+               "#" +
+               metricGroupName +
+               "#" +
+               metricName;
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/heatmap/vo/HeatMapData.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/heatmap/vo/HeatMapData.java
@@ -35,7 +35,7 @@ public class HeatMapData {
     public HeatMapData(int width, int height, long totalSuccessCount, long totalFailCount, TreeMap<Long, HeatMapMetricColumn> heatMapMetricColumnMap) {
         this.heatmapSize = new HeatmapSize(width, height);
         this.heatmapSummary = new HeatmapSummary(totalSuccessCount, totalFailCount);
-        this.heatMapMetricColumnMap = Objects.requireNonNull(heatMapMetricColumnMap,"heatMapMetricColumnMap");
+        this.heatMapMetricColumnMap = Objects.requireNonNull(heatMapMetricColumnMap, "heatMapMetricColumnMap");
     }
 
     public Map<Long, HeatMapMetricColumn> getHeatMapMetricColumnMap() {
@@ -65,9 +65,11 @@ public class HeatMapData {
     public String prettyToString() {
         String tab = "\t";
         StringBuilder sb = new StringBuilder();
-        sb.append("HeatMapData \n" +
-                    "{\n" +
-                    tab + "size : " + heatmapSize.prettyToString(tab + "\t") + ",\n");
+        sb.append("HeatMapData \n" + "{\n");
+        sb.append(tab);
+        sb.append("size : ");
+        sb.append(heatmapSize.prettyToString(tab + "\t"));
+        sb.append(",\n");
 
         for (HeatMapMetricColumn heatMapMetricColumn : heatMapMetricColumnMap.values()) {
             sb.append("\tHeatMapMetricColumn : \n").append(heatMapMetricColumn.prettyToString(tab + "\t\t\t\t\t")).append("\n");

--- a/web/src/main/java/com/navercorp/pinpoint/web/heatmap/vo/HeatMapMetricColumn.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/heatmap/vo/HeatMapMetricColumn.java
@@ -41,12 +41,12 @@ public record HeatMapMetricColumn(long timestamp, int column, Map<Integer, HeatM
     }
 
     public String prettyToString(String tab) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(tab + "{\n" +
-                    tab + "\ttimestamp= " + timestamp + ",\n" +
-                    tab + "\ttime= " + DateTimeFormatUtils.formatSimple(timestamp) + ",\n" +
-                    tab + "\tcolumn= " + column + ",\n" +
-                    tab + "\theatMapMetricCellList : \n");
+        StringBuilder sb = new StringBuilder(32);
+        sb.append(tab).append("{\n");
+        sb.append(tab).append("\ttimestamp= ").append(timestamp).append(",\n");
+        sb.append(tab).append("\ttime= ").append(DateTimeFormatUtils.formatSimple(timestamp)).append(",\n");
+        sb.append(tab).append("\tcolumn= ").append(column).append(",\n");
+        sb.append(tab).append("\theatMapMetricCellList : \n");
 
         for (HeatMapMetricCell heatMapMetricCell : heatMapMetricCellMap.values()) {
             sb.append(heatMapMetricCell.prettyToString(tab + tab + '\t')).append("\n");


### PR DESCRIPTION
This pull request includes updates to copyright years across multiple files and refactors string concatenation logic to improve code readability and efficiency. The refactoring primarily replaces `StringBuilder` usage with simpler string concatenation using the `+` operator and optimizes initialization of `StringBuilder` where necessary.

### Copyright Updates:
* Updated copyright years in `JtdsJdbcUrlParser.java`, `LauncherLaunchInterceptor.java`, and `SortKeyUtils.java` to reflect the year 2025. [[1]](diffhunk://#diff-f2e8462c3f80eba3d32eb4483c408b6b71af9b46f4ced7cf46d8f9782de651caL2-R2) [[2]](diffhunk://#diff-17c9457a67b83422a8dd0011bacfc4dc54a314ffa1370b3b452da4d585668cbaL2-R2) [[3]](diffhunk://#diff-6911c3e810142340a2605310df261f49994ce4c16269859ebb3b63ed678932ddL2-R2)

### Code Refactoring:
#### String Concatenation Improvements:
* Simplified `databaseId` extraction logic in `parse0` method of `JtdsJdbcUrlParser.java` by removing redundant `substring` parameters.
* Replaced `StringBuilder` with direct string concatenation in `extractNameFromJar` method of `LauncherLaunchInterceptor.java` for better readability.
* Refactored `generateKey` method in `SortKeyUtils.java` to use direct string concatenation instead of `StringBuilder`.

#### StringBuilder Optimization:
* Optimized `prettyToString` method in `HeatMapMetricColumn.java` by initializing `StringBuilder` with a specified capacity to improve performance.
* Reorganized string concatenation in `prettyToString` method of `HeatMapData.java` to enhance readability and maintain consistency.