### PR TITLE
[#noissue] Optimize StringBuilder usage by replacing `substring` with `append` using start and end indices

### DIFF
--- a/commons-mybatis/src/main/java/com/navercorp/pinpoint/mybatis/plugin/DefaultBindingLogFormatter.java
+++ b/commons-mybatis/src/main/java/com/navercorp/pinpoint/mybatis/plugin/DefaultBindingLogFormatter.java
@@ -62,7 +62,7 @@ public class DefaultBindingLogFormatter implements BindLogFormatter {
             i++;
         }
         if (queryPrev < query.length()) {
-            builder.append(query.substring(queryPrev));
+            builder.append(query, queryPrev, query.length());
         }
 
         return builder.toString();


### PR DESCRIPTION
… `append` using start and end indices

This pull request makes a minor optimization to the string formatting logic in the `DefaultBindingLogFormatter` class. The change improves code readability and efficiency by replacing a substring extraction with a more direct string append operation. 

- Refactored the final string append in the `format` method of `DefaultBindingLogFormatter` to use `builder.append(query, queryPrev, query.length())` instead of `builder.append(query.substring(queryPrev))`, which is more efficient and concise.