### PR TITLE
[#noissue] Implement ViewRender

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapView.java
@@ -20,16 +20,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Iterators;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
-import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
 import com.navercorp.pinpoint.web.applicationmap.link.Link;
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentHistogramNodeView;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentLinkView;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentTimeSeriesHistogramNodeView;
+import com.navercorp.pinpoint.web.applicationmap.view.LinkRender;
 import com.navercorp.pinpoint.web.applicationmap.view.LinkView;
+import com.navercorp.pinpoint.web.applicationmap.view.NodeRender;
 import com.navercorp.pinpoint.web.applicationmap.view.NodeView;
-import com.navercorp.pinpoint.web.applicationmap.view.ServerListNodeView;
-import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -38,34 +34,16 @@ import java.util.Objects;
 public class ApplicationMapView implements MapView {
     private final ApplicationMap applicationMap;
 
-    private final ServerListNodeView serverListNodeView;
-    private final AgentHistogramNodeView agentHistogramNodeView;
-    private final AgentTimeSeriesHistogramNodeView agentTimeSeriesHistogramNodeView;
+    private final NodeRender nodeRender;
+    private final LinkRender linkRender;
 
-    private final AgentLinkView agentLinkView;
-
-    private final HyperLinkFactory hyperLinkFactory;
-    private final TimeHistogramFormat timeHistogramFormat;
 
     public ApplicationMapView(ApplicationMap applicationMap,
-
-                              ServerListNodeView serverListNodeView,
-                              AgentHistogramNodeView agentHistogramNodeView,
-                              AgentTimeSeriesHistogramNodeView agentTimeSeriesHistogramNodeView,
-
-                              AgentLinkView agentLinkView,
-
-                              HyperLinkFactory hyperLinkFactory, TimeHistogramFormat timeHistogramFormat) {
+                              NodeRender nodeRender,
+                              LinkRender linkRender) {
         this.applicationMap = Objects.requireNonNull(applicationMap, "applicationMap");
-
-        this.serverListNodeView = Objects.requireNonNull(serverListNodeView, "serverListNodeView");
-        this.agentHistogramNodeView = Objects.requireNonNull(agentHistogramNodeView, "agentHistogramNodeView");
-        this.agentTimeSeriesHistogramNodeView = Objects.requireNonNull(agentTimeSeriesHistogramNodeView, "agentTimeSeriesHistogramNodeView");
-
-        this.agentLinkView = Objects.requireNonNull(agentLinkView, "agentLinkView");
-
-        this.hyperLinkFactory = Objects.requireNonNull(hyperLinkFactory, "hyperLinkFactory");
-        this.timeHistogramFormat = Objects.requireNonNull(timeHistogramFormat, "timeHistogramFormat");
+        this.nodeRender = Objects.requireNonNull(nodeRender, "nodeRender");
+        this.linkRender = Objects.requireNonNull(linkRender, "linkRender");
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -77,20 +55,14 @@ public class ApplicationMapView implements MapView {
     public Iterator<NodeView> getNodes() {
         Collection<Node> nodes = applicationMap.getNodes();
 
-        return Iterators.transform(nodes.iterator(), node -> new NodeView(node,
-                serverListNodeView,
-                agentHistogramNodeView,
-                agentTimeSeriesHistogramNodeView,
-
-                hyperLinkFactory, timeHistogramFormat));
+        return Iterators.transform(nodes.iterator(), nodeRender::render);
     }
 
     @JsonProperty("linkDataArray")
     public Iterator<LinkView> getLinks() {
         Collection<Link> links = applicationMap.getLinks();
 
-        return Iterators.transform(links.iterator(), link ->
-                new LinkView(link, agentLinkView, timeHistogramFormat));
+        return Iterators.transform(links.iterator(), linkRender::render);
     }
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapViewV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapViewV3.java
@@ -17,12 +17,8 @@
 package com.navercorp.pinpoint.web.applicationmap;
 
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
-import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentHistogramNodeView;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentLinkView;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentTimeSeriesHistogramNodeView;
-import com.navercorp.pinpoint.web.applicationmap.view.ServerListNodeView;
-import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
+import com.navercorp.pinpoint.web.applicationmap.view.LinkRender;
+import com.navercorp.pinpoint.web.applicationmap.view.NodeRender;
 
 import java.util.List;
 import java.util.Objects;
@@ -32,17 +28,8 @@ public class ApplicationMapViewV3 extends ApplicationMapView {
     private final TimeWindow timeWindow;
 
     public ApplicationMapViewV3(ApplicationMap applicationMap, TimeWindow timeWindow,
-                                ServerListNodeView serverListNodeView,
-                                AgentHistogramNodeView agentHistogramNodeView,
-                                AgentTimeSeriesHistogramNodeView agentTimeSeriesHistogramNodeView,
-                                AgentLinkView agentLinkView,
-                                HyperLinkFactory hyperLinkFactory) {
-        super(applicationMap,
-                serverListNodeView,
-                agentHistogramNodeView,
-                agentTimeSeriesHistogramNodeView,
-                agentLinkView,
-                hyperLinkFactory, TimeHistogramFormat.V3);
+                                NodeRender nodeRender, LinkRender linkRender) {
+        super(applicationMap, nodeRender, linkRender);
         this.timeWindow = Objects.requireNonNull(timeWindow, "timeWindow");
 
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
@@ -35,11 +35,9 @@ import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
 import com.navercorp.pinpoint.web.applicationmap.service.FilteredMapService;
 import com.navercorp.pinpoint.web.applicationmap.service.FilteredMapServiceOption;
 import com.navercorp.pinpoint.web.applicationmap.service.TraceIndexService;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentHistogramNodeView;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentLinkView;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentTimeSeriesHistogramNodeView;
+import com.navercorp.pinpoint.web.applicationmap.view.LinkRender;
+import com.navercorp.pinpoint.web.applicationmap.view.NodeRender;
 import com.navercorp.pinpoint.web.applicationmap.view.ScatterDataMapView;
-import com.navercorp.pinpoint.web.applicationmap.view.ServerListNodeView;
 import com.navercorp.pinpoint.web.filter.Filter;
 import com.navercorp.pinpoint.web.filter.FilterBuilder;
 import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
@@ -140,12 +138,11 @@ public class FilteredMapController {
 
         TimeWindow timeWindow = new TimeWindow(scannerRange);
         TimeHistogramFormat format = TimeHistogramFormat.V3;
-        ApplicationMapViewV3 applicationMapView = new ApplicationMapViewV3(map.getApplicationMap(), timeWindow,
-                ServerListNodeView.detailedView(),
-                AgentHistogramNodeView.detailedView(),
-                AgentTimeSeriesHistogramNodeView.detailedView(format),
-                AgentLinkView.detailedView(format),
-                hyperLinkFactory);
+
+        NodeRender nodeRender = NodeRender.detailedRender(format, hyperLinkFactory);
+        LinkRender linkRender = LinkRender.detailedRender(format);
+
+        ApplicationMapViewV3 applicationMapView = new ApplicationMapViewV3(map.getApplicationMap(), timeWindow, nodeRender, linkRender);
         ScatterDataMapView scatterDataMapView = new ScatterDataMapView(map.getScatterDataMap());
 //        FilteredHistogramView filteredHistogramView = new FilteredHistogramView(map.getApplicationMap(), timeWindow, hyperLinkFactory);
         return new FilterMapViewV3(applicationMapView, scatterDataMapView, null, lastScanTime);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.time.RangeValidator;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMap;
-import com.navercorp.pinpoint.web.applicationmap.ApplicationMapViewV3;
+import com.navercorp.pinpoint.web.applicationmap.ApplicationMapView;
 import com.navercorp.pinpoint.web.applicationmap.MapWrap;
 import com.navercorp.pinpoint.web.applicationmap.controller.form.ApplicationForm;
 import com.navercorp.pinpoint.web.applicationmap.controller.form.RangeForm;
@@ -29,10 +29,8 @@ import com.navercorp.pinpoint.web.applicationmap.controller.form.SearchOptionFor
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
 import com.navercorp.pinpoint.web.applicationmap.service.MapService;
 import com.navercorp.pinpoint.web.applicationmap.service.MapServiceOption;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentHistogramNodeView;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentLinkView;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentTimeSeriesHistogramNodeView;
-import com.navercorp.pinpoint.web.applicationmap.view.ServerListNodeView;
+import com.navercorp.pinpoint.web.applicationmap.view.LinkRender;
+import com.navercorp.pinpoint.web.applicationmap.view.NodeRender;
 import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
 import com.navercorp.pinpoint.web.util.ApplicationValidator;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -117,16 +115,12 @@ public class MapController {
         logger.info("Select applicationMap {}. option={}", TimeHistogramFormat.V3, option);
         final ApplicationMap map = this.mapService.selectApplicationMap(option);
 
-        ApplicationMapViewV3 applicationMapViewV3 = new ApplicationMapViewV3(map, timeWindow,
-                ServerListNodeView.emptyView(),
-                AgentHistogramNodeView.emptyView(),
-                AgentTimeSeriesHistogramNodeView.emptyView(),
-                AgentLinkView.emptyView(),
-                hyperLinkFactory);
+        NodeRender nodeRender = NodeRender.emptyRender(hyperLinkFactory);
+        LinkRender linkRender = LinkRender.emptyRender();
+        ApplicationMapView applicationMapView = new ApplicationMapView(map, nodeRender, linkRender);
 
-        return new MapWrap(applicationMapViewV3);
+        return new MapWrap(applicationMapView);
     }
-
 
     private Application getApplication(ApplicationForm appForm) {
         return applicationValidator.newApplication(appForm.getApplicationName(), appForm.getServiceTypeCode(), appForm.getServiceTypeName());

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ApplicationTimeSeriesHistogramLinkView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ApplicationTimeSeriesHistogramLinkView.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.view;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationTimeHistogram;
+import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
+import com.navercorp.pinpoint.web.applicationmap.link.Link;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public interface ApplicationTimeSeriesHistogramLinkView {
+
+    default void writeTimeSeriesHistogram(LinkView linkView, JsonGenerator jgen) throws IOException {
+    }
+
+    static ApplicationTimeSeriesHistogramLinkView detailedView(TimeHistogramFormat format) {
+        return new DetailedAgentHistogramNodeView(format);
+    }
+
+    static ApplicationTimeSeriesHistogramLinkView emptyView() {
+        return new ApplicationTimeSeriesHistogramLinkView() {
+        };
+    }
+
+    class DetailedAgentHistogramNodeView implements ApplicationTimeSeriesHistogramLinkView {
+
+        private final TimeHistogramFormat format;
+
+        public DetailedAgentHistogramNodeView(TimeHistogramFormat format) {
+            this.format = Objects.requireNonNull(format, "format");
+        }
+
+        @Override
+        public void writeTimeSeriesHistogram(LinkView linkView, JsonGenerator jgen) throws IOException {
+            Link link = linkView.getLink();
+            ApplicationTimeHistogram linkApplicationTimeSeriesHistogram = link.getLinkApplicationTimeSeriesHistogram();
+            TimeHistogramBuilder builder = new TimeHistogramBuilder(format);
+            List<TimeHistogramViewModel> sourceApplicationHistogram = builder.build(linkApplicationTimeSeriesHistogram);
+            jgen.writeFieldName("timeSeriesHistogram");
+            jgen.writeObject(sourceApplicationHistogram);
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ApplicationTimeSeriesHistogramNodeView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ApplicationTimeSeriesHistogramNodeView.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.view;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.navercorp.pinpoint.common.server.util.json.JacksonWriterUtils;
+import com.navercorp.pinpoint.web.applicationmap.histogram.ApplicationTimeHistogram;
+import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
+import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public interface ApplicationTimeSeriesHistogramNodeView {
+
+    default void writeTimeSeriesHistogram(NodeView nodeView, JsonGenerator jgen) throws IOException {
+    }
+
+    static ApplicationTimeSeriesHistogramNodeView detailedView(TimeHistogramFormat format) {
+        return new DetailedAgentHistogramNodeView(format);
+    }
+
+    static ApplicationTimeSeriesHistogramNodeView emptyView() {
+        return new ApplicationTimeSeriesHistogramNodeView() {
+        };
+    }
+
+    class DetailedAgentHistogramNodeView implements ApplicationTimeSeriesHistogramNodeView {
+
+        private final TimeHistogramFormat format;
+
+        public DetailedAgentHistogramNodeView(TimeHistogramFormat format) {
+            this.format = Objects.requireNonNull(format, "format");
+        }
+
+        @Override
+        public void writeTimeSeriesHistogram(NodeView nodeView, JsonGenerator jgen) throws IOException {
+            NodeHistogram nodeHistogram = nodeView.getNode().getNodeHistogram();
+            ApplicationTimeHistogram applicationTimeHistogram = nodeHistogram.getApplicationTimeHistogram();
+            TimeHistogramBuilder builder = new TimeHistogramBuilder(format);
+            List<TimeHistogramViewModel> applicationTimeSeriesHistogram = builder.build(applicationTimeHistogram);
+            if (applicationTimeSeriesHistogram == null) {
+                JacksonWriterUtils.writeEmptyArray(jgen, "timeSeriesHistogram");
+            } else {
+                jgen.writeObjectField("timeSeriesHistogram", applicationTimeSeriesHistogram);
+            }
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkRender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkRender.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.view;
+
+import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
+import com.navercorp.pinpoint.web.applicationmap.link.Link;
+
+import java.util.Objects;
+
+public interface LinkRender {
+    LinkView render(Link link);
+
+
+    static LinkRender emptyRender() {
+        return new DefaultLinkRender(
+                ApplicationTimeSeriesHistogramLinkView.emptyView(),
+                AgentLinkView.emptyView());
+    }
+
+    static LinkRender detailedRender(TimeHistogramFormat format) {
+        return new DefaultLinkRender(
+                ApplicationTimeSeriesHistogramLinkView.detailedView(format),
+                AgentLinkView.detailedView(format));
+    }
+
+    record DefaultLinkRender(ApplicationTimeSeriesHistogramLinkView applicationTimeSeriesHistogramLinkView,
+                                    AgentLinkView agentLinkView) implements LinkRender {
+
+        public DefaultLinkRender {
+            Objects.requireNonNull(applicationTimeSeriesHistogramLinkView, "applicationTimeSeriesHistogramLinkView");
+            Objects.requireNonNull(agentLinkView, "agentLinkView");
+        }
+
+        @Override
+        public LinkView render(Link link) {
+            return new LinkView(link, applicationTimeSeriesHistogramLinkView, agentLinkView);
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeRender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeRender.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.view;
+
+import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
+import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
+import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
+
+import java.util.Objects;
+
+public interface NodeRender {
+    NodeView render(Node node);
+
+    static NodeRender detailedRender(TimeHistogramFormat format, HyperLinkFactory hyperLinkFactory) {
+        return new DefaultNodeRender(
+                ApplicationTimeSeriesHistogramNodeView.detailedView(format),
+                ServerListNodeView.detailedView(),
+                AgentHistogramNodeView.detailedView(),
+                AgentTimeSeriesHistogramNodeView.detailedView(format), hyperLinkFactory);
+    }
+
+    static NodeRender emptyRender(HyperLinkFactory hyperLinkFactory) {
+        return new DefaultNodeRender(
+                ApplicationTimeSeriesHistogramNodeView.emptyView(),
+                ServerListNodeView.emptyView(),
+                AgentHistogramNodeView.emptyView(),
+                AgentTimeSeriesHistogramNodeView.emptyView(), hyperLinkFactory);
+    }
+
+
+    record DefaultNodeRender(ApplicationTimeSeriesHistogramNodeView applicationTimeSeriesHistogramNodeView,
+                                    ServerListNodeView serverListNodeView, AgentHistogramNodeView agentHistogramNodeView,
+                                    AgentTimeSeriesHistogramNodeView agentTimeSeriesHistogramNodeView,
+                                    HyperLinkFactory hyperLinkFactory) implements NodeRender {
+
+        public DefaultNodeRender {
+            Objects.requireNonNull(applicationTimeSeriesHistogramNodeView, "applicationTimeSeriesHistogramNodeView");
+            Objects.requireNonNull(serverListNodeView, "serverListNodeView");
+            Objects.requireNonNull(agentHistogramNodeView, "agentHistogramNodeView");
+            Objects.requireNonNull(agentTimeSeriesHistogramNodeView, "agentTimeSeriesHistogramNodeView");
+
+            Objects.requireNonNull(hyperLinkFactory, "hyperLinkFactory");
+        }
+
+
+        @Override
+        public NodeView render(Node node) {
+            return new NodeView(node,
+                    applicationTimeSeriesHistogramNodeView,
+                    serverListNodeView,
+                    agentHistogramNodeView,
+                    agentTimeSeriesHistogramNodeView,
+
+                    hyperLinkFactory);
+        }
+
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/TransactionController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/TransactionController.java
@@ -29,10 +29,8 @@ import com.navercorp.pinpoint.web.applicationmap.MapView;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogramFormat;
 import com.navercorp.pinpoint.web.applicationmap.service.FilteredMapService;
 import com.navercorp.pinpoint.web.applicationmap.service.FilteredMapServiceOption;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentHistogramNodeView;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentLinkView;
-import com.navercorp.pinpoint.web.applicationmap.view.AgentTimeSeriesHistogramNodeView;
-import com.navercorp.pinpoint.web.applicationmap.view.ServerListNodeView;
+import com.navercorp.pinpoint.web.applicationmap.view.LinkRender;
+import com.navercorp.pinpoint.web.applicationmap.view.NodeRender;
 import com.navercorp.pinpoint.web.calltree.span.CallTreeIterator;
 import com.navercorp.pinpoint.web.calltree.span.SpanFilters;
 import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
@@ -248,22 +246,17 @@ public class TransactionController {
     private MapView getApplicationMap(ApplicationMap map, TimeHistogramFormat format) {
         if (format == TimeHistogramFormat.V3) {
             TimeWindow timeWindow = new TimeWindow(map.getRange());
-            return new ApplicationMapViewV3(map, timeWindow,
-                    ServerListNodeView.detailedView(),
-                    AgentHistogramNodeView.detailedView(),
-                    AgentTimeSeriesHistogramNodeView.detailedView(format),
 
-                    AgentLinkView.detailedView(format),
+            NodeRender nodeRender = NodeRender.detailedRender(format, hyperLinkFactory);
+            LinkRender linkRender = LinkRender.detailedRender(format);
 
-                    hyperLinkFactory);
+            return new ApplicationMapViewV3(map, timeWindow, nodeRender, linkRender);
         }
-        return new ApplicationMapView(map,
-                ServerListNodeView.detailedView(),
-                AgentHistogramNodeView.detailedView(),
-                AgentTimeSeriesHistogramNodeView.detailedView(format),
 
-                AgentLinkView.detailedView(format),
+        NodeRender nodeRender = NodeRender.detailedRender(format, hyperLinkFactory);
+        LinkRender linkRender = LinkRender.detailedRender(format);
 
-                hyperLinkFactory, format);
+        return new ApplicationMapView(map, nodeRender, linkRender);
     }
+
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/view/LinkViewTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/view/LinkViewTest.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.web.applicationmap.link.Link;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.view.AgentLinkView;
+import com.navercorp.pinpoint.web.applicationmap.view.ApplicationTimeSeriesHistogramLinkView;
 import com.navercorp.pinpoint.web.applicationmap.view.LinkView;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.logging.log4j.LogManager;
@@ -82,6 +83,6 @@ public class LinkViewTest {
         Node node2 = new Node(new Application("test1", ServiceType.STAND_ALONE));
 
         Link link = new Link(LinkDirection.IN_LINK, node1, node2, Range.between(0, 1));
-        return new LinkView(link, AgentLinkView.emptyView(), version);
+        return new LinkView(link, ApplicationTimeSeriesHistogramLinkView.emptyView(), AgentLinkView.emptyView());
     }
 }


### PR DESCRIPTION
This pull request refactors how node and link views are rendered in the application map feature by introducing new abstraction layers (`NodeRender` and `LinkRender`). It removes direct dependencies on specific view implementations from controllers and view classes, replacing them with these new renderers. Additionally, it introduces new interfaces for time series histogram views and updates constructors and serialization logic to use these abstractions. These changes improve modularity, testability, and flexibility for rendering logic.

**Rendering Abstraction and Refactoring:**

* Introduced `NodeRender` and `LinkRender` interfaces to encapsulate node and link rendering logic, replacing direct usage of view classes in `ApplicationMapView`, `ApplicationMapViewV3`, and controllers. (`[[1]](diffhunk://#diff-a516961c89737f44c166457ec9589e8548d46a26847ee266dee720196a40427cL41-R46)`, `[[2]](diffhunk://#diff-49f6f9036ad931d0dabcbaa77583c139b3359334e888c71ae63ae4bfd9db1092L35-R32)`, `[[3]](diffhunk://#diff-d3a358a0cdba7441ba63fb562da9330ee7ffa2ceb86c5feb474e38cf48f35461L143-R145)`, `[[4]](diffhunk://#diff-ac916486b6086ae6f8151796efc30db2d5bf67f063407946da563a6d83e974e1L120-L130)`, `[[5]](diffhunk://#diff-5aa42f3f54c317ec2a9226e7243586892eb2053d5aeefe1b8eb2973fed3a0ef0R1-R53)`)
* Refactored `ApplicationMapView` and `ApplicationMapViewV3` constructors and their usages to accept `NodeRender` and `LinkRender` instead of multiple view and formatting parameters. (`[[1]](diffhunk://#diff-a516961c89737f44c166457ec9589e8548d46a26847ee266dee720196a40427cL41-R46)`, `[[2]](diffhunk://#diff-49f6f9036ad931d0dabcbaa77583c139b3359334e888c71ae63ae4bfd9db1092L35-R32)`, `[[3]](diffhunk://#diff-d3a358a0cdba7441ba63fb562da9330ee7ffa2ceb86c5feb474e38cf48f35461L143-R145)`, `[[4]](diffhunk://#diff-ac916486b6086ae6f8151796efc30db2d5bf67f063407946da563a6d83e974e1L120-L130)`)

**View Interface and Implementation Updates:**

* Added new interfaces `ApplicationTimeSeriesHistogramNodeView` and `ApplicationTimeSeriesHistogramLinkView` to encapsulate time series histogram rendering for nodes and links, including default and detailed implementations. (`[[1]](diffhunk://#diff-440468e6f10e3b70e426cbfda9429dc12b08040edfdac3e5d52b2c1b17d40eecR1-R64)`, `[[2]](diffhunk://#diff-1622fce269ea947fc0623a4001a102027367b32a375b37adadb9c640a60610fbR1-R60)`)
* Updated `LinkView` to use `ApplicationTimeSeriesHistogramLinkView` and `AgentLinkView`, modifying its constructor and serialization logic to delegate time series histogram rendering to the new interface. (`[[1]](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dL41-L48)`, `[[2]](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dL59-R62)`, `[[3]](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dL96-R99)`)

**Dependency Cleanup:**

* Removed unused imports and dependencies on specific view classes and formatting logic from files now using the new renderers. (`[[1]](diffhunk://#diff-a516961c89737f44c166457ec9589e8548d46a26847ee266dee720196a40427cL23-L32)`, `[[2]](diffhunk://#diff-49f6f9036ad931d0dabcbaa77583c139b3359334e888c71ae63ae4bfd9db1092L20-R21)`, `[[3]](diffhunk://#diff-d3a358a0cdba7441ba63fb562da9330ee7ffa2ceb86c5feb474e38cf48f35461L38-L42)`, `[[4]](diffhunk://#diff-ac916486b6086ae6f8151796efc30db2d5bf67f063407946da563a6d83e974e1L24-R33)`)

These changes collectively improve the codebase’s structure by decoupling rendering logic from controller and view classes, making future enhancements and testing easier.