### PR TITLE
[#noissue] Refactor TransactionCallTreeViewModel to use EnumSet and enhance CallStackMeta serialization

### DIFF
--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/view/TransactionInfoViewModelTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/view/TransactionInfoViewModelTest.java
@@ -16,30 +16,25 @@
 
 package com.navercorp.pinpoint.web.trace.view;
 
-import org.assertj.core.api.Assertions;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.common.server.util.json.Jackson;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.navercorp.pinpoint.web.trace.view.TransactionCallTreeViewModel.Field;
 
 class TransactionInfoViewModelTest {
+    private final Logger logger = LogManager.getLogger(this.getClass());
 
     @Test
-    void fieldName() {
+    void fieldName() throws JsonProcessingException {
+        Field.CallStackMeta callStackMeta = Field.getCallStackMeta();
 
-        List<String> fieldList = Arrays.stream(Field.values())
-                .map(Enum::name)
-                .collect(Collectors.toList());
+        ObjectMapper mapper = Jackson.newMapper();
+        String json = mapper.writeValueAsString(callStackMeta);
 
-        Map<String, Integer> map = Field.getFieldMap();
-        Set<String> keys = map.keySet();
-
-        Assertions.assertThat(fieldList).
-                containsExactly(keys.toArray(new String[0]));
+        logger.debug("{}", json);
     }
 }


### PR DESCRIPTION
…nhance CallStackMeta serialization

This pull request refactors how call stack field metadata is exposed and serialized in the `TransactionCallTreeViewModel`. The main improvement is replacing the raw map of field names to ordinals with a dedicated `CallStackMeta` class, which now handles serialization in a more robust and type-safe way. Test code has also been updated to reflect these changes.

### Refactoring of call stack field metadata:

* Replaced the `getFieldMap()` method (which returned a `Map<String, Integer>`) with a `CallStackMeta` class that encapsulates field metadata and provides a custom Jackson serializer for JSON output. (`TransactionCallTreeViewModel.java`) [[1]](diffhunk://#diff-d89939c24b6c5f1c463443462bd559e713b70c467b332c79d6bfab9aa2e33e26L118-R121) [[2]](diffhunk://#diff-d89939c24b6c5f1c463443462bd559e713b70c467b332c79d6bfab9aa2e33e26L182-L194)
* Updated the `getCallStackIndex()` method in `TransactionCallTreeViewModel` to return a `CallStackMeta` instance instead of a map. (`TransactionCallTreeViewModel.java`)
* Added a custom serializer (`EnumSerializer`) to the `CallStackMeta` class to control how field metadata is serialized to JSON. (`TransactionCallTreeViewModel.java`)

### Test updates:

* Updated the test in `TransactionInfoViewModelTest` to serialize and log the new `CallStackMeta` object, removing assertions that depended on the old map structure. (`TransactionInfoViewModelTest.java`)

### Dependency and import cleanup:

* Updated imports to support the new implementation, including Jackson serialization classes and removal of unused collections imports. (`TransactionCallTreeViewModel.java`) [[1]](diffhunk://#diff-d89939c24b6c5f1c463443462bd559e713b70c467b332c79d6bfab9aa2e33e26R20-R22) [[2]](diffhunk://#diff-d89939c24b6c5f1c463443462bd559e713b70c467b332c79d6bfab9aa2e33e26R31-L32)