### PR TITLE
[#noissue] Remove duplicate mapLinkRowKeyDistributor

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/config/BulkConfiguration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/config/BulkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -76,7 +76,7 @@ public class BulkConfiguration {
     public BulkWriter outLinkBulkWriter(BulkFactory factory,
                                         HbaseAsyncTemplate asyncTemplate,
                                         TableNameProvider tableNameProvider,
-                                        @Qualifier("mapOutLinkRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix,
+                                        @Qualifier("mapLinkRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix,
                                         @Qualifier("outLinkBulkIncrementer") BulkIncrementer bulkIncrementer,
                                         @Qualifier("outLinkBulkUpdater") BulkUpdater bulkUpdater) {
         String loggerName = newBulkWriterName(HbaseMapOutLinkDao.class.getName());
@@ -104,7 +104,7 @@ public class BulkConfiguration {
     public BulkWriter inLinkBulkWriter(BulkFactory factory,
                                        HbaseAsyncTemplate asyncTemplate,
                                        TableNameProvider tableNameProvider,
-                                       @Qualifier("mapInLinkRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix,
+                                       @Qualifier("mapLinkRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix,
                                        @Qualifier("inLinkBulkIncrementer") BulkIncrementer bulkIncrementer,
                                        @Qualifier("inLinkBulkUpdater") BulkUpdater bulkUpdater) {
         String loggerName = newBulkWriterName(HbaseMapInLinkDao.class.getName());

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/DistributorConfiguration.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/DistributorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -69,16 +69,11 @@ public class DistributorConfiguration {
     }
 
     @Bean
-    public RowKeyDistributorByHashPrefix mapInLinkRowKeyDistributor() {
+    public RowKeyDistributorByHashPrefix mapLinkRowKeyDistributor() {
         ByteHasher hasher = newRangeOneByteSimpleHash(0, 36, 32);
         return new RowKeyDistributorByHashPrefix(hasher);
     }
 
-    @Bean
-    public RowKeyDistributorByHashPrefix mapOutLinkRowKeyDistributor() {
-        ByteHasher hasher = newRangeOneByteSimpleHash(0, 36, 32);
-        return new RowKeyDistributorByHashPrefix(hasher);
-    }
 
     @Bean
     public RowKeyDistributorByHashPrefix mapSelfRowKeyDistributor() {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapHbaseConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapHbaseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.web.applicationmap.config;
@@ -160,7 +159,7 @@ public class MapHbaseConfiguration {
                                      @Qualifier("mapInLinkMapper")
                                      RowMapperFactory<LinkDataMap> inLinkMapper,
                                      MapScanFactory mapScanFactory,
-                                     @Qualifier("mapInLinkRowKeyDistributor")
+                                     @Qualifier("mapLinkRowKeyDistributor")
                                      RowKeyDistributorByHashPrefix rowKeyDistributor) {
         return new HbaseMapInLinkDao(hbaseTemplate, tableNameProvider, inLinkMapper, mapScanFactory, rowKeyDistributor);
     }
@@ -172,7 +171,7 @@ public class MapHbaseConfiguration {
                                        @Qualifier("mapOutLinkMapper")
                                        RowMapperFactory<LinkDataMap> outLinkMapper,
                                        MapScanFactory mapScanFactory,
-                                       @Qualifier("mapOutLinkRowKeyDistributor")
+                                       @Qualifier("mapLinkRowKeyDistributor")
                                        RowKeyDistributorByHashPrefix rowKeyDistributor) {
         return new HbaseMapOutLinkDao(hbaseTemplate, tableNameProvider, outLinkMapper, mapScanFactory, rowKeyDistributor);
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapMapperConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapMapperConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.web.applicationmap.config;
 
 
@@ -35,7 +51,7 @@ public class MapMapperConfiguration {
 
     @Bean
     public RowMapperFactory<LinkDataMap> mapOutLinkMapper(ApplicationFactory applicationFactory,
-                                                          @Qualifier("mapOutLinkRowKeyDistributor")
+                                                          @Qualifier("mapLinkRowKeyDistributor")
                                                           RowKeyDistributorByHashPrefix rowKeyDistributor) {
         return (windowFunction) -> new OutLinkMapper(applicationFactory, rowKeyDistributor, LinkFilter::skip, windowFunction);
     }
@@ -43,7 +59,7 @@ public class MapMapperConfiguration {
     @Bean
     public RowMapperFactory<LinkDataMap> mapInLinkMapper(ServiceTypeRegistryService registry,
                                                          ApplicationFactory applicationFactory,
-                                                         @Qualifier("mapInLinkRowKeyDistributor")
+                                                         @Qualifier("mapLinkRowKeyDistributor")
                                                          RowKeyDistributorByHashPrefix rowKeyDistributor) {
         return (windowFunction) -> new InLinkMapper(registry, applicationFactory, rowKeyDistributor, LinkFilter::skip, windowFunction);
     }


### PR DESCRIPTION
This pull request refactors the row key distributor beans used for mapping in-link and out-link data in the application map modules. The main change is the consolidation of separate distributors for in-link and out-link data into a single `mapLinkRowKeyDistributor` bean, simplifying configuration and reducing redundancy. Additionally, references to the old distributor beans have been updated across the codebase to use the new unified bean.

**Configuration refactoring:**

* Removed the separate `mapInLinkRowKeyDistributor` and `mapOutLinkRowKeyDistributor` beans, replacing them with a single `mapLinkRowKeyDistributor` bean in `DistributorConfiguration.java`.
* Updated all usages of the in-link and out-link row key distributors in `BulkConfiguration.java`, `MapHbaseConfiguration.java`, and `MapMapperConfiguration.java` to reference the new unified `mapLinkRowKeyDistributor` bean. [[1]](diffhunk://#diff-3902d33ed9b1510e2d92798c4d6951be62be74bb7cb0f798e28e83ad04e34fccL79-R79) [[2]](diffhunk://#diff-3902d33ed9b1510e2d92798c4d6951be62be74bb7cb0f798e28e83ad04e34fccL107-R107) [[3]](diffhunk://#diff-a96a2c5f31c389a4beaa10d2fe7cd39bcca806b0b1b4c33eb87bf4a6ee7cd75eL163-R162) [[4]](diffhunk://#diff-a96a2c5f31c389a4beaa10d2fe7cd39bcca806b0b1b4c33eb87bf4a6ee7cd75eL175-R174) [[5]](diffhunk://#diff-17856bf858d8167b0fe77ba7bd516cc06ed33bd43efb7e57a590453825191591L38-R62)

**Codebase maintenance:**

* Updated copyright years in `MapHbaseConfiguration.java` and added a copyright/license header to `MapMapperConfiguration.java`. [[1]](diffhunk://#diff-a96a2c5f31c389a4beaa10d2fe7cd39bcca806b0b1b4c33eb87bf4a6ee7cd75eL2-R2) [[2]](diffhunk://#diff-17856bf858d8167b0fe77ba7bd516cc06ed33bd43efb7e57a590453825191591R1-R16)
* Removed an unnecessary blank line in the license header of `MapHbaseConfiguration.java`.