### PR TITLE
[#12895] Prefer String.getBytes(Charset) over String.getBytes(String)

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -487,14 +487,7 @@ public final class BytesUtils {
     }
 
     public static byte[] toBytes(final String value) {
-        if (value == null) {
-            return null;
-        }
-        try {
-            return value.getBytes(UTF8);
-        } catch (UnsupportedEncodingException e) {
-            return value.getBytes(UTF8_CHARSET);
-        }
+        return value == null ? null : value.getBytes(UTF8_CHARSET);
     }
 
     public static byte[] toFixedLengthBytes(final String str, final int length) {


### PR DESCRIPTION
This pull request simplifies the implementation of the `toBytes` method in the `BytesUtils` utility class. The change removes unnecessary exception handling and streamlines the conversion of a `String` to a UTF-8 encoded byte array.

Code simplification:

* Refactored the `toBytes` method in `BytesUtils.java` to directly use `UTF8_CHARSET` for encoding, removing the try-catch block and fallback logic.