### PR TITLE
[#noissue] Refactor EventPublisher

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/event/SpanStorePublisherImpl.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/event/SpanStorePublisherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,13 +12,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.collector.event;
 
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import com.navercorp.pinpoint.common.server.event.ContextData;
 import com.navercorp.pinpoint.common.server.event.SpanChunkInsertEvent;
 import com.navercorp.pinpoint.common.server.event.SpanInsertEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -36,21 +36,23 @@ public class SpanStorePublisherImpl implements SpanStorePublisher {
 
     @Override
     public SpanInsertEvent captureContext(SpanBo spanBo) {
-        return new SpanInsertEvent(spanBo, false);
+        ContextData event = new ContextData(spanBo.getApplicationName(), spanBo.getAgentId(), spanBo.getStartTime());
+        return new SpanInsertEvent(event, false);
     }
 
     @Override
     public SpanChunkInsertEvent captureContext(SpanChunkBo spanChunkBo) {
-        return new SpanChunkInsertEvent(spanChunkBo, false);
+        ContextData event = new ContextData(spanChunkBo.getApplicationName(), spanChunkBo.getAgentId(), -1);
+        return new SpanChunkInsertEvent(event, false);
     }
 
     @Override
     public void publishEvent(SpanInsertEvent event, boolean success) {
-        publisher.publishEvent(new SpanInsertEvent(event.getSpanBo(), success));
+        publisher.publishEvent(new SpanInsertEvent(event.getContextData(), success));
     }
 
     @Override
     public void publishEvent(SpanChunkInsertEvent event, boolean success) {
-        publisher.publishEvent(new SpanChunkInsertEvent(event.getSpanChunkBo(), success));
+        publisher.publishEvent(new SpanChunkInsertEvent(event.getContextData(), success));
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/ContextData.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/ContextData.java
@@ -16,23 +16,5 @@
 
 package com.navercorp.pinpoint.common.server.event;
 
-import java.util.Objects;
-
-public class SpanInsertEvent {
-    private final ContextData contextData;
-    private final boolean success;
-
-    public SpanInsertEvent(ContextData contextData, boolean success) {
-        this.contextData = Objects.requireNonNull(contextData, "contextData");
-        this.success = success;
-    }
-
-    public ContextData getContextData() {
-        return contextData;
-    }
-
-    public boolean isSuccess() {
-        return success;
-    }
-
+public record ContextData(String applicationName, String agentId, long startTime) {
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SpanChunkInsertEvent.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SpanChunkInsertEvent.java
@@ -1,23 +1,38 @@
-package com.navercorp.pinpoint.common.server.event;
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+package com.navercorp.pinpoint.common.server.event;
 
 import java.util.Objects;
 
 public class SpanChunkInsertEvent {
-    private final SpanChunkBo spanChunkBo;
+    private final ContextData contextData;
     private final boolean success;
 
-    public SpanChunkInsertEvent(SpanChunkBo spanChunkBo, boolean success) {
-        this.spanChunkBo = Objects.requireNonNull(spanChunkBo, "spanChunkBo");
+    public SpanChunkInsertEvent(ContextData contextData, boolean success) {
+        this.contextData = Objects.requireNonNull(contextData, "contextData");
         this.success = success;
     }
 
-    public SpanChunkBo getSpanChunkBo() {
-        return spanChunkBo;
+    public ContextData getContextData() {
+        return contextData;
     }
 
     public boolean isSuccess() {
         return success;
     }
+
 }


### PR DESCRIPTION
This pull request refactors how span and span chunk events are handled by introducing a new `ContextData` record to encapsulate shared context information. The changes simplify event construction and decouple event classes from direct dependencies on `SpanBo` and `SpanChunkBo`. Additionally, copyright years are updated.

Core refactoring to event handling:

**Event Data Abstraction:**
* Introduced a new `ContextData` record for holding `applicationName`, `agentId`, and `startTime`, used in event classes to represent context information.
* Refactored `SpanInsertEvent` and `SpanChunkInsertEvent` to store a `ContextData` instance instead of `SpanBo` or `SpanChunkBo`, and updated their constructors and getters accordingly. [[1]](diffhunk://#diff-05e974477cc4e46127e10075918cccf22b23b872c493851129e37e27e6f606deL1-R37) [[2]](diffhunk://#diff-7387639ed44c7e50918b994cb5018e4968e19e158291a56fc7030846fce55ed2L1-R37)

**Usage Updates:**
* Updated `SpanStorePublisherImpl` to create and use `ContextData` when capturing and publishing span and span chunk events, replacing direct use of `SpanBo` and `SpanChunkBo`. [[1]](diffhunk://#diff-5d2f2fc6a8c838b0656603b02a1d5e1008a1b159ecc8bf29c334d55a3e742f72L15-R21) [[2]](diffhunk://#diff-5d2f2fc6a8c838b0656603b02a1d5e1008a1b159ecc8bf29c334d55a3e742f72L39-R56)

**Copyright Updates:**
* Updated copyright years to 2025 in affected files. [[1]](diffhunk://#diff-5d2f2fc6a8c838b0656603b02a1d5e1008a1b159ecc8bf29c334d55a3e742f72L2-R2) [[2]](diffhunk://#diff-801b5de73bd5d7fca76c0aaae3102338252e7dece3e4612b8366dfd0bd919da3R1-R20) [[3]](diffhunk://#diff-7387639ed44c7e50918b994cb5018e4968e19e158291a56fc7030846fce55ed2L1-R37) [[4]](diffhunk://#diff-05e974477cc4e46127e10075918cccf22b23b872c493851129e37e27e6f606deL1-R37)