### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/agent-module/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/agentdir/JavaAgentPathResolver.java
+++ b/agent-module/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/agentdir/JavaAgentPathResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ public class JavaAgentPathResolver {
                 return null;
             }
 
-            if (classURL.getProtocol().equals("jar")) {
+            if ("jar".equals(classURL.getProtocol())) {
                 String path = classURL.getPath();
                 int jarIndex = path.indexOf("!/");
                 if (jarIndex == -1) {

--- a/agent-module/plugins/grpc/src/main/java/com/navercorp/pinpoint/plugin/grpc/GrpcUtils.java
+++ b/agent-module/plugins/grpc/src/main/java/com/navercorp/pinpoint/plugin/grpc/GrpcUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,13 +58,13 @@ public final class GrpcUtils {
     public static void addServerListenerMethod(InstrumentClass target, boolean traceOnMessage) throws InstrumentException {
         List<InstrumentMethod> declaredMethods = target.getDeclaredMethods();
         for (InstrumentMethod declaredMethod : declaredMethods) {
-            if (declaredMethod.getName().equals("onMessage") && !traceOnMessage) {
+            if ("onMessage".equals(declaredMethod.getName()) && !traceOnMessage) {
                 PluginLogger logger = PluginLogManager.getLogger(GrpcUtils.class.getName());
                 logger.debug("skip add onMessage interceptor");
                 continue;
             }
 
-            if (declaredMethod.getName().equals("onHalfClose")) {
+            if ("onHalfClose".equals(declaredMethod.getName())) {
                 declaredMethod.addInterceptor(ServerHalfCloseListenerInterceptor.class);
                 continue;
             }

--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/PreAuthenticationCheckFilter.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/PreAuthenticationCheckFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public class PreAuthenticationCheckFilter extends GenericFilterBean {
             return;
         }
 
-        if (authentication.isAuthenticated() && ((HttpServletRequest) request).getRequestURI().equals(BasicLoginConstants.URI_LOGIN)) {
+        if (authentication.isAuthenticated() && BasicLoginConstants.URI_LOGIN.equals(((HttpServletRequest) request).getRequestURI())) {
             ((HttpServletResponse) response).sendRedirect(BasicLoginConstants.URI_MAIN);
         } else {
             chain.doFilter(request, response);

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/AvgUsingIntervalForTotalCountPostProcessor.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/AvgUsingIntervalForTotalCountPostProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright 2024 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
@@ -51,7 +51,7 @@ public class AvgUsingIntervalForTotalCountPostProcessor extends AvgUsingInterval
 
     private List<InspectorMetricValue> extractOtherMetric(List<InspectorMetricValue> metricValueList) {
         return metricValueList.stream()
-                .filter(metricValue -> !metricValue.getFieldName().equals(TOTAL_COUNT_FIELD) && !metricValue.getFieldName().equals(COLLECT_INTERVAL_FIELD))
+                .filter(metricValue -> !TOTAL_COUNT_FIELD.equals(metricValue.getFieldName()) && !COLLECT_INTERVAL_FIELD.equals(metricValue.getFieldName()))
                 .collect(Collectors.toList());
     }
 
@@ -65,7 +65,7 @@ public class AvgUsingIntervalForTotalCountPostProcessor extends AvgUsingInterval
 
     private InspectorMetricValue extractTotalCount(List<InspectorMetricValue> metricValueList) {
         return metricValueList.stream()
-                .filter(metricValue -> metricValue.getFieldName().equals(TOTAL_COUNT_FIELD))
+                .filter(metricValue -> TOTAL_COUNT_FIELD.equals(metricValue.getFieldName()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("not found totalCount"));
     }

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/AvgUsingIntervalPostProcessor.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/AvgUsingIntervalPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,13 +96,13 @@ public class AvgUsingIntervalPostProcessor implements MetricPostProcessor {
 
     private List<InspectorMetricValue> extractMetricCount(List<InspectorMetricValue> metricValueList) {
         return metricValueList.stream()
-                .filter(metricValue -> !metricValue.getFieldName().equals(COLLECT_INTERVAL_FIELD))
+                .filter(metricValue -> !COLLECT_INTERVAL_FIELD.equals(metricValue.getFieldName()))
                 .collect(Collectors.toList());
     }
 
     protected InspectorMetricValue findCollectInterval(List<InspectorMetricValue> metricValueList) {
         return metricValueList.stream()
-                .filter(metricValue -> metricValue.getFieldName().equals(COLLECT_INTERVAL_FIELD))
+                .filter(metricValue -> COLLECT_INTERVAL_FIELD.equals(metricValue.getFieldName()))
                 .findFirst()
                 .orElse(null);
     }

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/ServiceTypeMatchingPostProcessor.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/ServiceTypeMatchingPostProcessor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -67,7 +67,7 @@ public class ServiceTypeMatchingPostProcessor implements MetricPostProcessor {
         List<Tag> newTagList = new ArrayList<>(tagList.size());
 
         for (Tag tag : tagList) {
-            if (tag.getName().equals(SERVICE_TYPE_CODE)) {
+            if (SERVICE_TYPE_CODE.equals(tag.getName())) {
                 int serviceTypeCode = Integer.parseInt(tag.getValue());
                 String serviceTypeName = serviceTypeRegistryService.findServiceType(serviceTypeCode).getName();
                 newTagList.add(new Tag(SERVICE_TYPE, serviceTypeName));

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/UsingDataSourceTagForAgentPreProcessor.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/UsingDataSourceTagForAgentPreProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class UsingDataSourceTagForAgentPreProcessor implements MetricPreProcesso
 
         //TODO : (minwoo) Performance improvement, it seems that you need to import jdbcurl only once and fill the rest of the fields with data, rather than doing it in turn.
         for (Field field : metricDefinition.getFields()) {
-            if (!field.getMatchingRule().equals(MatchingRule.ALL)) {
+            if (!MatchingRule.ALL.equals(field.getMatchingRule())) {
                 continue;
             }
 
@@ -63,7 +63,7 @@ public class UsingDataSourceTagForAgentPreProcessor implements MetricPreProcesso
 
             List<Tag> filteredTagList = new ArrayList<>();
             for (Tag tag : tagList) {
-                if (tag.getName().equals(JDBC_URL)) {
+                if (JDBC_URL.equals(tag.getName())) {
                     filteredTagList.add(tag);
                 }
             }

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/UsingDataSourceTagForApplicationPreProcessor.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/UsingDataSourceTagForApplicationPreProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright 2024 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
@@ -53,7 +53,7 @@ public class UsingDataSourceTagForApplicationPreProcessor implements MetricPrePr
 
         //TODO : (minwoo) Performance improvement, it seems that you need to import jdbcurl only once and fill the rest of the fields with data, rather than doing it in turn.
         for (Field field : metricDefinition.getFields()) {
-            if (!field.getMatchingRule().equals(MatchingRule.ALL)) {
+            if (!MatchingRule.ALL.equals(field.getMatchingRule())) {
                 continue;
             }
 

--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/legacy/OtlpChartSummaryViewBuilder.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/legacy/OtlpChartSummaryViewBuilder.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,9 +36,9 @@ public class OtlpChartSummaryViewBuilder extends OtlpChartViewBuilder {
 
     @Override
     protected String checkChartType(String fieldName, String description) {
-        if (fieldName.equals(FIELD_KEYWORD_COUNT) || fieldName.equals(FIELD_KEYWORD_SUM)) {
+        if (FIELD_KEYWORD_COUNT.equals(fieldName) || FIELD_KEYWORD_SUM.equals(fieldName)) {
             return CHART_TYPE_SPLINE;
-        } else if (fieldName.equals(METADATA_KEYWORD_NUMQUANTILES)) {
+        } else if (METADATA_KEYWORD_NUMQUANTILES.equals(fieldName)) {
             return CHART_TYPE_NONE;
         } else {
             return CHART_TYPE_AREA;
@@ -47,7 +47,7 @@ public class OtlpChartSummaryViewBuilder extends OtlpChartViewBuilder {
 
     @Override
     protected void setMetadata(String name, List<Number> values, String description) {
-        if (name.equals(METADATA_KEYWORD_NUMQUANTILES)) {
+        if (METADATA_KEYWORD_NUMQUANTILES.equals(name)) {
             this.numQuantiles = values;
             this.description = description;
         } else {


### PR DESCRIPTION
This pull request makes several minor improvements across multiple modules, primarily focusing on code style and correctness. The main changes involve using constant-first comparisons for string equality checks, updating copyright years, and correcting a license comment.

Code style and correctness improvements:

* Refactored string equality checks throughout various classes to use constant-first comparisons (e.g., `CONSTANT.equals(variable)`), which is the recommended practice to avoid potential `NullPointerException`s. This affects files such as `JavaAgentPathResolver.java`, `GrpcUtils.java`, `PreAuthenticationCheckFilter.java`, `AvgUsingIntervalForTotalCountPostProcessor.java`, `AvgUsingIntervalPostProcessor.java`, `ServiceTypeMatchingPostProcessor.java`, `UsingDataSourceTagForAgentPreProcessor.java`, `UsingDataSourceTagForApplicationPreProcessor.java`, and `OtlpChartSummaryViewBuilder.java`. [[1]](diffhunk://#diff-dc4891e76250bc5444e60dd25764cb105b7191a0e5512a5fe98b7d2f5e5ca015L97-R97) [[2]](diffhunk://#diff-6dd4efcf548eed015363641b4905ea795da90b1b255baae9d4467c9d423603e0L61-R67) [[3]](diffhunk://#diff-07268c24570a981656e89d9294dab0888e5b28e71347a0e7935f07672b293636L56-R56) [[4]](diffhunk://#diff-9809a9b4cb2b8256c8efd144d329ca153e3621a93b980d6c3187f344772691e0L54-R54) [[5]](diffhunk://#diff-9809a9b4cb2b8256c8efd144d329ca153e3621a93b980d6c3187f344772691e0L68-R68) [[6]](diffhunk://#diff-60dd808312bd629df450108a8cf31ff060a610ab5aa43db06f8d07105d569f74L99-R105) [[7]](diffhunk://#diff-6bb97cd1bd12e8c000b01a9c9c002b6303564b6b329a78b85eb05b3a0de4bb46L70-R70) [[8]](diffhunk://#diff-b31487a5a9a96100153b14702f6ac0bc14dbe12b42f5e962eddad82139509dd4L58-R66) [[9]](diffhunk://#diff-b31487a5a9a96100153b14702f6ac0bc14dbe12b42f5e962eddad82139509dd4L58-R66) [[10]](diffhunk://#diff-e4deadf98619d105c580a599ef808af2e6882ceca9dab5b34534a06426daecb9L56-R56) [[11]](diffhunk://#diff-18190d801801cd53263391459ff3694ba9086ed1421a50611931da1e2237f7b1L39-R41) [[12]](diffhunk://#diff-18190d801801cd53263391459ff3694ba9086ed1421a50611931da1e2237f7b1L50-R50)

Documentation and license updates:

* Updated copyright years to 2025 in all affected files to reflect the current year. [[1]](diffhunk://#diff-dc4891e76250bc5444e60dd25764cb105b7191a0e5512a5fe98b7d2f5e5ca015L2-R2) [[2]](diffhunk://#diff-6dd4efcf548eed015363641b4905ea795da90b1b255baae9d4467c9d423603e0L2-R2) [[3]](diffhunk://#diff-07268c24570a981656e89d9294dab0888e5b28e71347a0e7935f07672b293636L2-R2) [[4]](diffhunk://#diff-9809a9b4cb2b8256c8efd144d329ca153e3621a93b980d6c3187f344772691e0L2-R2) [[5]](diffhunk://#diff-60dd808312bd629df450108a8cf31ff060a610ab5aa43db06f8d07105d569f74L2-R2) [[6]](diffhunk://#diff-6bb97cd1bd12e8c000b01a9c9c002b6303564b6b329a78b85eb05b3a0de4bb46L2-R2) [[7]](diffhunk://#diff-b31487a5a9a96100153b14702f6ac0bc14dbe12b42f5e962eddad82139509dd4L2-R2) [[8]](diffhunk://#diff-e4deadf98619d105c580a599ef808af2e6882ceca9dab5b34534a06426daecb9L2-R2) [[9]](diffhunk://#diff-18190d801801cd53263391459ff3694ba9086ed1421a50611931da1e2237f7b1L2-R2)
* Fixed a typo in the license comment to correctly read "either express or implied" instead of "either express implied" in two files. [[1]](diffhunk://#diff-9809a9b4cb2b8256c8efd144d329ca153e3621a93b980d6c3187f344772691e0L12-R12) [[2]](diffhunk://#diff-e4deadf98619d105c580a599ef808af2e6882ceca9dab5b34534a06426daecb9L12-R12)