### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkDataDuplexMap.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkDataDuplexMap.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,8 +17,11 @@
 package com.navercorp.pinpoint.web.applicationmap.rawdata;
 
 import com.navercorp.pinpoint.web.applicationmap.link.LinkKey;
+import com.navercorp.pinpoint.web.vo.Application;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -40,12 +43,30 @@ public class LinkDataDuplexMap {
         return sourceLinkDataMap;
     }
 
+    public List<Application> getSourceToApplication() {
+        Collection<LinkData> linkDataList = sourceLinkDataMap.getLinkDataList();
+        List<Application> list = new ArrayList<>(linkDataList.size());
+        for (LinkData linkData : linkDataList) {
+            list.add(linkData.getToApplication());
+        }
+        return list;
+    }
+
     public Collection<LinkData> getSourceLinkDataList() {
         return sourceLinkDataMap.getLinkDataList();
     }
 
     public LinkDataMap getTargetLinkDataMap() {
         return targetLinkDataMap;
+    }
+
+    public List<Application> getTargetFromApplication() {
+        Collection<LinkData> linkDataList = targetLinkDataMap.getLinkDataList();
+        List<Application> list = new ArrayList<>(linkDataList.size());
+        for (LinkData linkData : linkDataList) {
+            list.add(linkData.getFromApplication());
+        }
+        return list;
     }
 
     public Collection<LinkData> getTargetLinkDataList() {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/HistogramServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/HistogramServiceImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@ package com.navercorp.pinpoint.web.applicationmap.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.link.Link;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkDirection;
 import com.navercorp.pinpoint.web.applicationmap.link.LinkHistogramSummary;
@@ -34,7 +33,9 @@ import com.navercorp.pinpoint.web.applicationmap.map.processor.WasOnlyProcessor;
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.nodes.NodeList;
 import com.navercorp.pinpoint.web.applicationmap.nodes.NodeListFactory;
+import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkData;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataDuplexMap;
+import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.SearchOption;
 import org.apache.logging.log4j.LogManager;
@@ -140,12 +141,7 @@ public class HistogramServiceImpl implements HistogramService {
         // Get the 'from' applications from the target link data map
         // In the target link, 'from' -> 'to' where 'to' Application is the main application,
         // so we get the 'from' applications from the target link data map.
-        return linkDataDuplexMap.getTargetLinkDataMap()
-                .getLinkDataMap()
-                .keySet()
-                .stream()
-                .map(LinkKey::getFrom)
-                .toList();
+        return linkDataDuplexMap.getTargetFromApplication();
     }
 
     @Override
@@ -155,12 +151,7 @@ public class HistogramServiceImpl implements HistogramService {
         // Get the 'to' applications from the source link data map
         // In the source link, 'from' -> 'to' where 'from' Application is the main application,
         // so we get the 'to' applications from the source link data map.
-        return linkDataDuplexMap.getSourceLinkDataMap()
-                .getLinkDataMap()
-                .keySet()
-                .stream()
-                .map(LinkKey::getTo)
-                .toList();
+        return linkDataDuplexMap.getSourceToApplication();
     }
 
     @Override
@@ -170,16 +161,9 @@ public class HistogramServiceImpl implements HistogramService {
         Objects.requireNonNull(linkDataDuplexMap, "linkDataDuplexMap");
         Objects.requireNonNull(nodeApplication, "nodeApplication");
 
-        List<Application> fromApplication = linkDataDuplexMap.getTargetLinkDataMap()
-                .getLinkDataMap()
-                .keySet()
-                .stream()
-                .map(LinkKey::getFrom)
-                .toList();
-
-        for (Application application : fromApplication) {
-            if (application.getName().equals(nodeApplication.getName())
-                    && application.getServiceType().equals(nodeApplication.getServiceType())) {
+        LinkDataMap targetLinkDataMap = linkDataDuplexMap.getTargetLinkDataMap();
+        for (LinkData linkData : targetLinkDataMap.getLinkDataList()) {
+            if (linkData.getFromApplication().equals(nodeApplication)) {
                 return true;
             }
         }


### PR DESCRIPTION
This pull request refactors how source and target applications are extracted from `LinkDataDuplexMap`, simplifying the logic and improving maintainability. The main changes involve introducing new methods to retrieve lists of applications directly from link data, and updating usages in `HistogramServiceImpl` to use these methods instead of manual stream processing.

### LinkDataDuplexMap API improvements
* Added `getSourceToLink()` and `getTargetFromLink()` methods to `LinkDataDuplexMap`, which return lists of `Application` objects from source and target link data respectively. This provides a more direct and readable way to access these applications. [[1]](diffhunk://#diff-f9854d3cd2f8b30a9e354ce040199e699e6872ab050781b7384903ef8cedd924R46-R54) [[2]](diffhunk://#diff-f9854d3cd2f8b30a9e354ce040199e699e6872ab050781b7384903ef8cedd924R63-R71)

### Refactoring in HistogramServiceImpl
* Updated `getFromApplications()` to use `getTargetFromLink()` instead of streaming and mapping over the link data map.
* Updated `getToApplications()` to use `getSourceToLink()` for consistency and simplicity.
* Refactored `isToNode()` to iterate directly over `LinkData` objects and compare applications, reducing stream usage and improving clarity.

### Minor updates
* Updated copyright year in `LinkDataDuplexMap.java`.
* Minor import cleanups in both changed files. [[1]](diffhunk://#diff-f9854d3cd2f8b30a9e354ce040199e699e6872ab050781b7384903ef8cedd924R20-R24) [[2]](diffhunk://#diff-e26614f156f710b8c8c1ff2067b20647b8c9103d5b0d999b74fb510bd1ee6737L20) [[3]](diffhunk://#diff-e26614f156f710b8c8c1ff2067b20647b8c9103d5b0d999b74fb510bd1ee6737R36-R38)

These changes make the codebase cleaner and easier to maintain by encapsulating common logic and reducing repetitive stream operations.