### PR TITLE
[#noissue] Refactor ErrorCategoryResolver to return Set instead of EnumSet

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolver.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolver.java
@@ -16,14 +16,25 @@
 
 package com.navercorp.pinpoint.common.trace;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
 
 public class ErrorCategoryResolver {
 
-    private static final EnumSet<ErrorCategory> DISPLAY_CANDIDATE = EnumSet.complementOf(EnumSet.of(ErrorCategory.UNKNOWN));
+    private static final ErrorCategory[] DISPLAY_CANDIDATE = displayCandidate();
 
-    public EnumSet<ErrorCategory> resolve(int errorCode) {
-        EnumSet<ErrorCategory> flagged = EnumSet.noneOf(ErrorCategory.class);
+    private static ErrorCategory[] displayCandidate() {
+        ErrorCategory[] values = ErrorCategory.values();
+        List<ErrorCategory> list = new ArrayList<>(Arrays.asList(values));
+        list.remove(ErrorCategory.UNKNOWN);
+        return list.toArray(new ErrorCategory[0]);
+    }
+
+    public Set<ErrorCategory> resolve(int errorCode) {
+        Set<ErrorCategory> flagged = EnumSet.noneOf(ErrorCategory.class);
         for (ErrorCategory category : DISPLAY_CANDIDATE) {
             if ((errorCode & category.getBitMask()) != 0) {
                 flagged.add(category);

--- a/commons/src/test/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolverTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolverTest.java
@@ -20,27 +20,28 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
+import java.util.Set;
 
 class ErrorCategoryResolverTest {
 
     @Test
     public void resolveShouldReturnEmptySetForUnknownErrorCode() {
         int unknownErrorCode = ErrorCategory.UNKNOWN.getBitMask();
-        EnumSet<ErrorCategory> result = new ErrorCategoryResolver().resolve(unknownErrorCode);
+        Set<ErrorCategory> result = new ErrorCategoryResolver().resolve(unknownErrorCode);
         Assertions.assertTrue(result.isEmpty());
     }
 
     @Test
     public void resolveShouldReturnSingleCategoryForMatchingErrorCode() {
         int networkErrorCode = ErrorCategory.EXCEPTION.getBitMask();
-        EnumSet<ErrorCategory> result = new ErrorCategoryResolver().resolve(networkErrorCode);
+        Set<ErrorCategory> result = new ErrorCategoryResolver().resolve(networkErrorCode);
         Assertions.assertEquals(EnumSet.of(ErrorCategory.EXCEPTION), result);
     }
 
     @Test
     public void resolveShouldReturnEmptySetForZeroErrorCode() {
         int zeroErrorCode = 0;
-        EnumSet<ErrorCategory> result = new ErrorCategoryResolver().resolve(zeroErrorCode);
+        Set<ErrorCategory> result = new ErrorCategoryResolver().resolve(zeroErrorCode);
         Assertions.assertTrue(result.isEmpty());
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/service/TransactionInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/service/TransactionInfoServiceImpl.java
@@ -41,10 +41,10 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -327,7 +327,7 @@ public class TransactionInfoServiceImpl implements TransactionInfoService {
                 if (align.isSpan()) {
                     final SpanBo spanBo = align.getSpanBo();
                     if (spanBo.hasError()) {
-                        EnumSet<ErrorCategory> flagged = errorCategoryResolver.resolve(spanBo.getErrCode());
+                        Set<ErrorCategory> flagged = errorCategoryResolver.resolve(spanBo.getErrCode());
                         if (!flagged.isEmpty()) {
                             final Record errorCategoryRecord = factory.getErrorCategory(record.getTab() + 1, record.getId(), flagged);
                             recordList.add(errorCategoryRecord);


### PR DESCRIPTION
…umSet

This pull request refactors the way error categories are handled in the codebase, specifically updating the usage of `EnumSet<ErrorCategory>` to the more generic `Set<ErrorCategory>`. This change improves flexibility and consistency in error category handling across the affected files.

Error category type refactoring:

* Changed the return type of `ErrorCategoryResolver.resolve` from `EnumSet<ErrorCategory>` to `Set<ErrorCategory>`, and updated its implementation to use a generic `Set` instead of `EnumSet`. (`commons/src/main/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolver.java`)
* Updated variable declarations and method calls in `TransactionInfoServiceImpl` to use `Set<ErrorCategory>` instead of `EnumSet<ErrorCategory>`, ensuring compatibility with the refactored resolver. (`web/src/main/java/com/navercorp/pinpoint/web/trace/service/TransactionInfoServiceImpl.java`) [[1]](diffhunk://#diff-7f704935c0f90cf54752a4dd2652993a3908e23505af096c346b2cc24e14e47cL44-R47) [[2]](diffhunk://#diff-7f704935c0f90cf54752a4dd2652993a3908e23505af096c346b2cc24e14e47cL330-R330)