### PR TITLE
[#noissue] Improvement StackTrace Log

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/problem/CustomExceptionHandler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/problem/CustomExceptionHandler.java
@@ -37,7 +37,9 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static com.navercorp.pinpoint.web.problem.StackTraceProcessor.COMPOUND;
 import static java.util.Arrays.asList;
@@ -158,12 +160,12 @@ public final class CustomExceptionHandler extends ResponseEntityExceptionHandler
     public void addStackTraces(ProblemDetail problemDetail, Throwable th) {
         if (errorProperties.getIncludeStacktrace() == ErrorProperties.IncludeAttribute.ALWAYS) {
             final Collection<StackTraceElement> stackTrace = COMPOUND.process(asList(th.getStackTrace()));
-            String[] trace = traceToStringArray(stackTrace);
+            List<String> trace = traceToStringArray(stackTrace);
             problemDetail.setProperty("trace", trace);
         }
     }
 
-    private String[] traceToStringArray(Collection<StackTraceElement> stackTrace) {
-        return stackTrace.stream().map(serializer::valueToString).toArray(String[]::new);
+    private List<String> traceToStringArray(Collection<StackTraceElement> stackTrace) {
+        return stackTrace.stream().map(serializer::valueToString).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
This pull request refactors how stack traces are processed and stored in the `CustomExceptionHandler` class, moving from arrays to lists for better consistency with modern Java practices.

Stack trace handling improvements:

* Changed the return type of `traceToStringArray` from `String[]` to `List<String>`, and updated its implementation to use `Collectors.toList()` instead of creating an array.
* Updated the `addStackTraces` method to use a `List<String>` instead of a `String[]` for the stack trace property in `ProblemDetail`.

Imports and code consistency:

* Added imports for `List` and `Collectors` to support the refactored stack trace handling.