### PR TITLE
[#noissue] Refactor metric value retrieval

### DIFF
--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/view/InspectorMetricGroupDataView.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/view/InspectorMetricGroupDataView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 
 package com.navercorp.pinpoint.inspector.web.view;
 
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 import com.navercorp.pinpoint.inspector.web.model.InspectorMetricGroupData;
 import com.navercorp.pinpoint.inspector.web.model.InspectorMetricValue;
 import com.navercorp.pinpoint.metric.common.model.Tag;
 
-import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * @author minwoo.jung
@@ -46,27 +47,24 @@ public class InspectorMetricGroupDataView {
         return inspectorMetricGroupData.timestamps();
     }
 
-    public List<MetricValueGroupView> getMetricValueGroups() {
+    public Iterator<MetricValueGroupView> getMetricValueGroups() {
         Map<List<Tag>, List<InspectorMetricValue>> metricValueGroups = inspectorMetricGroupData.metricValueGroups();
 
-        List<MetricValueGroupView> metricValueGroupViewList= new ArrayList<>(metricValueGroups.size());
-
-        for (Map.Entry<List<Tag>, List<InspectorMetricValue>> entry : metricValueGroups.entrySet()) {
-            MetricValueGroupView metricValueGroupView = new MetricValueGroupView(entry.getKey(), entry.getValue());
-            metricValueGroupViewList.add(metricValueGroupView);
-        }
-
-        return metricValueGroupViewList;
+        Iterator<Map.Entry<List<Tag>, List<InspectorMetricValue>>> iterator = metricValueGroups.entrySet().iterator();
+        return Iterators.transform(iterator, MetricValueGroupView::ofEntry);
     }
 
     public static class MetricValueGroupView {
         private final List<Tag> tags;
-        private final List<MetricValueView> metricValues;
+        private final List<InspectorMetricValue> metricValues;
+
+        public static MetricValueGroupView ofEntry(Map.Entry<List<Tag>, List<InspectorMetricValue>> entry) {
+            return new MetricValueGroupView(entry.getKey(), entry.getValue());
+        }
 
         public MetricValueGroupView(List<Tag> tags, List<InspectorMetricValue> metricValues) {
             this.tags = Objects.requireNonNull(tags, "tags");
-            Objects.requireNonNull(metricValues, "metricValues");
-            this.metricValues = metricValues.stream().map(MetricValueView::new).collect(Collectors.toList());
+            this.metricValues = Objects.requireNonNull(metricValues, "metricValues");
         }
 
         public List<Tag> getTags() {
@@ -74,7 +72,7 @@ public class InspectorMetricGroupDataView {
         }
 
         public List<MetricValueView> getMetricValues() {
-            return metricValues;
+            return Lists.transform(metricValues, MetricValueView::new);
         }
     }
 

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/view/InspectorMetricView.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/view/InspectorMetricView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.inspector.web.view;
 
+import com.google.common.collect.Lists;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 import com.navercorp.pinpoint.inspector.web.model.InspectorMetricData;
 import com.navercorp.pinpoint.inspector.web.model.InspectorMetricValue;
@@ -23,7 +24,6 @@ import com.navercorp.pinpoint.metric.common.model.Tag;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * @author minwoo.jung
@@ -45,9 +45,7 @@ public class InspectorMetricView {
     }
 
     public List<MetricValueView> getMetricValues() {
-        return inspectorMetricData.metricValues().stream()
-                .map(MetricValueView::new)
-                .collect(Collectors.toList());
+        return Lists.transform(inspectorMetricData.metricValues(), MetricValueView::new);
     }
 
     public static class MetricValueView {

--- a/otlpmetric/otlpmetric-common/src/main/java/com/navercorp/pinpoint/otlp/common/web/vo/view/MetricDataView.java
+++ b/otlpmetric/otlpmetric-common/src/main/java/com/navercorp/pinpoint/otlp/common/web/vo/view/MetricDataView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,13 @@
 
 package com.navercorp.pinpoint.otlp.common.web.vo.view;
 
+import com.google.common.collect.Lists;
 import com.navercorp.pinpoint.otlp.common.web.definition.property.ChartType;
 import com.navercorp.pinpoint.otlp.common.web.vo.MetricData;
 import com.navercorp.pinpoint.otlp.common.web.vo.MetricValue;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 /**
  * @author minwoo-jung
@@ -58,7 +59,7 @@ public class MetricDataView {
     }
 
     public List<MetricValueView> getMetricValues() {
-        return metricValueList.stream().map(MetricValueView::new).collect(Collectors.toList());
+        return Lists.transform(metricValueList, MetricValueView::new);
     }
 
     public String getMessage() {
@@ -71,6 +72,7 @@ public class MetricDataView {
         private final String version;
 
         public MetricValueView(MetricValue metricValue) {
+            Objects.requireNonNull(metricValue, "metricValue");
             this.legendName = metricValue.legendName();
             this.valueList = metricValue.valueList();
             this.version = metricValue.version();

--- a/otlpmetric/otlpmetric-common/src/test/java/com/navercorp/pinpoint/otlp/common/web/vo/view/MetricDataViewTest.java
+++ b/otlpmetric/otlpmetric-common/src/test/java/com/navercorp/pinpoint/otlp/common/web/vo/view/MetricDataViewTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.common.web.vo.view;
+
+import com.navercorp.pinpoint.otlp.common.web.definition.property.ChartType;
+import com.navercorp.pinpoint.otlp.common.web.vo.MetricData;
+import com.navercorp.pinpoint.otlp.common.web.vo.MetricValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author minwoo-jung
+ */
+class MetricDataViewTest {
+
+    @Test
+    public void test() {
+        List<Long> timestampList = List.of(1747603560000L, 1747603570000L, 1747603580000L);
+        MetricData metricData = new MetricData(timestampList, ChartType.LINE, "count", "message");
+        List<List<Number>> valueGroupList = List.of(
+                List.of(100, 200, 300),
+                List.of(333, 444, 555),
+                List.of(777, 888, 999)
+        );
+
+        metricData.addMetricValue(new MetricValue("legend1", valueGroupList.get(0), "v1"));
+        metricData.addMetricValue(new MetricValue("legend2", valueGroupList.get(1), "v1"));
+        metricData.addMetricValue(new MetricValue("legend3", valueGroupList.get(2), "v1"));
+
+        MetricDataView metricDataView = new MetricDataView(metricData);
+
+        assertEquals(timestampList, metricDataView.getTimestamp());
+        assertEquals("line", metricDataView.getChartType());
+        assertEquals("count", metricDataView.getUnit());
+        assertEquals("message", metricDataView.getMessage());
+        List<MetricDataView.MetricValueView> metricValues = metricDataView.getMetricValues();
+        assertEquals(3, metricValues.size());
+
+        for (int i = 0; i < metricValues.size(); i++) {
+            MetricDataView.MetricValueView metricValueView = metricValues.get(i);
+            assertEquals("legend" + (i + 1), metricValueView.getLegendName());
+            assertEquals(valueGroupList.get(i), metricValueView.getValues());
+            assertEquals("v1", metricValueView.getVersion());
+        }
+
+    }
+}


### PR DESCRIPTION
This pull request refactors how metric values are accessed and iterated in several data view classes, improving consistency and memory efficiency by returning iterable or iterator types instead of materialized lists. It also introduces null safety checks and adds a new unit test for `MetricDataView`.

### Refactoring of metric value access patterns

* Changed `getMetricValues()` methods in `InspectorMetricView`, `InspectorMetricGroupDataView`, and `MetricDataView` to return `Iterable<MetricValueView>` or `Iterator<MetricValueGroupView>` using Guava's transformation utilities, replacing previous approaches that returned lists and used Java streams. This change promotes lazy evaluation and reduces memory usage. [[1]](diffhunk://#diff-040a7a2888228d025df58641cf7ccefe4c333d9227d8512d26a69d64b584712dL49-R75) [[2]](diffhunk://#diff-54e4953d2269867b7b1c1eff39546ea21b1b78fa097fab12951a9a96d83f366fL47-R48) [[3]](diffhunk://#diff-e0242b63248753cb0b72f400f64a3bb9cf2157a02727a54396284a8bdfb691b1L60-R62)
* Updated internal structure of `MetricValueGroupView` in `InspectorMetricGroupDataView` to store raw `InspectorMetricValue` objects and provide transformed views via `Iterables.transform`.

### Code safety and modernization

* Added `Objects.requireNonNull` checks to constructors, ensuring that null values are not accepted for critical fields in view classes. [[1]](diffhunk://#diff-040a7a2888228d025df58641cf7ccefe4c333d9227d8512d26a69d64b584712dL49-R75) [[2]](diffhunk://#diff-e0242b63248753cb0b72f400f64a3bb9cf2157a02727a54396284a8bdfb691b1R75)
* Updated copyright years to 2025 in affected files. [[1]](diffhunk://#diff-040a7a2888228d025df58641cf7ccefe4c333d9227d8512d26a69d64b584712dL2-R2) [[2]](diffhunk://#diff-54e4953d2269867b7b1c1eff39546ea21b1b78fa097fab12951a9a96d83f366fL2-R2)

### Testing

* Added a new unit test `MetricDataViewTest` to verify correct construction and transformation of metric values in `MetricDataView`.