### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcExceptionMetaDataHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcExceptionMetaDataHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,9 +35,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * @author intr3p1d
@@ -107,15 +107,18 @@ public class GrpcExceptionMetaDataHandler implements RequestResponseHandler<PExc
     private List<ExceptionWrapperBo> mapExceptionWrapperBo(
             List<PException> exceptions, final ServerHeader header
     ) {
-        return exceptions.stream().map(
-                (PException p) -> new ExceptionWrapperBo(
-                        StringUtils.defaultIfEmpty(p.getExceptionClassName(), EMPTY),
-                        StringUtils.defaultIfEmpty(p.getExceptionMessage(), EMPTY),
-                        getFallbackTime(p.getStartTime(), p, header),
-                        p.getExceptionId(), p.getExceptionDepth(),
-                        handleStackTraceElements(p.getStackTraceElementList())
-                )
-        ).collect(Collectors.toList());
+        List<ExceptionWrapperBo> list = new ArrayList<>(exceptions.size());
+        for (PException p : exceptions) {
+            ExceptionWrapperBo exceptionWrapperBo = new ExceptionWrapperBo(
+                    StringUtils.defaultIfEmpty(p.getExceptionClassName(), EMPTY),
+                    StringUtils.defaultIfEmpty(p.getExceptionMessage(), EMPTY),
+                    getFallbackTime(p.getStartTime(), p, header),
+                    p.getExceptionId(), p.getExceptionDepth(),
+                    handleStackTraceElements(p.getStackTraceElementList())
+            );
+            list.add(exceptionWrapperBo);
+        }
+        return list;
     }
 
     private long getFallbackTime(long actual, PException p, final ServerHeader header) {
@@ -130,15 +133,17 @@ public class GrpcExceptionMetaDataHandler implements RequestResponseHandler<PExc
     }
 
     private List<StackTraceElementWrapperBo> handleStackTraceElements(List<PStackTraceElement> pStackTraceElements) {
-        return pStackTraceElements.stream().map(
-                (PStackTraceElement p) ->
-                        new StackTraceElementWrapperBo(
-                                StringUtils.defaultIfEmpty(p.getClassName(), EMPTY),
-                                StringUtils.defaultIfEmpty(p.getFileName(), EMPTY),
-                                p.getLineNumber(),
-                                StringUtils.defaultIfEmpty(p.getMethodName(), EMPTY)
-                        )
-        ).collect(Collectors.toList());
+        List<StackTraceElementWrapperBo> list = new ArrayList<>(pStackTraceElements.size());
+        for (PStackTraceElement p : pStackTraceElements) {
+            StackTraceElementWrapperBo stackTraceElementWrapperBo = new StackTraceElementWrapperBo(
+                    StringUtils.defaultIfEmpty(p.getClassName(), EMPTY),
+                    StringUtils.defaultIfEmpty(p.getFileName(), EMPTY),
+                    p.getLineNumber(),
+                    StringUtils.defaultIfEmpty(p.getMethodName(), EMPTY)
+            );
+            list.add(stackTraceElementWrapperBo);
+        }
+        return list;
     }
 
     private TransactionId newTransactionId(PTransactionId pTransactionId, String spanAgentId) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/mapper/grpc/stat/GrpcAgentUriStatMapper.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/mapper/grpc/stat/GrpcAgentUriStatMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.navercorp.pinpoint.grpc.trace.PUriHistogram;
 import com.navercorp.pinpoint.io.request.ServerHeader;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -42,9 +43,11 @@ public class GrpcAgentUriStatMapper {
         int bucketVersion = agentUriStat.getBucketVersion();
         List<PEachUriStat> eachUriStatList = agentUriStat.getEachUriStatList();
 
-        List<EachUriStatBo> list = eachUriStatList.stream()
-                .map(this::createEachUriStatBo)
-                .toList();
+        List<EachUriStatBo> list = new ArrayList<>(eachUriStatList.size());
+        for (PEachUriStat pEachUriStat : eachUriStatList) {
+            EachUriStatBo eachUriStatBo = createEachUriStatBo(pEachUriStat);
+            list.add(eachUriStatBo);
+        }
 
         return new AgentUriStatBo(
                 (byte) bucketVersion,


### PR DESCRIPTION
This pull request refactors several methods in the `GrpcExceptionMetaDataHandler` and `GrpcAgentUriStatMapper` classes to replace Java Stream-based mapping with explicit for-loops and manual list construction. This change improves code readability and consistency, especially for teams who prefer traditional iteration over streams. Additionally, the copyright year in one file was updated.

Refactoring: Replace stream-based mapping with for-loops

* [`GrpcExceptionMetaDataHandler.java`](diffhunk://#diff-176ccc1f202bd93b15e7baa8389cae36ac16854b67751ee6354bc316f0884625L110-R121): The `mapExceptionWrapperBo` method now uses a for-loop to map `PException` objects to `ExceptionWrapperBo` instances, replacing the previous stream-based approach.
* [`GrpcExceptionMetaDataHandler.java`](diffhunk://#diff-176ccc1f202bd93b15e7baa8389cae36ac16854b67751ee6354bc316f0884625L133-R146): The `handleStackTraceElements` method now uses a for-loop to map `PStackTraceElement` objects to `StackTraceElementWrapperBo` instances, replacing the previous stream-based approach.
* [`GrpcAgentUriStatMapper.java`](diffhunk://#diff-a87a419e65486c50ffc7a5240f79eab285fccd75f4f998b129d362bbb0e9063fL45-R50): The `map` method now uses a for-loop to map `PEachUriStat` objects to `EachUriStatBo` instances, replacing the previous stream-based approach.

General codebase updates

* `GrpcExceptionMetaDataHandler.java`, `GrpcAgentUriStatMapper.java`: Added `ArrayList` import statements to support the new list construction approach. [[1]](diffhunk://#diff-176ccc1f202bd93b15e7baa8389cae36ac16854b67751ee6354bc316f0884625R38-L40) [[2]](diffhunk://#diff-a87a419e65486c50ffc7a5240f79eab285fccd75f4f998b129d362bbb0e9063fR28)
* [`GrpcAgentUriStatMapper.java`](diffhunk://#diff-a87a419e65486c50ffc7a5240f79eab285fccd75f4f998b129d362bbb0e9063fL2-R2): Updated the copyright year in the file header from 2020 to 2025.