### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/config/BulkFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/config/BulkFactory.java
@@ -70,10 +70,10 @@ public class BulkFactory {
                                     BulkIncrementer bulkIncrementer,
                                     BulkUpdater bulkUpdater) {
         if (bulkWriter) {
-            return new DefaultBulkWriter(loggerName, asyncTemplate, family, rowKeyDistributorByHashPrefix,
+            return new DefaultBulkWriter(loggerName, asyncTemplate, family, rowKeyDistributorByHashPrefix.getByteHasher(),
                     bulkIncrementer, bulkUpdater);
         } else {
-            return new SyncWriter(loggerName, asyncTemplate, family, rowKeyDistributorByHashPrefix);
+            return new SyncWriter(loggerName, asyncTemplate, family, rowKeyDistributorByHashPrefix.getByteHasher());
         }
     }
 

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkIncrementerTestClazz.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/BulkIncrementerTestClazz.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.collector.applicationmap.statistics;
 
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
-import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import org.apache.hadoop.hbase.TableName;
@@ -321,9 +320,9 @@ public class BulkIncrementerTestClazz {
         private final RowKeyMerge merge;
         private final CountDownLatch awaitLatch;
 
-        Flusher(BulkIncrementer bulkIncrementer, RowKeyDistributorByHashPrefix rowKeyDistributor, CountDownLatch awaitLatch) {
+        Flusher(BulkIncrementer bulkIncrementer, CountDownLatch awaitLatch) {
             this.bulkIncrementer = bulkIncrementer;
-            this.merge = new RowKeyMerge(rowKeyDistributor);
+            this.merge = new RowKeyMerge();
             this.awaitLatch = awaitLatch;
         }
 

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkUpdaterTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkUpdaterTest.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 public class DefaultBulkUpdaterTest {
     private static final byte[] CF = Bytes.toBytes("CF");
 
-    private final RowKeyMerge merge = new RowKeyMerge(null);
+    private final RowKeyMerge merge = new RowKeyMerge();
 
     @AutoClose
     private static final BulkIncrementerFactory bulkIncrementerFactory = new BulkIncrementerFactory();
@@ -146,7 +146,7 @@ public class DefaultBulkUpdaterTest {
         List<List<BulkIncrementerTestClazz.TestData>> testDataPartitions = ListUtils.partition(testDatas, testDatas.size() / (numIncrementers - 1));
         final CountDownLatch completeLatch = new CountDownLatch(testDataPartitions.size());
 
-        FutureTask<Map<TableName, List<Increment>>> flushTask = new FutureTask<>(new Flusher(bulkIncrementer, null, completeLatch));
+        FutureTask<Map<TableName, List<Increment>>> flushTask = new FutureTask<>(new Flusher(bulkIncrementer, completeLatch));
         Thread flusher = new Thread(flushTask, "Flusher");
         flusher.start();
 
@@ -187,7 +187,7 @@ public class DefaultBulkUpdaterTest {
         List<List<TestData>> testDataPartitions = ListUtils.partition(testDatas, testDatas.size() / (numIncrementers - 1));
         final CountDownLatch incrementorLatch = new CountDownLatch(testDataPartitions.size());
 
-        FutureTask<Map<TableName, List<Increment>>> flushTask = new FutureTask<>(new Flusher(bulkIncrementer, null, incrementorLatch));
+        FutureTask<Map<TableName, List<Increment>>> flushTask = new FutureTask<>(new Flusher(bulkIncrementer, incrementorLatch));
         Thread flusher = new Thread(flushTask, "Flusher");
         flusher.start();
 

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SizeLimitedBulkIncrementerTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/statistics/SizeLimitedBulkIncrementerTest.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
 public class SizeLimitedBulkIncrementerTest {
 
     private static final byte[] CF = Bytes.toBytes("CF");
-    private final RowKeyMerge merge = new RowKeyMerge(null);
+    private final RowKeyMerge merge = new RowKeyMerge();
 
     private final int bulkLimitSize = 1000;
 
@@ -153,7 +153,7 @@ public class SizeLimitedBulkIncrementerTest {
         List<List<BulkIncrementerTestClazz.TestData>> testDataPartitions = ListUtils.partition(testDatas, testDatas.size() / (numIncrementers - 1));
         final CountDownLatch completeLatch = new CountDownLatch(testDataPartitions.size());
 
-        FutureTask<Map<TableName, List<Increment>>> flushTask = new FutureTask<>(new Flusher(bulkIncrementer, null, completeLatch));
+        FutureTask<Map<TableName, List<Increment>>> flushTask = new FutureTask<>(new Flusher(bulkIncrementer, completeLatch));
         Thread flusher = new Thread(flushTask, "Flusher");
         flusher.start();
 
@@ -198,7 +198,7 @@ public class SizeLimitedBulkIncrementerTest {
         List<List<TestData>> testDataPartitions = ListUtils.partition(testDatas, testDatas.size() / (numIncrementers - 1));
         final CountDownLatch incrementorLatch = new CountDownLatch(testDataPartitions.size());
 
-        FutureTask<Map<TableName, List<Increment>>> flushTask = new FutureTask<>(new Flusher(bulkIncrementer, null, incrementorLatch));
+        FutureTask<Map<TableName, List<Increment>>> flushTask = new FutureTask<>(new Flusher(bulkIncrementer, incrementorLatch));
         Thread flusher = new Thread(flushTask, "Flusher");
         flusher.start();
 

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributorByHashPrefix.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributorByHashPrefix.java
@@ -56,7 +56,7 @@ public class RowKeyDistributorByHashPrefix implements RowKeyDistributor {
     public byte[] getOriginalKey(byte[] adjustedKey) {
         int prefixLength = hasher.getPrefixLength(adjustedKey);
         if (prefixLength > 0) {
-            return Bytes.tail(adjustedKey, adjustedKey.length - 1);
+            return Bytes.tail(adjustedKey, adjustedKey.length - prefixLength);
         } else {
             return adjustedKey;
         }


### PR DESCRIPTION
This pull request refactors how row key distribution is handled in the application map statistics writers. The main change is the removal of direct dependencies on `RowKeyDistributorByHashPrefix`, replacing it with a more flexible and testable approach using `ByteHasher` and functional interfaces. This simplifies the code, improves testability, and makes the row key distribution logic more explicit.

Key changes:

**Refactoring Writer Construction and Dependencies**
- Replaced the use of `RowKeyDistributorByHashPrefix` with `ByteHasher` in both `DefaultBulkWriter` and `SyncWriter`, updating constructors and member variables accordingly. (`DefaultBulkWriter.java` [[1]](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dL58-R66) `SyncWriter.java` [[2]](diffhunk://#diff-1a5bd45c868872214ec98331881df3d03d95b945dbb1e4a9b5ce6730e524b011L42-R50) [[3]](diffhunk://#diff-1a5bd45c868872214ec98331881df3d03d95b945dbb1e4a9b5ce6730e524b011L98-R98)
- Updated the `BulkFactory` to pass `ByteHasher` instead of `RowKeyDistributorByHashPrefix` when constructing writers. (`BulkFactory.java` [collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/config/BulkFactory.javaL73-R76](diffhunk://#diff-8c01d02f2770bb2487314de499060d98c556c2e1d03a6ad81fdae789ae8a3efeL73-R76))

**RowKeyMerge Refactor**
- Refactored `RowKeyMerge` to use a `Function<RowKey, byte[]>` for row key transformation, allowing for easier testing and more flexible row key distribution strategies. Added a default bypass function for tests and simplified increment creation. (`RowKeyMerge.java` [[1]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428L19-L21) [[2]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428R31-R32) [[3]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428L41-R50) [[4]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428L58-R74) [[5]](diffhunk://#diff-b621647135dc5628fc8e3a83f62edcdfc7ba11d09577f996438a8e7d61194428L81-L90)

**Test Code Updates**
- Updated tests to use the new `RowKeyMerge()` constructor and removed dependencies on `RowKeyDistributorByHashPrefix` in test helpers and test classes. (`BulkIncrementerTestClazz.java` [[1]](diffhunk://#diff-53830c4f112f70021041a9be608212787d8a23a05913144f1f6c844977c41720L20) [[2]](diffhunk://#diff-53830c4f112f70021041a9be608212787d8a23a05913144f1f6c844977c41720L324-R325); `DefaultBulkUpdaterTest.java` [[3]](diffhunk://#diff-511e4a0aa8dc30e59b03aabde92e1eb22f7b55f2a6458bda7a973b7999a09dfaL51-R51) [[4]](diffhunk://#diff-511e4a0aa8dc30e59b03aabde92e1eb22f7b55f2a6458bda7a973b7999a09dfaL149-R149) [[5]](diffhunk://#diff-511e4a0aa8dc30e59b03aabde92e1eb22f7b55f2a6458bda7a973b7999a09dfaL190-R190); `SizeLimitedBulkIncrementerTest.java` [[6]](diffhunk://#diff-bad72415df98403426a7d6a8819778bfb150bb641678187e47c1eb806c2f2e39L54-R54) [[7]](diffhunk://#diff-bad72415df98403426a7d6a8819778bfb150bb641678187e47c1eb806c2f2e39L156-R156) [[8]](diffhunk://#diff-bad72415df98403426a7d6a8819778bfb150bb641678187e47c1eb806c2f2e39L201-R201)

**Bug Fix**
- Fixed a bug in `RowKeyDistributorByHashPrefix#getOriginalKey` where the calculation of the tail length was incorrect, ensuring the correct original key is returned. (`RowKeyDistributorByHashPrefix.java` [commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributorByHashPrefix.javaL59-R59](diffhunk://#diff-bee0ded5124caaaa887c6fa9e86b52a97dc71b7069c3d0191bb1b949019fe4e5L59-R59))

**Internal Logic Simplification**
- Simplified the distributed key calculation logic in the writers, making the code more robust against null hashers and improving clarity. (`DefaultBulkWriter.java` [collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/statistics/DefaultBulkWriter.javaR151-R158](diffhunk://#diff-c176f754b16d83b58c43106952241d8c8e0191eaa92d510dbf976a861c3bed0dR151-R158))

These changes collectively improve maintainability, testability, and correctness of the row key distribution logic in the application map statistics components.