### PR TITLE
[#noissue] Replace deprecated RestTemplateBuilder methods

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/config/RestTemplateConfiguration.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/config/RestTemplateConfiguration.java
@@ -31,8 +31,8 @@ public class RestTemplateConfiguration {
     @Bean
     public RestTemplateBuilder restTemplateBuilder(RestTemplateBuilderConfigurer configurer) {
         return configurer.configure(new RestTemplateBuilder())
-                .setConnectTimeout(Duration.ofMillis(3000))
-                .setReadTimeout(Duration.ofMillis(6000));
+                .connectTimeout(Duration.ofMillis(3000))
+                .readTimeout(Duration.ofMillis(6000));
     }
 
 


### PR DESCRIPTION
This pull request makes a minor update to the `RestTemplateConfiguration` class, replacing deprecated `setConnectTimeout` and `setReadTimeout` methods with the recommended `connectTimeout` and `readTimeout` methods when configuring the `RestTemplateBuilder`.