### PR TITLE
[#noissue] Replace HashSet with Eclipse Collections IntSet to optimize primitive int handling

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/RpcURLPatternFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/RpcURLPatternFilter.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.web.filter;
 
-import com.google.common.collect.ImmutableSet;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
@@ -25,13 +24,14 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.loader.service.AnnotationKeyRegistryService;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
+import org.eclipse.collections.api.factory.primitive.IntSets;
+import org.eclipse.collections.api.set.primitive.IntSet;
+import org.eclipse.collections.api.set.primitive.MutableIntSet;
 import org.springframework.util.AntPathMatcher;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * @author emeroad
@@ -45,7 +45,7 @@ public class RpcURLPatternFilter implements URLPatternFilter {
     private final AnnotationKeyRegistryService annotationKeyRegistryService;
 
     // TODO remove. hard coded annotation for compatibility, need a better to group rpc url annotations
-    private final Set<Integer> rpcEndpointAnnotationCodes;
+    private final IntSet rpcEndpointAnnotationCodes;
 
     public RpcURLPatternFilter(String urlPattern, ServiceTypeRegistryService serviceTypeRegistryService, AnnotationKeyRegistryService annotationKeyRegistryService) {
         this.urlPattern = Objects.requireNonNull(urlPattern, "urlPattern");
@@ -57,12 +57,12 @@ public class RpcURLPatternFilter implements URLPatternFilter {
         // TODO remove. hard coded annotation for compatibility, need a better to group rpc url annotations
         this.rpcEndpointAnnotationCodes = initRpcEndpointAnnotations(
                 AnnotationKey.HTTP_URL.getName(), AnnotationKey.MESSAGE_QUEUE_URI.getName(),
-                "thrift.url", "npc.url", "nimm.url"
+                "thrift.url", "npc.url"
         );
     }
 
-    private Set<Integer> initRpcEndpointAnnotations(String... annotationKeyNames) {
-        Set<Integer> rpcEndPointAnnotationCodes = new HashSet<>();
+    private IntSet initRpcEndpointAnnotations(String... annotationKeyNames) {
+        MutableIntSet rpcEndPointAnnotationCodes = IntSets.mutable.of();
         for (String annotationKeyName : annotationKeyNames) {
             try {
                 final AnnotationKey pluginRpcEndpointAnnotationKey = annotationKeyRegistryService.findAnnotationKeyByName(annotationKeyName);
@@ -73,7 +73,7 @@ public class RpcURLPatternFilter implements URLPatternFilter {
                 // ignore
             }
         }
-        return ImmutableSet.copyOf(rpcEndPointAnnotationCodes);
+        return rpcEndPointAnnotationCodes.freeze();
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/ApplicationNameMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/ApplicationNameMapper.java
@@ -22,14 +22,14 @@ import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Result;
+import org.eclipse.collections.api.factory.primitive.IntSets;
+import org.eclipse.collections.api.set.primitive.MutableIntSet;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  *
@@ -48,19 +48,20 @@ public class ApplicationNameMapper implements RowMapper<List<Application>> {
         if (result.isEmpty()) {
             return Collections.emptyList();
         }
-        Set<Short> uniqueTypeCodes = new HashSet<>();
+        MutableIntSet uniqueTypeCodes = IntSets.mutable.of();
         String applicationName = CellUtils.rowToString(result);
         
         Cell[] rawCells = result.rawCells();
         for (Cell cell : rawCells) {
-            short serviceTypeCode = CellUtils.valueToShort(cell);
+            int serviceTypeCode = CellUtils.valueToShort(cell);
             uniqueTypeCodes.add(serviceTypeCode);
         }
+
         List<Application> applicationList = new ArrayList<>();
-        for (short serviceTypeCode : uniqueTypeCodes) {
+        uniqueTypeCodes.forEach(serviceTypeCode -> {
             final Application application = applicationFactory.createApplication(applicationName, serviceTypeCode);
             applicationList.add(application);
-        }
+        });
         return applicationList;
     }
 }


### PR DESCRIPTION
…e primitive int handling

This pull request refactors parts of the codebase to use Eclipse Collections' primitive collections for improved performance and memory efficiency, replacing standard Java collections and Guava's ImmutableSet. It also removes an unused annotation key and updates type handling for service type codes.

**Collection Refactoring and Type Handling:**

* Replaced usage of `Set<Integer>` and `Set<Short>` (including Guava's `ImmutableSet` and Java's `HashSet`) with Eclipse Collections' `IntSet` and `MutableIntSet` in `RpcURLPatternFilter` and `ApplicationNameMapper` for more efficient primitive collection handling. [[1]](diffhunk://#diff-192b3b81978aa6d9287cd28aca06e94f9bf33f0cb586932f61dea8fb38e92614L19) [[2]](diffhunk://#diff-192b3b81978aa6d9287cd28aca06e94f9bf33f0cb586932f61dea8fb38e92614R27-L34) [[3]](diffhunk://#diff-192b3b81978aa6d9287cd28aca06e94f9bf33f0cb586932f61dea8fb38e92614L48-R48) [[4]](diffhunk://#diff-192b3b81978aa6d9287cd28aca06e94f9bf33f0cb586932f61dea8fb38e92614L60-R65) [[5]](diffhunk://#diff-192b3b81978aa6d9287cd28aca06e94f9bf33f0cb586932f61dea8fb38e92614L76-R76) [[6]](diffhunk://#diff-fff69f3690522c64a2174cedcd643a974fb2a5773a37f55f7ddec02d94aabdcdR25-L32) [[7]](diffhunk://#diff-fff69f3690522c64a2174cedcd643a974fb2a5773a37f55f7ddec02d94aabdcdL51-R64)
* Updated the type of `serviceTypeCode` from `short` to `int` in `ApplicationNameMapper` to align with the new primitive collection usage.

**Code Cleanup:**

* Removed the unused `"nimm.url"` annotation key from the hardcoded list in `RpcURLPatternFilter`.