### PR TITLE
[#noissue] Refactor GrpcAnnotationHandler to use switch expression

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/GrpcAnnotationHandler.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/GrpcAnnotationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.common.server.bo.grpc;
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Descriptors;
 import com.navercorp.pinpoint.common.server.bo.AnnotationFactory;
 import com.navercorp.pinpoint.common.util.BytesStringStringValue;
 import com.navercorp.pinpoint.common.util.IntBooleanIntBooleanValue;
@@ -50,11 +49,24 @@ public class GrpcAnnotationHandler implements AnnotationFactory.AnnotationTypeHa
             return null;
         }
         final PAnnotationValue value = annotation.getValue();
-
-        Descriptors.Descriptor descriptorForType = value.getDescriptorForType();
-        int number = value.getFieldCase().getNumber();
-        Descriptors.FieldDescriptor fieldByNumber = descriptorForType.findFieldByNumber(number);
-        return value.getField(fieldByNumber);
+        PAnnotationValue.FieldCase fieldCase = value.getFieldCase();
+        return switch (fieldCase) {
+            case STRINGVALUE -> value.getStringValue();
+            case BOOLVALUE -> value.getBoolValue();
+            case INTVALUE -> value.getIntValue();
+            case LONGVALUE -> value.getLongValue();
+            case SHORTVALUE -> value.getShortValue();
+            case DOUBLEVALUE -> value.getDoubleValue();
+            case BINARYVALUE -> value.getBinaryValue();
+            case BYTEVALUE -> value.getByteValue();
+            case INTSTRINGVALUE -> value.getIntStringValue();
+            case STRINGSTRINGVALUE -> value.getStringStringValue();
+            case INTSTRINGSTRINGVALUE -> value.getIntStringStringValue();
+            case LONGINTINTBYTEBYTESTRINGVALUE -> value.getLongIntIntByteByteStringValue();
+            case INTBOOLEANINTBOOLEANVALUE -> value.getIntBooleanIntBooleanValue();
+            case BYTESSTRINGSTRINGVALUE -> value.getBytesStringStringValue();
+            case FIELD_NOT_SET -> null;
+        };
     }
 
 


### PR DESCRIPTION
This pull request updates the `GrpcAnnotationHandler` class to simplify and modernize how annotation values are extracted. The main improvement is replacing the previous reflection-based approach with a direct use of Java's switch expression, making the code easier to read and maintain.

**Refactoring of annotation value extraction:**

* Replaced the use of Protocol Buffers reflection (via `Descriptors.Descriptor` and `FieldDescriptor`) with a switch expression on `PAnnotationValue.FieldCase`, directly returning the appropriate value from `PAnnotationValue`. This removes complexity and improves performance.

**Minor updates:**

* Updated the copyright year in the file header to 2025.
* Removed an unused import for `com.google.protobuf.Descriptors`.