### PR TITLE
[#noissue] Add dual write support for LinkService

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapDualWriteConfiguration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapDualWriteConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.applicationmap.config;
+
+import com.navercorp.pinpoint.common.server.uid.ObjectNameVersion;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+        MapV2Configuration.class,
+        MapV3Configuration.class,
+})
+@ConditionalOnProperty(name = ObjectNameVersion.KEY, havingValue = "dual")
+public class MapDualWriteConfiguration {
+
+    private static final Logger logger = LogManager.getLogger(MapDualWriteConfiguration.class);
+
+    public MapDualWriteConfiguration() {
+        logger.info("Install {}", MapDualWriteConfiguration.class.getName());
+    }
+
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV2Configuration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV2Configuration.java
@@ -50,16 +50,12 @@ import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-//@ConditionalOnProperty(name = ServerNameVersion.KEY, havingValue = "v2")
-@ConditionalOnMissingBean(MapV3Configuration.class)
 public class MapV2Configuration {
     private static final Logger logger = LogManager.getLogger(MapV2Configuration.class);
-
 
     public MapV2Configuration() {
         logger.info("Install {}", MapV2Configuration.class.getName());

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV2Import.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV2Import.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.applicationmap.config;
+
+import com.navercorp.pinpoint.common.server.uid.ObjectNameVersion;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import(MapV2Configuration.class)
+@ConditionalOnProperty(name = ObjectNameVersion.KEY, havingValue = "v2", matchIfMissing = true)
+public class MapV2Import {
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV3Configuration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV3Configuration.java
@@ -48,21 +48,14 @@ import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
-import com.navercorp.pinpoint.common.server.uid.ObjectNameVersion;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan(basePackages = {
-        "com.navercorp.pinpoint.collector.applicationmap.dao.v3",
-})
-@ConditionalOnProperty(name = ObjectNameVersion.KEY, havingValue = "v3")
 public class MapV3Configuration {
     private static final Logger logger = LogManager.getLogger(MapV3Configuration.class);
 
@@ -70,7 +63,7 @@ public class MapV3Configuration {
         logger.info("Install {}", MapV3Configuration.class.getName());
     }
 
-    @Bean
+    @Bean(name = "outLinkBulkWriterV3")
     public BulkWriter outLinkBulkWriter(BulkFactory factory,
                                         BulkProperties bulkProperties,
                                         @Qualifier("uidRowKeyDistributor")
@@ -85,7 +78,7 @@ public class MapV3Configuration {
         return builder.build();
     }
 
-    @Bean
+    @Bean(name = "inLinkBulkWriterV3")
     public BulkWriter inLinkBulkWriter(BulkFactory factory,
                                        BulkProperties bulkProperties,
                                        @Qualifier("uidRowKeyDistributor")
@@ -101,7 +94,7 @@ public class MapV3Configuration {
     }
 
 
-    @Bean
+    @Bean(name = "selfAgentBulkWriterV3")
     public BulkWriter selfAgentBulkWriter(BulkFactory factory,
                                      BulkProperties bulkProperties,
                                      @Qualifier("uidRowKeyDistributor")
@@ -116,7 +109,7 @@ public class MapV3Configuration {
         return builder.build();
     }
 
-    @Bean
+    @Bean(name = "selfBulkWriterV3")
     public BulkWriter selfBulkWriter(BulkFactory factory,
                                           BulkProperties bulkProperties,
                                           @Qualifier("uidRowKeyDistributor")
@@ -136,48 +129,48 @@ public class MapV3Configuration {
     }
 
 
-    @Bean
+    @Bean(name = "mapInLinkDaoV3")
     public MapInLinkDao mapInLinkDao(MapLinkProperties mapLinkProperties,
                                      IgnoreStatFilter ignoreStatFilter,
                                      TimeSlot timeSlot,
                                      TableNameProvider tableNameProvider,
-                                     @Qualifier("inLinkBulkWriter") BulkWriter bulkWriter) {
+                                     @Qualifier("inLinkBulkWriterV3") BulkWriter bulkWriter) {
         InLinkFactory inLinkFactory = new InLinkFactoryV3();
         HbaseColumnFamily table = HbaseTables.MAP_APP_IN;
         return new HbaseMapInLinkDao(mapLinkProperties, table, ignoreStatFilter, timeSlot, tableNameProvider, bulkWriter, inLinkFactory);
     }
 
-    @Bean
+    @Bean(name = "mapOutLinkDaoV3")
     public MapOutLinkDao mapOutLinkDao(MapLinkProperties mapLinkProperties,
                                        TimeSlot timeSlot,
                                        TableNameProvider tableNameProvider,
-                                       @Qualifier("outLinkBulkWriter") BulkWriter bulkWriter) {
+                                       @Qualifier("outLinkBulkWriterV3") BulkWriter bulkWriter) {
         OutLinkFactory outLinkFactory = new OutLinkFactoryV3();
         HbaseColumnFamily table = HbaseTables.MAP_APP_OUT;
         return new HbaseMapOutLinkDao(mapLinkProperties, table, timeSlot, tableNameProvider, bulkWriter, outLinkFactory);
     }
 
-    @Bean
+    @Bean(name = "mapAgentResponseDaoV3")
     public MapAgentResponseTimeDao mapAgentResponseDao(MapLinkProperties mapLinkProperties,
                                                   TimeSlot timeSlot,
                                                   TableNameProvider tableNameProvider,
-                                                  @Qualifier("selfAgentBulkWriter") BulkWriter bulkWriter) {
+                                                  @Qualifier("selfAgentBulkWriterV3") BulkWriter bulkWriter) {
         SelfAgentNodeFactory selfAgentNodeFactory = new SelfAgentNodeFactoryV3();
         HbaseColumnFamily table = HbaseTables.MAP_AGENT_SELF;
         return new HbaseMapAgentResponseTimeDao(mapLinkProperties, table, timeSlot, tableNameProvider, bulkWriter, selfAgentNodeFactory);
     }
 
-    @Bean
+    @Bean(name = "mapResponseDaoV3")
     public MapResponseTimeDao mapResponseDao(MapLinkProperties mapLinkProperties,
                                                         TimeSlot timeSlot,
                                                         TableNameProvider tableNameProvider,
-                                                        @Qualifier("selfBulkWriter") BulkWriter bulkWriter) {
+                                                        @Qualifier("selfBulkWriterV3") BulkWriter bulkWriter) {
         SelfAppNodeFactory selfAppNodeFactory = new SelfAppNodeFactoryV3();
         HbaseColumnFamily table = HbaseTables.MAP_APP_SELF;
         return new HbaseMapResponseTimeDao(mapLinkProperties, table, timeSlot, tableNameProvider, bulkWriter, selfAppNodeFactory);
     }
 
-    @Bean
+    @Bean(name = "hostApplicationMapDaoV3")
     public HostApplicationMapDao hostApplicationMapDao(HbaseOperations hbaseTemplate,
                                                        TableNameProvider tableNameProvider,
                                                        @Qualifier("acceptApplicationRowKeyDistributor") RowKeyDistributor rowKeyDistributor,

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV3Import.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV3Import.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.applicationmap.config;
+
+import com.navercorp.pinpoint.common.server.uid.ObjectNameVersion;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import(MapV3Configuration.class)
+@ConditionalOnProperty(name = ObjectNameVersion.KEY, havingValue = "v3")
+public class MapV3Import {
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/LinkServiceDualWriteImpl.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/LinkServiceDualWriteImpl.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.applicationmap.service;
+
+import com.navercorp.pinpoint.collector.applicationmap.dao.MapAgentResponseTimeDao;
+import com.navercorp.pinpoint.collector.applicationmap.dao.MapInLinkDao;
+import com.navercorp.pinpoint.collector.applicationmap.dao.MapOutLinkDao;
+import com.navercorp.pinpoint.collector.applicationmap.dao.MapResponseTimeDao;
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+
+import java.util.Objects;
+
+/**
+ * Link service implementation.
+ * @author netspider
+ * @author jaehong.kim
+ */
+public class LinkServiceDualWriteImpl implements LinkService {
+    private final MapInLinkDao[] inLinkDao;
+    private final MapOutLinkDao[] outLinkDao;
+    private final MapAgentResponseTimeDao[] responseTimeDao;
+    private final MapResponseTimeDao[] applicationResponseTimeDao;
+
+    public LinkServiceDualWriteImpl(MapInLinkDao[] inLinkDao, MapOutLinkDao[] outLinkDao,
+                                    MapAgentResponseTimeDao[] responseTimeDao,
+                                    MapResponseTimeDao[] applicationResponseTimeDao) {
+        this.inLinkDao = Objects.requireNonNull(inLinkDao, "inLinkDao");
+        this.outLinkDao = Objects.requireNonNull(outLinkDao, "outLinkDao");
+        this.responseTimeDao = Objects.requireNonNull(responseTimeDao, "responseTimeDao");
+        this.applicationResponseTimeDao = Objects.requireNonNull(applicationResponseTimeDao, "applicationResponseTimeDao");
+    }
+
+    @Override
+    public void updateOutLink(
+            long requestTime,
+            Vertex selfVertex,
+            String selfAgentId,
+            Vertex outVertex,
+            String outHost,
+            int elapsed, boolean isError
+    ) {
+        for (MapOutLinkDao dao : outLinkDao) {
+            dao.outLink(requestTime, selfVertex, selfAgentId, outVertex, outHost, elapsed, isError);
+        }
+
+    }
+
+    @Override
+    public void updateInLink(
+            long requestTime,
+            Vertex inVertex,
+            Vertex selfVertex,
+            String selfHost,
+            int elapsed, boolean isError
+    ) {
+        for (MapInLinkDao dao : inLinkDao) {
+            dao.inLink(requestTime, inVertex, selfVertex, selfHost, elapsed, isError);
+        }
+    }
+
+    @Override
+    public void updateResponseTime(
+            long requestTime,
+            Vertex selfVertex,
+            String agentId,
+            int elapsed, boolean isError
+    ) {
+        for (MapAgentResponseTimeDao dao : responseTimeDao) {
+            dao.received(requestTime, selfVertex, agentId, elapsed, isError);
+        }
+        for (MapResponseTimeDao dao : applicationResponseTimeDao) {
+            dao.received(requestTime, selfVertex, elapsed, isError);
+        }
+    }
+
+    @Override
+    public void updateAgentState(
+            long requestTime,
+            final String outApplicationName,
+            final ServiceType outServiceType,
+            final String outAgentId
+    ) {
+        for (MapAgentResponseTimeDao dao : responseTimeDao) {
+            dao.updatePing(requestTime, outApplicationName, outServiceType, outAgentId, 0, false);
+        }
+    }
+}


### PR DESCRIPTION
This pull request refactors the configuration of the application map module to support dual-write mode, as well as to improve the modularity and conditional activation of V2 and V3 map configurations. The main changes introduce new configuration classes for conditional imports and bean creation based on the value of the `ObjectNameVersion.KEY` property, enabling more flexible and maintainable management of the map service versions.

**Dual-write and versioned configuration support:**

* Added new configuration classes: `MapDualWriteConfiguration`, `MapDualWriteImport`, `MapV2Import`, and `MapV3Import`, each using `@ConditionalOnProperty` to activate V2, V3, or dual-write mode based on the `ObjectNameVersion.KEY` property. This modularizes and clarifies which beans are loaded for each mode. [[1]](diffhunk://#diff-d96751c4eb385f1a9bf907956b57aa8067c750c1357ce573104f9553be293a4eR1-R40) [[2]](diffhunk://#diff-956f05f669443e4e791177fd312a3337173a74fd665c48bf59663422fcac9a60R1-R31) [[3]](diffhunk://#diff-156315e632b24bc70f0877c946128477c4a85d8ee87b9a0eafb271914793ee3bR1-R28) [[4]](diffhunk://#diff-8be46b25fd3b344e6f3d674056d5b017109481128facff5c764cec8311cfd972R1-R28)
* Updated `ApplicationMapModule` to import the new configuration classes and to conditionally provide either the standard `LinkService` or the new dual-write implementation `LinkServiceDualWriteImpl` depending on the mode, using Spring's conditional annotations. [[1]](diffhunk://#diff-6edc73dc7af5e7a1152068f7725370dce85925678160f12ac0700d20e4f28509R24-R31) [[2]](diffhunk://#diff-6edc73dc7af5e7a1152068f7725370dce85925678160f12ac0700d20e4f28509L39-R45) [[3]](diffhunk://#diff-6edc73dc7af5e7a1152068f7725370dce85925678160f12ac0700d20e4f28509R55-R67)

**Conditional activation logic:**

* Introduced `DualWriteV2Condition` and `DualWriteV3Condition` classes to encapsulate complex conditional logic for activating V2 and V3 configurations, supporting dual and default modes. [[1]](diffhunk://#diff-dc35de513dc6b3612e9ce4bbdf08ac4b6091368c233fb303326e606279f50f2eR1-R38) [[2]](diffhunk://#diff-49106607f12cf2f2c64ba8780ba2a8e79666e22e39466f417a486d1e759a87dbR1-R34)

**Bean naming and qualification improvements:**

* Updated bean definitions in `MapV3Configuration` to use explicit names (e.g., `inLinkBulkWriterV3`, `mapInLinkDaoV3`) to prevent bean conflicts and clarify their association with V3, supporting dual-write and multi-version scenarios. [[1]](diffhunk://#diff-f9de701ff7860e4af7022915e212e50b9f7fab058a8de2d27ec3c797eb10f645L51-R67) [[2]](diffhunk://#diff-f9de701ff7860e4af7022915e212e50b9f7fab058a8de2d27ec3c797eb10f645L88-R82) [[3]](diffhunk://#diff-f9de701ff7860e4af7022915e212e50b9f7fab058a8de2d27ec3c797eb10f645L104-R98) [[4]](diffhunk://#diff-f9de701ff7860e4af7022915e212e50b9f7fab058a8de2d27ec3c797eb10f645L119-R113) [[5]](diffhunk://#diff-f9de701ff7860e4af7022915e212e50b9f7fab058a8de2d27ec3c797eb10f645L139-R174)

**Preparation for future conditional logic:**

* Commented out previous conditional annotations in `MapV2Configuration` and `MapV3Configuration`, indicating a transition to the new modular and conditional approach using the dedicated import classes and condition objects. [[1]](diffhunk://#diff-20ae4db6ffbf81a008517d03ea19c707f604d496dcfb92e9cc8d1ad4e6e4245aL53-R59) [[2]](diffhunk://#diff-f9de701ff7860e4af7022915e212e50b9f7fab058a8de2d27ec3c797eb10f645L51-R67)

These changes make the application's map configuration system more flexible, maintainable, and ready for future enhancements involving versioned and dual-write support.