### PR TITLE
[#noissue] Refactor scan metric reporting to use collectors and improve metrics handling

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/DefaultScanMetricReporter.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/DefaultScanMetricReporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.hbase.util;
 
 import org.apache.hadoop.hbase.TableName;
@@ -7,6 +23,7 @@ import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -19,23 +36,27 @@ public class DefaultScanMetricReporter implements ScanMetricReporter {
     }
 
     @Override
-    public Reporter newReporter(TableName tableName, String comment, List<Scan> scans) {
-        for (Scan scan : scans) {
-            scan.setScanMetricsEnabled(true);
-        }
+    public Reporter newReporter(TableName tableName, String comment, Scan[] scans) {
+        applyMetricsEnabled(scans);
         return new MetricReporter(tableName, comment);
     }
 
-    @Override
-    public Reporter newReporter(TableName tableName, String comment, Scan[] scans) {
+    private void applyMetricsEnabled(Scan[] scans) {
         for (Scan scan : scans) {
             scan.setScanMetricsEnabled(true);
         }
-        return new MetricReporter(tableName, comment);
+    }
+
+    @Override
+    public ReportCollector collect(TableName tableName, String comment, Scan[] scans) {
+        applyMetricsEnabled(scans);
+        MetricReporter reporter = new MetricReporter(tableName, comment);
+        return new DefaultReportCollector(reporter, scans.length);
     }
 
     public static class MetricReporter implements Reporter {
         private final Logger logger = LogManager.getLogger(this.getClass());
+
         private final TableName name;
         private final String comment;
 
@@ -49,22 +70,20 @@ public class DefaultScanMetricReporter implements ScanMetricReporter {
             if (!logger.isInfoEnabled()) {
                 return;
             }
-            // simple metric
-            ScanMetrics summary = new ScanMetrics();
-            int actual = 0;
+            List<ScanMetrics> scanMetrics = scanMetric(scanners);
+
+            report(scanMetrics);
+        }
+
+        private List<ScanMetrics> scanMetric(ResultScanner[] scanners) {
+            List<ScanMetrics> scanMetricsList = new ArrayList<>(scanners.length);
             for (ResultScanner scanner : scanners) {
-                if (scanner == null) {
-                    continue;
-                }
                 ScanMetrics scanMetrics = scanner.getScanMetrics();
                 if (scanMetrics != null) {
-                    actual++;
-                    sum(summary, scanMetrics);
+                    scanMetricsList.add(scanMetrics);
                 }
             }
-            if (actual != 0) {
-                logger.info("ScanMetric {}/{} {} {}:{}", actual, scanners.length, name, comment, summary.getMetricsMap());
-            }
+            return scanMetricsList;
         }
 
         @Override
@@ -125,5 +144,36 @@ public class DefaultScanMetricReporter implements ScanMetricReporter {
             }
         }
     }
+
+    static class DefaultReportCollector implements ReportCollector {
+
+        private final MetricReporter reporter;
+        private final List<ScanMetrics> scanMetricsList;
+
+        public DefaultReportCollector(MetricReporter reporter, int capacity) {
+            this.reporter = Objects.requireNonNull(reporter, "reporter");
+            this.scanMetricsList = new ArrayList<>(capacity);
+        }
+
+        @Override
+        public void collect(ScanMetrics scanMetrics) {
+            if (scanMetrics == null) {
+                return;
+            }
+            synchronized (scanMetricsList) {
+                scanMetricsList.add(scanMetrics);
+            }
+        }
+
+        @Override
+        public void report() {
+            List<ScanMetrics> copy;
+            synchronized (scanMetricsList) {
+                copy = new ArrayList<>(scanMetricsList);
+            }
+            this.reporter.report(copy);
+        }
+    }
+
 
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/EmptyScanMetricReporter.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/EmptyScanMetricReporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.hbase.util;
 
 import org.apache.hadoop.hbase.TableName;
@@ -11,19 +27,23 @@ import java.util.function.Supplier;
 
 public class EmptyScanMetricReporter implements ScanMetricReporter {
 
-    private static final Reporter REPORTER = new EmptyReporter();
+    private static final Reporter REPORTER = new Reporter() {
+    };
+
+    private static final ScanMetricReporter.ReportCollector COLLECTOR = new ReportCollector() {
+    };
 
     public EmptyScanMetricReporter() {
     }
 
     @Override
-    public Reporter newReporter(TableName tableName, String comment, List<Scan> scans) {
+    public Reporter newReporter(TableName tableName, String comment, Scan[] scans) {
         return REPORTER;
     }
 
     @Override
-    public Reporter newReporter(TableName tableName, String comment, Scan[] scans) {
-        return REPORTER;
+    public ReportCollector collect(TableName tableName, String comment, Scan[] scans) {
+        return COLLECTOR;
     }
 
     public static class EmptyReporter implements Reporter {

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricReporter.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricReporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.common.hbase.util;
 
 import org.apache.hadoop.hbase.TableName;
@@ -11,18 +27,29 @@ import java.util.function.Supplier;
 
 public interface ScanMetricReporter {
 
-    Reporter newReporter(TableName tableName, String comment, List<Scan> scans);
-
     Reporter newReporter(TableName tableName, String comment, Scan[] scans);
 
+    ReportCollector collect(TableName tableName, String comment, Scan[] scans);
 
     interface Reporter {
-        void report(ResultScanner[] scanners);
+        default void report(ResultScanner[] scanners) {
+        }
 
-        void report(Supplier<List<ScanMetrics>> scanners);
+        default void report(Supplier<List<ScanMetrics>> scanners) {
+        }
 
-        void report(ResultScanner scanner);
+        default void report(ResultScanner scanner) {
+        }
 
-        void report(Collection<ScanMetrics> scanMetricsList);
+        default void report(Collection<ScanMetrics> scanMetricsList) {
+        }
+    }
+
+    interface ReportCollector {
+        default void collect(ScanMetrics scanMetrics) {
+        }
+
+        default void report() {
+        }
     }
 }


### PR DESCRIPTION
…ve metrics handling

This pull request refactors the scan metrics reporting mechanism in the HBase integration. It introduces a new `ReportCollector` interface to streamline the collection and reporting of scan metrics, replacing the previous approach that relied on passing collections of metrics around. The changes improve the clarity, extensibility, and thread-safety of scan metrics handling, and update the relevant implementations and usages accordingly.

**Scan metrics reporting refactor:**

* Introduced the `ScanMetricReporter.ReportCollector` interface, which encapsulates the collection and reporting of `ScanMetrics` objects, replacing the previous use of `Collection<ScanMetrics>` and simplifying the reporting workflow. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricReporter.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/DefaultScanMetricReporter.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/EmptyScanMetricReporter.java`) [[1]](diffhunk://#diff-9d3387c920b203d61a8316460e25d6368517c46b44180f56f7c8fc8a04f1d7e0R1-R16) [[2]](diffhunk://#diff-9d3387c920b203d61a8316460e25d6368517c46b44180f56f7c8fc8a04f1d7e0L14-R53) [[3]](diffhunk://#diff-95fb302e73509e1f1bc4c3ccb4b9ed001d97a05a7c8d2bfb43c700774ea643efL22-R59) [[4]](diffhunk://#diff-95fb302e73509e1f1bc4c3ccb4b9ed001d97a05a7c8d2bfb43c700774ea643efR150-R176) [[5]](diffhunk://#diff-b52871060fd7f83cecc1076f54d63610a30883f9652b5e6940f94e4b01b1a50cR1-R39)

* Updated `HbaseTemplate` to use the new `ReportCollector` for parallel scan operations, improving thread-safety and simplifying the collection and reporting of scan metrics. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java`) [[1]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L378-R377) [[2]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L396-R401) [[3]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L420-R417)

**Code cleanup and modernization:**

* Removed unused imports and outdated code related to the old scan metrics collection approach. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java`) [[1]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L49) [[2]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L58-L62)

* Added license headers to several files for consistency and legal compliance. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/DefaultScanMetricReporter.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/EmptyScanMetricReporter.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricReporter.java`) [[1]](diffhunk://#diff-95fb302e73509e1f1bc4c3ccb4b9ed001d97a05a7c8d2bfb43c700774ea643efR1-R16) [[2]](diffhunk://#diff-b52871060fd7f83cecc1076f54d63610a30883f9652b5e6940f94e4b01b1a50cR1-R39) [[3]](diffhunk://#diff-9d3387c920b203d61a8316460e25d6368517c46b44180f56f7c8fc8a04f1d7e0R1-R16)