### PR TITLE
[#noissue] Refactor RowKeyDistributor to replace Pair with ScanKey for improved type safety and clarity

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/ScanKey.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/ScanKey.java
@@ -1,0 +1,32 @@
+package com.navercorp.pinpoint.common.hbase.wd;
+
+import org.apache.hadoop.hbase.client.ClientUtil;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public record ScanKey(byte[] startRow, byte[] stopRow) {
+    public ScanKey {
+        Objects.requireNonNull(startRow, "startRow");
+        Objects.requireNonNull(stopRow, "stopRow");
+    }
+
+    public boolean includeStopRow() {
+        return ClientUtil.areScanStartRowAndStopRowEqual(this.startRow, this.stopRow);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ScanKey scanKey = (ScanKey) o;
+        return Arrays.equals(stopRow, scanKey.stopRow) && Arrays.equals(startRow, scanKey.startRow);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(startRow);
+        result = 31 * result + Arrays.hashCode(stopRow);
+        return result;
+    }
+}


### PR DESCRIPTION
…r improved type safety and clarity

This pull request refactors the way distributed scan intervals are represented in the `RowKeyDistributor` interface by replacing the use of the generic `Pair` class with a new, purpose-built `ScanKey` record. This improves type safety and code readability when handling HBase scan intervals.

Key changes:

**Refactoring of distributed scan intervals:**

* Introduced a new `ScanKey` record to encapsulate `startRow` and `stopRow` byte arrays, replacing the previous use of `Pair<byte[], byte[]>`. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/ScanKey.java`)
* Updated the `getDistributedIntervals` method in `RowKeyDistributor` to return an array of `ScanKey` instead of `Pair<byte[], byte[]>`, and refactored related logic to use `ScanKey`. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributor.java`) [[1]](diffhunk://#diff-f0d2576a146dbe2f072134865f7b20164beee46b7e93e73a090de80f35561f05L52-R51) [[2]](diffhunk://#diff-f0d2576a146dbe2f072134865f7b20164beee46b7e93e73a090de80f35561f05L63-R64)
* Modified the `getDistributedScans` method to use the new `ScanKey` record for setting start and stop rows in HBase `Scan` objects, replacing the use of `Pair`. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributor.java`)

**Dependency cleanup:**

* Removed the unused import of `Pair` from `RowKeyDistributor.java` since it is no longer needed. (`commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/wd/RowKeyDistributor.java`)