### PR TITLE
[#noissue] Add UnsignedBytePrefix API to Buffer

### DIFF
--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/AutomaticBuffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/AutomaticBuffer.java
@@ -86,6 +86,21 @@ public class AutomaticBuffer extends FixedBuffer {
     }
 
     @Override
+    public void putUnsignedBytePrefixedBytes(byte[] bytes) {
+        if (bytes == null) {
+            checkExpand(1);
+            super.putByte(BYTE_NULL);
+        } else {
+            if (bytes.length > Buffer.UNSIGNED_BYTE_MAX) {
+                throw new IndexOutOfBoundsException("too large bytes length:" + bytes.length);
+            }
+            checkExpand(bytes.length + 1);
+            super.putByte(ByteArrayUtils.toUnsignedByte(bytes.length));
+            super.putBytes(bytes);
+        }
+    }
+
+    @Override
     public void put2PrefixedBytes(final byte[] bytes) {
         if (bytes == null) {
             checkExpand(ByteArrayUtils.SHORT_BYTE_LENGTH);
@@ -123,6 +138,12 @@ public class AutomaticBuffer extends FixedBuffer {
     public void putPrefixedString(final String string) {
         byte[] bytes = BytesUtils.toBytes(string);
         this.putPrefixedBytes(bytes);
+    }
+
+    @Override
+    public void putUnsignedBytePrefixedString(String string) {
+        byte[] bytes = BytesUtils.toBytes(string);
+        this.putUnsignedBytePrefixedBytes(bytes);
     }
 
     @Override

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/Buffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/Buffer.java
@@ -27,6 +27,10 @@ public interface Buffer {
 
     int NULL = -1;
 
+    byte BYTE_NULL = NULL;
+    int UNSIGNED_BYTE_NULL = 255;
+    int UNSIGNED_BYTE_MAX = 254;
+
     int BOOLEAN_FALSE = 0;
     int BOOLEAN_TRUE = 1;
 
@@ -40,6 +44,11 @@ public interface Buffer {
 
     void putPrefixedBytes(byte[] bytes);
 
+    /**
+     * max 254 byte range
+     */
+    void putUnsignedBytePrefixedBytes(byte[] bytes);
+
     void put2PrefixedBytes(byte[] bytes);
 
     void put4PrefixedBytes(byte[] bytes);
@@ -47,6 +56,8 @@ public interface Buffer {
     void putPadString(String string, int totalLength);
 
     void putPrefixedString(String string);
+
+    void putUnsignedBytePrefixedString(String string);
 
     void put2PrefixedString(String string);
 
@@ -168,11 +179,15 @@ public interface Buffer {
 
     byte[] readPrefixedBytes();
 
+    byte[] readUnsignedBytePrefixedBytes();
+
     byte[] read2PrefixedBytes();
 
     byte[] read4PrefixedBytes();
 
     String readPrefixedString();
+
+    String readUnsignedBytePrefixedString();
 
     String read2PrefixedString();
 

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtils.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtils.java
@@ -114,4 +114,18 @@ public final class ByteArrayUtils {
         }
         return Arrays.compare(bytes1, offset, bytes1.length, bytes2, offset, bytes2.length);
     }
+
+
+    public static final int UNSIGNED_BYTE_MIN_VALUE = 0;
+    public static final int UNSIGNED_BYTE_MAX_VALUE = 255;
+
+    /**
+     * Range : 0 ~ 255
+     */
+    public static byte toUnsignedByte(int value) {
+        if (value < UNSIGNED_BYTE_MIN_VALUE || value > UNSIGNED_BYTE_MAX_VALUE) {
+            throw new IllegalArgumentException("UnsignedByte Out of Range (0~255)");
+        }
+        return (byte) (value & 0xff);
+    }
 }

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java
@@ -115,6 +115,56 @@ public class FixedBuffer implements Buffer {
     }
 
     @Override
+    public void putUnsignedBytePrefixedString(final String string) {
+        final byte[] bytes = BytesUtils.toBytes(string);
+        if (bytes == null) {
+            putByte(BYTE_NULL);
+            return;
+        }
+        if (bytes.length > UNSIGNED_BYTE_MAX) {
+            throw new IndexOutOfBoundsException("too large String size:" + bytes.length);
+        }
+        putUnsignedBytePrefixedBytes(bytes);
+    }
+
+    @Override
+    public void putUnsignedBytePrefixedBytes(final byte[] bytes) {
+        if (bytes == null) {
+            putByte(BYTE_NULL);
+        } else {
+            if (bytes.length > UNSIGNED_BYTE_MAX) {
+                throw new IndexOutOfBoundsException("too large bytes length:" + bytes.length);
+            }
+            putByte(ByteArrayUtils.toUnsignedByte(bytes.length));
+            putBytes(bytes);
+        }
+    }
+
+    @Override
+    public String readUnsignedBytePrefixedString() {
+        final int size = readUnsignedByte();
+        if (size == UNSIGNED_BYTE_NULL) {
+            return null;
+        }
+        if (size == 0) {
+            return "";
+        }
+        return readString(size);
+    }
+
+    @Override
+    public byte[] readUnsignedBytePrefixedBytes() {
+        final int size = readUnsignedByte();
+        if (size == UNSIGNED_BYTE_NULL) {
+            return null;
+        }
+        if (size == 0) {
+            return EMPTY;
+        }
+        return readBytes(size);
+    }
+
+    @Override
     public void put2PrefixedString(final String string) {
         final byte[] bytes = BytesUtils.toBytes(string);
         if (bytes == null) {

--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/AutomaticBufferTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/AutomaticBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,6 +133,25 @@ public class AutomaticBufferTest {
     }
 
     @Test
+    public void testPutUnsignedBytePrefixedBytes() {
+        byte[] bytes1 = new byte[2];
+        checkPutUnsignedBytePrefixedBytes(bytes1);
+
+        byte[] bytes2 = new byte[0];
+        checkPutUnsignedBytePrefixedBytes(bytes2);
+
+        byte[] bytes3 = new byte[Buffer.UNSIGNED_BYTE_MAX];
+        checkPutUnsignedBytePrefixedBytes(bytes3);
+
+        checkPutUnsignedBytePrefixedBytes(null);
+
+        Assertions.assertThrowsExactly(IndexOutOfBoundsException.class, () -> {
+            byte[] bytes4 = new byte[Buffer.UNSIGNED_BYTE_NULL];
+            checkPutUnsignedBytePrefixedBytes(bytes4);
+        });
+    }
+
+    @Test
     public void testPut2PrefixedBytes() {
         byte[] bytes1 = new byte[2];
         checkPut2PrefixedBytes(bytes1);
@@ -149,6 +168,14 @@ public class AutomaticBufferTest {
             byte[] bytes4 = new byte[Short.MAX_VALUE + 1];
             checkPut2PrefixedBytes(bytes4);
         });
+    }
+
+    private void checkPutUnsignedBytePrefixedBytes(byte[] bytes) {
+        Buffer buffer = new AutomaticBuffer(0);
+        buffer.putUnsignedBytePrefixedBytes(bytes);
+
+        Buffer copy = new FixedBuffer(buffer.getBuffer());
+        assertThat(bytes).isEqualTo(copy.readUnsignedBytePrefixedBytes());
     }
 
     private void checkPut2PrefixedBytes(byte[] bytes) {

--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/FixedBufferTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/FixedBufferTest.java
@@ -191,6 +191,80 @@ public class FixedBufferTest {
     }
 
     @Test
+    public void testPutUnsignedBytePrefixedBytes() {
+        String repeat = "1".repeat(254);
+        byte[] bytes = repeat.getBytes(UTF8_CHARSET);
+
+        FixedBuffer buffer = new FixedBuffer(255);
+        buffer.putUnsignedBytePrefixedBytes(bytes);
+        buffer.setOffset(0);
+
+        Assertions.assertArrayEquals(bytes, buffer.readUnsignedBytePrefixedBytes());
+
+        buffer.setOffset(0);
+        byte[] abc = "abc".getBytes(StandardCharsets.UTF_8);
+        buffer.putUnsignedBytePrefixedBytes(abc);
+        buffer.setOffset(0);
+        Assertions.assertArrayEquals(abc, buffer.readUnsignedBytePrefixedBytes());
+    }
+
+    @Test
+    public void testPutUnsignedBytePrefixedBytes_overflow() {
+        String repeat = "1".repeat(255);
+
+        FixedBuffer buffer = new FixedBuffer(256);
+        Assertions.assertThrowsExactly(IndexOutOfBoundsException.class, () -> {
+            buffer.putUnsignedBytePrefixedBytes(repeat.getBytes(UTF8_CHARSET));
+        });
+    }
+
+    @Test
+    public void testPutUnsignedBytePrefixedBytes_null() {
+        FixedBuffer buffer = new FixedBuffer(8);
+        buffer.putUnsignedBytePrefixedBytes(null);
+        buffer.setOffset(0);
+
+        Assertions.assertNull(buffer.readUnsignedBytePrefixedBytes());
+    }
+
+
+    @Test
+    public void testPutUnsignedBytePrefixedString() {
+        String repeat = "1".repeat(254);
+
+        FixedBuffer buffer = new FixedBuffer(255);
+        buffer.putUnsignedBytePrefixedString(repeat);
+        buffer.setOffset(0);
+
+        Assertions.assertEquals(repeat, buffer.readUnsignedBytePrefixedString());
+
+        buffer.setOffset(0);
+        String abc = "abc";
+        buffer.putUnsignedBytePrefixedString(abc);
+        buffer.setOffset(0);
+        Assertions.assertEquals(abc, buffer.readUnsignedBytePrefixedString());
+    }
+
+    @Test
+    public void testPutUnsignedBytePrefixedString_overflow() {
+        String repeat = "1".repeat(255);
+
+        FixedBuffer buffer = new FixedBuffer(256);
+        Assertions.assertThrowsExactly(IndexOutOfBoundsException.class, () -> {
+            buffer.putUnsignedBytePrefixedString(repeat);
+        });
+    }
+
+    @Test
+    public void testPutUnsignedBytePrefixedString_null() {
+        FixedBuffer buffer = new FixedBuffer(8);
+        buffer.putUnsignedBytePrefixedString(null);
+        buffer.setOffset(0);
+
+        Assertions.assertNull(buffer.readUnsignedBytePrefixedString());
+    }
+
+    @Test
     public void testPut2PrefixedBytes() {
         String test = "test";
         int endExpected = 3333;
@@ -460,9 +534,7 @@ public class FixedBufferTest {
     public void readVInt_errorCase() {
         byte[] errorCode = new byte[]{-118, -41, -17, -117, -81, -115, -64, -64, -108, -88};
         Buffer buffer = new FixedBuffer(errorCode);
-        Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> {
-            buffer.readVInt();
-        });
+        Assertions.assertThrowsExactly(IllegalArgumentException.class, buffer::readVInt);
 
         Assertions.assertEquals(0, buffer.getOffset());
     }
@@ -471,9 +543,7 @@ public class FixedBufferTest {
     public void readVLong_errorCase() {
         byte[] errorCode = new byte[]{-25, -45, -47, -14, -16, -104, -53, -48, -72, -9};
         Buffer buffer = new FixedBuffer(errorCode);
-        Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> {
-            buffer.readVLong();
-        });
+        Assertions.assertThrowsExactly(IllegalArgumentException.class, buffer::readVLong);
 
         Assertions.assertEquals(0, buffer.getOffset());
     }


### PR DESCRIPTION
This pull request adds support for storing and reading byte arrays and strings with unsigned byte length prefixes (max 254 bytes) in the buffer classes. It introduces new methods and constants for handling this format, updates both `AutomaticBuffer` and `FixedBuffer` implementations, and adds comprehensive tests to ensure correct behavior and error handling.

### Buffer API enhancements

* Added new constants (`BYTE_NULL`, `UNSIGNED_BYTE_NULL`, `UNSIGNED_BYTE_MAX`) and methods to the `Buffer` interface for handling unsigned byte-prefixed arrays and strings, including `putUnsignedBytePrefixedBytes`, `putUnsignedBytePrefixedString`, and corresponding read methods. [[1]](diffhunk://#diff-c8a5a7b8d2daa17abb6af7699d7f9ed11ca64433e7af1294345a210dd6d2bf8bR30-R33) [[2]](diffhunk://#diff-c8a5a7b8d2daa17abb6af7699d7f9ed11ca64433e7af1294345a210dd6d2bf8bR47-R51) [[3]](diffhunk://#diff-c8a5a7b8d2daa17abb6af7699d7f9ed11ca64433e7af1294345a210dd6d2bf8bR60-R61) [[4]](diffhunk://#diff-c8a5a7b8d2daa17abb6af7699d7f9ed11ca64433e7af1294345a210dd6d2bf8bR182-R191)

### Implementation in buffer classes

* Implemented the new unsigned byte-prefixed methods in both `AutomaticBuffer` and `FixedBuffer`, including range checks and null handling for byte arrays and strings. [[1]](diffhunk://#diff-032e842c580ecfdf240cbf33c89e64dcdcb95a15be678fee2ef1421ac33392ceR88-R102) [[2]](diffhunk://#diff-032e842c580ecfdf240cbf33c89e64dcdcb95a15be678fee2ef1421ac33392ceR143-R148) [[3]](diffhunk://#diff-c68e4c03b1efae379ff159cf8edd9f394ff6f4f67c2325fb75c04c048bd6dfcfR117-R166)

### Utilities

* Added `toUnsignedByte(int value)` method to `ByteArrayUtils` for safely converting integers to unsigned bytes, with range validation.

### Testing

* Added new tests in `AutomaticBufferTest` and `FixedBufferTest` to verify correct writing and reading of unsigned byte-prefixed arrays and strings, including edge cases for null and overflow scenarios. [[1]](diffhunk://#diff-2a4f11da9e7c26866f4f84bfc082f9eb2f9b4d750b44e8d6fab2a66d2ecd76fcR135-R153) [[2]](diffhunk://#diff-2a4f11da9e7c26866f4f84bfc082f9eb2f9b4d750b44e8d6fab2a66d2ecd76fcR173-R180) [[3]](diffhunk://#diff-2bc92f5321737e8677030b4c401a2e8d12aa98473ee238f684ebf534454e4643R193-R266)

### Minor improvements

* Simplified test code by using method references in exception assertions for better readability. [[1]](diffhunk://#diff-2bc92f5321737e8677030b4c401a2e8d12aa98473ee238f684ebf534454e4643L463-R537) [[2]](diffhunk://#diff-2bc92f5321737e8677030b4c401a2e8d12aa98473ee238f684ebf534454e4643L474-R546)