### PR TITLE
[#noissue] Refactor BulkWriter

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/name/v1/ObjectNameResolverV1.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/name/v1/ObjectNameResolverV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.profiler.name.v1;
 
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
+import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.profiler.name.Base64Utils;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.profiler.name.AgentIdType;
@@ -43,7 +44,7 @@ public class ObjectNameResolverV1 implements ObjectNameResolver {
 
     private final List<AgentProperties> agentPropertyList;
 
-    private final IdValidator idValidator = new IdValidatorV1();
+    private final IdValidator idValidator = new IdValidatorV1(PinpointConstants.APPLICATION_NAME_MAX_LEN_V3);
 
     public ObjectNameResolverV1(List<AgentProperties> agentPropertyList) {
         this.agentPropertyList = Objects.requireNonNull(agentPropertyList, "agentPropertyList");

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
@@ -103,7 +103,7 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
         // TODO should consider to add bellow codes again later.
         //String parentAgentId = null;
         //final byte[] rowKey = createRowKey(parentApplicationName, parentServiceType, statisticsRowSlot, parentAgentId);
-        final byte[] rowKey = createRowKey(parentApplicationName, parentServiceType, statisticsRowSlot, null);
+        final byte[] rowKey = createRowKey(parentApplicationName, parentServiceType, statisticsRowSlot);
 
         byte[] columnName = createColumnName(host, selfVertex);
 
@@ -123,14 +123,14 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
     }
 
 
-    private byte[] createRowKey(String parentApplicationName, short parentServiceType, long statisticsRowSlot, String parentAgentId) {
-        final byte[] rowKey = createRowKey0(hasher.getSaltKey().size(), parentApplicationName, parentServiceType, statisticsRowSlot, parentAgentId);
+    private byte[] createRowKey(String parentApplicationName, short parentServiceType, long statisticsRowSlot) {
+        final byte[] rowKey = createRowKey0(hasher.getSaltKey().size(), parentApplicationName, parentServiceType, statisticsRowSlot);
         return hasher.writeSaltKey(rowKey);
     }
 
 
     @VisibleForTesting
-    static byte[] createRowKey0(int saltKeySize, String parentApplicationName, short parentServiceType, long statisticsRowSlot, String parentAgentId) {
+    static byte[] createRowKey0(int saltKeySize, String parentApplicationName, short parentServiceType, long statisticsRowSlot) {
 
         // even if  a agentId be added for additional specifications, it may be safe to scan rows.
         // But is it needed to add parentAgentServiceType?

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/config/BulkConfiguration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/config/BulkConfiguration.java
@@ -16,15 +16,7 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.statistics.config;
 
-import com.navercorp.pinpoint.collector.applicationmap.dao.hbase.HbaseMapInLinkDao;
-import com.navercorp.pinpoint.collector.applicationmap.dao.hbase.HbaseMapOutLinkDao;
-import com.navercorp.pinpoint.collector.applicationmap.dao.hbase.HbaseMapResponseTimeDao;
-import com.navercorp.pinpoint.collector.applicationmap.statistics.BulkIncrementer;
-import com.navercorp.pinpoint.collector.applicationmap.statistics.BulkUpdater;
-import com.navercorp.pinpoint.collector.applicationmap.statistics.BulkWriter;
 import com.navercorp.pinpoint.common.hbase.async.HbaseAsyncTemplate;
-import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -48,87 +40,10 @@ public class BulkConfiguration {
 
     @Bean
     public BulkFactory bulkFactory(BulkProperties bulkProperties,
+                                   HbaseAsyncTemplate asyncTemplate,
                                    BulkIncrementerFactory bulkIncrementerFactory,
                                    BulkOperationReporterFactory bulkOperationReporterFactory) {
-        return new BulkFactory(bulkProperties, bulkIncrementerFactory, bulkOperationReporterFactory);
+        return new BulkFactory(bulkProperties.enableBulk(), asyncTemplate, bulkIncrementerFactory, bulkOperationReporterFactory);
     }
 
-    @Bean
-    public BulkIncrementer outLinkBulkIncrementer(BulkFactory factory, BulkProperties bulkProperties) {
-        String reporterName = "outLinkIncrementReporter";
-        int limitSize = bulkProperties.getCallerLimitSize();
-
-        return factory.newBulkIncrementer(reporterName, limitSize);
-    }
-
-    @Bean
-    public BulkUpdater outLinkBulkUpdater(BulkFactory factory) {
-        String reporterName = "outLinkUpdateReporter";
-        return factory.getBulkUpdater(reporterName);
-    }
-
-
-    @Bean
-    public BulkWriter outLinkBulkWriter(BulkFactory factory,
-                                        HbaseAsyncTemplate asyncTemplate,
-                                        @Qualifier("mapLinkRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix,
-                                        @Qualifier("outLinkBulkIncrementer") BulkIncrementer bulkIncrementer,
-                                        @Qualifier("outLinkBulkUpdater") BulkUpdater bulkUpdater) {
-        String loggerName = newBulkWriterName(HbaseMapOutLinkDao.class.getName());
-        return factory.newBulkWriter(loggerName, asyncTemplate, rowKeyDistributorByHashPrefix, bulkIncrementer, bulkUpdater);
-    }
-
-
-    @Bean
-    public BulkIncrementer inLinkBulkIncrementer(BulkFactory factory, BulkProperties bulkProperties) {
-        String reporterName = "inLinkIncrementReporter";
-        int limitSize = bulkProperties.getCalleeLimitSize();
-
-        return factory.newBulkIncrementer(reporterName, limitSize);
-    }
-
-
-    @Bean
-    public BulkUpdater inLinkBulkUpdater(BulkFactory factory) {
-        String reporterName = "inLinkUpdateReporter";
-        return factory.getBulkUpdater(reporterName);
-    }
-
-    @Bean
-    public BulkWriter inLinkBulkWriter(BulkFactory factory,
-                                       HbaseAsyncTemplate asyncTemplate,
-                                       @Qualifier("mapLinkRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix,
-                                       @Qualifier("inLinkBulkIncrementer") BulkIncrementer bulkIncrementer,
-                                       @Qualifier("inLinkBulkUpdater") BulkUpdater bulkUpdater) {
-        String loggerName = newBulkWriterName(HbaseMapInLinkDao.class.getName());
-        return factory.newBulkWriter(loggerName, asyncTemplate, rowKeyDistributorByHashPrefix, bulkIncrementer, bulkUpdater);
-    }
-
-    @Bean
-    public BulkIncrementer selfBulkIncrementer(BulkFactory factory, BulkProperties bulkProperties) {
-        String reporterName = "selfIncrementReporter";
-        int limitSize = bulkProperties.getSelfLimitSize();
-
-        return factory.newBulkIncrementer(reporterName, limitSize);
-    }
-
-    @Bean
-    public BulkUpdater selfBulkUpdater(BulkFactory factory) {
-        String reporterName = "selfUpdateReporter";
-        return factory.getBulkUpdater(reporterName);
-    }
-
-    @Bean
-    public BulkWriter selfBulkWriter(BulkFactory factory,
-                                     HbaseAsyncTemplate asyncTemplate,
-                                     @Qualifier("mapSelfRowKeyDistributor") RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix,
-                                     @Qualifier("selfBulkIncrementer") BulkIncrementer bulkIncrementer,
-                                     @Qualifier("selfBulkUpdater") BulkUpdater bulkUpdater) {
-        String loggerName = newBulkWriterName(HbaseMapResponseTimeDao.class.getName());
-        return factory.newBulkWriter(loggerName, asyncTemplate, rowKeyDistributorByHashPrefix, bulkIncrementer, bulkUpdater);
-    }
-
-    private String newBulkWriterName(String className) {
-        return className + "-writer";
-    }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDaoTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDaoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,7 +43,7 @@ public class HbaseHostApplicationMapDaoTest {
         ServiceType standAlone = ServiceType.STAND_ALONE;
         SaltKey saltKey = ByteSaltKey.SALT;
 
-        byte[] parentApps = HbaseHostApplicationMapDao.createRowKey0(saltKey.size(), parentApp, standAlone.getCode(), statisticsRowSlot, null);
+        byte[] parentApps = HbaseHostApplicationMapDao.createRowKey0(saltKey.size(), parentApp, standAlone.getCode(), statisticsRowSlot);
         logger.debug("rowKey size:{}", parentApps.length);
 
         Buffer readBuffer = new FixedBuffer(parentApps);

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/CheckAndMax.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/CheckAndMax.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.hbase;
 
 
@@ -8,33 +24,11 @@ import org.apache.hadoop.hbase.util.Bytes;
 
 import java.util.Objects;
 
-public final class CheckAndMax {
-    private final byte[] row;
-    private final byte[] family;
-    private final byte[] qualifier;
-    private final long value;
-
-    public CheckAndMax(byte[] row, byte[] family, byte[] qualifier, long value) {
-        this.row = Objects.requireNonNull(row, "row");
-        this.family = Objects.requireNonNull(family, "family");
-        this.qualifier = Objects.requireNonNull(qualifier, "qualifier");
-        this.value = value;
-    }
-
-    public byte[] row() {
-        return row;
-    }
-
-    public byte[] family() {
-        return family;
-    }
-
-    public byte[] qualifier() {
-        return qualifier;
-    }
-
-    public long value() {
-        return value;
+public record CheckAndMax(byte[] row, byte[] family, byte[] qualifier, long value) {
+    public CheckAndMax {
+        Objects.requireNonNull(row, "row");
+        Objects.requireNonNull(family, "family");
+        Objects.requireNonNull(qualifier, "qualifier");
     }
 
     public static CheckAndMutate initialMax(CheckAndMax max) {

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/DistributorConfiguration.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/DistributorConfiguration.java
@@ -16,8 +16,10 @@
 
 package com.navercorp.pinpoint.common.hbase.config;
 
+import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.OneByteSimpleHash;
+import com.navercorp.pinpoint.common.hbase.wd.RangeDoubleHash;
 import com.navercorp.pinpoint.common.hbase.wd.RangeOneByteSimpleHash;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import org.apache.logging.log4j.LogManager;
@@ -83,6 +85,16 @@ public class DistributorConfiguration {
 
     private ByteHasher newRangeOneByteSimpleHash(int start, int end, int maxBuckets) {
         return new RangeOneByteSimpleHash(start, end, maxBuckets);
+    }
+
+    public static final int UID_START_KEY_RANGE = PinpointConstants.APPLICATION_NAME_MAX_LEN_V3 + 8;
+    public static final int SECONDARY_BUCKET_SIZE = 4;
+
+    @Bean
+    public RowKeyDistributorByHashPrefix uidRowKeyDistributor() {
+        ByteHasher hasher = RangeDoubleHash.ofSecondary(0, UID_START_KEY_RANGE, ByteHasher.MAX_BUCKETS,
+                SECONDARY_BUCKET_SIZE, UID_START_KEY_RANGE, UID_START_KEY_RANGE + 8);
+        return new RowKeyDistributorByHashPrefix(hasher);
     }
 
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.java
@@ -80,12 +80,12 @@ public class UidLinkRowKey implements TimestampRowKey {
 
     public static byte[] makeRowKey(int saltKeySize, int serviceUid, String applicationName, int serviceType, long timestamp) {
         final Buffer buffer = new AutomaticBuffer(saltKeySize +
-                                                  PinpointConstants.UID_SERVICE_NAME_LEN +
+                                                  PinpointConstants.APPLICATION_NAME_MAX_LEN_V3 +
                                                   BytesUtils.INT_BYTE_LENGTH +
                                                   BytesUtils.INT_BYTE_LENGTH +
                                                   BytesUtils.LONG_BYTE_LENGTH);
         buffer.setOffset(saltKeySize);
-        buffer.putPadString(applicationName, PinpointConstants.UID_SERVICE_NAME_LEN);
+        buffer.putPadString(applicationName, PinpointConstants.APPLICATION_NAME_MAX_LEN_V3);
         buffer.putInt(serviceType);
         buffer.putInt(serviceUid);
         long reverseTimeMillis = TimeUtils.reverseTimeMillis(timestamp);
@@ -97,8 +97,8 @@ public class UidLinkRowKey implements TimestampRowKey {
 
         int offset = saltKey;
 
-        String applicationName = BytesUtils.toStringAndRightTrim(bytes, offset, PinpointConstants.UID_SERVICE_NAME_LEN);
-        offset += PinpointConstants.UID_SERVICE_NAME_LEN;
+        String applicationName = BytesUtils.toStringAndRightTrim(bytes, offset, PinpointConstants.APPLICATION_NAME_MAX_LEN_V3);
+        offset += PinpointConstants.APPLICATION_NAME_MAX_LEN_V3;
 
         int applicationServiceType = BytesUtils.bytesToInt(bytes, offset);
         offset += BytesUtils.INT_BYTE_LENGTH;

--- a/commons/src/main/java/com/navercorp/pinpoint/common/PinpointConstants.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/PinpointConstants.java
@@ -23,12 +23,11 @@ public final class PinpointConstants {
 
     @Deprecated
     public static final int APPLICATION_NAME_MAX_LEN = 24;
-
     public static final int AGENT_ID_MAX_LEN = 24;
 
     public static final int AGENT_NAME_MAX_LEN = 255;
 
-    public static final int UID_SERVICE_NAME_LEN = 254;
-    public static final int UID_APPLICATION_NAME_LEN = UID_SERVICE_NAME_LEN;
+    public static final int SERVICE_NAME_LEN = 254;
+    public static final int APPLICATION_NAME_MAX_LEN_V3 = SERVICE_NAME_LEN;
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapHbaseConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapHbaseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.web.applicationmap.config;
@@ -48,8 +47,8 @@ import java.util.concurrent.ExecutorService;
 
 @org.springframework.context.annotation.Configuration
 @Import({
-        MapMapperConfiguration.class,
-        MapV3MapperConfiguration.class
+        MapV3MapperConfiguration.class,
+        MapMapperConfiguration.class
 })
 public class MapHbaseConfiguration {
     private static final Logger logger = LogManager.getLogger(MapHbaseConfiguration.class);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapMapperConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapMapperConfiguration.java
@@ -55,6 +55,8 @@ import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.vo.RangeFactory;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -66,6 +68,11 @@ import java.util.Set;
 @Configuration
 @ConditionalOnMissingBean(MapV3MapperConfiguration.class)
 public class MapMapperConfiguration {
+    private static final Logger logger = LogManager.getLogger(MapMapperConfiguration.class);
+
+    public MapMapperConfiguration() {
+        logger.info("Install {}", MapMapperConfiguration.class.getSimpleName());
+    }
 
     @Bean
     public ResultsExtractor<Set<AcceptApplication>> hostApplicationResultExtractor(ApplicationFactory applicationFactory) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/InLinkV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/InLinkV3Mapper.java
@@ -95,13 +95,12 @@ public class InLinkV3Mapper implements RowMapper<LinkDataMap> {
             final Buffer buffer = new OffsetFixedBuffer(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
             int selfServiceType = buffer.readInt();
             String selfApplicationName = buffer.readUnsignedBytePrefixedString();
-            short histogramSlot = buffer.readShort();
-
             final Application self = readSelfApplication(selfApplicationName, selfServiceType, inApplication.getServiceType());
             if (filter.filter(self)) {
                 continue;
             }
 
+            short histogramSlot = buffer.readShort();
             long requestCount = CellUtils.valueToLong(cell);
             String selfHost = readOutHost(buffer);
             // There may be no outHost for virtual queue nodes from user-defined entry points.

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/OutLinkV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/OutLinkV3Mapper.java
@@ -113,7 +113,7 @@ public class OutLinkV3Mapper implements RowMapper<LinkDataMap> {
 
     private Application readInApplication(Buffer buffer) {
         int inServiceType = buffer.readInt();
-        String inApplicationName = buffer.readPrefixedString();
+        String inApplicationName = buffer.readUnsignedBytePrefixedString();
         return applicationFactory.createApplication(inApplicationName, inServiceType);
     }
 


### PR DESCRIPTION
This pull request refactors the bulk writer configuration and builder logic to simplify bean creation and improve maintainability. It introduces a builder pattern for constructing `BulkWriter` instances, removes redundant beans, and updates the `CheckAndMax` class to use Java's `record` feature. Additionally, it aligns key constants in the UID mapping configuration with shared definitions.

Bulk writer configuration and builder improvements:

* Refactored `BulkConfiguration.java` to remove separate beans for `BulkIncrementer` and `BulkUpdater`, replacing them with a builder pattern for constructing `BulkWriter` beans. This reduces boilerplate and centralizes configuration logic.
* Updated `BulkFactory.java` to add a `Builder` inner class, allowing for incremental configuration of `BulkWriter` instances. Also, modified `getBulkUpdater` to accept a `limitSize` parameter for flexibility. [[1]](diffhunk://#diff-8c01d02f2770bb2487314de499060d98c556c2e1d03a6ad81fdae789ae8a3efeR38-R47) [[2]](diffhunk://#diff-8c01d02f2770bb2487314de499060d98c556c2e1d03a6ad81fdae789ae8a3efeL54-L66) [[3]](diffhunk://#diff-8c01d02f2770bb2487314de499060d98c556c2e1d03a6ad81fdae789ae8a3efeR79-R110)

Code modernization:

* Migrated `CheckAndMax` from a traditional class to a Java `record`, simplifying its structure and ensuring immutability. [[1]](diffhunk://#diff-4786ca1b4dd002293c3d091f1a91c38e612a2dcb16845eb7d9a14ac5ec379a90R1-R16) [[2]](diffhunk://#diff-4786ca1b4dd002293c3d091f1a91c38e612a2dcb16845eb7d9a14ac5ec379a90L11-R31)

Configuration alignment:

* Updated `MapV3MapperConfiguration.java` to use `PinpointConstants.UID_SERVICE_NAME_LEN` for the UID key range, ensuring consistency across modules. Added a constant for secondary bucket size. [[1]](diffhunk://#diff-0d2efdc6379bf93868086a58c52681be3816b048375f1f6ec150d95ca4e2afa5R20) [[2]](diffhunk://#diff-0d2efdc6379bf93868086a58c52681be3816b048375f1f6ec150d95ca4e2afa5L74-R80)