### PR TITLE
[#noissue] Introduce `LastRowHandler` implementation to improve handling of last row processing and refactor scan methods to use it

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/DefaultLastRowHandler.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/DefaultLastRowHandler.java
@@ -1,0 +1,15 @@
+package com.navercorp.pinpoint.common.hbase;
+
+public class DefaultLastRowHandler<T> implements LastRowHandler<T> {
+    private T lastRow;
+
+    @Override
+    public void handleLastRow(T lastRow) {
+        this.lastRow = lastRow;
+    }
+
+    @Override
+    public T getLastRow() {
+        return lastRow;
+    }
+}

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/EmptyLimitEventHandler.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/EmptyLimitEventHandler.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.hbase.client.Result;
 /**
  * @author emeroad
  */
-public class EmptyLimitEventHandler implements LimitEventHandler{
+public class EmptyLimitEventHandler implements LimitEventHandler {
 
     @Override
     public void handleLastResult(Result lastResult) {

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseOperations.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/HbaseOperations.java
@@ -82,12 +82,14 @@ public interface HbaseOperations {
     <T> List<T> find(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, final RowMapper<T> action);
     <T> List<T> find(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, int limit, final RowMapper<T> action);
     <T> List<T> find(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, int limit, final RowMapper<T> action, final LimitEventHandler limitEventHandler);
+    <T> List<T> find(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, int limit, final RowMapper<T> action, final LastRowHandler<T> limitEventHandler);
     <T> T find(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, final ResultsExtractor<T> action);
 
     // Parallel scanners for distributed scans
     <T> List<T> findParallel(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, final RowMapper<T> action, int numParallelThreads);
     <T> List<T> findParallel(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, int limit, final RowMapper<T> action, int numParallelThreads);
     <T> List<T> findParallel(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, int limit, final RowMapper<T> action, final LimitEventHandler limitEventHandler, int numParallelThreads);
+    <T> List<T> findParallel(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, int limit, final RowMapper<T> action, final LastRowHandler<T> limitEventHandler, int numParallelThreads);
     <T> T findParallel(TableName tableName, final Scan scan, final RowKeyDistributor rowKeyDistributor, final ResultsExtractor<T> action, int numParallelThreads);
 
     Result increment(TableName tableName, final Increment increment);

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/LastRowHandler.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/LastRowHandler.java
@@ -1,0 +1,8 @@
+package com.navercorp.pinpoint.common.hbase;
+
+
+public interface LastRowHandler<T> {
+    void handleLastRow(T lastRow);
+
+    T getLastRow();
+}

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/LastRowResultsExtractor.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/LastRowResultsExtractor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase;
+
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.ToIntFunction;
+
+/**
+ * @author emeroad
+ */
+public class LastRowResultsExtractor<T> implements ResultsExtractor<List<T>> {
+
+    private int limit = Integer.MAX_VALUE;
+    private final RowMapper<T> rowMapper;
+
+    @Nullable
+    private final LastRowHandler<T> rowHandler;
+    private final ToIntFunction<T> resultSizeHandler;
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+
+    /**
+     * Create a new RowMapperResultSetExtractor.
+     *
+     * @param rowMapper the RowMapper which creates an object for each row
+     */
+    public LastRowResultsExtractor(RowMapper<T> rowMapper, int limit, LastRowHandler<T> rowHandler) {
+        this.rowMapper = Objects.requireNonNull(rowMapper, "RowMapper");
+        this.limit = limit;
+        this.rowHandler = rowHandler;
+        this.resultSizeHandler = resolveResultSizeHandler(rowMapper);
+    }
+
+    private ToIntFunction<T> resolveResultSizeHandler(RowMapper<T> rowMapper) {
+        if (rowMapper instanceof RowTypeHint hint) {
+            Class<?> clazz = hint.rowType();
+            return ResultSizeHandlers.getHandler(clazz);
+        }
+        return new LazyResultSizeHandler<>();
+    }
+
+    public List<T> extractData(ResultScanner results) throws Exception {
+        final List<T> rs = new ArrayList<>();
+        int rowNum = 0;
+        T t = null;
+
+        for (Result result : results) {
+            t = this.rowMapper.mapRow(result, rowNum);
+            if (t == null) {
+                // empty
+            } else {
+                rowNum += resultSizeHandler.applyAsInt(t);
+            }
+            rs.add(t);
+            if (rowNum >= limit) {
+                break;
+            }
+        }
+        if (rowHandler != null) {
+            rowHandler.handleLastRow(t);
+        }
+        return rs;
+    }
+}

--- a/web/src/test/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDaoTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDaoTest.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.web.scatter.dao.hbase;
 
 import com.navercorp.pinpoint.common.hbase.HbaseOperations;
 import com.navercorp.pinpoint.common.hbase.HbaseTableNameProvider;
-import com.navercorp.pinpoint.common.hbase.LimitEventHandler;
+import com.navercorp.pinpoint.common.hbase.LastRowHandler;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
@@ -98,7 +98,7 @@ public class HbaseTraceIndexDaoTest {
     public void scanTraceIndexTest() {
         final List<List<DotMetaData>> scannedList = List.of(Collections.nCopies(10, testDotMetaData));
         when(this.hbaseOperations.findParallel(any(TableName.class), any(Scan.class), any(RowKeyDistributor.class),
-                anyInt(), any(RowMapper.class), any(LimitEventHandler.class), anyInt())).thenReturn(scannedList);
+                anyInt(), any(RowMapper.class), any(LastRowHandler.class), anyInt())).thenReturn(scannedList);
         LimitedScanResult<List<DotMetaData>> result =
                 this.traceIndexDao.scanTraceIndex(serviceUid, "app", ServiceType.TEST_STAND_ALONE.getCode(), Range.between(1000L, 5000L), 20, false);
         Assertions.assertEquals(1000L, result.limitedTime());
@@ -118,7 +118,7 @@ public class HbaseTraceIndexDaoTest {
     public void scanTraceScatterDataEmptyTest() {
 
         when(this.hbaseOperations.findParallel(any(TableName.class), any(Scan.class), any(RowKeyDistributor.class),
-                anyInt(), any(RowMapper.class), any(LimitEventHandler.class), anyInt())).thenReturn(List.of());
+                anyInt(), any(RowMapper.class), any(LastRowHandler.class), anyInt())).thenReturn(List.of());
         Range range = Range.between(1000L, 5000L);
         LimitedScanResult<List<Dot>> scanResult
                 = this.traceIndexDao.scanTraceScatterData(serviceUid, "app", ServiceType.TEST_STAND_ALONE.getCode(), range, 10, false);


### PR DESCRIPTION
This pull request introduces a new mechanism for handling the "last row" in HBase scan operations, aiming to improve how the last scanned row is tracked and accessed. The changes add a generic `LastRowHandler` interface and its default implementation, update the HBase operations API to support this handler, and refactor relevant DAO code to use the new approach. This enhances flexibility and maintainability when working with scan limits and last-row information.

**Core HBase Scan Enhancements:**

* Introduced the `LastRowHandler<T>` interface and its default implementation `DefaultLastRowHandler<T>`, providing a generic way to handle and retrieve the last row processed during HBase scans. [[1]](diffhunk://#diff-f0bf37809a929abd8411f87834860512576fdab0945cff89e9f5d23bd8067d09R1-R8) [[2]](diffhunk://#diff-7a8454ac965a7ebe2b2dad9e89d76a9c2d69d88fa860df8968f82dff951977ffR1-R15)
* Added `LastRowResultsExtractor<T>`, a new `ResultsExtractor` implementation that leverages `LastRowHandler` to track the last row and integrates with existing scan logic.

**API and Implementation Updates:**

* Extended the `HbaseOperations` interface and `HbaseTemplate` implementation to support new `find` and `findParallel` methods that accept a `LastRowHandler` parameter, enabling last-row tracking in both distributed and parallel scan scenarios. [[1]](diffhunk://#diff-d9925c98f2ffa66fc25b8717cdda8df5628ef4155cd110ba36c9d66ef3306c09R85-R92) [[2]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6R455-R460) [[3]](diffhunk://#diff-37f3b51e8e738b9286ec3799b219d93e608f1f9bffa82acdd6d38a956981aef6R542-R553)

**DAO Refactoring:**

* Refactored DAO classes (e.g., `HbaseApplicationTraceIndexDao`, `HbaseTraceIndexDao`) to use `DefaultLastRowHandler` instead of custom or legacy last-row tracking, simplifying the code and aligning with the new API. [[1]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4R21-R24) [[2]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4L32-R45) [[3]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4L253-R232) [[4]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4L262-R241) [[5]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4L288-R288) [[6]](diffhunk://#diff-7d3c22915938d4dea4f29dc1b0152dd194c95ff29258857ec72b6ac88c6210e1R19-L30) [[7]](diffhunk://#diff-7d3c22915938d4dea4f29dc1b0152dd194c95ff29258857ec72b6ac88c6210e1L42-R52) [[8]](diffhunk://#diff-7d3c22915938d4dea4f29dc1b0152dd194c95ff29258857ec72b6ac88c6210e1L117-R122) [[9]](diffhunk://#diff-7d3c22915938d4dea4f29dc1b0152dd194c95ff29258857ec72b6ac88c6210e1L136-R135)
* Updated logic for calculating the last scan time to use the new handler and improved method signatures for clarity and type safety. [[1]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4L140-R148) [[2]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4L163-L185) [[3]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4L197-L207)

These changes collectively modernize and standardize how the last row is managed in HBase scan operations, making the codebase more robust and easier to extend.