### PR TITLE
[#noissue] Refactor SqlUidMetaDataMapper

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/SqlUidMetaDataMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/SqlUidMetaDataMapper.java
@@ -18,13 +18,14 @@ package com.navercorp.pinpoint.web.mapper;
 
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
+import com.navercorp.pinpoint.common.hbase.util.CellUtils;
 import com.navercorp.pinpoint.common.server.bo.SqlUidMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.uid.UidMetaDataRowKey;
 import com.navercorp.pinpoint.common.server.bo.serializer.metadata.uid.UidMetadataDecoder;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -33,7 +34,7 @@ import java.util.List;
 
 @Component
 public class SqlUidMetaDataMapper implements RowMapper<List<SqlUidMetaDataBo>> {
-    private final static String SQL_UID_METADATA_CF_SQL_QUALI_SQLSTATEMENT = Bytes.toString(HbaseTables.SQL_UID_METADATA_SQL.QUALIFIER_SQLSTATEMENT);
+    private final static byte[] SQL_UID_METADATA_CF_SQL_QUALI_SQLSTATEMENT = HbaseTables.SQL_UID_METADATA_SQL.QUALIFIER_SQLSTATEMENT;
 
     private final RowKeyDecoder<UidMetaDataRowKey> decoder = new UidMetadataDecoder();
 
@@ -52,14 +53,11 @@ public class SqlUidMetaDataMapper implements RowMapper<List<SqlUidMetaDataBo>> {
         List<SqlUidMetaDataBo> sqlUidMetaDataList = new ArrayList<>();
 
         for (Cell cell : result.rawCells()) {
-            String sql = Bytes.toString(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
-
-            if (SQL_UID_METADATA_CF_SQL_QUALI_SQLSTATEMENT.equals(sql)) {
-                sql = Bytes.toString(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength());
+            if (CellUtil.matchingQualifier(cell, SQL_UID_METADATA_CF_SQL_QUALI_SQLSTATEMENT)) {
+                String sqlStatement = CellUtils.valueToString(cell);
+                SqlUidMetaDataBo sqlUidMetaDataBo = new SqlUidMetaDataBo(key.getAgentId(), key.getAgentStartTime(), key.getUid(), sqlStatement);
+                sqlUidMetaDataList.add(sqlUidMetaDataBo);
             }
-
-            SqlUidMetaDataBo sqlUidMetaDataBo = new SqlUidMetaDataBo(key.getAgentId(), key.getAgentStartTime(), key.getUid(), sql);
-            sqlUidMetaDataList.add(sqlUidMetaDataBo);
         }
         return sqlUidMetaDataList;
     }


### PR DESCRIPTION
This pull request refactors the `SqlUidMetaDataMapper` class to improve how SQL statement qualifiers and values are handled, leading to cleaner and more reliable code. The main changes involve switching from manual byte array manipulation to using utility methods provided by HBase and Pinpoint, which enhances code readability and correctness.

**Refactoring for HBase cell handling:**

* Replaced manual byte array conversion for SQL statement qualifiers with the use of `CellUtil.matchingQualifier`, improving reliability and clarity when checking cell qualifiers. [[1]](diffhunk://#diff-94b95ffbe9a37df0377a84611023ff81b14dd0b8f27700510c44177fd00a3a22L36-R37) [[2]](diffhunk://#diff-94b95ffbe9a37df0377a84611023ff81b14dd0b8f27700510c44177fd00a3a22L55-R61)
* Switched from extracting SQL statement values using raw byte arrays to using `CellUtils.valueToString`, which simplifies and standardizes value extraction from HBase cells. [[1]](diffhunk://#diff-94b95ffbe9a37df0377a84611023ff81b14dd0b8f27700510c44177fd00a3a22R21-L27) [[2]](diffhunk://#diff-94b95ffbe9a37df0377a84611023ff81b14dd0b8f27700510c44177fd00a3a22L55-R61)

**Dependency and import updates:**

* Updated imports to include `CellUtils` and `CellUtil`, removing unnecessary usage of `Bytes` for qualifier and value handling.

These updates make the mapper code more maintainable and less error-prone when working with HBase cell data.