### PR TITLE
[#noissue] Add serviceName field

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/io/request/BindAttributes.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/io/request/BindAttributes.java
@@ -24,6 +24,7 @@ public class BindAttributes {
         return new BindAttribute(header.getAgentId(),
                 header.getAgentName(),
                 header.getApplicationName(),
+                header.getServiceName(),
                 header.getAgentStartTime(),
                 acceptedTime);
     }

--- a/collector/src/main/java/com/navercorp/pinpoint/io/request/GrpcServerHeaderV1.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/io/request/GrpcServerHeaderV1.java
@@ -1,14 +1,11 @@
 package com.navercorp.pinpoint.io.request;
 
-import com.navercorp.pinpoint.common.server.uid.ApplicationUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.grpc.Header;
-import com.navercorp.pinpoint.io.request.supplier.UidSuppliers;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 
@@ -44,15 +41,6 @@ public class GrpcServerHeaderV1 implements ServerHeader {
         return header.getApplicationName();
     }
 
-    @NonNull
-    @Override
-    public Supplier<ApplicationUid> getApplicationUid() {
-        String applicationName = getApplicationName();
-        CompletableFuture<ApplicationUid> future = this.uidFetcher.getApplicationUid(ServiceUid.DEFAULT, applicationName, getServiceType());
-        return UidSuppliers.of(applicationName, future);
-    }
-
-    @NonNull
     @Override
     public String getServiceName() {
         return header.getServiceName();

--- a/collector/src/main/java/com/navercorp/pinpoint/io/request/ServerHeader.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/io/request/ServerHeader.java
@@ -1,6 +1,5 @@
 package com.navercorp.pinpoint.io.request;
 
-import com.navercorp.pinpoint.common.server.uid.ApplicationUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import org.jspecify.annotations.NonNull;
 
@@ -17,8 +16,6 @@ public interface ServerHeader {
     // Application -----------------
     @NonNull
     String getApplicationName();
-
-    Supplier<ApplicationUid> getApplicationUid();
 
     // Service -----------------
     String getServiceName();

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/BasicSpan.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/BasicSpan.java
@@ -34,6 +34,9 @@ public interface BasicSpan {
     String getApplicationName();
     void setApplicationName(String applicationName);
 
+    String getServiceName();
+    void setServiceName(String serviceName);
+
     long getAgentStartTime();
     void setAgentStartTime(long agentStartTime);
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.common.server.bo;
 
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.ByteUtils;
 import com.navercorp.pinpoint.common.server.util.NumberPrecondition;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
@@ -44,6 +45,9 @@ public class SpanBo implements Event, BasicSpan {
 
     @NonNull
     private String applicationName;
+
+    @NonNull
+    private String serviceName = ServiceUid.DEFAULT_SERVICE_UID_NAME;
 
     private long agentStartTime;
 
@@ -110,6 +114,7 @@ public class SpanBo implements Event, BasicSpan {
         this.transactionId = transactionId;
     }
 
+    @NonNull
     @Override
     public String getAgentId() {
         return agentId;
@@ -131,6 +136,7 @@ public class SpanBo implements Event, BasicSpan {
     }
 
 
+    @NonNull
     @Override
     public String getApplicationName() {
         return applicationName;
@@ -140,6 +146,19 @@ public class SpanBo implements Event, BasicSpan {
     public void setApplicationName(String applicationName) {
         this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
     }
+
+    @NonNull
+    @Override
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    @Override
+    public void setServiceName(String applicationName) {
+        this.serviceName = StringPrecondition.requireHasLength(applicationName, "applicationName");
+    }
+
+    //------------
 
     @Override
     public long getAgentStartTime() {
@@ -436,6 +455,8 @@ public class SpanBo implements Event, BasicSpan {
         private String agentId;
         private String agentName;
         private String applicationName;
+        private String serviceName;
+
         private long agentStartTime;
 
         private ServerTraceId transactionId;
@@ -495,16 +516,13 @@ public class SpanBo implements Event, BasicSpan {
             return this;
         }
 
-        /**
-         * @deprecated 3.1.0 Use {@link #setApplicationName(String)} instead.
-         */
-        @Deprecated
-        public Builder setApplicationId(String applicationName) {
-            return setApplicationName(applicationName);
-        }
-
         public Builder setApplicationName(String applicationName) {
             this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
+            return this;
+        }
+
+        public Builder setServiceName(String serviceName) {
+            this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
             return this;
         }
 
@@ -626,9 +644,17 @@ public class SpanBo implements Event, BasicSpan {
         public SpanBo build() {
             SpanBo result = new SpanBo();
             result.setVersion(this.version);
+
             result.setAgentId(StringPrecondition.requireHasLength(this.agentId, "agentId"));
             result.setAgentName(this.agentName);
             result.setApplicationName(StringPrecondition.requireHasLength(this.applicationName, "applicationName"));
+            if (serviceName == null) {
+                this.serviceName = ServiceUid.DEFAULT_SERVICE_UID_NAME;
+            }
+            result.setServiceName(StringPrecondition.requireHasLength(this.serviceName, "serviceName"));
+
+
+
             result.setAgentStartTime(this.agentStartTime);
             result.setTransactionId(this.transactionId);
             result.setSpanId(this.spanId);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.common.server.bo;
 
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.ByteUtils;
 import com.navercorp.pinpoint.common.server.util.NumberPrecondition;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
@@ -40,6 +41,9 @@ public class SpanChunkBo implements BasicSpan {
     private String agentName;
     @NonNull
     private String applicationName;
+    @NonNull
+    private String serviceName = ServiceUid.DEFAULT_SERVICE_UID_NAME;
+
     private long agentStartTime;
 
     private ServerTraceId transactionId;
@@ -87,6 +91,7 @@ public class SpanChunkBo implements BasicSpan {
         this.agentName = agentName;
     }
 
+    @NonNull
     @Override
     public String getApplicationName() {
         return applicationName;
@@ -94,6 +99,17 @@ public class SpanChunkBo implements BasicSpan {
 
     public void setApplicationName(String applicationName) {
         this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
+    }
+
+    @NonNull
+    @Override
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    @Override
+    public void setServiceName(String serviceName) {
+        this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
     }
 
     @Override
@@ -195,6 +211,7 @@ public class SpanChunkBo implements BasicSpan {
                 ", agentId='" + agentId + '\'' +
                 ", agentName='" + agentName + '\'' +
                 ", applicationName='" + applicationName + '\'' +
+                ", serviceName='" + serviceName + '\'' +
                 ", agentStartTime=" + agentStartTime +
                 ", transactionId=" + transactionId +
                 ", spanId=" + spanId +

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/BindAttribute.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/BindAttribute.java
@@ -16,13 +16,13 @@
 
 package com.navercorp.pinpoint.common.server.bo.grpc;
 
-import java.util.Objects;
+import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 
 public class BindAttribute {
     private final String agentId;
     private final String agentName;
     private final String applicationName;
-
+    private final String serviceName;
 
     private final long agentStartTime;
     private final long acceptedTime;
@@ -30,11 +30,13 @@ public class BindAttribute {
     public BindAttribute(String agentId,
                          String agentName,
                          String applicationName,
+                         String serviceName,
                          long agentStartTime,
                          long acceptedTime) {
-        this.agentId = Objects.requireNonNull(agentId, "agentId");
+        this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
         this.agentName = agentName;
-        this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
+        this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
+        this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
         this.agentStartTime = agentStartTime;
         this.acceptedTime = acceptedTime;
     }
@@ -55,6 +57,9 @@ public class BindAttribute {
         return this.applicationName;
     }
 
+    public String getServiceName() {
+        return serviceName;
+    }
 
     public long getAgentStartTime() {
         return this.agentStartTime;
@@ -66,6 +71,7 @@ public class BindAttribute {
                "agentId='" + agentId + '\'' +
                ", agentName='" + agentName + '\'' +
                ", applicationName='" + applicationName + '\'' +
+                ", serviceName='" + serviceName + '\'' +
                ", agentStartTime=" + agentStartTime +
                ", acceptedTime=" + acceptedTime +
                '}';

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/grpc/CollectorGrpcSpanFactoryTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/grpc/CollectorGrpcSpanFactoryTest.java
@@ -41,7 +41,7 @@ public class CollectorGrpcSpanFactoryTest {
     private final BindAttribute attribute = newAttribute();
 
     private BindAttribute newAttribute() {
-        return new BindAttribute("agentId", "agentName", "applicationName", 88, System.currentTimeMillis());
+        return new BindAttribute("agentId", "agentName", "applicationName", "serviceName", 88, System.currentTimeMillis());
     }
 
     private final GrpcSpanFactory factory = new CollectorGrpcSpanFactory(binder, filter);

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/grpc/GrpcSpanBinderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/grpc/GrpcSpanBinderTest.java
@@ -28,7 +28,8 @@ class GrpcSpanBinderTest {
 
     GrpcSpanBinder grpcSpanBinder = new GrpcSpanBinder();
 
-    BindAttribute bindAttribute = new BindAttribute("agentId-1", "agentName-1", "appName-1", 1234, System.currentTimeMillis());
+    BindAttribute bindAttribute = new BindAttribute("agentId-1", "agentName-1", "appName-1", "serviceName",
+            1234, System.currentTimeMillis());
 
     @Test
     void bindSpanBo_parentApplicationName_invalid() {

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/grpc/SpanFactoryTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/grpc/SpanFactoryTest.java
@@ -46,7 +46,7 @@ public class SpanFactoryTest {
 
     private final long spanAcceptTime = System.currentTimeMillis();
 
-    private final BindAttribute attribute = new BindAttribute("agentId", "agentName", "applicationName", 88, spanAcceptTime);
+    private final BindAttribute attribute = new BindAttribute("agentId", "agentName", "applicationName", "serviceName", 88, spanAcceptTime);
     private final GrpcSpanBinder grpcSpanBinder = new GrpcSpanBinder();
     private final SpanEventFilter filter = new EmptySpanEventFilter();
     private final GrpcSpanFactory grpcSpanFactory = new CollectorGrpcSpanFactory(grpcSpanBinder, filter);

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
@@ -58,7 +58,8 @@ public class SpanEncoderTest {
     private final RandomTSpan randomTSpan = new RandomTSpan();
     private final Random random = new Random();
 
-    private final BindAttribute attribute = new BindAttribute("agentId", "agentName", "applicationName", 88, spanAcceptedTime);
+    private final BindAttribute attribute = new BindAttribute("agentId", "agentName", "applicationName", "serviceName",
+            88, spanAcceptedTime);
     private final GrpcSpanBinder grpcSpanBinder = new GrpcSpanBinder();
     private final SpanEventFilter filter = new EmptySpanEventFilter();
     private final GrpcSpanFactory grpcSpanFactory = new CollectorGrpcSpanFactory(grpcSpanBinder, filter);

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
@@ -219,6 +219,7 @@ public class RecordFactoryTest {
                 .setAgentId("express-node-sample-id")
                 .setAgentName("")
                 .setApplicationName("express-node-sample-name")
+                .setServiceName("express-node-sample-service")
                 .setAgentStartTime(1670293953108L)
                 .setTransactionId(new PinpointServerTraceId("express-node-sample-id", 1670293953108L, 30))
                 .setParentSpanId(-1)


### PR DESCRIPTION
This pull request introduces support for a new `serviceName` field throughout the tracing and span infrastructure. The changes ensure that both `SpanBo` and `SpanChunkBo` objects, as well as related classes and tests, now handle `serviceName` in addition to `applicationName`. Additionally, some unused code related to `ApplicationUid` fetching has been removed from the server header logic.

### Service name support in tracing objects

* Added `serviceName` field, getter, and setter to `BasicSpan`, `SpanBo`, and `SpanChunkBo`, including their builders and `toString()` methods, ensuring all span objects can carry service name information. [[1]](diffhunk://#diff-7ad1631ecb4e72ee628f32197b53b57a61a5e3df01b34c2ffaa24960f0b52514R37-R39) [[2]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bR48-R50) [[3]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bR138) [[4]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bR149-R161) [[5]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bR457-R458) [[6]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL498-R527) [[7]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bR646-R652) [[8]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cR43-R45) [[9]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cR93) [[10]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cR103-R113) [[11]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cR213)

* Updated `BindAttribute` to include a required `serviceName` field, with appropriate validation and accessors. [[1]](diffhunk://#diff-8c34430050baa9dc3e052b267a4e50dd626e42468d8df8021a85a135ae47139bL19-R39) [[2]](diffhunk://#diff-8c34430050baa9dc3e052b267a4e50dd626e42468d8df8021a85a135ae47139bR60-R62) [[3]](diffhunk://#diff-8c34430050baa9dc3e052b267a4e50dd626e42468d8df8021a85a135ae47139bR74)

### Test updates for service name

* Modified all test instantiations of `BindAttribute` to supply the new `serviceName` parameter. [[1]](diffhunk://#diff-c70a724a4d5d1404eab76c7cc286e890dac27cb41e5d5ad840bb5aafdc0b7206L31-R32) [[2]](diffhunk://#diff-5e1bb96e57bc62ce1ebd0cb922481fe59a4d71ff102a48d8931dc997cc97a581L49-R49) [[3]](diffhunk://#diff-c87ed6d0d98610e18522cb3f5adedcfc1f608b5f255f882b9691b9fd06be4965L61-R62)

### Server header interface simplification

* Removed the `getApplicationUid()` method from `ServerHeader` and its implementation in `GrpcServerHeaderV1`, cleaning up unused UID fetching logic. [[1]](diffhunk://#diff-4e40c2ecb1f5fc459b7005a898f88d38cb60d6e5b558a152c5d65e07cfd5a73cL21-L22) [[2]](diffhunk://#diff-7ddda804704984fe45b37a998c9d1040eef3b2da8b914851aaa7fa3985b19ac7L47-L55) [[3]](diffhunk://#diff-4e40c2ecb1f5fc459b7005a898f88d38cb60d6e5b558a152c5d65e07cfd5a73cL3) [[4]](diffhunk://#diff-7ddda804704984fe45b37a998c9d1040eef3b2da8b914851aaa7fa3985b19ac7L3-L11)