### PR TITLE
[#noissue] Extract `LastTimeListExtractor` for cleaner last-time comp…

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/LastTimeListExtractor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/LastTimeListExtractor.java
@@ -1,0 +1,50 @@
+package com.navercorp.pinpoint.web.scatter.dao;
+
+import com.navercorp.pinpoint.common.hbase.LastRowHandler;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+import java.util.function.ToLongFunction;
+
+public class LastTimeListExtractor {
+    private static final long DEFAULT_NULL = -1;
+    private final long nullTimestamp;
+
+    public LastTimeListExtractor() {
+        this(DEFAULT_NULL);
+    }
+
+    public LastTimeListExtractor(long nullTimestamp) {
+        this.nullTimestamp = nullTimestamp;
+    }
+
+
+    public <T> long getLastTime(LastRowHandler<List<T>> lastRowAccessor, ToLongFunction<T> timestampExtractor) {
+        List<T> lastRow = lastRowAccessor.getLastRow();
+        if (CollectionUtils.isEmpty(lastRow)) {
+            return nullTimestamp;
+        }
+        T last = CollectionUtils.lastElement(lastRow);
+        if (last == null) {
+            return nullTimestamp;
+        }
+        return timestampExtractor.applyAsLong(last);
+    }
+
+    static LastTimeListExtractor lastTimeExtractor = new LastTimeListExtractor();
+
+    public static <T> long getLastTime(boolean overflow, LastRowHandler<List<T>> lastRowAccessor, ToLongFunction<T> timestampExtractor,
+                                       long fallbackLastIndex) {
+        if (overflow) {
+            return lastTimeExtractor.getLastTime(lastRowAccessor, timestampExtractor);
+        } else {
+            return fallbackLastIndex;
+        }
+    }
+
+    public static boolean isOverflow(List<?> values, int limit) {
+        return values.size() >= limit;
+    }
+
+
+}


### PR DESCRIPTION
…utation logic and refactor DAO methods to utilize it

This pull request refactors how the "last time" value is determined in scatter data DAO classes by introducing a reusable utility, `LastTimeListExtractor`. The new class centralizes and simplifies the logic for extracting the last timestamp from lists, replacing similar code previously duplicated in multiple places. The changes improve code maintainability and readability.

**Core utility extraction and usage:**

* Introduced the `LastTimeListExtractor` class, which provides static methods to determine if a list overflows a limit and to extract the last timestamp from a list using a provided extractor function. (`web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/LastTimeListExtractor.java`)
* Replaced previous custom logic for determining the last time in `HbaseTraceIndexDao` and `HbaseApplicationTraceIndexDao` with calls to `LastTimeListExtractor.getLastTime` and `LastTimeListExtractor.isOverflow`. This reduces code duplication and ensures consistent behavior. (`web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java`, `web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseApplicationTraceIndexDao.java`) [[1]](diffhunk://#diff-7d3c22915938d4dea4f29dc1b0152dd194c95ff29258857ec72b6ac88c6210e1L122-R123) [[2]](diffhunk://#diff-7d3c22915938d4dea4f29dc1b0152dd194c95ff29258857ec72b6ac88c6210e1L144-R146) [[3]](diffhunk://#diff-7d3c22915938d4dea4f29dc1b0152dd194c95ff29258857ec72b6ac88c6210e1L169-R172) [[4]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4L238-R243) [[5]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4L288-R291)

**Code cleanup and removal:**

* Removed the old static `getLastTime` method from `HbaseTraceIndexDao`, as its logic is now handled by the new utility class. (`web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java`)
* Cleaned up unnecessary imports related to collections and function types that are no longer needed after the refactor. (`web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java`)

**Dependency updates:**

* Updated import statements in affected DAO classes to use the new utility class. (`web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseApplicationTraceIndexDao.java`, `web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java`) [[1]](diffhunk://#diff-5eeb2536f6633c930cc271c548175d3436593b5f4b2a8ba283cb738538dd01e4R41) [[2]](diffhunk://#diff-7d3c22915938d4dea4f29dc1b0152dd194c95ff29258857ec72b6ac88c6210e1R35)