### PR TITLE
[#noissue] Add ErrorCategoryResolver to categorize error codes

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolver.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolver.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.trace;
+
+import java.util.EnumSet;
+
+public class ErrorCategoryResolver {
+
+    private static final EnumSet<ErrorCategory> DISPLAY_CANDIDATE = EnumSet.complementOf(EnumSet.of(ErrorCategory.UNKNOWN));
+
+    public EnumSet<ErrorCategory> resolve(int errorCode) {
+        EnumSet<ErrorCategory> flagged = EnumSet.noneOf(ErrorCategory.class);
+        for (ErrorCategory category : DISPLAY_CANDIDATE) {
+            if ((errorCode & category.getBitMask()) != 0) {
+                flagged.add(category);
+            }
+        }
+        return flagged;
+    }
+}

--- a/commons/src/test/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolverTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolverTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.trace;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+class ErrorCategoryResolverTest {
+
+    @Test
+    public void resolveShouldReturnEmptySetForUnknownErrorCode() {
+        int unknownErrorCode = ErrorCategory.UNKNOWN.getBitMask();
+        EnumSet<ErrorCategory> result = new ErrorCategoryResolver().resolve(unknownErrorCode);
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void resolveShouldReturnSingleCategoryForMatchingErrorCode() {
+        int networkErrorCode = ErrorCategory.EXCEPTION.getBitMask();
+        EnumSet<ErrorCategory> result = new ErrorCategoryResolver().resolve(networkErrorCode);
+        Assertions.assertEquals(EnumSet.of(ErrorCategory.EXCEPTION), result);
+    }
+
+    @Test
+    public void resolveShouldReturnEmptySetForZeroErrorCode() {
+        int zeroErrorCode = 0;
+        EnumSet<ErrorCategory> result = new ErrorCategoryResolver().resolve(zeroErrorCode);
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+
+}


### PR DESCRIPTION
This pull request introduces a new utility class to centralize error category resolution logic and refactors existing code to use it, improving maintainability and readability. Additionally, comprehensive unit tests for the new resolver have been added.

Error category resolution improvements:

* Added new `ErrorCategoryResolver` class in `commons/src/main/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolver.java`, encapsulating the logic for extracting flagged error categories from an error code.
* Refactored `TransactionInfoServiceImpl` to use `ErrorCategoryResolver` for error category extraction, replacing inline logic with a single method call for clarity and reuse. [[1]](diffhunk://#diff-e92145dad5de9c659bdc63d1f89dceeb8938e80affa9df2fdfdab5337d65fbfbR26) [[2]](diffhunk://#diff-e92145dad5de9c659bdc63d1f89dceeb8938e80affa9df2fdfdab5337d65fbfbR73-R74) [[3]](diffhunk://#diff-e92145dad5de9c659bdc63d1f89dceeb8938e80affa9df2fdfdab5337d65fbfbL387-R390)

Testing:

* Added unit tests for `ErrorCategoryResolver` in `commons/src/test/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolverTest.java`, ensuring correct behavior for various error code scenarios.

Licensing:

* Updated copyright year to 2025 in modified files.