### PR TITLE
[#noissue] Apply commons3.StringUtils.remove

### DIFF
--- a/user/pom.xml
+++ b/user/pom.xml
@@ -62,6 +62,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/user/src/main/java/com/navercorp/pinpoint/user/vo/User.java
+++ b/user/src/main/java/com/navercorp/pinpoint/user/vo/User.java
@@ -18,6 +18,7 @@
 package com.navercorp.pinpoint.user.vo;
 
 import com.navercorp.pinpoint.common.util.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -120,7 +121,7 @@ public class User {
             if (phoneNumber == null) {
                 continue;
             } else if (phoneNumber.contains("-")) {
-                editedPhoneNumberList.add(phoneNumber.replace("-", ""));
+                editedPhoneNumberList.add(removeHyphenForPhoneNumber(phoneNumber));
             } else {
                 editedPhoneNumberList.add(phoneNumber);
             }
@@ -130,20 +131,19 @@ public class User {
     }
 
     public static String removeHyphenForPhoneNumber(String phoneNumber) {
-        return phoneNumber.replace("-", "");
+        return StringUtils.remove(phoneNumber, '-');
     }
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("User{");
-        sb.append("number='").append(number).append('\'');
-        sb.append(", userId='").append(userId).append('\'');
-        sb.append(", name='").append(name).append('\'');
-        sb.append(", department='").append(department).append('\'');
-        sb.append(", phoneCountryCode=").append(phoneCountryCode);
-        sb.append(", phoneNumber='").append(phoneNumber).append('\'');
-        sb.append(", email='").append(email).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "User{" +
+                "number='" + number + '\'' +
+                ", userId='" + userId + '\'' +
+                ", name='" + name + '\'' +
+                ", department='" + department + '\'' +
+                ", phoneCountryCode=" + phoneCountryCode +
+                ", phoneNumber='" + phoneNumber + '\'' +
+                ", email='" + email + '\'' +
+                '}';
     }
 }


### PR DESCRIPTION
This pull request updates the `User` class to use Apache Commons Lang utilities for string manipulation, specifically for removing hyphens from phone numbers. It also simplifies the `toString` method implementation. The most important changes are:

**Dependency Management:**

* Added the `commons-lang3` library as a dependency in `pom.xml` to enable the use of `StringUtils`.

**Code Improvements in `User.java`:**

* Updated import statements to include `StringUtils` from `commons-lang3`.
* Refactored the `removeHyphenForPhoneNumber` method to use `StringUtils.remove` instead of `String.replace`, improving clarity and leveraging a well-tested utility method.
* Updated `removeHyphenForPhoneNumberList` to call the refactored `removeHyphenForPhoneNumber` method for consistency and code reuse.
* Simplified the `toString` method by switching from a `StringBuilder` pattern to string concatenation, making the code more concise and readable.