### PR TITLE
[#noissue] Refactor AcceptApplicationLocalCache

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkMarker.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkMarker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,11 +12,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.web.applicationmap.map;
 
+import com.navercorp.pinpoint.web.applicationmap.map.processor.AcceptApplicationSet;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.logging.log4j.LogManager;
@@ -41,7 +41,7 @@ public class VirtualLinkMarker {
         return Collections.unmodifiableSet(virtualLinkDataMarker);
     }
 
-    public List<LinkData> createVirtualLink(LinkData linkData, Application toApplication, Set<AcceptApplication> acceptApplicationList) {
+    public List<LinkData> createVirtualLink(LinkData linkData, Application toApplication, AcceptApplicationSet acceptApplicationList) {
         logger.info("one to N replaced. node:{}->host:{} accept:{}", linkData.getFromApplication(), toApplication.getName(), acceptApplicationList);
         List<LinkData> virtualLinkDataList = new ArrayList<>();
         logger.debug("acceptApplicationList:{}", acceptApplicationList);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/AcceptApplicationLocalCache.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/AcceptApplicationLocalCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
@@ -20,10 +19,8 @@ package com.navercorp.pinpoint.web.applicationmap.map.processor;
 import com.navercorp.pinpoint.web.applicationmap.map.AcceptApplication;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.util.CollectionUtils;
+import org.jspecify.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -34,38 +31,46 @@ import java.util.concurrent.ConcurrentMap;
 class AcceptApplicationLocalCache {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
+    private final boolean isDebugEnabled = logger.isDebugEnabled();
 
-    private final ConcurrentMap<RpcApplication, Set<AcceptApplication>> acceptApplicationLocalCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<RpcApplication, AcceptApplicationSet> acceptApplicationLocalCache = new ConcurrentHashMap<>();
 
-    public Set<AcceptApplication> get(RpcApplication findKey) {
-        final Set<AcceptApplication> hit = this.acceptApplicationLocalCache.get(findKey);
+    @Nullable
+    public AcceptApplicationSet get(RpcApplication findKey) {
+        final AcceptApplicationSet hit = this.acceptApplicationLocalCache.get(findKey);
         if (hit != null) {
-            logger.debug("acceptApplicationLocalCache hit {}:{}", findKey, hit);
+            if (isDebugEnabled) {
+                logger.debug("acceptApplicationLocalCache hit {}:{}", findKey, hit);
+            }
             return hit;
         }
-        logger.debug("acceptApplicationLocalCache miss {}", findKey);
-        return Collections.emptySet();
+        if (isDebugEnabled) {
+            logger.debug("acceptApplicationLocalCache miss {}", findKey);
+        }
+        return null;
     }
 
-    public void put(RpcApplication findKey, Set<AcceptApplication> acceptApplicationSet) {
-        if (CollectionUtils.isEmpty(acceptApplicationSet)) {
+    public void put(RpcApplication findKey, AcceptApplicationSet acceptApplicationSet) {
+        if (AcceptApplicationSet.isEmpty(acceptApplicationSet)) {
             // initialize for empty value
             computeIfAbsent(findKey);
             return;
         }
-        logger.debug("findAcceptApplication:{}", acceptApplicationSet);
+        if (isDebugEnabled) {
+            logger.debug("findAcceptApplication:{}", acceptApplicationSet);
+        }
         // build cache
         // set AcceptApplication for each url
         for (AcceptApplication acceptApplication : acceptApplicationSet) {
             // acceptApplicationSet data contains the url and the accept node's applicationName.
             // we need to recreate the key set based on the url and the calling application.
             RpcApplication newKey = new RpcApplication(acceptApplication.getHost(), findKey.getApplication());
-            Set<AcceptApplication> findSet = computeIfAbsent(newKey);
+            AcceptApplicationSet findSet = computeIfAbsent(newKey);
             findSet.add(acceptApplication);
         }
     }
 
-    private Set<AcceptApplication> computeIfAbsent(RpcApplication key) {
-        return this.acceptApplicationLocalCache.computeIfAbsent(key, rpcApplication -> ConcurrentHashMap.newKeySet());
+    private AcceptApplicationSet computeIfAbsent(RpcApplication key) {
+        return this.acceptApplicationLocalCache.computeIfAbsent(key, rpcApplication -> new AcceptApplicationSet());
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/AcceptApplicationSet.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/AcceptApplicationSet.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.map.processor;
+
+import com.navercorp.pinpoint.web.applicationmap.map.AcceptApplication;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+public class AcceptApplicationSet implements Iterable<AcceptApplication> {
+
+    private final Set<AcceptApplication> set;
+
+    public AcceptApplicationSet() {
+        this(ConcurrentHashMap.newKeySet());
+    }
+
+    private AcceptApplicationSet(Set<AcceptApplication> set) {
+        this.set = Objects.requireNonNull(set, "set");
+    }
+
+    public static AcceptApplicationSet copyOf(Set<AcceptApplication> set) {
+        Objects.requireNonNull(set, "set");
+
+        if (set.isEmpty()) {
+            return new AcceptApplicationSet();
+        } else {
+            Set<AcceptApplication> copySet = ConcurrentHashMap.newKeySet();
+            copySet.addAll(set);
+            return new AcceptApplicationSet(copySet);
+        }
+    }
+
+    public boolean add(AcceptApplication acceptApplication) {
+        Objects.requireNonNull(acceptApplication, "acceptApplication");
+        return set.add(acceptApplication);
+    }
+
+
+    @Override
+    @NonNull
+    public Iterator<AcceptApplication> iterator() {
+        return set.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super AcceptApplication> action) {
+        Objects.requireNonNull(action, "action");
+        set.forEach(action);
+    }
+
+    @Nullable
+    public AcceptApplication firstElement() {
+        if (set.isEmpty()) {
+            return null;
+        }
+        return set.iterator().next();
+    }
+
+    public int size() {
+        return set.size();
+    }
+
+    public boolean isEmpty() {
+        return set.isEmpty();
+    }
+
+
+    public static boolean isEmpty(AcceptApplicationSet set) {
+        return set == null || set.isEmpty();
+    }
+
+    public static boolean hasSize(AcceptApplicationSet set) {
+        return set != null && !set.isEmpty();
+    }
+
+    public static int size(AcceptApplicationSet set) {
+        if (set == null) {
+            return 0;
+        }
+        return set.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AcceptApplicationSet that = (AcceptApplicationSet) o;
+        return set.equals(that.set);
+    }
+
+    @Override
+    public int hashCode() {
+        return set.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "AcceptApplicationSet{" +
+               "set=" + set +
+               '}';
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
@@ -20,7 +19,6 @@ package com.navercorp.pinpoint.web.applicationmap.map.processor;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.web.applicationmap.dao.HostApplicationMapDao;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.map.AcceptApplication;
@@ -30,9 +28,10 @@ import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -52,7 +51,7 @@ public class RpcCallProcessor implements LinkDataMapProcessor {
 
     private final VirtualLinkMarker virtualLinkMarker;
 
-    private final ConcurrentMap<AcceptApplicationCacheKey, Set<AcceptApplication>> acceptApplicationCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<AcceptApplicationCacheKey, AcceptApplicationSet> acceptApplicationCache = new ConcurrentHashMap<>();
 
     private final AcceptApplicationLocalCache rpcAcceptApplicationCache = new AcceptApplicationLocalCache();
 
@@ -63,28 +62,30 @@ public class RpcCallProcessor implements LinkDataMapProcessor {
 
     @Override
     public LinkDataMap processLinkDataMap(LinkDirection direction, LinkDataMap linkDataMap, TimeWindow timeWindow) {
+        final Range range = timeWindow.getWindowRange();
         final LinkDataMap replacedLinkDataMap = new LinkDataMap();
         for (LinkData linkData : linkDataMap.getLinkDataList()) {
-            final List<LinkData> replacedLinkDatas = replaceLinkData(direction, linkData, timeWindow);
+            final List<LinkData> replacedLinkDatas = replaceLinkData(direction, linkData, range);
             for (LinkData replacedLinkData : replacedLinkDatas)
                 replacedLinkDataMap.addLinkData(replacedLinkData);
         }
         return replacedLinkDataMap;
     }
 
-    private List<LinkData> replaceLinkData(LinkDirection direction, LinkData linkData, TimeWindow timeWindow) {
+    private List<LinkData> replaceLinkData(LinkDirection direction, LinkData linkData, Range range) {
         final Application toApplication = linkData.getToApplication();
         if (toApplication.getServiceType().isRpcClient() || toApplication.getServiceType().isQueue()) {
             // rpc client's destination could have an agent installed in which case the link data must be replaced to point
             // to the destination application.
-            logger.debug("Finding {} accept applications for {}, {}", direction, toApplication, timeWindow.getWindowRange());
-            final Set<AcceptApplication> acceptApplicationList = findAcceptApplications(linkData.getFromApplication(), toApplication.getName(), timeWindow.getWindowRange());
+            logger.debug("Finding {} accept applications for {}, {}", direction, toApplication, range);
+            final AcceptApplicationSet acceptApplicationList = findAcceptApplications(linkData.getFromApplication(), toApplication.getName(), range);
             logger.debug("Found {} accept applications: {}", direction, acceptApplicationList);
-            if (CollectionUtils.hasLength(acceptApplicationList)) {
-                if (acceptApplicationList.size() == 1) {
+            final int size = AcceptApplicationSet.size(acceptApplicationList);
+            if (size > 0) {
+                if (size == 1) {
                     logger.debug("Application info replaced. {} {} => {}", direction, linkData, acceptApplicationList);
 
-                    AcceptApplication first = acceptApplicationList.iterator().next();
+                    AcceptApplication first = acceptApplicationList.firstElement();
                     final LinkData acceptedLinkData = LinkData.copyOf(linkData.getFromApplication(), first.getApplication(), linkData.getLinkCallDataMap());
                     return Collections.singletonList(acceptedLinkData);
                 } else {
@@ -105,14 +106,16 @@ public class RpcCallProcessor implements LinkDataMapProcessor {
         return Collections.singletonList(linkData);
     }
 
-    private Set<AcceptApplication> filterAlias(Set<AcceptApplication> acceptApplicationList) {
-
-        if (acceptApplicationList.size() < 2) {
-            return acceptApplicationList;
+    private AcceptApplicationSet filterAlias(Set<AcceptApplication> acceptApplicationList) {
+        final int size = acceptApplicationList.size();
+        if (size == 0) {
+            return new AcceptApplicationSet();
+        }
+        if (size < 2) {
+            return AcceptApplicationSet.copyOf(acceptApplicationList);
         }
 
-        final Set<AcceptApplication> resultSet = new HashSet<>();
-
+        final AcceptApplicationSet resultSet = new AcceptApplicationSet();
         for (AcceptApplication acceptApplication : acceptApplicationList) {
             if (!acceptApplication.getApplication().getServiceType().isAlias()) {
                 resultSet.add(acceptApplication);
@@ -120,52 +123,49 @@ public class RpcCallProcessor implements LinkDataMapProcessor {
                 logger.debug("deduct alias application {}", acceptApplication);
             }
         }
-
-        if (resultSet.isEmpty()) {
-            return acceptApplicationList;
-        } else {
-            return resultSet;
-        }
+        return resultSet;
     }
 
-    private Set<AcceptApplication> findAcceptApplications(Application fromApplication, String host, Range range) {
+    @Nullable
+    private AcceptApplicationSet findAcceptApplications(Application fromApplication, String host, Range range) {
         logger.debug("findAcceptApplication {} {}", fromApplication, host);
 
         final RpcApplication rpcApplication = new RpcApplication(host, fromApplication);
-        final Set<AcceptApplication> hit = this.rpcAcceptApplicationCache.get(rpcApplication);
-        if (CollectionUtils.hasLength(hit)) {
+        final AcceptApplicationSet hit = this.rpcAcceptApplicationCache.get(rpcApplication);
+        if (AcceptApplicationSet.hasSize(hit)) {
             logger.debug("rpcAcceptApplicationCache hit {}", rpcApplication);
             return hit;
         }
-        final Set<AcceptApplication> acceptApplicationSet = getAcceptApplications(fromApplication, range);
-        this.rpcAcceptApplicationCache.put(rpcApplication, acceptApplicationSet);
+        final AcceptApplicationSet acceptApplicationSet = getAcceptApplications(fromApplication, range);
 
-        Set<AcceptApplication> acceptApplication = this.rpcAcceptApplicationCache.get(rpcApplication);
+        this.rpcAcceptApplicationCache.put(rpcApplication, acceptApplicationSet);
+        AcceptApplicationSet acceptApplication = this.rpcAcceptApplicationCache.get(rpcApplication);
         if (logger.isDebugEnabled()) {
             logger.debug("findAcceptApplication {}->{} result:{}", fromApplication, host, acceptApplication);
         }
         return acceptApplication;
     }
 
-    private Set<AcceptApplication> getAcceptApplications(Application fromApplication, Range range) {
+    private AcceptApplicationSet getAcceptApplications(Application fromApplication, Range range) {
         AcceptApplicationCacheKey cacheKey = new AcceptApplicationCacheKey(fromApplication, range);
-        final Set<AcceptApplication> cachedAcceptApplications = acceptApplicationCache.get(cacheKey);
+        final AcceptApplicationSet cachedAcceptApplications = acceptApplicationCache.get(cacheKey);
         if (cachedAcceptApplications != null) {
             logger.debug("acceptApplicationCache hit {}", fromApplication);
             return cachedAcceptApplications;
         }
+        AcceptApplicationSet acceptApplications = getAcceptApplicationsFromHostApplication(fromApplication, range);
+        return acceptApplicationCache.computeIfAbsent(cacheKey, acceptApplicationCacheKey -> acceptApplications);
+    }
 
+    @NotNull
+    private AcceptApplicationSet getAcceptApplicationsFromHostApplication(Application fromApplication, Range range) {
         logger.debug("acceptApplicationCache miss {}", fromApplication);
         Set<AcceptApplication> queriedAcceptApplications = hostApplicationMapDao.findAcceptApplicationName(fromApplication, range);
 
-        final Set<AcceptApplication> filteredApplicationList = filterAlias(queriedAcceptApplications);
+        final AcceptApplicationSet filteredApplicationList = filterAlias(queriedAcceptApplications);
         logger.debug("filteredApplicationList: {}", filteredApplicationList);
 
-        Set<AcceptApplication> acceptApplications = ConcurrentHashMap.newKeySet();
-        if (CollectionUtils.hasLength(filteredApplicationList)) {
-            acceptApplications.addAll(filteredApplicationList);
-        }
-        return acceptApplicationCache.computeIfAbsent(cacheKey, acceptApplicationCacheKey -> acceptApplications);
+        return filteredApplicationList;
     }
 
     private record AcceptApplicationCacheKey(Application application, Range range) {

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/processor/AcceptApplicationLocalCacheTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/processor/AcceptApplicationLocalCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.web.applicationmap.map.processor;
@@ -23,9 +22,8 @@ import com.navercorp.pinpoint.web.vo.Application;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class AcceptApplicationLocalCacheTest {
@@ -37,31 +35,34 @@ public class AcceptApplicationLocalCacheTest {
         AcceptApplicationLocalCache cache = new AcceptApplicationLocalCache();
 
         Application tomcat = new Application("Tomcat", ServiceType.STAND_ALONE);
-        RpcApplication rpc = new RpcApplication("localhost:8080", tomcat);
+        RpcApplication localHostRpc = new RpcApplication("localhost:8080", tomcat);
         // find the application that accept the rpc request of calling to localhost:8080 at tomcat itself
 
-        Set<AcceptApplication> findSet =  createAcceptApplication();
+        AcceptApplicationSet findSet =  createAcceptApplication(localhost);
 
-        cache.put(rpc, findSet);
+        cache.put(localHostRpc, findSet);
 
         // found
-        Set<AcceptApplication> acceptApplications = cache.get(rpc);
-        assertThat(acceptApplications).hasSize(1);
-        Assertions.assertEquals(acceptApplications.iterator().next(), localhost);
+        AcceptApplicationSet acceptApplications = cache.get(localHostRpc);
+        assertEquals(1, acceptApplications.size());
+        Assertions.assertEquals(acceptApplications.firstElement(), localhost);
 
         // not found
-        Set<AcceptApplication> unknown = cache.get(new RpcApplication("unknown:8080", tomcat));
-        assertThat(unknown).isEmpty();
-        Assertions.assertFalse(unknown.iterator().hasNext());
-
+        AcceptApplicationSet unknown = cache.get(new RpcApplication("unknown:8080", tomcat));
+        assertThat(unknown).isNull();
     }
 
 
-    private Set<AcceptApplication> createAcceptApplication() {
+    private AcceptApplicationSet createAcceptApplication(AcceptApplication acceptApplication) {
         AcceptApplication naver = new AcceptApplication("www.naver.com", new Application("Naver", ServiceType.STAND_ALONE));
         AcceptApplication daum = new AcceptApplication("www.daum.com", new Application("Daum", ServiceType.STAND_ALONE));
         AcceptApplication nate = new AcceptApplication("www.nate.com", new Application("Nate", ServiceType.STAND_ALONE));
 
-        return Set.of(naver, daum, nate, localhost);
+        AcceptApplicationSet set = new AcceptApplicationSet();
+        set.add(naver);
+        set.add(daum);
+        set.add(nate);
+        set.add(acceptApplication);
+        return set;
     }
 }


### PR DESCRIPTION
This pull request refactors how "accept applications" are managed within the application map logic, introducing a new `AcceptApplicationSet` class to replace the previous usage of raw `Set<AcceptApplication>`. This change improves thread safety, encapsulation, and code clarity. The update affects several core classes and their interactions, particularly around caching and processing RPC calls.

**Core Refactoring: AcceptApplicationSet Integration**

* Added new class `AcceptApplicationSet` to encapsulate and manage sets of `AcceptApplication` objects, providing thread-safe operations and utility methods.
* Replaced all usages of `Set<AcceptApplication>` with `AcceptApplicationSet` in `VirtualLinkMarker`, `AcceptApplicationLocalCache`, and `RpcCallProcessor`, updating method signatures, cache structures, and internal logic accordingly. [[1]](diffhunk://#diff-9d19e4cd9177769139314fed727ec7f4ad657975701e208da1d61abf875032efL44-R48) [[2]](diffhunk://#diff-8b969f5bb20e22c02e78aa7227a4200fc0303665a9dfa8b3ffcb47d2bb14f68aR34-R74) [[3]](diffhunk://#diff-10e8402c782ebbd45ab5d34b1a1ac1e94421db5358929374a50c57119c1ac4d2L55-R53) [[4]](diffhunk://#diff-10e8402c782ebbd45ab5d34b1a1ac1e94421db5358929374a50c57119c1ac4d2L108-R165)

**Caching and Processing Improvements**

* Updated `AcceptApplicationLocalCache` to use `AcceptApplicationSet` for storing and retrieving cached values, improving cache hit/miss handling and debug logging.
* Refactored `RpcCallProcessor` to utilize `AcceptApplicationSet` for accept application caching and filtering, enhancing the logic for finding and filtering applications, and improving code readability and maintainability. [[1]](diffhunk://#diff-10e8402c782ebbd45ab5d34b1a1ac1e94421db5358929374a50c57119c1ac4d2R64-R86) [[2]](diffhunk://#diff-10e8402c782ebbd45ab5d34b1a1ac1e94421db5358929374a50c57119c1ac4d2L108-R165)

**General Codebase Updates**

* Updated copyright years to 2025 across modified files.
* Cleaned up imports and removed unused utility classes related to collections. [[1]](diffhunk://#diff-8b969f5bb20e22c02e78aa7227a4200fc0303665a9dfa8b3ffcb47d2bb14f68aL15-L26) [[2]](diffhunk://#diff-10e8402c782ebbd45ab5d34b1a1ac1e94421db5358929374a50c57119c1ac4d2L15-L23) [[3]](diffhunk://#diff-10e8402c782ebbd45ab5d34b1a1ac1e94421db5358929374a50c57119c1ac4d2R31-L35) [[4]](diffhunk://#diff-da2b307b91441ee0c247bb64586086788d02185540177586af1018bb86863ce9L26-R26)

These changes lay the groundwork for more robust and maintainable handling of accept applications in the application map subsystem.