### PR TITLE
[#noissue] Refactor AnnotationUtils

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/AnnotationUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/AnnotationUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,7 +20,11 @@ import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import org.apache.commons.collections4.CollectionUtils;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.RandomAccess;
+import java.util.function.Predicate;
 
 /**
  * @author emeroad
@@ -41,7 +45,7 @@ public final class AnnotationUtils {
         if (CollectionUtils.isEmpty(list)) {
             return null;
         }
-        final AnnotationBo annotationBo = findAnnotationBo(list, annotationKey);
+        final AnnotationBo annotationBo = findAnnotation(list, annotationKey.getCode());
         if (annotationBo != null) {
             final Object value = annotationBo.getValue();
             if (type.isInstance(value)) {
@@ -52,14 +56,72 @@ public final class AnnotationUtils {
     }
 
 
-    public static AnnotationBo findAnnotationBo(List<AnnotationBo> annotationBoList, AnnotationKey annotationKey) {
-        for (AnnotationBo annotation : annotationBoList) {
-            final int key = annotation.getKey();
-            if (annotationKey.getCode() == key) {
-                return annotation;
+    @SuppressWarnings("ForLoopReplaceableByForEach")
+    public static AnnotationBo findAnnotation(List<AnnotationBo> list, int key) {
+        if (CollectionUtils.isEmpty(list)) {
+            return null;
+        }
+        if (list instanceof RandomAccess) {
+            for (int i = 0; i < list.size(); i++) {
+                final AnnotationBo annotationBo = list.get(i);
+                if (key == annotationBo.getKey()) {
+                    return annotationBo;
+                }
+            }
+            return null;
+        } else {
+            for (AnnotationBo annotationBo : list) {
+                if (key == annotationBo.getKey()) {
+                    return annotationBo;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * @deprecated use {@link #findAnnotation(List, AnnotationKey)}
+     */
+    @Deprecated
+    public static AnnotationBo findAnnotationBo(List<AnnotationBo> list, AnnotationKey annotationKey) {
+        return findAnnotation(list, annotationKey.getCode());
+    }
+
+    public static AnnotationBo findAnnotation(List<AnnotationBo> list, AnnotationKey annotationKey) {
+        return findAnnotation(list, annotationKey.getCode());
+    }
+
+    @SuppressWarnings("ForLoopReplaceableByForEach")
+    public static List<AnnotationBo> findAnnotations(List<AnnotationBo> list, Predicate<AnnotationBo> annotationPredicate) {
+        if (CollectionUtils.isEmpty(list)) {
+            return Collections.emptyList();
+        }
+        List<AnnotationBo> annotationList = null;
+        if (list instanceof RandomAccess) {
+            for (int i = 0; i < list.size(); i++) {
+                final AnnotationBo annotationBo = list.get(i);
+                if (annotationPredicate.test(annotationBo)) {
+                    if (annotationList == null) {
+                        annotationList = new ArrayList<>(2);
+                    }
+                    annotationList.add(annotationBo);
+                }
+            }
+        } else {
+            for (AnnotationBo annotationBo : list) {
+                if (annotationPredicate.test(annotationBo)) {
+                    if (annotationList == null) {
+                        annotationList = new ArrayList<>(2);
+                    }
+                    annotationList.add(annotationBo);
+                }
             }
         }
-        return null;
+        if (annotationList != null) {
+            return annotationList;
+        }
+        return Collections.emptyList();
     }
+
 
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/AnnotationUtilsTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/AnnotationUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.server.util;
 
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
@@ -5,6 +21,7 @@ import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedList;
 import java.util.List;
 
 public class AnnotationUtilsTest {
@@ -14,12 +31,31 @@ public class AnnotationUtilsTest {
         AnnotationBo annotationBo = AnnotationBo.of(AnnotationKey.API.getCode(), "a");
         String value = AnnotationUtils.findApiAnnotation(List.of(annotationBo));
         Assertions.assertEquals("a", value);
+
+        List<AnnotationBo> list = new LinkedList<>();
+        list.add(annotationBo);
+        String value2 = AnnotationUtils.findApiAnnotation(list);
+        Assertions.assertEquals("a", value2);
     }
 
     @Test
     public void findApiAnnotation_invalidType() {
         AnnotationBo annotationBo = AnnotationBo.of(AnnotationKey.API.getCode(), 1);
         String value = AnnotationUtils.findApiAnnotation(List.of(annotationBo));
-        Assertions.assertNull(null, value);
+        Assertions.assertNull(value);
+    }
+
+    @Test
+    public void findAnnotation() {
+        AnnotationBo annotationBo = AnnotationBo.of(AnnotationKey.API.getCode(), 1);
+        AnnotationBo value = AnnotationUtils.findAnnotation(List.of(annotationBo), AnnotationKey.API);
+        Assertions.assertEquals(annotationBo, value);
+    }
+
+    @Test
+    public void findAnnotation_filter() {
+        AnnotationBo annotationBo = AnnotationBo.of(AnnotationKey.API.getCode(), 1);
+        List<AnnotationBo> values = AnnotationUtils.findAnnotations(List.of(annotationBo), e -> e.getKey() == AnnotationKey.API.getCode());
+        Assertions.assertEquals(List.of(annotationBo), values);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/SpanServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/SpanServiceImpl.java
@@ -209,7 +209,7 @@ public class SpanServiceImpl implements SpanService {
         this.transitionAnnotation(spans, new AnnotationReplacementCallback() {
             @Override
             public void replacement(Align align, List<AnnotationBo> annotationBoList) {
-                AnnotationBo sqlIdAnnotation = findAnnotation(annotationBoList, AnnotationKey.SQL_ID.getCode());
+                AnnotationBo sqlIdAnnotation = AnnotationUtils.findAnnotation(annotationBoList, AnnotationKey.SQL_ID.getCode());
                 if (sqlIdAnnotation == null) {
                     return;
                 }
@@ -276,7 +276,7 @@ public class SpanServiceImpl implements SpanService {
         this.transitionAnnotation(spans, new AnnotationReplacementCallback() {
             @Override
             public void replacement(Align align, List<AnnotationBo> annotationBoList) {
-                AnnotationBo sqlUidAnnotation = findAnnotation(annotationBoList, AnnotationKey.SQL_UID.getCode());
+                AnnotationBo sqlUidAnnotation = AnnotationUtils.findAnnotation(annotationBoList, AnnotationKey.SQL_UID.getCode());
                 if (sqlUidAnnotation == null) {
                     return;
                 }
@@ -347,14 +347,14 @@ public class SpanServiceImpl implements SpanService {
                 for (int i = 0; i < annotationBoList.size(); i++) {
                     final AnnotationBo annotationBo = annotationBoList.get(i);
                     if (annotationBo.getKey() == MongoConstants.MONGO_COLLECTION_INFO.getCode()) {
-                        AnnotationBo collectionOption = findAnnotation(annotationBoList, MongoConstants.MONGO_COLLECTION_OPTION.getCode());
+                        AnnotationBo collectionOption = AnnotationUtils.findAnnotation(annotationBoList, MongoConstants.MONGO_COLLECTION_OPTION.getCode());
                         String collectionValue = getCollectionInfo(align.getDestinationId(), annotationBo, collectionOption);
                         AnnotationBo replace = AnnotationBo.of(annotationBo.getKey(), collectionValue);
                         annotationBoList.set(i, replace);
                     }
                 }
 
-                AnnotationBo jsonAnnotation = findAnnotation(annotationBoList, MongoConstants.MONGO_JSON_DATA.getCode());
+                AnnotationBo jsonAnnotation = AnnotationUtils.findAnnotation(annotationBoList, MongoConstants.MONGO_JSON_DATA.getCode());
                 if (jsonAnnotation == null) {
                     return;
                 }
@@ -389,15 +389,6 @@ public class SpanServiceImpl implements SpanService {
                 return builder.toString();
             }
         });
-    }
-
-    private AnnotationBo findAnnotation(List<AnnotationBo> annotationBoList, int key) {
-        for (AnnotationBo annotationBo : annotationBoList) {
-            if (key == annotationBo.getKey()) {
-                return annotationBo;
-            }
-        }
-        return null;
     }
 
     private void transitionDynamicApiId(List<Align> spans) {
@@ -456,7 +447,8 @@ public class SpanServiceImpl implements SpanService {
             @Override
             public void replacement(Align align, List<AnnotationBo> annotationBoList) {
 
-                List<AnnotationBo> cachedStringAnnotation = findCachedStringAnnotation(annotationBoList);
+                List<AnnotationBo> cachedStringAnnotation = AnnotationUtils.findAnnotations(annotationBoList,
+                        e -> AnnotationKeyUtils.isCachedArgsKey(e.getKey()));
                 if (cachedStringAnnotation.isEmpty()) {
                     return;
                 }
@@ -486,15 +478,6 @@ public class SpanServiceImpl implements SpanService {
         });
     }
 
-    private List<AnnotationBo> findCachedStringAnnotation(List<AnnotationBo> annotationBoList) {
-        List<AnnotationBo> findAnnotationBoList = new ArrayList<>(annotationBoList.size());
-        for (AnnotationBo annotationBo : annotationBoList) {
-            if (AnnotationKeyUtils.isCachedArgsKey(annotationBo.getKey())) {
-                findAnnotationBoList.add(annotationBo);
-            }
-        }
-        return findAnnotationBoList;
-    }
 
     private void transitionException(List<Align> alignList) {
         for (Align align : alignList) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/callstacks/RecordFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/callstacks/RecordFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,7 +227,7 @@ public class RecordFactory {
     }
 
     private Api getApi(final Align align) {
-        final AnnotationBo annotation = AnnotationUtils.findAnnotationBo(align.getAnnotationBoList(), AnnotationKey.API_METADATA);
+        final AnnotationBo annotation = AnnotationUtils.findAnnotation(align.getAnnotationBoList(), AnnotationKey.API_METADATA);
         if (annotation != null) {
             final ApiMetaDataBo apiMetaData = (ApiMetaDataBo) annotation.getValue();
             String apiInfo = apiMetaData.getDescription();


### PR DESCRIPTION
This pull request refactors the annotation utility methods to improve code clarity, performance, and flexibility. The main changes include replacing the old `findAnnotationBo` method with more efficient and flexible `findAnnotation` and `findAnnotations` methods, updating usages across the codebase, and adding new unit tests to ensure correct behavior.

### Annotation utility improvements

* Replaced the `findAnnotationBo` method with new `findAnnotation` and `findAnnotations` methods in `AnnotationUtils.java`, improving performance for `RandomAccess` lists and supporting predicate-based filtering. Deprecated the old method. [[1]](diffhunk://#diff-cbc91ba5fb3978da595f0c2246cb54aec5f37a20b8a145ed057a168ee3145605L44-R47) [[2]](diffhunk://#diff-cbc91ba5fb3978da595f0c2246cb54aec5f37a20b8a145ed057a168ee3145605L55-R114)
* Added the `findAnnotations` method to support retrieving multiple annotations matching a predicate.

### Codebase updates

* Updated all usages of the old `findAnnotationBo` and local `findAnnotation` implementations in `SpanServiceImpl.java` and `RecordFactory.java` to use the new `AnnotationUtils.findAnnotation` method, removing redundant code. [[1]](diffhunk://#diff-c18f4d0d7377603b12cf2803c47f15a430035056e44fed42cea7072b8cfdcdcfL212-R212) [[2]](diffhunk://#diff-c18f4d0d7377603b12cf2803c47f15a430035056e44fed42cea7072b8cfdcdcfL279-R279) [[3]](diffhunk://#diff-c18f4d0d7377603b12cf2803c47f15a430035056e44fed42cea7072b8cfdcdcfL350-R357) [[4]](diffhunk://#diff-c18f4d0d7377603b12cf2803c47f15a430035056e44fed42cea7072b8cfdcdcfL394-L402) [[5]](diffhunk://#diff-345be74e1e8b673198779a0d5b9661280d64b3e6d5992973817f3c46973ac97eL230-R230)

### Testing improvements

* Added new unit tests in `AnnotationUtilsTest.java` to cover the new methods and ensure correct behavior for different list types and predicates. [[1]](diffhunk://#diff-8e2ca13ef32f0629bd51d013aff1917b23f8b09b47e1517ee84a98268c3e6b5eR34-R38) [[2]](diffhunk://#diff-8e2ca13ef32f0629bd51d013aff1917b23f8b09b47e1517ee84a98268c3e6b5eR47-R60)

### Copyright updates

* Updated copyright years to 2025 in modified files. [[1]](diffhunk://#diff-cbc91ba5fb3978da595f0c2246cb54aec5f37a20b8a145ed057a168ee3145605L2-R2) [[2]](diffhunk://#diff-345be74e1e8b673198779a0d5b9661280d64b3e6d5992973817f3c46973ac97eL2-R2) [[3]](diffhunk://#diff-8e2ca13ef32f0629bd51d013aff1917b23f8b09b47e1517ee84a98268c3e6b5eR1-R24)