### PR TITLE
[#noissue] Refactor Rowkey handling

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java
@@ -478,7 +478,7 @@ public class HbaseTemplate extends HbaseAccessor implements HbaseOperations, Ini
                 final ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "block-multi", scans);
 
                 final ResultScanner[] splitScanners = ScanUtils.newScanners(table, scans);
-                final int saltKeySize = rowKeyDistributor.getByteHasher().getSaltKey().size();
+                final int saltKeySize = rowKeyDistributor.getSaltKeySize();
                 try (ResultScanner scanner = new DistributedScanner(saltKeySize, splitScanners)) {
                     if (debugEnabled) {
                         logger.debug("DistributedScanner createTime: {}ms", watch.stop());

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java
@@ -377,7 +377,7 @@ public class HbaseAsyncTemplate implements DisposableBean, AsyncHbaseOperations 
                 Scan[] scans = ScanUtils.splitScans(scan, rowKeyDistributor);
                 final ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "async-multi", scans);
                 final ResultScanner[] splitScanners = ScanUtils.newScanners(table, scans);
-                final int saltKeySize = rowKeyDistributor.getByteHasher().getSaltKey().size();
+                final int saltKeySize = rowKeyDistributor.getSaltKeySize();
                 try (ResultScanner scanner = new DistributedScanner(saltKeySize, splitScanners)) {
                     if (debugEnabled) {
                         logger.debug("DistributedScanner createTime: {}ms", watch.stop());
@@ -410,7 +410,7 @@ public class HbaseAsyncTemplate implements DisposableBean, AsyncHbaseOperations 
                 public T doInTable(AsyncTable<ScanResultConsumer> table) throws Throwable {
                     ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "async-multi", scans);
                     ResultScanner[] resultScanners = ScanUtils.newScanners(table, scans);
-                    int saltKeySize = rowKeyDistributor.getByteHasher().getSaltKey().size();
+                    int saltKeySize = rowKeyDistributor.getSaltKeySize();
                     ResultScanner scanner = new DistributedScanner(saltKeySize, resultScanners);
                     try (scanner) {
                         return action.extractData(scanner);

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ParallelResultScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ParallelResultScanner.java
@@ -52,7 +52,7 @@ public class ParallelResultScanner implements ResultScanner {
         Objects.requireNonNull(originalScan, "originalScan");
 
         Objects.requireNonNull(keyDistributor, "keyDistributor");
-        this.saltKeySize = keyDistributor.getByteHasher().getSaltKey().size();
+        this.saltKeySize = keyDistributor.getSaltKeySize();
 
         final ScanTaskConfig scanTaskConfig = ScanTaskConfig.of(tableName, hbaseAccessor, saltKeySize, originalScan.getCaching());
         final Scan[] splitScans = ScanUtils.splitScans(originalScan, keyDistributor);

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScanner.java
@@ -113,7 +113,7 @@ public class DistributedScanner implements ResultScanner {
         for (int i = 0; i < scans.length; i++) {
             rss[i] = hTable.getScanner(scans[i]);
         }
-        int saltKeySize = keyDistributor.getByteHasher().getSaltKey().size();
+        int saltKeySize = keyDistributor.getSaltKeySize();
         return new DistributedScanner(saltKeySize, rss);
     }
 

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributor.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,6 +32,8 @@ import java.util.Arrays;
  */
 public interface RowKeyDistributor {
     ByteHasher getByteHasher();
+
+    int getSaltKeySize();
     
     byte[] getDistributedKey(byte[] originalKey);
 

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributorByHashPrefix.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributorByHashPrefix.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,6 +38,12 @@ public class RowKeyDistributorByHashPrefix implements RowKeyDistributor {
     public ByteHasher getByteHasher() {
         return hasher;
     }
+
+    @Override
+    public int getSaltKeySize() {
+        return hasher.getSaltKey().size();
+    }
+
 
     @Override
     public byte[] getDistributedKey(byte[] originalKey) {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataDecoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataDecoder.java
@@ -1,31 +1,58 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.server.bo.serializer.metadata;
 
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
+import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.common.util.TimeUtils;
 
 public class MetadataDecoder implements RowKeyDecoder<MetaDataRowKey> {
 
+    private final int saltKeySize;
+
+    public MetadataDecoder() {
+        this(ByteSaltKey.SALT.size());
+    }
+
+    public MetadataDecoder(int saltKeySize) {
+        this.saltKeySize = saltKeySize;
+    }
+
     @Override
     public MetaDataRowKey decodeRowKey(byte[] rowkey) {
-        final String agentId = readAgentId(rowkey);
-        final long agentStartTime = readAgentStartTime(rowkey);
-        final int id = readId(rowkey);
+        final String agentId = readAgentId(rowkey, saltKeySize);
+        final long agentStartTime = readAgentStartTime(rowkey, PinpointConstants.AGENT_ID_MAX_LEN + saltKeySize);
+        final int id = readId(rowkey, PinpointConstants.AGENT_ID_MAX_LEN + BytesUtils.LONG_BYTE_LENGTH + saltKeySize);
 
         return new DefaultMetaDataRowKey(agentId, agentStartTime, id);
     }
 
-    private String readAgentId(byte[] rowKey) {
-        return BytesUtils.toStringAndRightTrim(rowKey, 0, PinpointConstants.AGENT_ID_MAX_LEN);
+    private String readAgentId(byte[] rowKey, int offset) {
+        return BytesUtils.toStringAndRightTrim(rowKey, offset, PinpointConstants.AGENT_ID_MAX_LEN);
     }
 
-    private long readAgentStartTime(byte[] rowKey) {
-        return TimeUtils.recoveryTimeMillis(ByteArrayUtils.bytesToLong(rowKey, PinpointConstants.AGENT_ID_MAX_LEN));
+    private long readAgentStartTime(byte[] rowKey, int offset) {
+        return TimeUtils.recoveryTimeMillis(ByteArrayUtils.bytesToLong(rowKey, offset));
     }
 
-    private int readId(byte[] rowKey) {
-        return ByteArrayUtils.bytesToInt(rowKey, PinpointConstants.AGENT_ID_MAX_LEN + BytesUtils.LONG_BYTE_LENGTH);
+    private int readId(byte[] rowKey, int offset) {
+        return ByteArrayUtils.bytesToInt(rowKey, offset);
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.common.server.bo.serializer.metadata;
 
 import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
 import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
-import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.util.BytesUtils;
@@ -43,7 +42,7 @@ public class MetadataEncoder implements RowKeyEncoder<MetaDataRowKey> {
     public byte[] encodeRowKey(MetaDataRowKey metadataRowKey) {
         Objects.requireNonNull(metadataRowKey, "metadataRowKey");
 
-        return encodeRowKey(ByteSaltKey.SALT.size(), metadataRowKey);
+        return encodeRowKey(hasher.getSaltKey().size(), metadataRowKey);
     }
 
     @Override

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/uid/UidMetadataDecoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/uid/UidMetadataDecoder.java
@@ -1,7 +1,24 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.server.bo.serializer.metadata.uid;
 
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
+import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.common.util.TimeUtils;
@@ -10,24 +27,34 @@ import java.util.Arrays;
 
 public class UidMetadataDecoder implements RowKeyDecoder<UidMetaDataRowKey> {
 
+    private final int saltKeySize;
+
+    public UidMetadataDecoder() {
+         this(ByteSaltKey.SALT.size());
+    }
+
+    public UidMetadataDecoder(int saltKeySize) {
+        this.saltKeySize = saltKeySize;
+    }
+
     @Override
     public UidMetaDataRowKey decodeRowKey(byte[] rowKey) {
-        final String agentId = readAgentId(rowKey);
-        final long agentStartTime = readAgentStartTime(rowKey);
-        final byte[] uid = readUid(rowKey);
+        final String agentId = readAgentId(rowKey, saltKeySize);
+        final long agentStartTime = readAgentStartTime(rowKey, PinpointConstants.AGENT_ID_MAX_LEN + saltKeySize);
+        final byte[] uid = readUid(rowKey, PinpointConstants.AGENT_ID_MAX_LEN + BytesUtils.LONG_BYTE_LENGTH + saltKeySize);
 
         return new DefaultUidMetaDataRowKey(agentId, agentStartTime, uid);
     }
 
-    private String readAgentId(byte[] rowKey) {
-        return BytesUtils.toStringAndRightTrim(rowKey, 0, PinpointConstants.AGENT_ID_MAX_LEN);
+    private String readAgentId(byte[] rowKey, int offset) {
+        return BytesUtils.toStringAndRightTrim(rowKey, offset, PinpointConstants.AGENT_ID_MAX_LEN);
     }
 
-    private long readAgentStartTime(byte[] rowKey) {
-        return TimeUtils.recoveryTimeMillis(ByteArrayUtils.bytesToLong(rowKey, PinpointConstants.AGENT_ID_MAX_LEN));
+    private long readAgentStartTime(byte[] rowKey, int offset) {
+        return TimeUtils.recoveryTimeMillis(ByteArrayUtils.bytesToLong(rowKey, offset));
     }
 
-    private byte[] readUid(byte[] rowKey) {
-        return Arrays.copyOfRange(rowKey, PinpointConstants.AGENT_ID_MAX_LEN + BytesUtils.LONG_BYTE_LENGTH, rowKey.length);
+    private byte[] readUid(byte[] rowKey, int offset) {
+        return Arrays.copyOfRange(rowKey, offset, rowKey.length);
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/uid/UidMetadataEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/uid/UidMetadataEncoder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +19,6 @@ package com.navercorp.pinpoint.common.server.bo.serializer.metadata.uid;
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
 import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
-import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.util.BytesUtils;
@@ -43,7 +42,7 @@ public class UidMetadataEncoder implements RowKeyEncoder<UidMetaDataRowKey> {
     public byte[] encodeRowKey(UidMetaDataRowKey metaDataRowKey) {
         Objects.requireNonNull(metaDataRowKey, "metaDataRowKey");
 
-        return encodeRowKey(ByteSaltKey.SALT.size(), metaDataRowKey);
+        return encodeRowKey(hasher.getSaltKey().size(), metaDataRowKey);
     }
 
     @Override

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.common.server.bo.serializer.metadata;
 
-import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.OneByteSimpleHash;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import org.junit.jupiter.api.Assertions;
@@ -30,7 +29,7 @@ public class MetadataEncoderTest {
     public void encodeRowKey() {
         long startTime = System.currentTimeMillis();
         MetaDataRowKey metaData = new DefaultMetaDataRowKey("agent", startTime, 1);
-        byte[] rowKey = encoder.encodeRowKey(ByteSaltKey.NONE.size(), metaData);
+        byte[] rowKey = encoder.encodeRowKey(metaData);
         MetaDataRowKey decodeRowKey = decoder.decodeRowKey(rowKey);
 
         Assertions.assertEquals("agent", decodeRowKey.getAgentId());

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/InLinkMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/InLinkMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,11 +56,9 @@ public class InLinkMapper implements RowMapper<LinkDataMap> {
 
     private final ApplicationFactory applicationFactory;
 
-
-    private final RowKeyDistributorByHashPrefix rowKeyDistributor;
-
     private final TimeWindowFunction timeWindowFunction;
 
+    private final int saltKeySize;
 
     public InLinkMapper(ServiceTypeRegistryService registry,
                         ApplicationFactory applicationFactory,
@@ -69,7 +67,8 @@ public class InLinkMapper implements RowMapper<LinkDataMap> {
                         TimeWindowFunction timeWindowFunction) {
         this.registry = Objects.requireNonNull(registry, "registry");
         this.applicationFactory = Objects.requireNonNull(applicationFactory, "applicationFactory");
-        this.rowKeyDistributor = Objects.requireNonNull(rowKeyDistributor, "rowKeyDistributor");
+        Objects.requireNonNull(rowKeyDistributor, "rowKeyDistributor");
+        this.saltKeySize = rowKeyDistributor.getSaltKeySize();
 
         this.filter = Objects.requireNonNull(filter, "filter");
         this.timeWindowFunction = Objects.requireNonNull(timeWindowFunction, "timeWindowFunction");
@@ -84,9 +83,10 @@ public class InLinkMapper implements RowMapper<LinkDataMap> {
             logger.debug("mapRow num:{} size:{}", rowNum, result.size());
         }
 
-        final byte[] rowKey = getOriginalKey(result.getRow());
+        final byte[] rowKey = result.getRow();
 
         final Buffer row = new FixedBuffer(rowKey);
+        row.setOffset(saltKeySize);
         final Application inApplication = readInApplication(row);
         final long timestamp = timeWindowFunction.refineTimestamp(TimeUtils.recoveryTimeMillis(row.readLong()));
 
@@ -154,7 +154,4 @@ public class InLinkMapper implements RowMapper<LinkDataMap> {
         return this.applicationFactory.createApplication(inApplicationName, inServiceType);
     }
 
-    private byte[] getOriginalKey(byte[] rowKey) {
-        return rowKeyDistributor.getOriginalKey(rowKey);
-    }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseApplicationTraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseApplicationTraceIndexDao.java
@@ -188,7 +188,7 @@ public class HbaseApplicationTraceIndexDao implements ApplicationTraceIndexDao {
         }
 
         private long readTimestamp(Cell last) {
-            int saltKeySize = traceIdRowKeyDistributor.getByteHasher().getSaltKey().size();
+            int saltKeySize = traceIdRowKeyDistributor.getSaltKeySize();
             byte[] rowArray = last.getRowArray();
             int rowOffset = last.getRowOffset();
             int timestampOffset = rowOffset + PinpointConstants.APPLICATION_NAME_MAX_LEN + saltKeySize;

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/ApiMetaDataMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/ApiMetaDataMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,7 +20,6 @@ import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.FixedBuffer;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
-import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
@@ -30,7 +29,6 @@ import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -49,15 +47,10 @@ public class ApiMetaDataMapper implements RowMapper<List<ApiMetaDataBo>> {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
-    private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
-
     private final RowKeyDecoder<MetaDataRowKey> decoder;
 
-    public ApiMetaDataMapper(RowKeyDecoder<MetaDataRowKey> decoder,
-                             @Qualifier("metadataRowKeyDistributor")
-                             RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
+    public ApiMetaDataMapper(RowKeyDecoder<MetaDataRowKey> decoder) {
         this.decoder = Objects.requireNonNull(decoder, "decoder");
-        this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
     }
 
     @Override
@@ -65,7 +58,7 @@ public class ApiMetaDataMapper implements RowMapper<List<ApiMetaDataBo>> {
         if (result.isEmpty()) {
             return Collections.emptyList();
         }
-        final byte[] rowKey = getOriginalKey(result.getRow());
+        final byte[] rowKey = result.getRow();
 
         final MetaDataRowKey key = decoder.decodeRowKey(rowKey);
 
@@ -108,11 +101,6 @@ public class ApiMetaDataMapper implements RowMapper<List<ApiMetaDataBo>> {
             return CellUtil.cloneQualifier(cell);
         }
     }
-
-    private byte[] getOriginalKey(byte[] rowKey) {
-        return rowKeyDistributorByHashPrefix.getOriginalKey(rowKey);
-    }
-
 
 }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/SqlMetaDataMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/SqlMetaDataMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,14 +19,12 @@ package com.navercorp.pinpoint.web.mapper;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.util.CellUtils;
-import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.SqlMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -43,15 +41,10 @@ public class SqlMetaDataMapper implements RowMapper<List<SqlMetaDataBo>> {
 
     private final static byte[] SQL_METADATA_CQ = HbaseTables.SQL_METADATA_VER2_SQL.QUALIFIER_SQLSTATEMENT;
 
-    private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
-
     private final RowKeyDecoder<MetaDataRowKey> decoder;
 
-    public SqlMetaDataMapper(RowKeyDecoder<MetaDataRowKey> decoder,
-                             @Qualifier("metadataRowKeyDistributor2")
-                             RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
+    public SqlMetaDataMapper(RowKeyDecoder<MetaDataRowKey> decoder) {
         this.decoder = Objects.requireNonNull(decoder, "decoder");
-        this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
     }
 
     @Override
@@ -59,7 +52,7 @@ public class SqlMetaDataMapper implements RowMapper<List<SqlMetaDataBo>> {
         if (result.isEmpty()) {
             return Collections.emptyList();
         }
-        final byte[] rowKey = getOriginalKey(result.getRow());
+        final byte[] rowKey = result.getRow();
 
         final MetaDataRowKey key = decoder.decodeRowKey(rowKey);
 
@@ -81,10 +74,6 @@ public class SqlMetaDataMapper implements RowMapper<List<SqlMetaDataBo>> {
             // backward compatibility
             return CellUtils.qualifierToString(cell);
         }
-    }
-
-    private byte[] getOriginalKey(byte[] rowKey) {
-        return rowKeyDistributorByHashPrefix.getOriginalKey(rowKey);
     }
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/SqlUidMetaDataMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/SqlUidMetaDataMapper.java
@@ -1,8 +1,23 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.web.mapper;
 
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
-import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.SqlUidMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.uid.UidMetaDataRowKey;
@@ -10,24 +25,19 @@ import com.navercorp.pinpoint.common.server.bo.serializer.metadata.uid.UidMetada
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 @Component
 public class SqlUidMetaDataMapper implements RowMapper<List<SqlUidMetaDataBo>> {
     private final static String SQL_UID_METADATA_CF_SQL_QUALI_SQLSTATEMENT = Bytes.toString(HbaseTables.SQL_UID_METADATA_SQL.QUALIFIER_SQLSTATEMENT);
 
-    private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
-
     private final RowKeyDecoder<UidMetaDataRowKey> decoder = new UidMetadataDecoder();
 
-    public SqlUidMetaDataMapper(@Qualifier("metadataRowKeyDistributor2") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
-        this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
+    public SqlUidMetaDataMapper() {
     }
 
     @Override
@@ -35,7 +45,7 @@ public class SqlUidMetaDataMapper implements RowMapper<List<SqlUidMetaDataBo>> {
         if (result.isEmpty()) {
             return Collections.emptyList();
         }
-        final byte[] rowKey = getOriginalKey(result.getRow());
+        final byte[] rowKey = result.getRow();
 
         final UidMetaDataRowKey key = decoder.decodeRowKey(rowKey);
 
@@ -52,10 +62,6 @@ public class SqlUidMetaDataMapper implements RowMapper<List<SqlUidMetaDataBo>> {
             sqlUidMetaDataList.add(sqlUidMetaDataBo);
         }
         return sqlUidMetaDataList;
-    }
-
-    private byte[] getOriginalKey(byte[] rowKey) {
-        return rowKeyDistributorByHashPrefix.getOriginalKey(rowKey);
     }
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/StringMetaDataMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/StringMetaDataMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,14 +19,12 @@ package com.navercorp.pinpoint.web.mapper;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.util.CellUtils;
-import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.StringMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.MetaDataRowKey;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -43,15 +41,10 @@ public class StringMetaDataMapper implements RowMapper<List<StringMetaDataBo>> {
 
     private final static byte[] STRING_METADATA_CQ = HbaseTables.STRING_METADATA_STR.QUALIFIER_STRING;
 
-    private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
-
     private final RowKeyDecoder<MetaDataRowKey> decoder;
 
-    public StringMetaDataMapper(RowKeyDecoder<MetaDataRowKey> decoder,
-                                @Qualifier("metadataRowKeyDistributor")
-                                RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
+    public StringMetaDataMapper(RowKeyDecoder<MetaDataRowKey> decoder) {
         this.decoder = Objects.requireNonNull(decoder, "decoder");
-        this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
     }
 
     @Override
@@ -59,7 +52,7 @@ public class StringMetaDataMapper implements RowMapper<List<StringMetaDataBo>> {
         if (result.isEmpty()) {
             return Collections.emptyList();
         }
-        final byte[] rowKey = getOriginalKey(result.getRow());
+        final byte[] rowKey = result.getRow();
         final MetaDataRowKey key = decoder.decodeRowKey(rowKey);
 
         List<StringMetaDataBo> stringMetaDataList = new ArrayList<>(result.size());
@@ -83,8 +76,4 @@ public class StringMetaDataMapper implements RowMapper<List<StringMetaDataBo>> {
         }
     }
 
-
-    private byte[] getOriginalKey(byte[] rowKey) {
-        return rowKeyDistributorByHashPrefix.getOriginalKey(rowKey);
-    }
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/mapper/ApiMetaDataMapperTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/mapper/ApiMetaDataMapperTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -76,7 +76,7 @@ public class ApiMetaDataMapperTest {
         when(mockedResult.getRow()).thenReturn(rowKey);
 
         RowKeyDecoder<MetaDataRowKey> decoder = new MetadataDecoder();
-        ApiMetaDataMapper dut = new ApiMetaDataMapper(decoder, givenRowKeyDistributorByHashPrefix);
+        ApiMetaDataMapper dut = new ApiMetaDataMapper(decoder);
         ApiMetaDataBo actual = dut.mapRow(mockedResult, 0).get(0);
 
         assertThat(actual).extracting("agentId", "startTime", "apiId", "apiInfo", "lineNumber", "methodTypeEnum", "location")


### PR DESCRIPTION
This pull request refactors the handling of the `saltKeySize` property across multiple components in the codebase to improve clarity, maintainability, and consistency. It introduces a new `getSaltKeySize()` method in the `RowKeyDistributor` interface and updates all relevant usages to rely on this method instead of accessing the `ByteHasher` directly. Additionally, some minor cleanup and copyright updates are included.

### Refactoring for `saltKeySize` Handling:

* **Centralized `saltKeySize` Access:**
  * Added `getSaltKeySize()` to the `RowKeyDistributor` interface and implemented it in `RowKeyDistributorByHashPrefix` to encapsulate access to the salt key size. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributor.java` - [[1]](diffhunk://#diff-f0d2576a146dbe2f072134865f7b20164beee46b7e93e73a090de80f35561f05R36-R37) `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributorByHashPrefix.java` - [[2]](diffhunk://#diff-bee0ded5124caaaa887c6fa9e86b52a97dc71b7069c3d0191bb1b949019fe4e5R42-R47)

* **Updated Usage in HBase Templates and Scanners:**
  * Replaced direct calls to `getByteHasher().getSaltKey().size()` with `getSaltKeySize()` in `HbaseTemplate`, `HbaseAsyncTemplate`, `ParallelResultScanner`, and `DistributedScanner`. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java` - [[1]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L481-R481) `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java` - [[2]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L380-R380) [[3]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L413-R413) `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ParallelResultScanner.java` - [[4]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL55-R55) `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScanner.java` - [[5]](diffhunk://#diff-2ec5a7b3b330c2b486114a5da93b2b958cfd07f704079dcda1c0f79587ce2585L116-R116)

### Metadata and UID Serialization Updates:

* **Refactored Metadata and UID Decoders:**
  * Introduced constructors in `MetadataDecoder` and `UidMetadataDecoder` to accept `saltKeySize` as a parameter, ensuring consistent handling of offsets during row key decoding. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataDecoder.java` - [[1]](diffhunk://#diff-38db4b6915b66db47ce0d3a5f6e7ef622f0ddf1fa92f2e7588e1d1c7e5a57dd8R1-R56) `commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/uid/UidMetadataDecoder.java` - [[2]](diffhunk://#diff-fb8536fd3dd27b0386377874bebecf1665cbf125e30738eb0cf642e44198268dR1-R21) [[3]](diffhunk://#diff-fb8536fd3dd27b0386377874bebecf1665cbf125e30738eb0cf642e44198268dR30-R58)

* **Updated Metadata and UID Encoders:**
  * Adjusted encoding logic to use `hasher.getSaltKey().size()` instead of hardcoded values. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoder.java` - [[1]](diffhunk://#diff-f22260021d003e110044b1b295299e8cbcf837bf686ddf19b5cc46c431180526L46-R45) `commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/uid/UidMetadataEncoder.java` - [[2]](diffhunk://#diff-8c6718e19bf93965a8ade9ecb62959d760e5d75f2f6f23ee205bf64b64604b3eL46-R45)

### Application Map DAO Improvements:

* **Removed Redundant `RowKeyDistributor` References:**
  * Eliminated unused `RowKeyDistributorByHashPrefix` fields and replaced calls to `getOriginalKey()` with direct row key usage, adjusted for `saltKeySize`. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ApplicationResponseTimeResultExtractor.java` - [[1]](diffhunk://#diff-44e6f5a7305106d10542530e1219b59a27792810aa5687859a836bd5cbe1589cL52-R52) [[2]](diffhunk://#diff-44e6f5a7305106d10542530e1219b59a27792810aa5687859a836bd5cbe1589cL81-R85) [[3]](diffhunk://#diff-44e6f5a7305106d10542530e1219b59a27792810aa5687859a836bd5cbe1589cL127-L129) `web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/InLinkMapper.java` - [[4]](diffhunk://#diff-2cee6c45d13ce39c5d88354b7633fb58ff3e25d551604e6dc042d90d7b7623aeL59-R61) [[5]](diffhunk://#diff-2cee6c45d13ce39c5d88354b7633fb58ff3e25d551604e6dc042d90d7b7623aeL87-R89)

### Minor Updates:

* **Test Updates:**
  * Adjusted test cases in `MetadataEncoderTest` to align with the updated encoder logic. (`commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoderTest.java` - [commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/metadata/MetadataEncoderTest.javaL33-R32](diffhunk://#diff-e170a540dd31ae23bbd11aeed3efc28a3072e1c010424c1614a6a1e601316657L33-R32))

* **Copyright and Licensing:**
  * Updated copyright years in affected files. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/InLinkMapper.java` - [web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/InLinkMapper.javaL2-R2](diffhunk://#diff-2cee6c45d13ce39c5d88354b7633fb58ff3e25d551604e6dc042d90d7b7623aeL2-R2))

This refactor enhances code readability, reduces coupling, and ensures consistent handling of the `saltKeySize` property across the project.