### PR TITLE
[#noissue] Refactor to use HistogramSlot in application map data handling

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapInLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapInLinkDao.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.util.MapSlotUtils;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -98,7 +99,7 @@ public class HbaseMapInLinkDao implements MapInLinkDao {
         final long rowTimeSlot = timeSlot.getTimeSlot(requestTime);
         final RowKey inLinkRowKey = inLinkFactory.rowkey(inVertex, rowTimeSlot);
 
-        final short outSlotNumber = MapSlotUtils.getSlotNumber(inVertex.serviceType(), elapsed, isError);
+        final HistogramSlot outSlotNumber = MapSlotUtils.getHistogramSlot(inVertex.serviceType(), elapsed, isError);
 
         final ColumnName outLink = inLinkFactory.histogram(selfVertex, selfHost, outSlotNumber);
         final TableName tableName = tableNameProvider.getTableName(table.getTable());

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -26,6 +26,7 @@ import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.util.MapSlotUtils;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -87,9 +88,9 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
         final long rowTimeSlot = timeSlot.getTimeSlot(requestTime);
         final RowKey selfLinkRowKey = outLinkFactory.rowkey(selfVertex, rowTimeSlot);
 
-        final short outSlotNumber = MapSlotUtils.getSlotNumber(outVertex.serviceType(), elapsed, isError);
+        final HistogramSlot outSlot = MapSlotUtils.getHistogramSlot(outVertex.serviceType(), elapsed, isError);
 
-        final ColumnName inLink = outLinkFactory.histogram(selfAgentId, outVertex, outHost, outSlotNumber);
+        final ColumnName inLink = outLinkFactory.histogram(selfAgentId, outVertex, outHost, outSlot);
         final TableName tableName = tableNameProvider.getTableName(table.getTable());
         this.bulkWriter.increment(tableName, selfLinkRowKey, inLink);
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapResponseTimeDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapResponseTimeDao.java
@@ -26,6 +26,7 @@ import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.util.MapSlotUtils;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.logging.log4j.LogManager;
@@ -82,8 +83,8 @@ public class HbaseMapResponseTimeDao implements MapResponseTimeDao {
         final long rowTimeSlot = timeSlot.getTimeSlot(requestTime);
         final RowKey selfRowKey = selfNodeFactory.rowkey(selfVertex, rowTimeSlot);
 
-        final short slotNumber = MapSlotUtils.getSlotNumber(selfVertex.serviceType(), elapsed, isError);
-        final ColumnName selfColumnName = selfNodeFactory.histogram(agentId, slotNumber);
+        final HistogramSlot slot = MapSlotUtils.getHistogramSlot(selfVertex.serviceType(), elapsed, isError);
+        final ColumnName selfColumnName = selfNodeFactory.histogram(agentId, slot);
         final TableName tableName = tableNameProvider.getTableName(table.getTable());
         this.bulkWriter.increment(tableName, selfRowKey, selfColumnName);
 
@@ -113,10 +114,10 @@ public class HbaseMapResponseTimeDao implements MapResponseTimeDao {
         Vertex selfVertex = Vertex.of(applicationName, applicationServiceType);
         final RowKey selfRowKey = selfNodeFactory.rowkey(selfVertex, rowTimeSlot);
 
-        final short slotNumber = MapSlotUtils.getPingSlotNumber(applicationServiceType);
+        final HistogramSlot pingSlot = MapSlotUtils.getPingSlot(applicationServiceType);
 //        final ColumnName selfColumnName = ResponseColumnName.histogram(agentId, slotNumber);
 
-        final ColumnName selfColumnName = selfNodeFactory.histogram(agentId, slotNumber);
+        final ColumnName selfColumnName = selfNodeFactory.histogram(agentId, pingSlot);
         final TableName tableName = tableNameProvider.getTableName(table.getTable());
         this.bulkWriter.increment(tableName, selfRowKey, selfColumnName);
     }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/InLinkFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/InLinkFactory.java
@@ -19,13 +19,14 @@ package com.navercorp.pinpoint.collector.applicationmap.dao.hbase;
 import com.navercorp.pinpoint.collector.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public interface InLinkFactory {
 
     RowKey rowkey(Vertex vertex, long rowTimeSlot);
 
-    ColumnName histogram(Vertex outVertex, String outHost, short columnSlotNumber);
+    ColumnName histogram(Vertex outVertex, String outHost, HistogramSlot columnSlotNumber);
 
     ColumnName sum(Vertex outVertex, String outHost, ServiceType inServiceType);
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/InLinkFactoryV2.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/InLinkFactoryV2.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.collector.applicationmap.statistics.InLinkV2Column
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.LinkRowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public class InLinkFactoryV2 implements InLinkFactory {
@@ -30,17 +31,19 @@ public class InLinkFactoryV2 implements InLinkFactory {
     }
 
     @Override
-    public ColumnName histogram(Vertex selfVertex, String selfHost, short outSlotNumber) {
-        return InLinkV2ColumnName.histogram(selfVertex, selfHost, outSlotNumber);
+    public ColumnName histogram(Vertex selfVertex, String selfHost, HistogramSlot outSlotNumber) {
+        return InLinkV2ColumnName.histogram(selfVertex, selfHost, outSlotNumber.getSlotTime());
     }
 
     @Override
     public ColumnName sum(Vertex selfVertex, String selfHost, ServiceType inServiceType) {
-        return InLinkV2ColumnName.sum(selfVertex, selfHost, inServiceType);
+        final short slotTime = inServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
+        return InLinkV2ColumnName.histogram(selfVertex, selfHost, slotTime);
     }
 
     @Override
     public ColumnName max(Vertex selfVertex, String selfHost, ServiceType inServiceType) {
-        return InLinkV2ColumnName.max(selfVertex, selfHost, inServiceType);
+        final short slotTime = inServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
+        return InLinkV2ColumnName.histogram(selfVertex, selfHost, slotTime);
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/OutLinkFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/OutLinkFactory.java
@@ -19,12 +19,13 @@ package com.navercorp.pinpoint.collector.applicationmap.dao.hbase;
 import com.navercorp.pinpoint.collector.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public interface OutLinkFactory {
     RowKey rowkey(Vertex vertex, long rowTimeSlot);
 
-    ColumnName histogram(String selfAgentId, Vertex outVertex, String outSubLink, short outSlotNumber);
+    ColumnName histogram(String selfAgentId, Vertex outVertex, String outSubLink, HistogramSlot outSlot);
 
     ColumnName sum(String selfAgentId, Vertex outVertex, String outHost, ServiceType selfServiceType);
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/OutLinkFactoryV2.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/OutLinkFactoryV2.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.collector.applicationmap.statistics.OutLinkV2Colum
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.LinkRowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public class OutLinkFactoryV2 implements OutLinkFactory {
@@ -30,17 +31,19 @@ public class OutLinkFactoryV2 implements OutLinkFactory {
     }
 
     @Override
-    public ColumnName histogram(String selfAgentId, Vertex outVertex, String outSubLink, short outSlotNumber) {
-        return OutLinkV2ColumnName.histogram(selfAgentId, outVertex, outSubLink, outSlotNumber);
+    public ColumnName histogram(String selfAgentId, Vertex outVertex, String outSubLink, HistogramSlot outSlot) {
+        return OutLinkV2ColumnName.histogram(selfAgentId, outVertex, outSubLink, outSlot.getSlotTime());
     }
 
     @Override
     public ColumnName sum(String selfAgentId, Vertex outVertex, String outHost, ServiceType selfServiceType) {
-        return OutLinkV2ColumnName.sum(selfAgentId, outVertex, outHost, selfServiceType);
+        final short slotTime = selfServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
+        return OutLinkV2ColumnName.histogram(selfAgentId, outVertex, outHost, slotTime);
     }
 
     @Override
     public ColumnName max(String selfAgentId, Vertex outVertex, String outHost, ServiceType selfServiceType) {
-        return OutLinkV2ColumnName.max(selfAgentId, outVertex, outHost, selfServiceType);
+        final short slotTime = selfServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
+        return OutLinkV2ColumnName.histogram(selfAgentId, outVertex, outHost, slotTime);
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/SelfNodeFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/SelfNodeFactory.java
@@ -19,12 +19,13 @@ package com.navercorp.pinpoint.collector.applicationmap.dao.hbase;
 import com.navercorp.pinpoint.collector.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public interface SelfNodeFactory {
     RowKey rowkey(Vertex vertex, long rowTimeSlot);
 
-    ColumnName histogram(String agentId, short columnSlotNumber);
+    ColumnName histogram(String agentId, HistogramSlot slot);
 
     ColumnName sum(String agentId, ServiceType serviceType);
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/SelfNodeFactoryV2.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/SelfNodeFactoryV2.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.collector.applicationmap.statistics.ResponseColumn
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.LinkRowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public class SelfNodeFactoryV2 implements SelfNodeFactory {
@@ -31,18 +32,20 @@ public class SelfNodeFactoryV2 implements SelfNodeFactory {
     };
 
     @Override
-    public ColumnName histogram(String agentId, short slotNumber) {
-        return ResponseColumnName.histogram(agentId, slotNumber);
+    public ColumnName histogram(String agentId, HistogramSlot slot) {
+        return ResponseColumnName.histogram(agentId, slot.getSlotTime());
     }
 
     @Override
     public ColumnName sum(String agentId, ServiceType selfServiceType) {
-        return ResponseColumnName.sum(agentId, selfServiceType);
+        short slotTime = selfServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
+        return ResponseColumnName.histogram(agentId, slotTime);
     }
 
     @Override
     public ColumnName max(String agentId, ServiceType selfServiceType) {
-        return ResponseColumnName.max(agentId, selfServiceType);
+        short slotTime = selfServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
+        return ResponseColumnName.histogram(agentId, slotTime);
     }
 
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/InLinkFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/InLinkFactoryV3.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.collector.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRowKey;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public class InLinkFactoryV3 implements InLinkFactory {
@@ -30,17 +31,19 @@ public class InLinkFactoryV3 implements InLinkFactory {
     }
 
     @Override
-    public ColumnName histogram(Vertex selfVertex, String selfHost, short outSlotNumber) {
-        return InLinkV3ColumnName.histogram(selfVertex, selfHost, outSlotNumber);
+    public ColumnName histogram(Vertex selfVertex, String selfHost, HistogramSlot outSlot) {
+        return InLinkV3ColumnName.histogram(selfVertex, selfHost, outSlot.getSlotTime());
     }
 
     @Override
     public ColumnName sum(Vertex selfVertex, String selfHost, ServiceType inServiceType) {
-        return InLinkV3ColumnName.sum(selfVertex, selfHost, inServiceType);
+        short sumStatSlot = inServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
+        return InLinkV3ColumnName.histogram(selfVertex, selfHost, sumStatSlot);
     }
 
     @Override
     public ColumnName max(Vertex selfVertex, String selfHost, ServiceType inServiceType) {
-        return InLinkV3ColumnName.max(selfVertex, selfHost, inServiceType);
+        short maxStatSlot = inServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
+        return InLinkV3ColumnName.histogram(selfVertex, selfHost, maxStatSlot);
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/InLinkV3ColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/InLinkV3ColumnName.java
@@ -42,24 +42,6 @@ public class InLinkV3ColumnName implements ColumnName {
         return new InLinkV3ColumnName(selfApplicationName, selfServiceType.getCode(), outHost, columnSlotNumber);
     }
 
-    public static ColumnName sum(Vertex outVertex, String outHost, ServiceType inServiceType) {
-        return sum(outVertex.applicationName(), outVertex.serviceType(), outHost, inServiceType);
-    }
-
-    public static ColumnName sum(String outApplicationName, ServiceType outServiceType, String outHost, ServiceType inServiceType) {
-        final short slotTime = inServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
-        return histogram(outApplicationName, outServiceType, outHost, slotTime);
-    }
-
-    public static ColumnName max(Vertex outVertex, String outHost, ServiceType inServiceType) {
-        return max(outVertex.applicationName(), outVertex.serviceType(), outHost, inServiceType);
-    }
-
-    public static ColumnName max(String outApplicationName, ServiceType outServiceType, String outHost, ServiceType inServiceType) {
-        final short slotTime = inServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
-        return histogram(outApplicationName, outServiceType, outHost, slotTime);
-    }
-
     public InLinkV3ColumnName(String selfApplicationName, short selfServiceType, String outHost, short columnSlotNumber) {
         this.selfServiceType = selfServiceType;
         this.selfApplicationName = Objects.requireNonNull(selfApplicationName, "selfApplicationName");

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/OutLinkFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/OutLinkFactoryV3.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.collector.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRowKey;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public class OutLinkFactoryV3 implements OutLinkFactory {
@@ -30,17 +31,19 @@ public class OutLinkFactoryV3 implements OutLinkFactory {
     }
 
     @Override
-    public ColumnName histogram(String selfAgentId, Vertex outVertex, String outSubLink, short outSlotNumber) {
-        return OutLinkV3ColumnName.histogram(outVertex, outSubLink, outSlotNumber);
+    public ColumnName histogram(String selfAgentId, Vertex outVertex, String outSubLink, HistogramSlot outSlot) {
+        return OutLinkV3ColumnName.histogram(outVertex, outSubLink, outSlot.getSlotTime());
     }
 
     @Override
     public ColumnName sum(String selfAgentId, Vertex outVertex, String outHost, ServiceType selfServiceType) {
-        return OutLinkV3ColumnName.sum(outVertex, outHost, selfServiceType);
+        short slotTime = selfServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
+        return OutLinkV3ColumnName.histogram(outVertex, outHost, slotTime);
     }
 
     @Override
     public ColumnName max(String selfAgentId, Vertex outVertex, String outHost, ServiceType selfServiceType) {
-        return OutLinkV3ColumnName.max(outVertex, outHost, selfServiceType);
+        short slotTime = selfServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
+        return OutLinkV3ColumnName.histogram(outVertex, outHost, slotTime);
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/OutLinkV3ColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/OutLinkV3ColumnName.java
@@ -42,25 +42,6 @@ public class OutLinkV3ColumnName implements ColumnName {
         return new OutLinkV3ColumnName(outServiceType.getCode(), inApplicationName, outSubLink, columnSlotNumber);
     }
 
-    public static ColumnName sum(Vertex inVertex, String callHost, ServiceType outServiceType) {
-        return sum(inVertex.serviceType(), inVertex.applicationName(), callHost, outServiceType);
-    }
-
-    public static ColumnName sum(ServiceType inServiceType, String inApplicationName, String outSubLink, ServiceType outServiceType) {
-        final short slotTime = outServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
-        return histogram(inServiceType, inApplicationName, outSubLink, slotTime);
-    }
-
-    public static ColumnName max(Vertex inVertex, String outSubLink, ServiceType outServiceType) {
-        final short slotTime = outServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
-        return histogram(inVertex.serviceType(), inVertex.applicationName(), outSubLink, slotTime);
-    }
-
-    public static ColumnName max(ServiceType inServiceType, String inApplicationName, String outSubLink, ServiceType outServiceType) {
-        final short slotTime = outServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
-        return histogram(inServiceType, inApplicationName, outSubLink, slotTime);
-    }
-
     public OutLinkV3ColumnName(int inServiceType, String inApplicationName, String outSubLink, short columnSlotNumber) {
         this.inServiceType = inServiceType;
         this.inApplicationName = Objects.requireNonNull(inApplicationName, "inApplicationName");

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/SelfNodeFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/SelfNodeFactoryV3.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.collector.applicationmap.statistics.ResponseColumn
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRowKey;
+import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public class SelfNodeFactoryV3 implements SelfNodeFactory {
@@ -32,18 +33,20 @@ public class SelfNodeFactoryV3 implements SelfNodeFactory {
     };
 
     @Override
-    public ColumnName histogram(String agentId, short slotNumber) {
-        return ResponseColumnName.histogram(agentId, slotNumber);
+    public ColumnName histogram(String agentId, HistogramSlot slot) {
+        return ResponseColumnName.histogram(agentId, slot.getSlotTime());
     }
 
     @Override
     public ColumnName sum(String agentId, ServiceType selfServiceType) {
-        return ResponseColumnName.sum(agentId, selfServiceType);
+        short slotTime = selfServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
+        return ResponseColumnName.histogram(agentId, slotTime);
     }
 
     @Override
     public ColumnName max(String agentId, ServiceType selfServiceType) {
-        return ResponseColumnName.max(agentId, selfServiceType);
+        short slotTime = selfServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
+        return ResponseColumnName.histogram(agentId, slotTime);
     }
 
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/InLinkV2ColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/InLinkV2ColumnName.java
@@ -43,23 +43,6 @@ public class InLinkV2ColumnName implements ColumnName {
         return new InLinkV2ColumnName(selfApplicationName, selfServiceType.getCode(), outHost, columnSlotNumber);
     }
 
-    public static ColumnName sum(Vertex outVertex, String outHost, ServiceType inServiceType) {
-        return sum(outVertex.applicationName(), outVertex.serviceType(), outHost, inServiceType);
-    }
-
-    public static ColumnName sum(String selfApplicationName, ServiceType selfServiceType, String outHost, ServiceType inServiceType) {
-        final short slotTime = inServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
-        return histogram(selfApplicationName, selfServiceType, outHost, slotTime);
-    }
-
-    public static ColumnName max(Vertex selfVertex, String selfHost, ServiceType inServiceType) {
-        return max(selfVertex.applicationName(), selfVertex.serviceType(), selfHost, inServiceType);
-    }
-
-    public static ColumnName max(String selfApplicationName, ServiceType selfServiceType, String outHost, ServiceType inServiceType) {
-        final short slotTime = inServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
-        return histogram(selfApplicationName, selfServiceType, outHost, slotTime);
-    }
 
     public InLinkV2ColumnName(String selfApplicationName, short selfServiceType, String outHost, short columnSlotNumber) {
         this.selfServiceType = selfServiceType;

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/OutLinkV2ColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/OutLinkV2ColumnName.java
@@ -43,25 +43,6 @@ public class OutLinkV2ColumnName implements ColumnName {
         return new OutLinkV2ColumnName(outAgentId, inServiceType.getCode(), inApplicationName, callHost, columnSlotNumber);
     }
 
-    public static ColumnName sum(String outAgentId, Vertex inVertex, String callHost, ServiceType outServiceType) {
-        return sum(outAgentId, inVertex.serviceType(), inVertex.applicationName(), callHost, outServiceType);
-    }
-
-    public static ColumnName sum(String outAgentId, ServiceType inServiceType, String inApplicationName, String callHost, ServiceType outServiceType) {
-        final short slotTime = outServiceType.getHistogramSchema().getSumStatSlot().getSlotTime();
-        return histogram(outAgentId, inServiceType, inApplicationName, callHost, slotTime);
-    }
-
-    public static ColumnName max(String outAgentId, Vertex inVertex, String callHost, ServiceType outServiceType) {
-        final short slotTime = outServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
-        return histogram(outAgentId, inVertex.serviceType(), inVertex.applicationName(), callHost, slotTime);
-    }
-
-    public static ColumnName max(String outAgentId, ServiceType inServiceType, String inApplicationName, String callHost, ServiceType outServiceType) {
-        final short slotTime = outServiceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
-        return histogram(outAgentId, inServiceType, inApplicationName, callHost, slotTime);
-    }
-
     public OutLinkV2ColumnName(String outAgentId, short inServiceType, String inApplicationName, String callHost, short columnSlotNumber) {
         this.outAgentId = Objects.requireNonNull(outAgentId, "outAgentId");
         this.inServiceType = inServiceType;

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/ResponseColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/ResponseColumnName.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.collector.applicationmap.statistics;
 
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 
 import java.util.Objects;
@@ -33,16 +32,6 @@ public class ResponseColumnName implements ColumnName {
 
     public static ColumnName histogram(String agentId, short columnSlotNumber) {
         return new ResponseColumnName(agentId, columnSlotNumber);
-    }
-
-    public static ColumnName sum(String agentId, ServiceType serviceType) {
-        short slotTime = serviceType.getHistogramSchema().getSumStatSlot().getSlotTime();
-        return new ResponseColumnName(agentId, slotTime);
-    }
-
-    public static ColumnName max(String agentId, ServiceType serviceType) {
-        short slotTime = serviceType.getHistogramSchema().getMaxStatSlot().getSlotTime();
-        return new ResponseColumnName(agentId, slotTime);
     }
 
     public ResponseColumnName(String agentId, short columnSlotNumber) {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/MapSlotUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/MapSlotUtils.java
@@ -37,22 +37,23 @@ public class MapSlotUtils {
 
 
     public static short getSlotNumber(ServiceType serviceType, int elapsed, boolean isError) {
-        return findResponseHistogramSlotNo(serviceType, elapsed, isError);
+        return getHistogramSlot(serviceType, elapsed, isError).getSlotTime();
     }
 
-
-    public static short getPingSlotNumber(ServiceType serviceType) {
-        final HistogramSchema histogramSchema = serviceType.getHistogramSchema();
-        return histogramSchema.getPingSlot().getSlotTime();
-    }
-
-
-    private static short findResponseHistogramSlotNo(ServiceType serviceType, int elapsed, boolean isError) {
+    public static HistogramSlot getHistogramSlot(ServiceType serviceType, int elapsed, boolean isError) {
         Objects.requireNonNull(serviceType, "serviceType");
 
         final HistogramSchema histogramSchema = serviceType.getHistogramSchema();
-        final HistogramSlot histogramSlot = histogramSchema.findHistogramSlot(elapsed, isError);
-        return histogramSlot.getSlotTime();
+        return histogramSchema.findHistogramSlot(elapsed, isError);
+    }
+
+    public static short getPingSlotNumber(ServiceType serviceType) {
+        return getPingSlot(serviceType).getSlotTime();
+    }
+
+    public static HistogramSlot getPingSlot(ServiceType serviceType) {
+        final HistogramSchema histogramSchema = serviceType.getHistogramSchema();
+        return histogramSchema.getPingSlot();
     }
 
 }


### PR DESCRIPTION
This pull request refactors how histogram slot information is handled throughout the application map DAO layer, replacing the use of primitive `short` slot numbers with the more expressive `HistogramSlot` type. This change improves type safety, clarity, and future extensibility when dealing with histogram-related operations across various factories and DAOs.

Key changes include:

### Histogram Slot Refactoring

* Replaced all usages of `short` slot numbers with the `HistogramSlot` type in method signatures and implementations for histogram-related operations in `InLinkFactory`, `OutLinkFactory`, and `SelfNodeFactory` interfaces and their V2/V3 implementations. [[1]](diffhunk://#diff-71174b13dfe6083ad1ec85d15eb25c501d003b551123351468523290d2a729f7R22-R29) [[2]](diffhunk://#diff-d68a7ce0e9c4a531aa4c30cf011e93e618e53984ade8462df4a98461296e9bc4R22-R28) [[3]](diffhunk://#diff-7465e239ad5e67b335e731bd55b98a02ef85f05b24024fea2fa07b233a05851aR22-R28) [[4]](diffhunk://#diff-298d488aa3c0e4fcaf663eb2719cc247448399be9c4d665a19fc3ead996139adR24) [[5]](diffhunk://#diff-9dff75db8ef3da07a758a0f55d910cb69afe506c360cec9ce466ee04015c323bR24) [[6]](diffhunk://#diff-3e1a35c95e198ec3090be0d053cb400d042e979687c1ba4a0fbbe918a0dcca3eR24) [[7]](diffhunk://#diff-0d5d4dc11c0bc28650a85168b8999761cec7502b4908c624dfb0b2e456ba416bR24) [[8]](diffhunk://#diff-4639b36b45133324b5a1e736caf85760bfa960439661f69e33e176007629e50eR24)

* Updated the DAO classes (`HbaseMapInLinkDao`, `HbaseMapOutLinkDao`, `HbaseMapResponseTimeDao`) to use `MapSlotUtils.getHistogramSlot` and `MapSlotUtils.getPingSlot`, propagating `HistogramSlot` instead of primitive types, and adjusted downstream method calls accordingly. [[1]](diffhunk://#diff-d76d17c39980e928a6f9a494cb5a559f60cd97ff34ab37514663f1858290dacfL101-R102) [[2]](diffhunk://#diff-4b07ea846dfc607b73cacf60ac8f045ab8ac879a205654de45731ec9f1d2db80L90-R93) [[3]](diffhunk://#diff-40d8993f9cc21b2e5126a8f739a0a4f28435a4ef3213fda8e4a18373681bf981L85-R87) [[4]](diffhunk://#diff-40d8993f9cc21b2e5126a8f739a0a4f28435a4ef3213fda8e4a18373681bf981L116-R120)

### Factory Implementation Updates

* Modified the V2 and V3 factory classes (`InLinkFactoryV2`, `OutLinkFactoryV2`, `SelfNodeFactoryV2`, `InLinkFactoryV3`, `OutLinkFactoryV3`) to accept `HistogramSlot` and extract the slot time internally, improving encapsulation and reducing primitive leakage. [[1]](diffhunk://#diff-298d488aa3c0e4fcaf663eb2719cc247448399be9c4d665a19fc3ead996139adL33-R47) [[2]](diffhunk://#diff-9dff75db8ef3da07a758a0f55d910cb69afe506c360cec9ce466ee04015c323bL33-R47) [[3]](diffhunk://#diff-3e1a35c95e198ec3090be0d053cb400d042e979687c1ba4a0fbbe918a0dcca3eL34-R48) [[4]](diffhunk://#diff-0d5d4dc11c0bc28650a85168b8999761cec7502b4908c624dfb0b2e456ba416bL33-R47) [[5]](diffhunk://#diff-4639b36b45133324b5a1e736caf85760bfa960439661f69e33e176007629e50eL33-R47)

* Updated the `sum` and `max` methods in these factories to directly use histogram slot times derived from the service type's histogram schema, standardizing the approach across all factory versions. [[1]](diffhunk://#diff-298d488aa3c0e4fcaf663eb2719cc247448399be9c4d665a19fc3ead996139adL33-R47) [[2]](diffhunk://#diff-9dff75db8ef3da07a758a0f55d910cb69afe506c360cec9ce466ee04015c323bL33-R47) [[3]](diffhunk://#diff-3e1a35c95e198ec3090be0d053cb400d042e979687c1ba4a0fbbe918a0dcca3eL34-R48) [[4]](diffhunk://#diff-0d5d4dc11c0bc28650a85168b8999761cec7502b4908c624dfb0b2e456ba416bL33-R47) [[5]](diffhunk://#diff-4639b36b45133324b5a1e736caf85760bfa960439661f69e33e176007629e50eL33-R47)

### Cleanup and Consistency

* Removed now-unnecessary overloads and methods in `InLinkV3ColumnName` that previously handled sum and max slot calculations, since this logic is now handled in the factories.

These changes collectively improve the maintainability and correctness of histogram slot handling in the application map data flow.