### PR TITLE
[#12877] Rollback hbase-client from 2.5.12-hadoop3 to 2.5.11-hadoop3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <build.frontend.skip>false</build.frontend.skip>
 
         <!-- hbase -->
-        <hbase.shaded.client.version>2.5.12-hadoop3</hbase.shaded.client.version>
+        <hbase.shaded.client.version>2.5.11-hadoop3</hbase.shaded.client.version>
         <!-- for shaded hbase client 1.5.0+ version -->
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <hbase2.client.version>2.5.10-hadoop3</hbase2.client.version>


### PR DESCRIPTION
#12877 