### PR TITLE
[#noissue] Refactor buffer management to use getStartOffset and getEndOffset

### DIFF
--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/AutomaticBuffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/AutomaticBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,8 @@ public class AutomaticBuffer extends FixedBuffer {
         if (remain >= size) {
             return;
         }
-        int length = buffer.length;
+        final int tempEndOffset= getEndOffset();
+        int length = tempEndOffset;
         if (length == 0) {
             length = 1;
         }
@@ -51,7 +52,7 @@ public class AutomaticBuffer extends FixedBuffer {
         final int expandedBufferSize = computeExpandedBufferSize(size, length, remain);
         // allocate buffer
         final byte[] expandedBuffer = new byte[expandedBufferSize];
-        System.arraycopy(buffer, 0, expandedBuffer, 0, buffer.length);
+        System.arraycopy(buffer, 0, expandedBuffer, 0, tempEndOffset);
         buffer = expandedBuffer;
     }
 
@@ -87,13 +88,13 @@ public class AutomaticBuffer extends FixedBuffer {
     @Override
     public void put2PrefixedBytes(final byte[] bytes) {
         if (bytes == null) {
-            checkExpand(BytesUtils.SHORT_BYTE_LENGTH);
+            checkExpand(ByteArrayUtils.SHORT_BYTE_LENGTH);
             super.putShort((short)NULL);
         } else {
             if (bytes.length > Short.MAX_VALUE) {
                 throw new IndexOutOfBoundsException("too large bytes length:" + bytes.length);
             }
-            checkExpand(bytes.length + BytesUtils.SHORT_BYTE_LENGTH);
+            checkExpand(bytes.length + ByteArrayUtils.SHORT_BYTE_LENGTH);
             super.putShort((short)bytes.length);
             super.putBytes(bytes);
         }
@@ -102,10 +103,10 @@ public class AutomaticBuffer extends FixedBuffer {
     @Override
     public void put4PrefixedBytes(final byte[] bytes) {
         if (bytes == null) {
-            checkExpand(BytesUtils.INT_BYTE_LENGTH);
+            checkExpand(ByteArrayUtils.INT_BYTE_LENGTH);
             super.putInt(NULL);
         } else {
-            checkExpand(bytes.length + BytesUtils.INT_BYTE_LENGTH);
+            checkExpand(bytes.length + ByteArrayUtils.INT_BYTE_LENGTH);
             super.putInt(bytes.length);
             super.putBytes(bytes);
         }

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/Buffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/Buffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -196,4 +196,7 @@ public interface Buffer {
 
     boolean hasRemaining();
 
+    int getStartOffset();
+
+    int getEndOffset();
 }

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/OffsetAutomaticBuffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/OffsetAutomaticBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 
 package com.navercorp.pinpoint.common.buffer;
-
-import java.nio.ByteBuffer;
 
 /**
  * @author emeroad
@@ -59,36 +57,14 @@ public class OffsetAutomaticBuffer extends AutomaticBuffer {
         this.endOffset = buffer.length;
     }
 
+
     @Override
-    public byte[] getBuffer() {
-        if (startOffset == 0 && offset == buffer.length) {
-            return this.buffer;
-        } else {
-            return copyBuffer();
-        }
+    public int getStartOffset() {
+        return startOffset;
     }
 
     @Override
-    public byte[] copyBuffer() {
-        final int length = offset - startOffset;
-        final byte[] copy = new byte[length];
-        System.arraycopy(buffer, startOffset, copy, 0, length);
-        return copy;
-    }
-
-    @Override
-    public ByteBuffer wrapByteBuffer() {
-        final int length = offset - startOffset;
-        return ByteBuffer.wrap(this.buffer, startOffset, length);
-    }
-
-    @Override
-    public int remaining() {
-        return endOffset - offset;
-    }
-
-    @Override
-    public boolean hasRemaining() {
-        return offset < endOffset;
+    public int getEndOffset() {
+        return endOffset;
     }
 }

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/OffsetFixedBuffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/OffsetFixedBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 
 package com.navercorp.pinpoint.common.buffer;
-
-import java.nio.ByteBuffer;
 
 /**
  * @author emeroad
@@ -56,35 +54,12 @@ public class OffsetFixedBuffer extends FixedBuffer {
     }
 
     @Override
-    public byte[] getBuffer() {
-        if (startOffset == 0 && offset == buffer.length) {
-            return this.buffer;
-        } else {
-            return copyBuffer();
-        }
+    public int getStartOffset() {
+        return startOffset;
     }
 
     @Override
-    public byte[] copyBuffer() {
-        final int length = offset - startOffset;
-        final byte[] copy = new byte[length];
-        System.arraycopy(buffer, startOffset, copy, 0, length);
-        return copy;
-    }
-
-    @Override
-    public ByteBuffer wrapByteBuffer() {
-        final int length = offset - startOffset;
-        return ByteBuffer.wrap(this.buffer, startOffset, length);
-    }
-
-    @Override
-    public int remaining() {
-        return endOffset - offset;
-    }
-
-    @Override
-    public boolean hasRemaining() {
-        return offset < endOffset;
+    public int getEndOffset() {
+        return endOffset;
     }
 }

--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/FixedBufferTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/FixedBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -306,7 +306,7 @@ public class FixedBufferTest {
 
         Buffer buffer = new FixedBuffer(result);
         String prefixedString = buffer.read4PrefixedString();
-        Assertions.assertEquals(prefixedString, value);
+        Assertions.assertEquals(value, prefixedString);
 
     }
 
@@ -559,7 +559,7 @@ public class FixedBufferTest {
     public void testGetBuffer() {
         Buffer buffer = new FixedBuffer(4);
         buffer.putInt(1);
-        Assertions.assertEquals(buffer.getOffset(), 4);
+        Assertions.assertEquals(4, buffer.getOffset());
         assertThat(buffer.getBuffer()).hasSize(4);
     }
 
@@ -570,15 +570,15 @@ public class FixedBufferTest {
         buffer.putInt(2);
 
         final ByteBuffer byteBuffer = buffer.wrapByteBuffer();
-        Assertions.assertEquals(byteBuffer.getInt(), 1);
-        Assertions.assertEquals(byteBuffer.getInt(), 2);
+        Assertions.assertEquals(1, byteBuffer.getInt());
+        Assertions.assertEquals(2, byteBuffer.getInt());
     }
 
     @Test
     public void testSliceGetBuffer() {
         Buffer buffer = new FixedBuffer(5);
         buffer.putInt(1);
-        Assertions.assertEquals(buffer.getOffset(), 4);
+        Assertions.assertEquals(4, buffer.getOffset());
         assertThat(buffer.getBuffer()).hasSize(4);
 
         byte[] buffer1 = buffer.getBuffer();
@@ -634,10 +634,10 @@ public class FixedBufferTest {
     @Test
     public void testGetOffset() {
         Buffer buffer = new FixedBuffer();
-        Assertions.assertEquals(buffer.getOffset(), 0);
+        Assertions.assertEquals(0, buffer.getOffset());
 
         buffer.putInt(4);
-        Assertions.assertEquals(buffer.getOffset(), 4);
+        Assertions.assertEquals(4, buffer.getOffset());
 
     }
 
@@ -646,22 +646,36 @@ public class FixedBufferTest {
     public void test_remaining() {
         final byte[] bytes = new byte[BytesUtils.INT_BYTE_LENGTH];
         Buffer buffer = new FixedBuffer(bytes);
-        Assertions.assertEquals(buffer.remaining(), 4);
+        Assertions.assertEquals(4, buffer.remaining());
         Assertions.assertTrue(buffer.hasRemaining());
 
         buffer.putInt(1234);
-        Assertions.assertEquals(buffer.remaining(), 0);
+        Assertions.assertEquals(0, buffer.remaining());
         Assertions.assertFalse(buffer.hasRemaining());
 
         buffer.setOffset(0);
         buffer.putShort((short) 12);
-        Assertions.assertEquals(buffer.remaining(), 2);
+        Assertions.assertEquals(2, buffer.remaining());
         Assertions.assertTrue(buffer.hasRemaining());
 
         buffer.putByte((byte) 1);
-        Assertions.assertEquals(buffer.remaining(), 1);
+        Assertions.assertEquals(1, buffer.remaining());
         Assertions.assertTrue(buffer.hasRemaining());
     }
 
 
+    @Test
+    void testBufferLength() {
+        final byte[] bytes = new byte[BytesUtils.INT_BYTE_LENGTH];
+        FixedBuffer buffer = new FixedBuffer(bytes);
+
+        Assertions.assertEquals(0, buffer.getBufferLength());
+
+        buffer.putByte((byte) 1);
+        Assertions.assertEquals(1, buffer.getBufferLength());
+
+        buffer.putByte((byte) 1);
+        Assertions.assertEquals(2, buffer.getBufferLength());
+
+    }
 }

--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/OffsetFixedBufferTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/OffsetFixedBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.common.buffer;
 
+import com.navercorp.pinpoint.common.util.BytesUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -95,4 +96,19 @@ public class OffsetFixedBufferTest {
         Assertions.assertEquals(2, byteBuffer.getInt());
     }
 
+
+    @Test
+    void testBufferLength() {
+        final byte[] bytes = new byte[BytesUtils.INT_BYTE_LENGTH + 1];
+        OffsetFixedBuffer buffer = new OffsetFixedBuffer(bytes, 1, bytes.length - 1);
+
+        Assertions.assertEquals(0, buffer.getBufferLength());
+
+        buffer.putByte((byte) 1);
+        Assertions.assertEquals(1, buffer.getBufferLength());
+
+        buffer.putByte((byte) 1);
+        Assertions.assertEquals(2, buffer.getBufferLength());
+
+    }
 }


### PR DESCRIPTION
This pull request refactors the buffer classes to improve offset handling and consistency across the API, while also updating copyright years. The main changes introduce `getStartOffset()` and `getEndOffset()` methods to the `Buffer` interface and update buffer implementations to use these methods for more robust offset management. Additionally, some redundant or duplicated buffer methods are removed from offset-based buffer classes.

### Buffer API Improvements

* Added `getStartOffset()` and `getEndOffset()` methods to the `Buffer` interface, enabling more flexible and accurate offset management across buffer types. (`commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/Buffer.java`)
* Updated `FixedBuffer`, `AutomaticBuffer`, `OffsetFixedBuffer`, and `OffsetAutomaticBuffer` to implement and use the new offset methods, replacing direct references to `buffer.length` and related logic. (`commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java`, `commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/AutomaticBuffer.java`, `commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/OffsetFixedBuffer.java`, `commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/OffsetAutomaticBuffer.java`) [[1]](diffhunk://#diff-c68e4c03b1efae379ff159cf8edd9f394ff6f4f67c2325fb75c04c048bd6dfcfL274-R273) [[2]](diffhunk://#diff-c68e4c03b1efae379ff159cf8edd9f394ff6f4f67c2325fb75c04c048bd6dfcfL347-R346) [[3]](diffhunk://#diff-c68e4c03b1efae379ff159cf8edd9f394ff6f4f67c2325fb75c04c048bd6dfcfL370-R369) [[4]](diffhunk://#diff-032e842c580ecfdf240cbf33c89e64dcdcb95a15be678fee2ef1421ac33392ceL45-R45) [[5]](diffhunk://#diff-032e842c580ecfdf240cbf33c89e64dcdcb95a15be678fee2ef1421ac33392ceL54-R54) [[6]](diffhunk://#diff-fedafa1901447c92e48189578cbfd2563e8ae5b1f8466078ab3fe460cdc4ce7aL62-R68) [[7]](diffhunk://#diff-8fdbdac652eb2e0f037bc775e9d81fa49bbf18dd629e19eb0b5e50ebff4b99abL59-R63)

### Code Simplification & Consistency

* Removed redundant buffer copying and wrapping methods from `OffsetFixedBuffer` and `OffsetAutomaticBuffer`, centralizing this logic in the base classes and relying on the new offset API. (`commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/OffsetFixedBuffer.java`, `commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/OffsetAutomaticBuffer.java`) [[1]](diffhunk://#diff-fedafa1901447c92e48189578cbfd2563e8ae5b1f8466078ab3fe460cdc4ce7aL62-R68) [[2]](diffhunk://#diff-8fdbdac652eb2e0f037bc775e9d81fa49bbf18dd629e19eb0b5e50ebff4b99abL59-R63)
* Updated usages of byte length constants to use `ByteArrayUtils` for consistency, replacing previous references to `BytesUtils`. (`commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/AutomaticBuffer.java`, `commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java`) [[1]](diffhunk://#diff-032e842c580ecfdf240cbf33c89e64dcdcb95a15be678fee2ef1421ac33392ceL90-R96) [[2]](diffhunk://#diff-032e842c580ecfdf240cbf33c89e64dcdcb95a15be678fee2ef1421ac33392ceL105-R108) [[3]](diffhunk://#diff-c68e4c03b1efae379ff159cf8edd9f394ff6f4f67c2325fb75c04c048bd6dfcfL336-R335) [[4]](diffhunk://#diff-c68e4c03b1efae379ff159cf8edd9f394ff6f4f67c2325fb75c04c048bd6dfcfL347-R346)

### Minor Fixes & Updates

* Updated copyright years from 2019 to 2025 in all affected buffer source files. [[1]](diffhunk://#diff-032e842c580ecfdf240cbf33c89e64dcdcb95a15be678fee2ef1421ac33392ceL2-R2) [[2]](diffhunk://#diff-c8a5a7b8d2daa17abb6af7699d7f9ed11ca64433e7af1294345a210dd6d2bf8bL2-R2) [[3]](diffhunk://#diff-c68e4c03b1efae379ff159cf8edd9f394ff6f4f67c2325fb75c04c048bd6dfcfL2-R2) [[4]](diffhunk://#diff-fedafa1901447c92e48189578cbfd2563e8ae5b1f8466078ab3fe460cdc4ce7aL2-R2) [[5]](diffhunk://#diff-8fdbdac652eb2e0f037bc775e9d81fa49bbf18dd629e19eb0b5e50ebff4b99abL2-R2)
* Removed unnecessary imports and exception handling for string conversion in `FixedBuffer`. (`commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java`, [[1]](diffhunk://#diff-fedafa1901447c92e48189578cbfd2563e8ae5b1f8466078ab3fe460cdc4ce7aL19-L20) [[2]](diffhunk://#diff-8fdbdac652eb2e0f037bc775e9d81fa49bbf18dd629e19eb0b5e50ebff4b99abL19-L20) [[3]](diffhunk://#diff-c68e4c03b1efae379ff159cf8edd9f394ff6f4f67c2325fb75c04c048bd6dfcfL541-L546)

These changes make buffer management more robust, maintainable, and consistent throughout the codebase.