### PR TITLE
[#noissue] Add HostApplicationMapDaoDelegate for dual write

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/ApplicationMapModule.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/ApplicationMapModule.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.collector.applicationmap.config;
 
 import com.navercorp.pinpoint.collector.applicationmap.dao.HostApplicationMapDao;
+import com.navercorp.pinpoint.collector.applicationmap.dao.HostApplicationMapDaoDelegate;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapAgentResponseTimeDao;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapInLinkDao;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapOutLinkDao;
@@ -38,6 +39,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.Objects;
+
 @Configuration
 @Import(value = {
         BulkConfiguration.class,
@@ -56,7 +59,7 @@ public class ApplicationMapModule {
         logger.info("Install {}", ApplicationMapModule.class.getName());
     }
 
-    @Bean()
+    @Bean
     @Validated
     @ConditionalOnProperty(name = ObjectNameVersion.KEY, havingValue = "dual")
     public LinkService statisticsServiceDualWrite(MapInLinkDao[] inLinkDaos,
@@ -77,9 +80,21 @@ public class ApplicationMapModule {
     }
 
     @Bean
-    public ApplicationMapService applicationMapService(HostApplicationMapDao hostApplicationMapDao,
+    public ApplicationMapService applicationMapService(HostApplicationMapDao[] hostApplicationMapDaos,
                                                        LinkService linkService,
                                                        ServiceTypeRegistryService registry) {
+        HostApplicationMapDao hostApplicationMapDao = deleageHostApplicationMapDao(hostApplicationMapDaos);
         return new HbaseApplicationMapService(hostApplicationMapDao, linkService, registry);
     }
+
+    private HostApplicationMapDao deleageHostApplicationMapDao(HostApplicationMapDao[] hostApplicationMapDaos) {
+        Objects.requireNonNull(hostApplicationMapDaos, "hostApplicationMapDaos");
+        if (hostApplicationMapDaos.length == 1) {
+            return new HostApplicationMapDaoDelegate(hostApplicationMapDaos);
+        } else {
+            return hostApplicationMapDaos[0];
+        }
+    }
+
+
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/HostApplicationMapDaoDelegate.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/HostApplicationMapDaoDelegate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.applicationmap.dao;
+
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+
+public class HostApplicationMapDaoDelegate implements HostApplicationMapDao {
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    private final HostApplicationMapDao[] delegates;
+
+    public HostApplicationMapDaoDelegate(HostApplicationMapDao[] delegates) {
+        this.delegates = Objects.requireNonNull(delegates, "delegates");
+    }
+
+    @Override
+    public void insert(long requestTime, String parentApplicationName, int parentServiceType, Vertex selfVertex, String host) {
+        for (HostApplicationMapDao delegate : delegates) {
+            try {
+                delegate.insert(requestTime, parentApplicationName, parentServiceType, selfVertex, host);
+            } catch (Exception e) {
+                logger.warn("Failed to insert host application map. parentApplicationName:{}, parentServiceType:{}, selfVertex:{}, host:{}", parentApplicationName, parentServiceType, selfVertex, host, e);
+            }
+        }}
+}


### PR DESCRIPTION
This pull request introduces a new delegate class to handle multiple `HostApplicationMapDao` implementations and updates the configuration to support this delegation. The main goal is to improve flexibility and error handling when dealing with multiple DAO beans.

**Application Map DAO Delegation:**

* Added a new class `HostApplicationMapDaoDelegate` that implements `HostApplicationMapDao` and delegates the `insert` operation to an array of DAOs, handling exceptions for each delegate and logging any failures.
* Updated the `applicationMapService` bean in `ApplicationMapModule.java` to accept an array of `HostApplicationMapDao` beans and use the new delegate for handling multiple DAO instances.
* Introduced the `deleageHostApplicationMapDao` method in `ApplicationMapModule.java` to select the appropriate DAO or delegate based on the number of beans provided.

**Configuration and Dependency Injection Improvements:**

* Modified imports and bean definitions in `ApplicationMapModule.java` to support the new delegate and ensure proper dependency injection of DAO arrays. [[1]](diffhunk://#diff-6edc73dc7af5e7a1152068f7725370dce85925678160f12ac0700d20e4f28509R20) [[2]](diffhunk://#diff-6edc73dc7af5e7a1152068f7725370dce85925678160f12ac0700d20e4f28509R42-R43) [[3]](diffhunk://#diff-6edc73dc7af5e7a1152068f7725370dce85925678160f12ac0700d20e4f28509L59-R62)

These changes enhance the application's ability to work with multiple DAO implementations, improving modularity and robustness in the application map service.