### PR TITLE
[#13257] Fix index increment in TimeseriesHistogramViewBuilder for correct result population

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/TimeseriesHistogramViewBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/TimeseriesHistogramViewBuilder.java
@@ -64,7 +64,7 @@ public class TimeseriesHistogramViewBuilder {
         long[] result = new long[size];
         for (int i = 0; i < size; i++) {
             TimeHistogram timeHistogram = histogramList.get(i);
-            result[i++] = function.applyAsLong(timeHistogram);
+            result[i] = function.applyAsLong(timeHistogram);
         }
         return LongLists.mutable.of(result);
     }


### PR DESCRIPTION
This pull request includes a minor fix to the `getColumnValue` method in `TimeseriesHistogramViewBuilder.java`. The change corrects the array assignment within a loop to prevent skipping elements, ensuring all values are set properly.