### PR TITLE
[#noissue] Add UNKNOWN HttpMethod constant

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/HttpMethod.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/HttpMethod.java
@@ -23,6 +23,11 @@ import java.util.Objects;
 public class HttpMethod implements Comparable<HttpMethod> {
 
     /**
+     * UNKNOWN
+     */
+    public static final HttpMethod UNKNOWN = new HttpMethod("UNKNOWN");
+
+    /**
      * GET method
      */
     public static final HttpMethod GET = new HttpMethod("GET");
@@ -290,7 +295,7 @@ public class HttpMethod implements Comparable<HttpMethod> {
         if (httpMethod != null) {
             return httpMethod;
         }
-        return null;
+        return UNKNOWN;
     }
 
     /**

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/callstacks/AnnotationRecordFormatter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/callstacks/AnnotationRecordFormatter.java
@@ -84,7 +84,7 @@ public class AnnotationRecordFormatter {
                 final String method = (String) annotationBo.getValue();
                 if (StringUtils.hasLength(method)) {
                     HttpMethod httpMethod = HttpMethod.valueOf(method);
-                    if (httpMethod != null) {
+                    if (httpMethod != HttpMethod.UNKNOWN) {
                         return httpMethod.name();
                     }
                 }


### PR DESCRIPTION
This pull request updates the handling of HTTP method values throughout the codebase to improve robustness and clarity. The main change is the introduction of an `UNKNOWN` constant in the `HttpMethod` class, which is now used as a default value when an unrecognized method is encountered, rather than returning `null`. This helps prevent potential null pointer issues and makes the code easier to reason about.

### Improvements to HTTP method handling

* Added a new constant `UNKNOWN` to the `HttpMethod` class to represent unrecognized HTTP methods.
* Updated the `valueOf` method in `HttpMethod` to return `UNKNOWN` instead of `null` when the input method string does not match any known HTTP method.

### Changes to annotation formatting

* Modified the logic in `AnnotationRecordFormatter` so that it only returns the method name if the parsed `HttpMethod` is not `UNKNOWN`, improving the accuracy of HTTP method reporting.