### PR TITLE
[#noissue] Replace with switch expressions

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/MethodTypeEnum.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/MethodTypeEnum.java
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.server.bo;
 
 import com.navercorp.pinpoint.common.trace.MethodType;
-import com.navercorp.pinpoint.common.util.apache.IntHashMap;
+import org.jspecify.annotations.Nullable;
 
 /**
  * readable class of MethodType
@@ -33,16 +49,6 @@ public enum MethodTypeEnum {
 
     private final int code;
 
-    private static final IntHashMap<MethodTypeEnum> METHOD_TYPE_MAP = toMethodTypeMap();
-
-    private static IntHashMap<MethodTypeEnum> toMethodTypeMap() {
-        IntHashMap<MethodTypeEnum> methodTypeEnumMap = new IntHashMap<>();
-        for (MethodTypeEnum methodType : values()) {
-            methodTypeEnumMap.put(methodType.getCode(), methodType);
-        }
-        return methodTypeEnumMap;
-    }
-
 
     MethodTypeEnum(int code) {
         this.code = code;
@@ -53,15 +59,28 @@ public enum MethodTypeEnum {
     }
 
     public static MethodTypeEnum valueOf(int code) {
-        final MethodTypeEnum methodTypeEnum = METHOD_TYPE_MAP.get(code);
+        MethodTypeEnum methodTypeEnum = getMethodTypeEnum(code);
         if (methodTypeEnum == null) {
             throw new IllegalStateException("unknown MethodType:" + code);
         }
         return methodTypeEnum;
     }
 
+    private static @Nullable MethodTypeEnum getMethodTypeEnum(int code) {
+        return switch (code) {
+            case MethodType.DEFAULT -> DEFAULT;
+            case MethodType.EXCEPTION -> EXCEPTION;
+            case MethodType.ANNOTATION -> ANNOTATION;
+            case MethodType.PARAMETER -> PARAMETER;
+            case MethodType.WEB_REQUEST -> WEB_REQUEST;
+            case MethodType.INVOCATION -> INVOCATION;
+            case MethodType.CORRUPTED -> CORRUPTED;
+            default -> null;
+        };
+    }
+
     public static MethodTypeEnum defaultValueOf(int code) {
-        final MethodTypeEnum methodTypeEnum = METHOD_TYPE_MAP.get(code);
+        MethodTypeEnum methodTypeEnum = getMethodTypeEnum(code);
         if (methodTypeEnum == null) {
             return DEFAULT;
         }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/AgentLifeCycleState.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/AgentLifeCycleState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.common.server.util;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.navercorp.pinpoint.common.util.apache.IntHashMap;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum AgentLifeCycleState {
@@ -26,8 +25,6 @@ public enum AgentLifeCycleState {
     UNEXPECTED_SHUTDOWN((short) 201, "Unexpected Shutdown"),
     DISCONNECTED((short) 300, "Disconnected"),
     UNKNOWN((short) -1, "Unknown");
-
-    private static final IntHashMap<AgentLifeCycleState> MAPPING = initializeCodeMapping();
 
     private final short code;
     private final String desc;
@@ -50,19 +47,13 @@ public enum AgentLifeCycleState {
         return this.desc;
     }
 
-    private static IntHashMap<AgentLifeCycleState> initializeCodeMapping() {
-        IntHashMap<AgentLifeCycleState> codeMap = new IntHashMap<>();
-        for (AgentLifeCycleState state : AgentLifeCycleState.values()) {
-            codeMap.put(state.getCode(), state);
-        }
-        return codeMap;
-    }
-
     public static AgentLifeCycleState getStateByCode(short code) {
-        AgentLifeCycleState state = MAPPING.get(code);
-        if (state != null) {
-            return state;
-        }
-        return UNKNOWN;
+        return switch (code) {
+            case 100 -> RUNNING;
+            case 200 -> SHUTDOWN;
+            case 201 -> UNEXPECTED_SHUTDOWN;
+            case 300 -> DISCONNECTED;
+            default -> UNKNOWN;
+        };
     }
 }

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/MetricDataType.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/common/model/MetricDataType.java
@@ -1,9 +1,21 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.metric.common.model;
 
-import com.navercorp.pinpoint.common.util.apache.IntHashMap;
-
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 public enum MetricDataType {
@@ -13,25 +25,6 @@ public enum MetricDataType {
 
     private final int code;
     private final String type;
-
-    private static final IntHashMap<MetricDataType> CODE_MAP = newCodeMap();
-    private static final Map<String, MetricDataType> TYPE_MAP = newTypeMap();
-
-    private static IntHashMap<MetricDataType> newCodeMap() {
-        IntHashMap<MetricDataType> map = new IntHashMap<>();
-        for (MetricDataType metricDataType : MetricDataType.values()) {
-            map.put(metricDataType.getCode(), metricDataType);
-        }
-        return map;
-    }
-
-    private static Map<String, MetricDataType> newTypeMap() {
-        Map<String, MetricDataType> map = new HashMap<>();
-        for (MetricDataType metricDataType : MetricDataType.values()) {
-            map.put(metricDataType.getType(), metricDataType);
-        }
-        return map;
-    }
 
     MetricDataType(int code, String type) {
         this.code = code;
@@ -47,18 +40,20 @@ public enum MetricDataType {
     }
 
     public static MetricDataType getByCode(int code) {
-        final MetricDataType metricDataType = CODE_MAP.get(code);
-        if (metricDataType == null) {
-            throw new IllegalArgumentException("Unknown code : " + code);
-        }
-        return metricDataType;
+        return switch (code) {
+            case 1 -> LONG;
+            case 2 -> DOUBLE;
+            case -1 -> UNKNOWN;
+            default -> throw new IllegalArgumentException("Unknown code : " + code);
+        };
     }
 
     public static MetricDataType getByType(String name) {
-        MetricDataType metricDataType = TYPE_MAP.get(name);
-        if (metricDataType == null) {
-            throw new IllegalArgumentException("Unknown name : " + name);
-        }
-        return metricDataType;
+        return switch (name) {
+            case "long" -> LONG;
+            case "double" -> DOUBLE;
+            case "unknown" -> UNKNOWN;
+            default -> throw new IllegalArgumentException("Unknown name : " + name);
+        };
     }
 }

--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/dto/CommandType.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/dto/CommandType.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.realtime.dto;
 
-import com.navercorp.pinpoint.common.util.apache.IntHashMap;
 
 public enum CommandType {
     // Using reflection would make code cleaner.
@@ -26,17 +41,6 @@ public enum CommandType {
     ACTIVE_THREAD_LIGHT_DUMP_RESPONSE((short) 751);
 
     private final short code;
-
-    private static final IntHashMap<CommandType> COMMAND_TYPES = buildCommandTypes();
-
-    private static IntHashMap<CommandType> buildCommandTypes() {
-        IntHashMap<CommandType> map = new IntHashMap<>();
-        for (CommandType value : CommandType.values()) {
-            map.put(value.getCode(), value);
-        }
-        return map;
-    }
-
 
     CommandType(short code) {
         this.code = code;


### PR DESCRIPTION
This pull request refactors several enums across the codebase to simplify their implementation and remove the use of `IntHashMap` for mapping codes to enum values. Instead, it replaces map-based lookups with Java `switch` statements, making the code more readable and reducing unnecessary allocation. Additionally, copyright years are updated to 2025 where appropriate. The changes are grouped below by theme.

### Enum Mapping Refactoring

* Replaced `IntHashMap`-based code-to-enum mapping in `MethodTypeEnum`, `AgentLifeCycleState`, `MetricDataType`, and `CommandType` with direct `switch` statements, simplifying lookup logic and reducing memory usage. [[1]](diffhunk://#diff-b014838a225708fa15fb3381adfbfe112a19f42806baf551fff3d28db73edf41L36-L45) [[2]](diffhunk://#diff-816d94b3fdf59ee5f96d2e57d373191cdcd01fe0050f75befba68bafbd103189L30-L31) [[3]](diffhunk://#diff-3afc1081dd459f53260dee4ba016c713910afc403f39d463b65973dfb6915f4cL17-L35) [[4]](diffhunk://#diff-5732bf7706c739044ce5c950b8d690514f40d9c22fd10ac37a41c23bcfda7efdL30-L40)
* Removed redundant map initialization methods and static map fields from these enums, further streamlining the code. [[1]](diffhunk://#diff-b014838a225708fa15fb3381adfbfe112a19f42806baf551fff3d28db73edf41L36-L45) [[2]](diffhunk://#diff-816d94b3fdf59ee5f96d2e57d373191cdcd01fe0050f75befba68bafbd103189L30-L31) [[3]](diffhunk://#diff-3afc1081dd459f53260dee4ba016c713910afc403f39d463b65973dfb6915f4cL17-L35) [[4]](diffhunk://#diff-5732bf7706c739044ce5c950b8d690514f40d9c22fd10ac37a41c23bcfda7efdL30-L40)

### Method Logic Updates

* Updated lookup methods such as `valueOf`, `getStateByCode`, `getByCode`, and `getByType` in the affected enums to use `switch` statements for code and string matching, improving performance and clarity. [[1]](diffhunk://#diff-b014838a225708fa15fb3381adfbfe112a19f42806baf551fff3d28db73edf41L56-R83) [[2]](diffhunk://#diff-816d94b3fdf59ee5f96d2e57d373191cdcd01fe0050f75befba68bafbd103189L53-R57) [[3]](diffhunk://#diff-3afc1081dd459f53260dee4ba016c713910afc403f39d463b65973dfb6915f4cL50-R55)

### Copyright Updates

* Updated copyright years to 2025 in the headers of several files for legal and project consistency. [[1]](diffhunk://#diff-b014838a225708fa15fb3381adfbfe112a19f42806baf551fff3d28db73edf41R1-R20) [[2]](diffhunk://#diff-816d94b3fdf59ee5f96d2e57d373191cdcd01fe0050f75befba68bafbd103189L2-R2) [[3]](diffhunk://#diff-3afc1081dd459f53260dee4ba016c713910afc403f39d463b65973dfb6915f4cL1-L6) [[4]](diffhunk://#diff-5732bf7706c739044ce5c950b8d690514f40d9c22fd10ac37a41c23bcfda7efdR1-L3)

### Dependency Cleanup

* Removed unused imports of `IntHashMap` and related code from all affected files, reflecting the new approach to enum mapping. [[1]](diffhunk://#diff-b014838a225708fa15fb3381adfbfe112a19f42806baf551fff3d28db73edf41R1-R20) [[2]](diffhunk://#diff-816d94b3fdf59ee5f96d2e57d373191cdcd01fe0050f75befba68bafbd103189L20) [[3]](diffhunk://#diff-3afc1081dd459f53260dee4ba016c713910afc403f39d463b65973dfb6915f4cL1-L6) [[4]](diffhunk://#diff-5732bf7706c739044ce5c950b8d690514f40d9c22fd10ac37a41c23bcfda7efdR1-L3)

These changes collectively modernize and simplify the handling of enum value lookup throughout the project.