### PR TITLE
[#noissue] Memory Optimization of DistributedScanner

### DIFF
--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtils.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.util.BytesUtils;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 
 public final class ByteArrayUtils {
     public static final int SHORT_BYTE_LENGTH = 2;
@@ -91,5 +92,26 @@ public final class ByteArrayUtils {
         BYTE_ARRAY_SHORT.set(buf, offset, value);
 
         return offset + SHORT_BYTE_LENGTH;
+    }
+
+    /**
+     * Compares two byte arrays starting from the specified offset.
+     *
+     * @param bytes1 the first byte array to compare
+     * @param bytes2 the second byte array to compare
+     * @param offset the starting position in both arrays for the comparison
+     * @return a negative integer, zero, or a positive integer as the first array is less than,
+     *         equal to, or greater than the second array
+     * @throws NullPointerException if either {@code bytes1} or {@code bytes2} is {@code null}
+     * @throws IndexOutOfBoundsException if the offset is out of bounds for either array
+     */
+    public static int compare(byte[] bytes1, byte[] bytes2, int offset) {
+        if (bytes1 == null) {
+            throw new NullPointerException("bytes1");
+        }
+        if (bytes2 == null) {
+            throw new NullPointerException("bytes2");
+        }
+        return Arrays.compare(bytes1, offset, bytes1.length, bytes2, offset, bytes2.length);
     }
 }

--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtilsTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -122,5 +122,28 @@ class ByteArrayUtilsTest {
         Assertions.assertThrows(ArrayIndexOutOfBoundsException.class, ()->{
             ByteArrayUtils.writeInt(100, bytes1, 1);
         });
+    }
+
+    @Test
+    void compareRowKey_true() {
+        byte[] row1 = BytesUtils.add((byte) 1, toInt(1));
+        byte[] row2 = BytesUtils.add((byte) 2, toInt(1));
+
+        Assertions.assertEquals(0, ByteArrayUtils.compare(row1, row2, 1));
+        Assertions.assertNotEquals(0, ByteArrayUtils.compare(row1, row2, 0));
+    }
+
+    @Test
+    void compareRowKey_false() {
+        byte[] row1 = BytesUtils.add((byte) 1, toInt(1));
+        byte[] row2 = BytesUtils.add((byte) 2, toInt(2));
+
+        Assertions.assertNotEquals(0, ByteArrayUtils.compare(row1, row2, 1));
+    }
+
+    private byte[] toInt(int value) {
+        byte[] buf = new byte[4];
+        BytesUtils.writeInt(value, buf, 0);
+        return buf;
     }
 }

--- a/commons-hbase/pom.xml
+++ b/commons-hbase/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 NAVER Corp.
+  ~ Copyright 2025 NAVER Corp.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -41,6 +41,10 @@
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-commons-buffer</artifactId>
         </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -478,7 +478,8 @@ public class HbaseTemplate extends HbaseAccessor implements HbaseOperations, Ini
                 final ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "block-multi", scans);
 
                 final ResultScanner[] splitScanners = ScanUtils.newScanners(table, scans);
-                try (ResultScanner scanner = new DistributedScanner(rowKeyDistributor, splitScanners)) {
+                final int saltKeySize = rowKeyDistributor.getByteHasher().getSaltKey().size();
+                try (ResultScanner scanner = new DistributedScanner(saltKeySize, splitScanners)) {
                     if (debugEnabled) {
                         logger.debug("DistributedScanner createTime: {}ms", watch.stop());
                     }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -377,7 +377,8 @@ public class HbaseAsyncTemplate implements DisposableBean, AsyncHbaseOperations 
                 Scan[] scans = ScanUtils.splitScans(scan, rowKeyDistributor);
                 final ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "async-multi", scans);
                 final ResultScanner[] splitScanners = ScanUtils.newScanners(table, scans);
-                try (ResultScanner scanner = new DistributedScanner(rowKeyDistributor, splitScanners)) {
+                final int saltKeySize = rowKeyDistributor.getByteHasher().getSaltKey().size();
+                try (ResultScanner scanner = new DistributedScanner(saltKeySize, splitScanners)) {
                     if (debugEnabled) {
                         logger.debug("DistributedScanner createTime: {}ms", watch.stop());
                         watch.start();
@@ -409,8 +410,8 @@ public class HbaseAsyncTemplate implements DisposableBean, AsyncHbaseOperations 
                 public T doInTable(AsyncTable<ScanResultConsumer> table) throws Throwable {
                     ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "async-multi", scans);
                     ResultScanner[] resultScanners = ScanUtils.newScanners(table, scans);
-
-                    ResultScanner scanner = new DistributedScanner(rowKeyDistributor, resultScanners);
+                    int saltKeySize = rowKeyDistributor.getByteHasher().getSaltKey().size();
+                    ResultScanner scanner = new DistributedScanner(saltKeySize, resultScanners);
                     try (scanner) {
                         return action.extractData(scanner);
                     } finally {

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ScanTask.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ScanTask.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.common.hbase.parallel;
 
 import com.navercorp.pinpoint.common.hbase.TableFactory;
 import com.navercorp.pinpoint.common.hbase.wd.DistributedScanner;
-import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -40,7 +39,7 @@ public class ScanTask implements Runnable {
 
     private final TableName tableName;
     private final TableFactory tableFactory;
-    private final RowKeyDistributor rowKeyDistributor;
+    private final int saltKeySize;
 
     private final Scan[] scans;
     private final BlockingQueue<Result> resultQueue;
@@ -54,7 +53,7 @@ public class ScanTask implements Runnable {
         Assert.notEmpty(scans, "scans");
         this.tableName = scanTaskConfig.getTableName();
         this.tableFactory = scanTaskConfig.getTableFactory();
-        this.rowKeyDistributor = scanTaskConfig.getRowKeyDistributor();
+        this.saltKeySize = scanTaskConfig.getSaltKeySize();
         this.scans = scans;
         this.resultQueue = new ArrayBlockingQueue<>(scanTaskConfig.getScanTaskQueueSize());
     }
@@ -96,7 +95,7 @@ public class ScanTask implements Runnable {
             for (int i = 0; i < scanners.length; i++) {
                 scanners[i] = table.getScanner(this.scans[i]);
             }
-            return new DistributedScanner(this.rowKeyDistributor, scanners);
+            return new DistributedScanner(saltKeySize, scanners);
         }
     }
 

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ScanTaskConfig.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ScanTaskConfig.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.common.hbase.parallel;
 
 import com.navercorp.pinpoint.common.hbase.HbaseAccessor;
 import com.navercorp.pinpoint.common.hbase.TableFactory;
-import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
@@ -36,19 +35,19 @@ public class ScanTaskConfig {
     private final Charset charset;
     private final TableFactory tableFactory;
 
-    private final RowKeyDistributor rowKeyDistributor;
+    private final int saltKeySize;
     private final int scanTaskQueueSize;
 
-    public ScanTaskConfig(TableName tableName, HbaseAccessor hbaseAccessor, RowKeyDistributor rowKeyDistributor, int scanCaching) {
-        this(tableName, hbaseAccessor.getConfiguration(), hbaseAccessor.getCharset(), hbaseAccessor.getTableFactory(), rowKeyDistributor, scanCaching);
+    public static ScanTaskConfig of(TableName tableName, HbaseAccessor hbaseAccessor, int saltKeySize, int scanCaching) {
+        return new ScanTaskConfig(tableName, hbaseAccessor.getConfiguration(), hbaseAccessor.getCharset(), hbaseAccessor.getTableFactory(), saltKeySize, scanCaching);
     }
 
-    public ScanTaskConfig(TableName tableName, Configuration configuration, Charset charset, TableFactory tableFactory, RowKeyDistributor rowKeyDistributor, int scanCaching) {
+    public ScanTaskConfig(TableName tableName, Configuration configuration, Charset charset, TableFactory tableFactory, int saltKeySize, int scanCaching) {
         this.tableName = Objects.requireNonNull(tableName, "tableName");
         this.configuration = configuration;
         this.charset = charset;
         this.tableFactory = tableFactory;
-        this.rowKeyDistributor = Objects.requireNonNull(rowKeyDistributor, "rowKeyDistributor");
+        this.saltKeySize = saltKeySize;
         if (scanCaching > 0) {
             this.scanTaskQueueSize = scanCaching;
         } else {
@@ -74,8 +73,8 @@ public class ScanTaskConfig {
         return tableFactory;
     }
 
-    public RowKeyDistributor getRowKeyDistributor() {
-        return rowKeyDistributor;
+    public int getSaltKeySize() {
+        return saltKeySize;
     }
 
     public int getScanTaskQueueSize() {


### PR DESCRIPTION
This pull request introduces enhancements to the `ByteArrayUtils` utility class, updates to the HBase-related components to improve scanning performance, and general maintenance changes. The most significant updates include adding a new `compare` method for byte arrays, replacing `RowKeyDistributor` with `saltKeySize` for distributed scanning, and updating copyright years.

### Enhancements to `ByteArrayUtils`:
* Added a new `compare` method to compare two byte arrays starting from a specified offset. This method uses `Arrays.compare` for efficient comparison and includes validation for null arrays and index bounds. (`commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtils.java`, [commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtils.javaR96-R116](diffhunk://#diff-3876cce0c604bd8f739a4aafa46d20d862f3d819b8c3ea95eec8fe6874998edbR96-R116))
* Added corresponding unit tests for the `compare` method to validate its behavior with different inputs. (`commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtilsTest.java`, [commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtilsTest.javaR126-R148](diffhunk://#diff-7c878e9a94de43329559cc8658973e80ec6b122a2f048248e09cb23ec94cba21R126-R148))

### Updates to HBase Scanning:
* Replaced the use of `RowKeyDistributor` with `saltKeySize` in `DistributedScanner` and related classes to simplify the implementation and improve performance. This change affects `DistributedScanner`, `ParallelResultScanner`, `ScanTask`, and `ScanTaskConfig`. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScanner.java`, [[1]](diffhunk://#diff-2ec5a7b3b330c2b486114a5da93b2b958cfd07f704079dcda1c0f79587ce2585R1-L8) [[2]](diffhunk://#diff-2ec5a7b3b330c2b486114a5da93b2b958cfd07f704079dcda1c0f79587ce2585L24-R47) [[3]](diffhunk://#diff-2ec5a7b3b330c2b486114a5da93b2b958cfd07f704079dcda1c0f79587ce2585L100-R117); `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ParallelResultScanner.java`, [[4]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL43-R57) [[5]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL127-R129); `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ScanTask.java`, [[6]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34L43-R42) [[7]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34L99-R98); `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ScanTaskConfig.java`, [[8]](diffhunk://#diff-eb17655650851e1d009923b2ce153a247ed72f8f4c0e84923cafc30a45326fe5L39-R50) [[9]](diffhunk://#diff-eb17655650851e1d009923b2ce153a247ed72f8f4c0e84923cafc30a45326fe5L77-R77)
* Updated `HbaseTemplate` and `HbaseAsyncTemplate` to use the new `saltKeySize` parameter in distributed scanning operations. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java`, [[1]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L481-R482); `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java`, [[2]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L380-R381) [[3]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L412-R414)

### General Maintenance:
* Updated copyright years in multiple files to 2025. (`commons-hbase/pom.xml`, [[1]](diffhunk://#diff-f0a710129d7e5684ae35d90d835c611badd2d0bf96f9d7701bd741a340f08afeL3-R3); `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java`, [[2]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L2-R2); `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ParallelResultScanner.java`, [[3]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL2-R2)
* Added a dependency on `pinpoint-commons-buffer` in the `commons-hbase/pom.xml` file to support the new utility methods. (`commons-hbase/pom.xml`, [commons-hbase/pom.xmlR45-R48](diffhunk://#diff-f0a710129d7e5684ae35d90d835c611badd2d0bf96f9d7701bd741a340f08afeR45-R48))