### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/otlpmetric/otlpmetric-collector/src/main/java/com/navercorp/pinpoint/otlp/collector/service/PinotOtlpMetricCollectorService.java
+++ b/otlpmetric/otlpmetric-collector/src/main/java/com/navercorp/pinpoint/otlp/collector/service/PinotOtlpMetricCollectorService.java
@@ -38,8 +38,9 @@ import java.util.stream.Collectors;
 @Service
 public class PinotOtlpMetricCollectorService implements OtlpMetricCollectorService {
 
+    private static final String DEFAULT_SERVICE_NAME = "";
+
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final String DEFAULT_SERVICE_NAME = "";
 
     @NonNull
     private final OtlpMetricDao otlpMetricDao;

--- a/otlpmetric/otlpmetric-common/src/test/java/com/navercorp/pinpoint/otlp/common/model/MetricTypeTest.java
+++ b/otlpmetric/otlpmetric-common/src/test/java/com/navercorp/pinpoint/otlp/common/model/MetricTypeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.common.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class MetricTypeTest {
+
+    @Test
+    void forNumber() {
+        assertNull(MetricType.forNumber(-1));
+    }
+}

--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/legacy/OtlpChartView.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/legacy/OtlpChartView.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,17 +16,13 @@
 
 package com.navercorp.pinpoint.otlp.web.view.legacy;
 
-import com.navercorp.pinpoint.otlp.common.model.MetricType;
-import com.navercorp.pinpoint.otlp.web.view.OtlpParsingException;
-
-import java.util.ArrayList;
 import java.util.List;
 
 public class OtlpChartView {
-    private List<Long> timestamp;
-    private String description;
-    private boolean hasSummary = false;
-    private List<OtlpChartFieldView> fields;
+    private final List<Long> timestamp;
+    private final String description;
+    private final boolean hasSummary;
+    private final List<OtlpChartFieldView> fields;
     //private OtlpChartFieldViewBuilder chartFieldViewBuilder;
 
     public OtlpChartView(List<Long> timestamp, String description, boolean hasSummary, List<OtlpChartFieldView> fields) {
@@ -34,14 +30,6 @@ public class OtlpChartView {
         this.description = description;
         this.hasSummary = hasSummary;
         this.fields = fields;
-    }
-
-    public OtlpChartView(int chartType) {
-        MetricType metricType = MetricType.forNumber(chartType);
-        if (metricType == null) {
-            throw new OtlpParsingException("Cannot get valid metric type for requested chart.");
-        }
-        fields = new ArrayList<>();
     }
 
     public List<Long> getTimestamp() {
@@ -56,26 +44,4 @@ public class OtlpChartView {
         return fields;
     }
 
-    /*
-    private void checkValidity(MetricType chartType) {
-        // make chart with above data
-        switch (chartType) {
-            case SUM:
-            case GAUGE:
-                this.chartFieldViewBuilder = new OtlpChartSumGaugeFieldViewBuilder();
-                this.hasSummary = true;
-                break;
-            case HISTOGRAM:
-                this.chartFieldViewBuilder = new OtlpChartHistogramFieldViewBuilder();
-                break;
-            case EXP_HISTOGRAM:
-                //this.chartFieldViewBuilder = new OtlpChartHistogramFieldViewBuilder();
-                break;
-            case SUMMARY:
-                //this.chartType = "area-spline";
-                break;
-            default:
-                throw new OtlpParsingException("Should not reach here.");
-        }
-    }*/
 }

--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/legacy/OtlpChartViewBuilder.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/legacy/OtlpChartViewBuilder.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -44,7 +44,7 @@ public abstract class OtlpChartViewBuilder {
 
     protected final OtlpChartFieldViewBuilder chartFieldViewBuilder;
 
-    public static OtlpChartView EMPTY_CHART_VIEW = new OtlpChartView(new ArrayList<>(), "", false, new ArrayList<>());
+    public static final OtlpChartView EMPTY_CHART_VIEW = new OtlpChartView(new ArrayList<>(), "", false, new ArrayList<>());
 
     protected OtlpChartViewBuilder(String defaultChartType) {
         this.defaultChartType = defaultChartType;

--- a/otlpmetric/otlpmetric-web/src/test/java/com/navercorp/pinpoint/otlp/web/view/OtlpChartViewTest.java
+++ b/otlpmetric/otlpmetric-web/src/test/java/com/navercorp/pinpoint/otlp/web/view/OtlpChartViewTest.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.otlp.web.view;
 
 import com.navercorp.pinpoint.otlp.common.model.AggreTemporality;
 import com.navercorp.pinpoint.otlp.common.model.DataType;
 import com.navercorp.pinpoint.otlp.common.model.MetricType;
 import com.navercorp.pinpoint.otlp.common.web.definition.property.AggregationFunction;
-import com.navercorp.pinpoint.otlp.web.view.legacy.OtlpChartView;
 import com.navercorp.pinpoint.otlp.web.view.legacy.OtlpChartViewBuilder;
 import com.navercorp.pinpoint.otlp.web.vo.FieldAttribute;
 import com.navercorp.pinpoint.otlp.web.vo.OtlpMetricChartResult;
@@ -15,7 +30,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OtlpChartViewTest {
 
@@ -56,8 +70,4 @@ public class OtlpChartViewTest {
         assertEquals(2, otlpChartViewBuilder.getFields().size());
     }
 
-    @Test
-    public void checkValidityShouldThrowExceptionForInvalidMetricType() {
-        assertThrows(OtlpParsingException.class, () -> new OtlpChartView(-1));
-    }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatmapChartController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatmapChartController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -44,8 +44,9 @@ import java.util.Optional;
 @Validated
 public class HeatmapChartController {
 
-    private final int MAX_TIMESLOT_COUNT = 60;
-    private final static String DEFAULT_SERVCIE_NAME = "DEFAULT";
+    private static final int MAX_TIMESLOT_COUNT = 60;
+    private static final String DEFAULT_SERVICE_NAME = "DEFAULT";
+
     private final TimeWindowSampler DEFAULT_TIME_WINDOW_SAMPLER = new TimeWindowSlotCentricSampler(10000L, MAX_TIMESLOT_COUNT);
     private final HeatmapChartService heatmapChartService;
 
@@ -62,7 +63,7 @@ public class HeatmapChartController {
                                   @RequestParam("maxElapsedTime") @Positive int maxElapsedTime) {
         Range range = Range.between(from, to);
         TimeWindow timeWindow = getTimeWindow(range);
-        HeatMapData heatMapData = heatmapChartService.getHeatmapAppData(DEFAULT_SERVCIE_NAME, applicationName, timeWindow, minElapsedTime, maxElapsedTime);
+        HeatMapData heatMapData = heatmapChartService.getHeatmapAppData(DEFAULT_SERVICE_NAME, applicationName, timeWindow, minElapsedTime, maxElapsedTime);
         return new HeatMapDataView(heatMapData);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/heatmap/service/HeatmapChartServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/heatmap/service/HeatmapChartServiceImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,11 +39,11 @@ public class HeatmapChartServiceImpl implements HeatmapChartService {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
-    private final String POSTFIX_SORT_KEY_SUCCESS = "#suc";
-    private final String POSTFIX_SORT_KEY_FAIL = "#fal";
+    private static final String POSTFIX_SORT_KEY_SUCCESS = "#suc";
+    private static final String POSTFIX_SORT_KEY_FAIL = "#fal";
 
-    private final int YAXIS_CELL_MAXCOUNT = 50;
-    private final int MIN_INTERVAL_FOR_ELAPSED_TIME = 200;
+    private static final int YAXIS_CELL_MAXCOUNT = 50;
+    private static final int MIN_INTERVAL_FOR_ELAPSED_TIME = 200;
 
     private final HeatmapChartDao heatmapChartDao;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexServiceImpl.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,7 @@ import java.util.Set;
  */
 @Service
 public class ApplicationIndexServiceImpl implements ApplicationIndexService {
-    private final String defaultServiceName = ServiceUid.DEFAULT_SERVICE_UID_NAME;
+    private static final String defaultServiceName = ServiceUid.DEFAULT_SERVICE_UID_NAME;
 
     private final ApplicationIndexDao applicationIndexDao;
     private final ApplicationIndexServiceV2 applicationIndexServiceV2;


### PR DESCRIPTION
This pull request refactors several classes to improve code consistency and maintainability, primarily by updating field modifiers to use `static final` where appropriate and making fields immutable. Additionally, copyright years have been updated to reflect the current year. These changes help clarify intent, reduce potential bugs, and ensure that constants are properly defined.

### Code consistency and maintainability

* Refactored multiple fields to use `static final` instead of instance-level or non-final fields in `PinotOtlpMetricCollectorService`, `HeatmapChartController`, `HeatmapChartServiceImpl`, and `ApplicationIndexServiceImpl`, ensuring proper constant definition and thread safety. [[1]](diffhunk://#diff-661c741b0f27494aeee2da16b487917db7196301cbfae69d3b3f5830d552ca97R41-L42) [[2]](diffhunk://#diff-c6db1656a9f681abce22cebc4318d059696b20dd8877f9899b6f2b5bacf6833bL47-R49) [[3]](diffhunk://#diff-a58ecb7b9ed0cd68ac9a8668c4049a7f955d0f5de8412947b376283762af569aL42-R46) [[4]](diffhunk://#diff-4848edec56e68a9e4c4456af3e145202237c675004f4033abcd1e5f6d9dc82e0L37-R37)
* Updated fields in `OtlpChartView` to be immutable (`final`) for safer and clearer data handling. [[1]](diffhunk://#diff-e9834939ef712aec59d89390561f28b3794246846bb81aa0368348247222c324L26-R29) [[2]](diffhunk://#diff-e9834939ef712aec59d89390561f28b3794246846bb81aa0368348247222c324L44-R47)
* Changed `EMPTY_CHART_VIEW` in `OtlpChartViewBuilder` to be `static final` for proper constant usage.

### Copyright updates

* Updated copyright years to 2025 in `OtlpChartView`, `OtlpChartViewBuilder`, and `ApplicationIndexServiceImpl`. [[1]](diffhunk://#diff-e9834939ef712aec59d89390561f28b3794246846bb81aa0368348247222c324L2-R2) [[2]](diffhunk://#diff-13419ef58b06ea649741f45379e003d983ae345cc27fc0bc5f5c80d3cf351f4aL2-R2) [[3]](diffhunk://#diff-4848edec56e68a9e4c4456af3e145202237c675004f4033abcd1e5f6d9dc82e0L2-R2)