### PR TITLE
[#noissue] Cleanup testcase

### DIFF
--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountCheckerTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,22 +17,24 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
-import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
+import com.navercorp.pinpoint.web.applicationmap.dao.ApplicationResponse;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.ResponseTime;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ErrorCountCheckerTest {
 
@@ -41,33 +43,38 @@ public class ErrorCountCheckerTest {
 
     private static MapResponseDao mockMapResponseDAO;
 
-    @BeforeAll
-    public static void before() {
-        mockMapResponseDAO = new MapResponseDao() {
 
+    @BeforeEach
+    public void before() {
+        mockMapResponseDAO = mock(MapResponseDao.class);
+        when(mockMapResponseDAO.selectApplicationResponse(any(), any())).thenAnswer(new Answer<ApplicationResponse>() {
             @Override
-            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
-                long timeStamp = 1409814914298L;
-                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
-
-                TimeHistogram histogram;
-                for (int i = 0; i < 5; i++) {
-                    for (int j = 0; j < 5; j++) {
-                        histogram = new TimeHistogram(ServiceType.STAND_ALONE, timeStamp);
-                        histogram.addCallCountByElapsedTime(1000, false);
-                        histogram.addCallCountByElapsedTime(3000, false);
-                        histogram.addCallCountByElapsedTime(1000, true);
-                        histogram.addCallCountByElapsedTime(1000, true);
-                        histogram.addCallCountByElapsedTime(1000, true);
-                        responseTime.addResponseTime("agent_" + i + "_" + j, histogram);
-                    }
-
-                    timeStamp += 1;
-                }
-
-                return List.of(responseTime.build());
+            public ApplicationResponse answer(InvocationOnMock invocation) throws Throwable {
+                Application application = invocation.getArgument(0, Application.class);
+                return testData(application);
             }
-        };
+        });
+    }
+
+    private ApplicationResponse testData(Application application) {
+        long timeStamp = 1409814914298L;
+        ApplicationResponse.Builder responseTime = ApplicationResponse.newBuilder(application);
+
+        TimeHistogram histogram;
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                histogram = new TimeHistogram(application.getServiceType(), timeStamp);
+                histogram.addCallCountByElapsedTime(1000, false);
+                histogram.addCallCountByElapsedTime(3000, false);
+                histogram.addCallCountByElapsedTime(1000, true);
+                histogram.addCallCountByElapsedTime(1000, true);
+                histogram.addCallCountByElapsedTime(1000, true);
+                responseTime.addResponseTime("agent_" + i + "_" + j, timeStamp, histogram);
+            }
+
+            timeStamp += 1;
+        }
+        return responseTime.build();
     }
 
     /*

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateCheckerTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,57 +17,64 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
-import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
+import com.navercorp.pinpoint.web.applicationmap.dao.ApplicationResponse;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.ResponseTime;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ErrorRateCheckerTest {
 
     private static final String SERVICE_NAME = "local_service";
     private static final String SERVICE_TYPE = "tomcat";
 
-    private static MapResponseDao mockMapResponseDAO;
+    private MapResponseDao mockMapResponseDAO;
 
-    @BeforeAll
-    public static void before() {
-        mockMapResponseDAO = new MapResponseDao() {
-
+    @BeforeEach
+    void before() {
+        mockMapResponseDAO = mock(MapResponseDao.class);
+        when(mockMapResponseDAO.selectApplicationResponse(any(), any())).thenAnswer(new Answer<ApplicationResponse>() {
             @Override
-            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
-                long timeStamp = 1409814914298L;
-                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
-
-                TimeHistogram histogram;
-                for (int i = 0; i < 5; i++) {
-                    for (int j = 0; j < 5; j++) {
-                        histogram = new TimeHistogram(ServiceType.STAND_ALONE, timeStamp);
-                        histogram.addCallCountByElapsedTime(1000, false);
-                        histogram.addCallCountByElapsedTime(3000, false);
-                        histogram.addCallCountByElapsedTime(1000, true);
-                        histogram.addCallCountByElapsedTime(1000, true);
-                        histogram.addCallCountByElapsedTime(1000, true);
-                        responseTime.addResponseTime("agent_" + i + "_" + j, histogram);
-                    }
-
-                    timeStamp += 1;
-                }
-
-                return List.of(responseTime.build());
+            public ApplicationResponse answer(InvocationOnMock invocation) throws Throwable {
+                Application application = invocation.getArgument(0, Application.class);
+                return testData(application);
             }
-        };
+        });
+    }
+
+    private ApplicationResponse testData(Application application) {
+        long timeStamp = 1409814914298L;
+        ApplicationResponse.Builder responseTime = ApplicationResponse.newBuilder(application);
+
+        TimeHistogram histogram;
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                histogram = new TimeHistogram(application.getServiceType(), timeStamp);
+                histogram.addCallCountByElapsedTime(1000, false);
+                histogram.addCallCountByElapsedTime(3000, false);
+                histogram.addCallCountByElapsedTime(1000, true);
+                histogram.addCallCountByElapsedTime(1000, true);
+                histogram.addCallCountByElapsedTime(1000, true);
+                responseTime.addResponseTime("agent_" + i + "_" + j, timeStamp, histogram);
+            }
+
+            timeStamp += 1;
+        }
+
+        return responseTime.build();
     }
 
     /*

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ResponseCountCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ResponseCountCheckerTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,22 +18,24 @@ package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.DataCollectorFactory;
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
-import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
+import com.navercorp.pinpoint.web.applicationmap.dao.ApplicationResponse;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.ResponseTime;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ResponseCountCheckerTest {
 
@@ -41,35 +43,41 @@ public class ResponseCountCheckerTest {
     private static final String SERVICE_NAME = "local_service";
     private static final String SERVICE_TYPE = "tomcat";
 
-    private static MapResponseDao mockMapResponseDAO;
+    private MapResponseDao mockMapResponseDAO;
 
-    @BeforeAll
-    public static void before() {
-        mockMapResponseDAO = new MapResponseDao() {
 
+    @BeforeEach
+    public void before() {
+        mockMapResponseDAO = mock(MapResponseDao.class);
+        when(mockMapResponseDAO.selectApplicationResponse(any(), any())).thenAnswer(new Answer<ApplicationResponse>() {
             @Override
-            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
-                long timeStamp = 1409814914298L;
-                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
-
-                TimeHistogram histogram;
-                for (int i = 0; i < 5; i++) {
-                    for (int j = 0; j < 5; j++) {
-                        histogram = new TimeHistogram(ServiceType.STAND_ALONE, timeStamp);
-                        histogram.addCallCountByElapsedTime(1000, false);
-                        histogram.addCallCountByElapsedTime(3000, false);
-                        histogram.addCallCountByElapsedTime(1000, true);
-                        histogram.addCallCountByElapsedTime(1000, true);
-                        histogram.addCallCountByElapsedTime(1000, true);
-                        responseTime.addResponseTime("agent_" + i + "_" + j, histogram);
-                    }
-
-                    timeStamp += 1;
-                }
-
-                return List.of(responseTime.build());
+            public ApplicationResponse answer(InvocationOnMock invocation) throws Throwable {
+                Application application = invocation.getArgument(0, Application.class);
+                return testData(application);
             }
-        };
+        });
+    }
+
+    private ApplicationResponse testData(Application application) {
+        long timeStamp = 1409814914298L;
+        ApplicationResponse.Builder responseTime = ApplicationResponse.newBuilder(application);
+
+        TimeHistogram histogram;
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                histogram = new TimeHistogram(application.getServiceType(), timeStamp);
+                histogram.addCallCountByElapsedTime(1000, false);
+                histogram.addCallCountByElapsedTime(3000, false);
+                histogram.addCallCountByElapsedTime(1000, true);
+                histogram.addCallCountByElapsedTime(1000, true);
+                histogram.addCallCountByElapsedTime(1000, true);
+                responseTime.addResponseTime("agent_" + i + "_" + j, timeStamp, histogram);
+            }
+
+            timeStamp += 1;
+        }
+
+        return responseTime.build();
     }
 
     /*

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountCheckerTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,56 +17,63 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
-import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
+import com.navercorp.pinpoint.web.applicationmap.dao.ApplicationResponse;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.ResponseTime;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SlowCountCheckerTest {
 
     private static final String SERVICE_NAME = "local_service";
     private static final String SERVICE_TYPE = "tomcat";
 
-    private static MapResponseDao mockMapResponseDAO;
+    private MapResponseDao mockMapResponseDAO;
 
-    @BeforeAll
-    public static void before() {
-        mockMapResponseDAO = new MapResponseDao() {
-
+    @BeforeEach
+    void before() {
+        mockMapResponseDAO = mock(MapResponseDao.class);
+        when(mockMapResponseDAO.selectApplicationResponse(any(), any())).thenAnswer(new Answer<ApplicationResponse>() {
             @Override
-            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
-                long timeStamp = 1409814914298L;
-                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
-                TimeHistogram histogram;
-                for (int i = 0; i < 5; i++) {
-                    for (int j = 0; j < 5; j++) {
-                        histogram = new TimeHistogram(ServiceType.STAND_ALONE, timeStamp);
-                        histogram.addCallCountByElapsedTime(1000, false);
-                        histogram.addCallCountByElapsedTime(3000, false);
-                        histogram.addCallCountByElapsedTime(5000, false);
-                        histogram.addCallCountByElapsedTime(6000, false);
-                        histogram.addCallCountByElapsedTime(7000, false);
-                        responseTime.addResponseTime("agent_" + i + "_" + j, histogram);
-                    }
-
-                    timeStamp += 1;
-                }
-
-                return List.of(responseTime.build());
+            public ApplicationResponse answer(InvocationOnMock invocation) throws Throwable {
+                Application application = invocation.getArgument(0, Application.class);
+                return testData(application);
             }
-        };
+        });
+    }
+
+    private ApplicationResponse testData(Application application) {
+        long timeStamp = 1409814914298L;
+        ApplicationResponse.Builder responseTime = ApplicationResponse.newBuilder(application);
+        TimeHistogram histogram;
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                histogram = new TimeHistogram(application.getServiceType(), timeStamp);
+                histogram.addCallCountByElapsedTime(1000, false);
+                histogram.addCallCountByElapsedTime(3000, false);
+                histogram.addCallCountByElapsedTime(5000, false);
+                histogram.addCallCountByElapsedTime(6000, false);
+                histogram.addCallCountByElapsedTime(7000, false);
+                responseTime.addResponseTime("agent_" + i + "_" + j, timeStamp, histogram);
+            }
+
+            timeStamp += 1;
+        }
+
+        return responseTime.build();
     }
 
     /*

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateCheckerTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,57 +17,63 @@
 package com.navercorp.pinpoint.batch.alarm.checker;
 
 import com.navercorp.pinpoint.batch.alarm.collector.ResponseTimeDataCollector;
-import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.DataCollectorCategory;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
+import com.navercorp.pinpoint.web.applicationmap.dao.ApplicationResponse;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapResponseDao;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.ResponseTime;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SlowRateCheckerTest {
 
     private static final String SERVICE_NAME = "local_service";
     private static final String SERVICE_TYPE = "tomcat";
 
-    private static MapResponseDao mockMapResponseDAO;
+    private MapResponseDao mockAppMapResponseDAO;
 
-    @BeforeAll
-    public static void before() {
-        mockMapResponseDAO = new MapResponseDao() {
-
+    @BeforeEach
+    void before() {
+        mockAppMapResponseDAO = mock(MapResponseDao.class);
+        when(mockAppMapResponseDAO.selectApplicationResponse(any(), any())).thenAnswer(new Answer<ApplicationResponse>() {
             @Override
-            public List<ResponseTime> selectResponseTime(Application application, TimeWindow timeWindow) {
-                long timeStamp = 1409814914298L;
-                ResponseTime.Builder responseTime = ResponseTime.newBuilder(SERVICE_NAME, ServiceType.STAND_ALONE, timeStamp);
-
-                TimeHistogram histogram;
-                for (int i = 0; i < 5; i++) {
-                    for (int j = 0; j < 5; j++) {
-                        histogram = new TimeHistogram(ServiceType.STAND_ALONE, timeStamp);
-                        histogram.addCallCountByElapsedTime(1000, false);
-                        histogram.addCallCountByElapsedTime(3000, false);
-                        histogram.addCallCountByElapsedTime(5000, false);
-                        histogram.addCallCountByElapsedTime(6000, false);
-                        histogram.addCallCountByElapsedTime(7000, false);
-                        responseTime.addResponseTime("agent_" + i + "_" + j, histogram);
-                    }
-
-                    timeStamp += 1;
-                }
-
-                return List.of(responseTime.build());
+            public ApplicationResponse answer(InvocationOnMock invocation) throws Throwable {
+                Application application = invocation.getArgument(0, Application.class);
+                return testData(application);
             }
-        };
+        });
+    }
+
+    private ApplicationResponse testData(Application application) {
+        long timeStamp = 1409814914298L;
+        ApplicationResponse.Builder responseTime = ApplicationResponse.newBuilder(application);
+
+        TimeHistogram histogram;
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                histogram = new TimeHistogram(ServiceType.STAND_ALONE, timeStamp);
+                histogram.addCallCountByElapsedTime(1000, false);
+                histogram.addCallCountByElapsedTime(3000, false);
+                histogram.addCallCountByElapsedTime(5000, false);
+                histogram.addCallCountByElapsedTime(6000, false);
+                histogram.addCallCountByElapsedTime(7000, false);
+                responseTime.addResponseTime("agent_" + i + "_" + j, timeStamp, histogram);
+            }
+            timeStamp += 1;
+        }
+
+        return responseTime.build();
     }
 
     /*
@@ -76,7 +82,8 @@ public class SlowRateCheckerTest {
     @Test
     public void checkTest1() {
         Application application = new Application(SERVICE_NAME, ServiceType.STAND_ALONE);
-        ResponseTimeDataCollector collector = new ResponseTimeDataCollector(DataCollectorCategory.RESPONSE_TIME, application, mockMapResponseDAO, System.currentTimeMillis(), 300000);
+
+        ResponseTimeDataCollector collector = new ResponseTimeDataCollector(DataCollectorCategory.RESPONSE_TIME, application, mockAppMapResponseDAO, System.currentTimeMillis(), 300000);
         Rule rule = new Rule(SERVICE_NAME, SERVICE_TYPE, CheckerCategory.SLOW_RATE.getName(), 60, "testGroup", false, false, false, "");
         SlowRateChecker filter = new SlowRateChecker(collector, rule);
 
@@ -90,7 +97,7 @@ public class SlowRateCheckerTest {
     @Test
     public void checkTest2() {
         Application application = new Application(SERVICE_NAME, ServiceType.STAND_ALONE);
-        ResponseTimeDataCollector collector = new ResponseTimeDataCollector(DataCollectorCategory.RESPONSE_TIME, application, mockMapResponseDAO, System.currentTimeMillis(), 300000);
+        ResponseTimeDataCollector collector = new ResponseTimeDataCollector(DataCollectorCategory.RESPONSE_TIME, application, mockAppMapResponseDAO, System.currentTimeMillis(), 300000);
         Rule rule = new Rule(SERVICE_NAME, SERVICE_TYPE, CheckerCategory.SLOW_RATE.getName(), 61, "testGroup", false, false, false, "");
         SlowRateChecker filter = new SlowRateChecker(collector, rule);
 


### PR DESCRIPTION
This pull request refactors the test setup for several alarm checker test classes in the batch module. The main goal is to modernize and standardize the mocking of `MapResponseDao`, improve maintainability, and update copyright years.

**Test modernization and refactoring:**

* Replaced manual anonymous inner classes for mocking `MapResponseDao` with Mockito-based mocks and `Answer` implementations, improving readability and maintainability in all affected test classes (`ApdexScoreCheckerTest`, `ErrorCountCheckerTest`, `ErrorRateCheckerTest`, `ResponseCountCheckerTest`, `SlowCountCheckerTest`, `SlowRateCheckerTest`). [[1]](diffhunk://#diff-1879fe809a9c5d64a83d69a20ec48d271194584923bf7cc479e5afdf73404c70L44-R77) [[2]](diffhunk://#diff-5eef0b896524c55f199719e811c1d0e1e1000fc19ebd4e344bbb5cccae28a14aL44-R77) [[3]](diffhunk://#diff-2a2d94e09d0292a282104da2f1a051a659e545a210e1d7c42e9e18e81c6802ebL20-R77) [[4]](diffhunk://#diff-0d55874c29eaa57389b7ca2ff279a548c5c32c0e41e9b27050962e0793e864afL21-R80) [[5]](diffhunk://#diff-d042221f4188804de913766609816608b2381c9a96ab6d9f380124c478acb2d3L20-R76) [[6]](diffhunk://#diff-b2c6eac16027222e65d42df91f53c247465ed591df5c1e1c0f53c3d8785d35d7L20-R60)

* Changed test lifecycle annotations from `@BeforeAll` (static) to `@BeforeEach` (instance), ensuring a fresh mock setup before each test method for better isolation and reliability. [[1]](diffhunk://#diff-1879fe809a9c5d64a83d69a20ec48d271194584923bf7cc479e5afdf73404c70L44-R77) [[2]](diffhunk://#diff-5eef0b896524c55f199719e811c1d0e1e1000fc19ebd4e344bbb5cccae28a14aL44-R77) [[3]](diffhunk://#diff-2a2d94e09d0292a282104da2f1a051a659e545a210e1d7c42e9e18e81c6802ebL20-R77) [[4]](diffhunk://#diff-0d55874c29eaa57389b7ca2ff279a548c5c32c0e41e9b27050962e0793e864afL21-R80) [[5]](diffhunk://#diff-d042221f4188804de913766609816608b2381c9a96ab6d9f380124c478acb2d3L20-R76) [[6]](diffhunk://#diff-b2c6eac16027222e65d42df91f53c247465ed591df5c1e1c0f53c3d8785d35d7L20-R60)

**Test data and API updates:**

* Updated test data generation to use `ApplicationResponse` and its builder consistently, replacing the older `ResponseTime` API. Adjusted method calls to match the new API, such as passing agent ID, timestamp, and histogram to `addResponseTime`. [[1]](diffhunk://#diff-1879fe809a9c5d64a83d69a20ec48d271194584923bf7cc479e5afdf73404c70L44-R77) [[2]](diffhunk://#diff-5eef0b896524c55f199719e811c1d0e1e1000fc19ebd4e344bbb5cccae28a14aL44-R77) [[3]](diffhunk://#diff-2a2d94e09d0292a282104da2f1a051a659e545a210e1d7c42e9e18e81c6802ebL20-R77) [[4]](diffhunk://#diff-0d55874c29eaa57389b7ca2ff279a548c5c32c0e41e9b27050962e0793e864afL21-R80) [[5]](diffhunk://#diff-d042221f4188804de913766609816608b2381c9a96ab6d9f380124c478acb2d3L20-R76) [[6]](diffhunk://#diff-b2c6eac16027222e65d42df91f53c247465ed591df5c1e1c0f53c3d8785d35d7L20-R60)

* Removed unused imports and cleaned up code to reflect the new test setup. [[1]](diffhunk://#diff-1879fe809a9c5d64a83d69a20ec48d271194584923bf7cc479e5afdf73404c70L19-R35) [[2]](diffhunk://#diff-5eef0b896524c55f199719e811c1d0e1e1000fc19ebd4e344bbb5cccae28a14aL20-R37) [[3]](diffhunk://#diff-2a2d94e09d0292a282104da2f1a051a659e545a210e1d7c42e9e18e81c6802ebL20-R77) [[4]](diffhunk://#diff-0d55874c29eaa57389b7ca2ff279a548c5c32c0e41e9b27050962e0793e864afL21-R80) [[5]](diffhunk://#diff-d042221f4188804de913766609816608b2381c9a96ab6d9f380124c478acb2d3L20-R76) [[6]](diffhunk://#diff-b2c6eac16027222e65d42df91f53c247465ed591df5c1e1c0f53c3d8785d35d7L20-R60)

**General maintenance:**

* Updated copyright years to 2025 in all modified test files. [[1]](diffhunk://#diff-1879fe809a9c5d64a83d69a20ec48d271194584923bf7cc479e5afdf73404c70L2-R2) [[2]](diffhunk://#diff-5eef0b896524c55f199719e811c1d0e1e1000fc19ebd4e344bbb5cccae28a14aL2-R2) [[3]](diffhunk://#diff-2a2d94e09d0292a282104da2f1a051a659e545a210e1d7c42e9e18e81c6802ebL2-R2) [[4]](diffhunk://#diff-0d55874c29eaa57389b7ca2ff279a548c5c32c0e41e9b27050962e0793e864afL2-R2) [[5]](diffhunk://#diff-d042221f4188804de913766609816608b2381c9a96ab6d9f380124c478acb2d3L2-R2) [[6]](diffhunk://#diff-b2c6eac16027222e65d42df91f53c247465ed591df5c1e1c0f53c3d8785d35d7L2-R2)