### PR TITLE
[#noissue] Add null check for PluginTestReport in PluginForkedTestUnitTestDescriptor

### DIFF
--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginForkedTestUnitTestDescriptor.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginForkedTestUnitTestDescriptor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -131,23 +131,30 @@ public class PluginForkedTestUnitTestDescriptor extends PluginTestDescriptor {
                     } else if ("executionFinished".equals(event)) {
                         final String reportId = rootUniqueId + "/" + tokens[2];
                         final PluginTestReport report = store.get(reportId, PluginTestReport.class);
-                        report.setOutput(pluginTestOutputList.toArray(new String[0]));
+
+                        String[] output = pluginTestOutputList.toArray(new String[0]);
                         pluginTestOutputList.clear();
                         isAgentOutput = true;
 
-                        final TestExecutionResult.Status status = TestExecutionResult.Status.valueOf(tokens[3]);
-                        if (status == TestExecutionResult.Status.SUCCESSFUL) {
-                            report.setResult(TestExecutionResult.successful());
-                        } else if (status == TestExecutionResult.Status.FAILED) {
-                            List<String> stackTrace = slice(tokens);
-                            Exception exception = toException(tokens[4], tokens[5], stackTrace);
-                            report.setResult(TestExecutionResult.failed(exception));
-                        } else if (status == TestExecutionResult.Status.ABORTED) {
-                            List<String> stackTrace = slice(tokens);
-                            Exception exception = toException(tokens[4], tokens[5], stackTrace);
-                            report.setResult(TestExecutionResult.aborted(exception));
+                        if (report != null) {
+                            report.setOutput(output);
+
+                            final TestExecutionResult.Status status = TestExecutionResult.Status.valueOf(tokens[3]);
+                            if (status == TestExecutionResult.Status.SUCCESSFUL) {
+                                report.setResult(TestExecutionResult.successful());
+                            } else if (status == TestExecutionResult.Status.FAILED) {
+                                List<String> stackTrace = slice(tokens);
+                                Exception exception = toException(tokens[4], tokens[5], stackTrace);
+                                report.setResult(TestExecutionResult.failed(exception));
+                            } else if (status == TestExecutionResult.Status.ABORTED) {
+                                List<String> stackTrace = slice(tokens);
+                                Exception exception = toException(tokens[4], tokens[5], stackTrace);
+                                report.setResult(TestExecutionResult.aborted(exception));
+                            } else {
+                                throw new IllegalStateException("unknown status=" + status);
+                            }
                         } else {
-                            throw new IllegalStateException("unknown status=" + status);
+                            System.out.println("report is null " + reportId + " token:" + Arrays.toString(tokens) + " output:" + Arrays.toString(output));
                         }
                     }
                 } else {


### PR DESCRIPTION
This pull request updates the copyright year and improves the robustness of the test report output handling in the `PluginForkedTestUnitTestDescriptor` class. The main change ensures that the code checks for a `null` report before setting output and logs a message if the report is missing, preventing potential `NullPointerException`s during test execution.

Improvements to test report output handling:

* Added a `null` check for the `report` object before setting its output, preventing exceptions when the report is missing.
* Introduced logging to notify when a report is `null`, including relevant identifiers and output for easier debugging.

General maintenance:

* Updated the copyright year in the file header to 2025.