### PR TITLE
[#noissue] Improvements to RowKey in ServerMapV3

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/DistributorConfiguration.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/DistributorConfiguration.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.common.hbase.config;
 
-import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.OneByteSimpleHash;
@@ -94,7 +93,7 @@ public class DistributorConfiguration {
         return new RangeOneByteSimpleHash(start, end, maxBuckets);
     }
 
-    public static final int UID_START_KEY_RANGE = PinpointConstants.APPLICATION_NAME_MAX_LEN_V3 + 4 + 4;
+    public static final int UID_START_KEY_RANGE = 4 + 4 + 4;
     public static final int SECONDARY_BUCKET_SIZE = 4;
 
     /**

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKeyTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKeyTest.java
@@ -99,7 +99,7 @@ class UidLinkRowKeyTest {
 
     @Test
     void makeRow_error() {
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             UidLinkRowKey.makeRowKey(0,
                     ServiceUid.DEFAULT_SERVICE_UID_CODE,
                     "a".repeat(PinpointConstants.APPLICATION_NAME_MAX_LEN_V3 + 1),

--- a/commons/src/main/java/com/navercorp/pinpoint/common/PinpointConstants.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/PinpointConstants.java
@@ -27,7 +27,7 @@ public final class PinpointConstants {
 
     public static final int AGENT_NAME_MAX_LEN = 255;
 
-    public static final int SERVICE_NAME_MAX_LEN = 127;
+    public static final int SERVICE_NAME_MAX_LEN = 254;
     public static final int APPLICATION_NAME_MAX_LEN_V3 = SERVICE_NAME_MAX_LEN;
 
     public static final int AGENT_NAME_MAX_LEN_V4 = APPLICATION_NAME_MAX_LEN_V3;

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapV3MapperConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapV3MapperConfiguration.java
@@ -52,6 +52,7 @@ import com.navercorp.pinpoint.web.applicationmap.dao.mapper.LinkRowKeyDecoder;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.ResultExtractorFactory;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.RowMapperFactory;
 import com.navercorp.pinpoint.web.applicationmap.dao.v3.ApplicationResponseTimeV3ResultExtractor;
+import com.navercorp.pinpoint.web.applicationmap.dao.v3.HostApplicationMapperV3;
 import com.navercorp.pinpoint.web.applicationmap.dao.v3.HostScanKeyFactoryV3;
 import com.navercorp.pinpoint.web.applicationmap.dao.v3.InLinkV3Mapper;
 import com.navercorp.pinpoint.web.applicationmap.dao.v3.MapScanKeyFactoryV3;
@@ -194,9 +195,14 @@ public class MapV3MapperConfiguration {
     }
 
     @Bean
+    public ResultsExtractor<Set<AcceptApplication>> hostApplicationResultExtractorV3(ApplicationFactory applicationFactory) {
+        return new HostApplicationMapperV3(applicationFactory);
+    }
+
+    @Bean
     public HostApplicationMapDao hostApplicationMapDao(HbaseOperations hbaseOperations,
                                                        TableNameProvider tableNameProvider,
-                                                       @Qualifier("hostApplicationResultExtractor")
+                                                       @Qualifier("hostApplicationResultExtractorV3")
                                                        ResultsExtractor<Set<AcceptApplication>> hostApplicationResultExtractor,
                                                        TimeSlot timeSlot,
                                                        @Qualifier("acceptApplicationRowKeyDistributor")

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostApplicationMapperV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostApplicationMapperV3.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.dao.v3;
+
+import com.navercorp.pinpoint.common.buffer.Buffer;
+import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
+import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
+import com.navercorp.pinpoint.web.applicationmap.map.AcceptApplication;
+import com.navercorp.pinpoint.web.component.ApplicationFactory;
+import com.navercorp.pinpoint.web.vo.Application;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * 
+ * @author netspider
+ * 
+ */
+@Component
+public class HostApplicationMapperV3 implements ResultsExtractor<Set<AcceptApplication>> {
+
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    private final ApplicationFactory applicationFactory;
+
+    public HostApplicationMapperV3(ApplicationFactory applicationFactory) {
+        this.applicationFactory = Objects.requireNonNull(applicationFactory, "applicationFactory");
+    }
+
+    @Override
+    public Set<AcceptApplication> extractData(ResultScanner results) throws Exception {
+        Set<AcceptApplication> applicationSet = new HashSet<>(16);
+        for (Result result : results) {
+            mapRow(result, applicationSet);
+        }
+        return applicationSet;
+    }
+
+
+    private void mapRow(Result result, Set<AcceptApplication> acceptApplicationSet) throws Exception {
+        if (result.isEmpty()) {
+            return;
+        }
+        for (Cell cell : result.rawCells()) {
+            AcceptApplication acceptedApplication = createAcceptedApplication(cell);
+            acceptApplicationSet.add(acceptedApplication);
+        }
+    }
+
+    private AcceptApplication createAcceptedApplication(Cell cell) {
+        Buffer reader = new OffsetFixedBuffer(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
+        String host = reader.readPrefixedString();
+        String bindApplicationName = reader.readPrefixedString();
+        int bindServiceTypeCode = reader.readInt();
+        // skip
+//        int serviceCode = reader.readInt();
+
+        final Application bindApplication = applicationFactory.createApplication(bindApplicationName, bindServiceTypeCode);
+        return new AcceptApplication(host, bindApplication);
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostScanKeyFactoryV3.java
@@ -16,28 +16,18 @@
 
 package com.navercorp.pinpoint.web.applicationmap.dao.v3;
 
-import com.navercorp.pinpoint.common.PinpointConstants;
+import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRowKey;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.HostScanKeyFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 
 public class HostScanKeyFactoryV3 implements HostScanKeyFactory {
-
-    private final int applicationNameMaxLength = PinpointConstants.APPLICATION_NAME_MAX_LEN_V3;
+    private static final int saltKeySize = ByteSaltKey.NONE.size();
 
     @Override
     public byte[] scanKey(Application parentApplication, long timestamp) {
-//        Buffer buffer = new AutomaticBuffer();
-//        buffer.putPadString(parentApplication.getName(), applicationNameMaxLength);
-//        buffer.putInt(parentApplication.getServiceTypeCode());
-//        buffer.putInt(ServiceUid.DEFAULT_SERVICE_UID_CODE);
-//        long reverseTimestamp = LongInverter.invert(timestamp);
-//        buffer.putLong(reverseTimestamp);
-//        return buffer.getBuffer();
-
-
-        return UidLinkRowKey.makeRowKey(0, ServiceUid.DEFAULT_SERVICE_UID_CODE,
+        return UidLinkRowKey.makeRowKey(saltKeySize, ServiceUid.DEFAULT_SERVICE_UID_CODE,
                 parentApplication.getName(), parentApplication.getServiceTypeCode(),
                 timestamp);
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapScanKeyFactoryV3.java
@@ -22,8 +22,10 @@ import com.navercorp.pinpoint.web.applicationmap.dao.hbase.MapScanKeyFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 
 public class MapScanKeyFactoryV3 implements MapScanKeyFactory {
+    private static final int saltKeySize = ByteSaltKey.NONE.size();
+
     public byte[] scanKey(int serviceUid, Application application, long timestamp) {
-        return UidLinkRowKey.makeRowKey(ByteSaltKey.NONE.size(), serviceUid,
+        return UidLinkRowKey.makeRowKey(saltKeySize, serviceUid,
                 application.getName(),
                 application.getServiceTypeCode(), timestamp);
     }


### PR DESCRIPTION
This pull request refactors the construction and usage of row keys for UID links, primarily to improve efficiency and correctness in handling application names and related metadata. The most significant changes involve updating the row key format to use a hash of the application name, enforcing stricter validation on application name lengths, and aligning key generation logic across modules.

### Row Key Format and Construction

* Changed the row key format in `UidLinkRowKey` to use a 4-byte hash of the application name instead of a padded string, followed by service UID, service type, timestamp, and the raw application name bytes. This reduces key size and improves lookup efficiency. [[1]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fL75-R93) [[2]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fR103-R154)
* Updated the logic for reading row keys to accommodate the new format, correctly extracting the application name and other fields.

### Validation and Constants

* Enforced a strict check on application name length in `UidLinkRowKey` and `makeRowKey`, throwing an `IllegalArgumentException` if the name exceeds the maximum allowed length. [[1]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fL34-R73) [[2]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fR103-R154) [[3]](diffhunk://#diff-ae9bae7d5005493c42ce29b72ab213d0af73884b0e2cd2fee69745b9c19f8a2cL102-R102)
* Increased `SERVICE_NAME_MAX_LEN` from 127 to 254 in `PinpointConstants` to support longer application names.

### Key Generation Consistency

* Updated `HostScanKeyFactoryV3` and `MapScanKeyFactoryV3` to use a consistent salt key size from `ByteSaltKey.NONE`, ensuring uniformity in key generation across modules. [[1]](diffhunk://#diff-d4e267b3cbbf69c9524647140d4459c5f22c88d40ef84299d8d89944bbefa904L19-R30) [[2]](diffhunk://#diff-1145bfdad888a64f5ae805ab8e27461a51656e47bff8accd9a2e32d126394cdaR25-R28)

### Miscellaneous Cleanup

* Removed unused imports and adjusted internal constants to reflect the new row key format and application name handling. [[1]](diffhunk://#diff-8257546c7fea389513ad28695f6762c33f44b3fea71297c68d774f5211cfc20aL19) [[2]](diffhunk://#diff-8257546c7fea389513ad28695f6762c33f44b3fea71297c68d774f5211cfc20aL97-R96)