### PR TITLE
[#noisue] Refactor ParallelResultScanner and ScanTask for improved ta…

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScanner.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.common.hbase.wd;
 
 import com.navercorp.pinpoint.common.hbase.util.CellUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
@@ -78,11 +79,7 @@ public class DistributedScanner implements ResultScanner {
     @Override
     public void close() {
         for (LocalScanner scanner : localScanners) {
-            try {
-                scanner.close();
-            } catch (IOException ignore) {
-                // ignore
-            }
+            IOUtils.closeQuietly(scanner);
         }
     }
 

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/LocalScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/LocalScanner.java
@@ -18,9 +18,10 @@ package com.navercorp.pinpoint.common.hbase.wd;
 
 import org.apache.hadoop.hbase.client.Result;
 
+import java.io.Closeable;
 import java.io.IOException;
 
-public interface LocalScanner {
+public interface LocalScanner extends Closeable {
     Result next() throws IOException;
 
     boolean isExhausted();


### PR DESCRIPTION
…sk management and local scanning

This pull request refactors the parallel HBase result scanning logic to simplify iteration and improve resource management. The main change is the introduction of a new `LocalScanner` interface, which allows `ScanTask` to directly provide results and manage its own buffer, removing the need for extra arrays and custom iterators in `ParallelResultScanner`. Several resource handling improvements and code simplifications are also included.

**Core refactoring and interface changes:**

* Refactored `ScanTask` to implement a new `LocalScanner` interface, providing `next()`, `consume()`, and `isExhausted()` methods for direct result retrieval and buffer management. This replaces the previous approach using blocking queues and external arrays for result tracking. [[1]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34R21-R43) [[2]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34R56-R57) [[3]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34L92-R175)
* Updated `ParallelResultScanner` to use an array of `ScanTask` (now `LocalScanner`), simplifying the logic for selecting the next result and removing the need for a custom iterator and result arrays. [[1]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL44-R45) [[2]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL61-R72) [[3]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL84-R89) [[4]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL113-R134) [[5]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL147-L162) [[6]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL177-L222)

**Resource management and error handling:**

* Improved scanner resource cleanup by adding helper methods to safely close individual and arrays of `ResultScanner` instances, and ensuring scanners are closed even on exceptions. [[1]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34L78-R85) [[2]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34L92-R175)
* Enhanced error handling in `ScanTask.next()` to properly handle thread interruption and signal exhaustion via `InterruptedIOException`.

**Code cleanup and simplification:**

* Removed unused imports and code (such as the iterator implementation and unused arrays), and updated type usage to arrays instead of lists where appropriate for performance and clarity. [[1]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL31) [[2]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL44-R45) [[3]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL61-R72) [[4]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL84-R89) [[5]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL147-L162) [[6]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL177-L222)

These changes collectively make the parallel scanning logic more robust, easier to maintain, and better at managing resources.