### PR TITLE
[#noissue] Refactor ScanTask for scanner management

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ScanTask.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ScanTask.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.common.hbase.parallel;
 
 import com.navercorp.pinpoint.common.hbase.TableFactory;
+import com.navercorp.pinpoint.common.hbase.scan.ScanUtils;
 import com.navercorp.pinpoint.common.hbase.wd.DistributedScanner;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Result;
@@ -75,7 +76,7 @@ public class ScanTask implements Runnable {
             } finally {
                 this.isDone = true;
                 this.resultQueue.put(END_RESULT);
-                scanner.close();
+                ScanUtils.closeScanner(scanner);
             }
         } catch (Throwable th) {
             this.throwable = th;
@@ -91,10 +92,7 @@ public class ScanTask implements Runnable {
             Scan scan = scans[0];
             return table.getScanner(scan);
         } else {
-            ResultScanner[] scanners = new ResultScanner[this.scans.length];
-            for (int i = 0; i < scanners.length; i++) {
-                scanners[i] = table.getScanner(this.scans[i]);
-            }
+            ResultScanner[] scanners = ScanUtils.newScanners(table, scans);
             return new DistributedScanner(saltKeySize, scanners);
         }
     }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/ScanUtils.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/ScanUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NAVER Corp.
+ * Copyright 2025 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.navercorp.pinpoint.common.hbase.scan;
@@ -85,15 +84,18 @@ public final class ScanUtils {
     public static void closeScanner(ResultScanner[] scannerList, int startOffset) {
         for (int i = startOffset; i < scannerList.length; i++) {
             ResultScanner scanner = scannerList[i];
-            if (scanner != null) {
-                try {
-                    scanner.close();
-                } catch (Throwable ignore) {
-                    // ignore
-                }
-            }
+            closeScanner(scanner);
         }
     }
 
+    public static void closeScanner(ResultScanner scanner) {
+        if (scanner != null) {
+            try {
+                scanner.close();
+            } catch (Throwable ignore) {
+                // ignore
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
This pull request refactors how HBase scanners are managed and closed in the `ScanTask` class by introducing utility methods in the `ScanUtils` class. The changes improve code reuse and safety when handling scanner resources, especially in cases where scanners might be null.

**Resource management improvements:**

* Replaced direct calls to `scanner.close()` in `ScanTask` with the new `ScanUtils.closeScanner(scanner)` utility method to ensure safer scanner closure.
* Updated the logic for creating multiple scanners in `ScanTask` to use `ScanUtils.newScanners(table, scans)`, centralizing scanner creation logic.

**Enhancements to `ScanUtils`:**

* Added a new `closeScanner(ResultScanner scanner)` method to safely close individual scanners, checking for nulls before closing.
* Modified `closeScanner(ResultScanner[] scannerList, int startOffset)` to use the new single-scanner close method, improving robustness when some scanners may be null.
* Updated copyright year in `ScanUtils.java` to 2025.

These changes help prevent resource leaks and make the scanner management code more maintainable and less error-prone.