### PR TITLE
[#13175] Refactor TraceConfiguration for improved structure and component scanning

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/BatchModule.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/BatchModule.java
@@ -34,6 +34,7 @@ import com.navercorp.pinpoint.web.WebHbaseModule;
 import com.navercorp.pinpoint.web.WebServiceConfig;
 import com.navercorp.pinpoint.web.component.config.ComponentConfiguration;
 import com.navercorp.pinpoint.web.hyperlink.HyperLinkConfiguration;
+import com.navercorp.pinpoint.web.trace.TraceConfiguration;
 import com.navercorp.pinpoint.web.uid.WebUidConfiguration;
 import com.navercorp.pinpoint.web.webhook.WebhookModule;
 import org.springframework.beans.factory.annotation.Value;
@@ -67,6 +68,7 @@ import java.util.List;
         AlarmJobModule.class,
 
         WebServiceConfig.CommonConfig.class,
+        TraceConfiguration.TraceServiceConfiguration.class,
         WebUidConfiguration.class,
 
         WebhookModule.class,

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/TraceConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/TraceConfiguration.java
@@ -27,31 +27,38 @@ import org.springframework.context.annotation.Import;
 import java.util.Optional;
 
 @Configuration
-@ComponentScan(
-        basePackages = {
-                "com.navercorp.pinpoint.web.trace.controller",
-                "com.navercorp.pinpoint.web.trace.service",
-
-                "com.navercorp.pinpoint.web.trace.dao.hbase",
-                "com.navercorp.pinpoint.web.trace.dao.mapper",
-        }
-)
 @Import(
         value = {
-                SpanSerializeConfiguration.class,
+                SpanSerializeConfiguration.class
         }
 )
 public class TraceConfiguration {
 
-    @Bean
-    public AnnotationRecordFormatter annotationRecordFormatter(Optional<ProxyRequestTypeRegistryService> proxyRequestTypeRegistryService) {
-        AnnotationRecordFormatter.Builder builder = AnnotationRecordFormatter.newBuilder();
-        builder.addDefaultHandlers();
-
-        if (proxyRequestTypeRegistryService.isPresent()) {
-            builder.addProxyHeaderAnnotationHeader(proxyRequestTypeRegistryService.get());
-        }
-        return builder.build();
+    @Configuration
+    @ComponentScan(basePackages = {
+            "com.navercorp.pinpoint.web.trace.controller",
+    })
+    public static class TraceWebConfiguration {
     }
 
+    @Configuration
+    @ComponentScan(
+            basePackages = {
+                    "com.navercorp.pinpoint.web.trace.service",
+                    "com.navercorp.pinpoint.web.trace.dao.hbase",
+                    "com.navercorp.pinpoint.web.trace.dao.mapper",
+            }
+    )
+    public static class TraceServiceConfiguration {
+        @Bean
+        public AnnotationRecordFormatter annotationRecordFormatter(Optional<ProxyRequestTypeRegistryService> proxyRequestTypeRegistryService) {
+            AnnotationRecordFormatter.Builder builder = AnnotationRecordFormatter.newBuilder();
+            builder.addDefaultHandlers();
+
+            if (proxyRequestTypeRegistryService.isPresent()) {
+                builder.addProxyHeaderAnnotationHeader(proxyRequestTypeRegistryService.get());
+            }
+            return builder.build();
+        }
+    }
 }


### PR DESCRIPTION
This pull request refactors the configuration of trace-related components in the Pinpoint application. The main focus is to modularize the trace configuration by splitting web and service configurations into separate classes and updating their registration in the batch module.

Configuration modularization and registration:

* Introduced a new `TraceConfiguration` class annotated with `@Configuration` and `@Import`, and split its configuration into two static classes: `TraceWebConfiguration` for controller scanning and `TraceServiceConfiguration` for service and DAO scanning.
* Moved the controller package scan from the service configuration into the new `TraceWebConfiguration` class for better separation of concerns.
* Updated the `BatchModule` to import only the `TraceServiceConfiguration` instead of the entire trace configuration, ensuring only necessary beans are loaded in the batch context. [[1]](diffhunk://#diff-cc9b0bf3a067263e10840a784fdb34e49bcbd018ed41bbe42142e3406251d69cR37) [[2]](diffhunk://#diff-cc9b0bf3a067263e10840a784fdb34e49bcbd018ed41bbe42142e3406251d69cR71)