### PR TITLE
[#noissue] Update enum for MessageType

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/RequestResponseHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/RequestResponseHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +18,11 @@ package com.navercorp.pinpoint.collector.handler;
 
 import com.navercorp.pinpoint.io.request.ServerRequest;
 import com.navercorp.pinpoint.io.request.ServerResponse;
-import com.navercorp.pinpoint.io.util.MessageType;
 
 /**
  * @author emeroad
  * @author koo.taejin
  */
 public interface RequestResponseHandler<REQ, RES> {
-
-    MessageType type();
-
     void handleRequest(ServerRequest<REQ> serverRequest, ServerResponse<RES> serverResponse);
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcAgentInfoHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcAgentInfoHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,6 @@ import com.navercorp.pinpoint.grpc.trace.PResult;
 import com.navercorp.pinpoint.io.request.ServerHeader;
 import com.navercorp.pinpoint.io.request.ServerRequest;
 import com.navercorp.pinpoint.io.request.ServerResponse;
-import com.navercorp.pinpoint.io.util.MessageType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -50,12 +49,6 @@ public class GrpcAgentInfoHandler implements RequestResponseHandler<PAgentInfo, 
         this.agentInfoService = Objects.requireNonNull(agentInfoService, "agentInfoService");
         this.agentInfoBoMapper = Objects.requireNonNull(agentInfoBoMapper, "agentInfoBoMapper");
     }
-
-    @Override
-    public MessageType type() {
-        return MessageType.AGENT_INFO;
-    }
-
 
     @Override
     public void handleRequest(ServerRequest<PAgentInfo> serverRequest, ServerResponse<PResult> serverResponse) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcApiMetaDataHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcApiMetaDataHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,6 @@ import com.navercorp.pinpoint.grpc.trace.PResult;
 import com.navercorp.pinpoint.io.request.ServerHeader;
 import com.navercorp.pinpoint.io.request.ServerRequest;
 import com.navercorp.pinpoint.io.request.ServerResponse;
-import com.navercorp.pinpoint.io.util.MessageType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -47,11 +46,6 @@ public class GrpcApiMetaDataHandler implements RequestResponseHandler<PApiMetaDa
 
     public GrpcApiMetaDataHandler(ApiMetaDataService apiMetaDataService) {
         this.apiMetaDataService = Objects.requireNonNull(apiMetaDataService, "apiMetaDataService");
-    }
-
-    @Override
-    public MessageType type() {
-        return MessageType.APIMETADATA;
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcExceptionMetaDataHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcExceptionMetaDataHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import com.navercorp.pinpoint.grpc.trace.PTransactionId;
 import com.navercorp.pinpoint.io.request.ServerHeader;
 import com.navercorp.pinpoint.io.request.ServerRequest;
 import com.navercorp.pinpoint.io.request.ServerResponse;
-import com.navercorp.pinpoint.io.util.MessageType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -54,11 +53,6 @@ public class GrpcExceptionMetaDataHandler implements RequestResponseHandler<PExc
 
     public GrpcExceptionMetaDataHandler(ExceptionMetaDataService exceptionMetaDataService) {
         this.exceptionMetaDataService = Objects.requireNonNull(exceptionMetaDataService, "exceptionMetaDataService");
-    }
-
-    @Override
-    public MessageType type() {
-        return MessageType.EXCEPTIONMETADATA;
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSqlMetaDataHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSqlMetaDataHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.grpc.trace.PSqlMetaData;
 import com.navercorp.pinpoint.io.request.ServerHeader;
 import com.navercorp.pinpoint.io.request.ServerRequest;
 import com.navercorp.pinpoint.io.request.ServerResponse;
-import com.navercorp.pinpoint.io.util.MessageType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -46,11 +45,6 @@ public class GrpcSqlMetaDataHandler implements RequestResponseHandler<PSqlMetaDa
     public GrpcSqlMetaDataHandler(SqlMetaDataService[] sqlMetaDataServices) {
         this.sqlMetaDataServices = Objects.requireNonNull(sqlMetaDataServices, "sqlMetaDataServices");
         logger.info("SqlMetaDataServices {}", Arrays.toString(sqlMetaDataServices));
-    }
-
-    @Override
-    public MessageType type() {
-        return MessageType.SQLMETADATA;
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSqlUidMetaDataHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSqlUidMetaDataHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.grpc.trace.PSqlUidMetaData;
 import com.navercorp.pinpoint.io.request.ServerHeader;
 import com.navercorp.pinpoint.io.request.ServerRequest;
 import com.navercorp.pinpoint.io.request.ServerResponse;
-import com.navercorp.pinpoint.io.util.MessageType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -43,11 +42,6 @@ public class GrpcSqlUidMetaDataHandler implements RequestResponseHandler<PSqlUid
     public GrpcSqlUidMetaDataHandler(SqlUidMetaDataService[] sqlUidMetaDataServices) {
         this.sqlUidMetaDataServices = Objects.requireNonNull(sqlUidMetaDataServices, "sqlUidMetaDataServices");
         logger.info("SqlUidMetaDataServices {}", Arrays.toString(sqlUidMetaDataServices));
-    }
-
-    @Override
-    public MessageType type() {
-        return MessageType.SQLUIDMETADATA;
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcStringMetaDataHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcStringMetaDataHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.grpc.trace.PStringMetaData;
 import com.navercorp.pinpoint.io.request.ServerHeader;
 import com.navercorp.pinpoint.io.request.ServerRequest;
 import com.navercorp.pinpoint.io.request.ServerResponse;
-import com.navercorp.pinpoint.io.util.MessageType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -44,11 +43,6 @@ public class GrpcStringMetaDataHandler implements RequestResponseHandler<PString
 
     public GrpcStringMetaDataHandler(StringMetaDataService stringMetaDataService) {
         this.stringMetaDataService = Objects.requireNonNull(stringMetaDataService, "stringMetaDataService");
-    }
-
-    @Override
-    public MessageType type() {
-        return MessageType.STRINGMETADATA;
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/AgentService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/AgentService.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,7 @@ import com.navercorp.pinpoint.grpc.trace.PAgentInfo;
 import com.navercorp.pinpoint.grpc.trace.PPing;
 import com.navercorp.pinpoint.grpc.trace.PResult;
 import com.navercorp.pinpoint.io.util.MessageType;
+import com.navercorp.pinpoint.io.util.MessageTypes;
 import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -74,7 +75,7 @@ public class AgentService extends AgentGrpc.AgentImplBase {
             logger.debug("Request PAgentInfo={}", MessageFormatUtils.debugLog(agentInfo));
         }
 
-        final MessageType messageType = MessageType.AGENT_INFO;
+        final MessageType messageType = MessageTypes.AGENT_INFO;
         doExecute(new Runnable() {
             @Override
             public void run() {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/MetadataService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/MetadataService.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.grpc.trace.PSqlMetaData;
 import com.navercorp.pinpoint.grpc.trace.PSqlUidMetaData;
 import com.navercorp.pinpoint.grpc.trace.PStringMetaData;
 import com.navercorp.pinpoint.io.util.MessageType;
+import com.navercorp.pinpoint.io.util.MessageTypes;
 import io.grpc.Context;
 import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
@@ -80,7 +81,7 @@ public class MetadataService extends MetadataGrpc.MetadataImplBase {
         if (isDebug) {
             logger.debug("Request PApiMetaData={}", debugLog(apiMetaData));
         }
-        MessageType messageType = MessageType.APIMETADATA;
+        MessageType messageType = MessageTypes.APIMETADATA;
         doExecute(() -> {
             jobRunner.execute(messageType, apiMetaData, responseObserver,
                     apiMetaDataHandler::handleRequest);
@@ -92,7 +93,7 @@ public class MetadataService extends MetadataGrpc.MetadataImplBase {
         if (isDebug) {
             logger.debug("Request PSqlMetaData={}", debugLog(sqlMetaData));
         }
-        MessageType messageType = MessageType.SQLMETADATA;
+        MessageType messageType = MessageTypes.SQLMETADATA;
         doExecute(() -> {
             jobRunner.execute(messageType, sqlMetaData, responseObserver,
                     sqlMetaDataHandler::handleRequest);
@@ -104,7 +105,7 @@ public class MetadataService extends MetadataGrpc.MetadataImplBase {
         if (isDebug) {
             logger.debug("Request PSqlUidMetaData={}", debugLog(sqlUidMetaData));
         }
-        MessageType messageType = MessageType.SQLUIDMETADATA;
+        MessageType messageType = MessageTypes.SQLUIDMETADATA;
         doExecute(() -> {
             jobRunner.execute(messageType, sqlUidMetaData, responseObserver,
                     sqlUidMetaDataHandler::handleRequest);
@@ -116,7 +117,7 @@ public class MetadataService extends MetadataGrpc.MetadataImplBase {
         if (isDebug) {
             logger.debug("Request PStringMetaData={}", debugLog(stringMetaData));
         }
-        MessageType messageType = MessageType.STRINGMETADATA;
+        MessageType messageType = MessageTypes.STRINGMETADATA;
         doExecute(() -> {
             jobRunner.execute(messageType, stringMetaData, responseObserver,
                     stringMetaDataHandler::handleRequest);
@@ -128,7 +129,7 @@ public class MetadataService extends MetadataGrpc.MetadataImplBase {
         if (isDebug) {
             logger.debug("Request PExceptionMetaData={}", debugLog(exceptionMetaData));
         }
-        MessageType messageType = MessageType.EXCEPTIONMETADATA;
+        MessageType messageType = MessageTypes.EXCEPTIONMETADATA;
         doExecute(() -> {
             jobRunner.execute(messageType, exceptionMetaData, responseObserver,
                     exceptionMetaDataHandler::handleRequest);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanService.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ import com.navercorp.pinpoint.grpc.trace.SpanGrpc;
 import com.navercorp.pinpoint.io.request.ServerRequest;
 import com.navercorp.pinpoint.io.request.UidFetcher;
 import com.navercorp.pinpoint.io.request.UidFetcherStreamService;
-import com.navercorp.pinpoint.io.util.MessageType;
+import com.navercorp.pinpoint.io.util.MessageTypes;
 import io.grpc.Context;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
@@ -86,14 +86,14 @@ public class SpanService extends SpanGrpc.SpanImplBase {
 
             Context current = Context.current();
             UidFetcher fetcher = call.getUidFetcher();
-            ServerRequest<PSpan> request = serverRequestFactory.newServerRequest(current, fetcher, MessageType.SPAN, span);
+            ServerRequest<PSpan> request = serverRequestFactory.newServerRequest(current, fetcher, MessageTypes.SPAN, span);
             this.dispatch(this.spanHandler, request, responseObserver);
         } else if (spanMessage.hasSpanChunk()) {
             PSpanChunk spanChunk = spanMessage.getSpanChunk();
 
             Context current = Context.current();
             UidFetcher fetcher = call.getUidFetcher();
-            ServerRequest<PSpanChunk> request = serverRequestFactory.newServerRequest(current, fetcher, MessageType.SPANCHUNK, spanChunk);
+            ServerRequest<PSpanChunk> request = serverRequestFactory.newServerRequest(current, fetcher, MessageTypes.SPANCHUNK, spanChunk);
             this.dispatch(this.spanCheckHandler, request, responseObserver);
         } else {
             if (logger.isInfoEnabled()) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/StatService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/StatService.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,7 @@ import com.navercorp.pinpoint.io.request.ServerRequest;
 import com.navercorp.pinpoint.io.request.UidFetcher;
 import com.navercorp.pinpoint.io.request.UidFetcherStreamService;
 import com.navercorp.pinpoint.io.util.MessageType;
+import com.navercorp.pinpoint.io.util.MessageTypes;
 import io.grpc.Context;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
@@ -86,13 +87,13 @@ public class StatService extends StatGrpc.StatImplBase {
         }
         if (statMessage.hasAgentStat()) {
             PAgentStat agentStat = statMessage.getAgentStat();
-            this.dispatch(agentStat, MessageType.AGENT_STAT, statHandler, call.getUidFetcher(), response);
+            this.dispatch(agentStat, MessageTypes.AGENT_STAT, statHandler, call.getUidFetcher(), response);
         } else if (statMessage.hasAgentStatBatch()) {
             PAgentStatBatch agentStatBatch = statMessage.getAgentStatBatch();
-            this.dispatch(agentStatBatch, MessageType.AGENT_STAT_BATCH, statBatchHandler, call.getUidFetcher(), response);
+            this.dispatch(agentStatBatch, MessageTypes.AGENT_STAT_BATCH, statBatchHandler, call.getUidFetcher(), response);
         } else if (statMessage.hasAgentUriStat()) {
             PAgentUriStat agentUriStat = statMessage.getAgentUriStat();
-            this.dispatch(agentUriStat, MessageType.AGENT_URI_STAT, uriStatHandler, call.getUidFetcher(), response);
+            this.dispatch(agentUriStat, MessageTypes.AGENT_URI_STAT, uriStatHandler, call.getUidFetcher(), response);
         } else {
             if (logger.isInfoEnabled()) {
                 logger.info("Found empty stat message header:{}", ServerContext.getAgentInfo());

--- a/collector/src/main/java/com/navercorp/pinpoint/io/util/MessageType.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/io/util/MessageType.java
@@ -1,80 +1,21 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.io.util;
 
-
-import com.navercorp.pinpoint.common.util.apache.IntHashMap;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-
-public class MessageType {
-
-    public static final MessageType EMPTY = new MessageType(-1);
-
-    public static final MessageType SPAN = new MessageType(40);
-
-    public static final MessageType AGENT_INFO = new MessageType(50);
-    public static final MessageType AGENT_STAT = new MessageType(55);
-    public static final MessageType AGENT_STAT_BATCH = new MessageType(56);
-    public static final MessageType AGENT_URI_STAT = new MessageType(57);
-
-    public static final MessageType PING = new MessageType(60);
-    public static final MessageType PING_CLOSE = new MessageType(62);
-
-    public static final MessageType SPANCHUNK = new MessageType(70);
-
-    public static final MessageType SQLMETADATA = new MessageType(300);
-    public static final MessageType SQLUIDMETADATA = new MessageType(301);
-    public static final MessageType APIMETADATA = new MessageType(310);
-
-    public static final MessageType STRINGMETADATA = new MessageType(330);
-    public static final MessageType EXCEPTIONMETADATA = new MessageType(340);
-
-    private static final IntHashMap<MessageType> MAP = buildMap();
-
-    private static IntHashMap<MessageType> buildMap() {
-        IntHashMap<MessageType> map = new IntHashMap<>();
-        try {
-            for (Field field : MessageType.class.getDeclaredFields()) {
-                if (Modifier.isStatic(field.getModifiers())) {
-                    if (field.getType() == MessageType.class) {
-                        MessageType messageType = (MessageType) field.get(MessageType.class);
-                        MessageType exist = map.put(messageType.getCode(), messageType);
-                        if (exist != null) {
-                            throw new IllegalArgumentException("Duplicate code: " + messageType.getCode() + " for " + messageType + " and " + exist);
-                        }
-                    }
-                }
-            }
-        } catch (IllegalAccessException e) {
-            throw new IllegalStateException("MessageType initialization fail", e);
-        }
-        return map;
-    }
-
-
-    private final int code;
-
-    private  MessageType(int code) {
-        this.code = code;
-    }
-
-    public int getCode() {
-        return code;
-    }
-
-    @Override
-    public String toString() {
-        return "MessageType{" +
-               "code=" + code +
-               '}';
-    }
-
-    public static MessageType getType(int code) {
-        MessageType messageType = MAP.get(code);
-        if (messageType != null) {
-            return messageType;
-        }
-        throw new IllegalArgumentException("Unknown code : " + code);
-    }
-
+public interface MessageType {
+    int getCode();
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/io/util/MessageTypes.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/io/util/MessageTypes.java
@@ -13,26 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.navercorp.pinpoint.io.request;
 
-import com.navercorp.pinpoint.io.util.MessageType;
+package com.navercorp.pinpoint.io.util;
 
-/**
- * @author minwoo.jung
- */
-public interface ServerRequest<T> extends AttributeMap {
 
-    ServerHeader getHeader();
 
-    MessageType getMessageType();
+public enum MessageTypes implements MessageType {
 
-    long getRequestTime();
+    EMPTY(-1),
+    SPAN(40),
+    AGENT_INFO(50),
+    AGENT_STAT(55),
+    AGENT_STAT_BATCH(56),
+    AGENT_URI_STAT(57),
+    PING(60),
+    PING_CLOSE(62),
+    SPANCHUNK(70),
+    SQLMETADATA(300),
+    SQLUIDMETADATA(301),
+    APIMETADATA(310),
+    STRINGMETADATA(330),
+    EXCEPTIONMETADATA(340);
 
-    T getData();
+    private final int code;
 
-    String getRemoteAddress();
+    MessageTypes(int code) {
+        this.code = code;
+    }
 
-    int getRemotePort();
+    @Override
+    public int getCode() {
+        return code;
+    }
 
-    Long getTransportId();
+
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/AgentServerTestMain.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/AgentServerTestMain.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,13 +36,11 @@ import com.navercorp.pinpoint.grpc.trace.PSqlUidMetaData;
 import com.navercorp.pinpoint.grpc.trace.PStringMetaData;
 import com.navercorp.pinpoint.io.request.ServerRequest;
 import com.navercorp.pinpoint.io.request.ServerResponse;
-import com.navercorp.pinpoint.io.util.MessageType;
 import io.grpc.BindableService;
 import io.grpc.ServerServiceDefinition;
 
 import java.net.InetAddress;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -69,14 +67,14 @@ public class AgentServerTestMain {
         grpcReceiver.setBindAddress(builder.build());
 
         PingEventHandler pingEventHandler = mock(PingEventHandler.class);
-        RequestResponseHandler<PAgentInfo, PResult> mockDispatchHandler = new MockDispatchHandler<>(MessageType.AGENT_INFO);
+        RequestResponseHandler<PAgentInfo, PResult> mockDispatchHandler = new MockDispatchHandler<>();
         BindableService agentService = new AgentService(mockDispatchHandler, pingEventHandler, Executors.newFixedThreadPool(8), serverRequestFactory, serverResponseFactory);
 
-        RequestResponseHandler<PApiMetaData, PResult> apiMetaDataHandler = new MockDispatchHandler<>(MessageType.APIMETADATA);
-        RequestResponseHandler<PSqlMetaData, PResult> sqlMetaDataHandler = new MockDispatchHandler<>(MessageType.SQLMETADATA);
-        RequestResponseHandler<PSqlUidMetaData, PResult> sqlUidMetaDataHandler = new MockDispatchHandler<>(MessageType.SQLUIDMETADATA);
-        RequestResponseHandler<PStringMetaData, PResult> stringMetaDataHandler = new MockDispatchHandler<>(MessageType.STRINGMETADATA);
-        RequestResponseHandler<PExceptionMetaData, PResult> exceptionMetaDataHandler = new MockDispatchHandler<>(MessageType.EXCEPTIONMETADATA);
+        RequestResponseHandler<PApiMetaData, PResult> apiMetaDataHandler = new MockDispatchHandler<>();
+        RequestResponseHandler<PSqlMetaData, PResult> sqlMetaDataHandler = new MockDispatchHandler<>();
+        RequestResponseHandler<PSqlUidMetaData, PResult> sqlUidMetaDataHandler = new MockDispatchHandler<>();
+        RequestResponseHandler<PStringMetaData, PResult> stringMetaDataHandler = new MockDispatchHandler<>();
+        RequestResponseHandler<PExceptionMetaData, PResult> exceptionMetaDataHandler = new MockDispatchHandler<>();
         MetadataService metadataService = new MetadataService(apiMetaDataHandler,
                 sqlMetaDataHandler, sqlUidMetaDataHandler,
                 stringMetaDataHandler, exceptionMetaDataHandler,
@@ -110,10 +108,8 @@ public class AgentServerTestMain {
     private static class MockDispatchHandler<Req> implements RequestResponseHandler<Req, PResult> {
         private static final AtomicInteger counter = new AtomicInteger(0);
 
-        private final MessageType messageType;
 
-        public MockDispatchHandler(MessageType messageType) {
-            this.messageType = Objects.requireNonNull(messageType, "messageType");
+        public MockDispatchHandler() {
         }
 
         @Override
@@ -126,11 +122,6 @@ public class AgentServerTestMain {
                 PResult result = PResult.newBuilder().setMessage("Success " + counter.getAndIncrement()).build();
                 serverResponse.write(result);
             }
-        }
-
-        @Override
-        public MessageType type() {
-            return messageType;
         }
     }
 

--- a/collector/src/test/java/com/navercorp/pinpoint/io/util/MessageTypeTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/io/util/MessageTypeTest.java
@@ -1,17 +1,31 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.io.util;
 
-import org.junit.jupiter.api.Assertions;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 class MessageTypeTest {
+    private final Logger logger = LogManager.getLogger(this.getClass());
 
     @Test
-    void getType() {
-        MessageType type = MessageType.getType(MessageType.SPAN.getCode());
-        assertEquals(MessageType.SPAN, type);
-
-        Assertions.assertThrows(IllegalArgumentException.class, () -> MessageType.getType((short)-2));
+    void enumString() {
+        MessageType type = MessageTypes.AGENT_INFO;
+        logger.info("toString:{}", type);
     }
 }


### PR DESCRIPTION
This pull request refactors the handling of `MessageType` across multiple classes in the `collector` module and updates copyright years. The primary changes involve removing the `type()` method from handler classes and replacing direct references to `MessageType` with `MessageTypes` in service classes.

### Refactoring of `MessageType` Handling:

#### Removal of `type()` Method:
* Removed the `type()` method from the `RequestResponseHandler` interface and its implementing classes, including `GrpcAgentInfoHandler`, `GrpcApiMetaDataHandler`, `GrpcExceptionMetaDataHandler`, `GrpcSqlMetaDataHandler`, `GrpcSqlUidMetaDataHandler`, and `GrpcStringMetaDataHandler`. These methods previously returned specific `MessageType` values. [[1]](diffhunk://#diff-f0c7312916df544585a34a8d6edbf165c1527f56590b43b345ae734da5130104L21-L30) [[2]](diffhunk://#diff-ed85198d6d5049e7252f4621af15fb8d2f786e435763a8aefa0f21d9a5a87459L54-L59) [[3]](diffhunk://#diff-d4712bc5976702a6d5db974044fab6cce70fb4e4816434dad00be59ee3a8520cL52-L56) [[4]](diffhunk://#diff-176ccc1f202bd93b15e7baa8389cae36ac16854b67751ee6354bc316f0884625L59-L63) [[5]](diffhunk://#diff-08c7e912b254939ce06b4e16a641df87b18ed3c816e1172d53de1223488dfdc0L51-L55) [[6]](diffhunk://#diff-05fcba0a0790592b71d50cdba9bc687dd35cc71d8d21e9e07436d2b8ee874c3aL48-L52) [[7]](diffhunk://#diff-06cf9d6dabf5f614db4b02cc6238a6350f6e4ee35357de4eb11fab7b19a3f107L49-L53)

#### Replacement of `MessageType` with `MessageTypes`:
* Updated service classes (`AgentService`, `MetadataService`, and `SpanService`) to use `MessageTypes` instead of `MessageType` for improved consistency and modularity. This affects calls to execute jobs based on message types. [[1]](diffhunk://#diff-8a61aeffbfaad3984ce463f0b3f96cf49ba6e59dd7add37fb2f5352466a96dc7L77-R78) [[2]](diffhunk://#diff-49f7305555576a37fb997a157986c0afeaebfc2e1d8eb0d9560d1eb54240239bL83-R84) [[3]](diffhunk://#diff-49f7305555576a37fb997a157986c0afeaebfc2e1d8eb0d9560d1eb54240239bL95-R96) [[4]](diffhunk://#diff-49f7305555576a37fb997a157986c0afeaebfc2e1d8eb0d9560d1eb54240239bL107-R108) [[5]](diffhunk://#diff-49f7305555576a37fb997a157986c0afeaebfc2e1d8eb0d9560d1eb54240239bL119-R120) [[6]](diffhunk://#diff-49f7305555576a37fb997a157986c0afeaebfc2e1d8eb0d9560d1eb54240239bL131-R132) [[7]](diffhunk://#diff-19a372329c351ef9161d64f2aaa98eed7fa18ba3ea033f7da06bd3cddef6b14bL30-R30)

### Copyright Updates:
* Updated the copyright year from various earlier years (e.g., 2018, 2019, 2023) to 2025 across all modified files to reflect the latest changes. [[1]](diffhunk://#diff-f0c7312916df544585a34a8d6edbf165c1527f56590b43b345ae734da5130104L2-R2) [[2]](diffhunk://#diff-ed85198d6d5049e7252f4621af15fb8d2f786e435763a8aefa0f21d9a5a87459L2-R2) [[3]](diffhunk://#diff-d4712bc5976702a6d5db974044fab6cce70fb4e4816434dad00be59ee3a8520cL2-R2) [[4]](diffhunk://#diff-176ccc1f202bd93b15e7baa8389cae36ac16854b67751ee6354bc316f0884625L2-R2) [[5]](diffhunk://#diff-08c7e912b254939ce06b4e16a641df87b18ed3c816e1172d53de1223488dfdc0L2-R2) [[6]](diffhunk://#diff-05fcba0a0790592b71d50cdba9bc687dd35cc71d8d21e9e07436d2b8ee874c3aL2-R2) [[7]](diffhunk://#diff-06cf9d6dabf5f614db4b02cc6238a6350f6e4ee35357de4eb11fab7b19a3f107L2-R2) [[8]](diffhunk://#diff-8a61aeffbfaad3984ce463f0b3f96cf49ba6e59dd7add37fb2f5352466a96dc7L2-R2) [[9]](diffhunk://#diff-49f7305555576a37fb997a157986c0afeaebfc2e1d8eb0d9560d1eb54240239bL2-R2) [[10]](diffhunk://#diff-19a372329c351ef9161d64f2aaa98eed7fa18ba3ea033f7da06bd3cddef6b14bL2-R2)