### PR TITLE
[#noissue] Refactor AcceptApplicationLocalCache

### DIFF
--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/CachedStringAllocator.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/CachedStringAllocator.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.common.buffer;
 
 import com.navercorp.pinpoint.common.cache.Cache;
+import com.navercorp.pinpoint.common.cache.LRUCache;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -24,6 +25,10 @@ import java.util.Objects;
 
 public class CachedStringAllocator implements StringAllocator {
     private final Cache<ByteBuffer, String> cache;
+
+    public CachedStringAllocator(int cacheSize) {
+        this(new LRUCache<>(cacheSize));
+    }
 
     public CachedStringAllocator(Cache<ByteBuffer, String> cache) {
         this.cache = Objects.requireNonNull(cache, "cache");

--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/CachedStringAllocatorTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/CachedStringAllocatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.buffer;
+
+import com.navercorp.pinpoint.common.util.BytesUtils;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CachedStringAllocatorTest {
+
+    private static final Charset UTF8 = StandardCharsets.UTF_8;
+
+    @Test
+    void allocate() {
+        // Arrange
+        CachedStringAllocator allocator = new CachedStringAllocator(10);
+        byte[] bytes = BytesUtils.toBytes("test");
+
+        // Act
+        String result1 = allocator.allocate(bytes, 0, bytes.length, UTF8);
+        String result2 = allocator.allocate(bytes, 0, bytes.length, UTF8);
+
+        // Assert
+        assertEquals(result1, result2);
+        assertSame(result1, result2, "Cached instance should be returned.");
+    }
+
+    @Test
+    void allocate_createsNewString() {
+        // Arrange
+        CachedStringAllocator allocator = new CachedStringAllocator(10);
+        byte[] bytes1 = BytesUtils.toBytes("test1");
+        byte[] bytes2 = BytesUtils.toBytes("test2");
+
+        // Act
+        String result1 = allocator.allocate(bytes1, 0, bytes1.length, UTF8);
+        String result2 = allocator.allocate(bytes2, 0, bytes2.length, UTF8);
+
+        // Assert
+        assertNotNull(result1);
+        assertNotNull(result2);
+        assertNotSame(result1, result2, "Different strings should not be the same instance.");
+        assertEquals("test1", result1);
+        assertEquals("test2", result2);
+    }
+
+    @Test
+    void allocate_handlesNullCharset() {
+        // Arrange
+        CachedStringAllocator allocator = new CachedStringAllocator(10);
+        byte[] bytes = BytesUtils.toBytes("test");
+
+        // Act & Assert
+        assertThrows(NullPointerException.class, () -> allocator.allocate(bytes, 0, bytes.length, null));
+    }
+
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class SpanDecoderV0 implements SpanDecoder {
         spanChunk.setCollectorAcceptTime(decodingContext.getCollectorAcceptedTime());
 
 
-        readQualifier(spanChunk, qualifier);
+        readQualifier(spanChunk, qualifier, decodingContext);
 
         readSpanChunkValue(columnValue, spanChunk, decodingContext);
 
@@ -86,7 +86,7 @@ public class SpanDecoderV0 implements SpanDecoder {
         span.setTransactionId(transactionId);
         span.setCollectorAcceptTime(decodingContext.getCollectorAcceptedTime());
 
-        readQualifier(span, qualifier);
+        readQualifier(span, qualifier, decodingContext);
 
         readSpanValue(columnValue, span, decodingContext);
 
@@ -372,11 +372,11 @@ public class SpanDecoderV0 implements SpanDecoder {
     }
 
 
-    private void readQualifier(BasicSpan basicSpan, Buffer buffer) {
-        String applicationName = buffer.readPrefixedString();
+    private void readQualifier(BasicSpan basicSpan, Buffer buffer, SpanDecodingContext decodingContext) {
+        String applicationName = decodingContext.encoding(buffer.readPrefixedBytes());;
         basicSpan.setApplicationName(applicationName);
 
-        String agentId = buffer.readPrefixedString();
+        String agentId = decodingContext.encoding(buffer.readPrefixedBytes());
         basicSpan.setAgentId(agentId);
 
         long agentStartTime = buffer.readVLong();

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecodingContext.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecodingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,27 @@
 
 package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 
+import com.navercorp.pinpoint.common.buffer.StringAllocator;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 /**
  * @author Woonduk Kang(emeroad)
  */
 public class SpanDecodingContext {
 
-//    private AnnotationBo prevAnnotationBo;
+    private final TransactionId transactionId;
+
+    //    private AnnotationBo prevAnnotationBo;
     private long collectorAcceptedTime;
-    private TransactionId transactionId;
+
+    private StringAllocator stringAllocator = StringAllocator.DEFAULT_ALLOCATOR;
+
+    public SpanDecodingContext(TransactionId transactionId) {
+        this.transactionId = Objects.requireNonNull(transactionId, "transactionId");
+    }
 
 //    public AnnotationBo getPrevFirstAnnotationBo() {
 //        return prevAnnotationBo;
@@ -35,7 +46,6 @@ public class SpanDecodingContext {
 //        this.prevAnnotationBo = prevAnnotationBo;
 //    }
 
-
     public void setCollectorAcceptedTime(long collectorAcceptedTime) {
         this.collectorAcceptedTime = collectorAcceptedTime;
     }
@@ -44,14 +54,17 @@ public class SpanDecodingContext {
         return collectorAcceptedTime;
     }
 
-    public void setTransactionId(TransactionId transactionId) {
-        this.transactionId = transactionId;
-    }
-
     public TransactionId getTransactionId() {
         return transactionId;
     }
 
+    public String encoding(byte[] bytes) {
+        return stringAllocator.allocate(bytes, 0, bytes.length, StandardCharsets.UTF_8);
+    }
+
+    public void setStringAllocator(StringAllocator stringAllocator) {
+        this.stringAllocator = Objects.requireNonNull(stringAllocator, "stringAllocator");
+    }
 
     public void next() {
     }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 
 import com.google.common.collect.Lists;
@@ -131,8 +147,7 @@ public class SpanEncoderTest {
         Buffer qualifier = wrapBuffer(spanEncoder.encodeSpanQualifier(encodingContext));
         Buffer column = wrapBuffer(spanEncoder.encodeSpanColumnValue(encodingContext));
 
-        SpanDecodingContext decodingContext = new SpanDecodingContext();
-        decodingContext.setTransactionId(spanBo.getTransactionId());
+        SpanDecodingContext decodingContext = new SpanDecodingContext(spanBo.getTransactionId());
         decodingContext.setCollectorAcceptedTime(spanBo.getCollectorAcceptTime());
 
         SpanBo decode = (SpanBo) spanDecoder.decode(qualifier, column, decodingContext);
@@ -166,8 +181,7 @@ public class SpanEncoderTest {
         Buffer qualifier = wrapBuffer(spanEncoder.encodeSpanChunkQualifier(encodingContext));
         Buffer column = wrapBuffer(spanEncoder.encodeSpanChunkColumnValue(encodingContext));
 
-        SpanDecodingContext decodingContext = new SpanDecodingContext();
-        decodingContext.setTransactionId(spanChunkBo.getTransactionId());
+        SpanDecodingContext decodingContext = new SpanDecodingContext(spanChunkBo.getTransactionId());
         decodingContext.setCollectorAcceptedTime(spanChunkBo.getCollectorAcceptTime());
 
         SpanChunkBo decode = (SpanChunkBo) spanDecoder.decode(qualifier, column, decodingContext);

--- a/web/src/test/java/com/navercorp/pinpoint/web/mapper/SpanMapperV2Test.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/mapper/SpanMapperV2Test.java
@@ -1,7 +1,24 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.web.mapper;
 
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
+import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.ExceptionInfo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
@@ -63,7 +80,8 @@ public class SpanMapperV2Test {
         Buffer buffer = new OffsetFixedBuffer(byteBuffer.array(), byteBuffer.arrayOffset(), byteBuffer.remaining());
 
         SpanBo readSpan = new SpanBo();
-        SpanDecodingContext decodingContext = new SpanDecodingContext();
+        TransactionId transactionId = TransactionId.of("test", 100, 1);
+        SpanDecodingContext decodingContext = new SpanDecodingContext(transactionId);
         decoder.readSpanValue(buffer, readSpan, decodingContext);
 
         assertThat(readSpan.getSpanEventBoList()).hasSize(2);


### PR DESCRIPTION
This pull request refactors the string allocation and decoding logic in the span decoding pipeline to improve performance and simplify buffer management. The main changes include introducing a cache-backed string allocator, updating the decoding context to use it, refactoring how qualifiers are read, and removing redundant buffer factory logic. Additionally, new and updated tests were added to verify the changes.

### String allocation and caching improvements
* Added a constructor to `CachedStringAllocator` that accepts a cache size and uses an `LRUCache` for string caching, improving memory efficiency and performance when decoding strings from buffers. [[1]](diffhunk://#diff-34a6cefc198857f68e8a946fb33a8649fc944e6528ed11078fd5f70ab18c6a77R20) [[2]](diffhunk://#diff-34a6cefc198857f68e8a946fb33a8649fc944e6528ed11078fd5f70ab18c6a77R29-R32)
* Updated `SpanDecodingContext` to accept a `StringAllocator` and provide an `encoding(byte[])` method for consistent string decoding. Also, the context now requires a `TransactionId` at construction. [[1]](diffhunk://#diff-8dbb6dd354af07f7fed2b8b74c99f3d05ace1d9302a0bd26b4675aece0f49b95R19-R39) [[2]](diffhunk://#diff-8dbb6dd354af07f7fed2b8b74c99f3d05ace1d9302a0bd26b4675aece0f49b95L47-R67)

### Span decoding logic updates
* Refactored `SpanDecoderV0` to use the new string allocation and decoding logic, including passing the decoding context to qualifier reading and using cached string decoding for `applicationName` and `agentId`. [[1]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L74-R74) [[2]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L89-R89) [[3]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L375-R379)

### Buffer and context management simplification
* Simplified buffer creation in `SpanMapperV2` by removing the `BufferFactory` and directly instantiating `OffsetFixedBuffer`. The decoding context now handles string caching internally if enabled. [[1]](diffhunk://#diff-ee12c0975b0f60cfc20f592409dbf04b20051d016ff3b7ed061d19a50285b486L106-R104) [[2]](diffhunk://#diff-ee12c0975b0f60cfc20f592409dbf04b20051d016ff3b7ed061d19a50285b486L118-R114) [[3]](diffhunk://#diff-ee12c0975b0f60cfc20f592409dbf04b20051d016ff3b7ed061d19a50285b486L151-L172)

### Test updates and additions
* Added comprehensive unit tests for `CachedStringAllocator` to verify caching behavior and error handling.
* Updated span encoding/decoding tests to use the new `SpanDecodingContext` constructor and verify correct transaction ID handling. [[1]](diffhunk://#diff-c87ed6d0d98610e18522cb3f5adedcfc1f608b5f255f882b9691b9fd06be4965L134-R150) [[2]](diffhunk://#diff-c87ed6d0d98610e18522cb3f5adedcfc1f608b5f255f882b9691b9fd06be4965L169-R184) [[3]](diffhunk://#diff-716bfc1ad64c179ffb3edddf46493589b806efc6e1783b6c9f2e571f5a751122L66-R84)

### License header updates
* Updated copyright headers in several files to reflect the year 2025. [[1]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L2-R2) [[2]](diffhunk://#diff-8dbb6dd354af07f7fed2b8b74c99f3d05ace1d9302a0bd26b4675aece0f49b95L2-R2) [[3]](diffhunk://#diff-c87ed6d0d98610e18522cb3f5adedcfc1f608b5f255f882b9691b9fd06be4965R1-R16) [[4]](diffhunk://#diff-716bfc1ad64c179ffb3edddf46493589b806efc6e1783b6c9f2e571f5a751122R1-R21)