### PR TITLE
[#noissue] Add nodeCategory to LinkView

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.web.applicationmap.view;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.link.Link;
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
@@ -119,8 +120,9 @@ public class LinkView {
             jgen.writeFieldName("filter");
             jgen.writeStartObject();
             jgen.writeStringField("applicationName", filterApplication.getName());
-            jgen.writeNumberField("serviceTypeCode", filterApplication.getServiceTypeCode());
-            jgen.writeStringField("serviceTypeName", filterApplication.getServiceType().getName());
+            ServiceType serviceType = filterApplication.getServiceType();
+            jgen.writeNumberField("serviceTypeCode", serviceType.getCode());
+            jgen.writeStringField("serviceTypeName", serviceType.getName());
             if (link.isWasToWasLink()) {
                 writeWasToWasTargetRpcList("outRpcList", link, jgen);
             }
@@ -165,9 +167,12 @@ public class LinkView {
             jgen.writeStartObject();
             Application application = node.getApplication();
             jgen.writeStringField("applicationName", application.getName());
-            jgen.writeStringField("serviceType", application.getServiceType().toString());
-            jgen.writeNumberField("serviceTypeCode", application.getServiceTypeCode());
-            jgen.writeBooleanField("isWas", application.getServiceType().isWas());
+            ServiceType serviceType = application.getServiceType();
+            jgen.writeStringField("serviceType", serviceType.toString());
+            jgen.writeNumberField("serviceTypeCode", serviceType.getCode());
+            jgen.writeBooleanField("isWas", serviceType.isWas());
+            jgen.writeStringField("nodeCategory", serviceType.getCategory().nodeCategory().toString());
+
             jgen.writeEndObject();
         }
     }


### PR DESCRIPTION
This pull request updates how service type information is serialized in the `LinkView` class to improve code consistency and add more detail to the node output. The changes focus on using the `ServiceType` object directly for serialization and introducing a new field for node category.

Serialization improvements:

* Updated the serialization logic in `writerFilterHint` and `writeSimpleNode` to use the `ServiceType` object directly for retrieving service type code, name, and WAS status, ensuring consistency and reducing redundant method calls. [[1]](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dL122-R125) [[2]](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dL168-R175)

Additional node information:

* Added a new field `nodeCategory` to the serialized node output, providing more detailed categorization of nodes based on their service type.

Dependency update:

* Added an import for `ServiceType` in `LinkView.java` to support the updated serialization logic.