### PR TITLE
[#noissue] Optimize call stack retrieval by reusing record list

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/view/TransactionCallTreeViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/TransactionCallTreeViewModel.java
@@ -121,10 +121,12 @@ public class TransactionCallTreeViewModel {
     @JsonProperty("callStack")
     public List<CallStack> getCallStack() {
 
-        List<CallStack> list = new ArrayList<>();
+        List<Record> recordList = recordSet.getRecordList();
+
+        List<CallStack> list = new ArrayList<>(recordList.size());
         boolean first = true;
         long barRatio = 0;
-        for (Record record : recordSet.getRecordList()) {
+        for (Record record : recordList) {
             if (first) {
                 if (record.isMethod()) {
                     long begin = record.getBegin();


### PR DESCRIPTION
This pull request makes a minor optimization to the `getCallStack()` method in `TransactionCallTreeViewModel.java`. The change improves memory usage when creating the `list` by pre-sizing the `ArrayList` based on the number of records.

* Pre-sized the `ArrayList` in `getCallStack()` using the size of `recordList` to optimize memory allocation.