### PR TITLE
[#noissue] Refactor BulkOperationMetrics to extract and test `cleanupParentClass` for class name processing

### DIFF
--- a/collector-monitor/src/test/java/com/navercorp/pinpoint/collector/monitor/micrometer/BulkOperationMetricsTest.java
+++ b/collector-monitor/src/test/java/com/navercorp/pinpoint/collector/monitor/micrometer/BulkOperationMetricsTest.java
@@ -1,0 +1,33 @@
+package com.navercorp.pinpoint.collector.monitor.micrometer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class BulkOperationMetricsTest {
+
+    @Test
+    void cleanupParentClass() {
+        String s = BulkOperationMetrics.cleanupParentClass("test$InnerClass$Another");
+        Assertions.assertEquals("test", s);
+
+        String s2 = BulkOperationMetrics.cleanupParentClass("test$InnerClass");
+        Assertions.assertEquals("test", s2);
+    }
+
+    @Test
+    void cleanupParentClassWithoutInnerClass() {
+        String s = BulkOperationMetrics.cleanupParentClass("test");
+        Assertions.assertEquals("test", s);
+    }
+
+    @Test
+    void cleanupParentClass_lambda() {
+        Runnable runnable = () -> {};
+
+        String simpleName = runnable.getClass().getSimpleName();
+        String s = BulkOperationMetrics.cleanupParentClass(simpleName);
+
+        Assertions.assertEquals("BulkOperationMetricsTest", s);
+    }
+
+}


### PR DESCRIPTION
…ParentClass` for class name processing

This pull request refactors how class names are processed for metric registration in `BulkOperationMetrics` by introducing a new utility method to clean up class names, and adds a corresponding unit test. The main goal is to simplify and clarify the extraction of parent class names for metric labeling.

**Refactoring and utility extraction:**

* Replaced the previous logic for extracting parent class names in `BulkOperationMetrics.registerMetrics()` with a new static method `cleanupParentClass`, which removes inner class suffixes from class names. [[1]](diffhunk://#diff-03b93467aa6697ad5a2e543889caf24462ef4b9e23a5386be3e18cb368cab172L48-R47) [[2]](diffhunk://#diff-03b93467aa6697ad5a2e543889caf24462ef4b9e23a5386be3e18cb368cab172R59-R67)
* Removed the unnecessary import of `StringUtils` as it is no longer used.

**Testing improvements:**

* Added a new unit test `BulkOperationMetricsTest` to verify the behavior of the `cleanupParentClass` method.