### PR TITLE
[#noissue] Refactor NodeView to consolidate agent count writing logic

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
@@ -112,23 +112,27 @@ public class NodeView {
 
             final MapViews activeView = nodeView.getActiveView();
             if (serverGroupList == null) {
-                jgen.writeNumberField("instanceCount", 0);
-                jgen.writeNumberField("instanceErrorCount", 0);
+                writeAgentCount(0, 0, jgen);
+
                 JacksonWriterUtils.writeEmptyArray(jgen, "agents");
 
                 if (activeView.isDetailed()) {
                     JacksonWriterUtils.writeEmptyObject(jgen, "serverList");
                 }
             } else {
-                jgen.writeNumberField("instanceCount", serverGroupList.getInstanceCount());
-                long instanceErrorCount = getInstanceErrorCount(node);
-                jgen.writeNumberField("instanceErrorCount", instanceErrorCount);
+                writeAgentCount(serverGroupList.getInstanceCount(), getInstanceErrorCount(node), jgen);
+
                 writeAgentList("agents", serverGroupList, jgen);
 
                 if (activeView.isDetailed()) {
                     jgen.writeObjectField("serverList", new ServerGroupListView(serverGroupList, nodeView.getHyperLinkFactory()));
                 }
             }
+        }
+
+        private void writeAgentCount(int instanceCount, long instanceErrorCount, JsonGenerator jgen) throws IOException {
+            jgen.writeNumberField("instanceCount", instanceCount);
+            jgen.writeNumberField("instanceErrorCount", instanceErrorCount);
         }
 
         private void writeAgentList(String fieldName, ServerGroupList serverGroupList, JsonGenerator jgen) throws IOException {


### PR DESCRIPTION
This pull request refactors how agent count fields are written in the `NodeView` class for improved code reuse and maintainability. The main change is the extraction of repeated logic for writing agent counts into a new helper method.

**Refactoring for code reuse:**

* Extracted the logic for writing `instanceCount` and `instanceErrorCount` fields into a new private method `writeAgentCount`, replacing duplicate code in `writeServerGroupList`. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java`) [[1]](diffhunk://#diff-283e153fc2bfe9495312ec388b0570be6d8dfdcb230261ad8429607a4fdc0cc9L115-R124) [[2]](diffhunk://#diff-283e153fc2bfe9495312ec388b0570be6d8dfdcb230261ad8429607a4fdc0cc9R133-R137)