### PR TITLE
[#noissue] Refactor MetadataEncoder

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseApiMetaDataDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseApiMetaDataDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
-import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataEncoder;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.logging.log4j.LogManager;
@@ -53,12 +52,14 @@ public class HbaseApiMetaDataDao implements ApiMetaDataDao {
 
     private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
 
-    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder = new MetadataEncoder();
+    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder;
 
     public HbaseApiMetaDataDao(HbaseOperations hbaseTemplate,
+                               RowKeyEncoder<MetaDataRowKey> rowKeyEncoder,
                                TableNameProvider tableNameProvider,
                                @Qualifier("metadataRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
         this.hbaseTemplate = Objects.requireNonNull(hbaseTemplate, "hbaseTemplate");
+        this.rowKeyEncoder = Objects.requireNonNull(rowKeyEncoder, "rowKeyEncoder");
         this.tableNameProvider = Objects.requireNonNull(tableNameProvider, "tableNameProvider");
         this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
     }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseSqlMetaDataDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseSqlMetaDataDao.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,6 @@ import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.SqlMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
-import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataEncoder;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -50,13 +49,15 @@ public class HbaseSqlMetaDataDao implements SqlMetaDataDao {
 
     private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
 
-    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder = new MetadataEncoder();
+    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder;
 
 
     public HbaseSqlMetaDataDao(HbaseOperations hbaseTemplate,
+                               RowKeyEncoder<MetaDataRowKey> rowKeyEncoder,
                                TableNameProvider tableNameProvider,
                                @Qualifier("metadataRowKeyDistributor2") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
         this.hbaseTemplate = Objects.requireNonNull(hbaseTemplate, "hbaseTemplate");
+        this.rowKeyEncoder = Objects.requireNonNull(rowKeyEncoder, "rowKeyEncoder");
         this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
         this.tableNameProvider = Objects.requireNonNull(tableNameProvider, "tableNameProvider");
     }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseStringMetaDataDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseStringMetaDataDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.StringMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
-import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataEncoder;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -52,12 +51,14 @@ public class HbaseStringMetaDataDao implements StringMetaDataDao {
 
     private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
 
-    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder = new MetadataEncoder();
+    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder;
 
     public HbaseStringMetaDataDao(HbaseOperations hbaseTemplate,
+                                  RowKeyEncoder<MetaDataRowKey> rowKeyEncoder,
                                   TableNameProvider tableNameProvider,
                                   @Qualifier("metadataRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
         this.hbaseTemplate = Objects.requireNonNull(hbaseTemplate, "hbaseTemplate");
+        this.rowKeyEncoder = Objects.requireNonNull(rowKeyEncoder, "rowKeyEncoder");
         this.tableNameProvider = Objects.requireNonNull(tableNameProvider, "tableNameProvider");
         this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
     }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseApiMetaDataDaoTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseApiMetaDataDaoTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.collector.dao.hbase;
 
 import com.navercorp.pinpoint.common.hbase.HbaseOperations;
@@ -7,6 +23,9 @@ import com.navercorp.pinpoint.common.hbase.config.DistributorConfiguration;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
+import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
+import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
+import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataEncoder;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Put;
 import org.junit.jupiter.api.Test;
@@ -25,9 +44,11 @@ public class HbaseApiMetaDataDaoTest {
     public void testInsert() {
         HbaseOperations mockedHbaseTemplate = mock(HbaseOperations.class);
         TableNameProvider mockedProvider = mock(TableNameProvider.class);
+
+        RowKeyEncoder<MetaDataRowKey> rowKeyEncoder = new MetadataEncoder();
         DistributorConfiguration givenConfiguration = new DistributorConfiguration();
         RowKeyDistributorByHashPrefix givenRowKeyDistributorByHashPrefix = givenConfiguration.metadataRowKeyDistributor();
-        HbaseApiMetaDataDao dut = new HbaseApiMetaDataDao(mockedHbaseTemplate, mockedProvider, givenRowKeyDistributorByHashPrefix);
+        HbaseApiMetaDataDao dut = new HbaseApiMetaDataDao(mockedHbaseTemplate, rowKeyEncoder, mockedProvider, givenRowKeyDistributorByHashPrefix);
 
         doAnswer((invocation) -> {
             Put actual = invocation.getArgument(1);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/CommonsHbaseConfiguration.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/CommonsHbaseConfiguration.java
@@ -16,8 +16,11 @@
 
 package com.navercorp.pinpoint.common.server;
 
+import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.agent.AgentIdRowKeyEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.agent.ApplicationNameRowKeyEncoder;
+import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
+import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.config.SpanSerializeConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -42,6 +45,11 @@ public class CommonsHbaseConfiguration {
     @Bean
     public ApplicationNameRowKeyEncoder applicationNameRowKeyEncoder() {
         return new ApplicationNameRowKeyEncoder();
+    }
+
+    @Bean
+    public RowKeyEncoder<MetaDataRowKey> metaDataRowKeyEncoder() {
+        return new MetadataEncoder();
     }
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/WebHbaseModule.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/WebHbaseModule.java
@@ -1,13 +1,33 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.web;
 
 import com.navercorp.pinpoint.common.hbase.config.DistributorConfiguration;
 import com.navercorp.pinpoint.common.hbase.config.HbaseNamespaceConfiguration;
 import com.navercorp.pinpoint.common.hbase.config.HbaseTemplateConfiguration;
 import com.navercorp.pinpoint.common.server.CommonsHbaseConfiguration;
+import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
+import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
+import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataDecoder;
 import com.navercorp.pinpoint.common.server.hbase.config.HbaseClientConfiguration;
 import com.navercorp.pinpoint.web.applicationmap.config.MapHbaseConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
@@ -45,5 +65,11 @@ public class WebHbaseModule {
 
     public WebHbaseModule() {
         logger.info("Install {}", WebHbaseModule.class.getSimpleName());
+    }
+
+
+    @Bean
+    public RowKeyDecoder<MetaDataRowKey> metadataDecoder() {
+        return new MetadataDecoder();
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseApiMetaDataDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseApiMetaDataDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.DefaultMetaDataRowKey;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
-import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataEncoder;
 import com.navercorp.pinpoint.web.cache.CacheConfiguration;
 import com.navercorp.pinpoint.web.dao.ApiMetaDataDao;
 import org.apache.hadoop.hbase.TableName;
@@ -54,13 +53,15 @@ public class HbaseApiMetaDataDao implements ApiMetaDataDao {
 
     private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
 
-    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder = new MetadataEncoder();
+    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder;
 
     public HbaseApiMetaDataDao(HbaseOperations hbaseOperations,
+                               RowKeyEncoder<MetaDataRowKey> rowKeyEncoder,
                                TableNameProvider tableNameProvider,
                                @Qualifier("apiMetaDataMapper") RowMapper<List<ApiMetaDataBo>> apiMetaDataMapper,
                                @Qualifier("metadataRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
         this.hbaseOperations = Objects.requireNonNull(hbaseOperations, "hbaseOperations");
+        this.rowKeyEncoder = Objects.requireNonNull(rowKeyEncoder, "rowKeyEncoder");
         this.tableNameProvider = Objects.requireNonNull(tableNameProvider, "tableNameProvider");
         this.apiMetaDataMapper = Objects.requireNonNull(apiMetaDataMapper, "apiMetaDataMapper");
         this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseSqlMetaDataDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseSqlMetaDataDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.common.server.bo.SqlMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.DefaultMetaDataRowKey;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
-import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataEncoder;
 import com.navercorp.pinpoint.web.dao.SqlMetaDataDao;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Get;
@@ -51,13 +50,15 @@ public class HbaseSqlMetaDataDao implements SqlMetaDataDao {
 
     private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
 
-    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder = new MetadataEncoder();
+    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder;
 
     public HbaseSqlMetaDataDao(HbaseOperations hbaseOperations,
+                               RowKeyEncoder<MetaDataRowKey> rowKeyEncoder,
                                TableNameProvider tableNameProvider,
                                @Qualifier("sqlMetaDataMapper") RowMapper<List<SqlMetaDataBo>> sqlMetaDataMapper,
                                @Qualifier("metadataRowKeyDistributor2") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
         this.hbaseOperations = Objects.requireNonNull(hbaseOperations, "hbaseOperations");
+        this.rowKeyEncoder = Objects.requireNonNull(rowKeyEncoder, "rowKeyEncoder");
         this.tableNameProvider = Objects.requireNonNull(tableNameProvider, "tableNameProvider");
         this.sqlMetaDataMapper = Objects.requireNonNull(sqlMetaDataMapper, "sqlMetaDataMapper");
         this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseStringMetaDataDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseStringMetaDataDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.common.server.bo.StringMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.DefaultMetaDataRowKey;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
-import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataEncoder;
 import com.navercorp.pinpoint.web.dao.StringMetaDataDao;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Get;
@@ -50,13 +49,15 @@ public class HbaseStringMetaDataDao implements StringMetaDataDao {
 
     private final HbaseTables.StringMetadataStr DESCRIPTOR = HbaseTables.STRING_METADATA_STR;
 
-    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder = new MetadataEncoder();
+    private final RowKeyEncoder<MetaDataRowKey> rowKeyEncoder;
 
     public HbaseStringMetaDataDao(HbaseOperations hbaseOperations,
+                                  RowKeyEncoder<MetaDataRowKey> rowKeyEncoder,
                                   TableNameProvider tableNameProvider,
                                   @Qualifier("stringMetaDataMapper") RowMapper<List<StringMetaDataBo>> stringMetaDataMapper,
                                   @Qualifier("metadataRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
         this.hbaseOperations = Objects.requireNonNull(hbaseOperations, "hbaseOperations");
+        this.rowKeyEncoder = Objects.requireNonNull(rowKeyEncoder, "rowKeyEncoder");
         this.tableNameProvider = Objects.requireNonNull(tableNameProvider, "tableNameProvider");
         this.stringMetaDataMapper = Objects.requireNonNull(stringMetaDataMapper, "stringMetaDataMapper");
         this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/ApiMetaDataMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/ApiMetaDataMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
-import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataDecoder;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
@@ -52,9 +51,12 @@ public class ApiMetaDataMapper implements RowMapper<List<ApiMetaDataBo>> {
 
     private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
 
-    private final RowKeyDecoder<MetaDataRowKey> decoder = new MetadataDecoder();
+    private final RowKeyDecoder<MetaDataRowKey> decoder;
 
-    public ApiMetaDataMapper(@Qualifier("metadataRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
+    public ApiMetaDataMapper(RowKeyDecoder<MetaDataRowKey> decoder,
+                             @Qualifier("metadataRowKeyDistributor")
+                             RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
+        this.decoder = Objects.requireNonNull(decoder, "decoder");
         this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/SqlMetaDataMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/SqlMetaDataMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.SqlMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
-import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataDecoder;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
@@ -46,9 +45,12 @@ public class SqlMetaDataMapper implements RowMapper<List<SqlMetaDataBo>> {
 
     private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
 
-    private final RowKeyDecoder<MetaDataRowKey> decoder = new MetadataDecoder();
+    private final RowKeyDecoder<MetaDataRowKey> decoder;
 
-    public SqlMetaDataMapper(@Qualifier("metadataRowKeyDistributor2") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
+    public SqlMetaDataMapper(RowKeyDecoder<MetaDataRowKey> decoder,
+                             @Qualifier("metadataRowKeyDistributor2")
+                             RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
+        this.decoder = Objects.requireNonNull(decoder, "decoder");
         this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/StringMetaDataMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/StringMetaDataMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.StringMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
-import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataDecoder;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
@@ -46,9 +45,12 @@ public class StringMetaDataMapper implements RowMapper<List<StringMetaDataBo>> {
 
     private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
 
-    private final RowKeyDecoder<MetaDataRowKey> decoder = new MetadataDecoder();
+    private final RowKeyDecoder<MetaDataRowKey> decoder;
 
-    public StringMetaDataMapper(@Qualifier("metadataRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
+    public StringMetaDataMapper(RowKeyDecoder<MetaDataRowKey> decoder,
+                                @Qualifier("metadataRowKeyDistributor")
+                                RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
+        this.decoder = Objects.requireNonNull(decoder, "decoder");
         this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
     }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/mapper/ApiMetaDataMapperTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/mapper/ApiMetaDataMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.web.mapper;
 
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
@@ -6,6 +22,9 @@ import com.navercorp.pinpoint.common.hbase.config.DistributorConfiguration;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
+import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
+import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
+import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetadataEncoder;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellBuilderFactory;
@@ -55,7 +74,8 @@ public class ApiMetaDataMapperTest {
         when(mockedResult.rawCells()).thenReturn(new Cell[] { cell });
         when(mockedResult.getRow()).thenReturn(rowKey);
 
-        ApiMetaDataMapper dut = new ApiMetaDataMapper(givenRowKeyDistributorByHashPrefix);
+        RowKeyDecoder<MetaDataRowKey> decoder = new MetadataDecoder();
+        ApiMetaDataMapper dut = new ApiMetaDataMapper(decoder, givenRowKeyDistributorByHashPrefix);
         ApiMetaDataBo actual = dut.mapRow(mockedResult, 0).get(0);
 
         assertThat(actual).extracting("agentId", "startTime", "apiId", "apiInfo", "lineNumber", "methodTypeEnum", "location")


### PR DESCRIPTION
This pull request refactors the handling of `RowKeyEncoder` for metadata-related DAOs and introduces dependency injection for better configurability. Additionally, it updates copyright years and adds new configuration beans for metadata encoding and decoding.

### Refactoring of `RowKeyEncoder` in DAOs:

* Removed hardcoded instantiations of `MetadataEncoder` in `HbaseApiMetaDataDao`, `HbaseSqlMetaDataDao`, and `HbaseStringMetaDataDao`, replacing them with dependency-injected `RowKeyEncoder` instances. This change improves flexibility and testability. (`[[1]](diffhunk://#diff-d1ce5f66eb273d3051f82476a4327b3a7104cd10b1271c1ba1a31a3327b44894L56-R62)`, `[[2]](diffhunk://#diff-521ff828238fbd63af8760528ca3d557e3c507f0a9433c0663737af933385a21L53-R60)`, `[[3]](diffhunk://#diff-49de948105cc00463d020bc7aee8c54505043dfb5308ae8ee2fd6610e19a84c2L55-R61)`, `[[4]](diffhunk://#diff-f435ed40d0cadbdafc8e2612091356ded8deca517992474a434b12208135c276L57-R64)`, `[[5]](diffhunk://#diff-81c7b5dec1100ca9d6183c68796a60321efcf8cae898c8fcac129e7d88efafbaL54-R61)`, `F0653d88L51R50`)

### Configuration Updates:

* Added a new Spring bean for `RowKeyEncoder<MetaDataRowKey>` in `CommonsHbaseConfiguration` to centralize the creation of `MetadataEncoder`. (`[commons-server/src/main/java/com/navercorp/pinpoint/common/server/CommonsHbaseConfiguration.javaR50-R54](diffhunk://#diff-13b201c4e3dcb4cd8404b0892300f17dbc1ed831ec329222f770b2cbbdb35decR50-R54)`)
* Introduced a Spring bean for `RowKeyDecoder<MetaDataRowKey>` in `WebHbaseModule` to support metadata decoding. (`[web/src/main/java/com/navercorp/pinpoint/web/WebHbaseModule.javaR69-R74](diffhunk://#diff-74fa469fd2756729df2b3989765cd36f80e32130a24948dcb881b51b5aa1323fR69-R74)`)

### Test Updates:

* Updated `HbaseApiMetaDataDaoTest` to use the newly injected `RowKeyEncoder` for testing, ensuring alignment with the refactored DAO constructors. (`[collector/src/test/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseApiMetaDataDaoTest.javaR47-R51](diffhunk://#diff-227bba3d23b7d765032e8f99c9cbb246060630df713e8b25cef1b3e01ba298e9R47-R51)`)

### Copyright Updates:

* Updated copyright years from 2014/2018 to 2025 across multiple files. (`[[1]](diffhunk://#diff-d1ce5f66eb273d3051f82476a4327b3a7104cd10b1271c1ba1a31a3327b44894L2-R2)`, `[[2]](diffhunk://#diff-521ff828238fbd63af8760528ca3d557e3c507f0a9433c0663737af933385a21L2-R2)`, `[[3]](diffhunk://#diff-49de948105cc00463d020bc7aee8c54505043dfb5308ae8ee2fd6610e19a84c2L2-R2)`, `[[4]](diffhunk://#diff-227bba3d23b7d765032e8f99c9cbb246060630df713e8b25cef1b3e01ba298e9R1-R16)`, `[[5]](diffhunk://#diff-74fa469fd2756729df2b3989765cd36f80e32130a24948dcb881b51b5aa1323fR1-R30)`, `[[6]](diffhunk://#diff-f435ed40d0cadbdafc8e2612091356ded8deca517992474a434b12208135c276L2-R2)`, `[[7]](diffhunk://#diff-81c7b5dec1100ca9d6183c68796a60321efcf8cae898c8fcac129e7d88efafbaL2-R2)`, `[[8]](diffhunk://#diff-6b765921018c3f8e4b3e5d691e1373fab8c32da6803748a93283932dc8d86eaaL2-R2)`)

These changes collectively improve the maintainability, configurability, and consistency of the codebase.