### PR TITLE
[#noissue] Replace `SpanUtils` with `TransactionIdParser` for improved transaction ID parsing and serialization

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/scatter/dao/hbase/HbaseApplicationTraceIndexDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/scatter/dao/hbase/HbaseApplicationTraceIndexDao.java
@@ -26,7 +26,7 @@ import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.async.HbasePutWriter;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
-import com.navercorp.pinpoint.common.server.util.SpanUtils;
+import com.navercorp.pinpoint.common.server.util.TransactionIdParser;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.logging.log4j.LogManager;
@@ -79,7 +79,7 @@ public class HbaseApplicationTraceIndexDao implements ApplicationTraceIndexDao {
 
         final Put put = new Put(distributedKey, true);
 
-        final byte[] qualifier = SpanUtils.getVarTransactionId(span);
+        final byte[] qualifier = TransactionIdParser.getVarTransactionId(span.getTransactionId(), span::getAgentId);
 
         final byte[] indexValue = buildIndexValue(span);
         put.addColumn(indexTable.getName(), qualifier, acceptedTime, indexValue);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/scatter/TraceIndexValue.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/scatter/TraceIndexValue.java
@@ -4,7 +4,7 @@ import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
-import com.navercorp.pinpoint.common.server.util.SpanUtils;
+import com.navercorp.pinpoint.common.server.util.TransactionIdParser;
 import org.apache.hadoop.hbase.util.Bytes;
 
 import java.util.Objects;
@@ -50,7 +50,7 @@ public class TraceIndexValue {
         public static byte[] encode(TransactionId transactionId, long startTime, String remoteAddr, String endpoint, String agentName) {
             final Buffer buffer = new AutomaticBuffer(128);
             buffer.putByte((byte) 1); // version
-            SpanUtils.writeTransactionIdV1(buffer, transactionId);
+            TransactionIdParser.writeTransactionIdV1(buffer, transactionId);
 
             buffer.putLong(startTime);
             buffer.putPrefixedString(remoteAddr);
@@ -62,7 +62,7 @@ public class TraceIndexValue {
         public static Meta decode(byte[] bytes, int offset, int length) {
             Buffer buffer = new OffsetFixedBuffer(bytes, offset, length);
             buffer.readByte(); // version
-            TransactionId transactionId = SpanUtils.readTransactionIdV1(buffer);
+            TransactionId transactionId = TransactionIdParser.readTransactionIdV1(buffer);
 
             long startTime = buffer.readLong();
             String remoteAddr = buffer.readPrefixedString();

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/SpanUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/SpanUtils.java
@@ -16,17 +16,16 @@
 
 package com.navercorp.pinpoint.common.server.util;
 
-import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
-import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 
-import java.util.Objects;
-
 /**
+ * @deprecated use {@link TransactionIdParser}
+ *
  * @author emeroad
  */
+@Deprecated
 public final class SpanUtils {
     private SpanUtils() {
     }
@@ -35,38 +34,18 @@ public final class SpanUtils {
      * deserializer ref : TransactionIdMapper.parseVarTransactionId
      */
     public static byte[] getVarTransactionId(SpanBo span) {
-        Objects.requireNonNull(span, "span");
-
-        final TransactionId transactionId = span.getTransactionId();
-        String agentId = transactionId.getAgentId();
-        if (agentId == null) {
-            agentId = span.getAgentId();
-        }
-
-        final Buffer buffer = new AutomaticBuffer(32);
-        buffer.putPrefixedString(agentId);
-        buffer.putSVLong(transactionId.getAgentStartTime());
-        buffer.putVLong(transactionId.getTransactionSequence());
-        return buffer.getBuffer();
+        return TransactionIdParser.getVarTransactionId(span.getTransactionId(), span::getAgentId);
     }
 
     public static TransactionId parseVarTransactionId(byte[] bytes, int offset, int length) {
-        Objects.requireNonNull(bytes, "bytes");
-
-        final Buffer buffer = new OffsetFixedBuffer(bytes, offset, length);
-        return readTransactionIdV1(buffer);
+        return TransactionIdParser.parseVarTransactionId(bytes, offset, length);
     }
 
     public static void writeTransactionIdV1(Buffer buffer, TransactionId transactionId) {
-        buffer.putPrefixedString(transactionId.getAgentId());
-        buffer.putSVLong(transactionId.getAgentStartTime());
-        buffer.putVLong(transactionId.getTransactionSequence());
+        TransactionIdParser.writeTransactionIdV1(buffer, transactionId);
     }
 
     public static TransactionId readTransactionIdV1(Buffer buffer) {
-        String agentId = buffer.readPrefixedString();
-        long agentStartTime = buffer.readSVLong();
-        long transactionSequence = buffer.readVLong();
-        return TransactionId.of(agentId, agentStartTime, transactionSequence);
+        return TransactionIdParser.readTransactionIdV1(buffer);
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/TransactionIdParser.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/TransactionIdParser.java
@@ -1,13 +1,16 @@
 package com.navercorp.pinpoint.common.server.util;
 
+import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.FixedBuffer;
+import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.profiler.util.TransactionIdUtils;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 public class TransactionIdParser {
 
@@ -32,4 +35,41 @@ public class TransactionIdParser {
         return TransactionId.of(agentId, agentStartTime,transactionSequence);
     }
 
+    /**
+     * deserializer ref : TransactionIdMapper.parseVarTransactionId
+     */
+    public static byte[] getVarTransactionId(TransactionId transactionId, Supplier<String> agentIdSupplier) {
+
+        Objects.requireNonNull(transactionId, "span");
+        String agentId = transactionId.getAgentId();
+        if (agentId == null) {
+            agentId = agentIdSupplier.get();
+        }
+
+        final Buffer buffer = new AutomaticBuffer(32);
+        buffer.putPrefixedString(agentId);
+        buffer.putSVLong(transactionId.getAgentStartTime());
+        buffer.putVLong(transactionId.getTransactionSequence());
+        return buffer.getBuffer();
+    }
+
+    public static TransactionId parseVarTransactionId(byte[] bytes, int offset, int length) {
+        Objects.requireNonNull(bytes, "bytes");
+
+        final Buffer buffer = new OffsetFixedBuffer(bytes, offset, length);
+        return readTransactionIdV1(buffer);
+    }
+
+    public static void writeTransactionIdV1(Buffer buffer, TransactionId transactionId) {
+        buffer.putPrefixedString(transactionId.getAgentId());
+        buffer.putSVLong(transactionId.getAgentStartTime());
+        buffer.putVLong(transactionId.getTransactionSequence());
+    }
+
+    public static TransactionId readTransactionIdV1(Buffer buffer) {
+        String agentId = buffer.readPrefixedString();
+        long agentStartTime = buffer.readSVLong();
+        long transactionSequence = buffer.readVLong();
+        return TransactionId.of(agentId, agentStartTime, transactionSequence);
+    }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TraceIndexMetaScatterMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TraceIndexMetaScatterMapper.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.RowTypeHint;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
-import com.navercorp.pinpoint.common.server.util.SpanUtils;
+import com.navercorp.pinpoint.common.server.util.TransactionIdParser;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 import org.apache.hadoop.hbase.Cell;
@@ -63,7 +63,7 @@ public class TraceIndexMetaScatterMapper implements RowMapper<List<DotMetaData>>
                 builder.setDot(dot);
             }
             if (CellUtil.matchingFamily(cell, meta.getName())) {
-                TransactionId transactionId = SpanUtils.parseVarTransactionId(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
+                TransactionId transactionId = TransactionIdParser.parseVarTransactionId(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
                 DotMetaData.Builder builder = getMetaDataBuilder(metaDataMap, transactionId);
                 builder.read(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength());
             }

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TraceIndexScatterMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TraceIndexScatterMapper.java
@@ -25,7 +25,7 @@ import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.RowTypeHint;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
-import com.navercorp.pinpoint.common.server.util.SpanUtils;
+import com.navercorp.pinpoint.common.server.util.TransactionIdParser;
 import com.navercorp.pinpoint.common.timeseries.util.LongInverter;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import org.apache.hadoop.hbase.Cell;
@@ -73,7 +73,7 @@ public class TraceIndexScatterMapper implements RowMapper<List<Dot>>, RowTypeHin
         String agentId = valueBuffer.readPrefixedString();
 
         long acceptedTime = extractAcceptTime(cell.getRowArray(), cell.getRowOffset());
-        TransactionId transactionId = SpanUtils.parseVarTransactionId(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
+        TransactionId transactionId = TransactionIdParser.parseVarTransactionId(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
 
         return new Dot(transactionId, acceptedTime, elapsed, exceptionCode, agentId);
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TransactionIdMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TransactionIdMapper.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.RowTypeHint;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
-import com.navercorp.pinpoint.common.server.util.SpanUtils;
+import com.navercorp.pinpoint.common.server.util.TransactionIdParser;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
@@ -57,7 +57,7 @@ public class TransactionIdMapper implements RowMapper<List<TransactionId>>, RowT
         List<TransactionId> traceIdList = new ArrayList<>(rawCells.length);
         for (Cell cell : rawCells) {
             if (CellUtil.matchingFamily(cell, traceIndex.getName())) {
-                TransactionId traceId = SpanUtils.parseVarTransactionId(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
+                TransactionId traceId = TransactionIdParser.parseVarTransactionId(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
                 traceIdList.add(traceId);
                 logger.debug("found traceId {}", traceId);
             }


### PR DESCRIPTION
…d transaction ID parsing and serialization

This pull request refactors transaction ID serialization and deserialization logic by moving related methods from the `SpanUtils` class to a new dedicated utility class, `TransactionIdParser`. This improves code organization and maintainability, and deprecates the old methods in `SpanUtils`. All usages throughout the codebase have been updated to use the new class.

**Transaction ID parsing and serialization refactor:**

* Introduced `TransactionIdParser` utility class, moving transaction ID encoding/decoding logic from `SpanUtils` to this new class, and added methods such as `getVarTransactionId`, `parseVarTransactionId`, `writeTransactionIdV1`, and `readTransactionIdV1`. (`commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/TransactionIdParser.java`) [[1]](diffhunk://#diff-e70b3d62db5cbe46a49e6b37776f3c823dbc40870c84c76b9e88d13e0142fbf4R3-R13) [[2]](diffhunk://#diff-e70b3d62db5cbe46a49e6b37776f3c823dbc40870c84c76b9e88d13e0142fbf4R38-R74)
* Updated all usages in the codebase to use `TransactionIdParser` instead of `SpanUtils` for transaction ID operations, including in `HbaseApplicationTraceIndexDao`, `TraceIndexValue`, and various scatter mapper classes. [[1]](diffhunk://#diff-9c461eda6384ca7743a2aa0536ac3c51eb7551962795e371e4c358ae4927e8d4L29-R29) [[2]](diffhunk://#diff-9c461eda6384ca7743a2aa0536ac3c51eb7551962795e371e4c358ae4927e8d4L82-R82) [[3]](diffhunk://#diff-e343b397cd8c675ddd36284a40e6031578703bb65cc0a07bc71c3668a724edc8L7-R7) [[4]](diffhunk://#diff-e343b397cd8c675ddd36284a40e6031578703bb65cc0a07bc71c3668a724edc8L53-R53) [[5]](diffhunk://#diff-e343b397cd8c675ddd36284a40e6031578703bb65cc0a07bc71c3668a724edc8L65-R65) [[6]](diffhunk://#diff-5a9aa46c52a4bcc12622dfb5e8a4e6e200eeb23c1eed3a6704721c514c8c9d66L24-R24) [[7]](diffhunk://#diff-5a9aa46c52a4bcc12622dfb5e8a4e6e200eeb23c1eed3a6704721c514c8c9d66L66-R66) [[8]](diffhunk://#diff-a8dee03176c8ed20a9d8ba12fea612adcc9fd48935b25b07fa3ddde4c085da53L28-R28) [[9]](diffhunk://#diff-a8dee03176c8ed20a9d8ba12fea612adcc9fd48935b25b07fa3ddde4c085da53L76-R76) [[10]](diffhunk://#diff-870bad902871e9a962d30fa90cf470d96eea2fbca7ab8782c433da6d99308811L24-R24) [[11]](diffhunk://#diff-870bad902871e9a962d30fa90cf470d96eea2fbca7ab8782c433da6d99308811L60-R60)

**Deprecation and cleanup:**

* Marked the `SpanUtils` class as deprecated and replaced its transaction ID methods with delegations to `TransactionIdParser`. [[1]](diffhunk://#diff-6355269a21b2faa1bf15cc963b0f0265504d341652881ff848b843f788205a47L19-R28) [[2]](diffhunk://#diff-6355269a21b2faa1bf15cc963b0f0265504d341652881ff848b843f788205a47L38-R49)

These changes help centralize transaction ID logic, making it easier to maintain and reducing code duplication.