### PR TITLE
[#noissue] Invert serviceType of UidLinkRowKey for distribution

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.java
@@ -116,7 +116,7 @@ public class UidLinkRowKey implements TimestampRowKey {
         buffer.setOffset(saltKeySize);
         buffer.putInt(hash(applicationNameBytes));
         buffer.putInt(serviceUid);
-        buffer.putInt(serviceType);
+        buffer.putInt(IntInverter.invert(serviceType));
 
         int secondTimestamp = SecondTimestamp.convertSecondTimestamp(timestamp);
         int reverseTimeMillis = IntInverter.invert(secondTimestamp);
@@ -141,7 +141,7 @@ public class UidLinkRowKey implements TimestampRowKey {
         buffer.setOffset(offset + BytesUtils.INT_BYTE_LENGTH);
 
         int serviceUid = buffer.readInt(); // serviceUid
-        int serviceType = buffer.readInt(); // serviceUid
+        int serviceType = IntInverter.restore(buffer.readInt()); // serviceType
 
         int secondTimestamp = IntInverter.restore(buffer.readInt());
         offset += BytesUtils.INT_BYTE_LENGTH;


### PR DESCRIPTION
This pull request updates how the `serviceType` field is handled in the `UidLinkRowKey` class to improve consistency and compatibility with inverted integer storage. The main changes involve inverting the `serviceType` value during row key creation and restoring it during reading.

**Row key encoding/decoding improvements:**

* In the `makeRowKey` method of `UidLinkRowKey.java`, the `serviceType` value is now inverted using `IntInverter.invert` before storing it in the buffer, ensuring consistent encoding for row keys.
* In the `read` method of `UidLinkRowKey.java`, the `serviceType` value is restored using `IntInverter.restore` after reading it from the buffer, ensuring correct decoding of the row key.