### PR TITLE
[#13180] Bump Junit from 5.11.3 to 5.12.2

### DIFF
--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginForkedTestUnitTestDescriptor.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginForkedTestUnitTestDescriptor.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.descriptor.ExtensionContextFactory;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
-import org.junit.jupiter.engine.execution.DefaultExecutableInvoker;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
 import org.junit.platform.engine.TestExecutionResult;
@@ -73,7 +72,7 @@ public class PluginForkedTestUnitTestDescriptor extends PluginTestDescriptor {
         JupiterEngineDescriptor engineDescriptor = new JupiterEngineDescriptor(this.getUniqueId(), configuration);
         ExtensionContext jupiterExtensionContext = ExtensionContextFactory.jupiterEngineContext(
                 context.getExecutionListener(), engineDescriptor,
-                context.getConfiguration(), ec -> new DefaultExecutableInvoker(ec, extensionRegistry));
+                context.getConfiguration(), extensionRegistry);
 
         // @formatter:off
         return context.extend()

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginJunitTestMethodTestDescriptor.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginJunitTestMethodTestDescriptor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,9 @@ import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.platform.engine.UniqueId;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 public class PluginJunitTestMethodTestDescriptor extends TestMethodTestDescriptor {
 
@@ -39,8 +41,8 @@ public class PluginJunitTestMethodTestDescriptor extends TestMethodTestDescripto
     private final ThreadContextExecutor executor;
 
 
-    public PluginJunitTestMethodTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod, JupiterConfiguration configuration, TestContext testContext) {
-        super(uniqueId, testClass, testMethod, configuration);
+    public PluginJunitTestMethodTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod, Supplier<List<Class<?>>> enclosingInstanceTypes, JupiterConfiguration configuration, TestContext testContext) {
+        super(uniqueId, testClass, testMethod, enclosingInstanceTypes, configuration);
         this.testContext = Objects.requireNonNull(testContext, "testContext");
         this.executor = new ThreadContextExecutor(testContext.getClassLoader());
     }

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginTestMethodTestDescriptor.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginTestMethodTestDescriptor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,15 +25,17 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public class PluginTestMethodTestDescriptor extends TestMethodTestDescriptor {
 
     private final PluginTestInstance pluginTestInstance;
     private final MethodSource source;
 
-    public PluginTestMethodTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod, JupiterConfiguration configuration, PluginTestInstance pluginTestInstance) {
-        super(uniqueId, testClass, testMethod, configuration);
+    public PluginTestMethodTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod, Supplier<List<Class<?>>> enclosingInstanceTypes, JupiterConfiguration configuration, PluginTestInstance pluginTestInstance) {
+        super(uniqueId, testClass, testMethod, enclosingInstanceTypes, configuration);
         this.pluginTestInstance = pluginTestInstance;
         this.source = MethodSource.from(testClass.getName(), testMethod.getName() + "[" + pluginTestInstance.getTestId() + "]");
     }

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/PluginTestEngine.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/PluginTestEngine.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -69,7 +69,8 @@ public class PluginTestEngine extends HierarchicalTestEngine<JupiterEngineExecut
 
     @Override
     public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
-        JupiterConfiguration configuration = new CachingJupiterConfiguration(new DefaultJupiterConfiguration(discoveryRequest.getConfigurationParameters()));
+        DefaultJupiterConfiguration jupiterConfiguration = new DefaultJupiterConfiguration(discoveryRequest.getConfigurationParameters(), discoveryRequest.getOutputDirectoryProvider());
+        JupiterConfiguration configuration = new CachingJupiterConfiguration(jupiterConfiguration);
         JupiterEngineDescriptor engineDescriptor = new JupiterEngineDescriptor(uniqueId, configuration);
         new DiscoverySelectorResolver().resolveSelectors(discoveryRequest, engineDescriptor);
 

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/discovery/PluginJunitTestDescriptorBuilder.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/discovery/PluginJunitTestDescriptorBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.test.plugin.junit5.engine.discovery;
 
 import com.navercorp.pinpoint.profiler.test.junit5.JunitAgentConfigPath;
@@ -33,7 +49,9 @@ public class PluginJunitTestDescriptorBuilder implements TestDescriptorBuilder {
                 final Method method = ((TestMethodTestDescriptor) descriptor).getTestMethod();
                 final Method testMethod = ReflectionUtils.findMethod(testClass, method.getName(), method.getParameterTypes()).orElseThrow(() -> new IllegalStateException("not found method"));
 
-                final PluginJunitTestMethodTestDescriptor pluginTestMethodTestDescriptor = new PluginJunitTestMethodTestDescriptor(descriptor.getUniqueId(), testClass, testMethod, configuration, testContext);
+                final PluginJunitTestMethodTestDescriptor pluginTestMethodTestDescriptor = new PluginJunitTestMethodTestDescriptor(
+                        descriptor.getUniqueId(), testClass, testMethod, pluginTestClassTestDescriptor::getEnclosingTestClasses, configuration, testContext
+                );
                 pluginTestClassTestDescriptor.addChild(pluginTestMethodTestDescriptor);
             }
         }

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/discovery/TestDescriptorFactory.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/discovery/TestDescriptorFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.test.plugin.junit5.engine.discovery;
 
 import com.navercorp.pinpoint.test.plugin.PluginForkedTestInstance;
@@ -87,7 +103,7 @@ public class TestDescriptorFactory {
             final Method testMethod = ReflectionUtils.findMethod(testClass, method.getName(), method.getParameterTypes()).orElseThrow(() -> new IllegalStateException("not found method"));
             final String testId = testMethod.getName();
             final UniqueId childId = childUniqueId(parentTestDescriptor, TestMethodTestDescriptor.SEGMENT_TYPE, testId);
-            return new PluginTestMethodTestDescriptor(childId, testClass, testMethod, configuration, pluginTestInstance);
+            return new PluginTestMethodTestDescriptor(childId, testClass, testMethod, parentTestDescriptor::getEnclosingTestClasses, configuration, pluginTestInstance);
         } catch (Throwable t) {
             logger.warn(t, () -> "newPluginTestMethodTestDescriptor error " + t.getMessage());
             return null;
@@ -100,7 +116,7 @@ public class TestDescriptorFactory {
             final Method testMethod = ReflectionUtils.findMethod(testClass, method.getName(), method.getParameterTypes()).orElseThrow(() -> new IllegalStateException("not found method"));
             final String testId = String.format("%s(%s)", method.getName(), ClassUtils.nullSafeToString(method.getParameterTypes()));
             final UniqueId childId = childUniqueId(parentTestDescriptor, TestMethodTestDescriptor.SEGMENT_TYPE, testId);
-            return new PluginForkedTestMethodTestDescriptor(childId, testClass, testMethod, configuration, pluginTestInstance);
+            return new PluginForkedTestMethodTestDescriptor(childId, testClass, testMethod, parentTestDescriptor::getEnclosingTestClasses, configuration, pluginTestInstance);
         } catch (Throwable t) {
             logger.warn(t, () -> "newPluginForkedTestMethodTestDescriptor error " + t.getMessage());
             return null;

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionContextFactory.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionContextFactory.java
@@ -1,19 +1,33 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.junit.jupiter.engine.descriptor;
 
-import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.EngineExecutionListener;
-
-import java.util.function.Function;
 
 public final class ExtensionContextFactory {
 
     public static ExtensionContext jupiterEngineContext(EngineExecutionListener engineExecutionListener,
                                                         JupiterEngineDescriptor testDescriptor,
                                                         JupiterConfiguration configuration,
-                                                        Function<ExtensionContext, ExecutableInvoker> executableInvokerFactory) {
-        return new JupiterEngineExtensionContext(engineExecutionListener, testDescriptor, configuration, executableInvokerFactory);
+                                                        ExtensionRegistry extensionRegistry) {
+        return new JupiterEngineExtensionContext(engineExecutionListener, testDescriptor, configuration, extensionRegistry);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <bytebuddy.version>1.12.23</bytebuddy.version>
 
         <testcontainers.version>1.21.3</testcontainers.version>
-        <junit-jupiter.version>5.11.3</junit-jupiter.version>
+        <junit-jupiter.version>5.12.2</junit-jupiter.version>
 
         <!-- maven-plugin -->
         <plugin.compiler.version>3.13.0</plugin.compiler.version>


### PR DESCRIPTION
This pull request updates the test plugin framework to support JUnit 5.12.2 and refactors several test descriptor classes to improve compatibility and maintainability. The most significant changes include updating the JUnit version, modifying test descriptor constructors to accept enclosing test class suppliers, and refactoring context creation for test execution.

### JUnit Version Upgrade

* Upgraded JUnit Jupiter dependency from version 5.11.3 to 5.12.2 in `pom.xml`, ensuring compatibility with the latest JUnit features and bug fixes.

### Test Descriptor Refactoring

* Changed constructors for `PluginForkedTestMethodTestDescriptor`, `PluginJunitTestMethodTestDescriptor`, and `PluginTestMethodTestDescriptor` to accept a `Supplier<List<Class<?>>>` for enclosing instance types, improving handling of nested test classes. [[1]](diffhunk://#diff-7b7d2dffe3831933f102f91fb13d0287ca0797575cb311bb15854e59247c6862L42-R45) [[2]](diffhunk://#diff-61ff0ce35ffd23e1424177a391cb0a3fadd9bea2af31c68ae8cdd11ef38e616eR34-R45) [[3]](diffhunk://#diff-d959c275e22d7716116cf5af3141a2876b551af67bd2fc452941c1b642ee9378R28-R38)
* Updated `PluginJunitTestDescriptorBuilder` and `TestDescriptorFactory` to use the new constructor signatures, passing suppliers for enclosing test classes instead of direct class lists. [[1]](diffhunk://#diff-23389bb7caa1c59f2aa28f7c26aac68d7045ba796fef4916267aeedbbd968026L36-R54) [[2]](diffhunk://#diff-7c65d2643e503e131718d8778e2d429d087e408cc5639c47820c58f83f4f6a88L90-R106) [[3]](diffhunk://#diff-7c65d2643e503e131718d8778e2d429d087e408cc5639c47820c58f83f4f6a88L103-R119)

### Engine and Extension Context Changes

* Refactored `ExtensionContextFactory` and related usage to remove the `DefaultExecutableInvoker` and use `ExtensionRegistry` directly, aligning with JUnit 5.12 API changes. [[1]](diffhunk://#diff-31874872e564f3464c3c0a739e509efdb4c5f26649dc9363e6695e403df555a7R1-R30) [[2]](diffhunk://#diff-56212a9c89aaa3d559da2853419aa9a3439f6a1488398b6c95047fac79340824L76-R75)
* Updated `PluginTestEngine` to use the new `DefaultJupiterConfiguration` constructor with an output directory provider, matching changes in JUnit internals.

### License and Copyright Updates

* Updated copyright years to 2025 in all modified source files to reflect current ownership and compliance. [[1]](diffhunk://#diff-7b7d2dffe3831933f102f91fb13d0287ca0797575cb311bb15854e59247c6862L2-R2) [[2]](diffhunk://#diff-61ff0ce35ffd23e1424177a391cb0a3fadd9bea2af31c68ae8cdd11ef38e616eL2-R2) [[3]](diffhunk://#diff-d959c275e22d7716116cf5af3141a2876b551af67bd2fc452941c1b642ee9378L2-R2) [[4]](diffhunk://#diff-df8b156df838a87a6f3eed01312359ced360e25fc94731da699690f0719d8d39L2-R2) [[5]](diffhunk://#diff-23389bb7caa1c59f2aa28f7c26aac68d7045ba796fef4916267aeedbbd968026R1-R16) [[6]](diffhunk://#diff-7c65d2643e503e131718d8778e2d429d087e408cc5639c47820c58f83f4f6a88R1-R16) [[7]](diffhunk://#diff-31874872e564f3464c3c0a739e509efdb4c5f26649dc9363e6695e403df555a7R1-R30)

### Minor Improvements

* Improved logging and error handling in test execution and skipping logic within `PluginForkedTestMethodTestDescriptor`. [[1]](diffhunk://#diff-7b7d2dffe3831933f102f91fb13d0287ca0797575cb311bb15854e59247c6862R65-R77) [[2]](diffhunk://#diff-7b7d2dffe3831933f102f91fb13d0287ca0797575cb311bb15854e59247c6862L83-R89)