### PR TITLE
[#noissue] Refactor SpanDecoder interfaces

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoder.java
@@ -1,6 +1,23 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 
 import com.navercorp.pinpoint.common.buffer.Buffer;
+import com.navercorp.pinpoint.common.server.bo.BasicSpan;
 
 
 /**
@@ -8,9 +25,7 @@ import com.navercorp.pinpoint.common.buffer.Buffer;
  */
 public interface SpanDecoder {
     
-    Object UNKNOWN = new Object();
-
-    Object decode(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext);
+    BasicSpan decode(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext);
 
     void next(SpanDecodingContext decodingContext);
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
@@ -50,7 +50,7 @@ public class SpanDecoderV0 implements SpanDecoder {
     private static final AnnotationTranscoder transcoder = new AnnotationTranscoder();
 
     @Override
-    public Object decode(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext) {
+    public BasicSpan decode(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext) {
         final byte type = qualifier.readByte();
 
         if (SpanEncoder.TYPE_SPAN == type) {
@@ -59,7 +59,7 @@ public class SpanDecoderV0 implements SpanDecoder {
             return readSpanChunk(qualifier, columnValue, decodingContext);
         } else {
             logger.warn("Unknown span type {}", type);
-            return UNKNOWN;
+            return null;
         }
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/FilteringSpanDecoder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/FilteringSpanDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@
 package com.navercorp.pinpoint.web.mapper;
 
 import com.navercorp.pinpoint.common.buffer.Buffer;
+import com.navercorp.pinpoint.common.server.bo.BasicSpan;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecodingContext;
+import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoder;
 
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -39,12 +41,17 @@ public class FilteringSpanDecoder implements SpanDecoder {
     }
 
     @Override
-    public Object decode(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext) {
-        final Object decodedObject = delegate.decode(qualifier, columnValue, decodingContext);
-
-        if (decodedObject instanceof SpanBo spanBo) {
-            if (spanFilter.test(spanBo)) {
-                return spanBo;
+    public BasicSpan decode(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext) {
+        if (!qualifier.hasRemaining()) {
+            return null;
+        }
+        final byte type = qualifier.getByte(0);
+        if (SpanEncoder.TYPE_SPAN == type) {
+            BasicSpan spanBo = delegate.decode(qualifier, columnValue, decodingContext);
+            if (spanBo != null ) {
+                if (spanFilter.test((SpanBo) spanBo)) {
+                    return spanBo;
+                }
             }
             return null;
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/SpanMapperV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/SpanMapperV2.java
@@ -114,7 +114,7 @@ public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
                 final Buffer columnValue = new OffsetFixedBuffer(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength());
 
                 spanDecoder = resolveDecoder(columnValue);
-                final Object decodeObject = spanDecoder.decode(qualifier, columnValue, decodingContext);
+                final BasicSpan decodeObject = spanDecoder.decode(qualifier, columnValue, decodingContext);
                 if (decodeObject instanceof SpanBo spanBo) {
                     if (logger.isTraceEnabled()) {
                         logger.trace("spanBo:{}", spanBo);

--- a/web/src/test/java/com/navercorp/pinpoint/web/mapper/FilteringSpanDecoderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/mapper/FilteringSpanDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,27 @@
 
 package com.navercorp.pinpoint.web.mapper;
 
+import com.navercorp.pinpoint.common.buffer.Buffer;
+import com.navercorp.pinpoint.common.buffer.FixedBuffer;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.bo.BasicSpan;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoder;
+import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoder;
 import com.navercorp.pinpoint.web.dao.hbase.SpanQuery;
 import com.navercorp.pinpoint.web.dao.hbase.SpanQueryBuilder;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.SpanHint;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * @author Taejin Koo
@@ -74,8 +81,17 @@ public class FilteringSpanDecoderTest {
 
         FilteringSpanDecoder filteringSpanDecoder = new FilteringSpanDecoder(mockSpanDecoder, query.getSpanFilter());
 
-        Object result = filteringSpanDecoder.decode(null, null, null);
+        Buffer buffer = newSpanBuffer();
+
+        BasicSpan result = filteringSpanDecoder.decode(buffer, null, null);
         Assertions.assertNull(result);
+    }
+
+    private @NotNull Buffer newSpanBuffer() {
+        Buffer buffer = new FixedBuffer(1);
+        buffer.putByte(SpanEncoder.TYPE_SPAN);
+        buffer.setOffset(0);
+        return buffer;
     }
 
     @Test
@@ -89,7 +105,8 @@ public class FilteringSpanDecoderTest {
 
         FilteringSpanDecoder filteringSpanDecoder = new FilteringSpanDecoder(mockSpanDecoder, query.getSpanFilter());
 
-        Object result = filteringSpanDecoder.decode(null, null, null);
+        Buffer buffer = newSpanBuffer();
+        BasicSpan result = filteringSpanDecoder.decode(buffer, null, null);
         Assertions.assertNotNull(result);
     }
 
@@ -105,7 +122,8 @@ public class FilteringSpanDecoderTest {
 
         FilteringSpanDecoder filteringSpanDecoder = new FilteringSpanDecoder(mockSpanDecoder, query.getSpanFilter());
 
-        Object result = filteringSpanDecoder.decode(null, null, null);
+        Buffer buffer = newSpanBuffer();
+        BasicSpan result = filteringSpanDecoder.decode(buffer, null, null);
         Assertions.assertNull(result);
     }
 
@@ -121,7 +139,8 @@ public class FilteringSpanDecoderTest {
 
         FilteringSpanDecoder filteringSpanDecoder = new FilteringSpanDecoder(mockSpanDecoder, query.getSpanFilter());
 
-        Object result = filteringSpanDecoder.decode(null, null, null);
+        Buffer buffer = newSpanBuffer();
+        BasicSpan result = filteringSpanDecoder.decode(buffer, null, null);
         Assertions.assertNotNull(result);
     }
 
@@ -140,7 +159,7 @@ public class FilteringSpanDecoderTest {
 
     private SpanDecoder createMockSpanDecoder(SpanBo spanBo) {
         SpanDecoder mockSpanDecoder = Mockito.mock(SpanDecoder.class);
-        Mockito.when(mockSpanDecoder.decode(null, null, null)).thenReturn(spanBo);
+        Mockito.when(mockSpanDecoder.decode(any(Buffer.class), any(), any())).thenReturn(spanBo);
         return mockSpanDecoder;
     }
 


### PR DESCRIPTION
This pull request refactors the span decoding logic to improve type safety and clarity. The main change is updating the `SpanDecoder` interface and related classes to use the more specific `BasicSpan` type instead of the generic `Object`, which helps prevent type errors and makes the code easier to understand. The changes also update downstream implementations, usages, and tests to work with the new type signature.

### API and Type Safety Improvements

* Changed the return type of the `decode` method in the `SpanDecoder` interface from `Object` to `BasicSpan`, removing the ambiguous `UNKNOWN` object and replacing unknown cases with `null`. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoder.java`)
* Updated the implementation in `SpanDecoderV0` to return `BasicSpan` and handle unknown span types by returning `null`. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java`) [[1]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L53-R53) [[2]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L62-R62)
* Refactored `FilteringSpanDecoder` to use the new `BasicSpan` type, including more precise filtering logic and improved handling of buffer input and span type checks. (`web/src/main/java/com/navercorp/pinpoint/web/mapper/FilteringSpanDecoder.java`)

### Usage Updates

* Updated usages of the `decode` method in `SpanMapperV2` and related code to expect and process `BasicSpan` instead of `Object`. (`web/src/main/java/com/navercorp/pinpoint/web/mapper/SpanMapperV2.java`)

### Test Updates

* Refactored unit tests in `FilteringSpanDecoderTest` to work with the new `BasicSpan` type, including creation of valid buffers and use of proper mocks. (`web/src/test/java/com/navercorp/pinpoint/web/mapper/FilteringSpanDecoderTest.java`) [[1]](diffhunk://#diff-8803face426fba1cac6894d7467e75739a02ccf4c9004517d844297c1a5f99f0L77-R96) [[2]](diffhunk://#diff-8803face426fba1cac6894d7467e75739a02ccf4c9004517d844297c1a5f99f0L92-R109) [[3]](diffhunk://#diff-8803face426fba1cac6894d7467e75739a02ccf4c9004517d844297c1a5f99f0L108-R126) [[4]](diffhunk://#diff-8803face426fba1cac6894d7467e75739a02ccf4c9004517d844297c1a5f99f0L124-R143) [[5]](diffhunk://#diff-8803face426fba1cac6894d7467e75739a02ccf4c9004517d844297c1a5f99f0L143-R162)

These changes collectively enhance code reliability and maintainability by making type expectations explicit and reducing the risk of runtime errors.