### PR TITLE
[#noissue] Refactor HostApplication RowKey handling

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV3Configuration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/MapV3Configuration.java
@@ -173,7 +173,7 @@ public class MapV3Configuration {
     @Bean(name = "hostApplicationMapDaoV3")
     public HostApplicationMapDao hostApplicationMapDao(HbaseOperations hbaseTemplate,
                                                        TableNameProvider tableNameProvider,
-                                                       @Qualifier("acceptApplicationRowKeyDistributor") RowKeyDistributor rowKeyDistributor,
+                                                       @Qualifier("uidRowKeyDistributor") RowKeyDistributor rowKeyDistributor,
                                                        TimeSlot timeSlot) {
         HostRowKeyEncoder encoder = new HostRowKeyEncoderV3(rowKeyDistributor.getByteHasher());
         HostLinkFactory hostLinkFactory = new HostLinkFactoryV3(encoder);

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKeyTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKeyTest.java
@@ -41,7 +41,7 @@ class UidLinkRowKeyTest {
 
     @Test
     void uidRowKey() {
-        RowKey rowKey = UidLinkRowKey.of(12, "appName", ServiceType.STAND_ALONE, 1000);
+        RowKey rowKey = UidLinkRowKey.of(12, "appName", ServiceType.STAND_ALONE, 3000);
 
         byte[] rowKeyBytes = rowKey.getRowKey(1);
 
@@ -55,7 +55,7 @@ class UidLinkRowKeyTest {
     void hashing() {
         int saltKeySize = hasher.getSaltKey().size();
 
-        RowKey rowKey = UidLinkRowKey.of(12, "appName", ServiceType.STAND_ALONE, 1000);
+        RowKey rowKey = UidLinkRowKey.of(12, "appName", ServiceType.STAND_ALONE, 3000);
         byte[] bytes = rowKey.getRowKey(saltKeySize);
 
         byte[] saltRowKey = hasher.writeSaltKey(bytes);
@@ -103,7 +103,7 @@ class UidLinkRowKeyTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             UidLinkRowKey.makeRowKey(0,
                     ServiceUid.DEFAULT_SERVICE_UID_CODE,
-                    "a".repeat(PinpointConstants.APPLICATION_NAME_MAX_LEN_V3 + 1),
+                    "a".repeat(UidLinkRowKey.KEY_SIZE + 1),
                     ServiceType.STAND_ALONE.getCode(),
                     1000);
         });

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapV3DaoConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapV3DaoConfiguration.java
@@ -195,8 +195,10 @@ public class MapV3DaoConfiguration {
     }
 
     @Bean
-    public ResultsExtractor<Set<AcceptApplication>> hostApplicationResultExtractorV3(ApplicationFactory applicationFactory) {
-        return new HostApplicationMapperV3(applicationFactory);
+    public ResultsExtractor<Set<AcceptApplication>> hostApplicationResultExtractorV3(ApplicationFactory applicationFactory,
+                                                                                     @Qualifier("uidRowKeyDistributor")
+                                                                                     RowKeyDistributor rowKeyDistributor) {
+        return new HostApplicationMapperV3(applicationFactory, rowKeyDistributor);
     }
 
     @Bean
@@ -205,10 +207,10 @@ public class MapV3DaoConfiguration {
                                                        @Qualifier("hostApplicationResultExtractorV3")
                                                        ResultsExtractor<Set<AcceptApplication>> hostApplicationResultExtractor,
                                                        TimeSlot timeSlot,
-                                                       @Qualifier("acceptApplicationRowKeyDistributor")
-                                                       RowKeyDistributor acceptApplicationRowKeyDistributor) {
+                                                       @Qualifier("uidRowKeyDistributor")
+                                                       RowKeyDistributor rowKeyDistributor) {
         HbaseColumnFamily table = HbaseTables.MAP_APP_HOST;
         HostScanKeyFactory hostScanKeyFactory = new HostScanKeyFactoryV3();
-        return new HbaseHostApplicationMapDao(table, hbaseOperations, tableNameProvider, hostScanKeyFactory, hostApplicationResultExtractor, timeSlot, acceptApplicationRowKeyDistributor);
+        return new HbaseHostApplicationMapDao(table, hbaseOperations, tableNameProvider, hostScanKeyFactory, hostApplicationResultExtractor, timeSlot, rowKeyDistributor);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
@@ -93,9 +93,14 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
         TableName hostApplicationMapTableName = tableNameProvider.getTableName(table.getTable());
         final Set<AcceptApplication> result = hbaseOperations.findParallel(hostApplicationMapTableName, scan, acceptApplicationRowKeyDistributor, hostApplicationResultExtractor, NUM_PARTITIONS);
         if (CollectionUtils.isNotEmpty(result)) {
-            logger.debug("findAcceptApplicationName result:{}", result);
+            if (logger.isDebugEnabled()) {
+                logger.debug("findAcceptApplicationName found {} {}", fromApplication, result);
+            }
             return result;
         } else {
+            if (logger.isDebugEnabled()) {
+                logger.debug("findAcceptApplicationName not found {}", fromApplication);
+            }
             return Collections.emptySet();
         }
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java
@@ -89,6 +89,9 @@ public class RpcCallProcessor implements LinkDataMapProcessor {
                     final LinkData acceptedLinkData = LinkData.copyOf(linkData.getFromApplication(), first.getApplication(), linkData.getLinkCallDataMap());
                     return Collections.singletonList(acceptedLinkData);
                 } else {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("virtualLinkMarker {} => {}", toApplication, acceptApplicationList);
+                    }
                     // special case - there are more than 2 nodes grouped by a single url
                     return virtualLinkMarker.createVirtualLink(linkData, toApplication, acceptApplicationList);
                 }


### PR DESCRIPTION
This pull request introduces a series of changes to improve the handling of UID-based row keys and related application mapping logic in both the collector and web modules. The main focus is on standardizing the use of `uidRowKeyDistributor` for row key distribution, updating row key encoding and decoding to use inversion for service type codes, and enhancing debug logging for better traceability. Additionally, the changes update test cases and refactor code for improved clarity and maintainability.

**Row Key Distribution and Encoding Updates:**

* Changed the row key distributor from `acceptApplicationRowKeyDistributor` to `uidRowKeyDistributor` in both collector and web configuration files to standardize row key handling. (`MapV3Configuration.java` [[1]](diffhunk://#diff-f9de701ff7860e4af7022915e212e50b9f7fab058a8de2d27ec3c797eb10f645L176-R176) `MapV3DaoConfiguration.java` [[2]](diffhunk://#diff-a7a9f39ade40c08f8a482ae304b0de60d6d053bea6e03dcbf1ba7843230d352fL208-R214)
* Updated `UidLinkRowKey` encoding to invert the service type code when writing and restore it when reading, ensuring consistency in row key structure. (`UidLinkRowKey.java` [[1]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fL119-R118) [[2]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fL144-L147)

**API and Constant Refactoring:**

* Replaced usage of `PinpointConstants.APPLICATION_NAME_MAX_LEN_V3` with a local `KEY_SIZE` constant for application name length validation in `UidLinkRowKey`. (`UidLinkRowKey.java` [commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.javaL106-R105](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fL106-R105))
* Updated test cases to use the new `KEY_SIZE` constant and adjusted timestamp values for consistency. (`UidLinkRowKeyTest.java` [[1]](diffhunk://#diff-ae9bae7d5005493c42ce29b72ab213d0af73884b0e2cd2fee69745b9c19f8a2cL44-R44) [[2]](diffhunk://#diff-ae9bae7d5005493c42ce29b72ab213d0af73884b0e2cd2fee69745b9c19f8a2cL58-R58) [[3]](diffhunk://#diff-ae9bae7d5005493c42ce29b72ab213d0af73884b0e2cd2fee69745b9c19f8a2cL106-R106)

**Dependency Injection and Mapper Improvements:**

* Modified `HostApplicationMapperV3` to require a `RowKeyDistributor` and log row key details for debugging, improving traceability of mapping operations. (`HostApplicationMapperV3.java` [[1]](diffhunk://#diff-e2f413397c5f46e92dec6b4bb5bd9a38d3fef96004574a4b95fa9480689444feR49-R56) [[2]](diffhunk://#diff-e2f413397c5f46e92dec6b4bb5bd9a38d3fef96004574a4b95fa9480689444feR71-R78)
* Updated the bean definition for `hostApplicationResultExtractorV3` to inject the `uidRowKeyDistributor`. (`MapV3DaoConfiguration.java` [web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapV3DaoConfiguration.javaL198-R201](diffhunk://#diff-a7a9f39ade40c08f8a482ae304b0de60d6d053bea6e03dcbf1ba7843230d352fL198-R201))

**Debug Logging Enhancements:**

* Added debug logging in several places to provide detailed information about application mapping and virtual link creation, aiding troubleshooting and diagnostics. (`HbaseHostApplicationMapDao.java` [[1]](diffhunk://#diff-3bd20ccad9be609f3175836ffce84fb7eaaad6ba8db40dd45064c6cf039421beL96-R103) `RpcCallProcessor.java` [[2]](diffhunk://#diff-10e8402c782ebbd45ab5d34b1a1ac1e94421db5358929374a50c57119c1ac4d2R92-R94) `HostApplicationMapperV3.java` [[3]](diffhunk://#diff-e2f413397c5f46e92dec6b4bb5bd9a38d3fef96004574a4b95fa9480689444feR71-R78)

**Minor Cleanups:**

* Removed unused imports and clarified comments in row key and mapping logic for better code readability. (`UidLinkRowKey.java` [[1]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fL22) `HostApplicationMapperV3.java` [[2]](diffhunk://#diff-e2f413397c5f46e92dec6b4bb5bd9a38d3fef96004574a4b95fa9480689444feL78-R91)