### PR TITLE
[#noissue] Refactor TraceViewerDataViewModel to use MutableIntIntMap and MutableStack for improved performance and clarity

### DIFF
--- a/web/src/test/java/com/navercorp/pinpoint/web/view/TraceViewerDataViewModelTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/view/TraceViewerDataViewModelTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.view;
+
+import com.navercorp.pinpoint.web.vo.callstacks.Record;
+import org.eclipse.collections.api.factory.Stacks;
+import org.eclipse.collections.api.stack.MutableStack;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Stack;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TraceViewerDataViewModelTest {
+
+    @Test
+    @Disabled
+    void stack() {
+        Stack<Record> stack = new Stack<>();
+
+        stack.push(newRecord(1));
+        stack.push(newRecord(2));
+        stack.push(newRecord(3));
+        stack.push(newRecord(4));
+        stack.push(newRecord(5));
+
+        int index = indexOf(stack, 2);
+
+        Assertions.assertEquals(3, index);
+        Assertions.assertEquals(2, stack.size());
+    }
+
+    @Test
+    void mutableStack_pop() {
+        MutableStack<Record> stack = Stacks.mutable.of();
+
+        stack.push(newRecord(1));
+        stack.push(newRecord(2));
+        stack.push(newRecord(3));
+        stack.push(newRecord(4));
+        stack.push(newRecord(5));
+
+        int index = TraceViewerDataViewModel.pop(stack, 2);
+
+        Assertions.assertEquals(3, index);
+        Assertions.assertEquals(2, stack.size());
+
+    }
+
+    @Test
+    void mutableStack_pop_notfound() {
+        MutableStack<Record> stack = Stacks.mutable.of();
+
+        stack.push(newRecord(1));
+        stack.push(newRecord(2));
+
+        int index = TraceViewerDataViewModel.pop(stack, 10);
+
+        Assertions.assertEquals(-1, index);
+        Assertions.assertEquals(2, stack.size());
+
+    }
+
+    private Record newRecord(int id) {
+        Record r = mock(Record.class);
+        when(r.getId()).thenReturn(id);
+        return r;
+    }
+
+
+    static int indexOf(Stack<Record> recordTrace, int id) {
+        int index = 0;
+        for (int i = recordTrace.size() - 1; i >= 0 ; i--) {
+            Record record = recordTrace.get(i);
+            if (record.getId() == id) {
+                recordTrace.setSize(i + 1);
+                return index;
+            }
+            index++;
+        }
+        return -1;
+    }
+
+}


### PR DESCRIPTION
This pull request refactors the `TraceViewerDataViewModel` class to improve stack management and invisible record handling in the trace viewer logic. The changes replace usage of Java's standard `Stack` and `IntObjectMap` with Eclipse Collections' `MutableStack` and `MutableIntIntMap`, introduce new utility methods for stack operations, and clean up the logic for managing invisible records and parent-child relationships. Additionally, new unit tests are added for the stack manipulation methods.

**Stack management and data structure improvements:**

* Replaced usages of Java's `Stack` with Eclipse Collections' `MutableStack` throughout `TraceViewerDataViewModel`, updating method signatures and stack operations accordingly. (`[[1]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L22-R44)`, `[[2]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L80-R94)`, `[[3]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L172-R178)`, `[[4]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L185-R193)`, `[[5]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L206-R264)`)
* Replaced `MutableIntObjectMap<Integer>` with `MutableIntIntMap` for `invisibleRecords`, simplifying the code and removing unnecessary boxing. (`[[1]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L22-R44)`, `[[2]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L49-R53)`)

**Invisible record and parent ID logic refactoring:**

* Refactored invisible record logic to use primitive int constants (`ID_NOT_EXIST`, `NOT_FOUND`) and streamlined parent ID resolution with new helper methods (`getParentId`, `findAncestorId`). (`[[1]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L130-R154)`, `[[2]](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L206-R264)`)
* Improved parent stack continuation and update logic to work with the new stack and map types. (`[web/src/main/java/com/navercorp/pinpoint/web/view/TraceViewerDataViewModel.javaL206-R264](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L206-R264)`)

**Utility methods for stack operations:**

* Added static utility methods `pop` and `indexOf` to efficiently find and remove records from a `MutableStack` by ID. (`[web/src/main/java/com/navercorp/pinpoint/web/view/TraceViewerDataViewModel.javaL206-R264](diffhunk://#diff-85ab9b456017c749407bdb313f3a56f4ee16a8991d62f620170460d99fb0d3b4L206-R264)`)

**Testing enhancements:**

* Added `TraceViewerDataViewModelTest` with unit tests for the new stack manipulation methods, including edge cases for popping elements and handling not-found scenarios. (`[web/src/test/java/com/navercorp/pinpoint/web/view/TraceViewerDataViewModelTest.javaR1-R101](diffhunk://#diff-5fcef866ab78796b2a4ce53bde96647d11448d4b270ae04ca32d8d43484237ffR1-R101)`)