### PR TITLE
[#noissue] Refactor scan handling for distributed scans

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java
@@ -471,7 +471,7 @@ public class HbaseTemplate extends HbaseAccessor implements HbaseOperations, Ini
                 final StopWatch watch = StopWatch.createStarted();
                 final boolean debugEnabled = logger.isDebugEnabled();
 
-                Scan[] scans = ScanUtils.splitScans(scan, rowKeyDistributor);
+                Scan[] scans = rowKeyDistributor.getDistributedScans(scan);
                 final ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "block-multi", scans);
 
                 final ResultScanner[] splitScanners = ScanUtils.newScanners(table, scans);

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java
@@ -374,7 +374,7 @@ public class HbaseAsyncTemplate implements DisposableBean, AsyncHbaseOperations 
                 final StopWatch watch = StopWatch.createStarted();
                 final boolean debugEnabled = logger.isDebugEnabled();
 
-                Scan[] scans = ScanUtils.splitScans(scan, rowKeyDistributor);
+                Scan[] scans = rowKeyDistributor.getDistributedScans(scan);
                 final ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "async-multi", scans);
                 final ResultScanner[] splitScanners = ScanUtils.newScanners(table, scans);
                 final int saltKeySize = rowKeyDistributor.getSaltKeySize();
@@ -404,7 +404,7 @@ public class HbaseAsyncTemplate implements DisposableBean, AsyncHbaseOperations 
         try {
             StopWatch watch = StopWatch.createStarted();
 
-            final Scan[] scans = ScanUtils.splitScans(scan, rowKeyDistributor);
+            final Scan[] scans = rowKeyDistributor.getDistributedScans(scan);
             T result = execute(tableName, new AsyncTableCallback<T>() {
                 @Override
                 public T doInTable(AsyncTable<ScanResultConsumer> table) throws Throwable {

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ParallelResultScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/parallel/ParallelResultScanner.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.common.hbase.parallel;
 
 import com.navercorp.pinpoint.common.hbase.HbaseAccessor;
-import com.navercorp.pinpoint.common.hbase.scan.ScanUtils;
 import com.navercorp.pinpoint.common.hbase.util.CellUtils;
 import com.navercorp.pinpoint.common.hbase.wd.LocalScanner;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
@@ -53,7 +52,7 @@ public class ParallelResultScanner implements ResultScanner {
         this.saltKeySize = keyDistributor.getSaltKeySize();
 
         final ScanTaskConfig scanTaskConfig = ScanTaskConfig.of(tableName, hbaseAccessor, saltKeySize, originalScan.getCaching());
-        final Scan[] splitScans = ScanUtils.splitScans(originalScan, keyDistributor);
+        final Scan[] splitScans = keyDistributor.getDistributedScans(originalScan);
 
         this.scanTasks = createScanTasks(scanTaskConfig, splitScans, numParallelThreads);
         for (ScanTask scanTask : scanTasks) {

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/ScanUtils.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/ScanUtils.java
@@ -28,6 +28,10 @@ import java.util.function.Function;
 
 public final class ScanUtils {
 
+    /**
+     * @deprecated Use {@link RowKeyDistributor#getDistributedScans(Scan)} instead.
+     */
+    @Deprecated
     public static Scan[] splitScans(Scan originalScan, RowKeyDistributor keyDistributor) throws IOException {
         Scan[] scans = keyDistributor.getDistributedScans(originalScan);
         applyScanOptions(originalScan, scans);

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributor.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributor.java
@@ -83,9 +83,18 @@ public interface RowKeyDistributor {
 
         Scan[] scans = new Scan[intervals.length];
         for (int i = 0; i < intervals.length; i++) {
-            scans[i] = new Scan(original);
-            scans[i].setStartRow(intervals[i].getFirst());
-            scans[i].setStopRow(intervals[i].getSecond());
+            Scan copy = new Scan(original);
+
+            Pair<byte[], byte[]> interval = intervals[i];
+            copy.setStartRow(interval.getFirst());
+            copy.setStopRow(interval.getSecond());
+
+            final String scanId = original.getId();
+            if (scanId != null) {
+                copy.setId(scanId + "-" + i);
+            }
+
+            scans[i] = copy;
         }
         return scans;
     }


### PR DESCRIPTION
This pull request refactors how distributed scans are created and used throughout the codebase, standardizing the approach and deprecating the old utility method. The main change is to use `RowKeyDistributor.getDistributedScans(Scan)` directly instead of the `ScanUtils.splitScans` helper, which is now deprecated. This improves clarity and centralizes distributed scan logic.

**Distributed scan creation and usage:**

* Replaced all usages of `ScanUtils.splitScans` with direct calls to `RowKeyDistributor.getDistributedScans(Scan)` in `HbaseTemplate`, `HbaseAsyncTemplate`, and `ParallelResultScanner` to standardize scan distribution. [[1]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L474-R474) [[2]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L377-R377) [[3]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L407-R407) [[4]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL56-R55)

**Deprecation and documentation:**

* Marked `ScanUtils.splitScans` as deprecated and updated its documentation to direct users to `RowKeyDistributor.getDistributedScans(Scan)` instead.

**Implementation improvements:**

* Enhanced `RowKeyDistributor.getDistributedScans(Scan)` to copy the scan ID with a unique suffix for each split scan, ensuring better traceability and debugging.

**Code cleanup:**

* Removed the unused import of `ScanUtils` from `ParallelResultScanner.java` since split logic is now handled directly by the distributor.