### PR TITLE
[#13145] Bug fix for Pinpoint Agent logger initialization

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/DefaultAgent.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/DefaultAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,11 +87,13 @@ public class DefaultAgent implements Agent {
         ObjectName objectName = buildObjectName();
 
         // save system config
-        saveSystemConfig(objectName);
+        AgentSystemConfig agentSystemConfig = agentSystemConfig(objectName);
         this.loggingSystem = newLoggingSystem(logConfigPath);
         this.loggingSystem.start();
 
         logger = LogManager.getLogger(this.getClass());
+        logger.info("Pinpoint agentId:{}, version:{}", agentSystemConfig.getAgentId(), agentSystemConfig.getVersion());
+
 
         logger.info("logConfig path:{}", loggingSystem.getConfigLocation());
 
@@ -123,11 +125,10 @@ public class DefaultAgent implements Agent {
         return AgentContextOptionBuilder.build(agentOption, objectName, profilerConfig);
     }
 
-    private void saveSystemConfig(ObjectName objectName) {
-        // set the path of log file as a system property
-        AgentSystemConfig agentSystemConfig = new AgentSystemConfig();
-        agentSystemConfig.saveAgentIdForLog(objectName.getAgentId());
-        agentSystemConfig.savePinpointVersion(Version.VERSION);
+    private AgentSystemConfig agentSystemConfig(ObjectName objectName) {
+        AgentSystemConfig agentSystemConfig = new AgentSystemConfig(objectName.getAgentId(), Version.VERSION);
+        agentSystemConfig.dump(System.getProperties());
+        return agentSystemConfig;
     }
 
     private void dumpAgentOption(AgentContextOption agentOption) {

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/config/AgentSystemConfig.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/config/AgentSystemConfig.java
@@ -1,32 +1,48 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.profiler.config;
 
 import com.navercorp.pinpoint.profiler.name.IdSourceType;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.Objects;
 import java.util.Properties;
 
 public class AgentSystemConfig {
-    private final Logger logger = LogManager.getLogger(getClass());
 
-    private final Properties systemProperty;
+    private final String agentId;
+    private final String version;
 
-    public AgentSystemConfig() {
-        this(System.getProperties());
+    public AgentSystemConfig(String agentId, String version) {
+        this.agentId = agentId;
+        this.version = version;
     }
 
-    AgentSystemConfig(Properties properties) {
-        this.systemProperty = Objects.requireNonNull(properties, "properties");
+
+    public void dump(Properties properties) {
+        Objects.requireNonNull(properties, "properties");
+        properties.setProperty(IdSourceType.SYSTEM.getAgentId(), agentId);
+        properties.setProperty("pinpoint.version", version);
     }
 
-    public void saveAgentIdForLog(String agentId) {
-        systemProperty.setProperty(IdSourceType.SYSTEM.getAgentId(), agentId);
+    public String getAgentId() {
+        return agentId;
     }
 
-    public void savePinpointVersion(String version) {
-        logger.info("pinpoint version:{}", version);
-        systemProperty.setProperty("pinpoint.version", version);
+    public String getVersion() {
+        return version;
     }
-
 }


### PR DESCRIPTION
This pull request refactors how agent system configuration is handled during agent initialization. The main focus is on improving the management and logging of agent information, such as agent ID and version, and simplifying the `AgentSystemConfig` class. Below are the most important changes grouped by theme:

**Agent Initialization and Logging Improvements**
* The agent now logs both the agent ID and version at startup using the newly created `AgentSystemConfig` object, improving traceability and diagnostics.

**Agent System Configuration Refactoring**
* The method for saving system configuration in `DefaultAgent` has been refactored to return an `AgentSystemConfig` object, which sets agent ID and version as system properties and provides getter methods for these values. [[1]](diffhunk://#diff-7dc4c443834bafa9a4afe9db5df30063d71456467233ce9b9b2ff8f44abd75f0L126-R132) [[2]](diffhunk://#diff-ab368b45d221b4f45da7067481e820530dc3f6bcb156f60b7df14996d6bab076R1-R45)
* The `AgentSystemConfig` class has been simplified: it now takes agent ID and version as constructor parameters, removes unnecessary logging and property management, and introduces a `dump` method for setting system properties.

**Copyright Update**
* The copyright year in affected files has been updated to 2025. [[1]](diffhunk://#diff-7dc4c443834bafa9a4afe9db5df30063d71456467233ce9b9b2ff8f44abd75f0L2-R2) [[2]](diffhunk://#diff-ab368b45d221b4f45da7067481e820530dc3f6bcb156f60b7df14996d6bab076R1-R45)