### PR TITLE
[#noissue] Cleanup reactor-netty-plugin

### DIFF
--- a/agent-module/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpClientRequestWrapper.java
+++ b/agent-module/plugins/reactor-netty/src/main/java/com/navercorp/pinpoint/plugin/reactor/netty/interceptor/HttpClientRequestWrapper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2020 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -61,6 +61,7 @@ public class HttpClientRequestWrapper implements ClientRequestWrapper {
     private String toRemoteHost() {
         if (request instanceof ChannelOperations) {
             try {
+                @SuppressWarnings("rawtypes")
                 final ChannelOperations channelOperations = (ChannelOperations) request;
                 final InetSocketAddress inetSocketAddress = (InetSocketAddress) channelOperations.channel().remoteAddress();
                 if (inetSocketAddress != null) {
@@ -76,21 +77,17 @@ public class HttpClientRequestWrapper implements ClientRequestWrapper {
     }
 
     private String toHost(String hostName, int port) {
-        final StringBuilder sb = new StringBuilder();
-        if (hostName != null) {
-            sb.append(hostName);
-            sb.append(':');
-            sb.append(port);
+        if (hostName == null) {
+            return "";
         }
-        return sb.toString();
+        return hostName + ':' + port;
     }
 
+    @SuppressWarnings("ConstantConditions")
     private String toUri() {
         if (request instanceof HttpInfos) {
-            final String uri = ((HttpInfos) request).uri();
-            return uri;
+            return request.uri();
         }
-
         return null;
     }
 }


### PR DESCRIPTION
This pull request makes minor improvements to the `HttpClientRequestWrapper` class in the Reactor Netty plugin, primarily focused on code clarity and modernization. The most notable changes are the update of the copyright year, the addition of suppression annotations, and simplification of string handling.

Code modernization and clarity:

* Updated the copyright year in `HttpClientRequestWrapper.java` from 2020 to 2025.
* Added `@SuppressWarnings("rawtypes")` to the casting of `ChannelOperations` and `@SuppressWarnings("ConstantConditions")` to the `toUri()` method to suppress relevant compiler warnings. [[1]](diffhunk://#diff-743dea2327844ae14cd743db69ce7727fa55ec176c79f3a0a16b072d4392e5c3R64) [[2]](diffhunk://#diff-743dea2327844ae14cd743db69ce7727fa55ec176c79f3a0a16b072d4392e5c3L79-L93)

Code simplification:

* Refactored the `toHost()` method to return an empty string if `hostName` is null, and to use string concatenation instead of `StringBuilder` for constructing the host and port string.
* Simplified the `toUri()` method by directly returning `request.uri()` when `request` is an instance of `HttpInfos`.