### PR TITLE
[#noissue] Simplify string conversion in BytesUtils

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/BytesUtils.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.common.util;
 
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -625,11 +624,7 @@ public final class BytesUtils {
         if (length == 0) {
             return "";
         }
-        try {
-            return new String(bytes, offset, length, UTF8);
-        } catch (UnsupportedEncodingException e) {
-            return new String(bytes, offset, length, UTF8_CHARSET);
-        }
+        return new String(bytes, offset, length, UTF8_CHARSET);
     }
 
     public static String toStringAndRightTrim(final byte[] bytes, final int offset, final int length) {


### PR DESCRIPTION
This pull request refactors the `BytesUtils` utility class by simplifying the implementation of the `toString` method. The change removes unnecessary exception handling and uses the standard `Charset` object for decoding bytes, making the code cleaner and more efficient.

Code simplification and modernization:

* Removed the use of `UnsupportedEncodingException` and the legacy `String` constructor with encoding name in `BytesUtils.toString`, replacing it with the constructor that takes a `Charset` object (`UTF8_CHARSET`).
* Removed the unused import of `UnsupportedEncodingException` from `BytesUtils.java`.