### PR TITLE
[#noissue] Refactor LimitRowMapperResultsExtractor

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -450,7 +450,7 @@ public class HbaseTemplate extends HbaseAccessor implements HbaseOperations, Ini
 
     @Override
     public <T> List<T> find(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, int limit, final RowMapper<T> action, final LimitEventHandler limitEventHandler) {
-        final LimitRowMapperResultsExtractor<T> resultsExtractor = new LimitRowMapperResultsExtractor<>(action, limit, limitEventHandler);
+        final ResultsExtractor<List<T>> resultsExtractor = new LimitRowMapperResultsExtractor<>(action, limit, limitEventHandler);
         return executeDistributedScan(tableName, scan, rowKeyDistributor, resultsExtractor);
     }
 
@@ -529,7 +529,7 @@ public class HbaseTemplate extends HbaseAccessor implements HbaseOperations, Ini
             return find(tableName, scan, rowKeyDistributor, limit, action, limitEventHandler);
         } else {
             int numThreadsUsed = getThreadsUsedNum(numParallelThreads);
-            final LimitRowMapperResultsExtractor<T> resultsExtractor = new LimitRowMapperResultsExtractor<>(action, limit, limitEventHandler);
+            final ResultsExtractor<List<T>> resultsExtractor = new LimitRowMapperResultsExtractor<>(action, limit, limitEventHandler);
             return executeParallelDistributedScan(tableName, scan, rowKeyDistributor, resultsExtractor, numThreadsUsed);
         }
     }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/LazyResultSizeHandler.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/LazyResultSizeHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase;
+
+import java.util.function.ToIntFunction;
+
+public class LazyResultSizeHandler<T> implements ToIntFunction<T> {
+    private ToIntFunction<T> handler;
+
+    public LazyResultSizeHandler() {
+    }
+
+    @Override
+    public int applyAsInt(T value) {
+        // Non-deterministic
+        if (handler == null) {
+            handler = ResultSizeHandlers.getHandler(value);
+        }
+        return handler.applyAsInt(value);
+    }
+}

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/ResultSizeHandlers.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/ResultSizeHandlers.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.ToIntFunction;
+
+public class ResultSizeHandlers {
+
+    public static final ToIntFunction<?> NULL_HANDLER = value -> 0;
+
+    public static final ToIntFunction<?> DEFAULT_HANDLER = value -> 1;
+
+    public static final ToIntFunction<Collection<?>> COLLECTION_HANDLER = Collection::size;
+
+    public static final ToIntFunction<Map<?, ?>> MAP_HANDLER = Map::size;
+
+    public static final ToIntFunction<?> ARRAY_HANDLER = Array::getLength;
+
+    @SuppressWarnings("unchecked")
+    public static <T> ToIntFunction<T> getHandler(T t) {
+        if (t == null) {
+            return (ToIntFunction<T>) NULL_HANDLER;
+        }
+        if (t instanceof Collection<?>) {
+            return (ToIntFunction<T>) COLLECTION_HANDLER;
+        } else if (t instanceof Map<?, ?>) {
+            return (ToIntFunction<T>) MAP_HANDLER;
+        } else if (t.getClass().isArray()) {
+            return (ToIntFunction<T>)  ARRAY_HANDLER;
+        }
+        return (ToIntFunction<T>) DEFAULT_HANDLER;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> ToIntFunction<T> getHandler(Class<?> clazz) {
+        Objects.requireNonNull(clazz, "clazz");
+
+        if (Collection.class.isAssignableFrom(clazz)) {
+            return (ToIntFunction<T>) COLLECTION_HANDLER;
+        } else if (Map.class.isAssignableFrom(clazz)) {
+            return (ToIntFunction<T>) MAP_HANDLER;
+        } else if (clazz.isArray()) {
+            return (ToIntFunction<T>) ARRAY_HANDLER;
+        }
+        return (ToIntFunction<T>) DEFAULT_HANDLER;
+    }
+
+}

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/RowTypeHint.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/RowTypeHint.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase;
+
+public interface RowTypeHint {
+    Class<?> rowType();
+}

--- a/commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/limit/ResultSizeHandlersTest.java
+++ b/commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/limit/ResultSizeHandlersTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase.limit;
+
+import com.navercorp.pinpoint.common.hbase.ResultSizeHandlers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToIntFunction;
+
+class ResultSizeHandlersTest {
+
+    @Test
+    void getHandler_array() {
+        int[] array = new int[10];
+
+        ToIntFunction<int[]> handler = ResultSizeHandlers.getHandler(array);
+        Assertions.assertEquals(ResultSizeHandlers.ARRAY_HANDLER, handler);
+
+        int size = handler.applyAsInt(array);
+        Assertions.assertEquals(10, size);
+    }
+
+    @Test
+    void getHandler_map() {
+        Map<String, String> map = Map.of("key1", "value1", "key2", "value2");
+
+        ToIntFunction<Map<?, ?>> handler = ResultSizeHandlers.getHandler(map);
+        Assertions.assertEquals(ResultSizeHandlers.MAP_HANDLER, handler);
+
+        int size = handler.applyAsInt(map);
+        Assertions.assertEquals(2, size);
+    }
+
+    @Test
+    void getHandler_collection() {
+        List<String> list = List.of("key1", "key2", "key3");
+
+        ToIntFunction<List<?>> handler = ResultSizeHandlers.getHandler(list);
+        Assertions.assertEquals(ResultSizeHandlers.COLLECTION_HANDLER, handler);
+
+        int size = handler.applyAsInt(list);
+        Assertions.assertEquals(3, size);
+    }
+
+    @Test
+    void getHandler_class() {
+        List<String> list = List.of("key1", "key2", "key3");
+
+        ToIntFunction<List<?>> handler = ResultSizeHandlers.getHandler(list.getClass());
+        Assertions.assertEquals(ResultSizeHandlers.COLLECTION_HANDLER, handler);
+
+        int size = handler.applyAsInt(list);
+        Assertions.assertEquals(3, size);
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/TraceIndexMetaScatterMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/TraceIndexMetaScatterMapper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.mapper;
 
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
+import com.navercorp.pinpoint.common.hbase.RowTypeHint;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.web.vo.scatter.Dot;
 import com.navercorp.pinpoint.web.vo.scatter.DotMetaData;
@@ -39,7 +40,7 @@ import java.util.stream.Collectors;
  * @author netspider
  */
 @Component
-public class TraceIndexMetaScatterMapper implements RowMapper<List<DotMetaData>> {
+public class TraceIndexMetaScatterMapper implements RowMapper<List<DotMetaData>>, RowTypeHint {
 
     private static final HbaseTables.ApplicationTraceIndexTrace INDEX = HbaseTables.APPLICATION_TRACE_INDEX_TRACE;
     private static final HbaseTables.ApplicationTraceIndexTrace META = HbaseTables.APPLICATION_TRACE_INDEX_META;
@@ -84,4 +85,8 @@ public class TraceIndexMetaScatterMapper implements RowMapper<List<DotMetaData>>
         return metaDataMap.computeIfAbsent(transactionId, txId -> new DotMetaData.Builder());
     }
 
+    @Override
+    public Class<?> rowType() {
+        return List.class;
+    }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/TraceIndexScatterMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/TraceIndexScatterMapper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
+import com.navercorp.pinpoint.common.hbase.RowTypeHint;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.util.TimeUtils;
 import com.navercorp.pinpoint.web.vo.scatter.Dot;
@@ -41,7 +42,7 @@ import java.util.function.Predicate;
  * @author netspider
  */
 @Component
-public class TraceIndexScatterMapper implements RowMapper<List<Dot>> {
+public class TraceIndexScatterMapper implements RowMapper<List<Dot>>, RowTypeHint {
 
     private static final HbaseTables.ApplicationTraceIndexTrace INDEX = HbaseTables.APPLICATION_TRACE_INDEX_TRACE;
 
@@ -98,4 +99,8 @@ public class TraceIndexScatterMapper implements RowMapper<List<Dot>> {
         return new Dot(transactionId, acceptedTime, elapsed, exceptionCode, agentId);
     }
 
+    @Override
+    public Class<?> rowType() {
+        return List.class;
+    }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/TransactionIdMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/TransactionIdMapper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
+import com.navercorp.pinpoint.common.hbase.RowTypeHint;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -38,7 +39,7 @@ import java.util.Objects;
  * @author netspider
  */
 @Component
-public class TransactionIdMapper implements RowMapper<List<TransactionId>> {
+public class TransactionIdMapper implements RowMapper<List<TransactionId>>, RowTypeHint {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
@@ -77,5 +78,10 @@ public class TransactionIdMapper implements RowMapper<List<TransactionId>> {
         long agentStartTime = buffer.readSVLong();
         long transactionSequence = buffer.readVLong();
         return TransactionId.of(agentId, agentStartTime, transactionSequence);
+    }
+
+    @Override
+    public Class<?> rowType() {
+        return List.class;
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality and maintainability of the HBase-related codebase, focusing on improving result size handling, adding type hints for row mappers, and updating copyright information. The most significant updates include the addition of `ResultSizeHandlers` and `LazyResultSizeHandler` for dynamic result size computation, integration of the `RowTypeHint` interface for type-specific row mapping, and refactoring `LimitRowMapperResultsExtractor` to leverage these new utilities.

### Result Size Handling Enhancements:
* **`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/ResultSizeHandlers.java`:** Added a utility class to provide dynamic and type-specific result size computation for collections, maps, arrays, and default objects.
* **`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/LazyResultSizeHandler.java`:** Introduced a lazy handler to defer result size computation until the type is determined.
* **`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/LimitRowMapperResultsExtractor.java`:** Refactored to use `ResultSizeHandlers` and added a `ToIntFunction` for dynamic size calculation, replacing hardcoded logic. [[1]](diffhunk://#diff-dd17a8f8c6150214cc2ab5164523536cb71acbea745fbfdbf8efab6c6de3f81dR37) [[2]](diffhunk://#diff-dd17a8f8c6150214cc2ab5164523536cb71acbea745fbfdbf8efab6c6de3f81dR65-R73) [[3]](diffhunk://#diff-dd17a8f8c6150214cc2ab5164523536cb71acbea745fbfdbf8efab6c6de3f81dL76-R87)

### Integration of Type Hints:
* **`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/RowTypeHint.java`:** Added an interface to provide type hints for row mappers, enabling type-specific handling.
* **Various Row Mapper Classes:** Updated `TraceIndexMetaScatterMapper`, `TraceIndexScatterMapper`, and `TransactionIdMapper` to implement `RowTypeHint` for type-specific row mapping. [[1]](diffhunk://#diff-dba1b4847bbe6e7361ad5be0144701fcb632766dde228cab99790fed606ff535L42-R43) [[2]](diffhunk://#diff-763a74a846392833980be17421dd648ab3eb2c175ce4f9c4e75f1cb06559a531L44-R45) [[3]](diffhunk://#diff-4831a6a4dbfbef23f32aeb81a6679abf30df94e7ff8cda02ef520f89035d226eL41-R42)

### Copyright Updates:
* Updated copyright year to 2025 across multiple files, including `HbaseTemplate.java`, `LimitRowMapperResultsExtractor.java`, and various web-related mapper classes. [[1]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L2-R2) [[2]](diffhunk://#diff-dd17a8f8c6150214cc2ab5164523536cb71acbea745fbfdbf8efab6c6de3f81dL2-R2) [[3]](diffhunk://#diff-dba1b4847bbe6e7361ad5be0144701fcb632766dde228cab99790fed606ff535L2-R2)

### Tests for Result Size Handlers:
* **`commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/limit/ResultSizeHandlersTest.java`:** Added unit tests to validate the behavior of `ResultSizeHandlers` for arrays, maps, collections, and classes.