### PR TITLE
[#13001] Fixed slotCode bug in SelfAgentNodeFactoryV3

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/SelfAgentNodeFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/SelfAgentNodeFactoryV3.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.collector.applicationmap.dao.v3;
 
 import com.navercorp.pinpoint.collector.applicationmap.dao.hbase.SelfAgentNodeFactory;
 import com.navercorp.pinpoint.collector.applicationmap.statistics.ColumnName;
-import com.navercorp.pinpoint.collector.applicationmap.statistics.ResponseColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRowKey;
@@ -34,7 +33,7 @@ public class SelfAgentNodeFactoryV3 implements SelfAgentNodeFactory {
 
     @Override
     public ColumnName histogram(String agentId, HistogramSlot slot) {
-        return ResponseColumnName.histogram(agentId, slot.getSlotTime());
+        return ResponseV3ColumnName.histogram(agentId, slot.getSlotCode());
     }
 
     @Override


### PR DESCRIPTION
This pull request makes a targeted update to the histogram column name generation logic in `SelfAgentNodeFactoryV3.java` to improve compatibility with the v3 schema.

* Switched from using `ResponseColumnName.histogram` (with `slot.getSlotTime()`) to `ResponseV3ColumnName.histogram` (with `slot.getSlotCode()`) for histogram column name creation, ensuring alignment with the v3 schema requirements.
* Removed the unused import of `ResponseColumnName` from `SelfAgentNodeFactoryV3.java` to clean up the code.