### PR TITLE
[#noissue] Replace StringUtils.equals

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/strategy/impl/StringAlwaysSameValueEncodingStrategy.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/strategy/impl/StringAlwaysSameValueEncodingStrategy.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,7 +20,7 @@ import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.server.bo.codec.StringTypedBufferHandler;
 import com.navercorp.pinpoint.common.server.bo.codec.strategy.EncodingStrategy;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +51,7 @@ public class StringAlwaysSameValueEncodingStrategy implements EncodingStrategy<S
 
         String initialValue = values.get(0);
         for (String value : values) {
-            if (!StringUtils.equals(value, initialValue)) {
+            if (!Strings.CS.equals(value, initialValue)) {
                 throw new IllegalArgumentException("values must be all same value");
             }
         }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/strategy/impl/StringRepeatCountEncodingStrategy.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/codec/strategy/impl/StringRepeatCountEncodingStrategy.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +19,7 @@ package com.navercorp.pinpoint.common.server.bo.codec.strategy.impl;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.server.bo.codec.StringTypedBufferHandler;
 import com.navercorp.pinpoint.common.server.bo.codec.strategy.EncodingStrategy;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,7 +47,7 @@ public class StringRepeatCountEncodingStrategy implements EncodingStrategy<Strin
         StringReference previousValueReference = null;
         int count = 0;
         for (String value : values) {
-            if (previousValueReference == null || !StringUtils.equals(value, previousValueReference.get())) {
+            if (previousValueReference == null || !Strings.CS.equals(value, previousValueReference.get())) {
                 if (previousValueReference != null) {
                     buffer.putVInt(count);
                     this.bufferHandler.put(buffer, previousValueReference.get());

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/SpanMapperV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/SpanMapperV2.java
@@ -39,7 +39,7 @@ import com.navercorp.pinpoint.common.trace.ServiceTypeCategory;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.common.util.LRUCache;
 import com.navercorp.pinpoint.io.SpanVersion;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
@@ -242,10 +242,10 @@ public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
         if (spanBo.getAgentStartTime() != spanChunkBo.getAgentStartTime()) {
             return false;
         }
-        if (!StringUtils.equals(spanBo.getAgentId(), spanChunkBo.getAgentId())) {
+        if (!Strings.CS.equals(spanBo.getAgentId(), spanChunkBo.getAgentId())) {
             return false;
         }
-        if (!StringUtils.equals(spanBo.getApplicationName(), spanChunkBo.getApplicationName())) {
+        if (!Strings.CS.equals(spanBo.getApplicationName(), spanChunkBo.getApplicationName())) {
             return false;
         }
         return true;

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/TraceViewerDataViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/TraceViewerDataViewModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.web.view;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.navercorp.pinpoint.web.vo.callstacks.Record;
 import com.navercorp.pinpoint.web.vo.callstacks.RecordSet;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -77,7 +77,7 @@ public class TraceViewerDataViewModel {
 
         for (Record record : recordSet.getRecordList()) {
             if (record.getElapsed() != 0) {
-                boolean isRecordHighlighted = StringUtils.equals(recordSet.getApplicationName(), record.getApplicationName());
+                boolean isRecordHighlighted = Strings.CS.equals(recordSet.getApplicationName(), record.getApplicationName());
                 boolean isApplicationNameChanged = !previousAppName.equals(record.getApplicationName());
 
                 if (recordTraces.isEmpty()) {


### PR DESCRIPTION
This pull request updates several files to replace usage of `StringUtils.equals` from Apache Commons Lang with `Strings.CS.equals`, and updates copyright years to 2025. The main focus is on standardizing string comparison logic across the codebase and keeping copyright information current.

**String comparison logic update:**

* Replaced `StringUtils.equals` with `Strings.CS.equals` for string equality checks in `StringAlwaysSameValueEncodingStrategy.java`, `StringRepeatCountEncodingStrategy.java`, `SpanMapperV2.java`, and `TraceViewerDataViewModel.java`. This change ensures consistent and possibly more efficient string comparison across the codebase. [[1]](diffhunk://#diff-acd7c26c601116bd80b98b090eb27396702865d3310afab3c2f968e81ad1f5b1L23-R23) [[2]](diffhunk://#diff-acd7c26c601116bd80b98b090eb27396702865d3310afab3c2f968e81ad1f5b1L54-R54) [[3]](diffhunk://#diff-45747c434db3871248808e5dca6c85419f728455b4dff4fcc38d1aae3ac93e42L22-R22) [[4]](diffhunk://#diff-45747c434db3871248808e5dca6c85419f728455b4dff4fcc38d1aae3ac93e42L50-R50) [[5]](diffhunk://#diff-ee12c0975b0f60cfc20f592409dbf04b20051d016ff3b7ed061d19a50285b486L42-R42) [[6]](diffhunk://#diff-ee12c0975b0f60cfc20f592409dbf04b20051d016ff3b7ed061d19a50285b486L245-R248) [[7]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L21-R21) [[8]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L80-R80)

**Copyright year update:**

* Updated the copyright year to 2025 in the headers of `StringAlwaysSameValueEncodingStrategy.java`, `StringRepeatCountEncodingStrategy.java`, and `TraceViewerDataViewModel.java` to reflect the current year. [[1]](diffhunk://#diff-acd7c26c601116bd80b98b090eb27396702865d3310afab3c2f968e81ad1f5b1L2-R2) [[2]](diffhunk://#diff-45747c434db3871248808e5dca6c85419f728455b4dff4fcc38d1aae3ac93e42L2-R2) [[3]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L2-R2)