### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/agent-module/bootstraps/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/config/ProfilableClassFilterTest.java
+++ b/agent-module/bootstraps/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/config/ProfilableClassFilterTest.java
@@ -24,6 +24,39 @@ import java.io.IOException;
 public class ProfilableClassFilterTest {
 
     @Test
+    public void testEmptyConfiguration() {
+        ProfilableClassFilter filter = new ProfilableClassFilter("");
+
+        Assertions.assertFalse(filter.filter("com/navercorp/pinpoint/testweb/MyClass"));
+        Assertions.assertFalse(filter.filter("com/navercorp/pinpoint/testweb/controller/MyController"));
+    }
+
+    @Test
+    public void testExactMatch() {
+        ProfilableClassFilter filter = new ProfilableClassFilter("com.navercorp.pinpoint.SomeSpecificClass");
+
+        Assertions.assertTrue(filter.filter("com/navercorp/pinpoint/SomeSpecificClass"));
+        Assertions.assertFalse(filter.filter("com/navercorp/pinpoint/SomeOtherClass"));
+    }
+
+    @Test
+    public void testSubpackageFiltering() {
+        ProfilableClassFilter filter = new ProfilableClassFilter("com.navercorp.pinpoint.testweb.controller.*");
+
+        Assertions.assertTrue(filter.filter("com/navercorp/pinpoint/testweb/controller/TestController1"));
+        Assertions.assertTrue(filter.filter("com/navercorp/pinpoint/testweb/controller/subcontroller/InnerController"));
+        Assertions.assertFalse(filter.filter("com/navercorp/pinpoint/testweb/otherpackage/NotController"));
+    }
+
+    @Test
+    public void testUnexpectedClassNames() {
+        ProfilableClassFilter filter = new ProfilableClassFilter("com.navercorp.pinpoint.testweb.*");
+
+        Assertions.assertFalse(filter.filter("random/unknown/path"));
+        Assertions.assertFalse(filter.filter("com/random/pinpoint/path"));
+    }
+
+    @Test
     public void testIsProfilableClassWithNoConfiguration() throws IOException {
         ProfilableClassFilter filter = new ProfilableClassFilter("com.navercorp.pinpoint.testweb.controller.*,com.navercorp.pinpoint.testweb.MyClass");
 


### PR DESCRIPTION
This pull request refactors the `ProfilableClassFilter` class to improve how it handles exact class matches and subpackage filtering, making the code more efficient and easier to understand. It also introduces comprehensive unit tests to ensure correct behavior for various input scenarios.

### Refactoring and logic improvements

* Replaced the `profileIncludeSub` set with an array to optimize subpackage filtering, and standardized the handling of subpackage patterns using the `SUFFIX` constant. (`ProfilableClassFilter.java`)
* Simplified the filtering logic by checking if the class name starts with any subpackage pattern directly, instead of extracting and comparing the package name. (`ProfilableClassFilter.java`)

### Code clarity and maintainability

* Updated the `toString()` method to use `Arrays.toString()` for clearer output of the subpackage array. (`ProfilableClassFilter.java`)
* Added an explicit import for `Arrays` to support the new `toString()` implementation. (`ProfilableClassFilter.java`)

### Testing improvements

* Added new unit tests to cover empty configuration, exact matches, subpackage filtering, and unexpected class names, ensuring the filter behaves correctly in all scenarios. (`ProfilableClassFilterTest.java`)