### PR TITLE
[#13103] Add EclipseCollectionsModule support to Jackson configuration

### DIFF
--- a/commons-server/pom.xml
+++ b/commons-server/pom.xml
@@ -83,6 +83,18 @@
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-eclipse-collections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/CommonsServerConfiguration.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/CommonsServerConfiguration.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.server;
 
+import com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule;
 import com.navercorp.pinpoint.common.server.util.AgentEventMessageDeserializerV1;
 import com.navercorp.pinpoint.common.server.util.AgentEventMessageSerializerV1;
 import com.navercorp.pinpoint.common.timeseries.window.DefaultTimeSlot;
@@ -25,5 +42,10 @@ public class CommonsServerConfiguration {
     @Bean
     public TimeSlot timeSlot() {
         return new DefaultTimeSlot();
+    }
+
+    @Bean
+    public com.fasterxml.jackson.databind.Module eclipseCollectionsModule() {
+        return new EclipseCollectionsModule();
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/json/Jackson.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/json/Jackson.java
@@ -20,6 +20,7 @@ package com.navercorp.pinpoint.common.server.util.json;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 public final class Jackson {
@@ -40,6 +41,7 @@ public final class Jackson {
                 SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
                 SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS
         );
+        builder.modulesToInstall(new EclipseCollectionsModule());
         return builder;
     }
 


### PR DESCRIPTION
This pull request adds support for Eclipse Collections to the server's JSON serialization and deserialization infrastructure. The main changes include updating dependencies, registering the necessary Jackson module, and ensuring the module is installed in the object mapper builder.

**Dependency updates:**

* Added `jackson-datatype-eclipse-collections`, `eclipse-collections-api`, and `eclipse-collections` dependencies to `commons-server/pom.xml` to enable serialization support for Eclipse Collections.

**Jackson module integration:**

* Registered the `EclipseCollectionsModule` as a Spring bean in `CommonsServerConfiguration.java` to make it available for Jackson configuration.
* Imported `EclipseCollectionsModule` in both `CommonsServerConfiguration.java` and `Jackson.java` to support usage throughout the codebase. [[1]](diffhunk://#diff-d0da5ef3781a8c33e6cab3e45b53f8e43395671652fb8c30fa0d50fe8b052e93R1-R19) [[2]](diffhunk://#diff-9179911bc39537fd48120938eced3b31c8f065599e8ce0191f5d5019bfe86f75R23)
* Configured the `Jackson2ObjectMapperBuilder` to install the `EclipseCollectionsModule` in `Jackson.java`, ensuring that Eclipse Collections types are properly handled during serialization and deserialization.