### PR TITLE
[#noissue] Refactor row comparison in CellUtils

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ParallelResultScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ParallelResultScanner.java
@@ -16,9 +16,9 @@
 
 package com.navercorp.pinpoint.common.hbase.parallel;
 
-import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
 import com.navercorp.pinpoint.common.hbase.HbaseAccessor;
 import com.navercorp.pinpoint.common.hbase.scan.ScanUtils;
+import com.navercorp.pinpoint.common.hbase.util.CellUtils;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Result;
@@ -126,7 +126,7 @@ public class ParallelResultScanner implements ResultScanner {
                     continue;
                 }
             }
-            if (result == null || ByteArrayUtils.compare(nextResults[i].getRow(), result.getRow(), saltKeySize) < 0) {
+            if (result == null || CellUtils.compareFirstRow(nextResults[i], result, saltKeySize) < 0) {
                 result = nextResults[i];
                 indexOfResultToUse = i;
             }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/CellUtils.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/CellUtils.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 public final class CellUtils {
@@ -87,5 +88,35 @@ public final class CellUtils {
             }
         }
         return last;
+    }
+
+    public static int compareFirstRow(Result left, Result right, int saltKeySize) {
+        if (isEmpty(left)) {
+            throw new IllegalArgumentException("left");
+        }
+        if (isEmpty(right)) {
+            throw new IllegalArgumentException("right");
+        }
+        final Cell leftCell = left.rawCells()[0];
+        final Cell rightCell = right.rawCells()[0];
+
+        return compareRow(leftCell, rightCell, saltKeySize);
+    }
+
+    public static boolean isEmpty(Result result) {
+        return result == null || result.isEmpty();
+    }
+
+    public static int compareRow(Cell leftCell, Cell rightCell, int saltKeySize) {
+        if (leftCell == null) {
+            throw new NullPointerException("leftCell");
+        }
+        if (rightCell == null) {
+            throw new NullPointerException("rightCell");
+        }
+        final int leftOffset = leftCell.getRowOffset();
+        final int rightOffset = rightCell.getRowOffset();
+        return Arrays.compare(leftCell.getRowArray(), leftOffset + saltKeySize, leftOffset + leftCell.getRowLength(),
+                rightCell.getRowArray(), rightOffset + saltKeySize, rightOffset + rightCell.getRowLength());
     }
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScanner.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.common.hbase.wd;
 
-import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
+import com.navercorp.pinpoint.common.hbase.util.CellUtils;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
@@ -138,7 +138,7 @@ public class DistributedScanner implements ResultScanner {
             }
 
             // if result is null or next record has original key less than the candidate to be returned
-            if (result == null || ByteArrayUtils.compare(nextOfScanners[i].get(0).getRow(), result.getRow(), saltKeySize) < 0) {
+            if (result == null || CellUtils.compareFirstRow(nextOfScanners[i].get(0), result, saltKeySize) < 0) {
                 result = nextOfScanners[i].get(0);
                 indexOfScannerToUse = i;
             }

--- a/commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/util/CellUtilsTest.java
+++ b/commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/util/CellUtilsTest.java
@@ -17,112 +17,153 @@
 package com.navercorp.pinpoint.common.hbase.util;
 
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.KeyValueTestUtil;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import java.util.List;
+
 
 public class CellUtilsTest {
 
     @Test
     public void rowToString() {
-        Cell cell = mock(Cell.class);
         String value = "abc";
         byte[] bytes = Bytes.toBytes(value);
-        when(cell.getRowArray()).thenReturn(bytes);
-        when(cell.getRowOffset()).thenReturn(0);
-        when(cell.getRowLength()).thenReturn((short) bytes.length);
-        Result result = mock(Result.class);
-        Cell[] cells = new Cell[]{cell};
-        when(result.rawCells()).thenReturn(cells);
+
+        Cell cell = new KeyValue(bytes, Bytes.toBytes("cf"),
+                Bytes.toBytes("qf"), 1L, KeyValue.Type.Put, Bytes.toBytes(1));
+
+        Result result = Result.create(List.of(cell));
 
         Assertions.assertEquals(value, CellUtils.rowToString(result));
     }
 
     @Test
     public void qualifierToShort() {
-        Cell cell = mock(Cell.class);
         short value = 5;
         byte[] bytes = Bytes.toBytes(value);
-        when(cell.getQualifierArray()).thenReturn(bytes);
-        when(cell.getQualifierOffset()).thenReturn(0);
-        when(cell.getQualifierLength()).thenReturn(bytes.length);
+
+        Cell cell = cellByQualifier(bytes, Bytes.toBytes(1));
 
         Assertions.assertEquals(value, CellUtils.qualifierToShort(cell));
     }
 
     @Test
     public void qualifierToInt() {
-        Cell cell = mock(Cell.class);
         int value = 5;
         byte[] bytes = Bytes.toBytes(value);
-        when(cell.getQualifierArray()).thenReturn(bytes);
-        when(cell.getQualifierOffset()).thenReturn(0);
-        when(cell.getQualifierLength()).thenReturn(bytes.length);
+
+        Cell cell = cellByQualifier(bytes, Bytes.toBytes(1));
 
         Assertions.assertEquals(value, CellUtils.qualifierToInt(cell));
     }
 
     @Test
     public void qualifierToString() {
-        Cell cell = mock(Cell.class);
         String value = "abc";
         byte[] bytes = Bytes.toBytes(value);
-        when(cell.getQualifierArray()).thenReturn(bytes);
-        when(cell.getQualifierOffset()).thenReturn(0);
-        when(cell.getQualifierLength()).thenReturn(bytes.length);
+
+        Cell cell = cellByQualifier(bytes, Bytes.toBytes(1));
 
         Assertions.assertEquals(value, CellUtils.qualifierToString(cell));
     }
 
     @Test
     public void valueToShort() {
-        Cell cell = mock(Cell.class);
         short value = 5;
         byte[] bytes = Bytes.toBytes(value);
-        when(cell.getValueArray()).thenReturn(bytes);
-        when(cell.getValueOffset()).thenReturn(0);
-        when(cell.getValueLength()).thenReturn(bytes.length);
+
+        Cell cell = cellByValue(bytes);
 
         Assertions.assertEquals(value, CellUtils.valueToShort(cell));
     }
 
     @Test
     public void valueToInt() {
-        Cell cell = mock(Cell.class);
         int value = Integer.MAX_VALUE;
         byte[] bytes = Bytes.toBytes(value);
-        when(cell.getValueArray()).thenReturn(bytes);
-        when(cell.getValueOffset()).thenReturn(0);
-        when(cell.getValueLength()).thenReturn(bytes.length);
+
+        Cell cell = cellByValue(bytes);
 
         Assertions.assertEquals(value, CellUtils.valueToInt(cell));
     }
 
     @Test
     public void valueToLong() {
-        Cell cell = mock(Cell.class);
         long value = Long.MAX_VALUE;
         byte[] bytes = Bytes.toBytes(value);
-        when(cell.getValueArray()).thenReturn(bytes);
-        when(cell.getValueOffset()).thenReturn(0);
-        when(cell.getValueLength()).thenReturn(bytes.length);
+
+        Cell cell = cellByValue(bytes);
 
         Assertions.assertEquals(value, CellUtils.valueToLong(cell));
     }
 
+    private Cell cellByValue(byte[] value) {
+        return new KeyValue(Bytes.toBytes("row"), Bytes.toBytes("cf"),
+                Bytes.toBytes("qf"), 1L, KeyValue.Type.Put, value);
+    }
+
+    private Cell cellByQualifier(byte[] qf, byte[] value) {
+        return new KeyValue(Bytes.toBytes("row"), Bytes.toBytes("cf"),
+                qf, 1L, KeyValue.Type.Put, value);
+    }
+
     @Test
     public void valueToString() {
-        Cell cell = mock(Cell.class);
         String value = "abc";
-        byte[] bytes = Bytes.toBytes(value);
-        when(cell.getValueArray()).thenReturn(bytes);
-        when(cell.getValueOffset()).thenReturn(0);
-        when(cell.getValueLength()).thenReturn(bytes.length);
+        Cell cell = KeyValueTestUtil.create("row", "cf", "cq", 1L, KeyValue.Type.Put, value);
 
         Assertions.assertEquals(value, CellUtils.valueToString(cell));
+    }
+
+    @Test
+    public void testCompareRow_whenRowsAreEqual() {
+        Cell leftCell = new KeyValue(Bytes.toBytes("row"), 1000L);
+        Cell rightCell = new KeyValue(Bytes.toBytes("row"), 1000L);
+        int saltKeySize = 0;
+
+        int result = CellUtils.compareRow(leftCell, rightCell, saltKeySize);
+
+        Assertions.assertEquals(0, result, "Rows should be equal.");
+    }
+
+    @Test
+    public void testCompareRow_whenLeftRowIsLess() {
+        Cell leftCell = new KeyValue(Bytes.toBytes("aa"), 1000L);
+        Cell rightCell = new KeyValue(Bytes.toBytes("bb"), 2000L);
+        int saltKeySize = 0;
+
+        int result = CellUtils.compareRow(leftCell, rightCell, saltKeySize);
+
+        Assertions.assertTrue(result < 0, "Left row should be less than right row.");
+    }
+
+    @Test
+    public void testCompareRow_whenRightRowIsLess() {
+        Cell leftCell = new KeyValue(Bytes.toBytes("bb"), 2000L);
+        Cell rightCell = new KeyValue(Bytes.toBytes("aa"), 1000L);
+        int saltKeySize = 0;
+
+        int result = CellUtils.compareRow(leftCell, rightCell, saltKeySize);
+
+        Assertions.assertTrue(result > 0, "Right row should be less than left row.");
+    }
+
+    @Test
+    public void testCompareRow_saltKey() {
+        byte[] leftRow = Bytes.add(new byte[]{2}, Bytes.toBytes(1));
+        Cell leftCell = new KeyValue(leftRow, 2000L);
+        byte[] rightRow = Bytes.add(new byte[]{1}, Bytes.toBytes(2));
+        Cell rightCell = new KeyValue(rightRow, 1000L);
+
+        int saltKeySize = 1;
+
+        int result = CellUtils.compareRow(leftCell, rightCell, saltKeySize);
+
+        Assertions.assertTrue(result < 0, "Left row should be less than right row.");
     }
 }


### PR DESCRIPTION
This pull request refactors how row comparison is handled in HBase scanners by introducing new utility methods in `CellUtils` for comparing rows, and updates the scanner logic to use these methods. It also adds unit tests for the new comparison logic.

**Refactoring and Code Improvements:**

* Introduced `compareFirstRow` and `compareRow` methods in `CellUtils` to encapsulate row comparison logic, replacing direct usage of `ByteArrayUtils.compare` in scanner classes.
* Updated `ParallelResultScanner` and `DistributedScanner` to use `CellUtils.compareFirstRow` instead of `ByteArrayUtils.compare`, improving code clarity and maintainability. [[1]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL129-R129) [[2]](diffhunk://#diff-2ec5a7b3b330c2b486114a5da93b2b958cfd07f704079dcda1c0f79587ce2585L141-R141)
* Removed unused import of `ByteArrayUtils` and replaced it with `CellUtils` in relevant files. [[1]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL19-R21) [[2]](diffhunk://#diff-2ec5a7b3b330c2b486114a5da93b2b958cfd07f704079dcda1c0f79587ce2585L19-R19)

**Testing:**

* Added comprehensive unit tests in `CellUtilsTest` for the new `compareRow` method, covering cases where rows are equal, left is less, and right is less.

**Utilities:**

* Added necessary imports for `Arrays` and other utilities in `CellUtils` to support the new comparison methods.