### PR TITLE
[#noissue] Refactor Hasher

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/LinkRowKey.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/LinkRowKey.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.collector.applicationmap.statistics;
 
 import com.navercorp.pinpoint.collector.applicationmap.Vertex;
-import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import com.navercorp.pinpoint.common.server.util.ApplicationMapStatisticsUtils;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
@@ -45,8 +44,8 @@ public class LinkRowKey implements RowKey {
         this.rowTimeSlot = rowTimeSlot;
     }
 
-    public byte[] getRowKey(SaltKey saltKey) {
-        return ApplicationMapStatisticsUtils.makeRowKey(saltKey, applicationName, serviceType, rowTimeSlot);
+    public byte[] getRowKey(int saltKeySize) {
+        return ApplicationMapStatisticsUtils.makeRowKey(saltKeySize, applicationName, serviceType, rowTimeSlot);
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/RowKey.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/RowKey.java
@@ -16,11 +16,9 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.statistics;
 
-import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
-
 /**
  * @author emeroad
  */
 public interface RowKey {
-    byte[] getRowKey(SaltKey saltKey);
+    byte[] getRowKey(int saltKeySize);
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/RowKeyMerge.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/RowKeyMerge.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.collector.applicationmap.statistics;
 
 import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
+import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import org.apache.hadoop.hbase.TableName;
@@ -87,11 +88,11 @@ public class RowKeyMerge {
 
     private byte[] getRowKey(RowKey rowKey, RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
         if (rowKeyDistributorByHashPrefix == null) {
-            return rowKey.getRowKey(ByteSaltKey.NONE);
+            return rowKey.getRowKey(ByteSaltKey.NONE.size());
         } else {
-            byte[] bytes = rowKey.getRowKey(ByteSaltKey.SALT);
-            bytes[0] = rowKeyDistributorByHashPrefix.getByteHasher().getHashPrefix(bytes, ByteSaltKey.SALT.size());
-            return bytes;
+            ByteHasher hasher = rowKeyDistributorByHashPrefix.getByteHasher();
+            byte[] bytes = rowKey.getRowKey(hasher.getSaltKey().size());
+            return hasher.writeSaltKey(bytes);
         }
     }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SyncWriter.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SyncWriter.java
@@ -21,9 +21,8 @@ import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.async.HbaseAsyncTemplate;
 import com.navercorp.pinpoint.common.hbase.util.Increments;
-import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
+import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
-import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import io.lettuce.core.internal.Futures;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Increment;
@@ -37,8 +36,6 @@ import java.util.concurrent.CompletableFuture;
  * @author emeroad
  */
 public class SyncWriter implements BulkWriter {
-
-    private static final SaltKey SALT_KEY = ByteSaltKey.SALT;
 
     private static final Duration awaitTimeout = Duration.ofMillis(100);
 
@@ -110,8 +107,8 @@ public class SyncWriter implements BulkWriter {
     }
 
     private byte[] getDistributedKey(RowKey rowKey) {
-        byte[] bytes = rowKey.getRowKey(SALT_KEY);
-        bytes[0] = rowKeyDistributorByHashPrefix.getByteHasher().getHashPrefix(bytes, SALT_KEY.size());
-        return bytes;
+        ByteHasher byteHasher = this.rowKeyDistributorByHashPrefix.getByteHasher();
+        byte[] bytes = rowKey.getRowKey(byteHasher.getSaltKey().size());
+        return byteHasher.writeSaltKey(bytes);
     }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDaoTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDaoTest.java
@@ -43,7 +43,7 @@ public class HbaseHostApplicationMapDaoTest {
         ServiceType standAlone = ServiceType.STAND_ALONE;
         SaltKey saltKey = ByteSaltKey.SALT;
 
-        byte[] parentApps = HbaseHostApplicationMapDao.createRowKey0(saltKey, parentApp, standAlone.getCode(), statisticsRowSlot, null);
+        byte[] parentApps = HbaseHostApplicationMapDao.createRowKey0(saltKey.size(), parentApp, standAlone.getCode(), statisticsRowSlot, null);
         logger.debug("rowKey size:{}", parentApps.length);
 
         Buffer readBuffer = new FixedBuffer(parentApps);

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkIncrementerTestClazz.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkIncrementerTestClazz.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.collector.applicationmap.statistics;
 
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
-import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Increment;
@@ -119,7 +118,7 @@ public class BulkIncrementerTestClazz {
             if (rows == null) {
                 Assertions.fail("Expected rows not found for " + testDataSet);
             }
-            Map<ByteBuffer, Long> keyValues = rows.get(getRowkey(expectedRowKey));
+            Map<ByteBuffer, Long> keyValues = rows.get(getRowKey(expectedRowKey));
             if (keyValues == null) {
                 Assertions.fail("Expected row not found for " + testDataSet);
             }
@@ -130,8 +129,8 @@ public class BulkIncrementerTestClazz {
             Assertions.assertEquals(expectedCount, (long) actualCount, "Expected counts do not match for " + testDataSet);
         }
 
-        private ByteBuffer getRowkey(RowKey expectedRowKey) {
-            byte[] bytes = expectedRowKey.getRowKey(ByteSaltKey.NONE);
+        private ByteBuffer getRowKey(RowKey expectedRowKey) {
+            byte[] bytes = expectedRowKey.getRowKey(ByteSaltKey.NONE.size());
 
             return ByteBuffer.wrap(bytes);
         }
@@ -231,8 +230,8 @@ public class BulkIncrementerTestClazz {
         }
 
         @Override
-        public byte[] getRowKey(SaltKey saltKey) {
-            byte[] saltKeyBytes = new byte[saltKey.size()];
+        public byte[] getRowKey(int saltKeySize) {
+            byte[] saltKeyBytes = new byte[saltKeySize];
             byte[] bytes = BytesUtils.intToVar32(id);
             return Bytes.add(saltKeyBytes, bytes);
         }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SizeLimitedBulkIncrementerTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SizeLimitedBulkIncrementerTest.java
@@ -216,7 +216,7 @@ public class SizeLimitedBulkIncrementerTest {
             if (rows == null) {
                 continue;
             }
-            Map<ByteBuffer, Long> keyValues = rows.get(ByteBuffer.wrap(expectedRowKey.getRowKey(ByteSaltKey.NONE)));
+            Map<ByteBuffer, Long> keyValues = rows.get(ByteBuffer.wrap(expectedRowKey.getRowKey(ByteSaltKey.NONE.size())));
             if (keyValues == null) {
                 continue;
             }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/dao/hbase/encode/ApplicationIndexRowKeyEncoderTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/dao/hbase/encode/ApplicationIndexRowKeyEncoderTest.java
@@ -55,7 +55,7 @@ class ApplicationIndexRowKeyEncoderTest {
     void encodeRowKey() {
         int elapsedTime = 1000 * 10;
 
-        byte[] rowKey = encoder.encodeRowKey(ByteSaltKey.SALT, "agent", elapsedTime, 2000L);
+        byte[] rowKey = encoder.encodeRowKey(ByteSaltKey.SALT.size(), "agent", elapsedTime, 2000L);
         rowKey = Arrays.copyOfRange(rowKey, 1, rowKey.length);
 
 

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/ByteHasher.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/ByteHasher.java
@@ -21,7 +21,9 @@ public interface ByteHasher {
 
     byte getHashPrefix(byte[] originalKey);
 
-    default byte getHashPrefix(byte[] originalKey, int prefixOffset) {
+    byte[] writeSaltKey(byte[] saltedKey);
+
+    default byte getHashPrefix(byte[] originalKey, int saltKeySize) {
         throw new UnsupportedOperationException();
     }
 
@@ -31,6 +33,9 @@ public interface ByteHasher {
         return getAllPossiblePrefixes();
     }
 
-    int getPrefixLength(byte[] adjustedKey);
+    default int getPrefixLength(byte[] adjustedKey) {
+        return getSaltKey().size();
+    }
 
+    SaltKey getSaltKey();
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/OneByteSimpleHash.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/OneByteSimpleHash.java
@@ -23,6 +23,8 @@ import com.navercorp.pinpoint.common.util.MathUtils;
  * Copy from sematext/HBaseWD
  */
 public class OneByteSimpleHash implements ByteHasher {
+    private static final SaltKey SALT_KEY = ByteSaltKey.SALT;
+
     private final int mod;
     private final byte[] prefix;
 
@@ -56,9 +58,15 @@ public class OneByteSimpleHash implements ByteHasher {
     }
 
     @Override
-    public byte getHashPrefix(byte[] originalKey, int hashOffset) {
-        int hash = MathUtils.fastAbs(BytesUtils.hashBytes(originalKey, hashOffset, originalKey.length));
+    public byte getHashPrefix(byte[] originalKey, int saltKeySize) {
+        int hash = MathUtils.fastAbs(BytesUtils.hashBytes(originalKey, saltKeySize, originalKey.length));
         return (byte) (hash % mod);
+    }
+
+    @Override
+    public byte[] writeSaltKey(byte[] saltedKey) {
+        saltedKey[0] = getHashPrefix(saltedKey, SALT_KEY.size());
+        return saltedKey;
     }
 
 
@@ -69,7 +77,12 @@ public class OneByteSimpleHash implements ByteHasher {
 
     @Override
     public int getPrefixLength(byte[] adjustedKey) {
-        return 1;
+        return SALT_KEY.size();
+    }
+
+    @Override
+    public SaltKey getSaltKey() {
+        return SALT_KEY;
     }
 
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RangeDoubleHash.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RangeDoubleHash.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,6 +27,8 @@ import java.util.concurrent.ThreadLocalRandom;
  *
  */
 public class RangeDoubleHash implements ByteHasher {
+    private static final SaltKey SALT_KEY = ByteSaltKey.SALT;
+
     private final int start;
     private final int end;
     private final int maxBuckets;
@@ -73,6 +75,12 @@ public class RangeDoubleHash implements ByteHasher {
         return (byte) index;
     }
 
+    @Override
+    public byte[] writeSaltKey(byte[] saltedKey) {
+        saltedKey[0] = getHashPrefix(saltedKey, SALT_KEY.size());
+        return saltedKey;
+    }
+
     int secondaryModIndex(int index, int secondaryIndex) {
         return (index + secondaryIndex) % maxBuckets;
     }
@@ -106,7 +114,10 @@ public class RangeDoubleHash implements ByteHasher {
 
     @Override
     public int getPrefixLength(byte[] adjustedKey) {
-        return 1;
+        return SALT_KEY.size();
     }
 
+    public SaltKey getSaltKey() {
+        return SALT_KEY;
+    }
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RangeOneByteSimpleHash.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RangeOneByteSimpleHash.java
@@ -29,6 +29,8 @@ import static com.navercorp.pinpoint.common.hbase.wd.OneByteSimpleHash.toModByte
  * @author emeroad
  */
 public class RangeOneByteSimpleHash implements ByteHasher {
+    private static final SaltKey SALT_KEY = ByteSaltKey.SALT;
+
     protected final int start;
     protected final int end;
     private final int mod;
@@ -55,9 +57,15 @@ public class RangeOneByteSimpleHash implements ByteHasher {
     }
 
     @Override
-    public byte getHashPrefix(byte[] originalKey, int hashOffset) {
-        int hash = MathUtils.fastAbs(hashBytes(originalKey, hashOffset));
+    public byte getHashPrefix(byte[] originalKey, int saltKeySize) {
+        int hash = MathUtils.fastAbs(hashBytes(originalKey, saltKeySize));
         return (byte) (hash % mod);
+    }
+
+    @Override
+    public byte[] writeSaltKey(byte[] saltedKey) {
+        saltedKey[0] = getHashPrefix(saltedKey, SALT_KEY.size());
+        return saltedKey;
     }
 
     /** Compute hash for binary data. */
@@ -78,7 +86,10 @@ public class RangeOneByteSimpleHash implements ByteHasher {
 
     @Override
     public int getPrefixLength(byte[] adjustedKey) {
-        return 1;
+        return SALT_KEY.size();
     }
 
+    public SaltKey getSaltKey() {
+        return SALT_KEY;
+    }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/RowKeyEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/RowKeyEncoder.java
@@ -16,8 +16,6 @@
 
 package com.navercorp.pinpoint.common.server.bo.serializer;
 
-import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
-
 /**
  * @author Woonduk Kang(emeroad)
  */
@@ -25,6 +23,6 @@ public interface RowKeyEncoder<V> {
 
     byte[] encodeRowKey(V value);
 
-    byte[] encodeRowKey(SaltKey saltKey, V value);
+    byte[] encodeRowKey(int saltKeySize, V value);
 
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/uid/UidMetadataEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/uid/UidMetadataEncoder.java
@@ -18,9 +18,9 @@ package com.navercorp.pinpoint.common.server.bo.serializer.metadata.uid;
 
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
+import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
-import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.common.util.TimeUtils;
@@ -32,32 +32,30 @@ import static com.navercorp.pinpoint.common.util.BytesUtils.LONG_BYTE_LENGTH;
 
 public class UidMetadataEncoder implements RowKeyEncoder<UidMetaDataRowKey> {
 
-    private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
+    private final ByteHasher hasher;
 
     public UidMetadataEncoder(RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
-        this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
+        Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
+        this.hasher = rowKeyDistributorByHashPrefix.getByteHasher();
     }
 
     @Override
     public byte[] encodeRowKey(UidMetaDataRowKey metaDataRowKey) {
         Objects.requireNonNull(metaDataRowKey, "metaDataRowKey");
 
-        return encodeRowKey(ByteSaltKey.SALT, metaDataRowKey);
+        return encodeRowKey(ByteSaltKey.SALT.size(), metaDataRowKey);
     }
 
     @Override
-    public byte[] encodeRowKey(SaltKey saltKeySize, UidMetaDataRowKey metaDataRowKey) {
-        Objects.requireNonNull(saltKeySize, "saltKeySize");
+    public byte[] encodeRowKey(int saltKeySize, UidMetaDataRowKey metaDataRowKey) {
 
-        byte[] rowKey = encodeMetaDataRowKey(saltKeySize.size(), metaDataRowKey.getAgentId(),
+        byte[] rowKey = encodeMetaDataRowKey(saltKeySize, metaDataRowKey.getAgentId(),
                 metaDataRowKey.getAgentStartTime(),
                 metaDataRowKey.getUid());
-        if (saltKeySize == ByteSaltKey.NONE) {
+        if (saltKeySize == 0) {
             return rowKey;
         }
-        byte hashPrefix = rowKeyDistributorByHashPrefix.getByteHasher().getHashPrefix(rowKey, saltKeySize.size());
-        rowKey[0] = hashPrefix;
-        return rowKey;
+        return hasher.writeSaltKey(rowKey);
     }
 
     public static byte[] encodeMetaDataRowKey(int saltKeySize, String agentId, long agentStartTime, byte[] keyCode) {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ApplicationMapStatisticsUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ApplicationMapStatisticsUtils.java
@@ -20,7 +20,6 @@ import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
-import com.navercorp.pinpoint.common.hbase.wd.SaltKey;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -142,13 +141,13 @@ public class ApplicationMapStatisticsUtils {
      * @param timestamp
      * @return
      */
-    public static byte[] makeRowKey(SaltKey saltKey, String applicationName, short applicationType, long timestamp) {
+    public static byte[] makeRowKey(int saltKeySize, String applicationName, short applicationType, long timestamp) {
         Objects.requireNonNull(applicationName, "applicationName");
 
         final byte[] applicationNameBytes= BytesUtils.toBytes(applicationName);
 
-        final Buffer buffer = new AutomaticBuffer(saltKey.size() + BytesUtils.SHORT_BYTE_LENGTH + applicationNameBytes.length + BytesUtils.SHORT_BYTE_LENGTH + BytesUtils.LONG_BYTE_LENGTH);
-        buffer.setOffset(saltKey.size());
+        final Buffer buffer = new AutomaticBuffer(saltKeySize + BytesUtils.SHORT_BYTE_LENGTH + applicationNameBytes.length + BytesUtils.SHORT_BYTE_LENGTH + BytesUtils.LONG_BYTE_LENGTH);
+        buffer.setOffset(saltKeySize);
 //        buffer.put2PrefixedString(applicationName);
         buffer.putShort((short)applicationNameBytes.length);
         buffer.putBytes(applicationNameBytes);

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoderTest.java
@@ -30,7 +30,7 @@ public class MetadataEncoderTest {
     public void encodeRowKey() {
         long startTime = System.currentTimeMillis();
         MetaDataRowKey metaData = new DefaultMetaDataRowKey("agent", startTime, 1);
-        byte[] rowKey = encoder.encodeRowKey(ByteSaltKey.NONE, metaData);
+        byte[] rowKey = encoder.encodeRowKey(ByteSaltKey.NONE.size(), metaData);
         MetaDataRowKey decodeRowKey = decoder.decodeRowKey(rowKey);
 
         Assertions.assertEquals("agent", decodeRowKey.getAgentId());

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/ApplicationMapStatisticsUtilsTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/ApplicationMapStatisticsUtilsTest.java
@@ -33,7 +33,7 @@ public class ApplicationMapStatisticsUtilsTest {
         short serviceType = 123;
         long time = System.currentTimeMillis();
 
-        byte[] bytes = ApplicationMapStatisticsUtils.makeRowKey(ByteSaltKey.NONE, applicationName, serviceType, time);
+        byte[] bytes = ApplicationMapStatisticsUtils.makeRowKey(ByteSaltKey.NONE.size(), applicationName, serviceType, time);
 
         Assertions.assertEquals(applicationName, ApplicationMapStatisticsUtils.getApplicationNameFromRowKey(bytes));
         Assertions.assertEquals(serviceType, ApplicationMapStatisticsUtils.getApplicationTypeFromRowKey(bytes));

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/MapScanFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/MapScanFactory.java
@@ -54,9 +54,9 @@ public class MapScanFactory {
         }
         // start key is replaced by end key because timestamp has been reversed
         byte[] startKey = ApplicationMapStatisticsUtils
-                .makeRowKey(ByteSaltKey.NONE, application.getName(), (short) application.getServiceTypeCode(), range.getTo());
+                .makeRowKey(ByteSaltKey.NONE.size(), application.getName(), (short) application.getServiceTypeCode(), range.getTo());
         byte[] endKey = ApplicationMapStatisticsUtils
-                .makeRowKey(ByteSaltKey.NONE, application.getName(), (short) application.getServiceTypeCode(), range.getFrom());
+                .makeRowKey(ByteSaltKey.NONE.size(), application.getName(), (short) application.getServiceTypeCode(), range.getFrom());
 
         final Scan scan = new Scan();
 


### PR DESCRIPTION
This pull request refactors the handling of row key distribution by replacing the `SaltKey` and `ByteSaltKey` classes with a new `ByteHasher` interface. The changes improve code maintainability and unify the approach to row key hashing across the codebase. Key updates include replacing `SaltKey` with `ByteHasher` in various classes and methods, as well as updating test cases to align with the new implementation.

### Refactoring of Row Key Distribution:
* Replaced `SaltKey` with `ByteHasher` in the `HbaseHostApplicationMapDao` class, including changes to the `createRowKey` and `createRowKey0` methods to use the `ByteHasher` interface for generating and applying salt keys. (`[[1]](diffhunk://#diff-67d647f20220b276cc88a58eac5ed57e1ad56d906395e43b74d5111517c21ab0L65-R65)`, `[[2]](diffhunk://#diff-67d647f20220b276cc88a58eac5ed57e1ad56d906395e43b74d5111517c21ab0L77-R78)`, `[[3]](diffhunk://#diff-67d647f20220b276cc88a58eac5ed57e1ad56d906395e43b74d5111517c21ab0L130-R141)`, `[[4]](diffhunk://#diff-67d647f20220b276cc88a58eac5ed57e1ad56d906395e43b74d5111517c21ab0L151-R150)`)
* Updated the `DefaultBulkWriter` class to use `ByteHasher` instead of `SaltKey`, modifying the `getDistributedKey` method to reflect this change. (`[[1]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dL23-L25)`, `[[2]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dL43-R45)`, `[[3]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dR66)`, `[[4]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dL154-R154)`)
* Updated the `SyncWriter` and `RowKeyMerge` classes to replace `SaltKey` with `ByteHasher` for row key generation and distribution. (`[[1]](diffhunk://#diff-1a5bd45c868872214ec98331881df3d03d95b945dbb1e4a9b5ce6730e524b011R24)`, `[[2]](diffhunk://#diff-1a5bd45c868872214ec98331881df3d03d95b945dbb1e4a9b5ce6730e524b011L113-R116)`, `[[3]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428R20)`, `[[4]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428L90-R95)`)

### Interface and Method Updates:
* Modified the `RowKey` interface to replace the `getRowKey(SaltKey saltKey)` method with `getRowKey(int saltKeySize)` for a more flexible and consistent API. (`[collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/RowKey.javaL19-R23](diffhunk://#diff-332485fee3d8cab0bb28af1eb197a8d4624bfeb840319bbdea6db8b72be72874L19-R23)`)
* Updated the `ByteHasher` interface to include a new `writeSaltKey` method for applying salt keys to row keys. (`[commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/ByteHasher.javaL24-R26](diffhunk://#diff-cd23cc7542683d549a613df239e1603c2ae524813352164d44b42a7b24c651a6L24-R26)`)

### Test Case Adjustments:
* Updated test cases across the codebase to align with the new `ByteHasher` implementation, replacing `SaltKey` with `int saltKeySize` in test methods and assertions. (`[[1]](diffhunk://#diff-89d9abedf92deb3fe7e7949ffb92e87c6f61f76e638c6d87887c6ed0bcf24103L46-R46)`, `[[2]](diffhunk://#diff-53830c4f112f70021041a9be608212787d8a23a05913144f1f6c844977c41720L122-R121)`, `[[3]](diffhunk://#diff-53830c4f112f70021041a9be608212787d8a23a05913144f1f6c844977c41720L133-R133)`, `[[4]](diffhunk://#diff-53830c4f112f70021041a9be608212787d8a23a05913144f1f6c844977c41720L234-R234)`, `[[5]](diffhunk://#diff-bad72415df98403426a7d6a8819778bfb150bb641678187e47c1eb806c2f2e39L219-R219)`, `[[6]](diffhunk://#diff-7a0d734a9388c4490e1e6fb2f0c5aadb940a27b4b10e4c398b77330d0b2f7336L58-R58)`)

These changes collectively streamline the row key distribution logic and improve the modularity of the codebase by centralizing salt key handling in the `ByteHasher` interface.