### PR TITLE
[#noissue] Update Jackson module

### DIFF
--- a/commons-server/pom.xml
+++ b/commons-server/pom.xml
@@ -136,6 +136,21 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/json/Jackson.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/json/Jackson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,41 +12,21 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.common.server.util.json;
 
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import org.springframework.beans.BeanUtils;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
-import org.springframework.util.ClassUtils;
-
-import java.lang.reflect.Constructor;
 
 public final class Jackson {
-
-    private static final Module parameterNamesModule = getParameterNamesModule();
 
     private Jackson() {
     }
 
-    @SuppressWarnings("unchecked")
-    private static Module getParameterNamesModule() {
-        try {
-            Class<? extends Module> parameterNamesModuleClass = (Class<? extends Module>)
-                    ClassUtils.forName("com.fasterxml.jackson.module.paramnames.ParameterNamesModule", Jackson.class.getClassLoader());
-            Constructor<? extends Module> constructor = parameterNamesModuleClass.getConstructor(JsonCreator.Mode.class);
-            return BeanUtils.instantiateClass(constructor, JsonCreator.Mode.DEFAULT);
-        } catch (ReflectiveOperationException ignore) {
-            return null;
-        }
-    }
 
     public static ObjectMapper newMapper() {
         Jackson2ObjectMapperBuilder builder = newBuilder();
@@ -55,9 +35,7 @@ public final class Jackson {
 
     public static Jackson2ObjectMapperBuilder newBuilder() {
         Jackson2ObjectMapperBuilder builder = new Jackson2ObjectMapperBuilder();
-        if (parameterNamesModule != null ) {
-            builder.modulesToInstall(parameterNamesModule);
-        }
+
         builder.featuresToDisable(
                 SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
                 SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/json/JacksonTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/json/JacksonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.common.server.util.json;
@@ -30,8 +29,7 @@ class JacksonTest {
     void newMapper() throws JsonProcessingException {
         ObjectMapper mapper = Jackson.newMapper();
 
-        User user1 = new User();
-        user1.setName("abc");
+        User user1 = new User("abc");
 
         String json = mapper.writeValueAsString(user1);
 
@@ -41,10 +39,10 @@ class JacksonTest {
     }
 
     static class User {
-        private String name;
+        private final String name;
 
-        public void setName(String name) {
-            this.name = name;
+        public User(String name) {
+            this.name = Objects.requireNonNull(name, "name");
         }
 
         public String getName() {
@@ -53,17 +51,15 @@ class JacksonTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
             User user = (User) o;
-
-            return Objects.equals(name, user.name);
+            return name.equals(user.name);
         }
 
         @Override
         public int hashCode() {
-            return name != null ? name.hashCode() : 0;
+            return name.hashCode();
         }
     }
 }

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -281,10 +281,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-parameter-names</artifactId>
-        </dependency>
 
         <!-- Logging dependencies -->
         <dependency>


### PR DESCRIPTION
This pull request updates the Jackson module configuration in both the `commons-server` and `web` modules to improve compatibility with Java 8+ features and simplify object mapping. The main changes involve adding new Jackson dependencies for JDK8 types and Java time support, removing manual module instantiation logic, and refactoring related tests and code to use constructor-based object creation.

**Dependency updates and configuration:**

* Added `jackson-datatype-jdk8`, `jackson-datatype-jsr310`, and `jackson-module-parameter-names` as runtime dependencies in `commons-server/pom.xml` to support Java 8 types and constructor parameter names.
* Removed the explicit `jackson-module-parameter-names` dependency from `web/pom.xml` since it is now handled by `commons-server`.

**Codebase simplification:**

* Removed manual reflection-based logic for instantiating the `ParameterNamesModule` in `Jackson.java`, relying on automatic module registration via dependencies instead. [[1]](diffhunk://#diff-9179911bc39537fd48120938eced3b31c8f065599e8ce0191f5d5019bfe86f75L15-L49) [[2]](diffhunk://#diff-9179911bc39537fd48120938eced3b31c8f065599e8ce0191f5d5019bfe86f75L58-R38)

**Test and object model refactoring:**

* Refactored the `User` class in `JacksonTest.java` to use a constructor for setting the `name` field, making it immutable and simplifying equality and hash code logic. [[1]](diffhunk://#diff-5b7844495a8a93d196e29e6a1888572ebf9922c1e95a5414a1adb34474619f5aL33-R32) [[2]](diffhunk://#diff-5b7844495a8a93d196e29e6a1888572ebf9922c1e95a5414a1adb34474619f5aL44-R45) [[3]](diffhunk://#diff-5b7844495a8a93d196e29e6a1888572ebf9922c1e95a5414a1adb34474619f5aL56-R62)

**General maintenance:**

* Updated copyright years to 2025 in modified files. [[1]](diffhunk://#diff-9179911bc39537fd48120938eced3b31c8f065599e8ce0191f5d5019bfe86f75L2-R2) [[2]](diffhunk://#diff-5b7844495a8a93d196e29e6a1888572ebf9922c1e95a5414a1adb34474619f5aL2-R2)
* Minor cleanup of file headers for consistency. [[1]](diffhunk://#diff-9179911bc39537fd48120938eced3b31c8f065599e8ce0191f5d5019bfe86f75L15-L49) [[2]](diffhunk://#diff-5b7844495a8a93d196e29e6a1888572ebf9922c1e95a5414a1adb34474619f5aL15)