### PR TITLE
[#noissue] Enhance SpanStorePublisher to support ContextSupplier

### DIFF
--- a/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/BasicCollectorApp.java
+++ b/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/BasicCollectorApp.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.collector.starter.multi.application;
 
 import com.navercorp.pinpoint.collector.PinpointCollectorModule;
-import com.navercorp.pinpoint.collector.event.config.CollectorEventConfiguration;
 import com.navercorp.pinpoint.datasource.MainDataSourceConfiguration;
 import com.navercorp.pinpoint.datasource.MainDataSourcePropertySource;
 import com.navercorp.pinpoint.redis.RedisPropertySources;
@@ -37,7 +52,6 @@ import org.springframework.context.annotation.Import;
         MainDataSourceConfiguration.class,
 
         RedisPropertySources.class,
-        CollectorEventConfiguration.class,
 })
 public class BasicCollectorApp {
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/CollectorApp.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/CollectorApp.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.collector;
 
-import com.navercorp.pinpoint.collector.event.config.CollectorEventConfiguration;
 import com.navercorp.pinpoint.common.server.util.ServerBootLogger;
 import com.navercorp.pinpoint.datasource.MainDataSourceConfiguration;
 import com.navercorp.pinpoint.datasource.MainDataSourcePropertySource;
@@ -33,7 +48,6 @@ import org.springframework.context.annotation.Import;
         MainDataSourceConfiguration.class,
 
         RedisPropertySources.class,
-        CollectorEventConfiguration.class,
 })
 public class CollectorApp {
     private static final ServerBootLogger logger = ServerBootLogger.getLogger(CollectorApp.class);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/PinpointCollectorModule.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/PinpointCollectorModule.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.collector.applicationmap.config.ApplicationMapModu
 import com.navercorp.pinpoint.collector.config.ClusterModule;
 import com.navercorp.pinpoint.collector.config.CollectorCommonConfiguration;
 import com.navercorp.pinpoint.collector.config.CollectorConfiguration;
+import com.navercorp.pinpoint.collector.event.config.CollectorEventConfiguration;
 import com.navercorp.pinpoint.collector.grpc.CollectorGrpcConfiguration;
 import com.navercorp.pinpoint.collector.grpc.ssl.GrpcSslModule;
 import com.navercorp.pinpoint.collector.heatmap.HeatmapCollectorModule;
@@ -62,6 +63,8 @@ import org.springframework.context.annotation.Import;
 
         CollectorUidConfiguration.class,
         HeatmapCollectorModule.class,
+
+        CollectorEventConfiguration.class
 })
 @ComponentScan(basePackages = {
         "com.navercorp.pinpoint.collector.handler",

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/event/SpanStorePublisherImpl.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/event/SpanStorePublisherImpl.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.collector.event;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.event.ContextData;
+import com.navercorp.pinpoint.common.server.event.ContextSupplier;
 import com.navercorp.pinpoint.common.server.event.SpanChunkInsertEvent;
 import com.navercorp.pinpoint.common.server.event.SpanInsertEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -29,21 +30,23 @@ import java.util.Objects;
 @Component
 public class SpanStorePublisherImpl implements SpanStorePublisher {
     private final ApplicationEventPublisher publisher;
+    private final ContextSupplier supplier;
 
-    public SpanStorePublisherImpl(ApplicationEventPublisher publisher) {
+    public SpanStorePublisherImpl(ApplicationEventPublisher publisher, ContextSupplier supplier) {
         this.publisher = Objects.requireNonNull(publisher, "publisher");
+        this.supplier = Objects.requireNonNull(supplier, "supplier");
     }
 
     @Override
     public SpanInsertEvent captureContext(SpanBo spanBo) {
-        ContextData event = new ContextData(spanBo.getApplicationName(), spanBo.getAgentId(), spanBo.getStartTime());
-        return new SpanInsertEvent(event, false);
+        ContextData contextData = supplier.applyAsContext(spanBo);
+        return new SpanInsertEvent(contextData, false);
     }
 
     @Override
     public SpanChunkInsertEvent captureContext(SpanChunkBo spanChunkBo) {
-        ContextData event = new ContextData(spanChunkBo.getApplicationName(), spanChunkBo.getAgentId(), -1);
-        return new SpanChunkInsertEvent(event, false);
+        ContextData contextData = supplier.applyAsContext(spanChunkBo);
+        return new SpanChunkInsertEvent(contextData, false);
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/event/config/CollectorEventConfiguration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/event/config/CollectorEventConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,22 +12,33 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.collector.event.config;
 
 import com.navercorp.pinpoint.collector.event.SpanStorePublisher;
 import com.navercorp.pinpoint.collector.event.SpanStorePublisherImpl;
+import com.navercorp.pinpoint.common.server.event.ContextSupplier;
+import com.navercorp.pinpoint.common.server.event.SimpleContextSupplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Optional;
+
 @Configuration
 public class CollectorEventConfiguration {
 
+    private final Logger logger = LogManager.getLogger(CollectorEventConfiguration.class);
+
+
     @Bean
-    public SpanStorePublisher spanPublisher(ApplicationEventPublisher publisher) {
-        return new SpanStorePublisherImpl(publisher);
+    public SpanStorePublisher spanPublisher(ApplicationEventPublisher publisher,
+                                            Optional<ContextSupplier> optionalSupplier) {
+        ContextSupplier supplier = optionalSupplier.orElseGet(SimpleContextSupplier::new);
+        logger.info("ContextSupplier:{}", supplier);
+        return new SpanStorePublisherImpl(publisher, supplier);
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/ContextSupplier.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/ContextSupplier.java
@@ -16,7 +16,13 @@
 
 package com.navercorp.pinpoint.common.server.event;
 
-import java.util.Map;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 
-public record ContextData(String applicationName, String agentId, long startTime, Map<String, Object> attribute) {
+public interface ContextSupplier {
+
+    ContextData applyAsContext(SpanBo spanBo);
+
+    ContextData applyAsContext(SpanChunkBo spanChunkBo);
+
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/InsertEvent.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/InsertEvent.java
@@ -16,7 +16,8 @@
 
 package com.navercorp.pinpoint.common.server.event;
 
-import java.util.Map;
+public interface InsertEvent {
+    ContextData getContextData();
 
-public record ContextData(String applicationName, String agentId, long startTime, Map<String, Object> attribute) {
+    boolean isSuccess();
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SimpleContextSupplier.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SimpleContextSupplier.java
@@ -16,7 +16,21 @@
 
 package com.navercorp.pinpoint.common.server.event;
 
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+
 import java.util.Map;
 
-public record ContextData(String applicationName, String agentId, long startTime, Map<String, Object> attribute) {
+public class SimpleContextSupplier implements ContextSupplier {
+
+    @Override
+    public ContextData applyAsContext(SpanBo spanBo) {
+        return new ContextData(spanBo.getApplicationName(), spanBo.getAgentId(), spanBo.getStartTime(), Map.of());
+    }
+
+    @Override
+    public ContextData applyAsContext(SpanChunkBo spanChunkBo) {
+        return new ContextData(spanChunkBo.getApplicationName(), spanChunkBo.getAgentId(), -1, Map.of());
+    }
+
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SpanChunkInsertEvent.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SpanChunkInsertEvent.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.common.server.event;
 
 import java.util.Objects;
 
-public class SpanChunkInsertEvent {
+public class SpanChunkInsertEvent implements InsertEvent {
     private final ContextData contextData;
     private final boolean success;
 
@@ -27,10 +27,12 @@ public class SpanChunkInsertEvent {
         this.success = success;
     }
 
+    @Override
     public ContextData getContextData() {
         return contextData;
     }
 
+    @Override
     public boolean isSuccess() {
         return success;
     }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SpanInsertEvent.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SpanInsertEvent.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.common.server.event;
 
 import java.util.Objects;
 
-public class SpanInsertEvent {
+public class SpanInsertEvent implements InsertEvent {
     private final ContextData contextData;
     private final boolean success;
 
@@ -27,10 +27,12 @@ public class SpanInsertEvent {
         this.success = success;
     }
 
+    @Override
     public ContextData getContextData() {
         return contextData;
     }
 
+    @Override
     public boolean isSuccess() {
         return success;
     }


### PR DESCRIPTION
This pull request introduces a refactor and extensibility improvements to the event context handling in the collector module. The main changes include generalizing how context data for span events is supplied, introducing new interfaces and implementations to support this, and updating the event data structures to be more flexible. There are also some minor updates to configuration and copyright years.

**Event context handling improvements:**

* Introduced the `ContextSupplier` interface and its default implementation `SimpleContextSupplier`, allowing for flexible creation of `ContextData` from `SpanBo` and `SpanChunkBo` objects. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/ContextSupplier.java` [[1]](diffhunk://#diff-89215b7306924a64895912ef2bbb8c93adbac15eb1689a5e4c08b38004f10267R1-R28) `commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SimpleContextSupplier.java` [[2]](diffhunk://#diff-aa745680b1fd14b8d2af66f5474aac39ff1db0ec22f97c60a44de59e3a7c9c2eR1-R36)
* Updated `SpanStorePublisherImpl` to use the injected `ContextSupplier` for creating `ContextData`, instead of constructing it directly. This allows for more extensible context enrichment. (`collector/src/main/java/com/navercorp/pinpoint/collector/event/SpanStorePublisherImpl.java` [[1]](diffhunk://#diff-5d2f2fc6a8c838b0656603b02a1d5e1008a1b159ecc8bf29c334d55a3e742f72R22) [[2]](diffhunk://#diff-5d2f2fc6a8c838b0656603b02a1d5e1008a1b159ecc8bf29c334d55a3e742f72R33-R49)
* Modified `CollectorEventConfiguration` to inject an optional `ContextSupplier` bean, defaulting to `SimpleContextSupplier` if none is provided, and to pass this supplier to `SpanStorePublisherImpl`. (`collector/src/main/java/com/navercorp/pinpoint/collector/event/config/CollectorEventConfiguration.java` [collector/src/main/java/com/navercorp/pinpoint/collector/event/config/CollectorEventConfiguration.javaL15-R42](diffhunk://#diff-93ab1948d38478483caa9fc88c5c5e75fd2c3531487ae1c697f8808a02e9d34bL15-R42))

**Event data structure enhancements:**

* Extended the `ContextData` record to include an `attribute` map, allowing for additional context attributes to be attached to events. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/ContextData.java` [commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/ContextData.javaL19-R21](diffhunk://#diff-801b5de73bd5d7fca76c0aaae3102338252e7dece3e4612b8366dfd0bd919da3L19-R21))
* Introduced the `InsertEvent` interface, and updated `SpanInsertEvent` and `SpanChunkInsertEvent` to implement it, standardizing access to context data and success status. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/InsertEvent.java` [[1]](diffhunk://#diff-943b959ecde399174c688fe6c7c0d7ba6ee9baf32302319c54c89960b29bbd3fR1-R23) `commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SpanInsertEvent.java` [[2]](diffhunk://#diff-05e974477cc4e46127e10075918cccf22b23b872c493851129e37e27e6f606deL21-R21) [[3]](diffhunk://#diff-05e974477cc4e46127e10075918cccf22b23b872c493851129e37e27e6f606deR30-R35) `commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SpanChunkInsertEvent.java` [[4]](diffhunk://#diff-7387639ed44c7e50918b994cb5018e4968e19e158291a56fc7030846fce55ed2L21-R21) [[5]](diffhunk://#diff-7387639ed44c7e50918b994cb5018e4968e19e158291a56fc7030846fce55ed2R30-R35)

**Configuration and copyright:**

* Moved the registration of `CollectorEventConfiguration` from the application classes (`CollectorApp`, `BasicCollectorApp`) to the `PinpointCollectorModule`, centralizing event configuration. (`collector/src/main/java/com/navercorp/pinpoint/collector/CollectorApp.java` [[1]](diffhunk://#diff-2e067f3d1e53d9d1f1ac15fca7bb579569ebcb3640bed8313f95c77d10d48bc7R1-L3) [[2]](diffhunk://#diff-2e067f3d1e53d9d1f1ac15fca7bb579569ebcb3640bed8313f95c77d10d48bc7L36) `collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/BasicCollectorApp.java` [[3]](diffhunk://#diff-5a1e422932c6d9943de86b99eb17479a21fa9f6a7dd288d6e2fb461932d603b3R1-L4) [[4]](diffhunk://#diff-5a1e422932c6d9943de86b99eb17479a21fa9f6a7dd288d6e2fb461932d603b3L40) `collector/src/main/java/com/navercorp/pinpoint/collector/PinpointCollectorModule.java` [[5]](diffhunk://#diff-2c08c4a8c9f96f190cf1af7029a45ff421f6d0ea7c49ecb74e1d631ce1b1dba0R24) [[6]](diffhunk://#diff-2c08c4a8c9f96f190cf1af7029a45ff421f6d0ea7c49ecb74e1d631ce1b1dba0R66-R67)
* Updated copyright years in several files to 2025. (`collector/src/main/java/com/navercorp/pinpoint/collector/event/config/CollectorEventConfiguration.java` [collector/src/main/java/com/navercorp/pinpoint/collector/event/config/CollectorEventConfiguration.javaL2-R2](diffhunk://#diff-93ab1948d38478483caa9fc88c5c5e75fd2c3531487ae1c697f8808a02e9d34bL2-R2))

These changes make the event publishing process more extensible and future-proof, allowing for richer context to be attached to events and for custom context-supplying strategies to be injected as needed.