### PR TITLE
[#noissue] Add qualifierToShort to CellUtils

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/CellUtils.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/CellUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.hbase.util;
 
 import com.navercorp.pinpoint.common.util.ArrayUtils;
@@ -20,6 +36,11 @@ public final class CellUtils {
         }
         final Cell firstCell = cells[0];
         return Bytes.toString(firstCell.getRowArray(), firstCell.getRowOffset(), firstCell.getRowLength());
+    }
+
+    public static short qualifierToShort(Cell cell) {
+        Objects.requireNonNull(cell, "cell");
+        return Bytes.toShort(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
     }
 
     public static int qualifierToInt(Cell cell) {

--- a/commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/util/CellUtilsTest.java
+++ b/commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/util/CellUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.hbase.util;
 
 import org.apache.hadoop.hbase.Cell;
@@ -24,6 +40,18 @@ public class CellUtilsTest {
         when(result.rawCells()).thenReturn(cells);
 
         Assertions.assertEquals(value, CellUtils.rowToString(result));
+    }
+
+    @Test
+    public void qualifierToShort() {
+        Cell cell = mock(Cell.class);
+        short value = 5;
+        byte[] bytes = Bytes.toBytes(value);
+        when(cell.getQualifierArray()).thenReturn(bytes);
+        when(cell.getQualifierOffset()).thenReturn(0);
+        when(cell.getQualifierLength()).thenReturn(bytes.length);
+
+        Assertions.assertEquals(value, CellUtils.qualifierToShort(cell));
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces a new utility method for converting a cell qualifier to a `short` in the `CellUtils` class and adds corresponding unit tests. It also includes standard copyright headers for the modified files.

### New functionality:
* Added a `qualifierToShort` method in `CellUtils` to convert a cell qualifier to a `short`. This method ensures the input cell is not null and extracts the `short` value from the qualifier array. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/CellUtils.java`)

### Unit tests:
* Added a unit test for the `qualifierToShort` method in `CellUtilsTest` to verify its correctness using a mocked `Cell` object. (`commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/util/CellUtilsTest.java`)

### Miscellaneous:
* Added Apache 2.0 license headers to `CellUtils.java` and `CellUtilsTest.java` to ensure compliance with licensing standards. [[1]](diffhunk://#diff-981108adfae9eb568cf83d2479c8b53a042c8314fd335523f9b956249bd06a4eR1-R16) [[2]](diffhunk://#diff-8f4bfa429d1ab3ae18fe53800a5d46bc487997682d03c2c6438fc94cbcd524c8R1-R16)