### PR TITLE
[#12606] Fix NPE when acceptorHost is null

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.java
@@ -182,7 +182,11 @@ public class HbaseTraceService implements TraceService {
         if (span.getParentSpanId() == -1) {
             if (spanServiceType.isQueue()) {
                 // create virtual queue node
-                Vertex acceptVertex = Vertex.of(span.getAcceptorHost(), spanServiceType);
+                String applicationName = span.getAcceptorHost();
+                if (applicationName == null) {
+                    applicationName = span.getRemoteAddr();
+                }
+                Vertex acceptVertex = Vertex.of(applicationName, spanServiceType);
                 linkService.updateOutLink(span.getCollectorAcceptTime(), acceptVertex, span.getRemoteAddr(),
                         selfVertex, MERGE_QUEUE, span.getElapsed(), span.hasError());
 


### PR DESCRIPTION
collector stacktrace:
```
java.lang.NullPointerException: applicationName
	at java.base/java.util.Objects.requireNonNull(Objects.java:235) ~[?:?]
	at com.navercorp.pinpoint.collector.applicationmap.Vertex.<init>(Vertex.java:10) ~[pinpoint-collector-3.1.0-SNAPSHOT.jar!/:3.1.0-SNAPSHOT]
	at com.navercorp.pinpoint.collector.applicationmap.Vertex.of(Vertex.java:16) ~[pinpoint-collector-3.1.0-SNAPSHOT.jar!/:3.1.0-SNAPSHOT]
	at com.navercorp.pinpoint.collector.service.HbaseTraceService.insertSpanStat(HbaseTraceService.java:185) ~[pinpoint-collector-3.1.0-SNAPSHOT.jar!/:3.1.0-SNAPSHOT]
	at com.navercorp.pinpoint.collector.service.HbaseTraceService.insertSpan(HbaseTraceService.java:123) ~[pinpoint-collector-3.1.0-SNAPSHOT.jar!/:3.1.0-SNAPSHOT]
```

---

@jaehong-kim 
I have fixed an additional NPE based on the previous commits. Please review the changes and let me know if anything looks incorrect.