### PR TITLE
[#noissue] Cleanup scanId

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
@@ -124,7 +124,7 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
         scan.setCaching(this.scanCacheSize);
         scan.withStartRow(startKey);
         scan.withStopRow(endKey);
-        scan.setId("HostApplicationScan_Ver2");
+        scan.setId("MHostApp");
 
         return scan;
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapAgentResponseTimeDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapAgentResponseTimeDao.java
@@ -87,7 +87,7 @@ public class HbaseMapAgentResponseTimeDao implements MapAgentResponseDao {
         }
 
         Range windowRange = timeWindow.getWindowRange();
-        Scan scan = scanFactory.createScan("MapSelfScan", ServiceUid.DEFAULT_SERVICE_UID_CODE, application, windowRange, table.getName());
+        Scan scan = scanFactory.createScan("MAgeRes", ServiceUid.DEFAULT_SERVICE_UID_CODE, application, windowRange, table.getName());
 
         ResultsExtractor<List<ResponseTime>> resultsExtractor = resultExtractFactory.newMapper(timeWindow, application);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java
@@ -89,7 +89,7 @@ public class HbaseMapInLinkDao implements MapInLinkDao {
         RowMapper<LinkDataMap> rowMapper = this.inLinkMapperFactory.newMapper(mapperWindow, inApplication);
         ResultsExtractor<LinkDataMap> resultExtractor = new RowMapReduceResultExtractor<>(rowMapper, new LinkTimeWindowReducer(timeWindow));
 
-        final Scan scan = scanFactory.createScan("MapInLinkScan", ServiceUid.DEFAULT_SERVICE_UID_CODE, inApplication, timeWindow.getWindowRange(), table.getName());
+        final Scan scan = scanFactory.createScan("MInLink", ServiceUid.DEFAULT_SERVICE_UID_CODE, inApplication, timeWindow.getWindowRange(), table.getName());
 
         final LinkDataMap linkDataMap = selectInLink(scan, table.getTable(), resultExtractor, NUM_PARTITIONS);
         if (logger.isDebugEnabled()) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -88,7 +88,7 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
 
         ResultsExtractor<LinkDataMap> resultExtractor = new RowMapReduceResultExtractor<>(rowMapper, new LinkTimeWindowReducer(timeWindow));
 
-        final Scan scan = scanFactory.createScan("MapOutLinkScan", ServiceUid.DEFAULT_SERVICE_UID_CODE, outApplication, timeWindow.getWindowRange(), table.getName());
+        final Scan scan = scanFactory.createScan("MOutLink", ServiceUid.DEFAULT_SERVICE_UID_CODE, outApplication, timeWindow.getWindowRange(), table.getName());
         final LinkDataMap linkDataMap = selectOutLink(scan, table.getTable(), resultExtractor, NUM_PARTITIONS);
         if (logger.isDebugEnabled()) {
             logger.debug("selectOutLink {} {}", outApplication, linkDataMap.getLinkDataSize());

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapResponseDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapResponseDao.java
@@ -81,7 +81,7 @@ public class HbaseMapResponseDao implements MapResponseDao {
         }
 
         Range windowRange = timeWindow.getWindowRange();
-        Scan scan = scanFactory.createScan("MapAppSelf", ServiceUid.DEFAULT_SERVICE_UID_CODE, application, windowRange, table.getName());
+        Scan scan = scanFactory.createScan("MAppRes", ServiceUid.DEFAULT_SERVICE_UID_CODE, application, windowRange, table.getName());
 
         ResultsExtractor<ApplicationResponse> mapper = resultExtractor.newMapper(timeWindow, application);
         TableName mapStatisticsSelfTableName = tableNameProvider.getTableName(table.getTable());


### PR DESCRIPTION
This pull request standardizes the identifiers used when creating HBase `Scan` objects across several DAO classes in the application map module. The changes primarily involve updating the `scan.setId` or scan name strings to use shorter, more consistent identifiers, likely for improved readability or internal tracking.

**HBase Scan Identifier Standardization:**

* Changed the scan ID in `HbaseHostApplicationMapDao.java` from `"HostApplicationScan_Ver2"` to `"MHostApp"` for consistency.
* Updated the scan name in `HbaseMapAgentResponseTimeDao.java` from `"MapSelfScan"` to `"MAgeRes"`.
* Changed the scan name in `HbaseMapInLinkDao.java` from `"MapInLinkScan"` to `"MInLink"`.
* Changed the scan name in `HbaseMapOutLinkDao.java` from `"MapOutLinkScan"` to `"MOutLink"`.
* Updated the scan name in `HbaseMapResponseDao.java` from `"MapAppSelf"` to `"MAppRes"`.