### PR TITLE
[#noissue] Apply Lists.transform for metadata

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/view/transactionlist/TransactionDotMetaDataViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/transactionlist/TransactionDotMetaDataViewModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package com.navercorp.pinpoint.web.view.transactionlist;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Lists;
 import com.navercorp.pinpoint.web.vo.scatter.DotMetaData;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -35,12 +35,7 @@ public class TransactionDotMetaDataViewModel {
 
     @JsonProperty("metadata")
     public List<DotMetaDataView> getMetadata() {
-        List<DotMetaDataView> list = new ArrayList<>(dotMetaDataList.size());
-        for (DotMetaData span : dotMetaDataList) {
-            list.add(new MetaData(span));
-        }
-
-        return list;
+        return Lists.transform(dotMetaDataList, MetaData::new);
     }
 
     public static class MetaData implements DotMetaDataView {

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/transactionlist/TransactionMetaDataViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/transactionlist/TransactionMetaDataViewModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package com.navercorp.pinpoint.web.view.transactionlist;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Lists;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -39,12 +39,7 @@ public class TransactionMetaDataViewModel {
 
     @JsonProperty("metadata")
     public List<MetaData> getMetadata() {
-        List<MetaData> list = new ArrayList<>(spanBoList.size());
-        for (SpanBo span : spanBoList) {
-            list.add(new MetaData(span));
-        }
-
-        return list;
+        return Lists.transform(spanBoList, MetaData::new);
     }
 
     public static class MetaData implements DotMetaDataView {


### PR DESCRIPTION
This pull request refactors two view model classes in the `transactionlist` package to simplify the way metadata lists are constructed. The main change is replacing manual list creation with Guava's `Lists.transform` utility, resulting in more concise and readable code. Additionally, copyright years are updated.

**Code simplification and modernization:**

* Replaced manual construction of metadata lists in `TransactionDotMetaDataViewModel#getMetadata` and `TransactionMetaDataViewModel#getMetadata` with `Lists.transform`, reducing boilerplate and improving readability. [[1]](diffhunk://#diff-d429e84032665e2a091bbd9e2abd131b5f3cf8994eab4a551536efde7d850168L38-R38) [[2]](diffhunk://#diff-28fb99995a905d46045dc9111884904a8f72a3b07841aaff4fd3a8295772f6e8L42-R42)
* Added import for `com.google.common.collect.Lists` and removed unused `ArrayList` imports in both view model classes. [[1]](diffhunk://#diff-d429e84032665e2a091bbd9e2abd131b5f3cf8994eab4a551536efde7d850168R19-L21) [[2]](diffhunk://#diff-28fb99995a905d46045dc9111884904a8f72a3b07841aaff4fd3a8295772f6e8R19-L21)

**Maintenance updates:**

* Updated copyright year from 2019 to 2025 in both `TransactionDotMetaDataViewModel.java` and `TransactionMetaDataViewModel.java`. [[1]](diffhunk://#diff-d429e84032665e2a091bbd9e2abd131b5f3cf8994eab4a551536efde7d850168L2-R2) [[2]](diffhunk://#diff-28fb99995a905d46045dc9111884904a8f72a3b07841aaff4fd3a8295772f6e8L2-R2)