### PR TITLE
[#13103] Apply eclipse-collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1064,6 +1064,18 @@
                 <version>1.3.4</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.eclipse.collections</groupId>
+                <artifactId>eclipse-collections-api</artifactId>
+                <version>13.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.collections</groupId>
+                <artifactId>eclipse-collections</artifactId>
+                <version>13.0.0</version>
+                <scope>runtime</scope>
+            </dependency>
+
             <!-- thrift logging lib -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>

--- a/service-module/pom.xml
+++ b/service-module/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025 NAVER Corp.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,6 +46,14 @@
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-commons-mybatis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
         </dependency>
 
         <dependency>

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/component/StaticServiceRegistry.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/component/StaticServiceRegistry.java
@@ -1,7 +1,25 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.service.component;
 
-import com.google.common.collect.ImmutableMap;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import org.eclipse.collections.api.factory.primitive.IntObjectMaps;
+import org.eclipse.collections.api.map.primitive.IntObjectMap;
+import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -13,7 +31,7 @@ import java.util.Map;
 public class StaticServiceRegistry {
 
     private final Map<String, ServiceUid> serviceNameLookupMap;
-    private final Map<Integer, String> serviceUidLookupMap;
+    private final IntObjectMap<String> serviceUidLookupMap;
 
     public StaticServiceRegistry() {
         this.serviceNameLookupMap = createNameLookupTable();
@@ -34,15 +52,15 @@ public class StaticServiceRegistry {
         } catch (IllegalAccessException e) {
             throw new IllegalStateException("static serviceUid map initialization fail", e);
         }
-        return ImmutableMap.copyOf(map);
+        return map;
     }
 
-    private Map<Integer, String> createUidLookupTable(Map<String, ServiceUid> serviceNameToUidMap) {
-        Map<Integer, String> map = new HashMap<>(serviceNameToUidMap.size());
+    private IntObjectMap<String> createUidLookupTable(Map<String, ServiceUid> serviceNameToUidMap) {
+        MutableIntObjectMap<String > map = IntObjectMaps.mutable.ofInitialCapacity(serviceNameToUidMap.size());
         for (Map.Entry<String, ServiceUid> entry : serviceNameToUidMap.entrySet()) {
             map.put(entry.getValue().getUid(), entry.getKey());
         }
-        return ImmutableMap.copyOf(map);
+        return map;
     }
 
     // ignore case for serviceName

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -138,6 +138,15 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/ApplicationResponse.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/ApplicationResponse.java
@@ -20,12 +20,12 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
+import org.eclipse.collections.api.factory.primitive.LongObjectMaps;
+import org.eclipse.collections.api.map.primitive.MutableLongObjectMap;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -81,7 +81,7 @@ public class ApplicationResponse {
 
     public static class Builder {
 
-        private final Map<Long, TimeHistogram> histogramMap;
+        private final MutableLongObjectMap<TimeHistogram> histogramMap;
         // agentId is the key
         private final Set<String> agentIdMap;
 
@@ -89,7 +89,7 @@ public class ApplicationResponse {
 
         Builder(Application application) {
             this.application = Objects.requireNonNull(application, "application");
-            this.histogramMap = new HashMap<>();
+            this.histogramMap = LongObjectMaps.mutable.of();
             this.agentIdMap = new HashSet<>();
         }
 
@@ -118,7 +118,7 @@ public class ApplicationResponse {
         }
 
         private TimeHistogram getTimeHistogram(long timeStamp) {
-            return this.histogramMap.computeIfAbsent(timeStamp, k -> new TimeHistogram(application.getServiceType(), timeStamp));
+            return this.histogramMap.getIfAbsentPutWithKey(timeStamp, k -> new TimeHistogram(application.getServiceType(), timeStamp));
         }
 
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogramBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogramBuilder.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,11 +25,11 @@ import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.collections.api.factory.primitive.LongObjectMaps;
+import org.eclipse.collections.api.map.primitive.MutableLongObjectMap;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -57,10 +57,10 @@ public class ApplicationTimeHistogramBuilder {
     public ApplicationTimeHistogram build(List<ResponseTime> responseHistogramList) {
         Objects.requireNonNull(responseHistogramList, "responseHistogramList");
 
-        Map<Long, TimeHistogram> applicationLevelHistogram = new HashMap<>();
+        MutableLongObjectMap<TimeHistogram> applicationLevelHistogram = LongObjectMaps.mutable.of();
 
         for (ResponseTime responseTime : responseHistogramList) {
-            final Long timeStamp = responseTime.getTimeStamp();
+            final long timeStamp = responseTime.getTimeStamp();
             TimeHistogram timeHistogram = applicationLevelHistogram.get(timeStamp);
             if (timeHistogram == null) {
                 timeHistogram = new TimeHistogram(application.getServiceType(), timeStamp);
@@ -87,10 +87,10 @@ public class ApplicationTimeHistogramBuilder {
     }
 
     public ApplicationTimeHistogram build(Collection<LinkCallData> linkCallDataMapList) {
-        Map<Long, TimeHistogram> applicationLevelHistogram = new HashMap<>();
+        MutableLongObjectMap<TimeHistogram> applicationLevelHistogram = LongObjectMaps.mutable.of();
         for (LinkCallData linkCallData : linkCallDataMapList) {
             for (TimeHistogram timeHistogram : linkCallData.getTimeHistogram()) {
-                Long timeStamp = timeHistogram.getTimeStamp();
+                long timeStamp = timeHistogram.getTimeStamp();
                 TimeHistogram histogram = applicationLevelHistogram.get(timeStamp);
                 if (histogram == null) {
                     histogram = new TimeHistogram(timeHistogram.getHistogramSchema(), timeStamp);
@@ -106,7 +106,7 @@ public class ApplicationTimeHistogramBuilder {
     private List<TimeHistogram> interpolation(Collection<TimeHistogram> histogramList) {
         // upon individual span query, "window time" alone may not be enough
         //
-        Map<Long, TimeHistogram> resultMap = new HashMap<>();
+        MutableLongObjectMap<TimeHistogram> resultMap = LongObjectMaps.mutable.of();
         for (Long time : window) {
             resultMap.put(time, new TimeHistogram(application.getServiceType(), time));
         }
@@ -114,7 +114,7 @@ public class ApplicationTimeHistogramBuilder {
         for (TimeHistogram timeHistogram : histogramList) {
             long time = window.refineTimestamp(timeHistogram.getTimeStamp());
 
-            TimeHistogram windowHistogram = resultMap.computeIfAbsent(time, t -> new TimeHistogram(application.getServiceType(), t));
+            TimeHistogram windowHistogram = resultMap.getIfAbsentPutWithKey(time, t -> new TimeHistogram(application.getServiceType(), t));
             windowHistogram.add(timeHistogram);
         }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/AgentHistogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/AgentHistogram.java
@@ -22,10 +22,10 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
+import org.eclipse.collections.api.factory.primitive.LongObjectMaps;
+import org.eclipse.collections.api.map.primitive.MutableLongObjectMap;
 
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -39,11 +39,11 @@ public class AgentHistogram {
      */
     private final Application agentId;
 
-    private final Map<Long, TimeHistogram> timeHistogramMap;
+    private final MutableLongObjectMap<TimeHistogram> timeHistogramMap;
 
     public AgentHistogram(Application agentId) {
         this.agentId = Objects.requireNonNull(agentId, "agentId");
-        this.timeHistogramMap = new HashMap<>();
+        this.timeHistogramMap = LongObjectMaps.mutable.of();
     }
 
     static AgentHistogram copyOf(AgentHistogram copyAgentHistogram) {
@@ -55,7 +55,7 @@ public class AgentHistogram {
 
         this.agentId = copyAgentHistogram.agentId;
 
-        this.timeHistogramMap = new HashMap<>();
+        this.timeHistogramMap = LongObjectMaps.mutable.of();
         addTimeHistogram(copyAgentHistogram.timeHistogramMap.values());
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/SpanAsyncEventMap.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/calltree/span/SpanAsyncEventMap.java
@@ -1,21 +1,37 @@
-package com.navercorp.pinpoint.web.calltree.span;
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+package com.navercorp.pinpoint.web.calltree.span;
 
 import com.navercorp.pinpoint.common.server.bo.LocalAsyncIdBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
+import org.eclipse.collections.api.factory.primitive.IntObjectMaps;
+import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 public class SpanAsyncEventMap {
 
-    private final Map<Integer, Map<Integer, List<Align>>> map = new HashMap<>();
+    private final MutableIntObjectMap<MutableIntObjectMap<List<Align>>> map = IntObjectMaps.mutable.of();
     private int size = -1;
 
     public static SpanAsyncEventMap build(SpanBo spanBo) {
@@ -52,7 +68,7 @@ public class SpanAsyncEventMap {
         final List<Align> alignList = toAlignList(spanBo, spanChunkBo, spanEventBoList);
         final int id = localAsyncId.getAsyncId();
 
-        Map<Integer, List<Align>> subMap = map.computeIfAbsent(id, k -> new HashMap<>());
+        MutableIntObjectMap<List<Align>> subMap = map.getIfAbsentPutWithKey(id, k -> IntObjectMaps.mutable.of());
         final int sequence = localAsyncId.getSequence();
         final List<Align> exist = subMap.get(sequence);
         if (exist != null) {
@@ -73,7 +89,7 @@ public class SpanAsyncEventMap {
     }
 
     private void sort() {
-        for (Map<Integer, List<Align>> subMap : map.values()) {
+        for (MutableIntObjectMap<List<Align>> subMap : map.values()) {
             for (List<Align> alignList : subMap.values()) {
                 alignList.sort(AlignComparator.INSTANCE);
             }
@@ -82,8 +98,7 @@ public class SpanAsyncEventMap {
 
     private int calculateSize() {
         int size = 0;
-        Collection<Map<Integer, List<Align>>> values = map.values();
-        for (Map<Integer, List<Align>> asyncSpanChunkBoMap : values) {
+        for (MutableIntObjectMap<List<Align>> asyncSpanChunkBoMap : map.values()) {
             for (List<Align> alignList : asyncSpanChunkBoMap.values()) {
                 size += alignList.size();
             }
@@ -92,7 +107,7 @@ public class SpanAsyncEventMap {
     }
 
     public Collection<List<Align>> getAsyncAlign(final int asyncId) {
-        final Map<Integer, List<Align>> subMap = map.get(asyncId);
+        final MutableIntObjectMap<List<Align>> subMap = map.get(asyncId);
         if (subMap == null) {
             return Collections.emptyList();
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ProxyRequestTypeRegistryServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ProxyRequestTypeRegistryServiceImpl.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,10 +19,11 @@ package com.navercorp.pinpoint.web.service;
 import com.navercorp.pinpoint.agent.plugin.proxy.common.ProxyRequestMetadataProvider;
 import com.navercorp.pinpoint.agent.plugin.proxy.common.ProxyRequestMetadataSetupContext;
 import com.navercorp.pinpoint.agent.plugin.proxy.common.ProxyRequestType;
-import com.navercorp.pinpoint.common.util.apache.IntHashMap;
 import jakarta.annotation.PostConstruct;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.collections.api.factory.primitive.IntObjectMaps;
+import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ClassUtils;
 
@@ -66,7 +67,7 @@ public class ProxyRequestTypeRegistryServiceImpl implements ProxyRequestTypeRegi
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
-    private final IntHashMap<ProxyRequestType> codeLookupTable = new IntHashMap<ProxyRequestType>();
+    private final MutableIntObjectMap<ProxyRequestType> codeLookupTable = IntObjectMaps.mutable.of();
 
     public ProxyRequestTypeRegistryServiceImpl() {
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/TraceViewerDataViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/TraceViewerDataViewModel.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.navercorp.pinpoint.web.vo.callstacks.Record;
 import com.navercorp.pinpoint.web.vo.callstacks.RecordSet;
 import org.apache.commons.lang3.Strings;
+import org.eclipse.collections.api.factory.primitive.IntObjectMaps;
+import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,7 +35,7 @@ public class TraceViewerDataViewModel {
     private final RecordSet recordSet;
     private final List<TraceEvent> traceEvents;
     private final List<Long[]> occupiedRange;
-    private final Map<Integer, Integer> invisibleRecords;
+    private final MutableIntObjectMap<Integer> invisibleRecords;
     private final long minBlank;
     private int maxTid;
 
@@ -42,7 +44,7 @@ public class TraceViewerDataViewModel {
         this.maxTid = 0;
         this.traceEvents = new ArrayList<>();
         this.occupiedRange = new ArrayList<>();
-        this.invisibleRecords = new HashMap<>();
+        this.invisibleRecords = IntObjectMaps.mutable.of();
         this.minBlank = (recordSet.getEndTime() - recordSet.getStartTime()) / 100;
         initialize();
     }
@@ -168,7 +170,7 @@ public class TraceViewerDataViewModel {
         traceEvents.add(arrowEnd);
 
         /* Adds the start call of an asynchronous call stack */
-        Stack<Record> recordTrace = new Stack<Record>();
+        Stack<Record> recordTrace = new Stack<>();
         recordTrace.push(record);
         recordTraces.add(recordTrace);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/ResponseHistograms.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/ResponseHistograms.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,6 +20,8 @@ import com.navercorp.pinpoint.common.annotations.VisibleForTesting;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
+import org.eclipse.collections.api.factory.primitive.LongObjectMaps;
+import org.eclipse.collections.api.map.primitive.MutableLongObjectMap;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,7 +50,7 @@ public class ResponseHistograms {
     public static class Builder {
 
         private final TimeWindow window;
-        private final Map<Long, Map<Application, ResponseTime.Builder>> map = new HashMap<>();
+        private final MutableLongObjectMap<Map<Application, ResponseTime.Builder>> map = LongObjectMaps.mutable.of();
 
         public Builder(TimeWindow window) {
             // don't sample for now
@@ -84,7 +86,7 @@ public class ResponseHistograms {
         }
 
         private ResponseTime.Builder getBuilder(Application application, long timestamp) {
-            Map<Application, ResponseTime.Builder> responseTimeMap = map.computeIfAbsent(timestamp, (Long k) -> new HashMap<>());
+            Map<Application, ResponseTime.Builder> responseTimeMap = map.getIfAbsentPutWithKey(timestamp, (k) -> new HashMap<>());
             ResponseTime.Builder responseTime = responseTimeMap.get(application);
             if (responseTime == null) {
                 responseTime = ResponseTime.newBuilder(application.getName(), application.getServiceType(), timestamp);
@@ -94,7 +96,7 @@ public class ResponseHistograms {
         }
 
         public ResponseHistograms build() {
-            final Map<Long, Map<Application, ResponseTime.Builder>> copyMap = this.map;
+            final MutableLongObjectMap<Map<Application, ResponseTime.Builder>> copyMap = this.map;
 
             final Map<Application, List<ResponseTime>> responseTimeMap = new HashMap<>(copyMap.size());
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/callstacks/AnnotationRecordFormatter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/callstacks/AnnotationRecordFormatter.java
@@ -21,14 +21,13 @@ import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.util.HttpMethod;
 import com.navercorp.pinpoint.common.util.IntBooleanIntBooleanValue;
 import com.navercorp.pinpoint.common.util.StringStringValue;
-import com.navercorp.pinpoint.common.util.apache.IntHashMap;
-import com.navercorp.pinpoint.common.util.apache.IntHashMapUtils;
 import com.navercorp.pinpoint.web.calltree.span.Align;
 import com.navercorp.pinpoint.web.service.ProxyRequestTypeRegistryService;
+import org.eclipse.collections.api.factory.primitive.IntObjectMaps;
+import org.eclipse.collections.api.map.primitive.IntObjectMap;
+import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -36,10 +35,10 @@ import java.util.Objects;
  */
 public class AnnotationRecordFormatter {
 
-    private final IntHashMap<AnnotationHandler> titleHandlers;
-    private final IntHashMap<AnnotationHandler> argumentHandlers;
+    private final IntObjectMap<AnnotationHandler> titleHandlers;
+    private final IntObjectMap<AnnotationHandler> argumentHandlers;
 
-    AnnotationRecordFormatter(IntHashMap<AnnotationHandler> titleHandlers, IntHashMap<AnnotationHandler> argumentHandlers) {
+    AnnotationRecordFormatter(IntObjectMap<AnnotationHandler> titleHandlers, IntObjectMap<AnnotationHandler> argumentHandlers) {
         this.titleHandlers = Objects.requireNonNull(titleHandlers, "titleHandlers");
         this.argumentHandlers = Objects.requireNonNull(argumentHandlers, "argumentHandlers");
     }
@@ -83,8 +82,8 @@ public class AnnotationRecordFormatter {
 
     public static class Builder {
 
-        private final Map<Integer, AnnotationHandler> titleHandlers = new HashMap<>();
-        private final Map<Integer, AnnotationHandler> argumentHandlers = new HashMap<>();
+        private final MutableIntObjectMap<AnnotationHandler> titleHandlers = IntObjectMaps.mutable.of();
+        private final MutableIntObjectMap<AnnotationHandler> argumentHandlers = IntObjectMaps.mutable.of();
 
         public void addTitleHandler(int code, AnnotationHandler handler) {
             Objects.requireNonNull(handler, "handler");
@@ -107,9 +106,9 @@ public class AnnotationRecordFormatter {
         }
 
         public AnnotationRecordFormatter build() {
-            IntHashMap<AnnotationHandler> copyTitleHandlers = IntHashMapUtils.copy(titleHandlers);
-            IntHashMap<AnnotationHandler> copyArgumentHandlers = IntHashMapUtils.copy(argumentHandlers);
-            return new AnnotationRecordFormatter(copyTitleHandlers, copyArgumentHandlers);
+            IntObjectMap<AnnotationHandler> titleHandlers = IntObjectMaps.mutable.ofAll(this.titleHandlers);
+            IntObjectMap<AnnotationHandler> argumentHandlers = IntObjectMaps.mutable.ofAll(this.argumentHandlers);
+            return new AnnotationRecordFormatter(titleHandlers, argumentHandlers);
         }
 
         public void addProxyHeaderAnnotationHeader(ProxyRequestTypeRegistryService proxyRequestTypeRegistryService) {


### PR DESCRIPTION
This pull request introduces the use of Eclipse Collections' primitive maps across several modules to improve memory efficiency and performance, replacing standard Java collections such as `HashMap` and Guava's `ImmutableMap`. The changes primarily affect components dealing with time-based histogram data and async event mapping, and also update project dependencies to include Eclipse Collections.

**Dependency and Library Updates**
* Added `eclipse-collections-api` and `eclipse-collections` dependencies to `pom.xml` and `web/pom.xml` to support usage of primitive collections throughout the codebase. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R1067-R1078) [[2]](diffhunk://#diff-06c528e8bf4bae607af1c54bfcfbb8f21c0d09a44cddb2851ffa08207dba3052R140-R148)

**Core Data Structure Refactoring**
* Replaced usages of `HashMap`, `Map`, and Guava's `ImmutableMap` with Eclipse Collections' primitive maps (`IntObjectMap`, `LongObjectMap`, and their mutable variants) in classes such as `StaticServiceRegistry`, `ApplicationResponse.Builder`, `ApplicationTimeHistogramBuilder`, `AgentHistogram`, `LinkCallData`, and `SpanAsyncEventMap`. This change improves both performance and memory usage for large datasets. [[1]](diffhunk://#diff-8be357851def1fed5362ef76c2ef4a520e122f32716fe75aecf8127a15d2a714R1-R22) [[2]](diffhunk://#diff-8be357851def1fed5362ef76c2ef4a520e122f32716fe75aecf8127a15d2a714L16-R34) [[3]](diffhunk://#diff-8be357851def1fed5362ef76c2ef4a520e122f32716fe75aecf8127a15d2a714L37-R63) [[4]](diffhunk://#diff-6359aee70ea42a8dd88eb310e58c4245efd7bf1b392cffe27bbf8045636e2039R23-L28) [[5]](diffhunk://#diff-6359aee70ea42a8dd88eb310e58c4245efd7bf1b392cffe27bbf8045636e2039L84-R92) [[6]](diffhunk://#diff-6359aee70ea42a8dd88eb310e58c4245efd7bf1b392cffe27bbf8045636e2039L121-R121) [[7]](diffhunk://#diff-b4885a7977363612cd2c838f0442a54e33f445e32aee153f6943ce215925964dR28-L32) [[8]](diffhunk://#diff-b4885a7977363612cd2c838f0442a54e33f445e32aee153f6943ce215925964dL60-R63) [[9]](diffhunk://#diff-b4885a7977363612cd2c838f0442a54e33f445e32aee153f6943ce215925964dL90-R93) [[10]](diffhunk://#diff-b4885a7977363612cd2c838f0442a54e33f445e32aee153f6943ce215925964dL109-R117) [[11]](diffhunk://#diff-2aa9c812ffc62583d244763595c8da4e8ebd02d4f9421d9ffbea161ccbf46e8fR25-L28) [[12]](diffhunk://#diff-2aa9c812ffc62583d244763595c8da4e8ebd02d4f9421d9ffbea161ccbf46e8fL42-R46) [[13]](diffhunk://#diff-2aa9c812ffc62583d244763595c8da4e8ebd02d4f9421d9ffbea161ccbf46e8fL58-R58) [[14]](diffhunk://#diff-9849ad902fe6287e8bde367ebce3411260a2fa31d4de0748c88dfdde4d6f218eR23-L26) [[15]](diffhunk://#diff-9849ad902fe6287e8bde367ebce3411260a2fa31d4de0748c88dfdde4d6f218eL39-R39) [[16]](diffhunk://#diff-9849ad902fe6287e8bde367ebce3411260a2fa31d4de0748c88dfdde4d6f218eL52-R52) [[17]](diffhunk://#diff-9849ad902fe6287e8bde367ebce3411260a2fa31d4de0748c88dfdde4d6f218eL96-R102) [[18]](diffhunk://#diff-959e0220a31b1ab66ada1675f73d6afac6f447167891cb150ff884248759b72bL1-R34) [[19]](diffhunk://#diff-959e0220a31b1ab66ada1675f73d6afac6f447167891cb150ff884248759b72bL55-R71) [[20]](diffhunk://#diff-959e0220a31b1ab66ada1675f73d6afac6f447167891cb150ff884248759b72bL76-R92) [[21]](diffhunk://#diff-959e0220a31b1ab66ada1675f73d6afac6f447167891cb150ff884248759b72bL85-R101) [[22]](diffhunk://#diff-959e0220a31b1ab66ada1675f73d6afac6f447167891cb150ff884248759b72bL95-R110)

**API and Method Updates**
* Updated methods that previously used standard Java Map APIs (such as `computeIfAbsent`) to use equivalent Eclipse Collections APIs (such as `getIfAbsentPutWithKey` and `forEachKeyValue`), ensuring compatibility and leveraging primitive map performance. [[1]](diffhunk://#diff-6359aee70ea42a8dd88eb310e58c4245efd7bf1b392cffe27bbf8045636e2039L121-R121) [[2]](diffhunk://#diff-b4885a7977363612cd2c838f0442a54e33f445e32aee153f6943ce215925964dL109-R117) [[3]](diffhunk://#diff-9849ad902fe6287e8bde367ebce3411260a2fa31d4de0748c88dfdde4d6f218eL96-R102) [[4]](diffhunk://#diff-959e0220a31b1ab66ada1675f73d6afac6f447167891cb150ff884248759b72bL55-R71)

**Copyright and Documentation**
* Updated copyright years to 2025 in affected files to reflect recent changes. [[1]](diffhunk://#diff-b4885a7977363612cd2c838f0442a54e33f445e32aee153f6943ce215925964dL2-R2) [[2]](diffhunk://#diff-959e0220a31b1ab66ada1675f73d6afac6f447167891cb150ff884248759b72bL1-R34)

These changes modernize the codebase and set the foundation for improved scalability and resource usage, especially in performance-critical areas dealing with large collections of time series and async event data.