### PR TITLE
[#12971] Add TestCase for JitterStartTimeDistributor

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/scheduler/JitterStartTimeDistributor.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/scheduler/JitterStartTimeDistributor.java
@@ -35,8 +35,11 @@ public class JitterStartTimeDistributor implements StartTimeDistributor {
     }
 
     private long jitter() {
-        long spreadTime = (long)((double)nextDelay * spread);
+        if (spread == 0) {
+            return 0;
+        }
 
+        long spreadTime = (long) ((double) nextDelay * spread);
         return ThreadLocalRandom.current().nextLong(-spreadTime, spreadTime);
     }
 

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/scheduler/JitterStartTimeDistributorTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/scheduler/JitterStartTimeDistributorTest.java
@@ -16,6 +16,26 @@
 
 package com.navercorp.pinpoint.collector.scheduler;
 
+import com.google.common.collect.Range;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 class JitterStartTimeDistributorTest {
+    @Test
+     void nextTick() {
+        JitterStartTimeDistributor distributor = new JitterStartTimeDistributor(1000, 0.0);
+        long tick = distributor.nextTick();
+        Assertions.assertTrue(tick > 0);
+    }
+
+    @Test
+    void nextTick_jitter() {
+        JitterStartTimeDistributor distributor = new JitterStartTimeDistributor(1000, 0.1);
+        long tick = distributor.nextTick();
+        Range<Long> range = Range.closed(900L, 1100L);
+
+        Assertions.assertTrue(range.contains(tick));
+        Assertions.assertTrue(range.contains(900L));
+    }
 
 }


### PR DESCRIPTION
This pull request improves the reliability of the jitter calculation in the `JitterStartTimeDistributor` class and enhances its test coverage. The main changes ensure that jitter is correctly handled when the spread is zero, and add tests to verify the behavior for both zero and non-zero spread values.

**Bug fix and reliability improvement:**

* Updated the `jitter()` method in `JitterStartTimeDistributor.java` to return `0` when the `spread` parameter is zero, preventing unnecessary randomization and ensuring predictable behavior.

**Testing enhancements:**

* Added new unit tests in `JitterStartTimeDistributorTest.java` to verify that `nextTick()` behaves correctly for both zero spread (always positive tick) and non-zero spread (tick falls within the expected range).