### PR TITLE
[#noissue] Replace byte-based slot code handling with SlotCode enum

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/ApplicationResponseColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/ApplicationResponseColumnName.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.collector.applicationmap.dao.v3;
 
 import com.navercorp.pinpoint.collector.applicationmap.statistics.ColumnName;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 
 /**
  * @author emeroad
@@ -25,8 +26,8 @@ public class ApplicationResponseColumnName implements ColumnName {
 
     private final byte slotCode;
 
-    public static ColumnName histogram(byte slotCode) {
-        return new ApplicationResponseColumnName(slotCode);
+    public static ColumnName histogram(SlotCode slotCode) {
+        return new ApplicationResponseColumnName(slotCode.code());
     }
 
     public ApplicationResponseColumnName(byte slotCode) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/InLinkV3ColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/InLinkV3ColumnName.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 
 import java.util.Objects;
 
@@ -34,12 +35,12 @@ public class InLinkV3ColumnName implements ColumnName {
     private final String outHost;
     private final byte slotCode;
 
-    public static ColumnName histogram(Vertex selfVertex, String outHost, byte slotCode) {
+    public static ColumnName histogram(Vertex selfVertex, String outHost, SlotCode slotCode) {
         return histogram(selfVertex.applicationName(), selfVertex.serviceType(), outHost, slotCode);
     }
 
-    public static ColumnName histogram(String selfApplicationName, ServiceType selfServiceType, String outHost, byte slotCode) {
-        return new InLinkV3ColumnName(selfApplicationName, selfServiceType.getCode(), outHost, slotCode);
+    public static ColumnName histogram(String selfApplicationName, ServiceType selfServiceType, String outHost, SlotCode slotCode) {
+        return new InLinkV3ColumnName(selfApplicationName, selfServiceType.getCode(), outHost, slotCode.code());
     }
 
     public InLinkV3ColumnName(String selfApplicationName, short selfServiceType, String outHost, byte slotCode) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/OutLinkV3ColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/OutLinkV3ColumnName.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 
 import java.util.Objects;
 
@@ -34,12 +35,12 @@ public class OutLinkV3ColumnName implements ColumnName {
     private final String outSubLink;
     private final byte slotCode;
 
-    public static ColumnName histogram(Vertex outVertex, String outSubLink, byte slotCode) {
+    public static ColumnName histogram(Vertex outVertex, String outSubLink, SlotCode slotCode) {
         return histogram(outVertex.serviceType(), outVertex.applicationName(), outSubLink, slotCode);
     }
 
-    public static ColumnName histogram(ServiceType outServiceType, String inApplicationName, String outSubLink, byte slotCode) {
-        return new OutLinkV3ColumnName(outServiceType.getCode(), inApplicationName, outSubLink, slotCode);
+    public static ColumnName histogram(ServiceType outServiceType, String inApplicationName, String outSubLink, SlotCode slotCode) {
+        return new OutLinkV3ColumnName(outServiceType.getCode(), inApplicationName, outSubLink, slotCode.code());
     }
 
     public OutLinkV3ColumnName(int inServiceType, String inApplicationName, String outSubLink, byte slotCode) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/ResponseV3ColumnName.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/ResponseV3ColumnName.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.collector.applicationmap.dao.v3;
 import com.navercorp.pinpoint.collector.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 
 import java.util.Objects;
@@ -31,8 +32,8 @@ public class ResponseV3ColumnName implements ColumnName {
     private final String agentId;
     private final byte slotCode;
 
-    public static ColumnName histogram(String agentId, byte slotCode) {
-        return new ResponseV3ColumnName(agentId, slotCode);
+    public static ColumnName histogram(String agentId, SlotCode slotCode) {
+        return new ResponseV3ColumnName(agentId, slotCode.code());
     }
 
     public ResponseV3ColumnName(String agentId, byte slotCode) {

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSchemas.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSchemas.java
@@ -16,29 +16,27 @@
 
 package com.navercorp.pinpoint.common.trace;
 
-import com.navercorp.pinpoint.common.util.apache.IntHashMap;
-
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.ERROR;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.F_FAST;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.F_FAST_ERROR;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.F_NORMAL;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.F_NORMAL_ERROR;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.F_SLOW;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.F_SLOW_ERROR;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.F_VERY_SLOW;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.F_VERY_SLOW_ERROR;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.MAX_STAT;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.N_FAST;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.N_FAST_ERROR;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.N_NORMAL;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.N_NORMAL_ERROR;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.N_SLOW;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.N_SLOW_ERROR;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.N_VERY_SLOW;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.N_VERY_SLOW_ERROR;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.PING;
-import static com.navercorp.pinpoint.common.trace.HistogramSchemas.SlotCodes.SUM_STAT;
 import static com.navercorp.pinpoint.common.trace.HistogramSlotGroup.entry;
+import static com.navercorp.pinpoint.common.trace.SlotCode.ERROR;
+import static com.navercorp.pinpoint.common.trace.SlotCode.F_FAST;
+import static com.navercorp.pinpoint.common.trace.SlotCode.F_FAST_ERROR;
+import static com.navercorp.pinpoint.common.trace.SlotCode.F_NORMAL;
+import static com.navercorp.pinpoint.common.trace.SlotCode.F_NORMAL_ERROR;
+import static com.navercorp.pinpoint.common.trace.SlotCode.F_SLOW;
+import static com.navercorp.pinpoint.common.trace.SlotCode.F_SLOW_ERROR;
+import static com.navercorp.pinpoint.common.trace.SlotCode.F_VERY_SLOW;
+import static com.navercorp.pinpoint.common.trace.SlotCode.F_VERY_SLOW_ERROR;
+import static com.navercorp.pinpoint.common.trace.SlotCode.MAX_STAT;
+import static com.navercorp.pinpoint.common.trace.SlotCode.N_FAST;
+import static com.navercorp.pinpoint.common.trace.SlotCode.N_FAST_ERROR;
+import static com.navercorp.pinpoint.common.trace.SlotCode.N_NORMAL;
+import static com.navercorp.pinpoint.common.trace.SlotCode.N_NORMAL_ERROR;
+import static com.navercorp.pinpoint.common.trace.SlotCode.N_SLOW;
+import static com.navercorp.pinpoint.common.trace.SlotCode.N_SLOW_ERROR;
+import static com.navercorp.pinpoint.common.trace.SlotCode.N_VERY_SLOW;
+import static com.navercorp.pinpoint.common.trace.SlotCode.N_VERY_SLOW_ERROR;
+import static com.navercorp.pinpoint.common.trace.SlotCode.PING;
+import static com.navercorp.pinpoint.common.trace.SlotCode.SUM_STAT;
 
 public final class HistogramSchemas {
 
@@ -52,34 +50,6 @@ public final class HistogramSchemas {
     private static final short PING_SLOT_TIME = Short.MAX_VALUE - 1;
     private static final short STAT_SLOT_TIME_TOTAL = Short.MAX_VALUE - 2;
     private static final short STAT_SLOT_TIME_MAX = Short.MAX_VALUE - 3;
-
-    public static class SlotCodes {
-        public static final byte F_FAST = 1;
-        public static final byte F_NORMAL = 2;
-        public static final byte F_SLOW = 3;
-        public static final byte F_VERY_SLOW = 4;
-
-        public static final byte F_FAST_ERROR = -1;
-        public static final byte F_NORMAL_ERROR = -2;
-        public static final byte F_SLOW_ERROR = -3;
-        public static final byte F_VERY_SLOW_ERROR = -4;
-
-        public static final byte N_FAST = 11;
-        public static final byte N_NORMAL = 12;
-        public static final byte N_SLOW = 13;
-        public static final byte N_VERY_SLOW = 14;
-
-        public static final byte N_FAST_ERROR = -11;
-        public static final byte N_NORMAL_ERROR = -12;
-        public static final byte N_SLOW_ERROR = -13;
-        public static final byte N_VERY_SLOW_ERROR = -14;
-
-        @Deprecated
-        public static final byte ERROR =  -128;
-        public static final byte SUM_STAT = 112;
-        public static final byte MAX_STAT = 114;
-        public static final byte PING = 126;
-    }
 
     @Deprecated
     public static final HistogramSlot ERROR_SLOT = new HistogramSlot(ERROR, ERROR_SLOT_TIME, SlotType.ERROR, "Error");
@@ -117,53 +87,5 @@ public final class HistogramSchemas {
                     entry(N_VERY_SLOW_ERROR, -9999, "Slow", SlotType.VERY_SLOW_ERROR)),
             ERROR_SLOT, SUM_STAT_SLOT, MAX_STAT_SLOT, PING_SLOT
     );
-
-    private static final IntHashMap<HistogramSlot> SLOT_MAP = toSlotCodeMap(FAST_SCHEMA, NORMAL_SCHEMA);
-
-
-    private static IntHashMap<HistogramSlot> toSlotCodeMap(HistogramSchema... schemas) {
-        HistogramSlotMapBuilder builder = new HistogramSlotMapBuilder();
-        for (HistogramSchema schema : schemas) {
-            builder.addSchema(schema);
-        }
-        builder.addSlot(SUM_STAT_SLOT);
-        builder.addSlot(MAX_STAT_SLOT);
-        builder.addSlot(PING_SLOT);
-        builder.addSlot(ERROR_SLOT);
-
-        return builder.build();
-    }
-
-    public static HistogramSlot getSlotFromCode(int code) {
-        return SLOT_MAP.get(code);
-    }
-
-    static class HistogramSlotMapBuilder {
-
-        private final IntHashMap<HistogramSlot> map = new IntHashMap<>();
-
-        public HistogramSlotMapBuilder() {
-        }
-
-        public HistogramSlotMapBuilder addSlot(HistogramSlot slot) {
-            HistogramSlot exist = map.put(slot.getSlotCode(), slot);
-            if (exist != null) {
-                throw new IllegalArgumentException("Duplicate slot:" + slot);
-            }
-            return this;
-        }
-
-        public HistogramSlotMapBuilder addSchema(HistogramSchema schema) {
-            addSlot(schema.getFastSlot());
-            addSlot(schema.getNormalSlot());
-            addSlot(schema.getSlowSlot());
-            addSlot(schema.getVerySlowSlot());
-            return this;
-        }
-
-        public IntHashMap<HistogramSlot> build() {
-            return map;
-        }
-    }
 
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSlot.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSlot.java
@@ -23,19 +23,19 @@ import java.util.Objects;
  */
 public class HistogramSlot {
 
-    private final byte slotCode;
+    private final SlotCode slotCode;
     private final short slotTime;
     private final SlotType slotType;
     private final String slotName;
 
-    public HistogramSlot(byte slotCode, short slotTime, SlotType slotType, String slotName) {
-        this.slotCode = slotCode;
+    public HistogramSlot(SlotCode slotCode, short slotTime, SlotType slotType, String slotName) {
+        this.slotCode = Objects.requireNonNull(slotCode, "slotCode");
         this.slotTime = slotTime;
         this.slotType = Objects.requireNonNull(slotType, "slotType");
         this.slotName = Objects.requireNonNull(slotName, "slotName");
     }
 
-    public byte getSlotCode() {
+    public SlotCode getSlotCode() {
         return slotCode;
     }
 

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSlotGroup.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/HistogramSlotGroup.java
@@ -25,7 +25,7 @@ public class HistogramSlotGroup {
     private final HistogramSlot verySlow;
 
 
-    public static HistogramSlot entry(byte code, int slotTime, String slotName, SlotType slotType) {
+    public static HistogramSlot entry(SlotCode code, int slotTime, String slotName, SlotType slotType) {
         return new HistogramSlot(code, (short) slotTime, slotType, slotName);
     }
 

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/SlotCode.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/SlotCode.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.trace;
+
+import com.navercorp.pinpoint.common.util.apache.IntHashMap;
+
+
+public enum SlotCode {
+
+    F_NORMAL(2),
+    F_FAST(1),
+    F_SLOW(3),
+    F_VERY_SLOW(4),
+
+    F_FAST_ERROR(-1),
+    F_NORMAL_ERROR(-2),
+    F_SLOW_ERROR(-3),
+    F_VERY_SLOW_ERROR(-4),
+
+    N_FAST(11),
+    N_NORMAL(12),
+    N_SLOW(13),
+    N_VERY_SLOW(14),
+
+    N_FAST_ERROR(-11),
+    N_NORMAL_ERROR(-12),
+    N_SLOW_ERROR(-13),
+    N_VERY_SLOW_ERROR(-14),
+
+
+    ERROR(-128),
+    SUM_STAT(112),
+    MAX_STAT(114),
+    PING(126);
+
+    private static final IntHashMap<SlotCode> CODE_MAP = mapping();
+
+    private static IntHashMap<SlotCode> mapping() {
+        IntHashMap<SlotCode> map = new IntHashMap<>();
+
+        for (SlotCode slotCode : values()) {
+            final SlotCode exist = map.put(slotCode.code, slotCode);
+            if (exist != null) {
+                throw new IllegalStateException("Duplicate slot code:" + slotCode);
+            }
+        }
+        return map;
+    }
+
+    final byte code;
+
+    SlotCode(int code) {
+        this.code = (byte) code;
+    }
+
+    public byte code() {
+        return code;
+    }
+
+    public static SlotCode valueOf(byte code) {
+        final SlotCode slotCode = CODE_MAP.get(code);
+        if (slotCode == null) {
+            throw new IllegalStateException("Unknown slot code:" + code);
+        }
+        return slotCode;
+    }
+
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/ApplicationResponse.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/ApplicationResponse.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.dao;
 
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -111,7 +112,7 @@ public class ApplicationResponse {
             timeHistogram.addCallCount(slotNumber, count);
         }
 
-        public void addResponseTimeBySlotCode(String agentId, long timeStamp, byte code, long count) {
+        public void addResponseTimeBySlotCode(String agentId, long timeStamp, SlotCode code, long count) {
             this.agentIdMap.add(agentId);
             TimeHistogram timeHistogram = getTimeHistogram(timeStamp);
             timeHistogram.addCallCountByCode(code, count);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/ApplicationResponseTimeV3ResultExtractor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/ApplicationResponseTimeV3ResultExtractor.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRow
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.applicationmap.dao.ApplicationResponse;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -117,7 +118,7 @@ public class ApplicationResponseTimeV3ResultExtractor implements ResultsExtracto
 
         final byte[] qArray = cell.getQualifierArray();
         final int qOffset = cell.getQualifierOffset();
-        final byte slotCode = qArray[qOffset];
+        final SlotCode slotCode = SlotCode.valueOf(qArray[qOffset]);
 
         // agentId should be added as data.
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/InLinkV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/InLinkV3Mapper.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.util.UserNodeUtils;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.LinkFilter;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
@@ -100,7 +101,7 @@ public class InLinkV3Mapper implements RowMapper<LinkDataMap> {
                 continue;
             }
 
-            byte slotCode = buffer.readByte();
+            SlotCode slotCode = SlotCode.valueOf(buffer.readByte());
             long requestCount = CellUtils.valueToLong(cell);
             String selfHost = readOutHost(buffer);
             // There may be no outHost for virtual queue nodes from user-defined entry points.

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/OutLinkV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/OutLinkV3Mapper.java
@@ -25,6 +25,7 @@ import com.navercorp.pinpoint.common.server.applicationmap.statistics.TimestampR
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRowKey;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.LinkFilter;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.component.ApplicationFactory;
@@ -90,7 +91,7 @@ public class OutLinkV3Mapper implements RowMapper<LinkDataMap> {
                 continue;
             }
 
-            byte slotCode = buffer.readByte();
+            SlotCode slotCode = SlotCode.valueOf(buffer.readByte());
             String outSubLink = buffer.readPrefixedString();
 
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/ResponseTimeV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/ResponseTimeV3Mapper.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRow
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
@@ -89,7 +90,7 @@ public class ResponseTimeV3Mapper implements RowMapper<ResponseTime> {
 
         final byte[] qArray = cell.getQualifierArray();
         final int qOffset = cell.getQualifierOffset();
-        byte slotCode = qArray[qOffset];
+        SlotCode slotCode = SlotCode.valueOf(qArray[qOffset]);
         int offset = BytesUtils.BYTE_LENGTH;
         // agentId should be added as data.
         String agentId = Bytes.toString(qArray, qOffset + offset, cell.getQualifierLength() - offset);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/ResponseTimeV3ResultExtractor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/ResponseTimeV3ResultExtractor.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRow
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
@@ -110,7 +111,7 @@ public class ResponseTimeV3ResultExtractor implements ResultsExtractor<List<Resp
 
         final byte[] qArray = cell.getQualifierArray();
         final int qOffset = cell.getQualifierOffset();
-        byte slotCode = qArray[qOffset];
+        SlotCode slotCode = SlotCode.valueOf(qArray[qOffset]);
         int offset = BytesUtils.BYTE_LENGTH;
 
         // agentId should be added as data.

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/Histogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/Histogram.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.web.view.HistogramSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -78,7 +79,7 @@ public class Histogram implements StatisticsHistogram {
         addCallCount(slotTime, 1);
     }
 
-    public void addCallCountByCode(final byte code, final long count) {
+    public void addCallCountByCode(final SlotCode code, final long count) {
         final HistogramSchema schema = this.schema;
 
         if (code == schema.getSumStatSlot().getSlotCode()) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkCallData.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkCallData.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.rawdata;
 
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkKey;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -66,7 +67,7 @@ public class LinkCallData {
         return targetHistogramTimeMap.values();
     }
 
-    public void addCallDataByCode(long timestamp, byte slotCode, long count) {
+    public void addCallDataByCode(long timestamp, SlotCode slotCode, long count) {
         TimeHistogram histogram = getTimeHistogram(timestamp);
         histogram.addCallCountByCode(slotCode, count);
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkCallDataMap.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkCallDataMap.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.applicationmap.rawdata;
 
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkKey;
 import com.navercorp.pinpoint.web.vo.Application;
@@ -55,7 +56,7 @@ public class LinkCallDataMap {
         linkCallData.addCallData(timeHistogramList);
     }
 
-    public void addCallDataByCode(String sourceAgentId, ServiceType sourceServiceType, String targetId, ServiceType targetServiceType, long timestamp, byte slotCode, long count) {
+    public void addCallDataByCode(String sourceAgentId, ServiceType sourceServiceType, String targetId, ServiceType targetServiceType, long timestamp, SlotCode slotCode, long count) {
         LinkKey linkKey = createLinkKey(sourceAgentId, sourceServiceType, targetId, targetServiceType);
         LinkCallData linkCallData = getLinkCallData(linkKey);
         linkCallData.addCallDataByCode(timestamp, slotCode, count);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkData.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkData.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.web.applicationmap.rawdata;
 
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.web.vo.Application;
 
 import java.util.Objects;
@@ -77,7 +78,7 @@ public class LinkData {
     }
 
     public void addLinkDataByCode(String outAgentId, ServiceType outServiceTypeCode, String hostname,
-                                  ServiceType serviceTypeCode, long timestamp, byte slotCode, long count) {
+                                  ServiceType serviceTypeCode, long timestamp, SlotCode slotCode, long count) {
         Objects.requireNonNull(hostname, "hostname");
 
         this.linkCallDataMap.addCallDataByCode(outAgentId, outServiceTypeCode, hostname, serviceTypeCode, timestamp, slotCode, count);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkDataMap.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkDataMap.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.rawdata;
 
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkKey;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -51,7 +52,7 @@ public class LinkDataMap {
         linkData.addLinkData(sourceAgentId, sourceApplication.getServiceType(), destinationAgentId, destinationApplication.getServiceType(), timestamp, slotTime, count);
     }
 
-    public void addLinkDataByCode(Application sourceApplication, String sourceAgentId, Application destinationApplication, String destinationAgentId, long timestamp, byte slotCode, long count) {
+    public void addLinkDataByCode(Application sourceApplication, String sourceAgentId, Application destinationApplication, String destinationAgentId, long timestamp, SlotCode slotCode, long count) {
         final LinkData linkData = getLinkData(sourceApplication, destinationApplication);
         linkData.addLinkDataByCode(sourceAgentId, sourceApplication.getServiceType(), destinationAgentId, destinationApplication.getServiceType(), timestamp, slotCode, count);
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/ResponseTime.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/ResponseTime.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.vo;
 
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.SlotCode;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
 import com.navercorp.pinpoint.web.applicationmap.histogram.TimeHistogram;
 
@@ -118,7 +119,7 @@ public class ResponseTime {
             histogram.addCallCount(slotNumber, count);
         }
 
-        public void addResponseTimeByCode(String agentId, byte slotCode, long count) {
+        public void addResponseTimeByCode(String agentId, SlotCode slotCode, long count) {
             Histogram histogram = getHistogram(agentId);
             histogram.addCallCountByCode(slotCode, count);
         }


### PR DESCRIPTION
This pull request refactors the handling of histogram slot codes throughout the codebase by introducing a new `SlotCode` enum. The changes replace the use of raw `byte` values for slot codes with the type-safe `SlotCode` enum, improving code clarity and reducing the risk of errors. This update affects both the collector and web modules, including data access objects, mappers, and histogram-related classes.

### SlotCode Enum Introduction and Usage

* Added a new `SlotCode` enum to replace raw `byte` slot codes, providing type safety and centralized management of slot code values. (`commons/src/main/java/com/navercorp/pinpoint/common/trace/SlotCode.java`)
* Refactored all relevant classes and methods to accept and use `SlotCode` instead of `byte` for histogram slot codes, including `HistogramSlot`, `HistogramSlotGroup`, and related DAOs and mappers. [[1]](diffhunk://#diff-4cf7d9bf5678e24ad10429c8138ba619851fc5c9d2b9353ae293702b4b0c16f7L26-R38) [[2]](diffhunk://#diff-65a2427b108734175c3b2934ba94c4d97dc0cad6c7af31648d79e4722efb488eL28-R28) [[3]](diffhunk://#diff-2d2dd376caea398c858b7c50b500a71c6cf28835362a8227f8572d2b8ccc087aL28-R30) [[4]](diffhunk://#diff-4370a9fd45ba0cc66eb33e6c4e77045e8aca109bfc6f0845741cbca85c21f689L37-R43) [[5]](diffhunk://#diff-5ac758210654711300075c4e1434287a43855f20129de5a1f44cc8b3496bc44aL34-R36) [[6]](diffhunk://#diff-6359aee70ea42a8dd88eb310e58c4245efd7bf1b392cffe27bbf8045636e2039L114-R115) [[7]](diffhunk://#diff-4f26941b9f7fc651c900879c1324faf1967bf32e00f8dfa580546ebe5e414610L120-R121) [[8]](diffhunk://#diff-a8e644e9411e71d0b0d0ba9f44a64c09ec073b19d4ce018b1c3f74fd7f719d66L103-R104) [[9]](diffhunk://#diff-ef6f08dffdb5aec027d7c2cf419c7eeff78b077179953165da2cf16bf98cee66L93-R94)

### Collector Module Updates

* Updated collector DAO classes (`ApplicationResponseColumnName`, `OutLinkV3ColumnName`, `ResponseV3ColumnName`, etc.) to use `SlotCode` for histogram column construction and data extraction. [[1]](diffhunk://#diff-2d2dd376caea398c858b7c50b500a71c6cf28835362a8227f8572d2b8ccc087aR20) [[2]](diffhunk://#diff-4370a9fd45ba0cc66eb33e6c4e77045e8aca109bfc6f0845741cbca85c21f689R24) [[3]](diffhunk://#diff-5ac758210654711300075c4e1434287a43855f20129de5a1f44cc8b3496bc44aR22)

### Web Module Updates

* Modified web DAO and mapper classes to use `SlotCode` for reading and processing slot codes from serialized data, improving type safety and consistency. [[1]](diffhunk://#diff-6359aee70ea42a8dd88eb310e58c4245efd7bf1b392cffe27bbf8045636e2039R20) [[2]](diffhunk://#diff-4f26941b9f7fc651c900879c1324faf1967bf32e00f8dfa580546ebe5e414610R26) [[3]](diffhunk://#diff-a8e644e9411e71d0b0d0ba9f44a64c09ec073b19d4ce018b1c3f74fd7f719d66R30) [[4]](diffhunk://#diff-ef6f08dffdb5aec027d7c2cf419c7eeff78b077179953165da2cf16bf98cee66R28) [[5]](diffhunk://#diff-b5ab87b3960ce279b40d642e96aac50ea7fd198e1baade01bc2690794985035eR27)

### HistogramSchemas Refactoring

* Removed the inner `SlotCodes` class from `HistogramSchemas` and updated all references to use the new `SlotCode` enum, simplifying slot code management and reducing duplication. [[1]](diffhunk://#diff-9a1c665dbe4a8c9aabcde831b91cf86fd241bede929f8b7b131877d35235fb8cL19-R39) [[2]](diffhunk://#diff-9a1c665dbe4a8c9aabcde831b91cf86fd241bede929f8b7b131877d35235fb8cL56-L83) [[3]](diffhunk://#diff-9a1c665dbe4a8c9aabcde831b91cf86fd241bede929f8b7b131877d35235fb8cL121-L168)

These changes collectively improve maintainability, type safety, and clarity in how histogram slot codes are handled across the application.