### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.java
@@ -28,7 +28,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -36,49 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class BytesUtilsTest {
     private final Logger logger = LogManager.getLogger(this.getClass());
 
-    @Test
-    public void testStringLongLongToBytes() {
-        final int strLength = 24;
-        byte[] bytes = BytesUtils.stringLongLongToBytes("123", strLength, 12345, 54321);
 
-        assertEquals("123", BytesUtils.toStringAndRightTrim(bytes, 0, strLength));
-        assertEquals(12345, ByteArrayUtils.bytesToLong(bytes, strLength));
-        assertEquals(54321, ByteArrayUtils.bytesToLong(bytes, strLength + BytesUtils.LONG_BYTE_LENGTH));
-    }
-
-    @Test
-    public void testStringLongLongToBytes_error() {
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
-            BytesUtils.stringLongLongToBytes("123", 2, 1, 2);
-        });
-    }
-
-    @Test
-    public void testStringLongLongToBytes2() {
-        byte[] bytes = BytesUtils.stringLongLongToBytes("123", 10, 1, 2);
-        String s = BytesUtils.toStringAndRightTrim(bytes, 0, 10);
-        assertEquals("123", s);
-        long l = ByteArrayUtils.bytesToLong(bytes, 10);
-        assertEquals(1, l);
-        long l2 = ByteArrayUtils.bytesToLong(bytes, 10 + BytesUtils.LONG_BYTE_LENGTH);
-        assertEquals(2, l2);
-    }
-
-    @Test
-    public void testStringLongLongToBytes_prefix0() {
-        byte[] bytes = BytesUtils.stringLongLongToBytes("123", 10, 1, 2);
-        byte[] prefixedBytes = BytesUtils.stringLongLongToBytes(0, "123", 10, 1, 2);
-
-        assertArrayEquals(bytes, prefixedBytes);
-    }
-
-    @Test
-    public void testStringLongLongToBytes_prefix2() {
-        byte[] bytes = BytesUtils.stringLongLongToBytes("123", 10, 1, 2);
-        byte[] prefixedBytes = BytesUtils.stringLongLongToBytes(2, "123", 10, 1, 2);
-
-        assertArrayEquals(bytes, Arrays.copyOfRange(prefixedBytes, 2, prefixedBytes.length));
-    }
 
 
     @Test

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2.java
@@ -20,7 +20,7 @@ import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
-import com.navercorp.pinpoint.common.util.BytesUtils;
+import com.navercorp.pinpoint.common.server.util.RowKeyUtils;
 
 import java.util.Objects;
 
@@ -41,7 +41,7 @@ public class TraceRowKeyEncoderV2 implements RowKeyEncoder<TransactionId> {
     public byte[] encodeRowKey(TransactionId transactionId) {
         Objects.requireNonNull(transactionId, "transactionId");
 
-        byte[] rowKey = BytesUtils.stringLongLongToBytes(DISTRIBUTE_HASH_SIZE, transactionId.getAgentId(), AGENT_ID_MAX_LEN, transactionId.getAgentStartTime(), transactionId.getTransactionSequence());
+        byte[] rowKey = RowKeyUtils.stringLongLongToBytes(DISTRIBUTE_HASH_SIZE, transactionId.getAgentId(), AGENT_ID_MAX_LEN, transactionId.getAgentStartTime(), transactionId.getTransactionSequence());
         byte prefix = this.rowKeyDistributor.getByteHasher().getHashPrefix(rowKey, DISTRIBUTE_HASH_SIZE);
         rowKey[0] = prefix;
         return rowKey;

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/RowKeyUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/RowKeyUtils.java
@@ -69,4 +69,27 @@ public final class RowKeyUtils {
         return rowKey;
     }
 
+    public static byte[] stringLongLongToBytes(final String string, final int maxStringSize, final long value1, final long value2) {
+        return stringLongLongToBytes(0, string, maxStringSize, value1, value2);
+    }
+
+    public static byte[] stringLongLongToBytes(int prefix, final String string, final int maxStringSize, final long value1, final long value2) {
+        if (string == null) {
+            throw new NullPointerException("string");
+        }
+        if (maxStringSize < 0) {
+            throw new StringIndexOutOfBoundsException(maxStringSize);
+        }
+        final byte[] stringBytes = BytesUtils.toBytes(string);
+        if (stringBytes.length > maxStringSize) {
+            throw new StringIndexOutOfBoundsException("string is max " + stringBytes.length + ", string='" + string + "'");
+        }
+        int offset = prefix + maxStringSize;
+        final byte[] buffer = new byte[offset + BytesUtils.LONG_LONG_BYTE_LENGTH];
+        BytesUtils.writeBytes(buffer, prefix, stringBytes);
+        offset = ByteArrayUtils.writeLong(value1, buffer, offset);
+        ByteArrayUtils.writeLong(value2, buffer, offset);
+        return buffer;
+    }
+
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/RowKeyUtilsTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/RowKeyUtilsTest.java
@@ -16,11 +16,16 @@
 
 package com.navercorp.pinpoint.common.server.util;
 
+import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
+import com.navercorp.pinpoint.common.util.BytesUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RowKeyUtilsTest {
 
@@ -63,5 +68,49 @@ class RowKeyUtilsTest {
         byte[] rowKey2 = RowKeyUtils.concatFixedByteAndLongFuzzySlot(1, agentId, length, timestamp, slot);
 
         Assertions.assertArrayEquals(rowKey1, Arrays.copyOfRange(rowKey2, 1, rowKey2.length));
+    }
+
+    @Test
+    public void testStringLongLongToBytes() {
+        final int strLength = 24;
+        byte[] bytes = RowKeyUtils.stringLongLongToBytes("123", strLength, 12345, 54321);
+
+        assertEquals("123", BytesUtils.toStringAndRightTrim(bytes, 0, strLength));
+        assertEquals(12345, ByteArrayUtils.bytesToLong(bytes, strLength));
+        assertEquals(54321, ByteArrayUtils.bytesToLong(bytes, strLength + BytesUtils.LONG_BYTE_LENGTH));
+    }
+
+    @Test
+    public void testStringLongLongToBytes_error() {
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
+            RowKeyUtils.stringLongLongToBytes("123", 2, 1, 2);
+        });
+    }
+
+    @Test
+    public void testStringLongLongToBytes2() {
+        byte[] bytes = RowKeyUtils.stringLongLongToBytes("123", 10, 1, 2);
+        String s = BytesUtils.toStringAndRightTrim(bytes, 0, 10);
+        assertEquals("123", s);
+        long l = ByteArrayUtils.bytesToLong(bytes, 10);
+        assertEquals(1, l);
+        long l2 = ByteArrayUtils.bytesToLong(bytes, 10 + BytesUtils.LONG_BYTE_LENGTH);
+        assertEquals(2, l2);
+    }
+
+    @Test
+    public void testStringLongLongToBytes_prefix0() {
+        byte[] bytes = RowKeyUtils.stringLongLongToBytes("123", 10, 1, 2);
+        byte[] prefixedBytes = RowKeyUtils.stringLongLongToBytes(0, "123", 10, 1, 2);
+
+        assertArrayEquals(bytes, prefixedBytes);
+    }
+
+    @Test
+    public void testStringLongLongToBytes_prefix2() {
+        byte[] bytes = RowKeyUtils.stringLongLongToBytes("123", 10, 1, 2);
+        byte[] prefixedBytes = RowKeyUtils.stringLongLongToBytes(2, "123", 10, 1, 2);
+
+        assertArrayEquals(bytes, Arrays.copyOfRange(prefixedBytes, 2, prefixedBytes.length));
     }
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java
@@ -41,28 +41,6 @@ public final class BytesUtils {
     private BytesUtils() {
     }
 
-    public static byte[] stringLongLongToBytes(final String string, final int maxStringSize, final long value1, final long value2) {
-        return stringLongLongToBytes(0, string, maxStringSize, value1, value2);
-    }
-
-    public static byte[] stringLongLongToBytes(int prefix, final String string, final int maxStringSize, final long value1, final long value2) {
-        if (string == null) {
-            throw new NullPointerException("string");
-        }
-        if (maxStringSize < 0) {
-            throw new StringIndexOutOfBoundsException(maxStringSize);
-        }
-        final byte[] stringBytes = toBytes(string);
-        if (stringBytes.length > maxStringSize) {
-            throw new StringIndexOutOfBoundsException("string is max " + stringBytes.length + ", string='" + string + "'");
-        }
-        int offset = prefix + maxStringSize;
-        final byte[] buffer = new byte[offset + LONG_LONG_BYTE_LENGTH];
-        writeBytes(buffer, prefix, stringBytes);
-        offset = writeLong(value1, buffer, offset);
-        writeLong(value2, buffer, offset);
-        return buffer;
-    }
 
     public static int writeBytes(final byte[] buffer, int bufferOffset, final byte[] srcBytes) {
         if (srcBytes == null) {


### PR DESCRIPTION
This pull request refactors the `stringLongLongToBytes` method by moving its implementation from `BytesUtils` to `RowKeyUtils`, along with the associated test cases. Additionally, it updates the codebase to use the new location of the method.

### Refactoring and Code Relocation:

* Moved the `stringLongLongToBytes` method and its overload from `BytesUtils` to `RowKeyUtils`. The method's implementation remains unchanged, but it is now part of a more contextually appropriate utility class. (`commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java`, [[1]](diffhunk://#diff-7ef761358947bcfc5f43ab6e136ff008a2d69a1da0fbc7b8dfdd59451fc6cbdfL44-L65); `commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/RowKeyUtils.java`, [[2]](diffhunk://#diff-ec4d9389ac14dead48fd5f458a803488ae600bf193b2368d21f05c3cb7ed1272R72-R94)

### Code Updates:

* Updated `TraceRowKeyEncoderV2` to use the `stringLongLongToBytes` method from `RowKeyUtils` instead of `BytesUtils`. This ensures the code reflects the new method location. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2.java`, [[1]](diffhunk://#diff-192941e29257ae3baddd9b014f89b65345c35438ed0bce9d6c5e330fbf1b3eccL23-R23) [[2]](diffhunk://#diff-192941e29257ae3baddd9b014f89b65345c35438ed0bce9d6c5e330fbf1b3eccL44-R44)

### Test Updates:

* Removed test cases for `stringLongLongToBytes` from `BytesUtilsTest` since the method is no longer part of `BytesUtils`. (`commons-buffer/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.java`, [commons-buffer/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.javaL31-L81](diffhunk://#diff-d8b6c643a0e840b66ca4be6a6bf030d4177b52d7eac8f3f81150e0df9c709ddfL31-L81))
* Added equivalent test cases for `stringLongLongToBytes` to `RowKeyUtilsTest` to maintain test coverage for the method in its new location. (`commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/RowKeyUtilsTest.java`, [[1]](diffhunk://#diff-15106f8f089a744393f233ea9ce836080a414ad454497943d35ba4e7eabd74caR19-R29) [[2]](diffhunk://#diff-15106f8f089a744393f233ea9ce836080a414ad454497943d35ba4e7eabd74caR72-R115)