### PR TITLE
[#noissue] Refactor JavaAssistUtils and analyzers to improve Type handling

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClass.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClass.java
@@ -265,10 +265,9 @@ public class ASMClass implements InstrumentClass {
         Objects.requireNonNull(accessorClass, "accessorClass");
         try {
 
-            final AccessorAnalyzer accessorAnalyzer = new AccessorAnalyzer();
-            final AccessorAnalyzer.AccessorDetails accessorDetails = accessorAnalyzer.analyze(accessorClass);
+            final AccessorAnalyzer.AccessorDetails accessorDetails = AccessorAnalyzer.instance().analyze(accessorClass);
 
-            final Type type = Type.getType(accessorDetails.getFieldType());
+            final Type type = accessorDetails.getFieldType();
             final String accessorTypeName = accessorClass.getName();
             final String fieldName = FIELD_PREFIX + JavaAssistUtils.javaClassNameToVariableName(accessorTypeName);
             final ASMFieldNodeAdapter fieldNode = this.classNode.addField(fieldName, type.getDescriptor());
@@ -287,15 +286,14 @@ public class ASMClass implements InstrumentClass {
         Objects.requireNonNull(fieldName, "fieldName");
 
         try {
-            final GetterAnalyzer.GetterDetails getterDetails = new GetterAnalyzer().analyze(getterClass);
+            final GetterAnalyzer.GetterDetails getterDetails = GetterAnalyzer.instance().analyze(getterClass);
             final ASMFieldNodeAdapter fieldNode = this.classNode.getField(fieldName, null);
             if (fieldNode == null) {
                 throw new IllegalArgumentException("Not found field. name=" + fieldName);
             }
-
-            final String fieldTypeName = JavaAssistUtils.javaClassNameToObjectName(getterDetails.getFieldType().getName());
-            if (!fieldNode.getClassName().equals(fieldTypeName)) {
-                throw new IllegalArgumentException("different return type. return=" + fieldTypeName + ", field=" + fieldNode.getClassName());
+            Type fieldType = getterDetails.getFieldType();
+            if (!fieldNode.getJavaType().equals(fieldType)) {
+                throw new IllegalArgumentException("different return type. return=" + fieldType + ", field=" + fieldNode.getJavaType());
             }
 
             this.classNode.addGetterMethod(getterDetails.getGetter().getName(), fieldNode);
@@ -315,15 +313,15 @@ public class ASMClass implements InstrumentClass {
     public void addSetter(Class<?> setterClass, String fieldName, boolean removeFinal) throws InstrumentException {
         Objects.requireNonNull(setterClass, "setterClass");
         try {
-            final SetterAnalyzer.SetterDetails setterDetails = new SetterAnalyzer().analyze(setterClass);
+            final SetterAnalyzer.SetterDetails setterDetails = SetterAnalyzer.instance().analyze(setterClass);
             final ASMFieldNodeAdapter fieldNode = this.classNode.getField(fieldName, null);
             if (fieldNode == null) {
                 throw new IllegalArgumentException("Not found field. name=" + fieldName);
             }
 
-            final String fieldTypeName = JavaAssistUtils.javaClassNameToObjectName(setterDetails.getFieldType().getName());
-            if (!fieldNode.getClassName().equals(fieldTypeName)) {
-                throw new IllegalArgumentException("Argument type of the setter is different with the field type. setterMethod: " + fieldTypeName + ", fieldType: " + fieldNode.getClassName());
+            final Type fieldType = setterDetails.getFieldType();
+            if (!fieldNode.getJavaType().equals(fieldType)) {
+                throw new IllegalArgumentException("Argument type of the setter is different with the field type. setterMethod: " + fieldType + ", fieldType: " + fieldNode.getJavaType());
             }
 
             if (fieldNode.isStatic()) {

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMFieldNodeAdapter.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMFieldNodeAdapter.java
@@ -24,6 +24,7 @@ import org.objectweb.asm.tree.FieldNode;
  */
 public class ASMFieldNodeAdapter {
     private final FieldNode fieldNode;
+    private Type type;
 
     public ASMFieldNodeAdapter(final FieldNode fieldNode) {
         this.fieldNode = fieldNode;
@@ -34,8 +35,14 @@ public class ASMFieldNodeAdapter {
     }
 
     public String getClassName() {
-        Type type = Type.getType(this.fieldNode.desc);
-        return type.getClassName();
+        return getJavaType().getClassName();
+    }
+
+    public Type getJavaType() {
+        if (this.type == null) {
+            this.type = Type.getType(this.fieldNode.desc);
+        }
+        return type;
     }
 
     public String getDesc() {

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/AccessorAnalyzer.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/AccessorAnalyzer.java
@@ -14,6 +14,8 @@
  */
 package com.navercorp.pinpoint.profiler.instrument;
 
+import org.objectweb.asm.Type;
+
 import java.lang.reflect.Method;
 import java.util.Objects;
 
@@ -22,6 +24,15 @@ import java.util.Objects;
  *
  */
 public class AccessorAnalyzer {
+    private static final AccessorAnalyzer INSTANCE = new AccessorAnalyzer();
+
+    public static AccessorAnalyzer instance() {
+        return INSTANCE;
+    }
+
+    private AccessorAnalyzer() {
+    }
+
     public AccessorDetails analyze(Class<?> accessorType) {
         Objects.requireNonNull(accessorType, "accessorType");
         
@@ -71,17 +82,17 @@ public class AccessorAnalyzer {
     }
 
     public static class AccessorDetails {
-        private final Class<?> fieldType;
+        private final Type fieldType;
         private final Method getter;
         private final Method setter;
         
         public AccessorDetails(Class<?> fieldType, Method getter, Method setter) {
-            this.fieldType = fieldType;
+            this.fieldType = Type.getType(Objects.requireNonNull(fieldType, "fieldType"));
             this.getter = getter;
             this.setter = setter;
         }
 
-        public Class<?> getFieldType() {
+        public Type getFieldType() {
             return fieldType;
         }
 

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/GetterAnalyzer.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/GetterAnalyzer.java
@@ -14,6 +14,8 @@
  */
 package com.navercorp.pinpoint.profiler.instrument;
 
+import org.objectweb.asm.Type;
+
 import java.lang.reflect.Method;
 import java.util.Objects;
 
@@ -22,6 +24,15 @@ import java.util.Objects;
  *
  */
 public class GetterAnalyzer {
+    private static final GetterAnalyzer INSTANCE = new GetterAnalyzer();
+
+    public static GetterAnalyzer instance() {
+        return INSTANCE;
+    }
+
+    private GetterAnalyzer() {
+    }
+
     public GetterDetails analyze(Class<?> getterType) {
         Objects.requireNonNull(getterType, "getterType");
         
@@ -52,18 +63,18 @@ public class GetterAnalyzer {
 
     public static final class GetterDetails {
         private final Method getter;
-        private final Class<?> fieldType;
+        private final Type fieldType;
 
         public GetterDetails(Method getter, Class<?> fieldType) {
-            this.getter = getter;
-            this.fieldType = fieldType;
+            this.getter = Objects.requireNonNull(getter, "getter");
+            this.fieldType = Type.getType(Objects.requireNonNull(fieldType, "fieldType"));
         }
 
         public Method getGetter() {
             return getter;
         }
 
-        public Class<?> getFieldType() {
+        public Type getFieldType() {
             return fieldType;
         }
     }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/SetterAnalyzer.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/SetterAnalyzer.java
@@ -16,6 +16,8 @@
 
 package com.navercorp.pinpoint.profiler.instrument;
 
+import org.objectweb.asm.Type;
+
 import java.lang.reflect.Method;
 import java.util.Objects;
 
@@ -23,6 +25,14 @@ import java.util.Objects;
  * @author HyunGil Jeong
  */
 public class SetterAnalyzer {
+    private static final SetterAnalyzer INSTANCE = new SetterAnalyzer();
+
+    public static SetterAnalyzer instance() {
+        return INSTANCE;
+    }
+
+    private SetterAnalyzer() {
+    }
 
     public SetterDetails analyze(Class<?> setterType) {
         Objects.requireNonNull(setterType, "setterType");
@@ -55,18 +65,18 @@ public class SetterAnalyzer {
 
     public static final class SetterDetails {
         private final Method setter;
-        private final Class<?> fieldType;
+        private final Type fieldType;
 
         public SetterDetails(Method setter, Class<?> fieldType) {
             this.setter = setter;
-            this.fieldType = fieldType;
+            this.fieldType = Type.getType(Objects.requireNonNull(fieldType, "fieldType"));
         }
 
         public Method getSetter() {
             return setter;
         }
 
-        public Class<?> getFieldType() {
+        public Type getFieldType() {
             return fieldType;
         }
     }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/util/StringMatchUtils.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/util/StringMatchUtils.java
@@ -12,7 +12,8 @@ public final class StringMatchUtils {
         Objects.requireNonNull(str, "str");
         Objects.requireNonNull(chars, "chars");
 
-        for (int i = 0; i < str.length(); i++) {
+        final int length = str.length();
+        for (int i = 0; i < length; i++) {
             final char c = str.charAt(i);
             if (contains(c, chars)) {
                 return i;
@@ -72,14 +73,19 @@ public final class StringMatchUtils {
         return count;
     }
 
+    static void appendAndReplace(String str, int startOffset, char oldChar, char newChar, StringBuilder output) {
+        Objects.requireNonNull(str, "str");
+        appendAndReplace(str, startOffset, str.length(), oldChar, newChar, output);
+    }
+
     /**
      * ExperimentalApi
      */
-    static void appendAndReplace(String str, int startOffset, char oldChar, char newChar, StringBuilder output) {
+    static void appendAndReplace(String str, int startOffset, int endOffset, char oldChar, char newChar, StringBuilder output) {
         Objects.requireNonNull(str, "str");
         Objects.requireNonNull(output, "output");
 
-        for (int i = startOffset; i < str.length(); i++) {
+        for (int i = startOffset; i < endOffset; i++) {
             final char c = str.charAt(i);
             if (c == oldChar) {
                 output.append(newChar);

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/util/JavaAssistUtilsTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/util/JavaAssistUtilsTest.java
@@ -256,4 +256,10 @@ public class JavaAssistUtilsTest {
         Assertions.assertEquals("(a)", variableName);
     }
 
+    @Test
+    public void getSignature() {
+        Assertions.assertEquals("Z", JavaAssistUtils.getSignature("boolean", 0));
+        Assertions.assertEquals("Z", JavaAssistUtils.getSignature(" boolean", 1));
+    }
+
 }


### PR DESCRIPTION
…dling

This pull request refactors how field type information is handled and improves analyzer classes for consistency and efficiency. The most significant changes include standardizing on the use of ASM's `Type` to represent field types, introducing singleton patterns for analyzer classes, and simplifying type signature conversion logic.

**Field type handling and analyzer improvements:**

* Updated `AccessorAnalyzer`, `GetterAnalyzer`, and `SetterAnalyzer` to use ASM's `Type` instead of `Class<?>` for field type representation, ensuring consistency and reducing conversions. Also, added singleton instances for each analyzer to minimize object creation and promote reuse. [[1]](diffhunk://#diff-bbf90b07daf35f081f08d38bc47868c1eef542473b59410dbd3e3bd1c940a5f5R27-R35) [[2]](diffhunk://#diff-bbf90b07daf35f081f08d38bc47868c1eef542473b59410dbd3e3bd1c940a5f5L74-R95) [[3]](diffhunk://#diff-28b6ed6a3ee436ca5a8c333f041094ce423383b25ac291f9ae1f42a02cd29dffR27-R35) [[4]](diffhunk://#diff-28b6ed6a3ee436ca5a8c333f041094ce423383b25ac291f9ae1f42a02cd29dffL55-R77) [[5]](diffhunk://#diff-2c5d7f9a11c5950f3ddeac64d31856a6f37aae21e1a7f80cc4c11935b282a55fR19-R35) [[6]](diffhunk://#diff-2c5d7f9a11c5950f3ddeac64d31856a6f37aae21e1a7f80cc4c11935b282a55fL58-R79) [[7]](diffhunk://#diff-a121b8d3acaf0e763d0cb8cdfcde7972d1cc4f79941e71c6e78c6343b6ad7027L268-R270) [[8]](diffhunk://#diff-a121b8d3acaf0e763d0cb8cdfcde7972d1cc4f79941e71c6e78c6343b6ad7027L290-R296) [[9]](diffhunk://#diff-a121b8d3acaf0e763d0cb8cdfcde7972d1cc4f79941e71c6e78c6343b6ad7027L318-R324)

* Refactored `ASMFieldNodeAdapter` to cache and expose the field's `Type` via a new `getJavaType()` method, and updated usages to rely on this method for type comparisons instead of string-based checks. [[1]](diffhunk://#diff-63672d8974465545fd24f9e353c5d498f4237c77420c9809b15a3da58123f6bbR27) [[2]](diffhunk://#diff-63672d8974465545fd24f9e353c5d498f4237c77420c9809b15a3da58123f6bbL37-R45)

**Type signature conversion and utility improvements:**

* Simplified and optimized `JavaAssistUtils.toJvmSignature()` by removing the primitive type map and replacing it with a direct string-matching approach via a new `getSignature()` method. Also added helper methods to handle array types and substring logic more efficiently. [[1]](diffhunk://#diff-710c28af5cf6f8f999d8d8e821163866f7ee97e3ecb8fba85e2e0d795e464c54L44-L59) [[2]](diffhunk://#diff-710c28af5cf6f8f999d8d8e821163866f7ee97e3ecb8fba85e2e0d795e464c54L96-R144)

* Enhanced `StringMatchUtils.appendAndReplace()` to support specifying a substring range, allowing more precise and efficient string manipulation during type signature conversion.

**Testing:**

* Added unit tests for the new `getSignature()` method in `JavaAssistUtils` to ensure correct primitive type signature detection.