### PR TITLE
[#noissue] Extract ServerTime module

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/PinpointWebModule.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/PinpointWebModule.java
@@ -34,6 +34,7 @@ import com.navercorp.pinpoint.web.install.InstallModule;
 import com.navercorp.pinpoint.web.problem.ProblemSpringWebConfig;
 import com.navercorp.pinpoint.web.query.QueryServiceConfiguration;
 import com.navercorp.pinpoint.web.realtime.RealtimeConfig;
+import com.navercorp.pinpoint.web.servertime.ServerTimeConfiguration;
 import com.navercorp.pinpoint.web.uid.WebUidConfiguration;
 import com.navercorp.pinpoint.web.webhook.WebhookFacadeModule;
 import org.springframework.context.annotation.Bean;
@@ -59,6 +60,7 @@ import org.springframework.core.env.StandardEnvironment;
 
         CacheConfiguration.class,
 
+        ServerTimeConfiguration.class,
         ApplicationMapModule.class,
         WebHbaseModule.class,
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,12 +18,11 @@ package com.navercorp.pinpoint.web.controller;
 
 import com.navercorp.pinpoint.web.service.CacheService;
 import com.navercorp.pinpoint.web.service.CommonService;
+import com.navercorp.pinpoint.web.util.TagApplicationsUtils;
 import com.navercorp.pinpoint.web.util.etag.ETag;
 import com.navercorp.pinpoint.web.util.etag.ETagUtils;
-import com.navercorp.pinpoint.web.util.TagApplicationsUtils;
 import com.navercorp.pinpoint.web.validation.NullOrNotBlank;
 import com.navercorp.pinpoint.web.view.ApplicationGroup;
-import com.navercorp.pinpoint.web.view.ServerTime;
 import com.navercorp.pinpoint.web.view.TagApplications;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.logging.log4j.LogManager;
@@ -123,11 +122,6 @@ public class MainController {
 
     private static boolean needClearCache(ETag eTag, String clearCache) {
         return eTag == null || clearCache != null;
-    }
-
-    @GetMapping(value = {"/api/serverTime", "/api-public/serverTime"})
-    public ServerTime getServerTime() {
-        return new ServerTime();
     }
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/servertime/ServerTimeConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/servertime/ServerTimeConfiguration.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,23 +14,13 @@
  * limitations under the License.
  */
 
-package com.navercorp.pinpoint.web.view;
+package com.navercorp.pinpoint.web.servertime;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 
-/**
- * @author emeroad
- */
-public class ServerTime {
+@ComponentScan(basePackages = "com.navercorp.pinpoint.web.controller")
+@Configuration
+public class ServerTimeConfiguration {
 
-    private final long currentServerTime;
-
-    public ServerTime() {
-        this.currentServerTime = System.currentTimeMillis();
-    }
-
-    @JsonProperty("currentServerTime")
-    public long getCurrentServerTime() {
-        return currentServerTime;
-    }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/servertime/controller/ServerTimeController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/servertime/controller/ServerTimeController.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.servertime.controller;
+
+import com.navercorp.pinpoint.web.servertime.view.ServerTime;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+public class ServerTimeController {
+
+    @GetMapping(value = {"/api/serverTime", "/api-public/serverTime"})
+    public ServerTime getServerTime() {
+        return new ServerTime();
+    }
+
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/servertime/view/ServerTime.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/servertime/view/ServerTime.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.servertime.view;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author emeroad
+ */
+public class ServerTime {
+
+    private final long currentServerTime;
+
+    public ServerTime() {
+        this.currentServerTime = System.currentTimeMillis();
+    }
+
+    @JsonProperty("currentServerTime")
+    public long getCurrentServerTime() {
+        return currentServerTime;
+    }
+}


### PR DESCRIPTION
This pull request refactors how server time is provided by moving its implementation to a dedicated module. The main controller's responsibility for serving server time is removed, and a new `ServerTimeController` is introduced under a separate package, with its configuration handled via Spring. The `ServerTime` view class is also relocated to align with the new module structure.

**Server time API refactoring:**

* The `/api/serverTime` and `/api-public/serverTime` endpoints are now handled by `ServerTimeController` in the `servertime` module, rather than `MainController`. (`[[1]](diffhunk://#diff-18f5b832a8494b5dcaf3967abd784deba5ea56f5ffe168ecc9c6df6c03bd60f5L128-L132)`, `[[2]](diffhunk://#diff-cf5c1c59881cdb9e3052c4e7a7e81a5c86c8bb536dafe251e5dae4283bb9637fR1-R33)`)
* Added `ServerTimeConfiguration` to provide the new controller as a Spring bean and included it in the main web module's configuration. (`[[1]](diffhunk://#diff-3a0818ef0b9bc64dc2f140183a836f3f9045448ea42be3742adad9237a2d63dbR1-R29)`, `[[2]](diffhunk://#diff-fbef329711c6bb944a1cbbba5c604385c6af2fe4f86783c1e9172b885e0dd009R37)`, `[[3]](diffhunk://#diff-fbef329711c6bb944a1cbbba5c604385c6af2fe4f86783c1e9172b885e0dd009R63)`)

**Code organization improvements:**

* The `ServerTime` view class was moved from `web.view` to `servertime.view`, updating its package and copyright. (`[[1]](diffhunk://#diff-306eb905582e5332a828757d4187375a8f991c5eb4a61594fe4259b295ec4ea5L2-R2)`, `[[2]](diffhunk://#diff-306eb905582e5332a828757d4187375a8f991c5eb4a61594fe4259b295ec4ea5L17-R17)`)
* Imports in `MainController` were updated to remove references to the old location of `ServerTime` and clean up unused imports. (`[web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.javaR21-L26](diffhunk://#diff-18f5b832a8494b5dcaf3967abd784deba5ea56f5ffe168ecc9c6df6c03bd60f5R21-L26)`)

**Copyright updates:**

* Updated copyright years to 2025 in affected files. (`[[1]](diffhunk://#diff-18f5b832a8494b5dcaf3967abd784deba5ea56f5ffe168ecc9c6df6c03bd60f5L2-R2)`, `[[2]](diffhunk://#diff-306eb905582e5332a828757d4187375a8f991c5eb4a61594fe4259b295ec4ea5L2-R2)`, `[[3]](diffhunk://#diff-3a0818ef0b9bc64dc2f140183a836f3f9045448ea42be3742adad9237a2d63dbR1-R29)`, `[[4]](diffhunk://#diff-cf5c1c59881cdb9e3052c4e7a7e81a5c86c8bb536dafe251e5dae4283bb9637fR1-R33)`)