### PR TITLE
[#13307] Refactor parsing logic to use `KeyValueTokenizer`

### DIFF
--- a/agent-module/plugins/dameng-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/dameng/DamengJdbcUrlParser.java
+++ b/agent-module/plugins/dameng-jdbc/src/main/java/com/navercorp/pinpoint/plugin/jdbc/dameng/DamengJdbcUrlParser.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.bootstrap.plugin.jdbc.JdbcUrlParserV2;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.StringMaker;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.UnKnownDatabaseInfo;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.util.KeyValueTokenizer;
 import com.navercorp.pinpoint.common.util.StringUtils;
 
 import java.util.Arrays;
@@ -73,10 +74,14 @@ public class DamengJdbcUrlParser implements JdbcUrlParserV2 {
         String host = DEFAULT_HOST;
         String port = DEFAULT_PORT;
         if (StringUtils.hasText(hostPort)) {
-            String[] hostPortInfo = hostPort.split(":", 2);
-            host = hostPortInfo[0];
-            if (hostPortInfo.length > 1) {
-                port = hostPortInfo[1];
+            KeyValueTokenizer.KeyValue hostPortInfo = KeyValueTokenizer.tokenize(hostPort, ":");
+            if (hostPortInfo == null) {
+                host = hostPort;
+            } else {
+                host = hostPortInfo.getKey();
+                if (!hostPortInfo.getValue().isEmpty()) {
+                    port = hostPortInfo.getValue();
+                }
             }
         }
 
@@ -122,11 +127,11 @@ public class DamengJdbcUrlParser implements JdbcUrlParserV2 {
             if (!StringUtils.hasText(v)) {
                 continue;
             }
-            String[] kv = v.split("=", 2);
-            if (kv.length > 1) {
-                map.put(kv[0], kv[1]);
+            KeyValueTokenizer.KeyValue keyValue = KeyValueTokenizer.tokenize(v, "=");
+            if (keyValue != null) {
+                map.put(keyValue.getKey(), keyValue.getValue());
             } else {
-                map.put(kv[0], StringUtils.EMPTY_STRING);
+                logger.info("Parse failed " + v) ;
             }
         }
         return map;

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/plugin/PluginPackageClassRequirementFilter.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/plugin/PluginPackageClassRequirementFilter.java
@@ -1,5 +1,6 @@
 package com.navercorp.pinpoint.profiler.plugin;
 
+import com.navercorp.pinpoint.common.util.KeyValueTokenizer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -53,10 +54,10 @@ public class PluginPackageClassRequirementFilter implements ClassNameFilter {
 
     private void parseRequirementList(List<String> packageRequirementList, List<String> packageList, List<String> requirementList) {
         for (String packageWithRequirement : packageRequirementList) {
-            String[] split = packageWithRequirement.split(":", 2);
-            if (split.length == 2) {
-                packageList.add(split[0]);
-                requirementList.add(split[1]);
+            KeyValueTokenizer.KeyValue keyValue = KeyValueTokenizer.tokenize(packageWithRequirement, ":");
+            if (keyValue != null) {
+                packageList.add(keyValue.getKey());
+                requirementList.add(keyValue.getValue());
             }
         }
     }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/grpc/channelz/service/ChannelzSocketLookup.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/grpc/channelz/service/ChannelzSocketLookup.java
@@ -16,6 +16,8 @@
 
 package com.navercorp.pinpoint.collector.grpc.channelz.service;
 
+import com.navercorp.pinpoint.common.util.KeyValueTokenizer;
+
 import javax.annotation.Nullable;
 import java.util.Collection;
 
@@ -48,16 +50,16 @@ public interface ChannelzSocketLookup {
          * @return entry of socket index
          */
         public static SocketEntry compose(Object remote, Object local, long socketId) {
-            String remoteAddr = split(remote)[0];
-            String localPort = split(local)[1];
+            String remoteAddr = split(remote).getKey();
+            String localPort = split(local).getValue();
             return new SocketEntry(remoteAddr.substring(1), parse(localPort), socketId);
         }
 
-        private static String[] split(Object obj) {
+        private static KeyValueTokenizer.KeyValue split(Object obj) {
             if (obj == null) {
                 return null;
             }
-            return obj.toString().split(":", 2);
+            return KeyValueTokenizer.tokenize(obj.toString(), ":");
         }
 
         private static Integer parse(String str) {

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/util/KeyValueTokenizerTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/util/KeyValueTokenizerTest.java
@@ -1,0 +1,43 @@
+package com.navercorp.pinpoint.common.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class KeyValueTokenizerTest {
+
+    @Test
+    void tokenize() {
+        KeyValueTokenizer.KeyValue keyValue = KeyValueTokenizer.tokenize("key=value", "=");
+        assertEquals("key", keyValue.getKey());
+        assertEquals("value", keyValue.getValue());
+    }
+
+    @Test
+    void tokenize2() {
+        KeyValueTokenizer.KeyValue keyValue = KeyValueTokenizer.tokenize("key==value", "==");
+        assertEquals("key", keyValue.getKey());
+        assertEquals("value", keyValue.getValue());
+    }
+
+    @Test
+    void tokenize_emptyValue() {
+        KeyValueTokenizer.KeyValue keyValue = KeyValueTokenizer.tokenize("key=", "=");
+        assertEquals("key", keyValue.getKey());
+        assertEquals("", keyValue.getValue());
+    }
+
+    @Test
+    void tokenize_emptyKeyValue() {
+        KeyValueTokenizer.KeyValue keyValue = KeyValueTokenizer.tokenize("=", "=");
+        assertEquals("", keyValue.getKey());
+        assertEquals("", keyValue.getValue());
+    }
+
+    @Test
+    void tokenize_empty() {
+        KeyValueTokenizer.KeyValue keyValue = KeyValueTokenizer.tokenize("", "=");
+        Assertions.assertNull(keyValue);
+    }
+}

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/KeyValueTokenizer.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/KeyValueTokenizer.java
@@ -1,0 +1,71 @@
+package com.navercorp.pinpoint.common.util;
+import java.util.Objects;
+
+public class KeyValueTokenizer {
+
+    public static final TokenFactory<KeyValue> KEY_VALUE_FACTORY = new TokenFactory<KeyValue>() {
+        public KeyValue accept(String key, String value) {
+            return new KeyValue(key, value);
+        }
+    };
+
+    public static final TokenFactory<KeyValue> KEY_VALUE_TRIM_FACTORY = new TokenFactory<KeyValue>() {
+        public KeyValue accept(String key, String value) {
+            return new KeyValue(key.trim(), value.trim());
+        }
+    };
+
+    public static KeyValue tokenize(String text, String delimiter) {
+        return tokenize(text, delimiter, KEY_VALUE_FACTORY);
+    }
+
+    /**
+     * Tokenizes the given text into a key and value using the specified delimiter and token factory.
+     *
+     * @param text the text to tokenize
+     * @param delimiter the delimiter separating key and value
+     * @param factory the factory used to create the token
+     * @param <T> the type of token to return
+     * @return the parsed token, or {@code null} if the delimiter is not found in the text
+     */
+    public static <T> T tokenize(String text, String delimiter, TokenFactory<T> factory) {
+        Objects.requireNonNull(text, "text");
+
+        final int delimiterIndex = text.indexOf(delimiter);
+        if (delimiterIndex == -1) {
+            return null;
+        }
+
+        final String key = text.substring(0, delimiterIndex);
+
+        final int delimiterLength = delimiter.length();
+        if (delimiterIndex == text.length() - delimiterLength) {
+            return factory.accept(key, "");
+        }
+        String value = text.substring(delimiterIndex + delimiterLength);
+        return factory.accept(key, value);
+    }
+
+
+    public interface TokenFactory<V> {
+        V accept(String key, String value);
+    }
+
+    public static class KeyValue {
+        private final String key;
+        private final String value;
+
+        public KeyValue(String key, String value) {
+            this.key = Objects.requireNonNull(key, "key");
+            this.value = Objects.requireNonNull(value, "value");
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/ExceptionTraceQueryParameter.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/util/ExceptionTraceQueryParameter.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.exceptiontrace.web.util;
 import com.google.common.primitives.Ints;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 import com.navercorp.pinpoint.common.timeseries.window.TimePrecision;
+import com.navercorp.pinpoint.common.util.KeyValueTokenizer;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.metric.web.util.QueryParameter;
 
@@ -197,8 +198,8 @@ public class ExceptionTraceQueryParameter extends QueryParameter {
                 return self();
             }
             for (String string : strings) {
-                String[] tag = string.split(":", 2);
-                filterByAttributes.put(tag[0], tag[1]);
+                KeyValueTokenizer.KeyValue keyValue = KeyValueTokenizer.tokenize(string, ":");
+                filterByAttributes.put(keyValue.getKey(), keyValue.getValue());
             }
             return self();
         }

--- a/metric-module/metric-commons/src/test/java/com/navercorp/pinpoint/metric/common/util/TagUtilsTest.java
+++ b/metric-module/metric-commons/src/test/java/com/navercorp/pinpoint/metric/common/util/TagUtilsTest.java
@@ -42,6 +42,14 @@ public class TagUtilsTest {
     }
 
     @Test
+    public void parseTagTest_emptyValue() {
+        Tag tag = TagUtils.parseTag("A:");
+
+        Assertions.assertEquals("A", tag.getName());
+        Assertions.assertEquals("", tag.getValue());
+    }
+
+    @Test
     public void parseTagsListTest() {
         List<Tag> tagList = List.of(
                 new Tag("A", "1"),

--- a/redis/src/main/java/com/navercorp/pinpoint/channel/redis/kv/RedisKVPubChannelProvider.java
+++ b/redis/src/main/java/com/navercorp/pinpoint/channel/redis/kv/RedisKVPubChannelProvider.java
@@ -17,6 +17,7 @@ package com.navercorp.pinpoint.channel.redis.kv;
 
 import com.navercorp.pinpoint.channel.PubChannel;
 import com.navercorp.pinpoint.channel.PubChannelProvider;
+import com.navercorp.pinpoint.common.util.KeyValueTokenizer;
 import org.springframework.data.redis.core.RedisTemplate;
 
 import java.time.Duration;
@@ -35,12 +36,12 @@ class RedisKVPubChannelProvider implements PubChannelProvider {
 
     @Override
     public PubChannel getPubChannel(String key) {
-        String[] words = key.split(":", 2);
-        if (words.length != 2) {
-            throw new IllegalArgumentException("the key must contain expire duration");
+        KeyValueTokenizer.KeyValue keyValue = KeyValueTokenizer.tokenize(key, ":");
+        if (keyValue == null) {
+            throw new IllegalArgumentException("the key must contain ':' key:" + key);
         }
-        Duration expire = Duration.parse(words[0]);
-        return new RedisKVPubChannel(this.template, expire.toMillis(), words[1]);
+        Duration expire = Duration.parse(keyValue.getKey());
+        return new RedisKVPubChannel(this.template, expire.toMillis(), keyValue.getValue());
     }
 
 }

--- a/redis/src/main/java/com/navercorp/pinpoint/channel/redis/kv/RedisKVSubChannelProvider.java
+++ b/redis/src/main/java/com/navercorp/pinpoint/channel/redis/kv/RedisKVSubChannelProvider.java
@@ -17,6 +17,7 @@ package com.navercorp.pinpoint.channel.redis.kv;
 
 import com.navercorp.pinpoint.channel.SubChannel;
 import com.navercorp.pinpoint.channel.SubChannelProvider;
+import com.navercorp.pinpoint.common.util.KeyValueTokenizer;
 import org.springframework.data.redis.core.RedisTemplate;
 import reactor.core.scheduler.Scheduler;
 
@@ -38,12 +39,12 @@ class RedisKVSubChannelProvider implements SubChannelProvider {
 
     @Override
     public SubChannel getSubChannel(String key) {
-        String[] words = key.split(":", 2);
-        if (words.length != 2) {
-            throw new IllegalArgumentException("the key must contain period");
+        KeyValueTokenizer.KeyValue keyValue = KeyValueTokenizer.tokenize(key, ":");
+        if (keyValue == null) {
+            throw new IllegalArgumentException("the key must contain ':' key:" + key);
         }
-        Duration period = Duration.parse(words[0]);
-        return new RedisKVSubChannel(this.template, this.scheduler, period, words[1]);
+        Duration period = Duration.parse(keyValue.getKey());
+        return new RedisKVSubChannel(this.template, this.scheduler, period, keyValue.getValue());
     }
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/ServerMapHistogramController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/ServerMapHistogramController.java
@@ -256,7 +256,7 @@ public class ServerMapHistogramController {
         if (!NODE_KEY_VALIDATION_PATTERN.matcher(nodeKey).matches()) {
             throw new IllegalArgumentException("Invalid node key format: " + nodeKey);
         }
-        String[] parts = NODE_DELIMITER_PATTERN.split(nodeKey);
+        String[] parts = NODE_DELIMITER_PATTERN.split(nodeKey, 2);
         String applicationName = parts[0];
         String serviceTypeName = parts[1];
 
@@ -345,7 +345,7 @@ public class ServerMapHistogramController {
         if (!LINK_KEY_VALIDATION_PATTERN.matcher(linkKey).matches()) {
             throw new IllegalArgumentException("Invalid linkKey format: expected 'fromApp~toApp' but got: " + linkKey);
         }
-        String[] parts = LINK_DELIMITER_PATTERN.split(linkKey);
+        String[] parts = LINK_DELIMITER_PATTERN.split(linkKey, 2);
         if (parts.length != 2) {
             throw new IllegalArgumentException("Invalid linkKey format: expected 'fromApp~toApp' but got: " + linkKey);
         }


### PR DESCRIPTION
This pull request introduces a new utility class, `KeyValueTokenizer`, to standardize and simplify the parsing of key-value pairs across the codebase. The change replaces various manual string splitting logic with this centralized utility, improving code readability and reducing duplication. The update also includes comprehensive unit tests for the new utility and refactors several modules to use it.

Key changes include:

**1. Introduction of `KeyValueTokenizer` utility:**
- Added `KeyValueTokenizer` in `commons/src/main/java/com/navercorp/pinpoint/common/util/KeyValueTokenizer.java`, providing methods for safe, null-aware key-value parsing with customizable factories for different value types.

**2. Refactoring to use `KeyValueTokenizer`:**
- Replaced manual string splitting with `KeyValueTokenizer` in:
  - Dameng JDBC URL parsing and query parameter parsing (`DamengJdbcUrlParser.java`). [[1]](diffhunk://#diff-baf694cb6798794a889798fbe6918cc62cd1c79f8aeaa547df1e5e02b1cf1323R27) [[2]](diffhunk://#diff-baf694cb6798794a889798fbe6918cc62cd1c79f8aeaa547df1e5e02b1cf1323L76-R80) [[3]](diffhunk://#diff-baf694cb6798794a889798fbe6918cc62cd1c79f8aeaa547df1e5e02b1cf1323L125-R127)
  - gRPC Channelz socket lookup logic (`ChannelzSocketLookup.java`). [[1]](diffhunk://#diff-c08a29c90a583edf4bc622e63dd3fc99f3a3d344934b08f3e4224fefa68a5e53R19-R20) [[2]](diffhunk://#diff-c08a29c90a583edf4bc622e63dd3fc99f3a3d344934b08f3e4224fefa68a5e53L51-R62)
  - Exception trace query parameter filter parsing (`ExceptionTraceQueryParameter.java`). [[1]](diffhunk://#diff-192c0cff0590236540b8cad6521117b6305523e5d90aa36ee8c7686ea91a38e3R22) [[2]](diffhunk://#diff-192c0cff0590236540b8cad6521117b6305523e5d90aa36ee8c7686ea91a38e3L200-R202)
  - Metric tag parsing utilities (`TagUtils.java`). [[1]](diffhunk://#diff-1a3f6e4c9869d0d5d712aee2bd861de42f8509fb78e65061f84dcc61b83007a0R21) [[2]](diffhunk://#diff-1a3f6e4c9869d0d5d712aee2bd861de42f8509fb78e65061f84dcc61b83007a0L36-R44) [[3]](diffhunk://#diff-1a3f6e4c9869d0d5d712aee2bd861de42f8509fb78e65061f84dcc61b83007a0L72-R80)
  - Redis channel key parsing (`RedisKVPubChannelProvider.java`, `RedisKVSubChannelProvider.java`). [[1]](diffhunk://#diff-1f7e1c81d7a26da5e70710b7dbb1c6adb7b82f3779261273e643ecd413edcfd1R20) [[2]](diffhunk://#diff-1f7e1c81d7a26da5e70710b7dbb1c6adb7b82f3779261273e643ecd413edcfd1L38-R44) [[3]](diffhunk://#diff-042e54570a9e52eb7cc64667de18a2cce999b179744de00ebfd86b6763c37382R20) [[4]](diffhunk://#diff-042e54570a9e52eb7cc64667de18a2cce999b179744de00ebfd86b6763c37382L41-R47)

**3. Testing improvements:**
- Added a dedicated test class, `KeyValueTokenizerTest`, with thorough unit tests covering various edge cases for the new utility.
- Added a new test for empty value parsing in metric tag utilities (`TagUtilsTest.java`).

**4. Minor related improvements:**
- Simplified and clarified tag string handling in `TagUtils` (e.g., improved JSON tag string cleaning).
- Minor fix to ensure split methods in `ServerMapHistogramController` only split into two parts for node and link key parsing. [[1]](diffhunk://#diff-dac809e0e51dbc33819c61865a5102591f8dac3201781304e9329c1261cc09e6L259-R259) [[2]](diffhunk://#diff-dac809e0e51dbc33819c61865a5102591f8dac3201781304e9329c1261cc09e6L348-R348)

These changes collectively improve code maintainability, reduce the risk of subtle bugs in key-value parsing, and make the parsing logic more consistent across the project.