### PR TITLE
[#noissue] Add slotCode to HistogramSchema

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/active/DefaultActiveTraceRepository.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/active/DefaultActiveTraceRepository.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,8 +18,8 @@ package com.navercorp.pinpoint.profiler.context.active;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
+import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.profiler.cache.CaffeineBuilder;
 import com.navercorp.pinpoint.profiler.context.id.LocalTraceRoot;
@@ -50,7 +50,7 @@ public class DefaultActiveTraceRepository implements ActiveTraceRepository {
 
     private final ResponseTimeCollector responseTimeCollector;
 
-    private final HistogramSchema histogramSchema = BaseHistogramSchema.NORMAL_SCHEMA;
+    private final HistogramSchema histogramSchema = HistogramSchemas.NORMAL_SCHEMA;
     private final ActiveTraceHistogram emptyActiveTraceHistogram = new EmptyActiveTraceHistogram(histogramSchema);
 
     public DefaultActiveTraceRepository(ResponseTimeCollector responseTimeCollector) {

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/active/EmptyActiveTraceRepository.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/active/EmptyActiveTraceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.profiler.context.active;
 
-import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
+import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import com.navercorp.pinpoint.profiler.context.id.LocalTraceRoot;
 import com.navercorp.pinpoint.profiler.monitor.metric.response.ResponseTimeCollector;
 
@@ -31,7 +31,7 @@ public class EmptyActiveTraceRepository implements ActiveTraceRepository {
 
     private final ResponseTimeCollector responseTimeCollector;
 
-    private final ActiveTraceHistogram emptyActiveTraceHistogram = new EmptyActiveTraceHistogram(BaseHistogramSchema.NORMAL_SCHEMA);
+    private final ActiveTraceHistogram emptyActiveTraceHistogram = new EmptyActiveTraceHistogram(HistogramSchemas.NORMAL_SCHEMA);
 
     public EmptyActiveTraceRepository(ResponseTimeCollector responseTimeCollector) {
         this.responseTimeCollector = Objects.requireNonNull(responseTimeCollector, "responseTimeCollector");

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/active/DefaultActiveTraceHistogramTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/active/DefaultActiveTraceHistogramTest.java
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.profiler.context.active;
 
-import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
+import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -12,7 +28,7 @@ class DefaultActiveTraceHistogramTest {
 
     @Test
     void getCounter() {
-        HistogramSchema schema = BaseHistogramSchema.NORMAL_SCHEMA;
+        HistogramSchema schema = HistogramSchemas.NORMAL_SCHEMA;
         DefaultActiveTraceHistogram histogram = new DefaultActiveTraceHistogram(schema);
 
         for (int i = 0; i < 1; i++) {

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/active/EmptyActiveTraceHistogramTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/active/EmptyActiveTraceHistogramTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.profiler.context.active;
 
-import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
+import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -31,16 +31,16 @@ public class EmptyActiveTraceHistogramTest {
     @Test
     public void getCounter() {
 
-        ActiveTraceHistogram emptyHistogram = new EmptyActiveTraceHistogram(BaseHistogramSchema.NORMAL_SCHEMA);
+        ActiveTraceHistogram emptyHistogram = new EmptyActiveTraceHistogram(HistogramSchemas.NORMAL_SCHEMA);
 
         List<Integer> counter = emptyHistogram.getCounter();
         assertThat(counter).hasSize(4)
                 .containsExactly(0, 0, 0, 0);
 
-        assertEquals(emptyHistogram.getFastCount(), 0);
-        assertEquals(emptyHistogram.getNormalCount(), 0);
-        assertEquals(emptyHistogram.getSlowCount(), 0);
-        assertEquals(emptyHistogram.getVerySlowCount(), 0);
+        assertEquals(0, emptyHistogram.getFastCount());
+        assertEquals(0, emptyHistogram.getNormalCount());
+        assertEquals(0, emptyHistogram.getSlowCount());
+        assertEquals(0, emptyHistogram.getVerySlowCount());
     }
 
 }

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/monitor/metric/rpc/DefaultAcceptHistogram.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/monitor/metric/rpc/DefaultAcceptHistogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.profiler.monitor.metric.rpc;
 
-import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
+import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import com.navercorp.pinpoint.common.trace.ServiceTypeCategory;
 
 import java.util.Objects;
@@ -57,7 +57,7 @@ public class DefaultAcceptHistogram implements AcceptHistogram {
         if (hit != null) {
             return hit;
         }
-        final Histogram histogram = new LongAdderHistogram(responseKey.getServiceType(), BaseHistogramSchema.NORMAL_SCHEMA);
+        final Histogram histogram = new LongAdderHistogram(responseKey.getServiceType(), HistogramSchemas.NORMAL_SCHEMA);
         final Histogram old = map.putIfAbsent(responseKey, histogram);
         if (old != null) {
             return old;

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/BaseHistogramSchema.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/BaseHistogramSchema.java
@@ -1,50 +1,27 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.trace;
 
 import java.util.Objects;
-
-import static com.navercorp.pinpoint.common.trace.HistogramSlotGroup.entry;
 
 /**
  * @author jaehong.kim
  */
 public class BaseHistogramSchema implements HistogramSchema {
-
-    private static final short VERY_SLOW_SLOT_TIME = 0;
-    // All negative numbers are included in error count
-    private static final short ERROR_SLOT_TIME = -1;
-    // Do not use negative numbers.
-    private static final short PING_SLOT_TIME = Short.MAX_VALUE - 1;
-    private static final short STAT_SLOT_TIME_TOTAL = Short.MAX_VALUE - 2;
-    private static final short STAT_SLOT_TIME_MAX = Short.MAX_VALUE - 3;
-
-
-    public static final HistogramSchema FAST_SCHEMA = new BaseHistogramSchema(Schema.FAST,
-            new HistogramSlotGroup(
-                    entry(100, "100ms", SlotType.FAST),
-                    entry(300, "300ms", SlotType.NORMAL),
-                    entry(500, "500ms", SlotType.SLOW),
-                    entry(VERY_SLOW_SLOT_TIME, "Slow", SlotType.VERY_SLOW)),
-            new HistogramSlotGroup(
-                    entry(-100, "100ms", SlotType.FAST_ERROR),
-                    entry(-300, "300ms", SlotType.NORMAL_ERROR),
-                    entry(-500, "500ms", SlotType.SLOW_ERROR),
-                    entry(-999, "Slow", SlotType.VERY_SLOW_ERROR))
-            );
-
-    public static final HistogramSchema NORMAL_SCHEMA = new BaseHistogramSchema(Schema.NORMAL,
-            new HistogramSlotGroup(
-                    entry(1000, "1s", SlotType.FAST),
-                    entry(3000, "3s", SlotType.NORMAL),
-                    entry(5000, "5s", SlotType.SLOW),
-                    entry(VERY_SLOW_SLOT_TIME, "Slow", SlotType.VERY_SLOW)),
-            new HistogramSlotGroup(
-                    entry(-1000, "1s", SlotType.FAST_ERROR),
-                    entry(-3000, "3s", SlotType.NORMAL_ERROR),
-                    entry(-5000, "5s", SlotType.SLOW_ERROR),
-                    entry(-9999, "Slow", SlotType.VERY_SLOW_ERROR))
-            );
-
-    private static final String PING_SLOT_NAME = "Ping";
 
     private final Schema schema;
 
@@ -58,26 +35,34 @@ public class BaseHistogramSchema implements HistogramSchema {
     private final HistogramSlot maxStatSlot;
     private final HistogramSlot pingSlot;
 
-    private BaseHistogramSchema(Schema schema,
-                                HistogramSlotGroup success,
-                                HistogramSlotGroup failed) {
+    BaseHistogramSchema(Schema schema,
+                        HistogramSlotGroup success,
+                        HistogramSlotGroup failed,
+                        HistogramSlot errorSlot,
+                        HistogramSlot sumStatSlot,
+                        HistogramSlot maxStatSlot,
+                        HistogramSlot pingSlot) {
         this.schema = Objects.requireNonNull(schema, "schema");
 
         this.success = Objects.requireNonNull(success, "success");
         this.failed = Objects.requireNonNull(failed, "failed");
 
-        this.errorSlot = new HistogramSlot(ERROR_SLOT_TIME, SlotType.ERROR, "Error");
+        this.errorSlot = Objects.requireNonNull(errorSlot, "errorSlot");
 
-        this.sumStatSlot = new HistogramSlot(STAT_SLOT_TIME_TOTAL, SlotType.SUM_STAT, "SumTime");
-        this.maxStatSlot = new HistogramSlot(STAT_SLOT_TIME_MAX, SlotType.MAX_STAT, "Max");
+        this.sumStatSlot = Objects.requireNonNull(sumStatSlot, "sumStatSlot");
+        this.maxStatSlot = Objects.requireNonNull(maxStatSlot, "maxStatSlot");
 
-        this.pingSlot = new HistogramSlot(PING_SLOT_TIME, SlotType.PING, PING_SLOT_NAME);
+        this.pingSlot = Objects.requireNonNull(pingSlot, "pingSlot");
+
     }
 
+
+    @Override
     public Schema getSchema() {
         return schema;
     }
 
+    @Override
     public int getTypeCode() {
         return getSchema().type();
     }
@@ -169,12 +154,12 @@ public class BaseHistogramSchema implements HistogramSchema {
     @Override
     public String toString() {
         return "BaseHistogramSchema{" +
-                "schema=" + schema +
-                ", success=" + success +
-                ", failed=" + failed +
-                ", errorSlot=" + errorSlot +
-                ", pingSlot=" + pingSlot +
-                '}';
+               "schema=" + schema +
+               ", success=" + success +
+               ", failed=" + failed +
+               ", errorSlot=" + errorSlot +
+               ", pingSlot=" + pingSlot +
+               '}';
     }
 
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSchemas.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSchemas.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.trace;
+
+import com.navercorp.pinpoint.common.util.apache.IntHashMap;
+
+import static com.navercorp.pinpoint.common.trace.HistogramSlotGroup.entry;
+
+public final class HistogramSchemas {
+
+    private HistogramSchemas() {
+    }
+
+    private static final short VERY_SLOW_SLOT_TIME = 0;
+    // All negative numbers are included in error count
+    private static final short ERROR_SLOT_TIME = -1;
+    // Do not use negative numbers.
+    private static final short PING_SLOT_TIME = Short.MAX_VALUE - 1;
+    private static final short STAT_SLOT_TIME_TOTAL = Short.MAX_VALUE - 2;
+    private static final short STAT_SLOT_TIME_MAX = Short.MAX_VALUE - 3;
+
+
+    @Deprecated
+    public static final HistogramSlot ERROR_SLOT = new HistogramSlot((byte) -128, ERROR_SLOT_TIME, SlotType.ERROR, "Error");
+
+    public static final HistogramSlot SUM_STAT_SLOT = new HistogramSlot((byte) 112, STAT_SLOT_TIME_TOTAL, SlotType.SUM_STAT, "SumTime");
+    public static final HistogramSlot MAX_STAT_SLOT = new HistogramSlot((byte) 114, STAT_SLOT_TIME_MAX, SlotType.MAX_STAT, "Max");
+    public static final HistogramSlot PING_SLOT = new HistogramSlot((byte) 126, PING_SLOT_TIME, SlotType.PING, "Ping");
+
+
+    public static final HistogramSchema FAST_SCHEMA = new BaseHistogramSchema(Schema.FAST,
+            new HistogramSlotGroup(
+                    entry((byte) 1, 100, "100ms", SlotType.FAST),
+                    entry((byte) 2, 300, "300ms", SlotType.NORMAL),
+                    entry((byte) 3, 500, "500ms", SlotType.SLOW),
+                    entry((byte) 4, VERY_SLOW_SLOT_TIME, "Slow", SlotType.VERY_SLOW)),
+            new HistogramSlotGroup(
+                    entry((byte) -1, -100, "100ms", SlotType.FAST_ERROR),
+                    entry((byte) -2, -300, "300ms", SlotType.NORMAL_ERROR),
+                    entry((byte) -3, -500, "500ms", SlotType.SLOW_ERROR),
+                    entry((byte) -4, -999, "Slow", SlotType.VERY_SLOW_ERROR)),
+            ERROR_SLOT, SUM_STAT_SLOT, MAX_STAT_SLOT, PING_SLOT
+    );
+
+    public static final HistogramSchema NORMAL_SCHEMA = new BaseHistogramSchema(Schema.NORMAL,
+            new HistogramSlotGroup(
+                    entry((byte) 11, 1000, "1s", SlotType.FAST),
+                    entry((byte) 12, 3000, "3s", SlotType.NORMAL),
+                    entry((byte) 13, 5000, "5s", SlotType.SLOW),
+                    entry((byte) 14, VERY_SLOW_SLOT_TIME, "Slow", SlotType.VERY_SLOW)),
+            new HistogramSlotGroup(
+                    entry((byte) -11, -1000, "1s", SlotType.FAST_ERROR),
+                    entry((byte) -12, -3000, "3s", SlotType.NORMAL_ERROR),
+                    entry((byte) -13, -5000, "5s", SlotType.SLOW_ERROR),
+                    entry((byte) -14, -9999, "Slow", SlotType.VERY_SLOW_ERROR)),
+            ERROR_SLOT, SUM_STAT_SLOT, MAX_STAT_SLOT, PING_SLOT
+    );
+
+    private static final IntHashMap<HistogramSlot> SLOT_MAP = toSlotCodeMap(FAST_SCHEMA, NORMAL_SCHEMA);
+
+
+    private static IntHashMap<HistogramSlot> toSlotCodeMap(HistogramSchema... schemas) {
+        HistogramSlotMapBuilder builder = new HistogramSlotMapBuilder();
+        for (HistogramSchema schema : schemas) {
+            builder.addSchema(schema);
+        }
+        builder.addSlot(SUM_STAT_SLOT);
+        builder.addSlot(MAX_STAT_SLOT);
+        builder.addSlot(PING_SLOT);
+        builder.addSlot(ERROR_SLOT);
+
+        return builder.build();
+    }
+
+    public static HistogramSlot getSlotFromCode(int code) {
+        return SLOT_MAP.get(code);
+    }
+
+    static class HistogramSlotMapBuilder {
+
+        private final IntHashMap<HistogramSlot> map = new IntHashMap<>();
+
+        public HistogramSlotMapBuilder() {
+        }
+
+        public HistogramSlotMapBuilder addSlot(HistogramSlot slot) {
+            Object exist = map.put((int) slot.getSlotCode(), slot);
+            if (exist != null) {
+                throw new IllegalArgumentException("Duplicate slot:" + slot);
+            }
+            return this;
+        }
+
+        public HistogramSlotMapBuilder addSchema(HistogramSchema schema) {
+            addSlot(schema.getFastSlot());
+            addSlot(schema.getNormalSlot());
+            addSlot(schema.getSlowSlot());
+            addSlot(schema.getVerySlowSlot());
+            return this;
+        }
+
+        public IntHashMap<HistogramSlot> build() {
+            return map;
+        }
+    }
+
+}

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSlot.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSlot.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,14 +23,20 @@ import java.util.Objects;
  */
 public class HistogramSlot {
 
+    private final byte slotCode;
     private final short slotTime;
     private final SlotType slotType;
     private final String slotName;
 
-    public HistogramSlot(short slotTime, SlotType slotType, String slotName) {
+    public HistogramSlot(byte slotCode, short slotTime, SlotType slotType, String slotName) {
+        this.slotCode = slotCode;
         this.slotTime = slotTime;
         this.slotType = Objects.requireNonNull(slotType, "slotType");
         this.slotName = Objects.requireNonNull(slotName, "slotName");
+    }
+
+    public byte getSlotCode() {
+        return slotCode;
     }
 
     public short getSlotTime() {
@@ -48,9 +54,10 @@ public class HistogramSlot {
     @Override
     public String toString() {
         return "HistogramSlot{" +
-                "slotTime=" + slotTime +
-                ", slotType=" + slotType +
-                ", slotName='" + slotName + '\'' +
-                '}';
+               "slotCode=" + slotCode +
+               "slotTime=" + slotTime +
+               ", slotType=" + slotType +
+               ", slotName='" + slotName + '\'' +
+               '}';
     }
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSlotGroup.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSlotGroup.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.trace;
 
 import java.util.Objects;
@@ -9,8 +25,8 @@ public class HistogramSlotGroup {
     private final HistogramSlot verySlow;
 
 
-    public static HistogramSlot entry(int slotTime, String slotName, SlotType slotType) {
-        return new HistogramSlot((short)slotTime, slotType, slotName);
+    public static HistogramSlot entry(byte code, int slotTime, String slotName, SlotType slotType) {
+        return new HistogramSlot(code, (short) slotTime, slotType, slotName);
     }
 
     public HistogramSlotGroup(HistogramSlot fast,

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/ServiceTypeCategory.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/ServiceTypeCategory.java
@@ -1,10 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,10 +29,10 @@ public enum ServiceTypeCategory {
     SERVER(1000, 1999, NodeCategory.SERVER),
     DATABASE(2000, 2999, NodeCategory.DATABASE),
     LIBRARY(5000, 7999, NodeCategory.UNDEFINED),
-    CACHE_LIBRARY(8000, 8299, NodeCategory.CACHE, BaseHistogramSchema.FAST_SCHEMA),
+    CACHE_LIBRARY(8000, 8299, NodeCategory.CACHE, HistogramSchemas.FAST_SCHEMA),
     MESSAGE_BROKER(8300, 8799, NodeCategory.MESSAGE_BROKER),
     HBASE(8800, 8899, NodeCategory.DATABASE),
-    CACHE_LIBRARY_SANDBOX(8900, 8999, NodeCategory.UNDEFINED, BaseHistogramSchema.FAST_SCHEMA),
+    CACHE_LIBRARY_SANDBOX(8900, 8999, NodeCategory.UNDEFINED, HistogramSchemas.FAST_SCHEMA),
     RPC(9000, 9999, NodeCategory.UNKNOWN);
 
 
@@ -45,7 +46,7 @@ public enum ServiceTypeCategory {
     private static final Set<ServiceTypeCategory> SERVICE_TYPE_CATEGORIES = EnumSet.allOf(ServiceTypeCategory.class);
 
     ServiceTypeCategory(int minCode, int maxCode, NodeCategory nodeCategory) {
-        this(minCode, maxCode, nodeCategory, BaseHistogramSchema.NORMAL_SCHEMA);
+        this(minCode, maxCode, nodeCategory, HistogramSchemas.NORMAL_SCHEMA);
     }
 
     ServiceTypeCategory(int minCode, int maxCode, NodeCategory nodeCategory, HistogramSchema histogramSchema) {

--- a/commons/src/test/java/com/navercorp/pinpoint/common/trace/BaseHistogramSchemaTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/trace/BaseHistogramSchemaTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.trace;
 
 import org.junit.jupiter.api.Assertions;
@@ -8,7 +24,7 @@ class BaseHistogramSchemaTest {
 
     @Test
     void findHistogramSlot() {
-        HistogramSchema schema = BaseHistogramSchema.NORMAL_SCHEMA;
+        HistogramSchema schema = HistogramSchemas.NORMAL_SCHEMA;
 
         HistogramSlot fastSuccess = schema.findHistogramSlot(1000, false);
         Assertions.assertEquals(schema.getFastSlot(), fastSuccess);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogramTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogramTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,8 +22,8 @@ import com.navercorp.pinpoint.common.server.util.json.JsonFields;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowSlotCentricSampler;
-import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
+import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkCallDataMap;
 import com.navercorp.pinpoint.web.applicationmap.view.TimeHistogramViewModel;
@@ -169,7 +169,7 @@ public class AgentTimeHistogramTest {
     private LinkCallDataMap createSourceLinkCallDataMap(String sourceAgentId, long timeStamp) {
         LinkCallDataMap linkCallDataMap = new LinkCallDataMap();
 
-        final HistogramSchema schema = BaseHistogramSchema.NORMAL_SCHEMA;
+        final HistogramSchema schema = HistogramSchemas.NORMAL_SCHEMA;
         linkCallDataMap.addCallData(sourceAgentId, ServiceType.STAND_ALONE, "targetAgentId", ServiceType.STAND_ALONE, timeStamp, schema.getFastSlot().getSlotTime(), 1L);
         linkCallDataMap.addCallData(sourceAgentId, ServiceType.STAND_ALONE, "targetAgentId", ServiceType.STAND_ALONE, timeStamp, schema.getNormalSlot().getSlotTime(), 2L);
         linkCallDataMap.addCallData(sourceAgentId, ServiceType.STAND_ALONE, "targetAgentId", ServiceType.STAND_ALONE, timeStamp, schema.getSlowErrorSlot().getSlotTime(), 3L);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogramTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogramTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.navercorp.pinpoint.common.server.util.json.Jackson;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
-import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
+import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkKey;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkCallData;
@@ -126,7 +126,7 @@ public class ApplicationTimeHistogramTest {
         LinkKey key = LinkKey.of("sourceAgentId", ServiceType.STAND_ALONE, "targetAgentId", ServiceType.STAND_ALONE);
         LinkCallData linkCallData = new LinkCallData(key);
 
-        final HistogramSchema schema = BaseHistogramSchema.NORMAL_SCHEMA;
+        final HistogramSchema schema = HistogramSchemas.NORMAL_SCHEMA;
         linkCallData.addCallData(timeStamp, schema.getFastSlot().getSlotTime(), 1L);
         linkCallData.addCallData(timeStamp, schema.getNormalSlot().getSlotTime(), 2L);
         linkCallData.addCallData(timeStamp, schema.getSlowSlot().getSlotTime(), 3L);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/HistogramTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/HistogramTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,8 +20,8 @@ package com.navercorp.pinpoint.web.applicationmap.histogram;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.common.server.util.json.Jackson;
 import com.navercorp.pinpoint.common.server.util.json.TypeRef;
-import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
+import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,7 +42,7 @@ public class HistogramTest {
     @Test
     public void pingSlot() {
         Histogram histogram = new Histogram(ServiceType.STAND_ALONE);
-        histogram.addCallCount(BaseHistogramSchema.NORMAL_SCHEMA.getPingSlot().getSlotTime(), 1);
+        histogram.addCallCount(HistogramSchemas.NORMAL_SCHEMA.getPingSlot().getSlotTime(), 1);
         Assertions.assertEquals(1, histogram.getPingCount());
 
         Assertions.assertEquals(0, histogram.getTotalErrorCount());
@@ -51,7 +51,7 @@ public class HistogramTest {
     @Test
     public void maxSlot() {
         Histogram histogram = new Histogram(ServiceType.STAND_ALONE);
-        histogram.addCallCount(BaseHistogramSchema.NORMAL_SCHEMA.getMaxStatSlot().getSlotTime(), 1000);
+        histogram.addCallCount(HistogramSchemas.NORMAL_SCHEMA.getMaxStatSlot().getSlotTime(), 1000);
         Assertions.assertEquals(1000, histogram.getMaxElapsed());
 
         Assertions.assertEquals(0, histogram.getTotalErrorCount());
@@ -60,7 +60,7 @@ public class HistogramTest {
     @Test
     public void errorSlot() {
         Histogram histogram = new Histogram(ServiceType.STAND_ALONE);
-        histogram.addCallCount(BaseHistogramSchema.NORMAL_SCHEMA.getSlowErrorSlot().getSlotTime(), 1);
+        histogram.addCallCount(HistogramSchemas.NORMAL_SCHEMA.getSlowErrorSlot().getSlotTime(), 1);
         Assertions.assertEquals(1, histogram.getSlowErrorCount());
         Assertions.assertEquals(0, histogram.getSuccessCount());
     }
@@ -68,7 +68,7 @@ public class HistogramTest {
     @Test
     public void slowSlot() {
         Histogram histogram = new Histogram(ServiceType.STAND_ALONE);
-        histogram.addCallCount(BaseHistogramSchema.NORMAL_SCHEMA.getSlowSlot().getSlotTime(), 1);
+        histogram.addCallCount(HistogramSchemas.NORMAL_SCHEMA.getSlowSlot().getSlotTime(), 1);
         Assertions.assertEquals(1, histogram.getSlowCount());
         Assertions.assertEquals(1, histogram.getSuccessCount());
     }
@@ -76,7 +76,7 @@ public class HistogramTest {
     @Test
     public void verySlowSlot() {
         Histogram histogram = new Histogram(ServiceType.STAND_ALONE);
-        histogram.addCallCount(BaseHistogramSchema.NORMAL_SCHEMA.getVerySlowSlot().getSlotTime(), 1);
+        histogram.addCallCount(HistogramSchemas.NORMAL_SCHEMA.getVerySlowSlot().getSlotTime(), 1);
         Assertions.assertEquals(1, histogram.getVerySlowCount());
         Assertions.assertEquals(1, histogram.getSuccessCount());
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
@@ -18,8 +18,8 @@ package com.navercorp.pinpoint.web.applicationmap.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
-import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
+import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeCategory;
 import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
@@ -122,7 +122,7 @@ public class ResponseTimeHistogramServiceImplTest {
         logger.debug("{}", nodeHistogramSummary);
         NodeHistogram nodeHistogram = nodeHistogramSummary.getNodeHistogram();
         Histogram histogram = nodeHistogram.getApplicationHistogram();
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 0);
     }
 
@@ -150,7 +150,7 @@ public class ResponseTimeHistogramServiceImplTest {
         logger.debug(nodeHistogramSummary);
         NodeHistogram nodeHistogram = nodeHistogramSummary.getNodeHistogram();
         Histogram histogram = nodeHistogram.getApplicationHistogram();
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -192,7 +192,7 @@ public class ResponseTimeHistogramServiceImplTest {
         logger.debug(nodeHistogramSummary);
         NodeHistogram nodeHistogram = nodeHistogramSummary.getNodeHistogram();
         Histogram histogram = nodeHistogram.getApplicationHistogram();
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -222,7 +222,7 @@ public class ResponseTimeHistogramServiceImplTest {
         logger.debug(nodeHistogramSummary);
         NodeHistogram nodeHistogram = nodeHistogramSummary.getNodeHistogram();
         Histogram histogram = nodeHistogram.getApplicationHistogram();
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -258,7 +258,7 @@ public class ResponseTimeHistogramServiceImplTest {
         logger.debug(nodeHistogramSummary);
         NodeHistogram nodeHistogram = nodeHistogramSummary.getNodeHistogram();
         Histogram histogram = nodeHistogram.getApplicationHistogram();
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         //two WAS node -> UNKNOWN node
         assertHistogramValues(histogram, 2);
     }
@@ -292,7 +292,7 @@ public class ResponseTimeHistogramServiceImplTest {
         NodeHistogram nodeHistogram = nodeHistogramSummary.getNodeHistogram();
         Histogram histogram = nodeHistogram.getApplicationHistogram();
         //CACHE Node's Histogram schema should be FAST_SCHEMA
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.FAST_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.FAST_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -324,7 +324,7 @@ public class ResponseTimeHistogramServiceImplTest {
         logger.debug(nodeHistogramSummary);
         NodeHistogram nodeHistogram = nodeHistogramSummary.getNodeHistogram();
         Histogram histogram = nodeHistogram.getApplicationHistogram();
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -359,7 +359,7 @@ public class ResponseTimeHistogramServiceImplTest {
         logger.debug(nodeHistogramSummary);
         NodeHistogram nodeHistogram = nodeHistogramSummary.getNodeHistogram();
         Histogram histogram = nodeHistogram.getApplicationHistogram();
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 0);
     }
 
@@ -398,7 +398,7 @@ public class ResponseTimeHistogramServiceImplTest {
         logger.debug(nodeHistogramSummary);
         NodeHistogram nodeHistogram = nodeHistogramSummary.getNodeHistogram();
         Histogram histogram = nodeHistogram.getApplicationHistogram();
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -425,7 +425,7 @@ public class ResponseTimeHistogramServiceImplTest {
 
         logger.debug(linkHistogramSummary);
         Assertions.assertThat(linkHistogramSummary.getLinkName()).isEqualTo(LinkName.of(fromApplication, toApplication));
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -452,7 +452,7 @@ public class ResponseTimeHistogramServiceImplTest {
 
         logger.debug(linkHistogramSummary);
         Assertions.assertThat(linkHistogramSummary.getLinkName()).isEqualTo(LinkName.of(fromApplication, toApplication));
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -477,7 +477,7 @@ public class ResponseTimeHistogramServiceImplTest {
 
         logger.debug(linkHistogramSummary);
         Assertions.assertThat(linkHistogramSummary.getLinkName()).isEqualTo(LinkName.of(fromApplication, toApplication));
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -505,7 +505,7 @@ public class ResponseTimeHistogramServiceImplTest {
         logger.debug(linkHistogramSummary);
         Assertions.assertThat(linkHistogramSummary.getLinkName()).isEqualTo(LinkName.of(fromApplication, toApplication));
         //link's target node Histogram schema(CACHE) should be FAST_SCHEMA
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.FAST_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.FAST_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -531,7 +531,7 @@ public class ResponseTimeHistogramServiceImplTest {
 
         logger.debug(linkHistogramSummary);
         Assertions.assertThat(linkHistogramSummary.getLinkName()).isEqualTo(LinkName.of(fromApplication, toApplication));
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 
@@ -558,7 +558,7 @@ public class ResponseTimeHistogramServiceImplTest {
 
         logger.debug(linkHistogramSummary);
         Assertions.assertThat(linkHistogramSummary.getLinkName()).isEqualTo(LinkName.of(fromApplication, toApplication));
-        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(BaseHistogramSchema.NORMAL_SCHEMA);
+        Assertions.assertThat(histogram.getHistogramSchema()).isEqualTo(HistogramSchemas.NORMAL_SCHEMA);
         assertHistogramValues(histogram, 1);
     }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/view/TimeHistogramChartTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/view/TimeHistogramChartTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@
 
 package com.navercorp.pinpoint.web.view;
 
-import com.navercorp.pinpoint.common.trace.BaseHistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
+import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.view.TimeSeries.TimeSeriesValueGroupView;
 import com.navercorp.pinpoint.web.view.TimeSeries.TimeSeriesValueView;
@@ -43,7 +43,7 @@ public class TimeHistogramChartTest {
 
     @BeforeEach
     public void setUp() {
-        HistogramSchema schema = BaseHistogramSchema.NORMAL_SCHEMA;
+        HistogramSchema schema = HistogramSchemas.NORMAL_SCHEMA;
         TimeHistogram timeHistogram1 = new TimeHistogram(schema, 0);
         TimeHistogram timeHistogram2 = new TimeHistogram(schema, 60000);
 
@@ -75,7 +75,7 @@ public class TimeHistogramChartTest {
         List<TimeSeriesValueView> metricValues = groupView.getMetricValues();
         Assertions.assertThat(metricValues.size()).isEqualTo(5);
 
-        HistogramSchema schema = BaseHistogramSchema.NORMAL_SCHEMA;
+        HistogramSchema schema = HistogramSchemas.NORMAL_SCHEMA;
         Assertions.assertThat(metricValues.get(0).getFieldName()).isEqualTo(schema.getFastSlot().getSlotName());
         Assertions.assertThat(metricValues.get(0).getValues()).isEqualTo(List.of(1L, 6L));
         Assertions.assertThat(metricValues.get(4).getFieldName()).isEqualTo(schema.getTotalErrorView().getSlotName());


### PR DESCRIPTION
This pull request refactors how histogram schemas are defined and accessed throughout the profiler and common trace modules. The main change is the migration from using static fields in `BaseHistogramSchema` to a new centralized `HistogramSchemas` class, which now provides all schema instances and slot definitions. This improves maintainability and extensibility for histogram-related logic. The changes also update all usages in the codebase to reference the new schema provider and enhance the structure of histogram slots by introducing a slot code.

### Histogram Schema Refactoring

* Introduced the new `HistogramSchemas` class to provide centralized definitions for histogram schemas and slots, replacing static fields in `BaseHistogramSchema`. All usages of `BaseHistogramSchema.NORMAL_SCHEMA` and similar are updated to use `HistogramSchemas.NORMAL_SCHEMA`. (`commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSchemas.java`, `commons/src/main/java/com/navercorp/pinpoint/common/trace/BaseHistogramSchema.java`, `agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/active/DefaultActiveTraceRepository.java`, `agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/active/EmptyActiveTraceRepository.java`, `agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/active/DefaultActiveTraceHistogramTest.java`, `agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/active/EmptyActiveTraceHistogramTest.java`, `agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/monitor/metric/rpc/DefaultAcceptHistogram.java`) [[1]](diffhunk://#diff-22be6b7a4af29e67cf580e428b10c6142b5f21f8257fafcedab4421ef0f5ef22L21-R22) [[2]](diffhunk://#diff-22be6b7a4af29e67cf580e428b10c6142b5f21f8257fafcedab4421ef0f5ef22L53-R53) [[3]](diffhunk://#diff-ba04374ca68a33941a070320415284c9ec0f06fb6003e716f880d070efb7fe57L19-R19) [[4]](diffhunk://#diff-ba04374ca68a33941a070320415284c9ec0f06fb6003e716f880d070efb7fe57L34-R34) [[5]](diffhunk://#diff-93bd59178f8f3e51b341bfeeb8db37c8aa5f845ed26dd9d633476e639f5ee2dbR1-R20) [[6]](diffhunk://#diff-93bd59178f8f3e51b341bfeeb8db37c8aa5f845ed26dd9d633476e639f5ee2dbL15-R31) [[7]](diffhunk://#diff-f8dbe6b711e6f7e699264fa22cd329621ddec4cb2d1a4f3efd96612a78180a12L19-R19) [[8]](diffhunk://#diff-f8dbe6b711e6f7e699264fa22cd329621ddec4cb2d1a4f3efd96612a78180a12L34-R43) [[9]](diffhunk://#diff-10decb21f18ff77e47b7f9ee3805d0369ece10971fd27935b722fa0864acb0fcL19-R19) [[10]](diffhunk://#diff-10decb21f18ff77e47b7f9ee3805d0369ece10971fd27935b722fa0864acb0fcL60-R60) [[11]](diffhunk://#diff-ba6a5901ef98266484906a45715ddfa91ccb4cc7578a7bf2bee27df687104474R1-L48) [[12]](diffhunk://#diff-ba6a5901ef98266484906a45715ddfa91ccb4cc7578a7bf2bee27df687104474L61-R65) [[13]](diffhunk://#diff-9a1c665dbe4a8c9aabcde831b91cf86fd241bede929f8b7b131877d35235fb8cR1-R121)

* Refactored the construction of `BaseHistogramSchema` to accept all slot definitions as constructor parameters, removing hardcoded static slot fields and improving flexibility. (`commons/src/main/java/com/navercorp/pinpoint/common/trace/BaseHistogramSchema.java`)

### Histogram Slot Improvements

* Enhanced `HistogramSlot` by adding a `slotCode` field and updating its constructor and `toString()` method, enabling more robust slot identification and mapping. (`commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSlot.java`) [[1]](diffhunk://#diff-4cf7d9bf5678e24ad10429c8138ba619851fc5c9d2b9353ae293702b4b0c16f7R26-R41) [[2]](diffhunk://#diff-4cf7d9bf5678e24ad10429c8138ba619851fc5c9d2b9353ae293702b4b0c16f7R57)

* Added slot mapping logic to `HistogramSchemas` for efficient lookup of slots by code, supporting future extensibility. (`commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSchemas.java`)

### Copyright Updates

* Updated copyright years to 2025 in all affected files. [[1]](diffhunk://#diff-22be6b7a4af29e67cf580e428b10c6142b5f21f8257fafcedab4421ef0f5ef22L2-R2) [[2]](diffhunk://#diff-ba04374ca68a33941a070320415284c9ec0f06fb6003e716f880d070efb7fe57L2-R2) [[3]](diffhunk://#diff-93bd59178f8f3e51b341bfeeb8db37c8aa5f845ed26dd9d633476e639f5ee2dbR1-R20) [[4]](diffhunk://#diff-f8dbe6b711e6f7e699264fa22cd329621ddec4cb2d1a4f3efd96612a78180a12L2-R2) [[5]](diffhunk://#diff-10decb21f18ff77e47b7f9ee3805d0369ece10971fd27935b722fa0864acb0fcL2-R2) [[6]](diffhunk://#diff-ba6a5901ef98266484906a45715ddfa91ccb4cc7578a7bf2bee27df687104474R1-L48) [[7]](diffhunk://#diff-65a2427b108734175c3b2934ba94c4d97dc0cad6c7af31648d79e4722efb488eR1-R16) [[8]](diffhunk://#diff-4cf7d9bf5678e24ad10429c8138ba619851fc5c9d2b9353ae293702b4b0c16f7L2-R2)

These changes collectively modernize and centralize histogram schema management, making future maintenance and extension easier.