### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/controller/TransactionController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/controller/TransactionController.java
@@ -113,9 +113,10 @@ public class TransactionController {
         final SpanResult spanResult = this.spanService.selectSpan(transactionId, spanMatchFilter, columnGetCount);
         final CallTreeIterator callTreeIterator = spanResult.callTree();
         final RecordSet recordSet = this.transactionInfoService.createRecordSet(callTreeIterator, spanMatchFilter);
-        final LogLinkView logLinkView = logLinkBuilder.build(transactionId, spanId, recordSet.getApplicationName(), recordSet.getStartTime());
 
-        return new TransactionCallTreeViewModel(transactionId, spanId, recordSet, spanResult.traceState(), logLinkView);
+        final String traceIdStr = transactionId.toString();
+        final LogLinkView logLinkView = logLinkBuilder.build(traceIdStr, spanId, recordSet.getApplicationName(), recordSet.getStartTime());
+        return new TransactionCallTreeViewModel(traceIdStr, spanId, recordSet, spanResult.traceState(), logLinkView);
     }
 
 
@@ -169,7 +170,7 @@ public class TransactionController {
         final ApplicationMap map = filteredMapService.selectApplicationMap(option);
         MapView mapView = getApplicationMap(map);
 
-        return new TransactionServerMapViewModel(transactionId, spanId, mapView);
+        return new TransactionServerMapViewModel(transactionId.toString(), spanId, mapView);
     }
 
     private MapView getApplicationMap(ApplicationMap map) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/view/TransactionCallTreeViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/view/TransactionCallTreeViewModel.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.web.trace.view;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.common.server.util.DateTimeFormatUtils;
 import com.navercorp.pinpoint.web.trace.callstacks.Record;
 import com.navercorp.pinpoint.web.trace.callstacks.RecordSet;
@@ -34,15 +33,15 @@ import java.util.Map;
 import java.util.Objects;
 
 public class TransactionCallTreeViewModel {
-    private final TransactionId transactionId;
+    private final String traceId;
     private final long spanId;
     private final RecordSet recordSet;
     private final TraceState.State completeState;
 
     private final LogLinkView logLinkView;
 
-    public TransactionCallTreeViewModel(TransactionId transactionId, long spanId, RecordSet recordSet, TraceState.State state, LogLinkView logLinkView) {
-        this.transactionId = transactionId;
+    public TransactionCallTreeViewModel(String traceId, long spanId, RecordSet recordSet, TraceState.State state, LogLinkView logLinkView) {
+        this.traceId = traceId;
         this.spanId = spanId;
 
         this.recordSet = recordSet;
@@ -57,7 +56,7 @@ public class TransactionCallTreeViewModel {
 
     @JsonProperty("transactionId")
     public String getTransactionId() {
-        return transactionId.toString();
+        return traceId;
     }
 
     @JsonProperty("spanId")

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/LogLinkBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/LogLinkBuilder.java
@@ -1,6 +1,5 @@
 package com.navercorp.pinpoint.web.view;
 
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.web.config.LogProperties;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
@@ -15,8 +14,8 @@ public class LogLinkBuilder {
         this.logProperties = Objects.requireNonNull(logProperties, "logProperties");
     }
 
-    public LogLinkView build(TransactionId transactionId, long spanId, String applicationName, long startTime) {
-        String logLinkUrl = buildLogLinkUrl(logProperties.getLogPageUrl(), transactionId, spanId, applicationName, startTime);
+    public LogLinkView build(String traceId, long spanId, String applicationName, long startTime) {
+        String logLinkUrl = buildLogLinkUrl(logProperties.getLogPageUrl(), traceId, spanId, applicationName, startTime);
 
         return new LogLinkView(logProperties.isLogLinkEnable(),
                 logProperties.getLogButtonName(),
@@ -24,9 +23,9 @@ public class LogLinkBuilder {
                 logLinkUrl);
     }
 
-    String buildLogLinkUrl(String logPageUrl, TransactionId txId, long spanId, String applicationName, long startTime) {
+    String buildLogLinkUrl(String logPageUrl, String traceId, long spanId, String applicationName, long startTime) {
         if (StringUtils.isNotEmpty(logPageUrl)) {
-            final String parameter = "transactionId=" + txId +
+            final String parameter = "transactionId=" + traceId +
                     "&spanId=" + spanId +
                     "&applicationName=" + applicationName +
                     "&time=" + startTime;

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/TransactionServerMapViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/TransactionServerMapViewModel.java
@@ -16,18 +16,17 @@
 package com.navercorp.pinpoint.web.view;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.navercorp.pinpoint.common.profiler.util.TransactionId;
 import com.navercorp.pinpoint.web.applicationmap.MapView;
 
 import java.util.Objects;
 
 public class TransactionServerMapViewModel {
 
-    private final TransactionId transactionId;
+    private final String transactionId;
     private final long spanId;
     private final MapView mapView;
 
-    public TransactionServerMapViewModel(TransactionId transactionId, long spanId,
+    public TransactionServerMapViewModel(String transactionId, long spanId,
                                          MapView mapView) {
         this.transactionId = transactionId;
         this.spanId = spanId;
@@ -36,7 +35,7 @@ public class TransactionServerMapViewModel {
 
     @JsonProperty("transactionId")
     public String getTransactionId() {
-        return transactionId.toString();
+        return transactionId;
     }
 
     @JsonProperty("spanId")


### PR DESCRIPTION
This pull request refactors the handling of transaction identifiers in the transaction trace and server map view models. The main change is to consistently use `String` representations of transaction IDs (trace IDs) instead of the `TransactionId` object throughout the web layer. This simplifies serialization and improves compatibility with APIs and view rendering.

**Refactoring transaction identifier handling:**

* Changed constructors and fields in `TransactionCallTreeViewModel` and `TransactionServerMapViewModel` to use `String traceId`/`transactionId` instead of `TransactionId`, and updated all related usages and getters accordingly. [[1]](diffhunk://#diff-d89939c24b6c5f1c463443462bd559e713b70c467b332c79d6bfab9aa2e33e26L37-R44) [[2]](diffhunk://#diff-d89939c24b6c5f1c463443462bd559e713b70c467b332c79d6bfab9aa2e33e26L60-R59) [[3]](diffhunk://#diff-a0899baad4c05796c2986fdb2956818daaa4927d655ff2d04e20aa00a850e119L19-R29) [[4]](diffhunk://#diff-a0899baad4c05796c2986fdb2956818daaa4927d655ff2d04e20aa00a850e119L39-R38)
* Updated `TransactionController` methods to convert `TransactionId` to `String` before passing to view models and the `LogLinkBuilder`. [[1]](diffhunk://#diff-e45e81680679f33327bc07e7c1ee2441098e9f0a461c11c03ec87a11fc086184L116-R119) [[2]](diffhunk://#diff-e45e81680679f33327bc07e7c1ee2441098e9f0a461c11c03ec87a11fc086184L172-R173)
* Modified `LogLinkBuilder` to accept `String traceId` instead of `TransactionId`, and updated all internal usages and URL construction logic. [[1]](diffhunk://#diff-e2072602afa6e7a753394c2f1abc2d7c5697331aa349d355fdc9931a921fcd12L3) [[2]](diffhunk://#diff-e2072602afa6e7a753394c2f1abc2d7c5697331aa349d355fdc9931a921fcd12L18-R28)

**Code cleanup:**

* Removed unused imports of `TransactionId` from affected files. [[1]](diffhunk://#diff-d89939c24b6c5f1c463443462bd559e713b70c467b332c79d6bfab9aa2e33e26L21) [[2]](diffhunk://#diff-e2072602afa6e7a753394c2f1abc2d7c5697331aa349d355fdc9931a921fcd12L3) [[3]](diffhunk://#diff-a0899baad4c05796c2986fdb2956818daaa4927d655ff2d04e20aa00a850e119L19-R29)