### PR TITLE
[#noissue] Refactor PinotExceptionMetaDataService

### DIFF
--- a/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/StackTraceMapper.java
+++ b/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/mapper/StackTraceMapper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@
  */
 package com.navercorp.pinpoint.exceptiontrace.collector.mapper;
 
-import com.navercorp.pinpoint.common.server.mapper.MapStructUtils;
 import com.navercorp.pinpoint.common.timeseries.array.IntArray;
 import com.navercorp.pinpoint.exceptiontrace.common.model.StackTraceElementWrapper;
 import org.mapstruct.Qualifier;
@@ -25,9 +24,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * @author intr3p1d
@@ -35,10 +33,7 @@ import java.util.stream.Collectors;
 @Component
 public class StackTraceMapper {
 
-    private final MapStructUtils mapStructUtils;
-
-    public StackTraceMapper(MapStructUtils mapStructUtils) {
-        this.mapStructUtils = Objects.requireNonNull(mapStructUtils, "mapStructUtils");
+    public StackTraceMapper() {
     }
 
     @Qualifier
@@ -67,16 +62,22 @@ public class StackTraceMapper {
 
     @StackTraceToClassNames
     public List<String> stackTraceToClassNames(List<StackTraceElementWrapper> classNames) {
-        return classNames.stream()
-                .map(StackTraceElementWrapper::getClassName)
-                .collect(Collectors.toList());
+        List<String> list = new ArrayList<>(classNames.size());
+        for (StackTraceElementWrapper className : classNames) {
+            String name = className.getClassName();
+            list.add(name);
+        }
+        return list;
     }
 
     @StackTraceToFileNames
     public List<String> stackTraceToFileNames(List<StackTraceElementWrapper> fileNames) {
-        return fileNames.stream()
-                .map(StackTraceElementWrapper::getFileName)
-                .collect(Collectors.toList());
+        List<String> list = new ArrayList<>(fileNames.size());
+        for (StackTraceElementWrapper fileName : fileNames) {
+            String name = fileName.getFileName();
+            list.add(name);
+        }
+        return list;
     }
 
     @StackTraceToLineNumbers
@@ -86,9 +87,12 @@ public class StackTraceMapper {
 
     @StackTraceToMethodNames
     public List<String> stackTraceToMethodNames(List<StackTraceElementWrapper> methodNames) {
-        return methodNames.stream()
-                .map(StackTraceElementWrapper::getMethodName)
-                .collect(Collectors.toList());
+        List<String> list = new ArrayList<>(methodNames.size());
+        for (StackTraceElementWrapper methodName : methodNames) {
+            String name = methodName.getMethodName();
+            list.add(name);
+        }
+        return list;
     }
 
 }

--- a/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/service/PinotExceptionMetaDataService.java
+++ b/exceptiontrace/exceptiontrace-collector/src/main/java/com/navercorp/pinpoint/exceptiontrace/collector/service/PinotExceptionMetaDataService.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,22 +26,18 @@ import com.navercorp.pinpoint.exceptiontrace.common.model.ExceptionMetaData;
 import com.navercorp.pinpoint.exceptiontrace.common.model.StackTraceElementWrapper;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
-import jakarta.validation.Valid;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
-import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * @author intr3p1d
  */
 @Service
 @ConditionalOnProperty(name = "pinpoint.modules.collector.exceptiontrace.enabled", havingValue = "true")
-@Validated
 public class PinotExceptionMetaDataService implements ExceptionMetaDataService {
     private final ExceptionTraceDao exceptionTraceDao;
     private final ServiceTypeRegistryService registry;
@@ -67,10 +63,12 @@ public class PinotExceptionMetaDataService implements ExceptionMetaDataService {
     private List<ExceptionMetaData> toExceptionMetaData(
             ExceptionMetaDataBo exceptionMetaDataBo
     ) {
-        List<ExceptionMetaData> exceptionMetaData = new ArrayList<>();
+        List<ExceptionWrapperBo> exceptionWrapperBos = exceptionMetaDataBo.getExceptionWrapperBos();
+
+        List<ExceptionMetaData> exceptionMetaData = new ArrayList<>(exceptionWrapperBos.size());
         final ServiceType serviceType = registry.findServiceType(exceptionMetaDataBo.getServiceType());
         final String tenantId = tenantProvider.getTenantId();
-        for (ExceptionWrapperBo e : exceptionMetaDataBo.getExceptionWrapperBos()) {
+        for (ExceptionWrapperBo e : exceptionWrapperBos) {
             final List<StackTraceElementWrapper> wrappers = traceElementWrappers(e.getStackTraceElements());
             exceptionMetaData.add(
                     ExceptionMetaData.valueOf(
@@ -94,9 +92,12 @@ public class PinotExceptionMetaDataService implements ExceptionMetaDataService {
     }
 
     private static List<StackTraceElementWrapper> traceElementWrappers(List<StackTraceElementWrapperBo> wrapperBos) {
-        return wrapperBos.stream().map(
-                (StackTraceElementWrapperBo s) -> new StackTraceElementWrapper(s.getClassName(), s.getFileName(), s.getLineNumber(), s.getMethodName())
-        ).collect(Collectors.toList());
+        List<StackTraceElementWrapper> list = new ArrayList<>(wrapperBos.size());
+        for (StackTraceElementWrapperBo s : wrapperBos) {
+            StackTraceElementWrapper stackTraceElementWrapper = new StackTraceElementWrapper(s.getClassName(), s.getFileName(), s.getLineNumber(), s.getMethodName());
+            list.add(stackTraceElementWrapper);
+        }
+        return list;
     }
 
 }


### PR DESCRIPTION
This pull request refactors parts of the exception trace collector codebase to remove unnecessary dependencies on streams and utility classes, replacing them with more explicit and efficient list operations. The main focus is on improving clarity and maintainability in mapping and transformation logic for stack trace and exception metadata handling.

### Refactoring for improved clarity and efficiency

* Replaced usage of Java streams and `Collectors.toList()` with explicit `for` loops and direct list construction in `StackTraceMapper` methods (`stackTraceToClassNames`, `stackTraceToFileNames`, `stackTraceToMethodNames`), removing the dependency on `MapStructUtils` and simplifying the code. [[1]](diffhunk://#diff-8b4ec9e271c5a2ca585b3ba11640bb86221d6d00efb2210b59c09d092d0e6a0fL18) [[2]](diffhunk://#diff-8b4ec9e271c5a2ca585b3ba11640bb86221d6d00efb2210b59c09d092d0e6a0fR27-R36) [[3]](diffhunk://#diff-8b4ec9e271c5a2ca585b3ba11640bb86221d6d00efb2210b59c09d092d0e6a0fL70-R80) [[4]](diffhunk://#diff-8b4ec9e271c5a2ca585b3ba11640bb86221d6d00efb2210b59c09d092d0e6a0fL89-R95)

* Updated `PinotExceptionMetaDataService` to use explicit list construction instead of streams when converting `ExceptionWrapperBo` objects to `StackTraceElementWrapper` objects, improving performance and readability. [[1]](diffhunk://#diff-295ee50379c7ed341a125df916789deb86311980820f447be0f32d16a3a77e8fL29-L44) [[2]](diffhunk://#diff-295ee50379c7ed341a125df916789deb86311980820f447be0f32d16a3a77e8fL70-R71) [[3]](diffhunk://#diff-295ee50379c7ed341a125df916789deb86311980820f447be0f32d16a3a77e8fL97-R100)

### Minor maintenance

* Updated copyright years from 2023 to 2025 in both `StackTraceMapper.java` and `PinotExceptionMetaDataService.java` for license compliance. [[1]](diffhunk://#diff-8b4ec9e271c5a2ca585b3ba11640bb86221d6d00efb2210b59c09d092d0e6a0fL2-R2) [[2]](diffhunk://#diff-295ee50379c7ed341a125df916789deb86311980820f447be0f32d16a3a77e8fL2-R2)