### PR TITLE
[#noissue] Refactor scan handling to integrate DistributedScan and im…

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/ScanUtils.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/ScanUtils.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.common.hbase.scan;
 
 import com.navercorp.pinpoint.common.hbase.HbaseSystemException;
+import com.navercorp.pinpoint.common.hbase.wd.DistributedScan;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
 import org.apache.hadoop.hbase.client.AsyncTable;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -33,9 +34,8 @@ public final class ScanUtils {
      */
     @Deprecated
     public static Scan[] splitScans(Scan originalScan, RowKeyDistributor keyDistributor) throws IOException {
-        Scan[] scans = keyDistributor.getDistributedScans(originalScan);
-        applyScanOptions(originalScan, scans);
-        return scans;
+        DistributedScan scans = keyDistributor.getDistributedScans(originalScan);
+        return scans.getScans();
     }
 
     private static void applyScanOptions(Scan originalScan, Scan[] scans) {

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/Scanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/scan/Scanner.java
@@ -2,11 +2,13 @@ package com.navercorp.pinpoint.common.hbase.scan;
 
 import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
 import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
 public interface Scanner<T> {
     List<T> extractData(ResultsExtractor<T> action);
 
+    @Nullable
     ScanMetrics getScanMetrics();
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/EmptyScanMetricReporter.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/EmptyScanMetricReporter.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.common.hbase.util;
 
 import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.Scan;
 
 public class EmptyScanMetricReporter implements ScanMetricReporter {
 
@@ -31,12 +30,12 @@ public class EmptyScanMetricReporter implements ScanMetricReporter {
     }
 
     @Override
-    public Reporter newReporter(TableName tableName, String comment, Scan[] scans) {
+    public Reporter newReporter(TableName tableName, String comment) {
         return REPORTER;
     }
 
     @Override
-    public ReportCollector collect(TableName tableName, String comment, Scan[] scans) {
+    public ReportCollector collect(TableName tableName, String comment) {
         return COLLECTOR;
     }
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricReporter.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/util/ScanMetricReporter.java
@@ -18,16 +18,19 @@ package com.navercorp.pinpoint.common.hbase.util;
 
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
 
 import java.util.Collection;
 
 public interface ScanMetricReporter {
 
-    Reporter newReporter(TableName tableName, String comment, Scan[] scans);
+    Reporter newReporter(TableName tableName, String comment);
 
-    ReportCollector collect(TableName tableName, String comment, Scan[] scans);
+    ReportCollector collect(TableName tableName, String comment);
+
+    default boolean isEnable() {
+        return false;
+    }
 
     interface Reporter {
 

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScan.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/DistributedScan.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase.wd;
+
+import org.apache.hadoop.hbase.client.Scan;
+
+import java.util.Objects;
+
+public class DistributedScan {
+    private final Scan[] scans;
+    private final int saltKeySize;
+
+    private boolean enableScanMetrics;
+
+    public DistributedScan(Scan[] scans, int saltKeySize) {
+        this.scans = Objects.requireNonNull(scans, "scans");
+
+        this.saltKeySize = saltKeySize;
+    }
+
+    public Scan[] getScans() {
+        return scans;
+    }
+
+    public int getSaltKeySize() {
+        return saltKeySize;
+    }
+
+    public void setScanMetricReporter(boolean enableScanMetrics) {
+        this.enableScanMetrics = enableScanMetrics;
+        if (enableScanMetrics) {
+            for (Scan scan : scans) {
+                scan.setScanMetricsEnabled(enableScanMetrics);
+            }
+        }
+    }
+
+    public boolean isEnableScanMetrics() {
+        return enableScanMetrics;
+    }
+};

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/LocalScanner.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/LocalScanner.java
@@ -17,6 +17,8 @@
 package com.navercorp.pinpoint.common.hbase.wd;
 
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -29,4 +31,7 @@ public interface LocalScanner extends Closeable {
     void consume();
 
     void close() throws IOException;
+
+    @Nullable
+    ScanMetrics getScanMetrics();
 }

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/LocalScannerImpl.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/LocalScannerImpl.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.common.hbase.wd;
 
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -33,14 +34,14 @@ import java.util.Objects;
  */
 public class LocalScannerImpl implements Closeable, LocalScanner {
 
-    private final ResultScanner scan;
+    private final ResultScanner scanner;
 
     private boolean exhausted = false;
 
     private Result localBuffer;
 
-    public LocalScannerImpl(ResultScanner scan) {
-        this.scan = Objects.requireNonNull(scan, "scan");
+    public LocalScannerImpl(ResultScanner scanner) {
+        this.scanner = Objects.requireNonNull(scanner, "scanner");
     }
 
     @Override
@@ -51,7 +52,7 @@ public class LocalScannerImpl implements Closeable, LocalScanner {
         if (localBuffer != null) {
             return localBuffer;
         }
-        Result next = scan.next();
+        Result next = scanner.next();
         if (next == null) {
             exhausted = true;
         }
@@ -72,6 +73,11 @@ public class LocalScannerImpl implements Closeable, LocalScanner {
 
     @Override
     public void close() throws IOException {
-        scan.close();
+        scanner.close();
+    }
+
+    @Override
+    public ScanMetrics getScanMetrics() {
+        return scanner.getScanMetrics();
     }
 }


### PR DESCRIPTION
…prove scan metrics reporting

This pull request refactors how distributed scans and scan metrics are handled in the HBase integration, focusing on improving scan metric reporting and streamlining the use of `DistributedScan` objects. The changes remove redundant parameters, update method signatures, and ensure that scan metrics are properly collected and reported across synchronous, asynchronous, and parallel scan operations.

**Distributed Scan Handling:**
- Replaced direct use of `Scan[]` arrays with `DistributedScan` objects throughout the codebase, including in `HbaseTemplate`, `HbaseAsyncTemplate`, and `ParallelResultScanner`. This allows for more flexible and feature-rich handling of distributed scans. [[1]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L475-R479) [[2]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L377-R380) [[3]](diffhunk://#diff-50f9a99402b55c62bb9978bb68567f6358a431e79fb540ee72c2830465dbf67dL54-R67) [[4]](diffhunk://#diff-ed60e5448a9395e008df0b7cb47214cecbf13bf7e60842d2021abc4734d82395L36-R38)

**Scan Metric Reporting Improvements:**
- Updated scan metric reporter usage to remove the need to pass scan arrays, instead reporting metrics based on the `DistributedScanner`'s collected metrics, improving accuracy and reducing boilerplate. [[1]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L349-R349) [[2]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L376-R376) [[3]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L358-R357) [[4]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L407-R418) [[5]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L391-R391) [[6]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L489-R489)

**Parallel and Task Configuration Enhancements:**
- Refactored `ScanTaskConfig` to remove unused fields and constructors, and added a `scanMetricsEnabled` flag for better control over scan metric collection. The configuration now directly supports the new distributed scan workflow. [[1]](diffhunk://#diff-eb17655650851e1d009923b2ce153a247ed72f8f4c0e84923cafc30a45326fe5L34-L70) [[2]](diffhunk://#diff-eb17655650851e1d009923b2ce153a247ed72f8f4c0e84923cafc30a45326fe5R77-R80)
- Updated `ScanTask` to initialize and aggregate scan metrics only when enabled, and exposed `getScanMetrics()` for external reporting. [[1]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34R58-R59) [[2]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34R68-R76) [[3]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34R97-R99) [[4]](diffhunk://#diff-afe8e6d8e9d8b2bb405f1c3551f5ccc6bc3946bd68bd566709c6f91fdd3c5c34R167-R170)

**Code Cleanup:**
- Removed unnecessary imports and deprecated usages, such as direct references to `ScanUtils` and unused constructor parameters, to simplify the codebase. [[1]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6L24-R28) [[2]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L28-R32) [[3]](diffhunk://#diff-1f87fcedb318473b17287642b1bca28d6775a783a4ec91b79b99e70385711661L46) [[4]](diffhunk://#diff-eb17655650851e1d009923b2ce153a247ed72f8f4c0e84923cafc30a45326fe5L19-L25)

These changes collectively modernize the scan workflow, improve metric visibility, and make the code easier to maintain and extend.