### PR TITLE
[#noissue] Extract HbaseTable interface for adding tables

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTable.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTable.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,38 +16,6 @@
 
 package com.navercorp.pinpoint.common.hbase;
 
-/**
- * @author emeroad
- * @author Taejin Koo
- */
-public enum HbaseTable {
-
-    AGENTINFO("AgentInfo"),
-    AGENT_EVENT("AgentEvent"),
-    AGENT_LIFECYCLE("AgentLifeCycle"),
-    API_METADATA("ApiMetaData"),
-    APPLICATION_INDEX("ApplicationIndex"),
-    APPLICATION_UID("ApplicationUid"),
-    APPLICATION_UID_ATTR("ApplicationUidAttr"),
-    AGENT_ID("AgentId"),
-    APPLICATION_TRACE_INDEX("ApplicationTraceIndex"),
-    HOST_APPLICATION_MAP_VER2("HostApplicationMap_Ver2"),
-    MAP_STATISTICS_CALLEE_VER2("ApplicationMapStatisticsCallee_Ver2"),
-    MAP_STATISTICS_CALLER_VER2("ApplicationMapStatisticsCaller_Ver2"),
-    MAP_STATISTICS_SELF_VER2("ApplicationMapStatisticsSelf_Ver2"),
-    SQL_METADATA_VER2("SqlMetaData_Ver2"),
-    SQL_UID_METADATA("SqlUidMetaData"),
-    STRING_METADATA("StringMetaData"),
-    TRACE_V2("TraceV2");
-
-    private final String name;
-
-    HbaseTable(String name) {
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
-    }
-
+public interface HbaseTable {
+    String getName();
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTableV2.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTableV2.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase;
+
+/**
+ * @author emeroad
+ * @author Taejin Koo
+ */
+public enum HbaseTableV2 implements HbaseTable {
+
+    AGENTINFO("AgentInfo"),
+    AGENT_EVENT("AgentEvent"),
+    AGENT_LIFECYCLE("AgentLifeCycle"),
+    API_METADATA("ApiMetaData"),
+    APPLICATION_INDEX("ApplicationIndex"),
+    APPLICATION_UID("ApplicationUid"),
+    APPLICATION_UID_ATTR("ApplicationUidAttr"),
+    AGENT_ID("AgentId"),
+    APPLICATION_TRACE_INDEX("ApplicationTraceIndex"),
+    HOST_APPLICATION_MAP_VER2("HostApplicationMap_Ver2"),
+    MAP_STATISTICS_CALLEE_VER2("ApplicationMapStatisticsCallee_Ver2"),
+    MAP_STATISTICS_CALLER_VER2("ApplicationMapStatisticsCaller_Ver2"),
+    MAP_STATISTICS_SELF_VER2("ApplicationMapStatisticsSelf_Ver2"),
+    SQL_METADATA_VER2("SqlMetaData_Ver2"),
+    SQL_UID_METADATA("SqlUidMetaData"),
+    STRING_METADATA("StringMetaData"),
+    TRACE_V2("TraceV2");
+
+    private final String name;
+
+    HbaseTableV2(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+}

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTables.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTables.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.hbase;
 
 import org.apache.hadoop.hbase.util.Bytes;
 
 public class HbaseTables {
 
-    public static final AgentInfo AGENTINFO_INFO = new AgentInfo(HbaseTable.AGENTINFO, Bytes.toBytes("Info"));
+    public static final AgentInfo AGENTINFO_INFO = new AgentInfo(HbaseTableV2.AGENTINFO, Bytes.toBytes("Info"));
     public static class AgentInfo extends HbaseColumnFamily {
         public byte[] QUALIFIER_IDENTIFIER = Bytes.toBytes("i");
         public byte[] QUALIFIER_SERVER_META_DATA = Bytes.toBytes("m");
@@ -15,9 +31,9 @@ public class HbaseTables {
         }
     }
 
-    public static final HbaseColumnFamily AGENT_EVENT_EVENTS = new HbaseColumnFamily(HbaseTable.AGENT_EVENT, Bytes.toBytes("E"));
+    public static final HbaseColumnFamily AGENT_EVENT_EVENTS = new HbaseColumnFamily(HbaseTableV2.AGENT_EVENT, Bytes.toBytes("E"));
 
-    public static final AgentLifeCycleStatus AGENT_LIFECYCLE_STATUS = new AgentLifeCycleStatus(HbaseTable.AGENT_LIFECYCLE, Bytes.toBytes("S"));
+    public static final AgentLifeCycleStatus AGENT_LIFECYCLE_STATUS = new AgentLifeCycleStatus(HbaseTableV2.AGENT_LIFECYCLE, Bytes.toBytes("S"));
     public static class AgentLifeCycleStatus extends HbaseColumnFamily {
         public static byte[] QUALIFIER_STATES = Bytes.toBytes("states");
 
@@ -26,7 +42,7 @@ public class HbaseTables {
         }
     }
 
-    public static final ApiMetadata API_METADATA_API = new ApiMetadata(HbaseTable.API_METADATA, Bytes.toBytes("Api"));
+    public static final ApiMetadata API_METADATA_API = new ApiMetadata(HbaseTableV2.API_METADATA, Bytes.toBytes("Api"));
     public static class ApiMetadata extends HbaseColumnFamily {
         public byte[] QUALIFIER_SIGNATURE = Bytes.toBytes("P_api_signature");
 
@@ -35,16 +51,16 @@ public class HbaseTables {
         }
     }
 
-    public static final HbaseColumnFamily APPLICATION_UID = new HbaseColumnFamily(HbaseTable.APPLICATION_UID, Bytes.toBytes("U"));
+    public static final HbaseColumnFamily APPLICATION_UID = new HbaseColumnFamily(HbaseTableV2.APPLICATION_UID, Bytes.toBytes("U"));
 
-    public static final HbaseColumnFamily APPLICATION_UID_ATTR = new HbaseColumnFamily(HbaseTable.APPLICATION_UID_ATTR, Bytes.toBytes("A"));
+    public static final HbaseColumnFamily APPLICATION_UID_ATTR = new HbaseColumnFamily(HbaseTableV2.APPLICATION_UID_ATTR, Bytes.toBytes("A"));
 
-    public static final HbaseColumnFamily AGENT_ID = new HbaseColumnFamily(HbaseTable.AGENT_ID, Bytes.toBytes("A"));
+    public static final HbaseColumnFamily AGENT_ID = new HbaseColumnFamily(HbaseTableV2.AGENT_ID, Bytes.toBytes("A"));
 
-    public static final HbaseColumnFamily APPLICATION_INDEX_AGENTS = new HbaseColumnFamily(HbaseTable.APPLICATION_INDEX, Bytes.toBytes("Agents"));
+    public static final HbaseColumnFamily APPLICATION_INDEX_AGENTS = new HbaseColumnFamily(HbaseTableV2.APPLICATION_INDEX, Bytes.toBytes("Agents"));
 
-    public static final ApplicationTraceIndexTrace APPLICATION_TRACE_INDEX_TRACE = new ApplicationTraceIndexTrace(HbaseTable.APPLICATION_TRACE_INDEX, Bytes.toBytes("I"));
-    public static final ApplicationTraceIndexTrace APPLICATION_TRACE_INDEX_META = new ApplicationTraceIndexTrace(HbaseTable.APPLICATION_TRACE_INDEX, Bytes.toBytes("M"));
+    public static final ApplicationTraceIndexTrace APPLICATION_TRACE_INDEX_TRACE = new ApplicationTraceIndexTrace(HbaseTableV2.APPLICATION_TRACE_INDEX, Bytes.toBytes("I"));
+    public static final ApplicationTraceIndexTrace APPLICATION_TRACE_INDEX_META = new ApplicationTraceIndexTrace(HbaseTableV2.APPLICATION_TRACE_INDEX, Bytes.toBytes("M"));
     public static class ApplicationTraceIndexTrace extends HbaseColumnFamily {
         public static final int ROW_DISTRIBUTE_SIZE = 1; // applicationIndex hash size
 
@@ -53,15 +69,15 @@ public class HbaseTables {
         }
     }
 
-    public static final HbaseColumnFamily HOST_APPLICATION_MAP_VER2_MAP = new HbaseColumnFamily(HbaseTable.HOST_APPLICATION_MAP_VER2, Bytes.toBytes("M"));
+    public static final HbaseColumnFamily HOST_APPLICATION_MAP_VER2_MAP = new HbaseColumnFamily(HbaseTableV2.HOST_APPLICATION_MAP_VER2, Bytes.toBytes("M"));
 
-    public static final HbaseColumnFamily MAP_STATISTICS_CALLEE_VER2_COUNTER = new HbaseColumnFamily(HbaseTable.MAP_STATISTICS_CALLEE_VER2, Bytes.toBytes("C"));
+    public static final HbaseColumnFamily MAP_STATISTICS_CALLEE_VER2_COUNTER = new HbaseColumnFamily(HbaseTableV2.MAP_STATISTICS_CALLEE_VER2, Bytes.toBytes("C"));
 
-    public static final HbaseColumnFamily MAP_STATISTICS_CALLER_VER2_COUNTER = new HbaseColumnFamily(HbaseTable.MAP_STATISTICS_CALLER_VER2, Bytes.toBytes("C"));
+    public static final HbaseColumnFamily MAP_STATISTICS_CALLER_VER2_COUNTER = new HbaseColumnFamily(HbaseTableV2.MAP_STATISTICS_CALLER_VER2, Bytes.toBytes("C"));
 
-    public static final HbaseColumnFamily MAP_STATISTICS_SELF_VER2_COUNTER = new HbaseColumnFamily(HbaseTable.MAP_STATISTICS_SELF_VER2, Bytes.toBytes("C"));
+    public static final HbaseColumnFamily MAP_STATISTICS_SELF_VER2_COUNTER = new HbaseColumnFamily(HbaseTableV2.MAP_STATISTICS_SELF_VER2, Bytes.toBytes("C"));
 
-    public static final SqlMetadataV2 SQL_METADATA_VER2_SQL = new SqlMetadataV2(HbaseTable.SQL_METADATA_VER2, Bytes.toBytes("Sql"));
+    public static final SqlMetadataV2 SQL_METADATA_VER2_SQL = new SqlMetadataV2(HbaseTableV2.SQL_METADATA_VER2, Bytes.toBytes("Sql"));
 
     public static class SqlMetadataV2 extends HbaseColumnFamily {
         public byte[] QUALIFIER_SQLSTATEMENT = Bytes.toBytes("P_sql_statement");
@@ -71,7 +87,7 @@ public class HbaseTables {
         }
     }
 
-    public static final SqlUidMetaData SQL_UID_METADATA_SQL = new SqlUidMetaData(HbaseTable.SQL_UID_METADATA, Bytes.toBytes("Sql"));
+    public static final SqlUidMetaData SQL_UID_METADATA_SQL = new SqlUidMetaData(HbaseTableV2.SQL_UID_METADATA, Bytes.toBytes("Sql"));
 
     public static class SqlUidMetaData extends HbaseColumnFamily {
         public byte[] QUALIFIER_SQLSTATEMENT = Bytes.toBytes("P_sql_statement");
@@ -81,7 +97,7 @@ public class HbaseTables {
         }
     }
 
-    public static final StringMetadataStr STRING_METADATA_STR = new StringMetadataStr(HbaseTable.STRING_METADATA, Bytes.toBytes("Str"));
+    public static final StringMetadataStr STRING_METADATA_STR = new StringMetadataStr(HbaseTableV2.STRING_METADATA, Bytes.toBytes("Str"));
 
     public static class StringMetadataStr extends HbaseColumnFamily {
         public byte[] QUALIFIER_STRING = Bytes.toBytes("P_string");
@@ -91,5 +107,5 @@ public class HbaseTables {
         }
     }
 
-    public static final HbaseColumnFamily TRACE_V2_SPAN = new HbaseColumnFamily(HbaseTable.TRACE_V2, Bytes.toBytes("S"));
+    public static final HbaseColumnFamily TRACE_V2_SPAN = new HbaseColumnFamily(HbaseTableV2.TRACE_V2, Bytes.toBytes("S"));
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/AsyncWarmup.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/AsyncWarmup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,12 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.common.hbase.config;
 
 import com.navercorp.pinpoint.common.hbase.HbaseTable;
+import com.navercorp.pinpoint.common.hbase.HbaseTableV2;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.TableName;
@@ -53,7 +53,7 @@ public class AsyncWarmup implements Consumer<AsyncConnection> {
         String warmup = this.getClass().getSimpleName();
 
         logger.info("{} for hbase AsyncConnection started", warmup);
-        List<HbaseTable> warmUpInclusive = new ArrayList<>(List.of(HbaseTable.values()));
+        List<HbaseTable> warmUpInclusive = new ArrayList<>(List.of(HbaseTableV2.values()));
         if (warmUpExclusive != null) {
             warmUpInclusive.removeAll(warmUpExclusive);
         }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/Warmup.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/Warmup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,12 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.common.hbase.config;
 
 import com.navercorp.pinpoint.common.hbase.HbaseTable;
+import com.navercorp.pinpoint.common.hbase.HbaseTableV2;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.TableName;
@@ -52,7 +52,7 @@ public class Warmup implements Consumer<Connection> {
         String warmup = this.getClass().getSimpleName();
 
         logger.info("{} for hbase Connection started", warmup);
-        List<HbaseTable> warmUpInclusive = new ArrayList<>(List.of(HbaseTable.values()));
+        List<HbaseTable> warmUpInclusive = new ArrayList<>(List.of(HbaseTableV2.values()));
         if (warmUpExclusive != null) {
             warmUpInclusive.removeAll(warmUpExclusive);
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package com.navercorp.pinpoint.web.applicationmap.dao.hbase;
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.hbase.HbaseOperations;
-import com.navercorp.pinpoint.common.hbase.HbaseTable;
 import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
+import com.navercorp.pinpoint.common.hbase.HbaseTableV2;
 import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
@@ -83,7 +83,7 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
         Objects.requireNonNull(fromApplication, "fromApplication");
         final Scan scan = createScan(fromApplication, range);
 
-        TableName hostApplicationMapTableName = tableNameProvider.getTableName(HbaseTable.HOST_APPLICATION_MAP_VER2);
+        TableName hostApplicationMapTableName = tableNameProvider.getTableName(HbaseTableV2.HOST_APPLICATION_MAP_VER2);
         final Set<AcceptApplication> result = hbaseOperations.findParallel(hostApplicationMapTableName, scan, acceptApplicationRowKeyDistributor, hostApplicationResultExtractor, HOST_APPLICATION_MAP_VER2_NUM_PARTITIONS);
         if (CollectionUtils.isNotEmpty(result)) {
             logger.debug("findAcceptApplicationName result:{}", result);


### PR DESCRIPTION
This pull request refactors the HBase table definitions in the codebase by replacing the `HbaseTable` enum with a new `HbaseTableV2` enum that implements a simplified `HbaseTable` interface. All usages of the old enum are updated to use the new version, improving code clarity and future extensibility. The changes also update copyright years and related imports.

Refactoring of HBase table definitions:

* Replaced the `HbaseTable` enum with a new `HbaseTableV2` enum implementing a `HbaseTable` interface, moving all table definitions to `HbaseTableV2` and simplifying the interface to only require a `getName()` method. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTable.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTableV2.java`) [[1]](diffhunk://#diff-41660a1b2960a9af2d43f9230d157f006b20027670371ad7dae49f86ca770e8aL19-R20) [[2]](diffhunk://#diff-26f96e689cce8f99fe3b7a8d4c12d801a8338c0976d1d25a51d8edcfba58a56fR1-R54)
* Updated all references to `HbaseTable` in `HbaseTables`, `AsyncWarmup`, `Warmup`, and `HbaseHostApplicationMapDao` to use `HbaseTableV2` instead, ensuring consistency throughout the codebase. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTables.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/AsyncWarmup.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/Warmup.java`, `web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java`) [[1]](diffhunk://#diff-9e71da4775af75a4b8190cb748536b140ab3068ec3af7d7de2e8e36559adb9d6R1-R23) [[2]](diffhunk://#diff-9e71da4775af75a4b8190cb748536b140ab3068ec3af7d7de2e8e36559adb9d6L18-R36) [[3]](diffhunk://#diff-9e71da4775af75a4b8190cb748536b140ab3068ec3af7d7de2e8e36559adb9d6L29-R45) [[4]](diffhunk://#diff-9e71da4775af75a4b8190cb748536b140ab3068ec3af7d7de2e8e36559adb9d6L38-R63) [[5]](diffhunk://#diff-9e71da4775af75a4b8190cb748536b140ab3068ec3af7d7de2e8e36559adb9d6L56-R80) [[6]](diffhunk://#diff-9e71da4775af75a4b8190cb748536b140ab3068ec3af7d7de2e8e36559adb9d6L74-R90) [[7]](diffhunk://#diff-9e71da4775af75a4b8190cb748536b140ab3068ec3af7d7de2e8e36559adb9d6L84-R100) [[8]](diffhunk://#diff-9e71da4775af75a4b8190cb748536b140ab3068ec3af7d7de2e8e36559adb9d6L94-R110) [[9]](diffhunk://#diff-0f64595e96c211f22e0c5d505a0c58e5347e80a086d43367555654e21f20c272L15-R20) [[10]](diffhunk://#diff-0f64595e96c211f22e0c5d505a0c58e5347e80a086d43367555654e21f20c272L56-R56) [[11]](diffhunk://#diff-dba3cc527c3a71daf2e8e878666c9fc5f2177f36889b35cf5405c165b4ee293cL15-R20) [[12]](diffhunk://#diff-dba3cc527c3a71daf2e8e878666c9fc5f2177f36889b35cf5405c165b4ee293cL55-R55) [[13]](diffhunk://#diff-3bd20ccad9be609f3175836ffce84fb7eaaad6ba8db40dd45064c6cf039421beL22-R23) [[14]](diffhunk://#diff-3bd20ccad9be609f3175836ffce84fb7eaaad6ba8db40dd45064c6cf039421beL86-R86)

General maintenance:

* Updated copyright years to 2025 in all modified files. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTable.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/AsyncWarmup.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/Warmup.java`, `web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java`) [[1]](diffhunk://#diff-41660a1b2960a9af2d43f9230d157f006b20027670371ad7dae49f86ca770e8aL2-R2) [[2]](diffhunk://#diff-0f64595e96c211f22e0c5d505a0c58e5347e80a086d43367555654e21f20c272L2-R2) [[3]](diffhunk://#diff-dba3cc527c3a71daf2e8e878666c9fc5f2177f36889b35cf5405c165b4ee293cL2-R2) [[4]](diffhunk://#diff-3bd20ccad9be609f3175836ffce84fb7eaaad6ba8db40dd45064c6cf039421beL2-R2)