### PR TITLE
[#noissue] Refactor application response handling to return agent IDs directly

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/ApplicationResponse.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/ApplicationResponse.java
@@ -52,6 +52,7 @@ public class ApplicationResponse {
         return application;
     }
 
+    @Deprecated
     public Set<String> getAgentIds() {
         return agentIdMap;
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapAgentResponseDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapAgentResponseDao.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  *
@@ -34,4 +35,5 @@ public interface MapAgentResponseDao {
 
     AgentResponse selectAgentResponse(Application application, TimeWindow timeWindow);
 
+    Set<String> selectAgentIds(Application application, TimeWindow timeWindow);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapAgentResponseTimeDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapAgentResponseTimeDao.java
@@ -24,11 +24,9 @@ import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
-import com.navercorp.pinpoint.web.applicationmap.dao.ApplicationResponse;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapAgentResponseDao;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ResultExtractorFactory;
 import com.navercorp.pinpoint.web.applicationmap.histogram.AgentResponse;
-import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
 import org.apache.hadoop.hbase.TableName;
@@ -37,9 +35,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Repository;
 
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author netspider
@@ -119,18 +118,14 @@ public class HbaseMapAgentResponseTimeDao implements MapAgentResponseDao {
         return builder.build();
     }
 
-    @Deprecated
-    public ApplicationResponse selectApplicationResponse(Application application, TimeWindow timeWindow) {
+    @Override
+    public Set<String> selectAgentIds(Application application, TimeWindow timeWindow) {
         List<ResponseTime> responseTimes = selectResponseTime(application, timeWindow);
-        ApplicationResponse.Builder builder = ApplicationResponse.newBuilder(application);
+        Set<String> agentIds = new HashSet<>();
         for (ResponseTime responseTime : responseTimes) {
-            for (Map.Entry<String, TimeHistogram> entry : responseTime.getAgentHistogram()) {
-                String agentId = entry.getKey();
-                TimeHistogram timeHistogram = entry.getValue();
-                builder.addResponseTime(agentId, timeHistogram.getTimeStamp(), timeHistogram);
-            }
+            agentIds.addAll(responseTime.getAgentIds());
         }
-        return builder.build();
+        return agentIds;
     }
 
 }


### PR DESCRIPTION
This pull request refactors how agent IDs are retrieved for application statistics, replacing the use of `MapResponseDao` and `ApplicationResponse` with a new method in `MapAgentResponseDao`. The changes streamline the code and improve clarity by directly returning agent ID sets, removing unnecessary intermediate objects.

**Refactoring and API changes:**

* Added a new `selectAgentIds` method to the `MapAgentResponseDao` interface, which returns a `Set<String>` of agent IDs for a given application and time window.
* Implemented the `selectAgentIds` method in `HbaseMapAgentResponseTimeDao`, replacing the deprecated `selectApplicationResponse` method and simplifying the logic to aggregate agent IDs directly from `ResponseTime`.

**Service layer updates:**

* Updated `ApplicationAgentListServiceImpl` to use `MapAgentResponseDao` instead of `MapResponseDao`, and refactored related methods to work with the new agent ID retrieval approach. [[1]](diffhunk://#diff-5fc593d4139a73933ba5ca69f86939c2fded3f33207d152b8829ef1caf98bb66L55-R64) [[2]](diffhunk://#diff-5fc593d4139a73933ba5ca69f86939c2fded3f33207d152b8829ef1caf98bb66L157-R169)

**Dependency and import clean-up:**

* Removed unused imports related to `ApplicationResponse` and `MapResponseDao` from affected files, and added necessary imports for collections. [[1]](diffhunk://#diff-5fc593d4139a73933ba5ca69f86939c2fded3f33207d152b8829ef1caf98bb66L23-R23) [[2]](diffhunk://#diff-7879b3cd3516b39d7e77e09befab9ccf034b845fa8333c48b9a1e73410a4e89aL27-L31) [[3]](diffhunk://#diff-7879b3cd3516b39d7e77e09befab9ccf034b845fa8333c48b9a1e73410a4e89aR38-R41)