### PR TITLE
[#noissue] Cleanup NodeView

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
@@ -95,15 +95,16 @@ public class NodeView {
 
             jgen.writeStringField("applicationName", node.getApplicationTextName()); // for go.js
 
-            jgen.writeStringField("category", node.getServiceType().toString());  // necessary for go.js
-            jgen.writeStringField("serviceType", node.getServiceType().toString());
+            final ServiceType serviceType = node.getServiceType();
 
-            final ServiceType serviceType = node.getApplication().getServiceType();
-
+            jgen.writeStringField("category", serviceType.toString());
+            jgen.writeStringField("serviceType", serviceType.toString());
             jgen.writeNumberField("serviceTypeCode", serviceType.getCode());
-//        jgen.writeStringField("terminal", Boolean.toString(serviceType.isTerminal()));
-            jgen.writeBooleanField("isWas", serviceType.isWas());  // for go.js
+
+            jgen.writeStringField("nodeCategory", serviceType.getCategory().nodeCategory().toString());
+            jgen.writeBooleanField("isWas", serviceType.isWas());
             jgen.writeBooleanField("isQueue", serviceType.isQueue());
+
             jgen.writeBooleanField("isAuthorized", node.isAuthorized());
 
             jgen.writeObjectField("apdex", node.getApdexScore());


### PR DESCRIPTION
This pull request refactors how service type information is serialized in the `NodeView` class, ensuring consistency and adding more detailed node categorization for the frontend. The main change is to consistently use the node's own `ServiceType` instead of accessing it via the application, and to provide additional categorization data.

**Improvements to service type serialization:**

* Updated `serialize` method in `NodeView.java` to consistently use `node.getServiceType()` for all service type fields, ensuring the correct service type is serialized.
* Added a new field `nodeCategory` to the serialized output, providing more detailed node categorization for frontend usage.

**Frontend data consistency:**

* Ensured that the `category` and `serviceType` fields both use the same consistent source (`node.getServiceType()`), reducing potential mismatches.
* Retained and clarified boolean fields such as `isWas`, `isQueue`, and `isAuthorized` for frontend logic.