### PR TITLE
[#noissue] Refactor LinkRowKey

### DIFF
--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/LinkRowKeyTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/LinkRowKeyTest.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.common.server.applicationmap.statistics;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.FixedBuffer;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
+import com.navercorp.pinpoint.common.trace.ServiceType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -28,15 +29,30 @@ class LinkRowKeyTest {
     public void makeRowKey() {
         String applicationName = "TESTAPP";
         short serviceType = 123;
-        long time = System.currentTimeMillis();
+        long timestamp = System.currentTimeMillis();
 
-        byte[] bytes = LinkRowKey.makeRowKey(ByteSaltKey.NONE.size(), applicationName, serviceType, time);
+        byte[] bytes = LinkRowKey.makeRowKey(ByteSaltKey.NONE.size(), applicationName, serviceType, timestamp);
 
         Buffer buffer = new FixedBuffer(bytes);
         String readApplicationName = buffer.read2PrefixedString();
         short readApplicationType = buffer.readShort();
         Assertions.assertEquals(applicationName, readApplicationName);
         Assertions.assertEquals(serviceType, readApplicationType);
+    }
+
+
+    @Test
+    public void linkRowKey() {
+        String applicationName = "TESTAPP";
+        ServiceType serviceType = ServiceType.TEST;
+        long timestamp = System.currentTimeMillis();
+
+        RowKey linkRowKey = LinkRowKey.of(applicationName, serviceType, timestamp);
+        byte[] rowKey = linkRowKey.getRowKey(0);
+
+        LinkRowKey read = LinkRowKey.read(0, rowKey);
+
+        Assertions.assertEquals(linkRowKey, read);
     }
 
 }


### PR DESCRIPTION
This pull request refactors how row key data is handled for application map statistics by introducing and standardizing the use of the `LinkRowKey` class. The changes improve code readability, encapsulation, and consistency across several modules by replacing manual buffer parsing with dedicated methods in `LinkRowKey`. Additionally, tests have been updated to validate the new approach.

**Core Refactoring: LinkRowKey usage**
- Replaced manual buffer parsing for row key extraction in multiple mapper classes (`ApplicationResponseTimeResultExtractor`, `InLinkMapper`, `OutLinkMapper`, `ResponseTimeMapper`, `ResponseTimeResultExtractor`) with the new `LinkRowKey.read()` method and accessor methods. This centralizes row key logic and reduces duplication. [[1]](diffhunk://#diff-44e6f5a7305106d10542530e1219b59a27792810aa5687859a836bd5cbe1589cL82-R84) [[2]](diffhunk://#diff-2cee6c45d13ce39c5d88354b7633fb58ff3e25d551604e6dc042d90d7b7623aeL85-R87) [[3]](diffhunk://#diff-2db964ebf613d729cee1a9d713c58032b65d8c5000e534da1864df32216ae3e0L79-R80) [[4]](diffhunk://#diff-2df536651fc95e3ed3f32b79e4935ff14b75b3112f2c089fc37c4137033ab22fL69-R69) [[5]](diffhunk://#diff-6abb4557a1b1b26cd038e1960e1598eafc46adc8124e9053a44d9884f11f0f64L91-R92)

**LinkRowKey class improvements**
- Renamed internal fields from `rowTimeSlot` to `timestamp`, added getter methods, and implemented the static `read()` method to parse row keys. Also updated `equals`, `hashCode`, and `toString` for consistency with the new field. [[1]](diffhunk://#diff-b5562c0a264374838bed0140d304d7e083a5e5876e99776f2cf7d83c0885ca21L34-R34) [[2]](diffhunk://#diff-b5562c0a264374838bed0140d304d7e083a5e5876e99776f2cf7d83c0885ca21L44-R64) [[3]](diffhunk://#diff-b5562c0a264374838bed0140d304d7e083a5e5876e99776f2cf7d83c0885ca21L68-R133)

**Mapper method updates**
- Updated methods such as `readInApplication`, `readOutApplication`, and `createResponseTime` to accept and use `LinkRowKey` objects instead of raw buffers, improving type safety and clarity. [[1]](diffhunk://#diff-2cee6c45d13ce39c5d88354b7633fb58ff3e25d551604e6dc042d90d7b7623aeL146-R145) [[2]](diffhunk://#diff-2db964ebf613d729cee1a9d713c58032b65d8c5000e534da1864df32216ae3e0L132-R130) [[3]](diffhunk://#diff-2df536651fc95e3ed3f32b79e4935ff14b75b3112f2c089fc37c4137033ab22fL97-R98) [[4]](diffhunk://#diff-6abb4557a1b1b26cd038e1960e1598eafc46adc8124e9053a44d9884f11f0f64L119-R122)

**Test enhancements**
- Added and updated unit tests in `LinkRowKeyTest` to verify correct serialization and deserialization of `LinkRowKey`, ensuring reliability of the new approach.

**Code cleanup**
- Removed unused imports related to buffer parsing and time utilities in affected files, reflecting the migration to `LinkRowKey`. [[1]](diffhunk://#diff-44e6f5a7305106d10542530e1219b59a27792810aa5687859a836bd5cbe1589cL19-L28) [[2]](diffhunk://#diff-2cee6c45d13ce39c5d88354b7633fb58ff3e25d551604e6dc042d90d7b7623aeL20-L28) [[3]](diffhunk://#diff-2db964ebf613d729cee1a9d713c58032b65d8c5000e534da1864df32216ae3e0L20-L26) [[4]](diffhunk://#diff-2df536651fc95e3ed3f32b79e4935ff14b75b3112f2c089fc37c4137033ab22fL19-L28) [[5]](diffhunk://#diff-6abb4557a1b1b26cd038e1960e1598eafc46adc8124e9053a44d9884f11f0f64L19-L28) [[6]](diffhunk://#diff-7dec8aca2bc86875f5b5a189376f7479555fea407e370e0bae41c8f8e14d4120R22)