### PR TITLE
[#noissue] Refactor row key decoding to support offset/length parameters and improve buffer handling

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidAgentRowKey.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidAgentRowKey.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.common.server.applicationmap.statistics;
 
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
-import com.navercorp.pinpoint.common.buffer.FixedBuffer;
+import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.BytesUtils;
@@ -121,8 +121,12 @@ public class UidAgentRowKey implements UidRowKey {
 
 
     public static UidAgentRowKey read(int saltKey, byte[] bytes) {
+        return read(saltKey, bytes, 0, bytes.length);
+    }
 
-        final Buffer buffer = new FixedBuffer(bytes);
+    public static UidAgentRowKey read(int saltKey, byte[] bytes, int offset, int length) {
+
+        final Buffer buffer = new OffsetFixedBuffer(bytes, offset, length);
         // skip offset & applicationNameHash
         buffer.skip(saltKey);
 
@@ -141,6 +145,7 @@ public class UidAgentRowKey implements UidRowKey {
 
         return new UidAgentRowKey(serviceUid, applicationName, serviceType, timestamp, agentId);
     }
+
 
 
     @Override

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidAppRowKey.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidAppRowKey.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.common.server.applicationmap.statistics;
 
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
-import com.navercorp.pinpoint.common.buffer.FixedBuffer;
+import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.BytesUtils;
@@ -103,8 +103,12 @@ public class UidAppRowKey implements UidRowKey {
     }
 
     public static UidAppRowKey read(int saltKey, byte[] bytes) {
+        return read(saltKey, bytes, 0, bytes.length);
+    }
 
-        final Buffer buffer = new FixedBuffer(bytes);
+    public static UidAppRowKey read(int saltKey, byte[] bytes, int offset, int length) {
+
+        final Buffer buffer = new OffsetFixedBuffer(bytes, offset, length);
         // skip offset & applicationNameHash
         buffer.skip(saltKey);
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.common.server.applicationmap.statistics;
 
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
-import com.navercorp.pinpoint.common.buffer.FixedBuffer;
+import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.BytesUtils;
@@ -140,8 +140,12 @@ public class UidLinkRowKey implements UidRowKey {
 
 
     public static UidLinkRowKey read(int saltKey, byte[] bytes) {
+        return read(saltKey, bytes, 0, bytes.length);
+    }
 
-        final Buffer buffer = new FixedBuffer(bytes);
+    public static UidLinkRowKey read(int saltKey, byte[] bytes, int offset, int length) {
+
+        final Buffer buffer = new OffsetFixedBuffer(bytes, offset, length);
         // skip offset & applicationNameHash
         buffer.skip(saltKey);
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/RowKeyDecoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/RowKeyDecoder.java
@@ -7,4 +7,8 @@ public interface RowKeyDecoder<V> {
 
     V decodeRowKey(byte[] rowkey);
 
+    default V decodeRowKey(byte[] rowkey, int offset, int length) {
+        throw new UnsupportedOperationException("operation not supported");
+    }
+
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/ApplicationResponseTimeV3ResultExtractor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/ApplicationResponseTimeV3ResultExtractor.java
@@ -87,8 +87,7 @@ public class ApplicationResponseTimeV3ResultExtractor implements ResultsExtracto
         }
         for (Cell cell : result.rawCells()) {
             if (CellUtil.matchingFamily(cell, table.getName())) {
-                byte[] row = CellUtil.cloneRow(cell);
-                UidAppRowKey uidRowKey = rowKeyDecoder.decodeRowKey(row);
+                UidAppRowKey uidRowKey = rowKeyDecoder.decodeRowKey(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength());
                 if (!rowFilter.test(uidRowKey)) {
                     continue;
                 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/InLinkV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/InLinkV3Mapper.java
@@ -31,7 +31,6 @@ import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -91,8 +90,7 @@ public class InLinkV3Mapper implements RowMapper<LinkDataMap> {
 
         final LinkDataMap linkDataMap = new LinkDataMap(timeWindowFunction);
         for (Cell cell : result.rawCells()) {
-            byte[] row = CellUtil.cloneRow(cell);
-            final UidLinkRowKey inRowKey = rowKeyDecoder.decodeRowKey(row);
+            final UidLinkRowKey inRowKey = rowKeyDecoder.decodeRowKey(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength());
             if (!rowFilter.test(inRowKey)) {
                 continue;
             }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/OutLinkV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/OutLinkV3Mapper.java
@@ -29,7 +29,6 @@ import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -84,8 +83,7 @@ public class OutLinkV3Mapper implements RowMapper<LinkDataMap> {
         // key is destApplicationName.
         final LinkDataMap linkDataMap = new LinkDataMap();
         for (Cell cell : result.rawCells()) {
-            byte[] row = CellUtil.cloneRow(cell);
-            UidLinkRowKey selfRowKey = rowKeyDecoder.decodeRowKey(row);
+            UidLinkRowKey selfRowKey = rowKeyDecoder.decodeRowKey(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength());
             if (!rowFilter.test(selfRowKey)) {
                 continue;
             }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/ResponseTimeV3ResultExtractor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/ResponseTimeV3ResultExtractor.java
@@ -97,8 +97,7 @@ public class ResponseTimeV3ResultExtractor implements ResultsExtractor<List<Resp
         ResponseTime.Builder responseTimeBuilder = null;
         for (Cell cell : result.rawCells()) {
             if (CellUtil.matchingFamily(cell, table.getName())) {
-                byte[] row = CellUtil.cloneRow(cell);
-                UidAgentRowKey uidRowKey = rowKeyDecoder.decodeRowKey(row);
+                UidAgentRowKey uidRowKey = rowKeyDecoder.decodeRowKey(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength());
                 if (!rowFilter.test(uidRowKey)) {
                     continue;
                 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/UidAgentLinkRowKeyDecoder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/UidAgentLinkRowKeyDecoder.java
@@ -27,7 +27,12 @@ public class UidAgentLinkRowKeyDecoder implements RowKeyDecoder<UidAgentRowKey> 
     }
 
     @Override
-    public UidAgentRowKey decodeRowKey(byte[] rowKey) {
-        return UidAgentRowKey.read(saltKeySize, rowKey);
+    public UidAgentRowKey decodeRowKey(byte[] rowkey) {
+        return UidAgentRowKey.read(saltKeySize, rowkey);
+    }
+
+    @Override
+    public UidAgentRowKey decodeRowKey(byte[] rowKey, int offset, int length) {
+        return UidAgentRowKey.read(saltKeySize, rowKey, offset, length);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/UidAppRowKeyDecoder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/UidAppRowKeyDecoder.java
@@ -27,7 +27,12 @@ public class UidAppRowKeyDecoder implements RowKeyDecoder<UidAppRowKey> {
     }
 
     @Override
-    public UidAppRowKey decodeRowKey(byte[] rowKey) {
-        return UidAppRowKey.read(saltKeySize, rowKey);
+    public UidAppRowKey decodeRowKey(byte[] rowkey) {
+        return UidAppRowKey.read(saltKeySize, rowkey);
+    }
+
+    @Override
+    public UidAppRowKey decodeRowKey(byte[] rowKey, int offset, int length) {
+        return UidAppRowKey.read(saltKeySize, rowKey, offset, length);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/UidLinkRowKeyDecoder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/UidLinkRowKeyDecoder.java
@@ -27,7 +27,12 @@ public class UidLinkRowKeyDecoder implements RowKeyDecoder<UidLinkRowKey> {
     }
 
     @Override
-    public UidLinkRowKey decodeRowKey(byte[] rowKey) {
-        return UidLinkRowKey.read(saltKeySize, rowKey);
+    public UidLinkRowKey decodeRowKey(byte[] rowkey) {
+        return UidLinkRowKey.read(saltKeySize, rowkey);
+    }
+
+    @Override
+    public UidLinkRowKey decodeRowKey(byte[] rowKey, int offset, int length) {
+        return UidLinkRowKey.read(saltKeySize, rowKey, offset, length);
     }
 }


### PR DESCRIPTION
This pull request adds support for decoding row keys from a byte array with a specified offset and length, improving flexibility and efficiency when working with subarrays. The changes introduce new overloaded `read` methods and update the relevant decoders and buffer usage to handle the offset/length parameters.

**Enhancements to Row Key Decoding:**

* Added overloaded `read` methods with offset and length parameters to `UidAgentRowKey`, `UidAppRowKey`, and `UidLinkRowKey`, and updated their buffer usage to use `OffsetFixedBuffer` instead of `FixedBuffer` for improved subarray handling. [[1]](diffhunk://#diff-89394423b0162fc0f352c9a4966c6911d2ac31de831fa6aea3cda8a9cda3f3d7L21-R21) [[2]](diffhunk://#diff-89394423b0162fc0f352c9a4966c6911d2ac31de831fa6aea3cda8a9cda3f3d7R124-R129) [[3]](diffhunk://#diff-dc293224485048fda0b6516a3b00892550186120406eee017f17e984fbae0aeaL21-R21) [[4]](diffhunk://#diff-dc293224485048fda0b6516a3b00892550186120406eee017f17e984fbae0aeaR106-R111) [[5]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fL21-R21) [[6]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fR143-R148)

* Updated the `RowKeyDecoder` interface to include a default method for decoding with offset and length, using `Arrays.copyOfRange` for backward compatibility.

**Decoder Implementations Update:**

* Modified `UidAgentLinkRowKeyDecoder`, `UidAppRowKeyDecoder`, and `UidLinkRowKeyDecoder` to implement the new overloaded `decodeRowKey` methods, delegating to the new `read` methods with offset and length support. [[1]](diffhunk://#diff-8eb17a38fbfe95909e24d661b62c392633391ab0234570287105ff3f09193866L30-R36) [[2]](diffhunk://#diff-95cd9069eb79d8531c94ae38883b91f5b54b20dd9a2668028f7522ad3dacd788L30-R36) [[3]](diffhunk://#diff-dbab51aee8bd1b4d28530e990996285026007060a6d889a9a3b2af1efd62b78aL30-R36)