### PR TITLE
[#noissue] Change the limit for parentApplicationName to 127

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/GrpcSpanBinder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/GrpcSpanBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.common.server.bo.grpc;
 
 
+import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.AnnotationComparator;
@@ -138,7 +139,7 @@ public class GrpcSpanBinder {
                 final String parentApplicationName = parentInfo.getParentApplicationName();
                 // If root node, parentApplicationName is null
                 if (StringUtils.hasLength(parentApplicationName)) {
-                    if (!IdValidateUtils.validateId(parentApplicationName)) {
+                    if (!IdValidateUtils.validateId(parentApplicationName, PinpointConstants.APPLICATION_NAME_MAX_LEN_V3)) {
                         throw new IllegalArgumentException("Invalid parentApplicationName " + parentApplicationName
                                 + " agent:" + attribute.getApplicationName() + "/" + attribute.getAgentId());
                     }


### PR DESCRIPTION
This pull request updates the copyright year and strengthens validation logic for parent application names in the `GrpcSpanBinder` class. The most important changes are grouped below:

General maintenance:

* Updated the copyright year in `GrpcSpanBinder.java` from 2019 to 2025.

Validation improvements:

* Enhanced parent application name validation in the `newSpanBo` method by specifying a maximum length constant (`PinpointConstants.APPLICATION_NAME_MAX_LEN_V3`). This helps ensure parent application names conform to expected constraints.
* Added an import for `PinpointConstants` to support the new validation logic.