### PR TITLE
[#noissue] Disable otlp.metrics.export for basic collector

### DIFF
--- a/collector/src/main/resources/application.yml
+++ b/collector/src/main/resources/application.yml
@@ -5,6 +5,12 @@ spring:
 server:
   port: 8081
 
+management:
+  otlp:
+    metrics:
+      export:
+        enabled: false
+
 pinpoint:
   modules:
     collector:


### PR DESCRIPTION
Disable otlp metrics export since there is no otlp metrics receiver endpoint in basic collector.
It is present in metric collector within collector-starter module, so it is not needed in collector module but it is currently enabled somehow and producing warning logs.