### PR TITLE
[#noissue] Enhance UidLinkRowKey to read unsigned byte-prefixed appli…

### DIFF
--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/AutomaticBuffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/AutomaticBuffer.java
@@ -95,7 +95,7 @@ public class AutomaticBuffer extends FixedBuffer {
                 throw new IndexOutOfBoundsException("too large bytes length:" + bytes.length);
             }
             checkExpand(bytes.length + 1);
-            super.putByte(ByteArrayUtils.toUnsignedByte(bytes.length));
+            super.putByte(BytesUtils.toUnsignedByte(bytes.length));
             super.putBytes(bytes);
         }
     }

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/Buffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/Buffer.java
@@ -16,6 +16,8 @@
 
 package com.navercorp.pinpoint.common.buffer;
 
+import com.navercorp.pinpoint.common.util.BytesUtils;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -28,8 +30,8 @@ public interface Buffer {
     int NULL = -1;
 
     byte BYTE_NULL = NULL;
-    int UNSIGNED_BYTE_NULL = 255;
-    int UNSIGNED_BYTE_MAX = 254;
+    int UNSIGNED_BYTE_NULL = BytesUtils.UNSIGNED_BYTE_MAX;
+    int UNSIGNED_BYTE_MAX = UNSIGNED_BYTE_NULL - 1;
 
     int BOOLEAN_FALSE = 0;
     int BOOLEAN_TRUE = 1;

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtils.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtils.java
@@ -115,17 +115,4 @@ public final class ByteArrayUtils {
         return Arrays.compare(bytes1, offset, bytes1.length, bytes2, offset, bytes2.length);
     }
 
-
-    public static final int UNSIGNED_BYTE_MIN_VALUE = 0;
-    public static final int UNSIGNED_BYTE_MAX_VALUE = 255;
-
-    /**
-     * Range : 0 ~ 255
-     */
-    public static byte toUnsignedByte(int value) {
-        if (value < UNSIGNED_BYTE_MIN_VALUE || value > UNSIGNED_BYTE_MAX_VALUE) {
-            throw new IllegalArgumentException("UnsignedByte Out of Range (0~255)");
-        }
-        return (byte) (value & 0xff);
-    }
 }

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java
@@ -135,7 +135,7 @@ public class FixedBuffer implements Buffer {
             if (bytes.length > UNSIGNED_BYTE_MAX) {
                 throw new IndexOutOfBoundsException("too large bytes length:" + bytes.length);
             }
-            putByte(ByteArrayUtils.toUnsignedByte(bytes.length));
+            putByte(BytesUtils.toUnsignedByte(bytes.length));
             putBytes(bytes);
         }
     }

--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/util/BytesUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,8 +34,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class BytesUtilsTest {
     private final Logger logger = LogManager.getLogger(this.getClass());
-
-
 
 
     @Test
@@ -539,5 +537,21 @@ public class BytesUtilsTest {
         byte[] result = BytesUtils.add(prefix, longBytes);
         Assertions.assertEquals(prefix, result[0]);
         Assertions.assertArrayEquals(longBytes, Arrays.copyOfRange(result, 1, result.length));
+    }
+
+    @Test
+    public void writeUnsignedByte() {
+        byte[] bytes = new byte[1];
+        BytesUtils.writeUnsignedByte(10, bytes, 0);
+        int i = BytesUtils.bytesToUnsignedInt(bytes, 0);
+        Assertions.assertEquals(10, i);
+    }
+
+    @Test
+    public void writeUnsignedByte_128over() {
+        byte[] bytes = new byte[1];
+        BytesUtils.writeUnsignedByte(254, bytes, 0);
+        int i = BytesUtils.bytesToUnsignedInt(bytes, 0);
+        Assertions.assertEquals(254, i);
     }
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKeyTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKeyTest.java
@@ -47,6 +47,7 @@ class UidLinkRowKeyTest {
 
         UidLinkRowKey read = UidLinkRowKey.read(1, rowKeyBytes);
 
+
         Assertions.assertEquals(rowKey, read);
     }
 
@@ -106,5 +107,17 @@ class UidLinkRowKeyTest {
                     ServiceType.STAND_ALONE.getCode(),
                     1000);
         });
+    }
+
+    @Test
+    void makeRow_254() {
+        byte[] bytes = UidLinkRowKey.makeRowKey(0,
+                ServiceUid.DEFAULT_SERVICE_UID_CODE,
+                "a".repeat(PinpointConstants.APPLICATION_NAME_MAX_LEN_V3),
+                ServiceType.STAND_ALONE.getCode(),
+                1000);
+
+        UidLinkRowKey rowKey = UidLinkRowKey.read(0, bytes);
+        Assertions.assertEquals(PinpointConstants.APPLICATION_NAME_MAX_LEN_V3, rowKey.getApplicationName().length());
     }
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java
@@ -34,6 +34,9 @@ public final class BytesUtils {
     public static final int VLONG_MAX_SIZE = 10;
     public static final int VINT_MAX_SIZE = 5;
 
+    public static final int UNSIGNED_BYTE_MIN = 0;
+    public static final int UNSIGNED_BYTE_MAX = 255;
+
     private static final byte[] EMPTY_BYTES = new byte[0];
 
     private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
@@ -96,6 +99,10 @@ public final class BytesUtils {
                 | ((buf[offset + 3] & 0xff));
 
         return v;
+    }
+
+    public static int bytesToUnsignedInt(final byte[] buf, final int offset) {
+        return buf[offset] & 0xff;
     }
 
     public static short bytesToShort(final byte[] buf, final int offset) {
@@ -266,6 +273,15 @@ public final class BytesUtils {
         return offset;
     }
 
+    public static int writeUnsignedByte(final int value, final byte[] buf, int offset) {
+        if (buf == null) {
+            throw new NullPointerException("buf");
+        }
+        checkBounds(buf, offset, BYTE_LENGTH);
+
+        buf[offset++] = toUnsignedByte(value);
+        return offset;
+    }
 
     public static int writeShort(final short value, final byte[] buf, int offset) {
         if (buf == null) {
@@ -507,6 +523,16 @@ public final class BytesUtils {
         System.arraycopy(b1, 0, b, 0, b1.length);
 
         return b;
+    }
+
+    /**
+     * Range : 0 ~ 255
+     */
+    public static byte toUnsignedByte(int value) {
+        if (value < UNSIGNED_BYTE_MIN || value > UNSIGNED_BYTE_MAX) {
+            throw new IllegalArgumentException("UnsignedByte Out of Range (0~255)");
+        }
+        return (byte) (value & 0xff);
     }
 
 


### PR DESCRIPTION
…cation name and add nullable handling

This pull request updates the row key encoding and decoding logic for `UidLinkRowKey` to improve how application names are serialized and deserialized. The main change is switching from a plain byte array for the application name to an unsigned byte-prefixed format, which allows for more robust handling of variable-length and nullable strings.

**Row key serialization improvements:**

* Changed the application name encoding in `makeRowKey` to use `putUnsignedBytePrefixedBytes`, ensuring the length is explicitly stored and supporting nullable values.
* Updated the decoding logic in `read` to use a new helper method `readUnsignedString`, which reads the length prefix and handles null values correctly.
* Added the `readUnsignedString` helper method to handle unsigned byte-prefixed string decoding, including null checks.

**General code improvements:**

* Added `org.jspecify.annotations.Nullable` import to support nullable type annotations in the new method.