### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV2Configuration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV2Configuration.java
@@ -72,7 +72,7 @@ public class MapV2Configuration {
         int limitSize = bulkProperties.getCallerLimitSize();
         String loggerName = newBulkWriterName(HbaseMapOutLinkDao.class.getName());
 
-        BulkFactory.Builder builder = factory.newBuilder(loggerName, rowKeyDistributorByHashPrefix);
+        BulkFactory.Builder builder = factory.newBuilder(loggerName, HbaseTables.MAP_V2_COLUMN_FAMILY_NAME, rowKeyDistributorByHashPrefix);
         builder.setIncrementer("outLinkIncrementReporter", limitSize);
         builder.setMaxUpdater("outLinkUpdateReporter", limitSize);
         return builder.build();
@@ -87,7 +87,7 @@ public class MapV2Configuration {
         int limitSize = bulkProperties.getCalleeLimitSize();
         String loggerName = newBulkWriterName(HbaseMapInLinkDao.class.getName());
 
-        BulkFactory.Builder builder = factory.newBuilder(loggerName, rowKeyDistributorByHashPrefix);
+        BulkFactory.Builder builder = factory.newBuilder(loggerName, HbaseTables.MAP_V2_COLUMN_FAMILY_NAME, rowKeyDistributorByHashPrefix);
         builder.setIncrementer("inLinkIncrementReporter", limitSize);
         builder.setMaxUpdater("inLinkUpdateReporter", limitSize);
         return builder.build();
@@ -103,7 +103,7 @@ public class MapV2Configuration {
         int limitSize = bulkProperties.getSelfLimitSize();
         String loggerName = newBulkWriterName(HbaseMapResponseTimeDao.class.getName());
 
-        BulkFactory.Builder builder = factory.newBuilder(loggerName, rowKeyDistributorByHashPrefix);
+        BulkFactory.Builder builder = factory.newBuilder(loggerName, HbaseTables.MAP_V2_COLUMN_FAMILY_NAME, rowKeyDistributorByHashPrefix);
         builder.setIncrementer("selfIncrementReporter", limitSize);
         builder.setMaxUpdater("selfUpdateReporter", limitSize);
         return builder.build();

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV3Configuration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV3Configuration.java
@@ -75,7 +75,7 @@ public class MapV3Configuration {
         int limitSize = bulkProperties.getCallerLimitSize();
         String loggerName = newBulkWriterName(HbaseMapOutLinkDao.class.getName());
 
-        BulkFactory.Builder builder = factory.newBuilder(loggerName, rowKeyDistributorByHashPrefix);
+        BulkFactory.Builder builder = factory.newBuilder(loggerName, HbaseTables.MAP_V3_COLUMN_FAMILY_NAME, rowKeyDistributorByHashPrefix);
         builder.setIncrementer("outLinkIncrementReporter", limitSize);
         builder.setMaxUpdater("outLinkUpdateReporter", limitSize);
         return builder.build();
@@ -90,7 +90,7 @@ public class MapV3Configuration {
         int limitSize = bulkProperties.getCalleeLimitSize();
         String loggerName = newBulkWriterName(HbaseMapInLinkDao.class.getName());
 
-        BulkFactory.Builder builder = factory.newBuilder(loggerName, rowKeyDistributorByHashPrefix);
+        BulkFactory.Builder builder = factory.newBuilder(loggerName, HbaseTables.MAP_V3_COLUMN_FAMILY_NAME, rowKeyDistributorByHashPrefix);
         builder.setIncrementer("inLinkIncrementReporter", limitSize);
         builder.setMaxUpdater("inLinkUpdateReporter", limitSize);
         return builder.build();
@@ -106,7 +106,7 @@ public class MapV3Configuration {
         int limitSize = bulkProperties.getSelfLimitSize();
         String loggerName = newBulkWriterName(HbaseMapResponseTimeDao.class.getName());
 
-        BulkFactory.Builder builder = factory.newBuilder(loggerName, rowKeyDistributorByHashPrefix);
+        BulkFactory.Builder builder = factory.newBuilder(loggerName, HbaseTables.MAP_V3_COLUMN_FAMILY_NAME, rowKeyDistributorByHashPrefix);
         builder.setIncrementer("selfIncrementReporter", limitSize);
         builder.setMaxUpdater("selfUpdateReporter", limitSize);
         return builder.build();

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapInLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapInLinkDao.java
@@ -102,15 +102,15 @@ public class HbaseMapInLinkDao implements MapInLinkDao {
 
         final ColumnName outLink = inLinkFactory.histogram(selfVertex, selfHost, outSlotNumber);
         final TableName tableName = tableNameProvider.getTableName(table.getTable());
-        this.bulkWriter.increment(tableName, table.getName(), inLinkRowKey, outLink);
+        this.bulkWriter.increment(tableName, inLinkRowKey, outLink);
 
         if (mapLinkProperties.isEnableAvg()) {
             final ColumnName sumOutLink = inLinkFactory.sum(selfVertex, selfHost, inVertex.serviceType());
-            this.bulkWriter.increment(tableName, table.getName(), inLinkRowKey, sumOutLink, elapsed);
+            this.bulkWriter.increment(tableName, inLinkRowKey, sumOutLink, elapsed);
         }
         if (mapLinkProperties.isEnableMax()) {
             final ColumnName maxOutLink = inLinkFactory.max(selfVertex, selfHost, inVertex.serviceType());
-            this.bulkWriter.updateMax(tableName, table.getName(), inLinkRowKey, maxOutLink, elapsed);
+            this.bulkWriter.updateMax(tableName, inLinkRowKey, maxOutLink, elapsed);
         }
     }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -91,15 +91,15 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
 
         final ColumnName inLink = outLinkFactory.histogram(selfAgentId, outVertex, outHost, outSlotNumber);
         final TableName tableName = tableNameProvider.getTableName(table.getTable());
-        this.bulkWriter.increment(tableName, table.getName(), selfLinkRowKey, inLink);
+        this.bulkWriter.increment(tableName, selfLinkRowKey, inLink);
 
         if (mapLinkProperties.isEnableAvg()) {
             final ColumnName sumInLink = outLinkFactory.sum(selfAgentId, outVertex, outHost, selfVertex.serviceType());
-            this.bulkWriter.increment(tableName, table.getName(), selfLinkRowKey, sumInLink, elapsed);
+            this.bulkWriter.increment(tableName, selfLinkRowKey, sumInLink, elapsed);
         }
         if (mapLinkProperties.isEnableMax()) {
             final ColumnName maxInLink = outLinkFactory.max(selfAgentId, outVertex, outHost, selfVertex.serviceType());
-            this.bulkWriter.updateMax(tableName, table.getName(), selfLinkRowKey, maxInLink, elapsed);
+            this.bulkWriter.updateMax(tableName, selfLinkRowKey, maxInLink, elapsed);
         }
 
     }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapResponseTimeDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapResponseTimeDao.java
@@ -85,16 +85,16 @@ public class HbaseMapResponseTimeDao implements MapResponseTimeDao {
         final short slotNumber = MapSlotUtils.getSlotNumber(selfVertex.serviceType(), elapsed, isError);
         final ColumnName selfColumnName = selfNodeFactory.histogram(agentId, slotNumber);
         final TableName tableName = tableNameProvider.getTableName(table.getTable());
-        this.bulkWriter.increment(tableName, table.getName(), selfRowKey, selfColumnName);
+        this.bulkWriter.increment(tableName, selfRowKey, selfColumnName);
 
         if (mapLinkProperties.isEnableAvg()) {
             final ColumnName sumColumnName = selfNodeFactory.sum(agentId, selfVertex.serviceType());
-            this.bulkWriter.increment(tableName, table.getName(), selfRowKey, sumColumnName, elapsed);
+            this.bulkWriter.increment(tableName, selfRowKey, sumColumnName, elapsed);
         }
 
         if (mapLinkProperties.isEnableMax()) {
             final ColumnName maxColumnName = selfNodeFactory.max(agentId, selfVertex.serviceType());
-            this.bulkWriter.updateMax(tableName, table.getName(), selfRowKey, maxColumnName, elapsed);
+            this.bulkWriter.updateMax(tableName, selfRowKey, maxColumnName, elapsed);
         }
     }
 
@@ -118,7 +118,7 @@ public class HbaseMapResponseTimeDao implements MapResponseTimeDao {
 
         final ColumnName selfColumnName = selfNodeFactory.histogram(agentId, slotNumber);
         final TableName tableName = tableNameProvider.getTableName(table.getTable());
-        this.bulkWriter.increment(tableName, table.getName(), selfRowKey, selfColumnName);
+        this.bulkWriter.increment(tableName, selfRowKey, selfColumnName);
     }
 
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkIncrementer.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkIncrementer.java
@@ -26,9 +26,9 @@ import java.util.Map;
  */
 public interface BulkIncrementer {
 
-    void increment(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName);
+    void increment(TableName tableName, RowKey rowKey, ColumnName columnName);
 
-    void increment(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName, long addition);
+    void increment(TableName tableName, RowKey rowKey, ColumnName columnName, long addition);
 
     Map<RowInfo, Long> getIncrements();
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkUpdater.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkUpdater.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public interface BulkUpdater {
 
-    void updateMax(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName, long value);
+    void updateMax(TableName tableName, RowKey rowKey, ColumnName columnName, long value);
 
     Map<RowInfo, Long> getMaxUpdate();
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkWriter.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkWriter.java
@@ -23,11 +23,11 @@ import org.apache.hadoop.hbase.TableName;
  * @author emeroad
  */
 public interface BulkWriter {
-    void increment(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName);
+    void increment(TableName tableName, RowKey rowKey, ColumnName columnName);
 
-    void increment(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName, long addition);
+    void increment(TableName tableName, RowKey rowKey, ColumnName columnName, long addition);
 
-    void updateMax(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName, long max);
+    void updateMax(TableName tableName, RowKey rowKey, ColumnName columnName, long max);
 
     void flushLink();
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkIncrementer.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkIncrementer.java
@@ -29,12 +29,12 @@ public class DefaultBulkIncrementer implements BulkIncrementer {
     public DefaultBulkIncrementer() {
     }
 
-    public void increment(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName) {
-        increment(tableName, family, rowKey, columnName, 1L);
+    public void increment(TableName tableName, RowKey rowKey, ColumnName columnName) {
+        increment(tableName, rowKey, columnName, 1L);
     }
 
-    public void increment(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName, long addition) {
-        RowInfo rowInfo = new DefaultRowInfo(tableName, family, rowKey, columnName);
+    public void increment(TableName tableName, RowKey rowKey, ColumnName columnName, long addition) {
+        RowInfo rowInfo = new DefaultRowInfo(tableName, rowKey, columnName);
         counter.addAndGet(rowInfo, addition);
     }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkUpdater.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkUpdater.java
@@ -28,8 +28,8 @@ public class DefaultBulkUpdater implements BulkUpdater {
     private final AtomicLongMap<RowInfo> max = AtomicLongMap.create();
 
     @Override
-    public void updateMax(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName, long addition) {
-        RowInfo rowInfo = new DefaultRowInfo(tableName, family, rowKey, columnName);
+    public void updateMax(TableName tableName, RowKey rowKey, ColumnName columnName, long addition) {
+        RowInfo rowInfo = new DefaultRowInfo(tableName, rowKey, columnName);
         max.accumulateAndGet(rowInfo, addition, Long::max);
     }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultRowInfo.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultRowInfo.java
@@ -19,7 +19,6 @@ package com.navercorp.pinpoint.collector.applicationmap.statistics;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import org.apache.hadoop.hbase.TableName;
 
-import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -27,13 +26,11 @@ import java.util.Objects;
  * @author HyunGil Jeong
  */
 public record DefaultRowInfo(TableName tableName,
-                             byte[] family,
                              RowKey rowKey,
                              ColumnName columnName) implements RowInfo {
 
     public DefaultRowInfo {
         Objects.requireNonNull(tableName, "tableName");
-        Objects.requireNonNull(family, "family");
         Objects.requireNonNull(rowKey, "rowKey");
         Objects.requireNonNull(columnName, "columnName");
     }
@@ -43,13 +40,12 @@ public record DefaultRowInfo(TableName tableName,
         if (o == null || getClass() != o.getClass()) return false;
 
         DefaultRowInfo that = (DefaultRowInfo) o;
-        return Arrays.equals(family, that.family) && rowKey.equals(that.rowKey) && tableName.equals(that.tableName) && columnName.equals(that.columnName);
+        return rowKey.equals(that.rowKey) && tableName.equals(that.tableName) && columnName.equals(that.columnName);
     }
 
     @Override
     public int hashCode() {
         int result = tableName.hashCode();
-        result = 31 * result + Arrays.hashCode(family);
         result = 31 * result + rowKey.hashCode();
         result = 31 * result + columnName.hashCode();
         return result;

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/RowInfo.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/RowInfo.java
@@ -26,8 +26,6 @@ public interface RowInfo {
 
     TableName tableName();
 
-    byte[] family();
-
     RowKey rowKey();
 
     ColumnName columnName();

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SizeLimitedBulkIncrementer.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SizeLimitedBulkIncrementer.java
@@ -41,17 +41,17 @@ public class SizeLimitedBulkIncrementer implements BulkIncrementer, BulkState {
     }
 
     @Override
-    public void increment(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName) {
-        this.increment(tableName, family, rowKey, columnName, 1L);
+    public void increment(TableName tableName, RowKey rowKey, ColumnName columnName) {
+        this.increment(tableName, rowKey, columnName, 1L);
     }
 
     @Override
-    public void increment(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName, long addition) {
+    public void increment(TableName tableName, RowKey rowKey, ColumnName columnName, long addition) {
         if (overflowState) {
             reporter.reportReject();
             return;
         }
-        delegate.increment(tableName, family, rowKey, columnName, addition);
+        delegate.increment(tableName, rowKey, columnName, addition);
     }
 
     // Called by monitoring thread

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SizeLimitedBulkUpdater.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SizeLimitedBulkUpdater.java
@@ -42,12 +42,12 @@ public class SizeLimitedBulkUpdater implements BulkUpdater, BulkState {
 
 
     @Override
-    public void updateMax(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName, long addition) {
+    public void updateMax(TableName tableName, RowKey rowKey, ColumnName columnName, long addition) {
         if (overflowState) {
             reporter.reportReject();
             return;
         }
-        delegate.updateMax(tableName, family, rowKey, columnName, addition);
+        delegate.updateMax(tableName, rowKey, columnName, addition);
     }
 
     // Called by monitoring thread

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SyncWriter.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SyncWriter.java
@@ -40,26 +40,27 @@ public class SyncWriter implements BulkWriter {
 
     private final HbaseAsyncTemplate hbaseTemplate;
     private final RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix;
-
-
+    private final byte[] family;
 
     public SyncWriter(String loggerName,
                             HbaseAsyncTemplate hbaseTemplate,
+                             byte[] family,
                              RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix) {
         this.hbaseTemplate = Objects.requireNonNull(hbaseTemplate, "hbaseTemplate");
+        this.family = Objects.requireNonNull(family, "family");
         this.rowKeyDistributorByHashPrefix = Objects.requireNonNull(rowKeyDistributorByHashPrefix, "rowKeyDistributorByHashPrefix");
     }
 
     @Override
-    public void increment(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName) {
+    public void increment(TableName tableName, RowKey rowKey, ColumnName columnName) {
         Objects.requireNonNull(rowKey, "rowKey");
         Objects.requireNonNull(columnName, "columnName");
 
-        this.increment(tableName, family, rowKey, columnName, 1L);
+        this.increment(tableName, rowKey, columnName, 1L);
     }
 
     @Override
-    public void increment(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName, long addition) {
+    public void increment(TableName tableName, RowKey rowKey, ColumnName columnName, long addition) {
         Objects.requireNonNull(rowKey, "rowKey");
         Objects.requireNonNull(columnName, "columnName");
 
@@ -73,7 +74,7 @@ public class SyncWriter implements BulkWriter {
     }
 
     @Override
-    public void updateMax(TableName tableName, byte[] family, RowKey rowKey, ColumnName columnName, long max) {
+    public void updateMax(TableName tableName, RowKey rowKey, ColumnName columnName, long max) {
 
         Objects.requireNonNull(rowKey, "rowKey");
         Objects.requireNonNull(columnName, "columnName");

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/config/BulkFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/config/BulkFactory.java
@@ -66,23 +66,25 @@ public class BulkFactory {
 
     public BulkWriter newBulkWriter(String loggerName,
                                     RowKeyDistributorByHashPrefix rowKeyDistributorByHashPrefix,
+                                    byte[] family,
                                     BulkIncrementer bulkIncrementer,
                                     BulkUpdater bulkUpdater) {
         if (bulkWriter) {
-            return new DefaultBulkWriter(loggerName, asyncTemplate, rowKeyDistributorByHashPrefix,
+            return new DefaultBulkWriter(loggerName, asyncTemplate, family, rowKeyDistributorByHashPrefix,
                     bulkIncrementer, bulkUpdater);
         } else {
-            return new SyncWriter(loggerName, asyncTemplate, rowKeyDistributorByHashPrefix);
+            return new SyncWriter(loggerName, asyncTemplate, family, rowKeyDistributorByHashPrefix);
         }
     }
 
-    public Builder newBuilder(String loggerName, RowKeyDistributorByHashPrefix distributor) {
-        return new Builder(this, loggerName, distributor);
+    public Builder newBuilder(String loggerName, byte[] family, RowKeyDistributorByHashPrefix distributor) {
+        return new Builder(this, loggerName, family, distributor);
     }
 
     public static class Builder {
         private final String loggerName;
         private final BulkFactory factory;
+        private final byte[] family;
         private final RowKeyDistributorByHashPrefix distributor;
 
         private BulkIncrementer increment;
@@ -90,9 +92,11 @@ public class BulkFactory {
 
         public Builder(BulkFactory factory,
                        String loggerName,
+                       byte[] family,
                        RowKeyDistributorByHashPrefix distributor) {
             this.loggerName = Objects.requireNonNull(loggerName, "loggerName");
             this.factory = Objects.requireNonNull(factory, "factory");
+            this.family = Objects.requireNonNull(family, "family");
             this.distributor = Objects.requireNonNull(distributor, "distributor");
         }
 
@@ -105,7 +109,7 @@ public class BulkFactory {
         }
 
         public BulkWriter build() {
-            return factory.newBulkWriter(loggerName, this.distributor, increment, maxUpdater);
+            return factory.newBulkWriter(loggerName, this.distributor, family, increment, maxUpdater);
         }
     }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkIncrementerTestClazz.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkIncrementerTestClazz.java
@@ -308,7 +308,7 @@ public class BulkIncrementerTestClazz {
         @Override
         public void run() {
             for (TestData testData : testDatas) {
-                bulkIncrementer.increment(testData.getTableName(), CF, testData.getRowKey(), testData.getColumnName());
+                bulkIncrementer.increment(testData.getTableName(), testData.getRowKey(), testData.getColumnName());
             }
             completeLatch.countDown();
         }
@@ -329,7 +329,7 @@ public class BulkIncrementerTestClazz {
 
         private void flushToMap(Map<TableName, List<Increment>> resultMap) {
             Map<RowInfo, Long> snapshot = bulkIncrementer.getIncrements();
-            Map<TableName, List<Increment>> incrementMap = merge.createBulkIncrement(snapshot);
+            Map<TableName, List<Increment>> incrementMap = merge.createBulkIncrement(snapshot, CF);
 
             for (Map.Entry<TableName, List<Increment>> incrementMapEntry : incrementMap.entrySet()) {
                 TableName tableName = incrementMapEntry.getKey();

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkUpdaterTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkUpdaterTest.java
@@ -71,7 +71,7 @@ public class DefaultBulkUpdaterTest {
 
         // When
         for (TestData testData : testDatas) {
-            bulkIncrementer.increment(testData.getTableName(), CF, testData.getRowKey(), testData.getColumnName());
+            bulkIncrementer.increment(testData.getTableName(), testData.getRowKey(), testData.getColumnName());
         }
 
         // Then
@@ -83,7 +83,7 @@ public class DefaultBulkUpdaterTest {
 
     private Map<TableName, List<Increment>> createIncrements() {
         Map<RowInfo, Long> increments = bulkIncrementer.getIncrements();
-        return merge.createBulkIncrement(increments);
+        return merge.createBulkIncrement(increments, CF);
     }
 
     @Test
@@ -113,7 +113,7 @@ public class DefaultBulkUpdaterTest {
 
         // When
         for (TestData testData : testDatas) {
-            bulkIncrementer.increment(testData.getTableName(), CF, testData.getRowKey(), testData.getColumnName());
+            bulkIncrementer.increment(testData.getTableName(), testData.getRowKey(), testData.getColumnName());
         }
 
         // Then

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SizeLimitedBulkIncrementerTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SizeLimitedBulkIncrementerTest.java
@@ -64,7 +64,7 @@ public class SizeLimitedBulkIncrementerTest {
 
     private Map<TableName, List<Increment>> createIncrements() {
         Map<RowInfo, Long> increments = bulkIncrementer.getIncrements();
-        return merge.createBulkIncrement(increments);
+        return merge.createBulkIncrement(increments, CF);
     }
 
     @Test
@@ -81,7 +81,7 @@ public class SizeLimitedBulkIncrementerTest {
 
         // When
         for (TestData testData : testDatas) {
-            bulkIncrementer.increment(testData.getTableName(), CF, testData.getRowKey(), testData.getColumnName());
+            bulkIncrementer.increment(testData.getTableName(), testData.getRowKey(), testData.getColumnName());
         }
 
         // Then
@@ -119,7 +119,7 @@ public class SizeLimitedBulkIncrementerTest {
 
         // When
         for (TestData testData : testDatas) {
-            bulkIncrementer.increment(testData.getTableName(), CF, testData.getRowKey(), testData.getColumnName());
+            bulkIncrementer.increment(testData.getTableName(), testData.getRowKey(), testData.getColumnName());
         }
 
         // Then


### PR DESCRIPTION
This pull request refactors how HBase table family information is handled in the application map statistics code. The main change is to remove the `family` field from the `RowInfo` and related interfaces and records, and instead manage it centrally within the `DefaultBulkWriter`. This simplifies the method signatures and data structures, making the codebase easier to maintain and less error-prone. The changes affect several interfaces, implementations, and bulk writing logic.

**Refactoring of table family handling:**

* Removed the `family` field from `RowInfo` and `DefaultRowInfo`, and updated all related method signatures to exclude the `family` parameter. Now, `RowInfo` only contains `tableName`, `rowKey`, and `columnName`. (`[[1]](diffhunk://#diff-1166a14f0140194505f412777adfb801d4e77b3a26a962ae1626136b5f36c179L29-L30)`, `[[2]](diffhunk://#diff-0b03b8c586b37fd2d061e36b53262978b34268b8d171e42246283ab183f1005eL22-L36)`, `[[3]](diffhunk://#diff-0b03b8c586b37fd2d061e36b53262978b34268b8d171e42246283ab183f1005eL46-L52)`)
* Updated `BulkWriter`, `BulkIncrementer`, and `BulkUpdater` interfaces and their implementations to remove the `family` parameter from their methods, and changed their usage throughout the codebase. (`[[1]](diffhunk://#diff-feffc46a2b97b4be46fa8c2fde4010d511382fa17be7eeb3c9d79d8b0135c1cfL29-R31)`, `[[2]](diffhunk://#diff-780f2cdf6c27418e623347ba7a28f518289d6897e66547f7f9b2e29b1acb25abL26-R26)`, `[[3]](diffhunk://#diff-9dbebb7ba00195c5ea7f8aa7d420d2d67047dac57dc7ff08aa1f10f2cbf07362L26-R30)`, `[[4]](diffhunk://#diff-aa436d973ffc69b8fcaeac5201bcac58afc2902ea4b76ab79862b65345b0462dL32-R37)`, `[[5]](diffhunk://#diff-a09ce518d663b7227c04ba1b7a670526ac8f0c228663d5373276f4f0e6864a94L31-R32)`)
* Modified `DefaultBulkWriter` to store the `family` as a constructor parameter and use it internally for all bulk operations, ensuring consistency. (`[[1]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dR43)`, `[[2]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dR56-R62)`, `[[3]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dL74-R88)`, `[[4]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dL131-R134)`)
* Refactored the bulk increment and row key merging logic in `RowKeyMerge` to use only `tableName` as the key and pass the `family` as a method argument, removing the previous `TableKey` record. (`[[1]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428L29-L33)`, `[[2]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428L48-R72)`, `[[3]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428L89-R92)`, `[[4]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428L99-R102)`, `[[5]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428L109-L130)`)
* Updated all usages of bulk writing methods in DAO classes to match the new method signatures, removing the `family` argument. (`[[1]](diffhunk://#diff-d76d17c39980e928a6f9a494cb5a559f60cd97ff34ab37514663f1858290dacfL105-R113)`, `[[2]](diffhunk://#diff-4b07ea846dfc607b73cacf60ac8f045ab8ac879a205654de45731ec9f1d2db80L94-R102)`, `[[3]](diffhunk://#diff-40d8993f9cc21b2e5126a8f739a0a4f28435a4ef3213fda8e4a18373681bf981L88-R97)`, `[[4]](diffhunk://#diff-40d8993f9cc21b2e5126a8f739a0a4f28435a4ef3213fda8e4a18373681bf981L121-R121)`)