### PR TITLE
[#noissue] Replace ApplicationUid with applicationName

### DIFF
--- a/agent-statistics/agent-statistics-collector/src/main/java/com/navercorp/pinpoint/agentstatistics/collector/dao/AgentInfoStatisticsDao.java
+++ b/agent-statistics/agent-statistics-collector/src/main/java/com/navercorp/pinpoint/agentstatistics/collector/dao/AgentInfoStatisticsDao.java
@@ -16,12 +16,11 @@
 package com.navercorp.pinpoint.agentstatistics.collector.dao;
 
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
-import com.navercorp.pinpoint.common.server.uid.ApplicationUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 
 /**
  * @author intr3p1d
  */
 public interface AgentInfoStatisticsDao {
-    void insert(ServiceUid serviceUid, ApplicationUid applicationUid, AgentInfoBo agentInfoBo);
+    void insert(ServiceUid serviceUid, String applicationName, AgentInfoBo agentInfoBo);
 }

--- a/agent-statistics/agent-statistics-collector/src/main/java/com/navercorp/pinpoint/agentstatistics/collector/dao/PinotAgentInfoStatisticsDao.java
+++ b/agent-statistics/agent-statistics-collector/src/main/java/com/navercorp/pinpoint/agentstatistics/collector/dao/PinotAgentInfoStatisticsDao.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.agentstatistics.collector.dao;
 import com.navercorp.pinpoint.agentstatistics.collector.entity.AgentInfoEntity;
 import com.navercorp.pinpoint.agentstatistics.collector.mapper.AgentInfoMapper;
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
-import com.navercorp.pinpoint.common.server.uid.ApplicationUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.pinot.kafka.util.KafkaCallbacks;
 import org.apache.logging.log4j.LogManager;
@@ -63,7 +62,7 @@ public class PinotAgentInfoStatisticsDao implements AgentInfoStatisticsDao {
     @Override
     public void insert(
             ServiceUid serviceUid,
-            ApplicationUid applicationUid,
+            String applicationName,
             AgentInfoBo agentInfoBo
     ) {
         Objects.requireNonNull(agentInfoBo, "agentInfoBo");

--- a/agent-statistics/agent-statistics-collector/src/main/java/com/navercorp/pinpoint/agentstatistics/collector/service/PinotAgentInfoStatisticsService.java
+++ b/agent-statistics/agent-statistics-collector/src/main/java/com/navercorp/pinpoint/agentstatistics/collector/service/PinotAgentInfoStatisticsService.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.agentstatistics.collector.service;
 import com.navercorp.pinpoint.agentstatistics.collector.dao.AgentInfoStatisticsDao;
 import com.navercorp.pinpoint.collector.service.AgentInfoStatisticsService;
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
-import com.navercorp.pinpoint.common.server.uid.ApplicationUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -52,11 +51,11 @@ public class PinotAgentInfoStatisticsService implements AgentInfoStatisticsServi
     @Override
     public void insert(
             Supplier<ServiceUid> serviceUidSupplier,
-            Supplier<ApplicationUid> applicationUidSupplier,
+            String applicationName,
             AgentInfoBo agentInfoBo
     ) {
         Objects.requireNonNull(serviceUidSupplier, "serviceUidSupplier");
-        Objects.requireNonNull(applicationUidSupplier, "applicationUidSupplier");
+        Objects.requireNonNull(applicationName, "applicationName");
         Objects.requireNonNull(agentInfoBo, "agentInfoBo");
 
         final String tenantId = tenantProvider.getTenantId();
@@ -66,7 +65,7 @@ public class PinotAgentInfoStatisticsService implements AgentInfoStatisticsServi
 
         agentInfoStatisticsDao.insert(
                 null, // TODO: will be replaced with serviceUidSupplier.get()
-                null, // TODO: will be replaced with applicationUidSupplier.get()
+                applicationName,
                 agentInfoBo
         );
     }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcAgentInfoHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcAgentInfoHandler.java
@@ -81,7 +81,7 @@ public class GrpcAgentInfoHandler implements RequestResponseHandler<PAgentInfo, 
             final AgentInfoBo agentInfoBo = this.agentInfoBoMapper.map(agentInfo, header);
             this.agentInfoService.insert(agentInfoBo);
             this.applicationIndexV2Service.insert(header.getServiceUid(), agentInfoBo);
-            this.agentInfoStatisticsService.insert(header.getServiceUid(), header.getApplicationUid(), agentInfoBo);
+            this.agentInfoStatisticsService.insert(header.getServiceUid(), header.getApplicationName(), agentInfoBo);
             return PResults.SUCCESS;
         } catch (Exception e) {
             logger.warn("Failed to handle. agentInfo={}", MessageFormatUtils.debugLog(agentInfo), e);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/service/AgentInfoStatisticsService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/service/AgentInfoStatisticsService.java
@@ -16,7 +16,6 @@
 package com.navercorp.pinpoint.collector.service;
 
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
-import com.navercorp.pinpoint.common.server.uid.ApplicationUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 
 import java.util.function.Supplier;
@@ -25,5 +24,5 @@ import java.util.function.Supplier;
  * @author intr3p1d
  */
 public interface AgentInfoStatisticsService {
-    void insert(Supplier<ServiceUid> serviceUidSupplier, Supplier<ApplicationUid> applicationUidSupplier, AgentInfoBo agentInfoBo);
+    void insert(Supplier<ServiceUid> serviceUidSupplier, String applicationName, AgentInfoBo agentInfoBo);
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/service/EmptyAgentInfoStatisticsService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/service/EmptyAgentInfoStatisticsService.java
@@ -16,7 +16,6 @@
 package com.navercorp.pinpoint.collector.service;
 
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
-import com.navercorp.pinpoint.common.server.uid.ApplicationUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Service;
@@ -30,7 +29,7 @@ import java.util.function.Supplier;
 @Service
 public class EmptyAgentInfoStatisticsService implements AgentInfoStatisticsService {
     @Override
-    public void insert(Supplier<ServiceUid> serviceUidSupplier, Supplier<ApplicationUid> applicationUidSupplier, AgentInfoBo agentInfoBo) {
+    public void insert(Supplier<ServiceUid> serviceUidSupplier, String applicationName, AgentInfoBo agentInfoBo) {
         // do nothing
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/io/request/GrpcServerHeaderV1.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/io/request/GrpcServerHeaderV1.java
@@ -4,6 +4,7 @@ import com.navercorp.pinpoint.common.server.uid.ApplicationUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.grpc.Header;
 import com.navercorp.pinpoint.io.request.supplier.UidSuppliers;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Map;
 import java.util.Objects;
@@ -25,21 +26,25 @@ public class GrpcServerHeaderV1 implements ServerHeader {
         this.uidFetcher = Objects.requireNonNull(uidFetcher, "uidFetcher");
     }
 
+    @NonNull
     @Override
     public String getAgentId() {
         return header.getAgentId();
     }
 
+    @NonNull
     @Override
     public String getAgentName() {
         return header.getAgentName();
     }
 
+    @NonNull
     @Override
     public String getApplicationName() {
         return header.getApplicationName();
     }
 
+    @NonNull
     @Override
     public Supplier<ApplicationUid> getApplicationUid() {
         String applicationName = getApplicationName();
@@ -47,6 +52,7 @@ public class GrpcServerHeaderV1 implements ServerHeader {
         return UidSuppliers.of(applicationName, future);
     }
 
+    @NonNull
     @Override
     public String getServiceName() {
         return header.getServiceName();

--- a/collector/src/main/java/com/navercorp/pinpoint/io/request/ServerHeader.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/io/request/ServerHeader.java
@@ -2,23 +2,25 @@ package com.navercorp.pinpoint.io.request;
 
 import com.navercorp.pinpoint.common.server.uid.ApplicationUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import org.jspecify.annotations.NonNull;
 
 import java.util.function.Supplier;
 
 public interface ServerHeader {
 
+    @NonNull
     String getAgentId();
 
+    @NonNull
     String getAgentName();
 
-    // -----------------
-
+    // Application -----------------
+    @NonNull
     String getApplicationName();
 
     Supplier<ApplicationUid> getApplicationUid();
 
-    // -----------------
-
+    // Service -----------------
     String getServiceName();
 
     Supplier<ServiceUid> getServiceUid();


### PR DESCRIPTION
This pull request refactors the way agent information statistics are inserted by replacing the use of the `ApplicationUid` class with a simple `String` representing the application name throughout the service and DAO layers. This change simplifies the interface and removes unnecessary dependencies on the `ApplicationUid` type.

**Refactoring to Use Application Name String Instead of ApplicationUid:**

* Changed the `AgentInfoStatisticsDao` and its implementation (`PinotAgentInfoStatisticsDao`) to accept a `String applicationName` instead of an `ApplicationUid` when inserting agent info statistics. [[1]](diffhunk://#diff-bcda9b2ff0eb8bd5f6c650abaa84e975475e3f4c3d958830f719dd4c84c3b435L19-R25) [[2]](diffhunk://#diff-037e25c6806b55b3b6e9e16aa8ce00b74c0847fef4edf4cad66c6fc296c3f6b0L66-R65)
* Updated the `AgentInfoStatisticsService` interface and its implementations (`PinotAgentInfoStatisticsService`, `EmptyAgentInfoStatisticsService`) to use `String applicationName` instead of `Supplier<ApplicationUid>`. [[1]](diffhunk://#diff-56c838d2b094dd9652611cf90a4fbb16a9aa9d0c460f68b87c98b1e605d1f889L28-R27) [[2]](diffhunk://#diff-50b8f17d436a7413293b6b0c9a4b2448b362ae5323ae32ad18fc477b00b8f393L55-R58) [[3]](diffhunk://#diff-8d1e9429c03d6b1e58e527cf206e57a3045b677b26baf1eee0e297f3dceb944eL33-R32)
* Modified the call sites, such as in `GrpcAgentInfoHandler`, to pass `header.getApplicationName()` instead of `header.getApplicationUid()`.

**Dependency Cleanup:**

* Removed unnecessary imports of `ApplicationUid` from affected files. [[1]](diffhunk://#diff-037e25c6806b55b3b6e9e16aa8ce00b74c0847fef4edf4cad66c6fc296c3f6b0L21) [[2]](diffhunk://#diff-50b8f17d436a7413293b6b0c9a4b2448b362ae5323ae32ad18fc477b00b8f393L21) [[3]](diffhunk://#diff-56c838d2b094dd9652611cf90a4fbb16a9aa9d0c460f68b87c98b1e605d1f889L19) [[4]](diffhunk://#diff-8d1e9429c03d6b1e58e527cf206e57a3045b677b26baf1eee0e297f3dceb944eL19)

**Internal Logic Adjustments:**

* Updated null checks and comments to reflect the change from `applicationUidSupplier` to `applicationName`. [[1]](diffhunk://#diff-50b8f17d436a7413293b6b0c9a4b2448b362ae5323ae32ad18fc477b00b8f393L55-R58) [[2]](diffhunk://#diff-50b8f17d436a7413293b6b0c9a4b2448b362ae5323ae32ad18fc477b00b8f393L69-R68)