### PR TITLE
[#noissue] Refactor DistributedScanner to use LocalScanner

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScanner.java
@@ -24,10 +24,6 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -38,33 +34,39 @@ import java.util.Objects;
  */
 public class DistributedScanner implements ResultScanner {
     private final int saltKeySize;
-    private final ResultScanner[] scanners;
-    private final List<Result>[] nextOfScanners;
+
+    private final LocalScanner[] localScanners;
     private Result next = null;
 
-    @SuppressWarnings("unchecked")
     public DistributedScanner(int saltKeySize, ResultScanner[] scanners) {
+        Objects.requireNonNull(scanners, "scanners");
+
         this.saltKeySize = saltKeySize;
-        this.scanners = Objects.requireNonNull(scanners, "scanners");
-        this.nextOfScanners = new List[scanners.length];
-        for (int i = 0; i < this.nextOfScanners.length; i++) {
-            this.nextOfScanners[i] = new ArrayList<>();
-        }
+        this.localScanners = wrapLocalScanners(scanners);
     }
 
-    private boolean hasNext(int nbRows) throws IOException {
+    private LocalScanner[] wrapLocalScanners(ResultScanner[] scanners) {
+        final LocalScanner[] localScanners = new LocalScanner[scanners.length];
+        for (int i = 0; i < scanners.length; i++) {
+            ResultScanner scanner = scanners[i];
+            localScanners[i] = new LocalScannerImpl(scanner);
+        }
+        return localScanners;
+    }
+
+    private boolean hasNext() throws IOException {
         if (next != null) {
             return true;
         }
 
-        next = nextInternal(nbRows);
+        next = nextInternal();
 
         return next != null;
     }
 
     @Override
     public Result next() throws IOException {
-        if (hasNext(1)) {
+        if (hasNext()) {
             Result toReturn = next;
             next = null;
             return toReturn;
@@ -74,25 +76,13 @@ public class DistributedScanner implements ResultScanner {
     }
 
     @Override
-    public Result[] next(int nbRows) throws IOException {
-        // Identical to HTable.ClientScanner implementation
-        // Collect values to be returned here
-        ArrayList<Result> resultSets = new ArrayList<>(nbRows);
-        for(int i = 0; i < nbRows; i++) {
-            Result next = next();
-            if (next != null) {
-                resultSets.add(next);
-            } else {
-                break;
-            }
-        }
-        return resultSets.toArray(new Result[0]);
-    }
-
-    @Override
     public void close() {
-        for (ResultScanner scanner : scanners) {
-            scanner.close();
+        for (LocalScanner scanner : localScanners) {
+            try {
+                scanner.close();
+            } catch (IOException ignore) {
+                // ignore
+            }
         }
     }
 
@@ -117,84 +107,31 @@ public class DistributedScanner implements ResultScanner {
         return new DistributedScanner(saltKeySize, rss);
     }
 
-    private Result nextInternal(int nbRows) throws IOException {
+    private Result nextInternal() throws IOException {
         Result result = null;
-        int indexOfScannerToUse = -1;
-        for (int i = 0; i < nextOfScanners.length; i++) {
-            if (nextOfScanners[i] == null) {
+        LocalScanner fetchedScanner = null;
+        for (LocalScanner localScanner : localScanners) {
+            if (localScanner.isExhausted()) {
                 // result scanner is exhausted, don't advance it any more
                 continue;
             }
 
-            if (nextOfScanners[i].isEmpty()) {
-                // advancing result scanner
-                Result[] results = scanners[i].next(nbRows);
-                if (results.length == 0) {
-                    // marking result scanner as exhausted
-                    nextOfScanners[i] = null;
-                    continue;
-                }
-                nextOfScanners[i].addAll(Arrays.asList(results));
+            Result localResult = localScanner.next();
+            if (localResult == null) {
+                continue;
             }
 
             // if result is null or next record has original key less than the candidate to be returned
-            if (result == null || CellUtils.compareFirstRow(nextOfScanners[i].get(0), result, saltKeySize) < 0) {
-                result = nextOfScanners[i].get(0);
-                indexOfScannerToUse = i;
+            if (result == null || CellUtils.compareFirstRow(localResult, result, saltKeySize) < 0) {
+                result = localResult;
+                fetchedScanner = localScanner;
             }
         }
 
-        if (indexOfScannerToUse >= 0) {
-            nextOfScanners[indexOfScannerToUse].remove(0);
+        if (fetchedScanner != null) {
+            fetchedScanner.consume();
         }
-
         return result;
-    }
-
-    @Override
-    public Iterator<Result> iterator() {
-        // Identical to HTable.ClientScanner implementation
-        return new Iterator<>() {
-            // The next RowResult, possibly pre-read
-            Result next = null;
-
-            // return true if there is another item pending, false if there isn't.
-            // this method is where the actual advancing takes place, but you need
-            // to call next() to consume it. hasNext() will only advance if there
-            // isn't a pending next().
-            public boolean hasNext() {
-                if (next == null) {
-                    try {
-                        next = DistributedScanner.this.next();
-                        return next != null;
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-                return true;
-            }
-
-            // get the pending next item and advance the iterator. returns null if
-            // there is no next item.
-            public Result next() {
-                // since hasNext() does the real advancing, we call this to determine
-                // if there is a next before proceeding.
-                if (!hasNext()) {
-                    return null;
-                }
-
-                // if we get to here, then hasNext() has given us an item to return.
-                // we want to return the item and then null out the next pointer, so
-                // we use a temporary variable.
-                Result temp = next;
-                next = null;
-                return temp;
-            }
-
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
-        };
     }
 }
 

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/LocalScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/LocalScanner.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase.wd;
+
+import org.apache.hadoop.hbase.client.Result;
+
+import java.io.IOException;
+
+public interface LocalScanner {
+    Result next() throws IOException;
+
+    boolean isExhausted();
+
+    void consume();
+
+    void close() throws IOException;
+}

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/LocalScannerImpl.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/LocalScannerImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase.wd;
+
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A local wrapper around a {@link ResultScanner} that provides single-result buffering
+ * and tracks when the underlying scanner has been exhausted.
+ * <p>
+ * Intended for use by {@code DistributedScanner} to manage per-scanner state, allowing
+ * callers to peek at the next {@link Result} and query exhaustion state before
+ * consuming it.
+ */
+public class LocalScannerImpl implements Closeable, LocalScanner {
+
+    private final ResultScanner scan;
+
+    private boolean exhausted = false;
+
+    private Result localBuffer;
+
+    public LocalScannerImpl(ResultScanner scan) {
+        this.scan = Objects.requireNonNull(scan, "scan");
+    }
+
+    @Override
+    public Result next() throws IOException {
+        if (exhausted) {
+            throw new IllegalStateException("Scanner is exhausted, cannot call next() again");
+        }
+        if (localBuffer != null) {
+            return localBuffer;
+        }
+        Result next = scan.next();
+        if (next == null) {
+            exhausted = true;
+        }
+        localBuffer = next;
+        return localBuffer;
+    }
+
+    @Override
+    public boolean isExhausted() {
+        return exhausted;
+    }
+
+    @Override
+    public void consume() {
+        // clear buffer to allow fetching next result
+        localBuffer = null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        scan.close();
+    }
+}


### PR DESCRIPTION
This pull request refactors the `DistributedScanner` implementation to improve code clarity, maintainability, and correctness in handling multiple HBase `ResultScanner` instances. The main change is the introduction of a new abstraction, `LocalScanner`, which wraps each `ResultScanner` and manages its state and buffering. This leads to a cleaner and more robust merging of results across scanners. Additionally, unused methods and bulk-fetching logic are removed, simplifying the class.

Key changes:

### Refactoring and Abstraction

* Introduced the `LocalScanner` interface and its implementation `LocalScannerImpl`, which wraps a `ResultScanner` to provide single-result buffering, exhaustion tracking, and resource management. This abstraction allows `DistributedScanner` to manage scanner state more cleanly. [[1]](diffhunk://#diff-bc2d82b7d9e946b95f2223a2ad2ccf03f045967dc9f975be6d08753088e53ec2R1-R31) [[2]](diffhunk://#diff-7712537d675b58e19735fc66aa63a1280b2ee193c9cd7a0730496376754b8979R1-R77)
* Refactored `DistributedScanner` to use an array of `LocalScanner` instances instead of managing lists of results and scanner states directly. This eliminates manual buffer management and simplifies the merging logic.

### Simplification and Cleanup

* Removed the `next(int nbRows)` method and related bulk-fetching logic, as well as the custom iterator implementation, focusing the class on single-result fetching and reducing complexity. [[1]](diffhunk://#diff-2ec5a7b3b330c2b486114a5da93b2b958cfd07f704079dcda1c0f79587ce2585L76-R85) [[2]](diffhunk://#diff-2ec5a7b3b330c2b486114a5da93b2b958cfd07f704079dcda1c0f79587ce2585L120-L198)
* Updated the resource cleanup in the `close()` method to use the new `LocalScanner` abstraction and to safely handle exceptions during close.

### Minor Improvements

* Cleaned up unused imports in `DistributedScanner` for better code hygiene.