### PR TITLE
[#noissue] Refactor histogram calculations

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/MapApplicationResponseNodeHistogramDataSource.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/datasource/MapApplicationResponseNodeHistogramDataSource.java
@@ -69,9 +69,7 @@ public class MapApplicationResponseNodeHistogramDataSource implements WasNodeHis
     }
 
     private Histogram getHistogram(Application application, List<? extends Histogram> histograms) {
-        Histogram histogram = new Histogram(application.getServiceType());
-        histograms.forEach(histogram::add);
-        return histogram;
+        return Histogram.sumOf(application.getServiceType(), histograms);
     }
 
     private Map<String, Histogram> getAgentIdMap(Application application, Set<String> agentIds) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/ApplicationResponse.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/ApplicationResponse.java
@@ -62,9 +62,7 @@ public class ApplicationResponse {
     }
 
     public Histogram getApplicationTotalHistogram() {
-        Histogram histogram = new Histogram(application.getServiceType());
-        histogram.addAll(histograms);
-        return histogram;
+        return Histogram.sumOf(application.getServiceType(), histograms);
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/Histogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/Histogram.java
@@ -55,6 +55,12 @@ public class Histogram implements StatisticsHistogram {
 
     private long pingCount; // for internal
 
+    public static Histogram sumOf(ServiceType serviceType, Collection<? extends Histogram> histograms) {
+        Histogram result = new Histogram(serviceType);
+        result.addAll(histograms);
+        return result;
+    }
+
     public Histogram(ServiceType serviceType) {
         Objects.requireNonNull(serviceType, "serviceType");
         this.schema = serviceType.getHistogramSchema();

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/AgentHistogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/AgentHistogram.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -76,9 +76,7 @@ public class AgentHistogram {
 
     @JsonProperty("histogram")
     public Histogram getHistogram() {
-        Histogram histogram = new Histogram(agentId.getServiceType());
-        histogram.addAll(timeHistogramMap.values());
-        return histogram;
+        return Histogram.sumOf(agentId.getServiceType(), timeHistogramMap.values());
     }
 
     @JsonIgnore

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/ResponseTime.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/ResponseTime.java
@@ -77,9 +77,7 @@ public class ResponseTime {
     }
 
     public Histogram getApplicationResponseHistogram() {
-        Histogram result = new Histogram(applicationServiceType);
-        result.addAll(responseHistogramMap.values());
-        return result;
+        return Histogram.sumOf(applicationServiceType, responseHistogramMap.values());
     }
 
     public Set<Map.Entry<String, TimeHistogram>> getAgentHistogram() {
@@ -88,7 +86,8 @@ public class ResponseTime {
 
     @Override
     public String toString() {
-        return "ResponseTime{" + "applicationName='" + applicationName + '\'' +
+        return "ResponseTime{" +
+                "applicationName='" + applicationName + '\'' +
                 ", applicationServiceType=" + applicationServiceType +
                 ", timeStamp=" + timeStamp +
                 ", responseHistogramMap=" + responseHistogramMap +


### PR DESCRIPTION
This pull request refactors how histograms are aggregated across several classes in the application map and response time modules. The main change is the introduction and consistent use of the new static method `Histogram.sumOf` to combine multiple histograms, replacing manual instantiation and addition logic. This improves code readability and centralizes the aggregation logic, making future maintenance easier.

**Histogram aggregation refactor:**

* Added the static method `Histogram.sumOf(ServiceType, Collection<? extends Histogram>)` to the `Histogram` class, encapsulating the logic for combining multiple histograms into one.
* Refactored all usages of manual histogram aggregation in `ApplicationResponse`, `MapApplicationResponseNodeHistogramDataSource`, `AgentHistogram`, and `ResponseTime` to use the new `Histogram.sumOf` method. [[1]](diffhunk://#diff-6359aee70ea42a8dd88eb310e58c4245efd7bf1b392cffe27bbf8045636e2039L65-R65) [[2]](diffhunk://#diff-9dc72fa4e11bc67e34890f0b2de8a7641a7cf8fb32c638bacda61c3727f79216L72-R72) [[3]](diffhunk://#diff-2aa9c812ffc62583d244763595c8da4e8ebd02d4f9421d9ffbea161ccbf46e8fL79-R79) [[4]](diffhunk://#diff-17ff2ac0b2d9d1fe9bfd2f0855d25aa892149e7480b745a9fbb2b965f5b28de1L80-R80)

**Minor code improvements:**

* Improved formatting in the `toString` method of the `ResponseTime` class for better readability.

**Documentation update:**

* Updated copyright year to 2025 in `AgentHistogram.java`.