### PR TITLE
[#13228] Apply @PreAuthorize annotations for Apply @PreAuthorize annotations for security in inspector module

### DIFF
--- a/inspector-module/inspector-web/pom.xml
+++ b/inspector-module/inspector-web/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>spring-jdbc</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
@@ -32,6 +32,7 @@ import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -62,6 +63,7 @@ public class AgentInspectorStatController {
     }
 
     // TODO : (minwoo) tenantId should be considered. The collector side should also be considered.
+    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
     @GetMapping(value = "/chart")
     public InspectorMetricView getAgentStatChart(
             @RequestParam("applicationName") String applicationName,
@@ -80,6 +82,7 @@ public class AgentInspectorStatController {
         return new InspectorMetricView(inspectorMetricData);
     }
 
+    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
     @GetMapping(value = "/chart", params = "metricDefinitionId=apdex")
     public InspectorMetricView getApdexStatChart(
             @RequestParam("applicationName") String applicationName,
@@ -95,6 +98,7 @@ public class AgentInspectorStatController {
         return new InspectorMetricView(inspectorMetricData);
     }
 
+    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
     @GetMapping(value = "/chartList")
     public InspectorMetricGroupDataView getAgentStatChartList(
             @RequestParam("applicationName") String applicationName,

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
@@ -16,6 +16,7 @@ import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -41,6 +42,7 @@ public class ApplicationInspectorStatController {
         this.rangeValidator = new ForwardRangeValidator(Duration.ofDays(inspectorWebProperties.getInspectorPeriodMax()));
     }
 
+    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
     @GetMapping(value = "/chart")
     public InspectorMetricView getApplicationStatChart(
             @RequestParam("applicationName") String applicationName,
@@ -58,6 +60,7 @@ public class ApplicationInspectorStatController {
         return new InspectorMetricView(inspectorMetricData);
     }
 
+    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
     @GetMapping(value = "/chart", params = "metricDefinitionId=apdex")
     public InspectorMetricView getApdexStatChart(
             @RequestParam("applicationName") String applicationName,
@@ -72,6 +75,7 @@ public class ApplicationInspectorStatController {
         return new InspectorMetricView(inspectorMetricData);
     }
 
+    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
     @GetMapping(value = "/chartList")
     public InspectorMetricGroupDataView getApplicationStatChartList(
             @RequestParam("applicationName") String applicationName,


### PR DESCRIPTION
This pull request adds method-level security to the inspector web controllers by introducing pre-authorization checks for key endpoints. The main focus is on restricting access to application and agent metric chart endpoints, ensuring that only users with the appropriate permissions can access these resources. Additionally, the necessary Spring Security dependency is added to the project.

**Security Enhancements:**

* Added `@PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")` annotations to the following endpoints in both `AgentInspectorStatController` and `ApplicationInspectorStatController`:
  - `/chart`
  - `/chart` with `metricDefinitionId=apdex`
  - `/chartList`
  This enforces permission checks for accessing metric data based on the application name. [[1]](diffhunk://#diff-096c4e2d87085952cd3f07baa81da2a12ebc546672670696f6d1d6fee33c93ebR66) [[2]](diffhunk://#diff-096c4e2d87085952cd3f07baa81da2a12ebc546672670696f6d1d6fee33c93ebR85) [[3]](diffhunk://#diff-096c4e2d87085952cd3f07baa81da2a12ebc546672670696f6d1d6fee33c93ebR101) [[4]](diffhunk://#diff-16002e7364937d0b306f4968048ac8474c09c7d212f0ecb79cd378e55c8d04acR45) [[5]](diffhunk://#diff-16002e7364937d0b306f4968048ac8474c09c7d212f0ecb79cd378e55c8d04acR63) [[6]](diffhunk://#diff-16002e7364937d0b306f4968048ac8474c09c7d212f0ecb79cd378e55c8d04acR78)

**Dependency Updates:**

* Added the `spring-security-web` dependency with `provided` scope to `pom.xml` to support the new security annotations.

**Code Imports:**

* Imported `org.springframework.security.access.prepost.PreAuthorize` in both controller files to enable the use of security annotations. [[1]](diffhunk://#diff-096c4e2d87085952cd3f07baa81da2a12ebc546672670696f6d1d6fee33c93ebR35) [[2]](diffhunk://#diff-16002e7364937d0b306f4968048ac8474c09c7d212f0ecb79cd378e55c8d04acR19)