### PR TITLE
[#noissue] Improved error handling in CustomExceptionHandler

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/PinpointWebModule.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/PinpointWebModule.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.web;
 
 import com.navercorp.pinpoint.common.server.CommonsServerConfiguration;
@@ -15,6 +31,7 @@ import com.navercorp.pinpoint.web.config.WebMysqlDaoConfiguration;
 import com.navercorp.pinpoint.web.frontend.FrontendConfigExportConfiguration;
 import com.navercorp.pinpoint.web.heatmap.HeatmapWebModule;
 import com.navercorp.pinpoint.web.install.InstallModule;
+import com.navercorp.pinpoint.web.problem.ProblemSpringWebConfig;
 import com.navercorp.pinpoint.web.query.QueryServiceConfiguration;
 import com.navercorp.pinpoint.web.realtime.RealtimeConfig;
 import com.navercorp.pinpoint.web.uid.WebUidConfiguration;

--- a/web/src/main/java/com/navercorp/pinpoint/web/problem/ProblemSpringWebConfig.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/problem/ProblemSpringWebConfig.java
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.navercorp.pinpoint.web;
+package com.navercorp.pinpoint.web.problem;
 
 import com.navercorp.pinpoint.common.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.web.ErrorProperties;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -36,12 +38,15 @@ public class ProblemSpringWebConfig {
 
     @Bean
     @Primary
-    public ResponseEntityExceptionHandler pinpointExceptionHandling(@Value("${pinpoint.problemdetails.hostname:}") String hostnameAlias) {
+    public ResponseEntityExceptionHandler pinpointExceptionHandling(
+            @Value("${server.error.hostname:}") String hostnameAlias,
+            ServerProperties serverProperties) {
         if (StringUtils.isEmpty(hostnameAlias)) {
             hostnameAlias = getHostName();
         }
-        logger.info("pinpoint.problemdetails.hostname:{}", hostnameAlias);
-        return new CustomExceptionHandler(hostnameAlias);
+        logger.info("server.error.hostname:{}", hostnameAlias);
+        ErrorProperties error = serverProperties.getError();
+        return new CustomExceptionHandler(hostnameAlias, error);
     }
 
     static private String getHostName() {


### PR DESCRIPTION
This pull request refactors and improves the exception handling mechanism in the web module by moving the custom exception handler into a dedicated package, updating its dependencies, and enhancing its configurability and logging. The changes also introduce more robust error reporting, including stack trace handling based on configuration, and make the error handler easier to configure via Spring Boot properties.

**Exception Handling Improvements:**

* Moved `CustomExceptionHandler` and `ProblemSpringWebConfig` to the new `com.navercorp.pinpoint.web.problem` package for better organization and modularity. [[1]](diffhunk://#diff-5e2521cd07ca9a7ea63add19259255205d37d414bbbd3263104e81291fa6d5eaL16-R26) [[2]](diffhunk://#diff-33adee735eb4d930729bd0019e3bb11a2d5d88fa1d05802e2005f6de09191c93L16-R23)
* Updated `CustomExceptionHandler` to accept `ErrorProperties` for configurable error reporting, and improved stack trace inclusion logic to respect the `ErrorProperties.IncludeAttribute.ALWAYS` setting. [[1]](diffhunk://#diff-5e2521cd07ca9a7ea63add19259255205d37d414bbbd3263104e81291fa6d5eaR51-R67) [[2]](diffhunk://#diff-5e2521cd07ca9a7ea63add19259255205d37d414bbbd3263104e81291fa6d5eaL87-R164)
* Enhanced logging and error reporting: added exclusion paths for error reports, improved logging when responses are already committed, and refined error detail population. [[1]](diffhunk://#diff-5e2521cd07ca9a7ea63add19259255205d37d414bbbd3263104e81291fa6d5eaR51-R67) [[2]](diffhunk://#diff-5e2521cd07ca9a7ea63add19259255205d37d414bbbd3263104e81291fa6d5eaL87-R164)

**Spring Boot Integration:**

* Refactored bean creation in `ProblemSpringWebConfig` to use `ServerProperties` and the new error property, making hostname and error configuration easier and more standard with Spring Boot.

**General Codebase Maintenance:**

* Added missing Apache license headers to `PinpointWebModule.java` and updated imports to reference the new package structure. [[1]](diffhunk://#diff-fbef329711c6bb944a1cbbba5c604385c6af2fe4f86783c1e9172b885e0dd009R1-R16) [[2]](diffhunk://#diff-fbef329711c6bb944a1cbbba5c604385c6af2fe4f86783c1e9172b885e0dd009R34)