### PR TITLE
[#noissue] Apply MutableStack for improved performance and consistency

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/query/util/DefaultMongoJsonParser.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/query/util/DefaultMongoJsonParser.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,11 +18,12 @@ package com.navercorp.pinpoint.web.query.util;
 
 import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.common.util.StringUtils;
+import org.eclipse.collections.api.factory.Stacks;
+import org.eclipse.collections.api.stack.MutableStack;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
-import java.util.Stack;
 
 /**
  * @author Roy Kim
@@ -70,7 +71,7 @@ public class DefaultMongoJsonParser implements MongoJsonParser {
         final int length = json.length();
         final StringBuilder result = new StringBuilder(length + additionalSize);
 
-        Stack<Character> stack = new Stack<>();
+        MutableStack<Character> stack = Stacks.mutable.of();
 
         boolean statusKey = true;
         boolean inString = false;
@@ -88,9 +89,9 @@ public class DefaultMongoJsonParser implements MongoJsonParser {
                 } else if (ch == '{') {
                     statusKey = true;
                     stack.push(ch);
-                } else if (ch == '}' && !stack.empty()) {
+                } else if (ch == '}' && !stack.isEmpty()) {
                     stack.pop();
-                    if (!stack.empty()){
+                    if (!stack.isEmpty()){
                         if(stack.peek() != '[') {
                             statusKey = true;
                         } else if(stack.peek() == '[') {
@@ -99,9 +100,9 @@ public class DefaultMongoJsonParser implements MongoJsonParser {
                     }
                 } else if (ch == '[') {
                     stack.push(ch);
-                } else if (ch == ']' && !stack.empty()) {
+                } else if (ch == ']' && !stack.isEmpty()) {
                     stack.pop();
-                    if (!stack.empty() && stack.peek() != '[') {
+                    if (!stack.isEmpty() && stack.peek() != '[') {
                         statusKey = true;
                     }
                 }
@@ -111,7 +112,7 @@ public class DefaultMongoJsonParser implements MongoJsonParser {
                     if (!bindValueQueue.isEmpty()) {
                         result.append(bindValueQueue.poll());
                         i += 2;
-                        if (!stack.empty() && stack.peek() != '[') {
+                        if (!stack.isEmpty() && stack.peek() != '[') {
                             statusKey = true;
                         }
                     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/calltree/span/CallTreeFactory.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/calltree/span/CallTreeFactory.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,15 +15,17 @@
  */
 package com.navercorp.pinpoint.web.calltree.span;
 
+import org.eclipse.collections.api.factory.Stacks;
+import org.eclipse.collections.api.stack.MutableStack;
+
 import java.util.List;
-import java.util.Stack;
 
 /**
  * @author jaehong.kim
  */
 public class CallTreeFactory {
 
-    private final Stack<CallStackMock> callStacks = new Stack<CallStackMock>();
+    private final MutableStack<CallStackMock> callStacks = Stacks.mutable.of();
     private int nextAsyncId = 0;
 
     public CallTree get(List<String> events) {
@@ -39,7 +41,7 @@ public class CallTreeFactory {
                 type = EventType.END;
             }
 
-            if (callStacks.empty() && type == EventType.REMOTE) {
+            if (callStacks.isEmpty() && type == EventType.REMOTE) {
                 callStacks.push(new CallStackMock());
                 continue;
             }


### PR DESCRIPTION
This pull request updates the codebase to use Eclipse Collections' `MutableStack` instead of the standard Java `Stack` for stack operations in both main and test code. It also updates copyright years in affected files. The most important changes are grouped below.

**Migration to Eclipse Collections Stack:**

* Replaced usage of `java.util.Stack` with `org.eclipse.collections.api.stack.MutableStack` and initialized stacks using `Stacks.mutable.of()` in both `DefaultMongoJsonParser.java` and `CallTreeFactory.java`. [[1]](diffhunk://#diff-70803f1c0ef6e617270a4fcd756aef0a2e22e4b5447964b1f879f9a747b579cdR21-L25) [[2]](diffhunk://#diff-52ef597f30fdfcfb7341a4757958d45c9f6ed2ed7dd78c074af65b7cd7dc02e0R18-R28)
* Updated stack operation methods from `.empty()` to `.isEmpty()` to match the new stack implementation in all relevant stack usage locations. [[1]](diffhunk://#diff-70803f1c0ef6e617270a4fcd756aef0a2e22e4b5447964b1f879f9a747b579cdL73-R74) [[2]](diffhunk://#diff-70803f1c0ef6e617270a4fcd756aef0a2e22e4b5447964b1f879f9a747b579cdL91-R94) [[3]](diffhunk://#diff-70803f1c0ef6e617270a4fcd756aef0a2e22e4b5447964b1f879f9a747b579cdL102-R105) [[4]](diffhunk://#diff-70803f1c0ef6e617270a4fcd756aef0a2e22e4b5447964b1f879f9a747b579cdL114-R115) [[5]](diffhunk://#diff-52ef597f30fdfcfb7341a4757958d45c9f6ed2ed7dd78c074af65b7cd7dc02e0L42-R44)
* Changed stack field declaration in `CallTreeFactory` from `Stack<CallStackMock>` to `MutableStack<CallStackMock>`.

**Copyright Updates:**

* Updated copyright year to 2025 in `DefaultMongoJsonParser.java` and `CallTreeFactory.java`. [[1]](diffhunk://#diff-70803f1c0ef6e617270a4fcd756aef0a2e22e4b5447964b1f879f9a747b579cdL2-R2) [[2]](diffhunk://#diff-52ef597f30fdfcfb7341a4757958d45c9f6ed2ed7dd78c074af65b7cd7dc02e0L2-R2)