### PR TITLE
[#noissue] Refactor CollectorStateSerde

### DIFF
--- a/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/vo/ProfilerDescription.java
+++ b/realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/vo/ProfilerDescription.java
@@ -17,6 +17,8 @@ package com.navercorp.pinpoint.realtime.vo;
 
 import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
 
+import java.util.Objects;
+
 /**
  * @author youngjin.kim2
  */
@@ -25,7 +27,7 @@ public class ProfilerDescription {
     private final ClusterKey clusterKey;
 
     public ProfilerDescription(ClusterKey clusterKey) {
-        this.clusterKey = clusterKey;
+        this.clusterKey = Objects.requireNonNull(clusterKey, "clusterKey");
     }
 
     public ClusterKey getClusterKey() {
@@ -45,4 +47,17 @@ public class ProfilerDescription {
         return new ProfilerDescription(new ClusterKey(words[0], words[1], Long.parseLong(words[2])));
     }
 
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ProfilerDescription that = (ProfilerDescription) o;
+        return Objects.equals(clusterKey, that.clusterKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(clusterKey);
+    }
 }

--- a/realtime/realtime-common/src/test/java/com/navercorp/pinpoint/realtime/serde/CollectorStateSerdeTest.java
+++ b/realtime/realtime-common/src/test/java/com/navercorp/pinpoint/realtime/serde/CollectorStateSerdeTest.java
@@ -1,0 +1,35 @@
+package com.navercorp.pinpoint.realtime.serde;
+
+import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.realtime.vo.CollectorState;
+import com.navercorp.pinpoint.realtime.vo.ProfilerDescription;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CollectorStateSerdeTest {
+
+    @Test
+    void serde() throws IOException {
+        List<ProfilerDescription> profilers = List.of(
+                new ProfilerDescription(new ClusterKey("app1", "agent1", 1)),
+                new ProfilerDescription(new ClusterKey("app2", "agent2", 1))
+        );
+        CollectorState state = new CollectorState(profilers);
+
+        CollectorStateSerde serde = new CollectorStateSerde();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        serde.serialize(state, outputStream);
+        CollectorState deserializedState = serde.deserialize(new ByteArrayInputStream(outputStream.toByteArray()));
+
+        assertEquals(state.getProfilers(), deserializedState.getProfilers());
+    }
+
+}


### PR DESCRIPTION
This pull request improves the serialization and deserialization logic for `CollectorState` and enhances the robustness of the `ProfilerDescription` class. It also introduces a new unit test for `CollectorStateSerde`. The main changes focus on making the serialization process more precise, ensuring null safety, and providing proper equality checks for `ProfilerDescription`.

**Serialization and Deserialization Improvements:**
* Refactored `CollectorStateSerde` to use `BufferedReader` for deserialization, reading lines in UTF-8, and to write each profiler entry individually with explicit delimiters during serialization. This avoids issues with line splitting and encoding, and ensures more reliable data handling. (`realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/serde/CollectorStateSerde.java`)

**ProfilerDescription Enhancements:**
* Added null safety to the `ProfilerDescription` constructor by requiring a non-null `clusterKey`. (`realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/vo/ProfilerDescription.java`)
* Implemented `equals` and `hashCode` methods for `ProfilerDescription`, enabling proper comparison and usage in collections. (`realtime/realtime-common/src/main/java/com/navercorp/pinpoint/realtime/vo/ProfilerDescription.java`)

**Testing:**
* Added a unit test for `CollectorStateSerde` to verify correct serialization and deserialization of `CollectorState` objects. (`realtime/realtime-common/src/test/java/com/navercorp/pinpoint/realtime/serde/CollectorStateSerdeTest.java`)