### PR TITLE
[#noissue] Refactor TagUtils to move to util package and deprecate old implementation

### DIFF
--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/field/Field.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/definition/metric/field/Field.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.navercorp.pinpoint.inspector.web.definition.AggregationFunction;
 import com.navercorp.pinpoint.metric.common.model.Tag;
-import com.navercorp.pinpoint.metric.common.model.TagUtils;
+import com.navercorp.pinpoint.metric.common.util.TagUtils;
 import com.navercorp.pinpoint.metric.web.model.basic.metric.group.MatchingRule;
 
 import java.util.List;

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultApdexStatService.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultApdexStatService.java
@@ -29,7 +29,7 @@ import com.navercorp.pinpoint.inspector.web.definition.YMLInspectorManager;
 import com.navercorp.pinpoint.inspector.web.definition.metric.field.Field;
 import com.navercorp.pinpoint.inspector.web.model.InspectorMetricData;
 import com.navercorp.pinpoint.inspector.web.model.InspectorMetricValue;
-import com.navercorp.pinpoint.metric.common.model.TagUtils;
+import com.navercorp.pinpoint.metric.common.util.TagUtils;
 import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.service.ApdexScoreService;
 import com.navercorp.pinpoint.web.vo.Application;

--- a/metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/model/TagUtils.java
+++ b/metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/model/TagUtils.java
@@ -17,18 +17,19 @@
 
 package com.navercorp.pinpoint.metric.common.model;
 
-import java.util.Collections;
 import java.util.List;
 
+/**
+ * @deprecated use {@link com.navercorp.pinpoint.metric.common.util.TagUtils}
+ */
+@Deprecated
 public final class TagUtils {
 
     private TagUtils() {
     }
 
+    @Deprecated
     public static List<Tag> defaultTags(List<Tag> tags) {
-        if (tags == null) {
-            return Collections.emptyList();
-        }
-        return tags;
+        return com.navercorp.pinpoint.metric.common.util.TagUtils.defaultTags(tags);
     }
 }

--- a/metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/util/TagUtils.java
+++ b/metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/util/TagUtils.java
@@ -100,4 +100,11 @@ public class TagUtils {
         }
         return joiner.toString();
     }
+
+    public static List<Tag> defaultTags(List<Tag> tags) {
+        if (tags == null) {
+            return List.of();
+        }
+        return tags;
+    }
 }

--- a/metric-module/metric-commons/src/test/java/com/navercorp/pinpoint/metric/common/util/TagUtilsTest.java
+++ b/metric-module/metric-commons/src/test/java/com/navercorp/pinpoint/metric/common/util/TagUtilsTest.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.navercorp.pinpoint.metric.common.model;
+package com.navercorp.pinpoint.metric.common.util;
 
-import com.navercorp.pinpoint.metric.common.util.TagUtils;
+import com.navercorp.pinpoint.metric.common.model.Tag;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/mapping/Field.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/mapping/Field.java
@@ -19,7 +19,7 @@ package com.navercorp.pinpoint.metric.web.mapping;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.navercorp.pinpoint.metric.common.model.Tag;
-import com.navercorp.pinpoint.metric.common.model.TagUtils;
+import com.navercorp.pinpoint.metric.common.util.TagUtils;
 import com.navercorp.pinpoint.metric.web.model.basic.metric.group.MatchingRule;
 
 import java.util.List;


### PR DESCRIPTION
…d implementation

This pull request refactors the usage of the `TagUtils` utility class throughout the codebase, moving references from the old location in `com.navercorp.pinpoint.metric.common.model` to the new location in `com.navercorp.pinpoint.metric.common.util`. It also marks the old class as deprecated and introduces a new implementation for the `defaultTags` method. Related test files are updated and relocated accordingly.

### Refactoring and Deprecation

* Updated all imports to use `com.navercorp.pinpoint.metric.common.util.TagUtils` instead of the deprecated `com.navercorp.pinpoint.metric.common.model.TagUtils` across multiple files, including `Field.java` in both the inspector and metric modules, and `DefaultApdexStatService.java`. [[1]](diffhunk://#diff-d155ba0a12b5c37465205d047a5dfc2850d8b6aad7906d8d7e428ac088869167L23-R23) [[2]](diffhunk://#diff-09cb59b65e97791d342834f7a44c27a7d05f7e46f6edb6fe839523ef73a20531L32-R32) [[3]](diffhunk://#diff-443e0d6e1c181d89182c44f87ef85c4488d1c6d03708b4d92803819b8a7a0e94L22-R22)
* Marked the old `TagUtils` class in `com.navercorp.pinpoint.metric.common.model` as deprecated, and its `defaultTags` method now delegates to the new utility class.

### Utility Method Enhancement

* Added a new `defaultTags` method to `com.navercorp.pinpoint.metric.common.util.TagUtils` to return an empty list if the input is `null`, replacing the previous implementation.

### Test File Relocation

* Renamed and updated the test file for `TagUtils`, moving it from the `model` package to the `util` package to match the new location of the class.