### PR TITLE
[#noissue] Add AgentServerGroupListWriter for improved agent serialization

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/AgentServerGroupListWriter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/AgentServerGroupListWriter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.nodes;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.navercorp.pinpoint.common.server.util.json.JacksonWriterUtils;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class AgentServerGroupListWriter {
+
+    public void write(String fieldName, ServerGroupList serverGroups, JsonGenerator jgen) throws IOException {
+        Objects.requireNonNull(fieldName, "fieldName");
+
+        if (serverGroups == null) {
+            JacksonWriterUtils.writeEmptyArray(jgen, fieldName);
+            return;
+        }
+
+        jgen.writeFieldName(fieldName);
+        jgen.writeStartArray();
+        for (ServerGroup serverGroup : serverGroups.getServerGroupList()) {
+            for (ServerInstance serverInstance : serverGroup.getInstanceList()) {
+                jgen.writeStartObject();
+                jgen.writeStringField("id", serverInstance.getName());
+                jgen.writeStringField("name", serverInstance.getAgentName());
+                jgen.writeEndObject();
+            }
+        }
+        jgen.writeEndArray();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/Node.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/Node.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.web.applicationmap.histogram.ApdexScore;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.NodeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -60,6 +61,7 @@ public class Node {
         this.serverGroupList = Objects.requireNonNull(serverGroupList, "serverGroupList");
     }
 
+    @Nullable
     public ServerGroupList getServerGroupList() {
         return serverGroupList;
     }
@@ -81,6 +83,7 @@ public class Node {
         return application.getServiceType();
     }
 
+    @Nullable
     public NodeHistogram getNodeHistogram() {
         return nodeHistogram;
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/ServerGroupList.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/ServerGroupList.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,7 +20,6 @@ package com.navercorp.pinpoint.web.applicationmap.nodes;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,18 +58,6 @@ public class ServerGroupList {
             }
         }
         return list;
-    }
-
-    public Map<String, String> getAgentIdNameMap() {
-        // Stream is not recommended
-        final Map<String, String> map = new LinkedHashMap<>();
-        for (ServerGroup serverGroup : this.serverGroupList) {
-            for (ServerInstance serverInstance : serverGroup.getInstanceList()) {
-                // NPE
-                map.put(serverInstance.getName(), serverInstance.getAgentName());
-            }
-        }
-        return map;
     }
 
     public int getInstanceCount() {
@@ -122,7 +109,7 @@ public class ServerGroupList {
         }
 
         public ServerGroupList build() {
-            List<ServerGroup> serverGroups = new ArrayList<>();
+            List<ServerGroup> serverGroups = new ArrayList<>(map.size());
             for (Map.Entry<String, List<ServerInstance>> entry : map.entrySet()) {
                 String hostName = entry.getKey();
                 List<ServerInstance> serverInstances = entry.getValue();


### PR DESCRIPTION
This pull request refactors how agent lists are serialized and improves type safety and code clarity in the application map node and view components. The main change is the introduction of a new `AgentServerGroupListWriter` class, which centralizes the logic for writing agent lists to JSON, replacing duplicated code in serializers. Additionally, several methods are updated for better nullability annotation and some unused or redundant code is removed.

### Serialization improvements

* Introduced the `AgentServerGroupListWriter` class to handle agent list serialization, replacing duplicated logic in both `NodeView` and `LinkView` serializers. This ensures consistent output and easier future maintenance.
* Updated `NodeViewSerializer` and `LinkViewSerializer` to use `AgentServerGroupListWriter` for writing agent lists, removing their own implementations of agent list serialization. (Fef7789fL131R131, F651d440L133R133)

### Code cleanup and simplification

* Removed the `getAgentIdNameMap` method and related serialization logic from `ServerGroupList`, as its functionality is now handled by `AgentServerGroupListWriter`. ([web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/ServerGroupList.javaL64-L75](diffhunk://#diff-e9aa1a9960854cbb283fb2358329c168882ff03f307f4f13a4b6af2ac3f62dd0L64-L75), Fef7789fL143R143, F651d440L133R133)
* Removed the redundant `hasAlert` method and unused imports from `NodeView` and `LinkView`. (Fef7789fL210R210, F651d440L32R32)

### Type safety and annotations

* Added `@Nullable` annotations to `Node#getServerGroupList` and `Node#getNodeHistogram` to clarify possible null return values and improve type safety. (F82a0ac3L61R61, F82a0ac3L83R83)

### Minor optimizations

* Updated the `ServerGroupList.Builder` to pre-size its internal list for efficiency. (F551ce18L109R109)

### Licensing and copyright

* Updated copyright years from 2017 to 2025 in modified files to reflect recent changes. [[1]](diffhunk://#diff-e9aa1a9960854cbb283fb2358329c168882ff03f307f4f13a4b6af2ac3f62dd0L2-R2) [[2]](diffhunk://#diff-8bbab9fabc966648d87f09b8353cfeec7f775db210d32d8ae256ed4a30ef3177R1-R47)