### PR TITLE
[#noissue] Refactor NodeRender and ServerListNodeView to remove HyperLinkFactory dependency

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java
@@ -115,7 +115,7 @@ public class MapController {
         logger.info("Select applicationMap {}. option={}", TimeHistogramFormat.V3, option);
         final ApplicationMap map = this.mapService.selectApplicationMap(option);
 
-        NodeRender nodeRender = NodeRender.emptyRender(hyperLinkFactory);
+        NodeRender nodeRender = NodeRender.emptyRender();
         LinkRender linkRender = LinkRender.emptyRender();
         ApplicationMapView applicationMapView = new ApplicationMapView(map, nodeRender, linkRender);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeRender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeRender.java
@@ -28,32 +28,29 @@ public interface NodeRender {
     static NodeRender detailedRender(TimeHistogramFormat format, HyperLinkFactory hyperLinkFactory) {
         return new DefaultNodeRender(
                 ApplicationTimeSeriesHistogramNodeView.detailedView(format),
-                ServerListNodeView.detailedView(),
+                ServerListNodeView.detailedView(hyperLinkFactory),
                 AgentHistogramNodeView.detailedView(),
-                AgentTimeSeriesHistogramNodeView.detailedView(format), hyperLinkFactory);
+                AgentTimeSeriesHistogramNodeView.detailedView(format));
     }
 
-    static NodeRender emptyRender(HyperLinkFactory hyperLinkFactory) {
+    static NodeRender emptyRender() {
         return new DefaultNodeRender(
                 ApplicationTimeSeriesHistogramNodeView.emptyView(),
                 ServerListNodeView.emptyView(),
                 AgentHistogramNodeView.emptyView(),
-                AgentTimeSeriesHistogramNodeView.emptyView(), hyperLinkFactory);
+                AgentTimeSeriesHistogramNodeView.emptyView());
     }
 
 
     record DefaultNodeRender(ApplicationTimeSeriesHistogramNodeView applicationTimeSeriesHistogramNodeView,
                                     ServerListNodeView serverListNodeView, AgentHistogramNodeView agentHistogramNodeView,
-                                    AgentTimeSeriesHistogramNodeView agentTimeSeriesHistogramNodeView,
-                                    HyperLinkFactory hyperLinkFactory) implements NodeRender {
+                                    AgentTimeSeriesHistogramNodeView agentTimeSeriesHistogramNodeView) implements NodeRender {
 
         public DefaultNodeRender {
             Objects.requireNonNull(applicationTimeSeriesHistogramNodeView, "applicationTimeSeriesHistogramNodeView");
             Objects.requireNonNull(serverListNodeView, "serverListNodeView");
             Objects.requireNonNull(agentHistogramNodeView, "agentHistogramNodeView");
             Objects.requireNonNull(agentTimeSeriesHistogramNodeView, "agentTimeSeriesHistogramNodeView");
-
-            Objects.requireNonNull(hyperLinkFactory, "hyperLinkFactory");
         }
 
 
@@ -63,9 +60,7 @@ public interface NodeRender {
                     applicationTimeSeriesHistogramNodeView,
                     serverListNodeView,
                     agentHistogramNodeView,
-                    agentTimeSeriesHistogramNodeView,
-
-                    hyperLinkFactory);
+                    agentTimeSeriesHistogramNodeView);
         }
 
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
@@ -26,7 +26,6 @@ import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.nodes.ServerGroupList;
-import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
 import com.navercorp.pinpoint.web.vo.ResponseTimeStatics;
 
 import java.io.IOException;
@@ -43,23 +42,17 @@ public class NodeView {
     private final AgentHistogramNodeView agentHistogramNodeView;
     private final AgentTimeSeriesHistogramNodeView agentTimeSeriesHistogramNodeView;
 
-    private final HyperLinkFactory hyperLinkFactory;
-
     public NodeView(Node node,
                     ApplicationTimeSeriesHistogramNodeView applicationTimeSeriesHistogramNodeView,
                     ServerListNodeView serverListNodeView,
                     AgentHistogramNodeView agentHistogramNodeView,
-                    AgentTimeSeriesHistogramNodeView agentTimeSeriesHistogramNodeView,
-
-                    HyperLinkFactory hyperLinkFactory) {
+                    AgentTimeSeriesHistogramNodeView agentTimeSeriesHistogramNodeView) {
         this.node = Objects.requireNonNull(node, "node");
 
         this.applicationTimeSeriesHistogramNodeView = Objects.requireNonNull(applicationTimeSeriesHistogramNodeView, "applicationTimeSeriesHistogramNodeView");
         this.serverListNodeView = Objects.requireNonNull(serverListNodeView, "serverListView");
         this.agentHistogramNodeView = Objects.requireNonNull(agentHistogramNodeView, "agentHistogramView");
         this.agentTimeSeriesHistogramNodeView = Objects.requireNonNull(agentTimeSeriesHistogramNodeView, "agentTimeSeriesHistogramView");
-
-        this.hyperLinkFactory = Objects.requireNonNull(hyperLinkFactory, "hyperLinkFactory");
     }
 
     public Node getNode() {
@@ -80,10 +73,6 @@ public class NodeView {
 
     public AgentTimeSeriesHistogramNodeView getAgentTimeSeriesHistogramView() {
         return agentTimeSeriesHistogramNodeView;
-    }
-
-    public HyperLinkFactory getHyperLinkFactory() {
-        return hyperLinkFactory;
     }
 
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ServerListNodeView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/ServerListNodeView.java
@@ -20,16 +20,18 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.navercorp.pinpoint.common.server.util.json.JacksonWriterUtils;
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.nodes.ServerGroupList;
+import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public interface ServerListNodeView {
 
     default void writeServerList(NodeView nodeView, JsonGenerator jgen) throws IOException {
     }
 
-    static ServerListNodeView detailedView() {
-        return new DetailedServerListNodeView();
+    static ServerListNodeView detailedView(HyperLinkFactory hyperLinkFactory) {
+        return new DetailedServerListNodeView(hyperLinkFactory);
     }
 
     static ServerListNodeView emptyView() {
@@ -40,6 +42,12 @@ public interface ServerListNodeView {
 
     class DetailedServerListNodeView implements ServerListNodeView {
 
+        private final HyperLinkFactory hyperLinkFactory;
+
+        public DetailedServerListNodeView(HyperLinkFactory hyperLinkFactory) {
+            this.hyperLinkFactory = Objects.requireNonNull(hyperLinkFactory, "hyperLinkFactory");
+        }
+
         @Override
         public void writeServerList(NodeView nodeView, JsonGenerator jgen) throws IOException {
             Node node = nodeView.getNode();
@@ -47,7 +55,7 @@ public interface ServerListNodeView {
                 JacksonWriterUtils.writeEmptyObject(jgen, "serverList");
             } else {
                 ServerGroupList serverGroupList = node.getServerGroupList();
-                jgen.writeObjectField("serverList", new ServerGroupListView(serverGroupList, nodeView.getHyperLinkFactory()));
+                jgen.writeObjectField("serverList", new ServerGroupListView(serverGroupList, hyperLinkFactory));
             }
         }
     }


### PR DESCRIPTION
This pull request refactors how the `HyperLinkFactory` dependency is managed within the application map view layer. The main change is that `HyperLinkFactory` is now passed directly to components that need it, rather than being stored in the `NodeView` and passed through multiple layers. This simplifies the code and improves separation of concerns.

**Dependency Management Refactoring**

* The `NodeRender` interface and its implementations (`detailedRender` and `emptyRender`) no longer require a `HyperLinkFactory` parameter except for the `ServerListNodeView`, which now receives it directly when needed. (`[web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeRender.javaL31-L56](diffhunk://#diff-3fb87307ff2b45b9f0245ef22eebc10517451669c70df498a6716750a8c8dbbfL31-L56)`)
* The `NodeView` class no longer stores or exposes a `HyperLinkFactory`, removing its constructor parameter and related getter. (`[[1]](diffhunk://#diff-283e153fc2bfe9495312ec388b0570be6d8dfdcb230261ad8429607a4fdc0cc9L46-L62)`, `[[2]](diffhunk://#diff-283e153fc2bfe9495312ec388b0570be6d8dfdcb230261ad8429607a4fdc0cc9L85-L88)`, `[[3]](diffhunk://#diff-283e153fc2bfe9495312ec388b0570be6d8dfdcb230261ad8429607a4fdc0cc9L29)`)
* The `ServerListNodeView` interface and its `DetailedServerListNodeView` implementation now explicitly require a `HyperLinkFactory` in their constructors, ensuring the dependency is only present where necessary. (`[[1]](diffhunk://#diff-ff76c36e59533f0f59178d6486ae71da51702c163a9026d06081c276b8b4a2adR23-R34)`, `[[2]](diffhunk://#diff-ff76c36e59533f0f59178d6486ae71da51702c163a9026d06081c276b8b4a2adR45-R58)`)
* The `MapController` instantiates `NodeRender.emptyRender()` without a `HyperLinkFactory`, reflecting the updated constructor signature. (`[web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.javaL118-R118](diffhunk://#diff-ac916486b6086ae6f8151796efc30db2d5bf67f063407946da563a6d83e974e1L118-R118)`)

**Codebase Simplification**

* The construction and rendering logic in `NodeRender` and `NodeView` have been simplified by removing the need to pass `HyperLinkFactory` through multiple layers, resulting in cleaner and more maintainable code. (`[web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeRender.javaL66-R63](diffhunk://#diff-3fb87307ff2b45b9f0245ef22eebc10517451669c70df498a6716750a8c8dbbfL66-R63)`)