### PR TITLE
[#noissue] Refactor to replace ByteSaltKey with SaltKey

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
@@ -32,6 +32,7 @@ import com.navercorp.pinpoint.common.hbase.util.Puts;
 import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
+import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.common.util.TimeUtils;
@@ -53,7 +54,7 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
     private static final HbaseColumnFamily DESCRIPTOR = HbaseTables.HOST_APPLICATION_MAP_VER2_MAP;
-    private static final ByteSaltKey SALT_KEY = ByteSaltKey.SALT;
+    private static final SaltKey SALT_KEY = ByteSaltKey.SALT;
 
     private final HbaseOperations hbaseTemplate;
 
@@ -134,7 +135,7 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
 
 
     @VisibleForTesting
-    static byte[] createRowKey0(ByteSaltKey saltKey, String parentApplicationName, short parentServiceType, long statisticsRowSlot, String parentAgentId) {
+    static byte[] createRowKey0(SaltKey saltKey, String parentApplicationName, short parentServiceType, long statisticsRowSlot, String parentAgentId) {
 
         // even if  a agentId be added for additional specifications, it may be safe to scan rows.
         // But is it needed to add parentAgentServiceType?

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkWriter.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkWriter.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.async.HbaseAsyncTemplate;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
+import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Increment;
@@ -39,7 +40,7 @@ import java.util.Objects;
  */
 public class DefaultBulkWriter implements BulkWriter {
 
-    private static final ByteSaltKey SALT_KEY = ByteSaltKey.SALT;
+    private static final SaltKey SALT_KEY = ByteSaltKey.SALT;
 
     private final Logger logger;
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SyncWriter.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SyncWriter.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.util.Increments;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
+import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Increment;
 
@@ -33,7 +34,7 @@ import java.util.Objects;
  */
 public class SyncWriter implements BulkWriter {
 
-    private static final ByteSaltKey SALT_KEY = ByteSaltKey.SALT;
+    private static final SaltKey SALT_KEY = ByteSaltKey.SALT;
 
     private final HbaseOperations hbaseTemplate;
     private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/encode/ApplicationIndexRowKeyEncoder.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/encode/ApplicationIndexRowKeyEncoder.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.collector.dao.hbase.encode;
 
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
+import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.agent.ApplicationNameRowKeyEncoder;
@@ -38,7 +39,7 @@ public class ApplicationIndexRowKeyEncoder implements RowKeyEncoder<SpanBo> {
         this.rowKeyDistributor = Objects.requireNonNull(rowKeyDistributor, "rowKeyDistributor");
     }
 
-    public byte[] encodeRowKey(ByteSaltKey saltKey, String applicationName, int elapsedTime, long acceptedTime) {
+    public byte[] encodeRowKey(SaltKey saltKey, String applicationName, int elapsedTime, long acceptedTime) {
         Objects.requireNonNull(saltKey, "saltKey");
         // distribute key evenly
         byte fuzzyKey = fuzzyRowKeyFactory.getKey(elapsedTime);
@@ -58,7 +59,7 @@ public class ApplicationIndexRowKeyEncoder implements RowKeyEncoder<SpanBo> {
     }
 
     @Override
-    public byte[] encodeRowKey(ByteSaltKey saltKey, SpanBo span) {
+    public byte[] encodeRowKey(SaltKey saltKey, SpanBo span) {
         return encodeRowKey(saltKey, span.getApplicationName(), span.getElapsed(), span.getCollectorAcceptTime());
     }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDaoTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDaoTest.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.FixedBuffer;
 import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
+import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import com.navercorp.pinpoint.common.timeseries.window.DefaultTimeSlot;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -40,7 +41,7 @@ public class HbaseHostApplicationMapDaoTest {
         String parentApp = "parentApp";
         long statisticsRowSlot = timeSlot.getTimeSlot(System.currentTimeMillis());
         ServiceType standAlone = ServiceType.STAND_ALONE;
-        ByteSaltKey saltKey = ByteSaltKey.SALT;
+        SaltKey saltKey = ByteSaltKey.SALT;
 
         byte[] parentApps = HbaseHostApplicationMapDao.createRowKey0(saltKey, parentApp, standAlone.getCode(), statisticsRowSlot, null);
         logger.debug("rowKey size:{}", parentApps.length);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/RowKeyEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/RowKeyEncoder.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.common.server.bo.serializer;
 
-import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
+import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -25,6 +25,6 @@ public interface RowKeyEncoder<V> {
 
     byte[] encodeRowKey(V value);
 
-    byte[] encodeRowKey(ByteSaltKey saltKey, V value);
+    byte[] encodeRowKey(SaltKey saltKey, V value);
 
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoder.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.common.server.bo.serializer.metadata;
 import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
+import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.common.util.TimeUtils;
@@ -45,7 +46,7 @@ public class MetadataEncoder implements RowKeyEncoder<MetaDataRowKey> {
     }
 
     @Override
-    public byte[] encodeRowKey(ByteSaltKey saltKeySize, MetaDataRowKey metadataRowKey) {
+    public byte[] encodeRowKey(SaltKey saltKeySize, MetaDataRowKey metadataRowKey) {
 
         byte[] rowKey = readMetaDataRowKey(saltKeySize.size(), metadataRowKey.getAgentId(),
                 metadataRowKey.getAgentStartTime(), metadataRowKey.getId());

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/uid/UidMetadataEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/uid/UidMetadataEncoder.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
+import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.common.util.TimeUtils;
@@ -45,7 +46,7 @@ public class UidMetadataEncoder implements RowKeyEncoder<UidMetaDataRowKey> {
     }
 
     @Override
-    public byte[] encodeRowKey(ByteSaltKey saltKeySize, UidMetaDataRowKey metaDataRowKey) {
+    public byte[] encodeRowKey(SaltKey saltKeySize, UidMetaDataRowKey metaDataRowKey) {
         Objects.requireNonNull(saltKeySize, "saltKeySize");
 
         byte[] rowKey = encodeMetaDataRowKey(saltKeySize.size(), metaDataRowKey.getAgentId(),

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
+import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.util.RowKeyUtils;
@@ -43,7 +44,7 @@ public class TraceRowKeyEncoderV2 implements RowKeyEncoder<TransactionId> {
     }
 
     @Override
-    public byte[] encodeRowKey(ByteSaltKey saltKey, TransactionId transactionId) {
+    public byte[] encodeRowKey(SaltKey saltKey, TransactionId transactionId) {
         Objects.requireNonNull(saltKey, "saltKey");
         Objects.requireNonNull(transactionId, "transactionId");
 


### PR DESCRIPTION
This pull request refactors the usage of the `ByteSaltKey` class across multiple files and replaces it with the more generic `SaltKey` interface. This change aims to improve code consistency and flexibility by standardizing the interface used for salt key operations. The changes primarily affect method signatures, constants, and imports.

### Key Changes:

#### Refactoring for Consistency:
* Replaced `ByteSaltKey` with `SaltKey` in constants and method signatures across several classes, including `HbaseHostApplicationMapDao`, `DefaultBulkWriter`, `SyncWriter`, and various row key encoder classes. (`[[1]](diffhunk://#diff-67d647f20220b276cc88a58eac5ed57e1ad56d906395e43b74d5111517c21ab0L56-R57)`, `[[2]](diffhunk://#diff-67d647f20220b276cc88a58eac5ed57e1ad56d906395e43b74d5111517c21ab0L137-R138)`, `[[3]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dL42-R43)`, `[[4]](diffhunk://#diff-1a5bd45c868872214ec98331881df3d03d95b945dbb1e4a9b5ce6730e524b011L36-R37)`, `[[5]](diffhunk://#diff-e95d5269c4640ec678d03e00e75165024d6f7df31c93c952324f3ff7ebab4c4cL41-R42)`, `[[6]](diffhunk://#diff-e95d5269c4640ec678d03e00e75165024d6f7df31c93c952324f3ff7ebab4c4cL61-R62)`, `[[7]](diffhunk://#diff-9089619b1cf80c942661acf7fcbaaf2e1078a7ef57319ac3cae0e728282b2d0bL28-R28)`, `[[8]](diffhunk://#diff-f22260021d003e110044b1b295299e8cbcf837bf686ddf19b5cc46c431180526L48-R49)`, `[[9]](diffhunk://#diff-8c6718e19bf93965a8ade9ecb62959d760e5d75f2f6f23ee205bf64b64604b3eL48-R49)`, `[[10]](diffhunk://#diff-192941e29257ae3baddd9b014f89b65345c35438ed0bce9d6c5e330fbf1b3eccL46-R47)`)

#### Updates to Imports:
* Updated imports to include `SaltKey` instead of `ByteSaltKey` in all affected files. (`[[1]](diffhunk://#diff-67d647f20220b276cc88a58eac5ed57e1ad56d906395e43b74d5111517c21ab0R35)`, `[[2]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dR25)`, `[[3]](diffhunk://#diff-1a5bd45c868872214ec98331881df3d03d95b945dbb1e4a9b5ce6730e524b011R26)`, `[[4]](diffhunk://#diff-e95d5269c4640ec678d03e00e75165024d6f7df31c93c952324f3ff7ebab4c4cR21)`, `[[5]](diffhunk://#diff-89d9abedf92deb3fe7e7949ffb92e87c6f61f76e638c6d87887c6ed0bcf24103R23)`, `[[6]](diffhunk://#diff-9089619b1cf80c942661acf7fcbaaf2e1078a7ef57319ac3cae0e728282b2d0bL19-R19)`, `[[7]](diffhunk://#diff-f22260021d003e110044b1b295299e8cbcf837bf686ddf19b5cc46c431180526R22)`, `[[8]](diffhunk://#diff-8c6718e19bf93965a8ade9ecb62959d760e5d75f2f6f23ee205bf64b64604b3eR23)`, `[[9]](diffhunk://#diff-192941e29257ae3baddd9b014f89b65345c35438ed0bce9d6c5e330fbf1b3eccR22)`)

#### Test Updates:
* Modified test cases in `HbaseHostApplicationMapDaoTest` to use `SaltKey` instead of `ByteSaltKey` for consistency with the updated implementation. (`[collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDaoTest.javaL43-R44](diffhunk://#diff-89d9abedf92deb3fe7e7949ffb92e87c6f61f76e638c6d87887c6ed0bcf24103L43-R44)`)