### PR TITLE
[#13023] Bump spring-security from 6.5.3 to 6.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <spring.batch.version>5.1.2</spring.batch.version>
         <spring.retry.version>2.0.12</spring.retry.version>
 
-        <spring.security.version>6.5.3</spring.security.version>
+        <spring.security.version>6.5.6</spring.security.version>
         <spring-boot2.version>2.7.18</spring-boot2.version>
 
         <spring.version>${spring6.version}</spring.version>


### PR DESCRIPTION
This pull request updates the Spring Security dependency version in the `pom.xml` file to address potential bug fixes and security improvements.

Dependency version update:

* Bumped `spring.security.version` from `6.5.3` to `6.5.6` in `pom.xml` to ensure the project uses the latest compatible release.