### PR TITLE
[#13243] Refactor ServerTraceId

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseTraceDaoV2.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/HbaseTraceDaoV2.java
@@ -22,13 +22,13 @@ import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.async.HbasePutWriter;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanChunkSerializerV2;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanSerializerV2;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
@@ -60,7 +60,7 @@ public class HbaseTraceDaoV2 implements TraceDao {
 
     private final SpanChunkSerializerV2 spanChunkSerializer;
 
-    private final RowKeyEncoder<TransactionId> rowKeyEncoder;
+    private final RowKeyEncoder<ServerTraceId> rowKeyEncoder;
     private final HbasePutWriter putWriter;
 
     private final DurabilityApplier durabilityApplier;
@@ -68,7 +68,7 @@ public class HbaseTraceDaoV2 implements TraceDao {
     public HbaseTraceDaoV2(@Qualifier("spanPutWriter")
                            HbasePutWriter putWriter,
                            TableNameProvider tableNameProvider,
-                           @Qualifier("traceRowKeyEncoderV2") RowKeyEncoder<TransactionId> rowKeyEncoder,
+                           @Qualifier("traceRowKeyEncoderV2") RowKeyEncoder<ServerTraceId> rowKeyEncoder,
                            SpanSerializerV2 spanSerializer,
                            SpanChunkSerializerV2 spanChunkSerializer,
                            DurabilityApplier durabilityApplier) {
@@ -106,7 +106,7 @@ public class HbaseTraceDaoV2 implements TraceDao {
 
         long acceptedTime = spanBo.getCollectorAcceptTime();
 
-        TransactionId transactionId = spanBo.getTransactionId();
+        ServerTraceId transactionId = spanBo.getTransactionId();
         final byte[] rowKey = this.rowKeyEncoder.encodeRowKey(transactionId);
         final Put put = new Put(rowKey, acceptedTime, true);
 
@@ -122,7 +122,7 @@ public class HbaseTraceDaoV2 implements TraceDao {
     public void insertSpanChunk(SpanChunkBo spanChunkBo) {
         Objects.requireNonNull(spanChunkBo, "spanChunkBo");
 
-        TransactionId transactionId = spanChunkBo.getTransactionId();
+        ServerTraceId transactionId = spanChunkBo.getTransactionId();
         final byte[] rowKey = this.rowKeyEncoder.encodeRowKey(transactionId);
 
         final long acceptedTime = spanChunkBo.getCollectorAcceptTime();

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampler/BasicSpanSampler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampler/BasicSpanSampler.java
@@ -1,0 +1,28 @@
+package com.navercorp.pinpoint.collector.sampler;
+
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.navercorp.pinpoint.common.server.bo.BasicSpan;
+import com.navercorp.pinpoint.common.server.trace.OtelServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+
+import java.util.function.ToLongFunction;
+
+public class BasicSpanSampler implements ToLongFunction<BasicSpan> {
+
+    private static final HashFunction hashFunction = Hashing.murmur3_128();
+
+    @Override
+    public long applyAsLong(BasicSpan span) {
+        final ServerTraceId serverTraceId = span.getTransactionId();
+        if (serverTraceId instanceof PinpointServerTraceId pinpointServerTraceId) {
+            return pinpointServerTraceId.getTransactionSequence();
+        } else if (serverTraceId instanceof OtelServerTraceId otelServerTraceId) {
+            byte[] id = otelServerTraceId.getId();
+            return hashFunction.hashBytes(id).asLong();
+        }
+
+        throw new IllegalArgumentException("Unsupported server trace id:" + serverTraceId);
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampler/SimpleSpanSamplerFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampler/SimpleSpanSamplerFactory.java
@@ -45,7 +45,7 @@ public class SimpleSpanSamplerFactory implements SpanSamplerFactory {
     }
 
     private ToLongFunction<BasicSpan> createBasicSpanSamplingFunction() {
-        return (span -> span.getTransactionId().getTransactionSequence());
+        return new BasicSpanSampler();
     }
 
     private Sampler<BasicSpan> createPercentageSampler(String percentSamplingRateStr,

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/scatter/dao/hbase/HbaseApplicationTraceIndexDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/scatter/dao/hbase/HbaseApplicationTraceIndexDao.java
@@ -26,7 +26,6 @@ import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.async.HbasePutWriter;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
-import com.navercorp.pinpoint.common.server.util.TransactionIdParser;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.logging.log4j.LogManager;
@@ -79,7 +78,7 @@ public class HbaseApplicationTraceIndexDao implements ApplicationTraceIndexDao {
 
         final Put put = new Put(distributedKey, true);
 
-        final byte[] qualifier = TransactionIdParser.getVarTransactionId(span.getTransactionId(), span::getAgentId);
+        final byte[] qualifier = span.getTransactionId().getId();
 
         final byte[] indexValue = buildIndexValue(span);
         put.addColumn(indexTable.getName(), qualifier, acceptedTime, indexValue);

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampler/SimpleSpanFactoryTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampler/SimpleSpanFactoryTest.java
@@ -1,11 +1,11 @@
 package com.navercorp.pinpoint.collector.sampler;
 
 import com.navercorp.pinpoint.collector.config.CollectorProperties;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
-import com.navercorp.pinpoint.common.profiler.util.TransactionIdUtils;
 import com.navercorp.pinpoint.common.server.bo.BasicSpan;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +43,7 @@ public class SimpleSpanFactoryTest {
         SpanChunkBo mockSpanChunkBo = mock(SpanChunkBo.class);
         SpanBo mockSpanBo = mock(SpanBo.class);
         for (long i = 0; i < 10; i++) {
-            TransactionId transactionId = createTransactionId(agentId, time, i);
+            ServerTraceId transactionId = createTransactionId(agentId, time, i);
             when(mockSpanBo.getTransactionId()).thenReturn(transactionId);
             when(mockSpanChunkBo.getTransactionId()).thenReturn(transactionId);
 
@@ -54,8 +54,8 @@ public class SimpleSpanFactoryTest {
         verify(mockSpanChunkBo, atLeastOnce()).getTransactionId();
     }
 
-    private TransactionId createTransactionId(String agentId, long agentStartTime, long sequenceId) {
-        return TransactionIdUtils.parseTransactionId(TransactionIdUtils.formatString(agentId, agentStartTime, sequenceId));
+    private ServerTraceId createTransactionId(String agentId, long agentStartTime, long sequenceId) {
+        return new PinpointServerTraceId(agentId, agentStartTime, sequenceId);
     }
 
     @Test

--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtilsTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtilsTest.java
@@ -146,4 +146,22 @@ class ByteArrayUtilsTest {
         BytesUtils.writeInt(value, buf, 0);
         return buf;
     }
+
+
+    @Test
+    void compareByteArray() {
+        byte[] bytes1 = {1, 1, 2, 3};
+        byte[] bytes2 = {2, 1, 2, 3};
+
+        Assertions.assertEquals(-1, ByteArrayUtils.compare(bytes1, bytes2, 0));
+        Assertions.assertEquals(0, ByteArrayUtils.compare(bytes1, bytes2, 1));
+    }
+
+    @Test
+    void compareByteArray_checkLastOffset() {
+        byte[] bytes1 = {1, 2, 3, 1};
+        byte[] bytes2 = {1, 2, 3, 2};
+
+        Assertions.assertEquals(-1, ByteArrayUtils.compare(bytes1, bytes2, 0));
+    }
 }

--- a/commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/util/CellUtilsTest.java
+++ b/commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/util/CellUtilsTest.java
@@ -155,8 +155,8 @@ public class CellUtilsTest {
 
     @Test
     public void testCompareRow_unsigned() {
-        byte[] row1 = new byte[] {(byte) 0x00 }; // 0
-        byte[] row2 = new byte[] {(byte) 0xFF }; // -1 (unsigned 255)
+        byte[] row1 = new byte[]{(byte) 0x00 }; // 0
+        byte[] row2 = new byte[]{(byte) 0xFF }; // -1 (unsigned 255)
 
         Cell leftCell = new KeyValue(row1, 1000L);
         Cell rightCell = new KeyValue(row2, 2000L);
@@ -169,9 +169,9 @@ public class CellUtilsTest {
 
     @Test
     public void testCompareRow_saltKey() {
-        byte[] leftRow = Bytes.add(new byte[]{2}, Bytes.toBytes(1));
+        byte[] leftRow = new byte[]{2, 1};
         Cell leftCell = new KeyValue(leftRow, 2000L);
-        byte[] rightRow = Bytes.add(new byte[]{1}, Bytes.toBytes(2));
+        byte[] rightRow = new byte[]{1, 2};
         Cell rightCell = new KeyValue(rightRow, 1000L);
 
         int saltKeySize = 1;

--- a/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/name/Base64Utils.java
+++ b/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/name/Base64Utils.java
@@ -66,9 +66,20 @@ public class Base64Utils {
     public static String encode(UUID uuid) {
         Objects.requireNonNull(uuid, "uuid");
 
+        return encode(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+    }
+
+    public static String encode(long msb, long lsb) {
         final byte[] bytes = new byte[16];
-        BytesUtils.writeLong(uuid.getMostSignificantBits(), bytes, 0);
-        BytesUtils.writeLong(uuid.getLeastSignificantBits(), bytes, BytesUtils.LONG_BYTE_LENGTH);
+        BytesUtils.writeLong(msb, bytes, 0);
+        BytesUtils.writeLong(lsb, bytes, BytesUtils.LONG_BYTE_LENGTH);
+
+        byte[] encode = ENCODER.encode(bytes);
+        return new String(encode, ISO_8859);
+    }
+
+    public static String encode(byte[] bytes) {
+        Objects.requireNonNull(bytes, "bytes");
 
         byte[] encode = ENCODER.encode(bytes);
         return new String(encode, ISO_8859);

--- a/commons-server/pom.xml
+++ b/commons-server/pom.xml
@@ -163,6 +163,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/BasicSpan.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/BasicSpan.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.common.server.bo;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -52,7 +52,7 @@ public interface BasicSpan {
     long getSpanId();
     void setSpanId(long spanId);
 
-    TransactionId getTransactionId();
+    ServerTraceId getTransactionId();
 //    void setTransactionId(TransactionId transactionId);
 
     int getApplicationServiceType();

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.common.server.bo;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.util.ByteUtils;
 import com.navercorp.pinpoint.common.server.util.NumberPrecondition;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
@@ -25,6 +25,7 @@ import org.jspecify.annotations.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author emeroad
@@ -46,7 +47,7 @@ public class SpanBo implements Event, BasicSpan {
 
     private long agentStartTime;
 
-    private TransactionId transactionId;
+    private ServerTraceId transactionId;
 
     private long spanId;
     private long parentSpanId;
@@ -101,11 +102,11 @@ public class SpanBo implements Event, BasicSpan {
     }
 
     @Override
-    public TransactionId getTransactionId() {
+    public ServerTraceId getTransactionId() {
         return this.transactionId;
     }
 
-    public void setTransactionId(TransactionId transactionId) {
+    public void setTransactionId(ServerTraceId transactionId) {
         this.transactionId = transactionId;
     }
 
@@ -448,7 +449,7 @@ public class SpanBo implements Event, BasicSpan {
         private String applicationName;
         private long agentStartTime;
 
-        private TransactionId transactionId;
+        private ServerTraceId transactionId;
 
         private final long spanId;
 
@@ -523,8 +524,8 @@ public class SpanBo implements Event, BasicSpan {
             return this;
         }
 
-        public Builder setTransactionId(TransactionId transactionId) {
-            this.transactionId = transactionId;
+        public Builder setTransactionId(ServerTraceId transactionId) {
+            this.transactionId = Objects.requireNonNull(transactionId, "transactionId");
             return this;
         }
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.common.server.bo;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.util.ByteUtils;
 import com.navercorp.pinpoint.common.server.util.NumberPrecondition;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
@@ -42,7 +42,7 @@ public class SpanChunkBo implements BasicSpan {
     private String applicationName;
     private long agentStartTime;
 
-    private TransactionId transactionId;
+    private ServerTraceId transactionId;
 
     private long spanId;
     private String endPoint;
@@ -118,11 +118,11 @@ public class SpanChunkBo implements BasicSpan {
     }
 
     @Override
-    public TransactionId getTransactionId() {
+    public ServerTraceId getTransactionId() {
         return transactionId;
     }
 
-    public void setTransactionId(TransactionId transactionId) {
+    public void setTransactionId(ServerTraceId transactionId) {
         this.transactionId = transactionId;
     }
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/GrpcSpanBinder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/GrpcSpanBinder.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.common.server.bo.grpc;
 
 
 import com.navercorp.pinpoint.common.PinpointConstants;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.AnnotationComparator;
 import com.navercorp.pinpoint.common.server.bo.AnnotationFactory;
@@ -28,6 +27,8 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventComparator;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.grpc.MessageFormatUtils;
@@ -91,7 +92,7 @@ public class GrpcSpanBinder {
         if (!pSpan.hasTransactionId()) {
             throw new IllegalStateException("hasTransactionId() is false " + MessageFormatUtils.debugLog(pSpan));
         }
-        final TransactionId transactionId = newTransactionId(pSpan.getTransactionId(), spanBo.getAgentId());
+        final ServerTraceId transactionId = newTransactionId(pSpan.getTransactionId(), spanBo.getAgentId());
         spanBo.setTransactionId(transactionId);
 
         spanBo.setSpanId(pSpan.getSpanId());
@@ -276,7 +277,7 @@ public class GrpcSpanBinder {
 
         if (pSpanChunk.hasTransactionId()) {
             PTransactionId pTransactionId = pSpanChunk.getTransactionId();
-            TransactionId transactionId = newTransactionId(pTransactionId, spanChunkBo.getAgentId());
+            ServerTraceId transactionId = newTransactionId(pTransactionId, spanChunkBo.getAgentId());
             spanChunkBo.setTransactionId(transactionId);
         } else {
             logger.warn("PTransactionId is not set {}", pSpanChunk);
@@ -290,12 +291,12 @@ public class GrpcSpanBinder {
         return spanChunkBo;
     }
 
-    private TransactionId newTransactionId(PTransactionId pTransactionId, String spanAgentId) {
+    private ServerTraceId newTransactionId(PTransactionId pTransactionId, String spanAgentId) {
         final String transactionAgentId = pTransactionId.getAgentId();
         if (StringUtils.hasLength(transactionAgentId)) {
-            return TransactionId.of(transactionAgentId, pTransactionId.getAgentStartTime(), pTransactionId.getSequence());
+            return new PinpointServerTraceId(transactionAgentId, pTransactionId.getAgentStartTime(), pTransactionId.getSequence());
         } else {
-            return TransactionId.of(spanAgentId, pTransactionId.getAgentStartTime(), pTransactionId.getSequence());
+            return new PinpointServerTraceId(spanAgentId, pTransactionId.getAgentStartTime(), pTransactionId.getSequence());
         }
     }
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 
 import com.navercorp.pinpoint.common.buffer.Buffer;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.AnnotationTranscoder;
 import com.navercorp.pinpoint.common.server.bo.BasicSpan;
@@ -31,6 +30,7 @@ import com.navercorp.pinpoint.common.server.bo.filter.SpanEventFilter;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.SpanBitField;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.SpanEventBitField;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.SpanEventQualifierBitField;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.io.SpanVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -66,7 +66,7 @@ public class SpanDecoderV0 implements SpanDecoder {
     private SpanChunkBo readSpanChunk(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext) {
         final SpanChunkBo spanChunk = new SpanChunkBo();
 
-        final TransactionId transactionId = decodingContext.getTransactionId();
+        final ServerTraceId transactionId = decodingContext.getTransactionId();
         spanChunk.setTransactionId(transactionId);
         spanChunk.setCollectorAcceptTime(decodingContext.getCollectorAcceptedTime());
 
@@ -82,7 +82,7 @@ public class SpanDecoderV0 implements SpanDecoder {
     private SpanBo readSpan(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext) {
         final SpanBo span = new SpanBo();
 
-        final TransactionId transactionId = decodingContext.getTransactionId();
+        final ServerTraceId transactionId = decodingContext.getTransactionId();
         span.setTransactionId(transactionId);
         span.setCollectorAcceptTime(decodingContext.getCollectorAcceptedTime());
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecodingContext.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecodingContext.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 
 import com.navercorp.pinpoint.common.buffer.StringAllocator;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -27,14 +27,14 @@ import java.util.Objects;
  */
 public class SpanDecodingContext {
 
-    private final TransactionId transactionId;
+    private final ServerTraceId transactionId;
 
     //    private AnnotationBo prevAnnotationBo;
     private long collectorAcceptedTime;
 
     private StringAllocator stringAllocator = StringAllocator.DEFAULT_ALLOCATOR;
 
-    public SpanDecodingContext(TransactionId transactionId) {
+    public SpanDecodingContext(ServerTraceId transactionId) {
         this.transactionId = Objects.requireNonNull(transactionId, "transactionId");
     }
 
@@ -54,7 +54,7 @@ public class SpanDecodingContext {
         return collectorAcceptedTime;
     }
 
-    public TransactionId getTransactionId() {
+    public ServerTraceId getTransactionId() {
         return transactionId;
     }
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/trace/OtelServerTraceId.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/trace/OtelServerTraceId.java
@@ -1,0 +1,45 @@
+package com.navercorp.pinpoint.common.server.trace;
+
+
+import com.navercorp.pinpoint.common.PinpointConstants;
+import com.navercorp.pinpoint.common.server.util.Base16Utils;
+
+import java.util.Arrays;
+
+public class OtelServerTraceId implements ServerTraceId {
+
+    private final byte[] traceId;
+
+    public OtelServerTraceId(byte[] traceId) {
+        if (traceId == null) {
+            throw new NullPointerException("traceId must not be null");
+        }
+        if (traceId.length != PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN) {
+            throw new IllegalArgumentException("invalid OtelServerTraceId bytes length:"  + traceId.length);
+        }
+        this.traceId = traceId;
+    }
+
+    @Override
+    public byte[] getId() {
+        return traceId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OtelServerTraceId that = (OtelServerTraceId) o;
+        return Arrays.equals(traceId, that.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(traceId);
+    }
+
+    @Override
+    public String toString() {
+        return Base16Utils.encodeToString(traceId);
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/trace/PinpointServerTraceId.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/trace/PinpointServerTraceId.java
@@ -1,0 +1,116 @@
+package com.navercorp.pinpoint.common.server.trace;
+
+import com.navercorp.pinpoint.common.buffer.Buffer;
+import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
+import com.navercorp.pinpoint.common.profiler.util.TransactionIdUtils;
+import com.navercorp.pinpoint.common.server.util.TransactionIdParser;
+import com.navercorp.pinpoint.common.util.IdValidateUtils;
+
+import java.util.Objects;
+
+public class PinpointServerTraceId implements ServerTraceId {
+
+    public static final char DELIMITER = '^';
+    public static final int DELIMITER_LENGTH = 1;
+
+    private final String agentId;
+    private final long agentStartTime;
+    private final long transactionSequence;
+
+
+    public static ServerTraceId of(byte[] traceIdBytes, int offset, int length) {
+        Buffer buffer = new OffsetFixedBuffer(traceIdBytes, offset, length);
+        return of(buffer);
+    }
+
+    public static ServerTraceId of(Buffer buffer) {
+        String agentId = buffer.readPrefixedString();
+        long agentStartTime = buffer.readSVLong();
+        long transactionSequence = buffer.readVLong();
+        return new PinpointServerTraceId(agentId, agentStartTime, transactionSequence);
+    }
+
+    public static ServerTraceId of(final String transactionId) {
+        Objects.requireNonNull(transactionId, "transactionId");
+
+        final int agentIdIndex = indexOf(transactionId, 0);
+        if (agentIdIndex == -1) {
+            throw new IllegalArgumentException("agentIndex not found:" + transactionId);
+        }
+        if (!IdValidateUtils.checkId(transactionId, 0, agentIdIndex)) {
+            throw new IllegalArgumentException("invalid transactionId:" + transactionId);
+        }
+        final String agentId = transactionId.substring(0, agentIdIndex);
+
+        final int agentStartTimeIndex = indexOf(transactionId, agentIdIndex + DELIMITER_LENGTH);
+        if (agentStartTimeIndex == -1) {
+            throw new IllegalArgumentException("agentStartTimeIndex not found:" + transactionId);
+        }
+        final long agentStartTime = parseLong(transactionId, agentIdIndex + DELIMITER_LENGTH, agentStartTimeIndex);
+
+        int transactionSequenceIndex = indexOf(transactionId, agentStartTimeIndex + DELIMITER_LENGTH);
+        if (transactionSequenceIndex == -1) {
+            // next index may not exist since default value does not have a delimiter after transactionSequence.
+            // may need fixing when id spec changes
+            transactionSequenceIndex = transactionId.length();
+        }
+        final long transactionSequence = parseLong(transactionId, agentStartTimeIndex + DELIMITER_LENGTH, transactionSequenceIndex);
+        return new PinpointServerTraceId(agentId, agentStartTime, transactionSequence);
+    }
+
+    private static int indexOf(String transactionId, int fromIndex) {
+        return transactionId.indexOf(DELIMITER, fromIndex);
+    }
+
+    private static long parseLong(String traceId, int beginIndex, int endIndex) {
+        try {
+            return Long.parseLong(traceId, beginIndex, endIndex, 10);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("parseLong Error. " + traceId);
+        }
+    }
+
+    public PinpointServerTraceId(String agentId, long agentStartTime, long transactionSequence) {
+        this.agentId = agentId;
+        this.agentStartTime = agentStartTime;
+        this.transactionSequence = transactionSequence;
+    }
+
+    @Override
+    public byte[] getId() {
+        return TransactionIdParser.getVarTransactionId(agentId, agentStartTime, transactionSequence);
+    }
+
+    public String getAgentId() {
+        return agentId;
+    }
+
+    public long getAgentStartTime() {
+        return agentStartTime;
+    }
+
+    public long getTransactionSequence() {
+        return transactionSequence;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PinpointServerTraceId that = (PinpointServerTraceId) o;
+        return agentStartTime == that.agentStartTime && transactionSequence == that.transactionSequence && Objects.equals(agentId, that.agentId);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(agentId);
+        result = 31 * result + Long.hashCode(agentStartTime);
+        result = 31 * result + Long.hashCode(transactionSequence);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return TransactionIdUtils.formatString(agentId, agentStartTime, transactionSequence);
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/trace/ServerTraceId.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/trace/ServerTraceId.java
@@ -1,0 +1,5 @@
+package com.navercorp.pinpoint.common.server.trace;
+
+public interface ServerTraceId {
+    byte[] getId();
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/Base16Utils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/Base16Utils.java
@@ -1,0 +1,14 @@
+package com.navercorp.pinpoint.common.server.util;
+
+import org.apache.commons.codec.binary.Base16;
+
+public final class Base16Utils {
+    private static final Base16 BASE16 = new Base16(true);
+
+    private Base16Utils() {
+    }
+
+    public static String encodeToString(byte[] bytes) {
+        return BASE16.encodeToString(bytes);
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/SpanUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/SpanUtils.java
@@ -19,6 +19,8 @@ package com.navercorp.pinpoint.common.server.util;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 
 /**
  * @deprecated use {@link TransactionIdParser}
@@ -34,7 +36,12 @@ public final class SpanUtils {
      * deserializer ref : TransactionIdMapper.parseVarTransactionId
      */
     public static byte[] getVarTransactionId(SpanBo span) {
-        return TransactionIdParser.getVarTransactionId(span.getTransactionId(), span::getAgentId);
+        ServerTraceId serverTraceId = span.getTransactionId();
+        if (serverTraceId instanceof PinpointServerTraceId) {
+            return TransactionIdParser.getVarTransactionId(serverTraceId, span::getAgentId);
+        } else {
+            return serverTraceId.getId();
+        }
     }
 
     public static TransactionId parseVarTransactionId(byte[] bytes, int offset, int length) {

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/SpanFactoryAssert.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/SpanFactoryAssert.java
@@ -16,7 +16,8 @@
 
 package com.navercorp.pinpoint.common.server.bo;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.grpc.trace.PAcceptEvent;
 import com.navercorp.pinpoint.grpc.trace.PAnnotation;
 import com.navercorp.pinpoint.grpc.trace.PIntStringValue;
@@ -39,7 +40,7 @@ import java.util.Map;
 public class SpanFactoryAssert {
 
     public void assertSpan(PSpan pSpan, SpanBo spanBo) {
-        TransactionId transactionId = spanBo.getTransactionId();
+        ServerTraceId transactionId = spanBo.getTransactionId();
         PTransactionId pTransactionId = pSpan.getTransactionId();
         assertTransactionId(transactionId, pTransactionId);
 
@@ -86,10 +87,11 @@ public class SpanFactoryAssert {
 
     }
 
-    private void assertTransactionId(TransactionId transactionId, PTransactionId pTransactionId) {
-        Assertions.assertEquals(transactionId.getAgentId(), pTransactionId.getAgentId());
-        Assertions.assertEquals(transactionId.getAgentStartTime(), pTransactionId.getAgentStartTime());
-        Assertions.assertEquals(transactionId.getTransactionSequence(), pTransactionId.getSequence());
+    private void assertTransactionId(ServerTraceId transactionId, PTransactionId pTransactionId) {
+        PinpointServerTraceId pinpointServerTraceId = (PinpointServerTraceId) transactionId;
+        Assertions.assertEquals(pinpointServerTraceId.getAgentId(), pTransactionId.getAgentId());
+        Assertions.assertEquals(pinpointServerTraceId.getAgentStartTime(), pTransactionId.getAgentStartTime());
+        Assertions.assertEquals(pinpointServerTraceId.getTransactionSequence(), pTransactionId.getSequence());
     }
 
     public void assertAnnotation(List<PAnnotation> tAnnotationList, List<AnnotationBo> annotationBoList) {
@@ -147,7 +149,7 @@ public class SpanFactoryAssert {
     public void assertSpanChunk(PSpanChunk pSpanChunk, SpanChunkBo spanChunkBo) {
 
 
-        TransactionId transactionId = spanChunkBo.getTransactionId();
+        ServerTraceId transactionId = spanChunkBo.getTransactionId();
         PTransactionId pTransactionId = pSpanChunk.getTransactionId();
         assertTransactionId(transactionId, pTransactionId);
 

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/grpc/SpanFactoryTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/grpc/SpanFactoryTest.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.common.server.bo.grpc;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.RandomTSpan;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
@@ -24,6 +23,8 @@ import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.SpanFactoryAssert;
 import com.navercorp.pinpoint.common.server.bo.filter.EmptySpanEventFilter;
 import com.navercorp.pinpoint.common.server.bo.filter.SpanEventFilter;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.grpc.trace.PSpan;
 import com.navercorp.pinpoint.grpc.trace.PSpanChunk;
 import com.navercorp.pinpoint.grpc.trace.PSpanEvent;
@@ -127,11 +128,12 @@ public class SpanFactoryTest {
         tSpan.setVersion(SpanVersion.TRACE_V2);
 
         SpanBo spanBo = grpcSpanBinder.bindSpanBo(tSpan.build(), attribute);
-        TransactionId transactionId = spanBo.getTransactionId();
+        ServerTraceId transactionId = spanBo.getTransactionId();
 
-        Assertions.assertEquals("agentId", transactionId.getAgentId());
-        Assertions.assertEquals(1, transactionId.getAgentStartTime());
-        Assertions.assertEquals(2, transactionId.getTransactionSequence());
+        PinpointServerTraceId pinpointServerTraceId = (PinpointServerTraceId) transactionId;
+        Assertions.assertEquals("agentId", pinpointServerTraceId.getAgentId());
+        Assertions.assertEquals(1, pinpointServerTraceId.getAgentStartTime());
+        Assertions.assertEquals(2, pinpointServerTraceId.getTransactionSequence());
     }
 
     @Test
@@ -147,11 +149,12 @@ public class SpanFactoryTest {
                 .build();
 
         SpanBo spanBo = grpcSpanFactory.buildSpanBo(tSpan, attribute);
-        TransactionId transactionId = spanBo.getTransactionId();
+        ServerTraceId transactionId = spanBo.getTransactionId();
 
-        Assertions.assertEquals("transactionAgentId", transactionId.getAgentId());
-        Assertions.assertEquals(1, transactionId.getAgentStartTime());
-        Assertions.assertEquals(2, transactionId.getTransactionSequence());
+        PinpointServerTraceId pinpointServerTraceId = (PinpointServerTraceId) transactionId;
+        Assertions.assertEquals("transactionAgentId", pinpointServerTraceId.getAgentId());
+        Assertions.assertEquals(1, pinpointServerTraceId.getAgentStartTime());
+        Assertions.assertEquals(2, pinpointServerTraceId.getTransactionSequence());
     }
 
 

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2Test.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2Test.java
@@ -20,9 +20,10 @@ import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RangeOneByteSimpleHash;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -44,17 +45,17 @@ public class TraceRowKeyEncoderV2Test {
         return new RowKeyDistributorByHashPrefix(oneByteSimpleHash);
     }
 
-    private final RowKeyEncoder<TransactionId> traceRowKeyEncoder = new TraceRowKeyEncoderV2(distributorByHashPrefix);
+    private final RowKeyEncoder<ServerTraceId> traceRowKeyEncoder = new TraceRowKeyEncoderV2(distributorByHashPrefix);
 
-    private final RowKeyDecoder<TransactionId> traceRowKeyDecoder = new TraceRowKeyDecoderV2(ByteSaltKey.SALT);
+    private final RowKeyDecoder<ServerTraceId> traceRowKeyDecoder = new TraceRowKeyDecoderV2(ByteSaltKey.SALT);
 
     @Test
     public void encodeRowKey() {
 
-        TransactionId spanTransactionId = TransactionId.of("traceAgentId", System.currentTimeMillis(), random.nextLong(0, 10000));
+        ServerTraceId spanTransactionId = new PinpointServerTraceId("traceAgentId", System.currentTimeMillis(), random.nextLong(0, 10000));
 
         byte[] rowKey = traceRowKeyEncoder.encodeRowKey(spanTransactionId);
-        TransactionId transactionId = traceRowKeyDecoder.decodeRowKey(rowKey);
+        ServerTraceId transactionId = traceRowKeyDecoder.decodeRowKey(rowKey);
 
         Assertions.assertEquals(transactionId, spanTransactionId);
 

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/trace/OtelServerTraceIdTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/trace/OtelServerTraceIdTest.java
@@ -1,0 +1,27 @@
+package com.navercorp.pinpoint.common.server.trace;
+
+import com.navercorp.pinpoint.common.util.BytesUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+class OtelServerTraceIdTest {
+
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    @Test
+    void getId() {
+
+        UUID uuid = UUID.randomUUID();
+        byte[] uuidBytes = new byte[16];
+        BytesUtils.writeLong(uuid.getMostSignificantBits(), uuidBytes, 0);
+        BytesUtils.writeLong(uuid.getLeastSignificantBits(), uuidBytes, 8);
+
+        OtelServerTraceId otelServerTraceId = new OtelServerTraceId(uuidBytes);
+
+        String id = otelServerTraceId.toString();
+        logger.info("{}", id);
+    }
+}

--- a/commons-server/src/test/resources/log4j2-test.xml
+++ b/commons-server/src/test/resources/log4j2-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration status="INFO">
+    <Properties>
+        <Property name="console_message_pattern">%d{MM-dd HH:mm:ss.SSS} [%15.15t] %clr{%-5level} %clr{%-40.40logger{1.}}{cyan}:%3L -- %msg%n</Property>
+        <Property name="file_message_pattern">%d{MM-dd HH:mm:ss.SSS} [%15.15t] %-5level %-40.40logger{1.}:%3L -- %msg%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="console" target="system_out">
+            <PatternLayout pattern="${file_message_pattern}"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="com.navercorp.pinpoint" level="DEBUG" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Root level="DEBUG">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/commons/src/main/java/com/navercorp/pinpoint/common/PinpointConstants.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/PinpointConstants.java
@@ -16,6 +16,8 @@
 
 package com.navercorp.pinpoint.common;
 
+import com.navercorp.pinpoint.common.util.BytesUtils;
+
 /**
  * @author emeroad
  */
@@ -31,5 +33,6 @@ public final class PinpointConstants {
     public static final int APPLICATION_NAME_MAX_LEN_V3 = SERVICE_NAME_MAX_LEN;
 
     public static final int AGENT_NAME_MAX_LEN_V4 = APPLICATION_NAME_MAX_LEN_V3;
-    public static final int OPENTELEMETRY_TRACE_ID_LEN = 32;
+
+    public static final int OPENTELEMETRY_TRACE_ID_LEN = BytesUtils.LONG_BYTE_LENGTH + BytesUtils.LONG_BYTE_LENGTH;
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
@@ -16,8 +16,8 @@
 
 package com.navercorp.pinpoint.web.applicationmap.controller;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.DateTimeFormatUtils;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
@@ -116,7 +116,7 @@ public class FilteredMapController {
         final boolean useTraceIndexV2 = traceIndexReadV2.orElse(defaultTraceIndexReadV2);
 
 
-        final LimitedScanResult<List<TransactionId>> limitedScanResult;
+        final LimitedScanResult<List<ServerTraceId>> limitedScanResult;
         if (!useTraceIndexV2) {
             limitedScanResult = traceIndexService.getTraceIndex(applicationName, range, limit);
         } else {
@@ -149,7 +149,7 @@ public class FilteredMapController {
         return new FilterMapViewV3(applicationMapView, scatterDataMapView, null, lastScanTime);
     }
 
-    private FilteredMapServiceOption newFilteredOption(List<TransactionId> transactionIdList,
+    private FilteredMapServiceOption newFilteredOption(List<ServerTraceId> transactionIdList,
                                                        Range originalRange,
                                                        GroupForm groupForm,
                                                        Filter<List<SpanBo>> filter,

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceOption.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceOption.java
@@ -18,8 +18,8 @@
 package com.navercorp.pinpoint.web.applicationmap.service;
 
 import com.navercorp.pinpoint.common.hbase.bo.ColumnGetCount;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.filter.Filter;
 
@@ -31,7 +31,7 @@ import java.util.Objects;
  * @author jaehong.kim
  */
 public class FilteredMapServiceOption {
-    private final List<TransactionId> transactionIdList;
+    private final List<ServerTraceId> transactionIdList;
     private final Range range;
     private final int xGroupUnit;
     private final int yGroupUnit;
@@ -49,7 +49,7 @@ public class FilteredMapServiceOption {
         this.columnGetCount = builder.columnGetCount;
     }
 
-    public List<TransactionId> getTransactionIdList() {
+    public List<ServerTraceId> getTransactionIdList() {
         return transactionIdList;
     }
 
@@ -90,7 +90,7 @@ public class FilteredMapServiceOption {
     }
 
     public static class Builder {
-        private final List<TransactionId> transactionIdList;
+        private final List<ServerTraceId> transactionIdList;
         private final Range range;
         private int xGroupUnit;
         private int yGroupUnit;
@@ -99,7 +99,7 @@ public class FilteredMapServiceOption {
 
         private boolean useStatisticsAgentState;
 
-        public Builder(TransactionId transactionId, Range range, ColumnGetCount columnGetCount) {
+        public Builder(ServerTraceId transactionId, Range range, ColumnGetCount columnGetCount) {
             Objects.requireNonNull(transactionId, "transactionId");
             this.transactionIdList = Collections.singletonList(transactionId);
             this.range = Objects.requireNonNull(range, "scanRange");
@@ -107,7 +107,7 @@ public class FilteredMapServiceOption {
             this.filter = Filter.acceptAllFilter();
         }
 
-        public Builder(List<TransactionId> transactionIdList, Range range, int xGroupUnit, int yGroupUnit, Filter<List<SpanBo>> filter) {
+        public Builder(List<ServerTraceId> transactionIdList, Range range, int xGroupUnit, int yGroupUnit, Filter<List<SpanBo>> filter) {
             this.transactionIdList = Objects.requireNonNull(transactionIdList, "transactionIdList");
             this.filter = Objects.requireNonNull(filter, "filter");
             this.range = Objects.requireNonNull(range, "range");

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/TraceIndexService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/TraceIndexService.java
@@ -17,16 +17,16 @@
 package com.navercorp.pinpoint.web.applicationmap.service;
 
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
 
 import java.util.List;
 
 public interface TraceIndexService {
-    LimitedScanResult<List<TransactionId>> getTraceIndex(String applicationName, Range range, int limit);
+    LimitedScanResult<List<ServerTraceId>> getTraceIndex(String applicationName, Range range, int limit);
 
-    LimitedScanResult<List<TransactionId>> getTraceIndex(String applicationName, Range range, int limit, boolean backwardDirection);
+    LimitedScanResult<List<ServerTraceId>> getTraceIndex(String applicationName, Range range, int limit, boolean backwardDirection);
 
-    LimitedScanResult<List<TransactionId>> getTraceIndexV2(int serviceUid, String applicationName, int serviceTypeCode, Range range, int limit);
+    LimitedScanResult<List<ServerTraceId>> getTraceIndexV2(int serviceUid, String applicationName, int serviceTypeCode, Range range, int limit);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/TraceIndexServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/TraceIndexServiceImpl.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.service;
 
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.scatter.dao.ApplicationTraceIndexDao;
 import com.navercorp.pinpoint.web.scatter.dao.TraceIndexDao;
@@ -43,12 +43,12 @@ public class TraceIndexServiceImpl implements TraceIndexService {
     }
 
     @Override
-    public LimitedScanResult<List<TransactionId>> getTraceIndex(String applicationName, Range range, int limit) {
+    public LimitedScanResult<List<ServerTraceId>> getTraceIndex(String applicationName, Range range, int limit) {
         return getTraceIndex(applicationName, range, limit, true);
     }
 
     @Override
-    public LimitedScanResult<List<TransactionId>> getTraceIndex(String applicationName, Range range, int limit, boolean backwardDirection) {
+    public LimitedScanResult<List<ServerTraceId>> getTraceIndex(String applicationName, Range range, int limit, boolean backwardDirection) {
         Objects.requireNonNull(applicationName, "applicationName");
         Objects.requireNonNull(range, "range");
 
@@ -60,7 +60,7 @@ public class TraceIndexServiceImpl implements TraceIndexService {
     }
 
     @Override
-    public LimitedScanResult<List<TransactionId>> getTraceIndexV2(int serviceUid, String applicationName, int serviceTypeCode, Range range, int limit) {
+    public LimitedScanResult<List<ServerTraceId>> getTraceIndexV2(int serviceUid, String applicationName, int serviceTypeCode, Range range, int limit) {
         Objects.requireNonNull(applicationName, "applicationName");
         Objects.requireNonNull(range, "range");
 
@@ -69,7 +69,7 @@ public class TraceIndexServiceImpl implements TraceIndexService {
         }
 
         LimitedScanResult<List<DotMetaData>> listLimitedScanResult = this.traceIndexDao.scanTraceIndex(serviceUid, applicationName, serviceTypeCode, range, limit);
-        List<TransactionId> transactionIds = listLimitedScanResult.scanData().stream()
+        List<ServerTraceId> transactionIds = listLimitedScanResult.scanData().stream()
                 .map(meta -> meta.getDot().getTransactionId())
                 .toList();
         return new LimitedScanResult<>(listLimitedScanResult.limitedTime(), transactionIds);

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/ApplicationTraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/ApplicationTraceIndexDao.java
@@ -16,12 +16,12 @@
 
 package com.navercorp.pinpoint.web.scatter.dao;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
-import com.navercorp.pinpoint.web.vo.LimitedScanResult;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
+import com.navercorp.pinpoint.web.vo.LimitedScanResult;
 
 import java.util.List;
 
@@ -33,7 +33,7 @@ public interface ApplicationTraceIndexDao {
 
     boolean hasTraceIndex(String applicationName, Range range, boolean backwardDirection);
 
-    LimitedScanResult<List<TransactionId>> scanTraceIndex(String applicationName, Range range, int limit, boolean backwardDirection);
+    LimitedScanResult<List<ServerTraceId>> scanTraceIndex(String applicationName, Range range, int limit, boolean backwardDirection);
 
     LimitedScanResult<List<Dot>> scanTraceScatterData(String applicationName, Range range, int limit, boolean scanBackward);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TraceIndexDotMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TraceIndexDotMapper.java
@@ -20,9 +20,10 @@ import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.RowTypeHint;
-import com.navercorp.pinpoint.common.profiler.util.TransactionIdV1;
 import com.navercorp.pinpoint.common.server.scatter.TraceIndexRowKeyUtils;
 import com.navercorp.pinpoint.common.server.scatter.TraceIndexValue;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -34,6 +35,9 @@ import java.util.function.Predicate;
 
 // TraceIndexScatterMapper version 2
 public class TraceIndexDotMapper implements RowMapper<List<Dot>>, RowTypeHint {
+
+    private static final ServerTraceId EMPTY = new PinpointServerTraceId("EMPTY", 0, 0);
+
     private final HbaseColumnFamily index = HbaseTables.TRACE_INDEX;
     private final Predicate<byte[]> rowPredicate;
 
@@ -61,7 +65,7 @@ public class TraceIndexDotMapper implements RowMapper<List<Dot>>, RowTypeHint {
 
     private Dot createDot(long acceptedTime, Cell cell) {
         TraceIndexValue.Index index = TraceIndexValue.Index.decode(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength());
-        return new Dot(TransactionIdV1.EMPTY_ID, acceptedTime, index.elapsed(), index.errorCode(), index.agentId());
+        return new Dot(EMPTY, acceptedTime, index.elapsed(), index.errorCode(), index.agentId());
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TraceIndexScatterMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TraceIndexScatterMapper.java
@@ -24,8 +24,8 @@ import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.RowTypeHint;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
-import com.navercorp.pinpoint.common.server.util.TransactionIdParser;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.util.LongInverter;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import org.apache.hadoop.hbase.Cell;
@@ -73,9 +73,9 @@ public class TraceIndexScatterMapper implements RowMapper<List<Dot>>, RowTypeHin
         String agentId = valueBuffer.readPrefixedString();
 
         long acceptedTime = extractAcceptTime(cell.getRowArray(), cell.getRowOffset());
-        TransactionId transactionId = TransactionIdParser.parseVarTransactionId(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
+        ServerTraceId serverTraceId = PinpointServerTraceId.of(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
 
-        return new Dot(transactionId, acceptedTime, elapsed, exceptionCode, agentId);
+        return new Dot(serverTraceId, acceptedTime, elapsed, exceptionCode, agentId);
     }
 
     static long extractAcceptTime(byte[] bytes, int baseOffset) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TransactionIdMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/mapper/TransactionIdMapper.java
@@ -20,8 +20,8 @@ import com.navercorp.pinpoint.common.hbase.HbaseColumnFamily;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.RowTypeHint;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
-import com.navercorp.pinpoint.common.server.util.TransactionIdParser;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.Result;
@@ -38,7 +38,7 @@ import java.util.List;
  * @author netspider
  */
 @Component
-public class TransactionIdMapper implements RowMapper<List<TransactionId>>, RowTypeHint {
+public class TransactionIdMapper implements RowMapper<List<ServerTraceId>>, RowTypeHint {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
@@ -49,17 +49,17 @@ public class TransactionIdMapper implements RowMapper<List<TransactionId>>, RowT
     }
 
     @Override
-    public List<TransactionId> mapRow(Result result, int rowNum) throws Exception {
+    public List<ServerTraceId> mapRow(Result result, int rowNum) throws Exception {
         if (result.isEmpty()) {
             return Collections.emptyList();
         }
         Cell[] rawCells = result.rawCells();
-        List<TransactionId> traceIdList = new ArrayList<>(rawCells.length);
+        List<ServerTraceId> traceIdList = new ArrayList<>(rawCells.length);
         for (Cell cell : rawCells) {
             if (CellUtil.matchingFamily(cell, traceIndex.getName())) {
-                TransactionId traceId = TransactionIdParser.parseVarTransactionId(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
-                traceIdList.add(traceId);
-                logger.debug("found traceId {}", traceId);
+                ServerTraceId serverTraceId = PinpointServerTraceId.of(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
+                traceIdList.add(serverTraceId);
+                logger.debug("found traceId {}", serverTraceId);
             }
         }
         return traceIdList;

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/vo/Dot.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/vo/Dot.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.web.scatter.vo;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.view.DotSerializer;
 
 import java.util.Objects;
@@ -40,7 +40,7 @@ public class Dot {
         }
     }
 
-    private final TransactionId transactionId;
+    private final ServerTraceId transactionId;
     private final long acceptedTime;
     private final int elapsedTime;
     private final int exceptionCode;
@@ -53,7 +53,7 @@ public class Dot {
      * @param elapsedTime
      * @param exceptionCode 0 : success, 1 : error
      */
-    public Dot(TransactionId transactionId, long acceptedTime, int elapsedTime, int exceptionCode, String agentId) {
+    public Dot(ServerTraceId transactionId, long acceptedTime, int elapsedTime, int exceptionCode, String agentId) {
         this.transactionId = Objects.requireNonNull(transactionId, "transactionId");
         this.agentId = Objects.requireNonNull(agentId, "agentId");
 
@@ -62,7 +62,7 @@ public class Dot {
         this.exceptionCode = exceptionCode;
     }
 
-    public TransactionId getTransactionId() {
+    public ServerTraceId getTransactionId() {
         return transactionId;
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/vo/DotAgentInfo.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/vo/DotAgentInfo.java
@@ -25,7 +25,7 @@ public class DotAgentInfo {
     private final long transactionAgentStartTime;
 
     public DotAgentInfo(Dot dot) {
-        this(dot.getAgentId(), dot.getTransactionId().getAgentId(), dot.getTransactionId().getAgentStartTime());
+        this(dot.getAgentId(), dot.getTransactionId().toString(), 0);
     }
 
     public DotAgentInfo(String agentId, String transactionAgentId, long transactionAgentStartTime) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/DotExtractor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/DotExtractor.java
@@ -16,14 +16,14 @@
 
 package com.navercorp.pinpoint.web.service;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.scatter.ScatterData;
 import com.navercorp.pinpoint.web.scatter.ScatterDataBuilder;
-import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.scatter.vo.ApplicationScatterScanResult;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.scatter.vo.ScatterScanResult;
+import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -59,7 +59,7 @@ public class DotExtractor {
     public Dot newDot(SpanBo span) {
         Objects.requireNonNull(span, "span");
 
-        final TransactionId transactionId = span.getTransactionId();
+        final ServerTraceId transactionId = span.getTransactionId();
         return new Dot(transactionId, span.getCollectorAcceptTime(), span.getElapsed(), span.getErrCode(), span.getAgentId());
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapServiceImpl.java
@@ -16,8 +16,8 @@
 
 package com.navercorp.pinpoint.web.service;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
 import com.navercorp.pinpoint.web.scatter.dao.ApplicationTraceIndexDao;
@@ -173,7 +173,7 @@ public class HeatMapServiceImpl implements HeatMapService {
     }
 
     private GetTraceInfo dotToGetTraceInfo(String applicationName, Dot dot) {
-        TransactionId transactionId = dot.getTransactionId();
+        ServerTraceId transactionId = dot.getTransactionId();
 
         SpanHint spanHint = new SpanHint(dot.getAcceptedTime(),
                 dot.getElapsedTime(), applicationName, dot.getAgentId());

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartService.java
@@ -16,8 +16,8 @@
 
 package com.navercorp.pinpoint.web.service;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.scatter.ScatterData;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
@@ -28,7 +28,7 @@ public interface ScatterChartService {
 
     List<SpanBo> selectTransactionMetadata(List<GetTraceInfo> getTraceInfoList);
 
-    List<SpanBo> selectTransactionMetadata(TransactionId transactionId);
+    List<SpanBo> selectTransactionMetadata(ServerTraceId transactionId);
 
     ScatterData selectScatterData(String applicationName, Range range, int xGroupUnit, int yGroupUnit, int limit, boolean backwardDirection);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartServiceImpl.java
@@ -16,20 +16,20 @@
 
 package com.navercorp.pinpoint.web.service;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
-import com.navercorp.pinpoint.web.scatter.dao.ApplicationTraceIndexDao;
-import com.navercorp.pinpoint.web.scatter.dao.TraceIndexDao;
 import com.navercorp.pinpoint.web.scatter.ScatterData;
 import com.navercorp.pinpoint.web.scatter.ScatterDataBuilder;
+import com.navercorp.pinpoint.web.scatter.dao.ApplicationTraceIndexDao;
+import com.navercorp.pinpoint.web.scatter.dao.TraceIndexDao;
+import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.trace.dao.TraceDao;
 import com.navercorp.pinpoint.web.trace.service.SpanService;
 import com.navercorp.pinpoint.web.util.ListListUtils;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
-import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -79,7 +79,7 @@ public class ScatterChartServiceImpl implements ScatterChartService {
     }
 
     @Override
-    public List<SpanBo> selectTransactionMetadata(TransactionId transactionId) {
+    public List<SpanBo> selectTransactionMetadata(ServerTraceId transactionId) {
         final List<SpanBo> selectedSpans = traceDao.selectSpan(transactionId);
         populateAgentName(selectedSpans);
         return selectedSpans;

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/TraceDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/TraceDao.java
@@ -18,8 +18,8 @@ package com.navercorp.pinpoint.web.trace.dao;
 
 
 import com.navercorp.pinpoint.common.hbase.bo.ColumnGetCount;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.service.FetchResult;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 
@@ -30,15 +30,15 @@ import java.util.List;
  */
 public interface TraceDao {
 
-    List<SpanBo> selectSpan(TransactionId transactionId);
+    List<SpanBo> selectSpan(ServerTraceId transactionId);
 
-    FetchResult<List<SpanBo>> selectSpan(TransactionId transactionId, ColumnGetCount columnGetCount);
+    FetchResult<List<SpanBo>> selectSpan(ServerTraceId transactionId, ColumnGetCount columnGetCount);
 
     List<List<SpanBo>> selectSpans(List<GetTraceInfo> getTraceInfoList);
     
-    List<List<SpanBo>> selectAllSpans(List<TransactionId> transactionIdList);
+    List<List<SpanBo>> selectAllSpans(List<ServerTraceId> transactionIdList);
 
-    List<List<SpanBo>> selectAllSpans(List<TransactionId> transactionIdList, ColumnGetCount columnGetCount);
+    List<List<SpanBo>> selectAllSpans(List<ServerTraceId> transactionIdList, ColumnGetCount columnGetCount);
 
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/hbase/SpanQuery.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/hbase/SpanQuery.java
@@ -16,29 +16,29 @@
 
 package com.navercorp.pinpoint.web.trace.dao.hbase;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.apache.hadoop.hbase.filter.Filter;
 
 import java.util.Objects;
 import java.util.function.Predicate;
 
 public class SpanQuery {
-    private final TransactionId transactionId;
+    private final ServerTraceId transactionId;
     private final Predicate<SpanBo> spanFilter;
     private final Filter filter;
 
-    public SpanQuery(TransactionId transactionId, Predicate<SpanBo> spanFilter, Filter filter) {
+    public SpanQuery(ServerTraceId transactionId, Predicate<SpanBo> spanFilter, Filter filter) {
         this.transactionId = Objects.requireNonNull(transactionId, "transactionId");
         this.spanFilter = spanFilter;
         this.filter = filter;
     }
 
-    public SpanQuery(TransactionId transactionId) {
+    public SpanQuery(ServerTraceId transactionId) {
         this(transactionId, null, null);
     }
 
-    public TransactionId getTransactionId() {
+    public ServerTraceId getTransactionId() {
         return transactionId;
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/hbase/SpanQueryBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/hbase/SpanQueryBuilder.java
@@ -17,8 +17,8 @@
 package com.navercorp.pinpoint.web.trace.dao.hbase;
 
 import com.navercorp.pinpoint.common.annotations.VisibleForTesting;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.trace.span.SpanFilters;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.SpanHint;
@@ -44,7 +44,7 @@ public class SpanQueryBuilder {
     }
 
     @VisibleForTesting
-    Predicate<SpanBo> newSpanFilter(TransactionId transactionId, SpanHint spanHint) {
+    Predicate<SpanBo> newSpanFilter(ServerTraceId transactionId, SpanHint spanHint) {
         SpanFilters.FilterBuilder builder = SpanFilters.newBuilder();
 
         builder.addFilter(SpanFilters.transactionIdFilter(transactionId));

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperFactory.java
@@ -17,11 +17,11 @@
 package com.navercorp.pinpoint.web.trace.dao.mapper;
 
 import com.navercorp.pinpoint.common.hbase.RowMapper;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoderV0;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -36,7 +36,7 @@ import java.util.function.Predicate;
 @Component
 public class SpanMapperFactory {
 
-    private final RowKeyDecoder<TransactionId> rowKeyDecoder;
+    private final RowKeyDecoder<ServerTraceId> rowKeyDecoder;
 
     private final int stringCacheSize;
 
@@ -44,7 +44,7 @@ public class SpanMapperFactory {
 
     private final SpanDecoder spanDecoder = new SpanDecoderV0();
 
-    public SpanMapperFactory(@Qualifier("traceRowKeyDecoderV2") RowKeyDecoder<TransactionId> rowKeyDecoder,
+    public SpanMapperFactory(@Qualifier("traceRowKeyDecoderV2") RowKeyDecoder<ServerTraceId> rowKeyDecoder,
                              @Value("${web.hbase.mapper.cache.string.size:-1}") int stringCacheSize) {
         this.rowKeyDecoder = Objects.requireNonNull(rowKeyDecoder, "rowKeyDecoder");
         this.stringCacheSize = stringCacheSize;

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2.java
@@ -23,7 +23,6 @@ import com.navercorp.pinpoint.common.buffer.CachedStringAllocator;
 import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.BasicSpan;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
@@ -33,6 +32,7 @@ import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoderV0;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecodingContext;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.trace.ServiceTypeCategory;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.io.SpanVersion;
@@ -61,23 +61,23 @@ public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
 
     private final SpanDecoder spanDecoder;
 
-    private final RowKeyDecoder<TransactionId> rowKeyDecoder;
+    private final RowKeyDecoder<ServerTraceId> rowKeyDecoder;
 
     private final int cacheSize;
 
-    public SpanMapperV2(RowKeyDecoder<TransactionId> rowKeyDecoder) {
+    public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder) {
         this(rowKeyDecoder, new SpanDecoderV0(), DISABLED_CACHE);
     }
 
-    public SpanMapperV2(RowKeyDecoder<TransactionId> rowKeyDecoder, int cacheSize) {
+    public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder, int cacheSize) {
         this(rowKeyDecoder, new SpanDecoderV0(), cacheSize);
     }
 
-    public SpanMapperV2(RowKeyDecoder<TransactionId> rowKeyDecoder, SpanDecoder spanDecoder) {
+    public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder, SpanDecoder spanDecoder) {
         this(rowKeyDecoder, spanDecoder, DISABLED_CACHE);
     }
 
-    public SpanMapperV2(RowKeyDecoder<TransactionId> rowKeyDecoder, SpanDecoder spanDecoder, int cacheSize) {
+    public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder, SpanDecoder spanDecoder, int cacheSize) {
         this.rowKeyDecoder = Objects.requireNonNull(rowKeyDecoder, "rowKeyDecoder");
         this.spanDecoder = Objects.requireNonNull(spanDecoder, "spanDecoder");
         this.cacheSize = cacheSize;
@@ -91,7 +91,7 @@ public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
 
 
         byte[] rowKey = result.getRow();
-        final TransactionId transactionId = this.rowKeyDecoder.decodeRowKey(rowKey);
+        final ServerTraceId transactionId = this.rowKeyDecoder.decodeRowKey(rowKey);
 
         final Cell[] rawCells = result.rawCells();
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/service/SpanService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/service/SpanService.java
@@ -17,8 +17,8 @@
 package com.navercorp.pinpoint.web.trace.service;
 
 import com.navercorp.pinpoint.common.hbase.bo.ColumnGetCount;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -28,9 +28,9 @@ import java.util.function.Predicate;
  */
 public interface SpanService {
 
-    SpanResult selectSpan(TransactionId transactionId, Predicate<SpanBo> filter);
+    SpanResult selectSpan(ServerTraceId transactionId, Predicate<SpanBo> filter);
 
-    SpanResult selectSpan(TransactionId transactionId, Predicate<SpanBo> filter, ColumnGetCount columnGetCount);
+    SpanResult selectSpan(ServerTraceId transactionId, Predicate<SpanBo> filter, ColumnGetCount columnGetCount);
 
     void populateAgentName(List<SpanBo> spanBoList);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/service/SpanServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/service/SpanServiceImpl.java
@@ -20,7 +20,6 @@ import com.navercorp.pinpoint.common.hbase.bo.ColumnGetCount;
 import com.navercorp.pinpoint.common.profiler.sql.DefaultSqlNormalizer;
 import com.navercorp.pinpoint.common.profiler.sql.OutputParameterParser;
 import com.navercorp.pinpoint.common.profiler.sql.SqlNormalizer;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.ExceptionInfo;
@@ -29,6 +28,7 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SqlMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.SqlUidMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.StringMetaDataBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.util.AnnotationUtils;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.OpenTelemetryServiceTypeCategory;
@@ -134,12 +134,12 @@ public class SpanServiceImpl implements SpanService {
     }
 
     @Override
-    public SpanResult selectSpan(TransactionId transactionId, Predicate<SpanBo> filter) {
+    public SpanResult selectSpan(ServerTraceId transactionId, Predicate<SpanBo> filter) {
         return selectSpan(transactionId, filter, ColumnGetCount.UNLIMITED_COLUMN_GET_COUNT);
     }
 
     @Override
-    public SpanResult selectSpan(TransactionId transactionId, Predicate<SpanBo> filter, ColumnGetCount columnGetCount) {
+    public SpanResult selectSpan(ServerTraceId transactionId, Predicate<SpanBo> filter, ColumnGetCount columnGetCount) {
         Objects.requireNonNull(transactionId, "transactionId");
         Objects.requireNonNull(filter, "filter");
         Objects.requireNonNull(columnGetCount, "columnGetCount");

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/span/LinkedCallTree.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/span/LinkedCallTree.java
@@ -16,11 +16,11 @@
 
 package com.navercorp.pinpoint.web.trace.span;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.util.LineNumber;
 
@@ -82,7 +82,7 @@ public class LinkedCallTree implements CallTree {
 
     private SpanAlign createMultiChildSpanAlign(int serviceType, long startTime) {
         SpanBo spanBo = new SpanBo();
-        spanBo.setTransactionId(TransactionId.of("UNKNOWN", 0, 0));
+        spanBo.setTransactionId(new PinpointServerTraceId("UNKNOWN", 0, 0));
         spanBo.setServiceType(serviceType);
         spanBo.setStartTime(startTime);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/span/MetaSpanCallTreeFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/span/MetaSpanCallTreeFactory.java
@@ -16,11 +16,11 @@
 
 package com.navercorp.pinpoint.web.trace.span;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.AnnotationKeyUtils;
@@ -43,7 +43,7 @@ public class MetaSpanCallTreeFactory {
 
     public CallTree unknown(final long startTimeMillis) {
         final SpanBo rootSpan = new SpanBo();
-        rootSpan.setTransactionId(TransactionId.of(UNKNOWN_AGENT_ID, AGENT_START_TIME, 0));
+        rootSpan.setTransactionId(new PinpointServerTraceId(UNKNOWN_AGENT_ID, AGENT_START_TIME, 0));
         rootSpan.setAgentId(UNKNOWN_AGENT_ID);
         rootSpan.setApplicationName("UNKNOWN");
         rootSpan.setStartTime(startTimeMillis);
@@ -69,7 +69,7 @@ public class MetaSpanCallTreeFactory {
         rootSpan.setSpanId(spanId);
         rootSpan.setStartTime(startTimeMillis);
 
-        rootSpan.setTransactionId(TransactionId.of(CORRUPTED_AGENT_ID, AGENT_START_TIME, 0));
+        rootSpan.setTransactionId(new PinpointServerTraceId(CORRUPTED_AGENT_ID, AGENT_START_TIME, 0));
         rootSpan.setAgentId(CORRUPTED_AGENT_ID);
         rootSpan.setApplicationName("CORRUPTED");
         rootSpan.setServiceType(ServiceType.UNKNOWN.getCode());

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/span/SpanFilters.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/span/SpanFilters.java
@@ -16,8 +16,8 @@
 
 package com.navercorp.pinpoint.web.trace.span;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.web.trace.controller.TransactionController;
 
@@ -169,7 +169,7 @@ public class SpanFilters {
 
     // -----------------------
     // SpanQueryBuilder
-    public static Predicate<SpanBo> transactionIdFilter(TransactionId transactionId) {
+    public static Predicate<SpanBo> transactionIdFilter(ServerTraceId transactionId) {
         Objects.requireNonNull(transactionId, "transactionId");
         return new Predicate<>() {
             @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/ScatterDataSerializer.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/ScatterDataSerializer.java
@@ -18,6 +18,8 @@ package com.navercorp.pinpoint.web.view;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.scatter.DotGroup;
 import com.navercorp.pinpoint.web.scatter.DotGroups;
 import com.navercorp.pinpoint.web.scatter.ScatterAgentMetaData;
@@ -82,10 +84,15 @@ public class ScatterDataSerializer extends JsonSerializer<ScatterData> {
         int agentId = metaData.getId(dot);
         jgen.writeNumber(agentId);
 
+        ServerTraceId serverTraceId = dot.getTransactionId();
         if (agentId == -1) {
-            jgen.writeString(dot.getTransactionId().toString());
+            jgen.writeString(serverTraceId.toString());
         } else {
-            jgen.writeNumber(dot.getTransactionId().getTransactionSequence());
+            if (serverTraceId instanceof PinpointServerTraceId pServerTraceId) {
+                jgen.writeNumber(pServerTraceId.getTransactionSequence());
+            } else {
+                jgen.writeNumber(0);
+            }
         }
 
         jgen.writeNumber(dot.getStatus().getCode());

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/GetTraceInfo.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/GetTraceInfo.java
@@ -16,7 +16,7 @@
 
 package com.navercorp.pinpoint.web.vo;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 
 import java.util.Objects;
 
@@ -27,20 +27,20 @@ public class GetTraceInfo {
 
     private static final SpanHint NO_HINT = new SpanHint();
 
-    private final TransactionId transactionId;
+    private final ServerTraceId transactionId;
     private final SpanHint hint;
 
-    public GetTraceInfo(TransactionId transactionId) {
+    public GetTraceInfo(ServerTraceId transactionId) {
         this.transactionId = Objects.requireNonNull(transactionId, "transactionId");
         this.hint = NO_HINT;
     }
 
-    public GetTraceInfo(TransactionId transactionId, SpanHint hint) {
+    public GetTraceInfo(ServerTraceId transactionId, SpanHint hint) {
         this.transactionId = Objects.requireNonNull(transactionId, "transactionId");
         this.hint = Objects.requireNonNull(hint, "hint");
     }
 
-    public TransactionId getTransactionId() {
+    public ServerTraceId getTransactionId() {
         return transactionId;
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/GetTraceInfoParser.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/GetTraceInfoParser.java
@@ -16,10 +16,10 @@
 
 package com.navercorp.pinpoint.web.vo;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
-import com.navercorp.pinpoint.common.profiler.util.TransactionIdUtils;
-import org.apache.logging.log4j.Logger;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,10 +52,10 @@ public class GetTraceInfoParser {
                 break;
             }
 
-            TransactionId traceId = TransactionIdUtils.parseTransactionId(transactionId);
             SpanHint spanHint = new SpanHint(Long.parseLong(time), Integer.parseInt(responseTime), applicationName);
+            ServerTraceId serverTraceId = PinpointServerTraceId.of(transactionId);
 
-            final GetTraceInfo getTraceInfo = new GetTraceInfo(traceId, spanHint);
+            final GetTraceInfo getTraceInfo = new GetTraceInfo(serverTraceId, spanHint);
             getTraceInfoList.add(getTraceInfo);
             index++;
         }

--- a/web/src/test/java/com/navercorp/pinpoint/web/TestTraceUtils.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/TestTraceUtils.java
@@ -17,9 +17,10 @@
 package com.navercorp.pinpoint.web;
 
 import com.navercorp.pinpoint.bootstrap.context.SpanId;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.util.ServiceTypeRegistryMockFactory;
@@ -81,9 +82,9 @@ public class TestTraceUtils {
 
         private final Map<String, AtomicInteger> sequenceMap = new ConcurrentHashMap<>();
 
-        TransactionId generate(String agentId) {
+        ServerTraceId generate(String agentId) {
             int nextSequence = getNextSequence(agentId);
-            return TransactionId.of(agentId, 0L, nextSequence);
+            return new PinpointServerTraceId(agentId, 0L, nextSequence);
         }
 
         private int getNextSequence(String agentId) {

--- a/web/src/test/java/com/navercorp/pinpoint/web/scatter/ElpasedTimeDotPredicateTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/scatter/ElpasedTimeDotPredicateTest.java
@@ -1,6 +1,7 @@
 package com.navercorp.pinpoint.web.scatter;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ public class ElpasedTimeDotPredicateTest {
     }
 
     private Dot newDot(int elapsedTime) {
-        TransactionId transactionId = TransactionId.of("agent", 0, 1);
+        ServerTraceId transactionId = new PinpointServerTraceId("agent", 0, 1);
         return new Dot(transactionId, 0, elapsedTime, 0, "agentId");
     }
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/scatter/ScatterDataTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/scatter/ScatterDataTest.java
@@ -16,7 +16,8 @@
 
 package com.navercorp.pinpoint.web.scatter;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import org.junit.jupiter.api.Test;
 
@@ -67,8 +68,8 @@ public class ScatterDataTest {
 
         long currentTime = System.currentTimeMillis();
 
-        TransactionId transactionId1 = TransactionId.of(transactionAgentId, currentTime, 1);
-        TransactionId transactionId2 = TransactionId.of(transactionAgentId, currentTime, 2);
+        ServerTraceId transactionId1 = new PinpointServerTraceId(transactionAgentId, currentTime, 1);
+        ServerTraceId transactionId2 = new PinpointServerTraceId(transactionAgentId, currentTime, 2);
 
         long acceptedTime = Math.max(Math.abs(ThreadLocalRandom.current().nextLong(Long.MAX_VALUE)), from);
         int executionTime = (int) Math.abs(ThreadLocalRandom.current().nextLong(60 * 1000));
@@ -102,7 +103,7 @@ public class ScatterDataTest {
 
         long currentTime = System.currentTimeMillis();
 
-        TransactionId transactionId = TransactionId.of(transactionAgentId, currentTime, 1);
+        ServerTraceId transactionId = new PinpointServerTraceId(transactionAgentId, currentTime, 1);
 
         long acceptedTime = Math.max(Math.abs(ThreadLocalRandom.current().nextLong(Long.MAX_VALUE)), from);
         int executionTime = (int) Math.abs(ThreadLocalRandom.current().nextLong(60 * 1000));
@@ -122,9 +123,9 @@ public class ScatterDataTest {
     private List<Dot> createDotList(String agentId, String transactionAgentId, int createSize, long from) {
         long currentTime = System.currentTimeMillis();
 
-        List<TransactionId> transactionIdList = new ArrayList<>(createSize);
+        List<ServerTraceId> transactionIdList = new ArrayList<>(createSize);
         for (int i = 0; i < createSize; i++) {
-            transactionIdList.add(TransactionId.of(transactionAgentId, currentTime, i));
+            transactionIdList.add(new PinpointServerTraceId(transactionAgentId, currentTime, i));
         }
 
         long acceptedTime = Math.max(Math.abs(ThreadLocalRandom.current().nextLong(Long.MAX_VALUE)), from);

--- a/web/src/test/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseApplicationTraceIndexDaoTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseApplicationTraceIndexDaoTest.java
@@ -22,8 +22,9 @@ import com.navercorp.pinpoint.common.hbase.LimitEventHandler;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.serializer.agent.ApplicationNameRowKeyEncoder;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.config.ScatterChartProperties;
 import com.navercorp.pinpoint.web.scatter.ScatterData;
@@ -91,10 +92,10 @@ public class HbaseApplicationTraceIndexDaoTest {
 
     @Test
     public void scanTraceIndexTest() {
-        final List<List<TransactionId>> scannedList = createTraceIndexList();
+        final List<List<ServerTraceId>> scannedList = createTraceIndexList();
         when(this.hbaseOperations.findParallel(any(TableName.class), any(Scan.class), any(RowKeyDistributor.class),
                 anyInt(), any(RowMapper.class), any(LimitEventHandler.class), anyInt())).thenReturn(scannedList);
-        LimitedScanResult<List<TransactionId>> result =
+        LimitedScanResult<List<ServerTraceId>> result =
                 this.applicationTraceIndexDao.scanTraceIndex("app", Range.between(1000L, 5000L), 20, false);
         Assertions.assertEquals(1000L, result.limitedTime());
         Assertions.assertEquals(ListListUtils.toList(scannedList), result.scanData());
@@ -149,7 +150,7 @@ public class HbaseApplicationTraceIndexDaoTest {
 
     private List<List<Dot>> createScatterDotList() {
         List<List<Dot>> ret = new ArrayList<>();
-        TransactionId transactionId = TransactionId.of("A", 1, 1);
+        ServerTraceId transactionId = new PinpointServerTraceId("A", 1, 1);
         addDot(ret, new Dot(transactionId, 2000L, 1000, 0, "a1"));
         addDot(ret, new Dot(transactionId, 3000L, 5000, 0, "a2"));
         addDot(ret, new Dot(transactionId, 2400L, 3000, 0, "a3"));
@@ -161,12 +162,12 @@ public class HbaseApplicationTraceIndexDaoTest {
     }
 
 
-    private List<List<TransactionId>> createTraceIndexList() {
-        List<List<TransactionId>> ret = new ArrayList<>();
+    private List<List<ServerTraceId>> createTraceIndexList() {
+        List<List<ServerTraceId>> ret = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             ret.add(new ArrayList<>());
             for (int j = 0; j < 2; j++) {
-                ret.get(i).add(j, TransactionId.of("agentId" + i, 1000L * (i + 1), j));
+                ret.get(i).add(j, new PinpointServerTraceId("agentId" + i, 1000L * (i + 1), j));
             }
         }
         return ret;

--- a/web/src/test/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDaoTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDaoTest.java
@@ -22,8 +22,8 @@ import com.navercorp.pinpoint.common.hbase.LastRowHandler;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
-import com.navercorp.pinpoint.common.profiler.util.TransactionIdV1;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -56,8 +56,10 @@ import static org.mockito.Mockito.when;
 
 public class HbaseTraceIndexDaoTest {
 
+    private static final ServerTraceId EMPTY = new PinpointServerTraceId("EMPTY", 0, 0);
+
     private static final int serviceUid = ServiceUid.DEFAULT_SERVICE_UID_CODE;
-    private static final DotMetaData testDotMetaData = new DotMetaData(new Dot(TransactionIdV1.EMPTY_ID, 10, 10, 0, "testAgentId"),
+    private static final DotMetaData testDotMetaData = new DotMetaData(new Dot(EMPTY, 10, 10, 0, "testAgentId"),
             "testAgentName", "remoteAddr", "rpc", "endpoint", -1, 0);
 
     @Mock
@@ -144,7 +146,7 @@ public class HbaseTraceIndexDaoTest {
 
     private List<List<Dot>> createScatterDotList() {
         List<List<Dot>> result = new ArrayList<>();
-        TransactionId transactionId = TransactionId.of("A", 1, 1);
+        ServerTraceId transactionId = new PinpointServerTraceId("A", 1, 1);
         result.add(List.of(new Dot(transactionId, 2000L, 1000, 0, "a1")));
         result.add(List.of(new Dot(transactionId, 3000L, 5000, 0, "a2")));
         result.add(List.of(new Dot(transactionId, 2400L, 3000, 0, "a3")));

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/HeatMapServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/HeatMapServiceImplTest.java
@@ -16,16 +16,17 @@
 
 package com.navercorp.pinpoint.web.service;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
 import com.navercorp.pinpoint.web.scatter.dao.ApplicationTraceIndexDao;
 import com.navercorp.pinpoint.web.scatter.dao.TraceIndexDao;
-import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
+import com.navercorp.pinpoint.web.scatter.vo.Dot;
+import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 import com.navercorp.pinpoint.web.trace.dao.TraceDao;
 import com.navercorp.pinpoint.web.trace.service.SpanService;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
-import com.navercorp.pinpoint.web.scatter.vo.Dot;
-import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,8 +49,8 @@ public class HeatMapServiceImplTest {
 
     private static final String APPLICATION_NAME = "applicationName";
     private static final int LIMIT = 50;
-    private static final TransactionId TRANSACTION_ID_1 = TransactionId.of("txAgent1", 10, 100);
-    private static final TransactionId TRANSACTION_ID_2 = TransactionId.of("txAgent2", 20, 200);
+    private static final ServerTraceId TRANSACTION_ID_1 = new PinpointServerTraceId("txAgent1", 10, 100);
+    private static final ServerTraceId TRANSACTION_ID_2 = new PinpointServerTraceId("txAgent2", 20, 200);
 
     @Test
     public void legacyCompatibilityCheckPassTest() {
@@ -154,7 +155,7 @@ public class HeatMapServiceImplTest {
         return List.of(List.of(), List.of());
     }
 
-    private SpanBo createSpan(TransactionId transactionId) {
+    private SpanBo createSpan(ServerTraceId transactionId) {
         SpanBo newSpan = new SpanBo();
         newSpan.setTransactionId(transactionId);
         return newSpan;

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.web.trace.callstacks;
 
 import com.navercorp.pinpoint.common.profiler.trace.AnnotationKeyRegistry;
 import com.navercorp.pinpoint.common.profiler.trace.TraceMetadataLoader;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.ExceptionInfo;
@@ -26,6 +25,7 @@ import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.trace.ApiParserProvider;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.server.util.ServerTraceMetadataLoaderService;
 import com.navercorp.pinpoint.loader.service.AnnotationKeyRegistryService;
 import com.navercorp.pinpoint.loader.service.DefaultAnnotationKeyRegistryService;
@@ -92,7 +92,7 @@ public class RecordFactoryTest {
         final RecordFactory factory = newRecordFactory();
 
         SpanBo spanBo = new SpanBo();
-        spanBo.setTransactionId(TransactionId.of("test", 0, 0));
+        spanBo.setTransactionId(new PinpointServerTraceId("test", 0, 0));
         spanBo.setExceptionInfo(new ExceptionInfo(1, null));
         Align align = new SpanAlign(spanBo);
 
@@ -220,7 +220,7 @@ public class RecordFactoryTest {
                 .setAgentName("")
                 .setApplicationName("express-node-sample-name")
                 .setAgentStartTime(1670293953108L)
-                .setTransactionId(TransactionId.of("express-node-sample-id", 1670293953108L, 30))
+                .setTransactionId(new PinpointServerTraceId("express-node-sample-id", 1670293953108L, 30))
                 .setParentSpanId(-1)
                 .setParentApplicationId(null)
                 .setParentApplicationServiceType((short) 0)

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/hbase/SpanQueryBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/hbase/SpanQueryBuilderTest.java
@@ -16,8 +16,9 @@
 
 package com.navercorp.pinpoint.web.trace.dao.hbase;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.trace.span.SpanFilters;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.SpanHint;
@@ -31,7 +32,7 @@ public class SpanQueryBuilderTest {
 
     private static final int COLLECTOR_ACCEPTOR_TIME = 100;
     private static final int RESPONSE_TIME = 200;
-    private static final TransactionId txId = TransactionId.of("agent", 1, 2);
+    private static final ServerTraceId txId = new PinpointServerTraceId("agent", 1, 2);
 
     @Test
     public void spanQuery_build() {
@@ -42,7 +43,7 @@ public class SpanQueryBuilderTest {
         SpanQuery spanQuery = builder.build(traceInfo);
 
         SpanBo span = new SpanBo();
-        span.setTransactionId(TransactionId.of("agent", 1, 2));
+        span.setTransactionId(new PinpointServerTraceId("agent", 1, 2));
         span.setCollectorAcceptTime(100);
         span.setElapsed(200);
         span.setApplicationName("appName");

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/mapper/FilteringSpanDecoderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/mapper/FilteringSpanDecoderTest.java
@@ -18,11 +18,12 @@ package com.navercorp.pinpoint.web.trace.dao.mapper;
 
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.FixedBuffer;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.BasicSpan;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoder;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.trace.dao.hbase.SpanQuery;
 import com.navercorp.pinpoint.web.trace.dao.hbase.SpanQueryBuilder;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
@@ -63,7 +64,7 @@ public class FilteringSpanDecoderTest {
         Assertions.assertThrows(NullPointerException.class, () -> {
             SpanDecoder mockSpanDecoder = Mockito.mock(SpanDecoder.class);
 
-            TransactionId transactionId = Random.createTransactionId();
+            ServerTraceId transactionId = Random.createTransactionId();
             GetTraceInfo getTraceInfo = new GetTraceInfo(transactionId);
             SpanQueryBuilder builder = new SpanQueryBuilder();
             SpanQuery query = builder.build(getTraceInfo);
@@ -183,7 +184,7 @@ public class FilteringSpanDecoderTest {
             return spanBo;
         }
 
-        private static TransactionId createTransactionId() {
+        private static ServerTraceId createTransactionId() {
             String agentId = RandomStringUtils.insecure().nextAlphanumeric(4, 24);
 
             long boundAgentStartTime = System.currentTimeMillis();
@@ -191,7 +192,7 @@ public class FilteringSpanDecoderTest {
             long agentStartTime = ThreadLocalRandom.current().nextLong(originAgentStartTime, boundAgentStartTime);
 
             int transactionSequence = ThreadLocalRandom.current().nextInt(0, 10);
-            return TransactionId.of(agentId, agentStartTime, transactionSequence);
+            return new PinpointServerTraceId(agentId, agentStartTime, transactionSequence);
         }
 
         private static long createCollectorAcceptTime() {

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2Test.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2Test.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.web.trace.dao.mapper;
 
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.ExceptionInfo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
@@ -28,6 +27,8 @@ import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecodingC
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoderV0;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncodingContext;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -80,7 +81,7 @@ public class SpanMapperV2Test {
         Buffer buffer = new OffsetFixedBuffer(byteBuffer.array(), byteBuffer.arrayOffset(), byteBuffer.remaining());
 
         SpanBo readSpan = new SpanBo();
-        TransactionId transactionId = TransactionId.of("test", 100, 1);
+        ServerTraceId transactionId = new PinpointServerTraceId("test", 100, 1);
         SpanDecodingContext decodingContext = new SpanDecodingContext(transactionId);
         decoder.readSpanValue(buffer, readSpan, decodingContext);
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/view/DotSerializerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/view/DotSerializerTest.java
@@ -17,8 +17,8 @@
 package com.navercorp.pinpoint.web.view;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
-import com.navercorp.pinpoint.common.profiler.util.TransactionIdUtils;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.util.json.Jackson;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import org.apache.logging.log4j.LogManager;
@@ -37,7 +37,7 @@ public class DotSerializerTest {
 
     @Test
     public void testSerialize() throws Exception {
-        TransactionId transactionId = TransactionIdUtils.parseTransactionId("aigw.dev.1^1395798795017^1527177");
+        ServerTraceId transactionId = PinpointServerTraceId.of("aigw.dev.1^1395798795017^1527177");
         Dot dot = new Dot(transactionId, 100, 99, 1, "agent");
         String jsonValue = mapper.writeValueAsString(dot);
         Assertions.assertEquals("[100,99,\"aigw.dev.1^1395798795017^1527177\",0]", jsonValue);


### PR DESCRIPTION
This pull request introduces a significant refactor across the codebase, standardizing the use of the new `ServerTraceId` type in place of the legacy `TransactionId` for identifying traces. This change impacts the core data model, serialization, sampling logic, and various DAO and test classes. The update improves trace ID abstraction, paving the way for supporting multiple trace ID formats (such as Pinpoint and OTEL), and enhances type safety and maintainability.

Key changes include:

### Core Data Model Refactoring

* Replaced all usages of `TransactionId` with `ServerTraceId` in `BasicSpan`, `SpanBo`, and `SpanChunkBo` classes and their respective builders, getter/setter methods, and interfaces. This change unifies how trace IDs are handled throughout the system and enables support for different trace ID formats. [[1]](diffhunk://#diff-7ad1631ecb4e72ee628f32197b53b57a61a5e3df01b34c2ffaa24960f0b52514L19-R19) [[2]](diffhunk://#diff-7ad1631ecb4e72ee628f32197b53b57a61a5e3df01b34c2ffaa24960f0b52514L55-R55) [[3]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL19-R19) [[4]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL49-R50) [[5]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL104-R109) [[6]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL451-R452) [[7]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL526-R528) [[8]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cL19-R19) [[9]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cL45-R45) [[10]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cL121-R125)

### DAO and Serialization Updates

* Updated DAOs such as `HbaseTraceDaoV2` and `HbaseApplicationTraceIndexDao` to use `ServerTraceId` for row key encoding and trace index handling, ensuring consistency with the new trace ID abstraction. [[1]](diffhunk://#diff-b99c597a5f0e7e6c5beb9dd73fd40835f06dbdac4c29071442d8a246e42d9d79L25-R31) [[2]](diffhunk://#diff-b99c597a5f0e7e6c5beb9dd73fd40835f06dbdac4c29071442d8a246e42d9d79L63-R71) [[3]](diffhunk://#diff-b99c597a5f0e7e6c5beb9dd73fd40835f06dbdac4c29071442d8a246e42d9d79L109-R109) [[4]](diffhunk://#diff-b99c597a5f0e7e6c5beb9dd73fd40835f06dbdac4c29071442d8a246e42d9d79L125-R125) [[5]](diffhunk://#diff-9c461eda6384ca7743a2aa0536ac3c51eb7551962795e371e4c358ae4927e8d4L29) [[6]](diffhunk://#diff-9c461eda6384ca7743a2aa0536ac3c51eb7551962795e371e4c358ae4927e8d4L82-R81)

### Sampler and Factory Enhancements

* Introduced `BasicSpanSampler` to provide trace ID-based sampling for both Pinpoint and OTEL trace IDs, using appropriate sequence extraction or hashing as needed. Updated the sampler factory to use this new logic. [[1]](diffhunk://#diff-79cbd924bffd134c2742e5020c1f24619b9568fe950aecac14e9db047d9ce68bR1-R28) [[2]](diffhunk://#diff-eb64237be59cbc340ef831cb7ee0c818a9e6694da0b20e259999669c829a099cL48-R48)

### gRPC and Test Adaptations

* Modified gRPC binder logic and tests to construct and handle `ServerTraceId` instances, replacing all references to the old `TransactionId`. [[1]](diffhunk://#diff-cae404055e360fa4ae69a7ad646b9f98c695589b92d8b0aa59dd385f0bf37d2aL21) [[2]](diffhunk://#diff-cae404055e360fa4ae69a7ad646b9f98c695589b92d8b0aa59dd385f0bf37d2aR30-R31) [[3]](diffhunk://#diff-cae404055e360fa4ae69a7ad646b9f98c695589b92d8b0aa59dd385f0bf37d2aL94-R95) [[4]](diffhunk://#diff-cae404055e360fa4ae69a7ad646b9f98c695589b92d8b0aa59dd385f0bf37d2aL279-R280) [[5]](diffhunk://#diff-c6332fa2a3823c0b918c2c7687feb346a9944b730a9231ebe16751f07da266e6L4-R8) [[6]](diffhunk://#diff-c6332fa2a3823c0b918c2c7687feb346a9944b730a9231ebe16751f07da266e6L46-R46) [[7]](diffhunk://#diff-c6332fa2a3823c0b918c2c7687feb346a9944b730a9231ebe16751f07da266e6L57-R58)

### Utility and Dependency Updates

* Enhanced `Base64Utils` to provide additional encoding methods for trace IDs and added the `java-uuid-generator` dependency to support UUID-based trace IDs. [[1]](diffhunk://#diff-7827d342c2a6f88f402e22aefdc2bc23f71619f1c3720f8341ca14ded7361504R69-R82) [[2]](diffhunk://#diff-6046c9bf905b5d37d5aa4bb5cac699138b22e18986726d7cecfa570915998583R165-R169)

These changes collectively modernize the trace ID infrastructure, making the system more extensible for future trace protocols and improving code clarity.