### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/agent-module/plugins/rabbitmq/src/main/java/com/navercorp/pinpoint/plugin/rabbitmq/client/interceptor/ChannelBasicPublishInterceptor.java
+++ b/agent-module/plugins/rabbitmq/src/main/java/com/navercorp/pinpoint/plugin/rabbitmq/client/interceptor/ChannelBasicPublishInterceptor.java
@@ -12,6 +12,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScopeInvoca
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
 import com.navercorp.pinpoint.common.util.ArrayUtils;
+import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.plugin.rabbitmq.client.RabbitMQClientConstants;
 import com.navercorp.pinpoint.plugin.rabbitmq.client.RabbitMQClientPluginConfig;
 import com.navercorp.pinpoint.plugin.rabbitmq.client.field.accessor.RemoteAddressAccessor;
@@ -98,7 +99,7 @@ public class ChannelBasicPublishInterceptor implements AroundInterceptor {
             String exchange = (String) args[0];
             String routingKey = (String) args[1];
 
-            if (exchange == null || exchange.equals("")) {
+            if (StringUtils.isEmpty(exchange)) {
                 exchange = RabbitMQClientConstants.UNKNOWN;
             }
 


### PR DESCRIPTION
This pull request introduces a minor improvement to the `ChannelBasicPublishInterceptor` in the RabbitMQ plugin by using a utility method to check if the `exchange` string is empty or null.

* Refactored the check for an empty or null `exchange` value in the `after` method to use `StringUtils.isEmpty` for improved readability and consistency.
* Added an import statement for `StringUtils` to support the new utility method usage.