### PR TITLE
[#13217] Applied Spring Boot Actuator to pinpoint-collector, pinpoint-collector-stater

### DIFF
--- a/collector-starter/src/main/resources/application.yml
+++ b/collector-starter/src/main/resources/application.yml
@@ -8,6 +8,58 @@ spring:
     history:
       enabled: false
 
+management:
+  otlp:
+    metrics:
+      export:
+        enabled: false
+  health:
+    defaults:
+      enabled: false
+    diskspace:
+      enabled: true
+  endpoint:
+    health:
+      show-details: always
+      enabled: true
+    beans:
+      enabled: true
+    conditions:
+      enabled: true
+    configprops:
+      enabled: true
+      show-values: always
+    env:
+      enabled: true
+      show-values: always
+    logfile:
+      enabled: true
+    loggers:
+      enabled: true
+    mappings:
+      enabled: true
+    info:
+      enabled: true
+    threaddump:
+      enabled: true
+    heapdump:
+      enabled: true
+    metrics:
+      enabled: true
+    httptrace:
+      enabled: false
+    prometheus:
+      enabled: false
+    shutdown:
+      enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: health,beans,conditions,configprops,env,logfile,loggers,mappings,info,threaddump,heapdump,metrics,pause
+      base-path: /monitor
+      path-mapping:
+        health: l7check
+
 pinpoint:
   modules:
     collector:

--- a/collector/src/main/resources/application.yml
+++ b/collector/src/main/resources/application.yml
@@ -5,11 +5,58 @@ spring:
 server:
   port: 8081
 
+
 management:
   otlp:
     metrics:
       export:
         enabled: false
+  health:
+    defaults:
+      enabled: false
+    diskspace:
+      enabled: true
+  endpoint:
+    health:
+      show-details: always
+      enabled: true
+    beans:
+      enabled: true
+    conditions:
+      enabled: true
+    configprops:
+      enabled: true
+      show-values: always
+    env:
+      enabled: true
+      show-values: always
+    logfile:
+      enabled: true
+    loggers:
+      enabled: true
+    mappings:
+      enabled: true
+    info:
+      enabled: true
+    threaddump:
+      enabled: true
+    heapdump:
+      enabled: true
+    metrics:
+      enabled: true
+    httptrace:
+      enabled: false
+    prometheus:
+      enabled: false
+    shutdown:
+      enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: health,beans,conditions,configprops,env,logfile,loggers,mappings,info,threaddump,heapdump,metrics,pause
+      base-path: /monitor
+      path-mapping:
+        health: l7check
 
 pinpoint:
   modules:


### PR DESCRIPTION
This pull request enhances the observability and monitoring configuration for both the Collector Starter and Collector services by enabling and customizing various Spring Boot Actuator endpoints. These changes make it easier to monitor application health and access diagnostic information through a dedicated base path, while disabling unnecessary or potentially sensitive endpoints.

Key configuration changes:

**Actuator Endpoint Enhancements:**

* Enabled a wide range of management endpoints (such as `health`, `beans`, `conditions`, `configprops`, `env`, `logfile`, `loggers`, `mappings`, `info`, `threaddump`, `heapdump`, and `metrics`) for both services, providing detailed operational and diagnostic information. [[1]](diffhunk://#diff-6540639273c232e22d4d06bbc6cbef6b61602ede1838ab44670497517548c9e1R11-R62) [[2]](diffhunk://#diff-db0d608bc82c6d2eb7537e344661b327c7ebb6fef591e822ffc9bf8d973d6767R8-R59)
* Configured endpoints to always show details and values where applicable (e.g., `health.show-details: always`, `configprops.show-values: always`, `env.show-values: always`). [[1]](diffhunk://#diff-6540639273c232e22d4d06bbc6cbef6b61602ede1838ab44670497517548c9e1R11-R62) [[2]](diffhunk://#diff-db0d608bc82c6d2eb7537e344661b327c7ebb6fef591e822ffc9bf8d973d6767R8-R59)
* Disabled certain endpoints (`httptrace`, `prometheus`, and `shutdown`) to reduce exposure of sensitive or unnecessary information. [[1]](diffhunk://#diff-6540639273c232e22d4d06bbc6cbef6b61602ede1838ab44670497517548c9e1R11-R62) [[2]](diffhunk://#diff-db0d608bc82c6d2eb7537e344661b327c7ebb6fef591e822ffc9bf8d973d6767R8-R59)

**Endpoint Exposure and Path Customization:**

* Set the base path for all web-exposed actuator endpoints to `/monitor` and included a specific set of endpoints for web exposure. [[1]](diffhunk://#diff-6540639273c232e22d4d06bbc6cbef6b61602ede1838ab44670497517548c9e1R11-R62) [[2]](diffhunk://#diff-db0d608bc82c6d2eb7537e344661b327c7ebb6fef591e822ffc9bf8d973d6767R8-R59)
* Mapped the `health` endpoint to `/monitor/l7check` for easier integration with load balancers or external health checks. [[1]](diffhunk://#diff-6540639273c232e22d4d06bbc6cbef6b61602ede1838ab44670497517548c9e1R11-R62) [[2]](diffhunk://#diff-db0d608bc82c6d2eb7537e344661b327c7ebb6fef591e822ffc9bf8d973d6767R8-R59)

**Health and Metrics Configuration:**

* Disabled default health checks except for disk space, focusing health monitoring on essential resources. [[1]](diffhunk://#diff-6540639273c232e22d4d06bbc6cbef6b61602ede1838ab44670497517548c9e1R11-R62) [[2]](diffhunk://#diff-db0d608bc82c6d2eb7537e344661b327c7ebb6fef591e822ffc9bf8d973d6767R8-R59)
* Explicitly disabled OTLP metrics export, likely to prevent unnecessary external reporting. [[1]](diffhunk://#diff-6540639273c232e22d4d06bbc6cbef6b61602ede1838ab44670497517548c9e1R11-R62) [[2]](diffhunk://#diff-db0d608bc82c6d2eb7537e344661b327c7ebb6fef591e822ffc9bf8d973d6767R8-R59)