### PR TITLE
[#noissue] Refactor to replace EnumSet with Enum.values() cache

### DIFF
--- a/agent-module/plugins/mariadb-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDBJdbcUrlParser.java
+++ b/agent-module/plugins/mariadb-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/mariadb/MariaDBJdbcUrlParser.java
@@ -27,9 +27,7 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * @author dawidmalina
@@ -41,8 +39,6 @@ public class MariaDBJdbcUrlParser implements JdbcUrlParserV2 {
     static final String MARIA_URL_PREFIX = "jdbc:mariadb:";
     static final String MYSQL_URL_PREFIX = "jdbc:mysql:";
 
-    private static final Set<Type> TYPES = EnumSet.allOf(Type.class);
-
     private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
 
     @Override
@@ -52,7 +48,7 @@ public class MariaDBJdbcUrlParser implements JdbcUrlParserV2 {
             return UnKnownDatabaseInfo.INSTANCE;
         }
 
-        Type type = getType(jdbcUrl);
+        Type type = Type.getType(jdbcUrl);
         if (type == null) {
             logger.info("jdbcUrl has invalid prefix.(url:{}, valid prefixes:{}, {})", jdbcUrl, MARIA_URL_PREFIX, MYSQL_URL_PREFIX);
             return UnKnownDatabaseInfo.INSTANCE;
@@ -101,21 +97,14 @@ public class MariaDBJdbcUrlParser implements JdbcUrlParserV2 {
         return MariaDBConstants.MARIADB;
     }
 
-    private static Type getType(String jdbcUrl) {
-        for (Type type : TYPES) {
-            if (jdbcUrl.startsWith(type.getUrlPrefix())) {
-                return type;
-            }
-        }
-        return null;
-    }
-
     private enum Type {
         MARIA(MARIA_URL_PREFIX),
         MYSQL(MYSQL_URL_PREFIX);
 
         private final String urlPrefix;
         private final String loadbalanceUrlPrefix;
+
+        private static final Type[] TYPES = Type.values();
 
         Type(String urlPrefix) {
             this.urlPrefix = urlPrefix;
@@ -128,6 +117,15 @@ public class MariaDBJdbcUrlParser implements JdbcUrlParserV2 {
 
         private String getLoadbalanceUrlPrefix() {
             return loadbalanceUrlPrefix;
+        }
+
+        public static Type getType(String jdbcUrl) {
+            for (Type type : TYPES) {
+                if (jdbcUrl.startsWith(type.getUrlPrefix())) {
+                    return type;
+                }
+            }
+            return null;
         }
     }
 }

--- a/agent-module/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftHeader.java
+++ b/agent-module/plugins/thrift/src/main/java/com/navercorp/pinpoint/plugin/thrift/ThriftHeader.java
@@ -18,9 +18,6 @@ package com.navercorp.pinpoint.plugin.thrift;
 
 import org.apache.thrift.protocol.TType;
 
-import java.util.EnumSet;
-import java.util.Set;
-
 public enum ThriftHeader {
     THRIFT_TRACE_ID(TType.STRING, (short) Short.MIN_VALUE),
     THRIFT_SPAN_ID(TType.I64, (short) (Short.MIN_VALUE + 1)),
@@ -36,7 +33,7 @@ public enum ThriftHeader {
 
     private final byte type;
 
-    private static final Set<ThriftHeader> HEADERS = EnumSet.allOf(ThriftHeader.class);
+    private static final ThriftHeader[] HEADERS = ThriftHeader.values();
 
     ThriftHeader(byte type, short id) {
         this.type = type;

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/error/ConfigurableErrorRecorder.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/error/ConfigurableErrorRecorder.java
@@ -4,14 +4,14 @@ import com.navercorp.pinpoint.bootstrap.context.ErrorRecorder;
 import com.navercorp.pinpoint.common.trace.ErrorCategory;
 import com.navercorp.pinpoint.profiler.context.id.LocalTraceRoot;
 
-import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 
 public class ConfigurableErrorRecorder implements ErrorRecorder {
     private final LocalTraceRoot traceRoot;
-    private final EnumSet<ErrorCategory> enabledCategories;
+    private final Set<ErrorCategory> enabledCategories;
 
-    public ConfigurableErrorRecorder(LocalTraceRoot localTraceRoot, EnumSet<ErrorCategory> enabledCategories) {
+    public ConfigurableErrorRecorder(LocalTraceRoot localTraceRoot, Set<ErrorCategory> enabledCategories) {
         this.traceRoot = Objects.requireNonNull(localTraceRoot, "localTraceRoot");
         this.enabledCategories = Objects.requireNonNull(enabledCategories, "enabledCategories");
     }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/error/ConfigurableErrorRecorderFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/error/ConfigurableErrorRecorderFactory.java
@@ -11,11 +11,12 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 
 public class ConfigurableErrorRecorderFactory implements ErrorRecorderFactory {
     private static final Logger logger = LogManager.getLogger(ConfigurableErrorRecorderFactory.class);
 
-    private final EnumSet<ErrorCategory> enabledTypes;
+    private final Set<ErrorCategory> enabledTypes;
 
     @Inject
     public ConfigurableErrorRecorderFactory(ErrorRecorderConfig errorRecorderConfig) {
@@ -24,9 +25,9 @@ public class ConfigurableErrorRecorderFactory implements ErrorRecorderFactory {
     }
 
     @VisibleForTesting
-    static EnumSet<ErrorCategory> getEnabledTypes(String errorMarkString, String errorMarkExcludeString) {
-        EnumSet<ErrorCategory> mark = errorMarkString != null ? toCategorySet(errorMarkString) : EnumSet.allOf(ErrorCategory.class);
-        EnumSet<ErrorCategory> exclude = errorMarkExcludeString != null ? toCategorySet(errorMarkExcludeString) : EnumSet.noneOf(ErrorCategory.class);
+    static Set<ErrorCategory> getEnabledTypes(String errorMarkString, String errorMarkExcludeString) {
+        Set<ErrorCategory> mark = errorMarkString != null ? toCategorySet(errorMarkString) : EnumSet.allOf(ErrorCategory.class);
+        Set<ErrorCategory> exclude = errorMarkExcludeString != null ? toCategorySet(errorMarkExcludeString) : EnumSet.noneOf(ErrorCategory.class);
 
         mark.removeAll(exclude);
         mark.add(ErrorCategory.UNKNOWN);
@@ -34,10 +35,11 @@ public class ConfigurableErrorRecorderFactory implements ErrorRecorderFactory {
         return mark;
     }
 
-    private static EnumSet<ErrorCategory> toCategorySet(String categoryString) {
-        EnumSet<ErrorCategory> result = EnumSet.noneOf(ErrorCategory.class);
+    private static Set<ErrorCategory> toCategorySet(String categoryString) {
+        String[] categories = categoryString.split(",");
 
-        for (String category : categoryString.split(",")) {
+        Set<ErrorCategory> result = EnumSet.noneOf(ErrorCategory.class);
+        for (String category : categories) {
             switch (category.trim().toLowerCase()) {
                 case "exception":
                     result.add(ErrorCategory.EXCEPTION);

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/stat/filedescriptor/FileDescriptorMetricProvider.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/stat/filedescriptor/FileDescriptorMetricProvider.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Constructor;
-import java.util.EnumSet;
 import java.util.Objects;
 
 /**
@@ -42,6 +41,9 @@ public class FileDescriptorMetricProvider implements Provider<FileDescriptorMetr
 
     private static final String ORACLE_FILE_DESCRIPTOR_METRIC = "com.navercorp.pinpoint.profiler.monitor.metric.filedescriptor.oracle.OracleFileDescriptorMetric";
     private static final String IBM_FILE_DESCRIPTOR_METRIC = "com.navercorp.pinpoint.profiler.monitor.metric.filedescriptor.ibm.IbmFileDescriptorMetric";
+
+    private static final JvmType[] ORACLE_JDK = new JvmType[]{JvmType.ORACLE, JvmType.OPENJDK};
+    private static final OsType[] SUPPORTED_OS = new OsType[]{OsType.MAC, OsType.SOLARIS, OsType.LINUX, OsType.AIX, OsType.HP_UX, OsType.BSD};
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
@@ -91,14 +93,21 @@ public class FileDescriptorMetricProvider implements Provider<FileDescriptorMetr
     }
 
     private boolean isOracleJdk(JvmType jvmType) {
-        EnumSet<JvmType> orackeJdk = EnumSet.of(JvmType.ORACLE, JvmType.OPENJDK);
-        return orackeJdk.contains(jvmType);
+        for (JvmType type : ORACLE_JDK) {
+            if (type == jvmType) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isSupportedOS(OsType osType) {
-        EnumSet<OsType> supportedOs = EnumSet.of(OsType.MAC, OsType.SOLARIS, OsType.LINUX
-                , OsType.AIX, OsType.HP_UX, OsType.BSD);
-        return supportedOs.contains(osType);
+        for (OsType os : SUPPORTED_OS) {
+            if (os == osType) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private JvmType getJvmType() {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/ManagedAgentLifeCycle.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/ManagedAgentLifeCycle.java
@@ -3,9 +3,6 @@ package com.navercorp.pinpoint.collector.receiver.grpc.service;
 import com.navercorp.pinpoint.common.server.util.AgentEventType;
 import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.Set;
 
 public enum ManagedAgentLifeCycle {
@@ -26,10 +23,10 @@ public enum ManagedAgentLifeCycle {
             SocketStateCode.ERROR_ILLEGAL_STATE_CHANGE, SocketStateCode.ERROR_SYNC_STATE_SESSION);
 
 
-    private static final EnumSet<ManagedAgentLifeCycle> CLOSED_EVENT
-            = EnumSet.of(CLOSED_BY_CLIENT, UNEXPECTED_CLOSE_BY_CLIENT, CLOSED_BY_SERVER, UNEXPECTED_CLOSE_BY_SERVER);
+    private static final ManagedAgentLifeCycle[] CLOSED_EVENT
+            = new ManagedAgentLifeCycle[] {CLOSED_BY_CLIENT, UNEXPECTED_CLOSE_BY_CLIENT, CLOSED_BY_SERVER, UNEXPECTED_CLOSE_BY_SERVER};
 
-    private static final EnumSet<ManagedAgentLifeCycle> ALL = EnumSet.allOf(ManagedAgentLifeCycle.class);
+    private static final ManagedAgentLifeCycle[] ALL = ManagedAgentLifeCycle.values();
 
     private final int eventCounter;
     private final Set<SocketStateCode> managedStateCodeSet;
@@ -41,7 +38,7 @@ public enum ManagedAgentLifeCycle {
         this.agentLifeCycleState = agentLifeCycleState;
         this.agentEventType = agentEventType;
 
-        this.managedStateCodeSet = EnumSet.copyOf(Arrays.asList(managedStateCodes));
+        this.managedStateCodeSet = Set.of(managedStateCodes);
     }
 
     public int getEventCounter() {
@@ -49,7 +46,7 @@ public enum ManagedAgentLifeCycle {
     }
 
     public Set<SocketStateCode> getManagedStateCodes() {
-        return Collections.unmodifiableSet(this.managedStateCodeSet);
+        return this.managedStateCodeSet;
     }
 
     public AgentLifeCycleState getMappedState() {
@@ -73,6 +70,11 @@ public enum ManagedAgentLifeCycle {
     }
 
     public boolean isClosedEvent() {
-        return CLOSED_EVENT.contains(this);
+        for (ManagedAgentLifeCycle managedAgentLifeCycle : CLOSED_EVENT) {
+            if (managedAgentLifeCycle == this) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SocketStateCode.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SocketStateCode.java
@@ -1,8 +1,6 @@
 package com.navercorp.pinpoint.collector.receiver.grpc.service;
 
-import java.util.EnumSet;
 import java.util.Objects;
-import java.util.Set;
 
 public enum SocketStateCode {
 
@@ -32,7 +30,7 @@ public enum SocketStateCode {
     private final byte id;
     private final SocketStateCode[] beforeStateSet;
 
-    private static final Set<SocketStateCode> ALL_STATE_CODES = EnumSet.allOf(SocketStateCode.class);
+    private static final SocketStateCode[] ALL_STATE_CODES = SocketStateCode.values();
 
     SocketStateCode(byte id, SocketStateCode... beforeStateSet) {
         this.id = id;

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/JvmGcType.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/JvmGcType.java
@@ -16,9 +16,6 @@
 
 package com.navercorp.pinpoint.common.server.bo;
 
-import java.util.EnumSet;
-import java.util.Set;
-
 /**
  * @author HyunGil Jeong
  */
@@ -32,7 +29,7 @@ public enum JvmGcType {
 
     private final int typeCode;
 
-    private static final Set<JvmGcType> JVM_GC_TYPES = EnumSet.allOf(JvmGcType.class);
+    private static final JvmGcType[] JVM_GC_TYPES = JvmGcType.values();
 
 
     JvmGcType(int typeCode) {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/stat/AgentStatType.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/stat/AgentStatType.java
@@ -18,9 +18,6 @@ package com.navercorp.pinpoint.common.server.bo.stat;
 
 import com.navercorp.pinpoint.common.server.util.ByteUtils;
 
-import java.util.EnumSet;
-import java.util.Set;
-
 /**
  * @author HyunGil Jeong
  */
@@ -45,7 +42,7 @@ public enum AgentStatType {
     private final String name;
     private final String chartType;
 
-    private static final Set<AgentStatType> AGENT_STAT_TYPES = EnumSet.allOf(AgentStatType.class);
+    private static final AgentStatType[] AGENT_STAT_TYPES = AgentStatType.values();
 
     AgentStatType(int typeCode, String name, String chartType) {
         this.typeCode = ByteUtils.toUnsignedByte(typeCode);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/AgentEventType.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/AgentEventType.java
@@ -17,12 +17,9 @@
 package com.navercorp.pinpoint.common.server.util;
 
 import com.navercorp.pinpoint.common.server.bo.event.DeadlockBo;
-import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static com.navercorp.pinpoint.common.server.util.AgentEventTypeCategory.AGENT_LIFECYCLE;
@@ -49,20 +46,13 @@ public enum AgentEventType {
     private final Class<?> messageType;
     private final Set<AgentEventTypeCategory> category;
 
-    private static final Set<AgentEventType> AGENT_EVENT_TYPE = EnumSet.allOf(AgentEventType.class);
+    private static final AgentEventType[] AGENT_EVENT_TYPE = AgentEventType.values();
 
     AgentEventType(int code, String desc, Class<?> messageType, AgentEventTypeCategory... category) {
         this.code = code;
         this.desc = desc;
         this.messageType = messageType;
-        this.category = asSet(category);
-    }
-
-    private Set<AgentEventTypeCategory> asSet(AgentEventTypeCategory[] category) {
-        if (ArrayUtils.isEmpty(category)) {
-           return Collections.emptySet();
-       }
-       return EnumSet.copyOf(List.of(category));
+        this.category = Set.of(category);
     }
 
     public int getCode() {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/EnumGetter.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/EnumGetter.java
@@ -16,13 +16,14 @@
 package com.navercorp.pinpoint.common.server.util;
 
 import java.util.EnumSet;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
  * @author intr3p1d
  */
 public class EnumGetter<E extends Enum<E>> {
-    private final EnumSet<E> set;
+    private final Set<E> set;
 
     public EnumGetter(Class<E> eClass) {
         this.set = EnumSet.allOf(eClass);

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/ServiceTypeCategory.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/ServiceTypeCategory.java
@@ -15,9 +15,7 @@
  */
 package com.navercorp.pinpoint.common.trace;
 
-import java.util.EnumSet;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * @author Jongho Moon <jongho.moon@navercorp.com>
@@ -43,7 +41,7 @@ public enum ServiceTypeCategory {
 
     private final HistogramSchema histogramSchema;
 
-    private static final Set<ServiceTypeCategory> SERVICE_TYPE_CATEGORIES = EnumSet.allOf(ServiceTypeCategory.class);
+    private static final ServiceTypeCategory[] SERVICE_TYPE_CATEGORIES = ServiceTypeCategory.values();
 
     ServiceTypeCategory(int minCode, int maxCode, NodeCategory nodeCategory) {
         this(minCode, maxCode, nodeCategory, HistogramSchemas.NORMAL_SCHEMA);

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/UriStatHistogramBucket.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/UriStatHistogramBucket.java
@@ -16,8 +16,6 @@
 
 package com.navercorp.pinpoint.common.trace;
 
-import java.util.EnumSet;
-
 /**
  * @author Taejin Koo
  */
@@ -37,8 +35,7 @@ public enum UriStatHistogramBucket {
     private final int index;
     private final String description;
 
-    private static final EnumSet<UriStatHistogramBucket> BUCKETS = EnumSet.allOf(UriStatHistogramBucket.class);
-    private static final int SIZE = BUCKETS.size();
+    private static final UriStatHistogramBucket[] BUCKETS = UriStatHistogramBucket.values();
 
     UriStatHistogramBucket(long from, long to, int index) {
         this.from = from;
@@ -96,7 +93,7 @@ public enum UriStatHistogramBucket {
         }
 
         public int getBucketSize() {
-            return SIZE;
+            return BUCKETS.length;
         }
 
         public byte getBucketVersion() {

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/ByteSizeUnit.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/ByteSizeUnit.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.common.util;
 
 
-import java.util.EnumSet;
 import java.util.Objects;
 
 /**
@@ -31,7 +30,7 @@ public enum ByteSizeUnit {
     GIGA_BYTES(new String[]{"G", "g", "GB"}, ByteSizeUnit.GIGA_SIZE),
     TERA_BYTES(new String[]{"T", "t", "TB"}, ByteSizeUnit.TERA_SIZE);
 
-    private static final EnumSet<ByteSizeUnit> ALL = EnumSet.allOf(ByteSizeUnit.class);
+    private static final ByteSizeUnit[] ALL = ByteSizeUnit.values();
 
     private static final long BYTES_SIZE = 1;
     private static final long KILO_SIZE = 1024;

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/JvmType.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/JvmType.java
@@ -16,8 +16,6 @@
 
 package com.navercorp.pinpoint.common.util;
 
-import java.util.EnumSet;
-
 /**
  * @author HyunGil Jeong
  */
@@ -31,7 +29,7 @@ public enum JvmType {
 
     private final String inclusiveString;
 
-    private static final EnumSet<JvmType> JVM_TYPE = EnumSet.allOf(JvmType.class);
+    private static final JvmType[] JVM_TYPE = JvmType.values();
 
     JvmType(String inclusiveString) {
         this.inclusiveString = inclusiveString;

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/JvmVersion.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/JvmVersion.java
@@ -18,9 +18,6 @@ package com.navercorp.pinpoint.common.util;
 
 import com.navercorp.pinpoint.common.util.apache.IntHashMap;
 
-import java.util.EnumSet;
-import java.util.Set;
-
 /**
  * @author hyungil.jeong
  */
@@ -63,7 +60,7 @@ public enum JvmVersion {
     private final float version;
     private final int classVersion;
 
-    private static final Set<JvmVersion> JVM_VERSION = EnumSet.allOf(JvmVersion.class);
+    private static final JvmVersion[] JVM_VERSION = JvmVersion.values();
     private static final IntHashMap<JvmVersion> CLASS_VERSION_MAP = toClassVersionMap();
 
 

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/OsType.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/OsType.java
@@ -16,8 +16,6 @@
 
 package com.navercorp.pinpoint.common.util;
 
-import java.util.EnumSet;
-
 /**
  * @author Roy Kim
  */
@@ -37,7 +35,7 @@ public enum OsType {
 
     private final String inclusiveString;
 
-    private static final EnumSet<OsType> OS_TYPE = EnumSet.allOf(OsType.class);
+    private static final OsType[] OS_TYPE = OsType.values();
 
     OsType(String inclusiveString) {
         this.inclusiveString = inclusiveString;

--- a/inspector-module/inspector-collector/src/main/java/com/navercorp/pinpoint/inspector/collector/model/kafka/AgentStatField.java
+++ b/inspector-module/inspector-collector/src/main/java/com/navercorp/pinpoint/inspector/collector/model/kafka/AgentStatField.java
@@ -18,9 +18,6 @@ package com.navercorp.pinpoint.inspector.collector.model.kafka;
 
 import com.navercorp.pinpoint.common.server.util.ByteUtils;
 
-import java.util.EnumSet;
-import java.util.Set;
-
 /**
  * @author minwoo.jung
  */
@@ -87,7 +84,7 @@ public enum AgentStatField {
     private final String metricName;
     private final String fieldName;
 
-    private static final Set<AgentStatField> AGENT_STAT_TYPES = EnumSet.allOf(AgentStatField.class);
+    private static final AgentStatField[] AGENT_STAT_TYPES = AgentStatField.values();
 
     AgentStatField(int typeCode, String metricName, String fieldName) {
         this.typeCode = ByteUtils.toUnsignedByte(typeCode);

--- a/otlpmetric/otlpmetric-common/src/main/java/com/navercorp/pinpoint/otlp/common/web/definition/property/ChartType.java
+++ b/otlpmetric/otlpmetric-common/src/main/java/com/navercorp/pinpoint/otlp/common/web/definition/property/ChartType.java
@@ -17,10 +17,11 @@
 package com.navercorp.pinpoint.otlp.common.web.definition.property;
 
 import com.navercorp.pinpoint.common.server.util.EnumGetter;
+import org.jspecify.annotations.NonNull;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * @author minwoo-jung
@@ -47,8 +48,16 @@ public enum ChartType {
         return chartName;
     }
 
-    private static final EnumSet<ChartType> ENUM_SET = EnumSet.allOf(ChartType.class);
-    private static final EnumGetter<ChartType> GETTER = new EnumGetter<>(ENUM_SET);
+    private static final List<String> CHART_NAME_LIST = chartNameList();
+
+    private static @NonNull List<String> chartNameList() {
+        List<String> collect = Arrays.stream(ChartType.values())
+                .map(ChartType::getChartName)
+                .toList();
+        return List.copyOf(collect);
+    }
+
+    private static final EnumGetter<ChartType> GETTER = new EnumGetter<>(EnumSet.allOf(ChartType.class));
 
 
     public static ChartType fromChartName(String chartName) {
@@ -56,8 +65,6 @@ public enum ChartType {
     }
 
     public static List<String> getChartNameList() {
-        return ENUM_SET.stream()
-                .map(ChartType::getChartName)
-                .collect(Collectors.toList());
+        return CHART_NAME_LIST;
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/CheckerCategory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/CheckerCategory.java
@@ -17,9 +17,7 @@
 package com.navercorp.pinpoint.web.alarm;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * @author minwoo.jung
@@ -60,7 +58,7 @@ public enum CheckerCategory {
     DEADLOCK_OCCURRENCE("DEADLOCK OCCURRENCE", DataCollectorCategory.AGENT_EVENT),
     FILE_DESCRIPTOR_COUNT("FILE DESCRIPTOR COUNT", DataCollectorCategory.FILE_DESCRIPTOR);
 
-    private static final Set<CheckerCategory> CHECKER_CATEGORIES = EnumSet.allOf(CheckerCategory.class);
+    private static final CheckerCategory[] CHECKER_CATEGORIES = CheckerCategory.values();
 
     
     public static CheckerCategory getValue(String value) {
@@ -74,7 +72,7 @@ public enum CheckerCategory {
 
     public static List<String> getNames() {
 
-        final List<String> names = new ArrayList<>(CHECKER_CATEGORIES.size());
+        final List<String> names = new ArrayList<>(CHECKER_CATEGORIES.length);
         for (CheckerCategory category : CHECKER_CATEGORIES) {
             names.add(category.getName());
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/query/service/BindType.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/query/service/BindType.java
@@ -1,14 +1,12 @@
 package com.navercorp.pinpoint.web.query.service;
 
-import java.util.EnumSet;
 import java.util.Objects;
-import java.util.Set;
 
 public enum BindType {
     SQL("sql"),
     MONGO_JSON("mongoJson");
 
-    private static final Set<BindType> BIND_TYPE = EnumSet.allOf(BindType.class);
+    private static final BindType[] BIND_TYPE = BindType.values();
 
     private final String typeName;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/websocket/message/PinpointWebSocketMessageType.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/websocket/message/PinpointWebSocketMessageType.java
@@ -16,9 +16,6 @@
 
 package com.navercorp.pinpoint.web.websocket.message;
 
-import java.util.EnumSet;
-import java.util.Set;
-
 /**
  * @author Taejin Koo
  */
@@ -31,7 +28,7 @@ public enum PinpointWebSocketMessageType {
     PONG,
     UNKNOWN;
 
-    private static final Set<PinpointWebSocketMessageType> MESSAGE_TYPES = EnumSet.allOf(PinpointWebSocketMessageType.class);
+    private static final PinpointWebSocketMessageType[] MESSAGE_TYPES = PinpointWebSocketMessageType.values();
 
     public static PinpointWebSocketMessageType getType(String name) {
         for (PinpointWebSocketMessageType type : MESSAGE_TYPES) {


### PR DESCRIPTION
This pull request refactors several enum-related usages across the codebase to reduce reliance on `EnumSet` and `Set`, replacing them with arrays of enum values where possible. This change aims to improve performance and simplify code by avoiding unnecessary collections when only iteration or containment checks are needed. Additionally, some methods are updated to use more modern Java idioms such as `Set.of(...)` for immutable sets.

Key changes include:

**Refactoring enum collections:**

* Replaced `EnumSet.allOf(...)` and `EnumSet.of(...)` with static arrays of enum values (e.g., `Type[]`, `ManagedAgentLifeCycle[]`, `AgentEventType[]`) in multiple files, such as `MariaDBJdbcUrlParser.java`, `ManagedAgentLifeCycle.java`, `SocketStateCode.java`, `JvmGcType.java`, `AgentStatType.java`, and `ServiceTypeCategory.java`. [[1]](diffhunk://#diff-9b904ea48926494a94232db0b907fdeb4a06667adec13acde61309d02e153cfdL44-L45) [[2]](diffhunk://#diff-6adb453c633c9e5caa8061c6b745af439452e055aa0abd657c333d3a9f7eb76cL29-R29) [[3]](diffhunk://#diff-888653bafb06da5a354bc40c8c6fde8c4af34c910b6e1d7368efe17d61f9dbb2L35-R33) [[4]](diffhunk://#diff-081587255aa0a51f9111772c5517da68ce531535697aeae6b9f3574040bdd448L35-R32) [[5]](diffhunk://#diff-c4565b36ac2f6fc25e0922fa4f082117e8440072f10197f38141f093a79a03dcL48-R45) [[6]](diffhunk://#diff-151d7ed65a61951d4e53f47de715f28f069580b0afcdd1aa0daa5828cd1eed61L46-R44) [[7]](diffhunk://#diff-218895162f17036e7c15c9ff98910e14caf575d299e07125626f766440f6757bL52-R55)

* Updated containment checks from `EnumSet.contains()` to explicit iteration over arrays, as seen in methods like `isClosedEvent()` in `ManagedAgentLifeCycle.java`.

**Simplifying set creation and usage:**

* Replaced usages of `EnumSet.copyOf(...)` and `Collections.unmodifiableSet(...)` with `Set.of(...)` for immutable sets, and removed unnecessary wrapping in several enum constructors and getter methods. [[1]](diffhunk://#diff-6adb453c633c9e5caa8061c6b745af439452e055aa0abd657c333d3a9f7eb76cL44-R49) [[2]](diffhunk://#diff-218895162f17036e7c15c9ff98910e14caf575d299e07125626f766440f6757bL52-R55)

* Changed method and constructor signatures to use `Set<...>` instead of `EnumSet<...>` for greater flexibility, especially in error recording classes (`ConfigurableErrorRecorder`, `ConfigurableErrorRecorderFactory`). [[1]](diffhunk://#diff-6b63e789e03a076562bf3fff09a79e0c402939eb02b178eaf27dd68d7f3bca69L7-R14) [[2]](diffhunk://#diff-bb713ce53fe79020bffe951ce3a0c5179935f3679f92f9424613da186db5eddcR14-R19) [[3]](diffhunk://#diff-bb713ce53fe79020bffe951ce3a0c5179935f3679f92f9424613da186db5eddcL27-R42)

**Code cleanup and modernization:**

* Removed unused imports and redundant code related to `EnumSet` and `Set` in various files. [[1]](diffhunk://#diff-9b904ea48926494a94232db0b907fdeb4a06667adec13acde61309d02e153cfdL30-L32) [[2]](diffhunk://#diff-184fa6be73b52f3dd7cdefd6d80d59d6b295e79fc370db8db47122ff48f570deL21-L23) [[3]](diffhunk://#diff-081587255aa0a51f9111772c5517da68ce531535697aeae6b9f3574040bdd448L19-L21) [[4]](diffhunk://#diff-c4565b36ac2f6fc25e0922fa4f082117e8440072f10197f38141f093a79a03dcL21-L23) [[5]](diffhunk://#diff-151d7ed65a61951d4e53f47de715f28f069580b0afcdd1aa0daa5828cd1eed61L18-L20) [[6]](diffhunk://#diff-218895162f17036e7c15c9ff98910e14caf575d299e07125626f766440f6757bL20-L25)

* Refactored logic for checking membership in sets of enums, such as in `FileDescriptorMetricProvider.java`, to use arrays and simple loops instead of `EnumSet`. [[1]](diffhunk://#diff-c166fb359c68a524f37823cb558a844408b096f5d517d1c8bd846baa92d25aeaR45-R47) [[2]](diffhunk://#diff-c166fb359c68a524f37823cb558a844408b096f5d517d1c8bd846baa92d25aeaL94-R110)

These changes collectively modernize the codebase, reduce unnecessary object creation, and make enum usage more consistent and efficient.