### PR TITLE
[#13228] Implement AccessDeniedExceptionHandler in inspector controllers for enhanced security handling

### DIFF
--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
@@ -31,6 +31,7 @@ import com.navercorp.pinpoint.inspector.web.service.ApdexStatService;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.web.authorization.controller.AccessDeniedExceptionHandler;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,7 +47,7 @@ import java.util.Objects;
  */
 @RestController
 @RequestMapping("/api/inspector/agentStat")
-public class AgentInspectorStatController {
+public class AgentInspectorStatController implements AccessDeniedExceptionHandler {
 
     private final TimeWindowSampler DEFAULT_TIME_WINDOW_SAMPLER = new TimeWindowSlotCentricSampler(10000L, 200);
     private final AgentStatService agentStatService;

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
@@ -15,6 +15,7 @@ import com.navercorp.pinpoint.inspector.web.service.ApplicationStatService;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.web.authorization.controller.AccessDeniedExceptionHandler;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,7 +28,7 @@ import java.util.Objects;
 
 @RestController
 @RequestMapping("/api/inspector/applicationStat")
-public class ApplicationInspectorStatController {
+public class ApplicationInspectorStatController implements AccessDeniedExceptionHandler {
     private final TimeWindowSampler DEFAULT_TIME_WINDOW_SAMPLER_30M = new TimeWindowSlotCentricSampler(30000L, 200);
     private final TenantProvider tenantProvider;
     private final ApplicationStatService applicationStatService;


### PR DESCRIPTION
This pull request updates the inspector web controllers to improve handling of access denied exceptions. The main change is that both the `AgentInspectorStatController` and `ApplicationInspectorStatController` now implement the `AccessDeniedExceptionHandler` interface, which will allow them to handle authorization errors in a standardized way.

Authorization and exception handling improvements:

* Both `AgentInspectorStatController` and `ApplicationInspectorStatController` now implement the `AccessDeniedExceptionHandler` interface to provide consistent handling of access denied exceptions. (`AgentInspectorStatController.java` [[1]](diffhunk://#diff-096c4e2d87085952cd3f07baa81da2a12ebc546672670696f6d1d6fee33c93ebR34) [[2]](diffhunk://#diff-096c4e2d87085952cd3f07baa81da2a12ebc546672670696f6d1d6fee33c93ebL49-R50); `ApplicationInspectorStatController.java` [[3]](diffhunk://#diff-16002e7364937d0b306f4968048ac8474c09c7d212f0ecb79cd378e55c8d04acR18) [[4]](diffhunk://#diff-16002e7364937d0b306f4968048ac8474c09c7d212f0ecb79cd378e55c8d04acL30-R31)