### PR TITLE
[#noissue] Refactor scan metrics handling for simplified collection and reporting

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java
@@ -341,12 +341,13 @@ public class HbaseTemplate extends HbaseAccessor implements HbaseOperations, Ini
             @Override
             public List<T> doInTable(Table table) throws Throwable {
                 Scan[] copy = scanList.toArray(new Scan[0]);
-                final ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "find", copy);
+
                 Scanner<T> scanner = resultScannerFactory.newScanner(table, copy);
 
                 List<T> result = scanner.extractData(action);
 
-                reporter.report(scanner::getScanMetrics);
+                final ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "find", copy);
+                reporter.report(scanner.getScanMetrics());
                 return result;
             }
         });

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java
@@ -352,11 +352,11 @@ public class HbaseAsyncTemplate implements DisposableBean, AsyncHbaseOperations 
             public List<T> doInTable(AsyncTable<ScanResultConsumer> table) throws Throwable {
                 final Scan[] copy = scans.toArray(new Scan[0]);
 
-                final ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "async-multi", copy);
-
                 Scanner<T> scanner = scannerFactory.newScanner(table, copy);
                 List<T> results = scanner.extractData(action);
-                reporter.report(scanner::getScanMetrics);
+
+                final ScanMetricReporter.Reporter reporter = scanMetric.newReporter(tableName, "async-multi", copy);
+                reporter.report(scanner.getScanMetrics());
                 return results;
             }
         });

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/DefaultScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/DefaultScanner.java
@@ -2,8 +2,10 @@ package com.navercorp.pinpoint.common.hbase.scan;
 
 import com.navercorp.pinpoint.common.hbase.HbaseSystemException;
 import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
+import com.navercorp.pinpoint.common.hbase.util.ScanMetricUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,12 +47,19 @@ public class DefaultScanner<T> implements Scanner<T> {
         }
     }
 
-
+    @Nullable
     @Override
-    public List<ScanMetrics> getScanMetrics() {
-        List<ScanMetrics> metrics = new ArrayList<>();
+    public ScanMetrics getScanMetrics() {
+        ScanMetrics metrics = null;
         for (ResultScannerSupplier resultScanner : resultScanners) {
-            metrics.add(resultScanner.getScanMetrics());
+            ScanMetrics scanMetrics = resultScanner.getScanMetrics();
+            if (scanMetrics == null) {
+                continue;
+            }
+            if (metrics == null) {
+                metrics = new ScanMetrics();
+            }
+            ScanMetricUtils.sum(metrics, scanMetrics);
         }
         return metrics;
     }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/Scanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/Scanner.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface Scanner<T> {
     List<T> extractData(ResultsExtractor<T> action);
 
-    List<ScanMetrics> getScanMetrics();
+    ScanMetrics getScanMetrics();
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/EmptyScanMetricReporter.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/EmptyScanMetricReporter.java
@@ -17,13 +17,7 @@
 package com.navercorp.pinpoint.common.hbase.util;
 
 import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.function.Supplier;
 
 public class EmptyScanMetricReporter implements ScanMetricReporter {
 
@@ -44,25 +38,5 @@ public class EmptyScanMetricReporter implements ScanMetricReporter {
     @Override
     public ReportCollector collect(TableName tableName, String comment, Scan[] scans) {
         return COLLECTOR;
-    }
-
-    public static class EmptyReporter implements Reporter {
-        @Override
-        public void report(ResultScanner[] scanners) {
-        }
-
-        @Override
-        public void report(Supplier<List<ScanMetrics>> scanners) {
-
-        }
-
-        @Override
-        public void report(ResultScanner scanner) {
-        }
-
-        @Override
-        public void report(Collection<ScanMetrics> scanMetricsList) {
-
-        }
     }
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricReporter.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricReporter.java
@@ -22,8 +22,6 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.function.Supplier;
 
 public interface ScanMetricReporter {
 
@@ -32,13 +30,11 @@ public interface ScanMetricReporter {
     ReportCollector collect(TableName tableName, String comment, Scan[] scans);
 
     interface Reporter {
+
         default void report(ResultScanner[] scanners) {
         }
 
-        default void report(Supplier<List<ScanMetrics>> scanners) {
-        }
-
-        default void report(ResultScanner scanner) {
+        default void report(ScanMetrics scanMetrics) {
         }
 
         default void report(Collection<ScanMetrics> scanMetricsList) {

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricUtils.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricUtils.java
@@ -1,0 +1,49 @@
+package com.navercorp.pinpoint.common.hbase.util;
+
+import com.navercorp.pinpoint.common.util.CollectionUtils;
+import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ScanMetricUtils {
+
+    public static ScanMetrics merge(Collection<ScanMetrics> metricsList) {
+        if (CollectionUtils.isEmpty(metricsList)) {
+            return new ScanMetrics();
+        }
+
+        ScanMetrics sum = new ScanMetrics();
+        for (ScanMetrics target : metricsList) {
+            sum(sum, target);
+        }
+
+        return sum;
+    }
+
+    public static void sum(ScanMetrics source, ScanMetrics target) {
+        if (target == null) {
+            return;
+        }
+        add(source.countOfRPCcalls, target.countOfRPCcalls);
+        add(source.countOfRemoteRPCcalls, target.countOfRemoteRPCcalls);
+        add(source.sumOfMillisSecBetweenNexts, target.sumOfMillisSecBetweenNexts);
+        add(source.countOfNSRE, target.countOfNSRE);
+        add(source.countOfBytesInResults, target.countOfBytesInResults);
+        add(source.countOfBytesInRemoteResults, target.countOfBytesInRemoteResults);
+        add(source.countOfRegions, target.countOfRegions);
+        add(source.countOfRPCRetries, target.countOfRPCRetries);
+        add(source.countOfRemoteRPCRetries, target.countOfRemoteRPCRetries);
+
+        add(source.countOfRowsFiltered, target.countOfRowsFiltered);
+        add(source.countOfRowsScanned, target.countOfRowsScanned);
+        add(source.bytesReadFromFs, target.bytesReadFromFs);
+        add(source.bytesReadFromBlockCache, target.bytesReadFromBlockCache);
+        add(source.bytesReadFromMemstore, target.bytesReadFromMemstore);
+        add(source.blockReadOpsCount, target.blockReadOpsCount);
+    }
+
+    private static void add(AtomicLong source, AtomicLong target) {
+        source.addAndGet(target.get());
+    }
+}


### PR DESCRIPTION
…nd reporting

This pull request refactors and simplifies the scan metrics reporting logic in the HBase commons module. The main focus is on consolidating scan metrics handling, reducing interface complexity, and introducing utility methods for merging and summing scan metrics. It also updates dependencies and cleans up unused code.

**Refactoring and Simplification of Scan Metrics Reporting:**

* Changed the `Scanner` interface and its implementations to return a single merged `ScanMetrics` object instead of a list, simplifying metric aggregation. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/Scanner.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/DefaultScanner.java`) [[1]](diffhunk://#diff-830be742e88c65f7e27bc839cc6887e476dad964001cb04af827ed380f8228bfL11-R11) [[2]](diffhunk://#diff-2b73b35fd524521de0a77b9d0efee0d2e7e25e6966d1aece101fa70ca6adfd79L48-R62)
* Refactored `ScanMetricReporter` and its implementations to use the new single `ScanMetrics` approach, removing methods that accepted lists or suppliers and consolidating reporting logic. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/DefaultScanMetricReporter.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/EmptyScanMetricReporter.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricReporter.java`) [[1]](diffhunk://#diff-95fb302e73509e1f1bc4c3ccb4b9ed001d97a05a7c8d2bfb43c700774ea643efL54-R50) [[2]](diffhunk://#diff-95fb302e73509e1f1bc4c3ccb4b9ed001d97a05a7c8d2bfb43c700774ea643efR64-R96) [[3]](diffhunk://#diff-95fb302e73509e1f1bc4c3ccb4b9ed001d97a05a7c8d2bfb43c700774ea643efL101-R133) [[4]](diffhunk://#diff-b52871060fd7f83cecc1076f54d63610a30883f9652b5e6940f94e4b01b1a50cL48-L67) [[5]](diffhunk://#diff-9d3387c920b203d61a8316460e25d6368517c46b44180f56f7c8fc8a04f1d7e0L35-R37)

**Introduction of Utility Methods for Scan Metrics:**

* Added a new `ScanMetricUtils` class with static methods for merging and summing `ScanMetrics` instances, centralizing this logic and removing duplication. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricUtils.java`)
* Updated all relevant code to use `ScanMetricUtils` for metrics aggregation. [[1]](diffhunk://#diff-2b73b35fd524521de0a77b9d0efee0d2e7e25e6966d1aece101fa70ca6adfd79L48-R62) [[2]](diffhunk://#diff-95fb302e73509e1f1bc4c3ccb4b9ed001d97a05a7c8d2bfb43c700774ea643efL101-R133)

**Dependency and Code Cleanup:**

* Added `eclipse-collections-api` and `eclipse-collections` dependencies to the project. (`commons-hbase/pom.xml`)
* Removed unused imports and code from metric reporting classes, streamlining the codebase. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/DefaultScanMetricReporter.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/EmptyScanMetricReporter.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricReporter.java`) [[1]](diffhunk://#diff-95fb302e73509e1f1bc4c3ccb4b9ed001d97a05a7c8d2bfb43c700774ea643efL26-L31) [[2]](diffhunk://#diff-b52871060fd7f83cecc1076f54d63610a30883f9652b5e6940f94e4b01b1a50cL20-L26) [[3]](diffhunk://#diff-9d3387c920b203d61a8316460e25d6368517c46b44180f56f7c8fc8a04f1d7e0L25-L26)

**API Usage Updates:**

* Updated usages in `HbaseTemplate` and `HbaseAsyncTemplate` to use the new `getScanMetrics()` method and reporting pattern. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseTemplate.java`, `commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/HbaseAsyncTemplate.java`) [[1]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L344-R350) [[2]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L355-R359)