### PR TITLE
[#noissue] Fix missing saltkey masking

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HostRowKeyEncoderV2.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HostRowKeyEncoderV2.java
@@ -39,6 +39,11 @@ public class HostRowKeyEncoderV2 implements HostRowKeyEncoder {
     }
 
     public byte[] encodeRowKey(String parentApplicationName, int parentServiceType, int parentServiceUid, long timestamp) {
+        byte[] rowkey = encodeRowKey0(parentApplicationName, parentServiceType, parentServiceUid, timestamp);
+        return hasher.writeSaltKey(rowkey);
+    }
+
+    byte[] encodeRowKey0(String parentApplicationName, int parentServiceType, int parentServiceUid, long timestamp) {
 
         // even if  a agentId be added for additional specifications, it may be safe to scan rows.
         // But is it needed to add parentAgentServiceType?

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/HostRowKeyEncoderV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/HostRowKeyEncoderV3.java
@@ -40,6 +40,11 @@ public class HostRowKeyEncoderV3 implements HostRowKeyEncoder {
     }
 
     public byte[] encodeRowKey(String parentApplicationName, int parentServiceType, int parentServiceUid, long timestamp) {
+        byte[] rowkey = encodeRowKey0(parentApplicationName, parentServiceType, parentServiceUid, timestamp);
+        return hasher.writeSaltKey(rowkey);
+    }
+
+    byte[] encodeRowKey0(String parentApplicationName, int parentServiceType, int parentServiceUid, long timestamp) {
 
         // even if  a agentId be added for additional specifications, it may be safe to scan rows.
         // But is it needed to add parentAgentServiceType?


### PR DESCRIPTION
This pull request refactors the row key encoding process in both `HostRowKeyEncoderV2` and `HostRowKeyEncoderV3` to improve code clarity and modularity. The main change is the extraction of the core row key encoding logic into a new internal method, making the code easier to maintain and test.

Refactoring and code structure improvements:

* Extracted the core row key encoding logic into a new internal method `encodeRowKey0` in both `HostRowKeyEncoderV2` and `HostRowKeyEncoderV3`, allowing the public `encodeRowKey` method to handle salting separately. [[1]](diffhunk://#diff-e3d7e5b9a3e925b5e4ac06176cdeed8b2873eb1733e9ac79c74df387a15b4850R42-R46) [[2]](diffhunk://#diff-0d06dfe3b6cfb30b28c2d96c0c42e9aacfcfd21a1247162c3880970cf4a2a7d9R43-R47)