### PR TITLE
[#13287] Improved MyBatis TypeHandler configuration

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/config/AlarmJobConfig.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/config/AlarmJobConfig.java
@@ -30,7 +30,7 @@ import com.navercorp.pinpoint.batch.alarm.dao.pinot.PinotAlarmDao;
 import com.navercorp.pinpoint.batch.alarm.vo.AppAlarmChecker;
 import com.navercorp.pinpoint.batch.common.BatchProperties;
 import com.navercorp.pinpoint.batch.common.Divider;
-import com.navercorp.pinpoint.batch.alarm.dao.AlarmDao; // PinotAlarmDao용 인터페이스 import
+import com.navercorp.pinpoint.batch.alarm.dao.AlarmDao;
 import com.navercorp.pinpoint.batch.dao.mysql.MysqlAlarmDao;
 import com.navercorp.pinpoint.batch.service.AlarmService;
 import com.navercorp.pinpoint.batch.service.AlarmServiceImpl;
@@ -60,34 +60,19 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.retry.interceptor.RetryInterceptorBuilder;
 import org.springframework.retry.interceptor.RetryOperationsInterceptor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.transaction.PlatformTransactionManager;
 
-/**
- * XML(job/applicationContext-alarmJob.xml) 정의를 Java Config로 옮긴 설정.
- *
- * BatchJavaConfigModule에 의해 조건부 로드됨
- *
- * 주의: Job/Step/bean 이름이 BatchJobLauncher에서 사용하는 문자열과 동일해야 합니다.
- *
- * 참고: AlarmCheckerConfiguration, BatchPinotDaoConfiguration은
- *      AlarmJobModule에서 이미 Import하므로 여기서는 제외
- */
 @Configuration(proxyBeanMethods = false)
 public class AlarmJobConfig {
-
-    // ---- job / steps
 
     @Bean
     public Job alarmJob(JobRepository jobRepository,
                         @Qualifier("alarmPartitionStep") Step alarmPartitionStep,
-                        @Qualifier("jobFailListener") Object jobFailListener) { // jobFailListener 타입은 BatchInfrastructureConfig를 따름
-        // XML에서는 jobFailListener가 참조되지만, 현재 컨텍스트(XML 인프라)에서 해당 빈을 제공합니다.
-        // XML 정의: <batch:listener ref="jobFailListener"/>
+                        @Qualifier("jobFailListener") Object jobFailListener) {
         return new JobBuilder("alarmJob", jobRepository)
                 .start(alarmPartitionStep)
                 .listener((org.springframework.batch.core.JobExecutionListener) jobFailListener)
@@ -113,14 +98,13 @@ public class AlarmJobConfig {
 
     @Bean(name = "alarmStep")
     public TaskletStep alarmStep(JobRepository jobRepository,
-                                 @Qualifier("transactionManager") PlatformTransactionManager transactionManager, // 기본 TM 사용
+                                 @Qualifier("transactionManager") PlatformTransactionManager transactionManager,
                                  @Qualifier("alarmExecutor") TaskExecutor alarmExecutor,
                                  @Qualifier("reader") ItemReader<Application> reader,
                                  @Qualifier("processor") ItemProcessor<Application, AppAlarmChecker> processor,
                                  @Qualifier("writer") ItemWriter<AppAlarmChecker> writer,
                                  @Value("${alarm.worker.maxSize:2}") int throttleLimit) {
 
-        // XML: commit-interval=1, task-executor=alarmExecutor, throttle-limit=${alarm.worker.maxSize:2}
         return new StepBuilder("alarmStep", jobRepository)
                 .<Application, AppAlarmChecker>chunk(1, transactionManager)
                 .reader(reader)
@@ -130,8 +114,6 @@ public class AlarmJobConfig {
                 .throttleLimit(throttleLimit)
                 .build();
     }
-
-    // ---- infrastructure beans from XML
 
     @Bean(name = "alarmExecutor")
     public ThreadPoolTaskExecutor alarmExecutor(
@@ -157,8 +139,6 @@ public class AlarmJobConfig {
         executor.setThreadNamePrefix("alarm-partition-");
         return executor;
     }
-
-    // ---- batch beans (step scope)
 
     @Bean(name = "alarmPartitioner")
     public Partitioner alarmPartitioner(Optional<Divider> divider) {
@@ -188,8 +168,6 @@ public class AlarmJobConfig {
                                      ObjectProvider<AlarmWriterInterceptor> alarmWriterInterceptor) {
         return new AlarmWriter(alarmMessageSender, batchAlarmService, alarmWriterInterceptor.getIfAvailable());
     }
-
-    // ---- Alarm Service & DAO (from XML) ----
 
     @Bean
     public com.navercorp.pinpoint.batch.dao.AlarmDao batchAlarmDao(

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/config/BatchRegistryHandler.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/config/BatchRegistryHandler.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.batch.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.batch.alarm.dao.model.BatchQueryParameter;
 import com.navercorp.pinpoint.batch.alarm.vo.AgentFieldUsage;
 import com.navercorp.pinpoint.batch.alarm.vo.AgentUsage;
@@ -25,13 +26,29 @@ import com.navercorp.pinpoint.common.model.TagInformation;
 import com.navercorp.pinpoint.metric.common.model.Tag;
 import com.navercorp.pinpoint.metric.common.mybatis.typehandler.TagTypeHandler;
 import com.navercorp.pinpoint.mybatis.MyBatisRegistryHandler;
+import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.TypeAliasRegistry;
 import org.apache.ibatis.type.TypeHandlerRegistry;
+import org.apache.ibatis.type.TypeReference;
+
+import java.util.List;
+import java.util.Objects;
 
 /**
  * @author minwoo-jung
  */
 public class BatchRegistryHandler implements MyBatisRegistryHandler {
+
+    private final ObjectMapper mapper;
+
+    public BatchRegistryHandler(ObjectMapper mapper) {
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+    }
+
+    public void registerHandlers(Configuration config) {
+        registerTypeAlias(config.getTypeAliasRegistry());
+        registerTypeHandler(config.getTypeHandlerRegistry());
+    }
 
     @Override
     public void registerTypeAlias(TypeAliasRegistry typeAliasRegistry) {
@@ -47,5 +64,8 @@ public class BatchRegistryHandler implements MyBatisRegistryHandler {
     @Override
     public void registerTypeHandler(TypeHandlerRegistry typeHandlerRegistry) {
         typeHandlerRegistry.register(Tag.class, TagTypeHandler.class);
+
+        TypeReference<List<Tag>> javaTypeReference = new TypeReference<>() {};
+        typeHandlerRegistry.register(javaTypeReference, new MultiValueTagTypeHandler(mapper));
     }
 }


### PR DESCRIPTION
This pull request refactors the batch configuration for alarm jobs and Pinot DAO integration, focusing on code cleanup, improved modularity, and better type handler registration for MyBatis. The main changes remove outdated XML-related comments, streamline bean definitions, and enhance the registration of custom type handlers using Jackson's `ObjectMapper`.

**Batch configuration and cleanup:**

* Removed legacy and redundant XML-based comments and section markers from `AlarmJobConfig.java` to improve readability and maintainability. [[1]](diffhunk://#diff-c8738a4c8da9d120d1bf27add0fa8e3726b8e3a1ff91f35d00133c2455301becL63-R75) [[2]](diffhunk://#diff-c8738a4c8da9d120d1bf27add0fa8e3726b8e3a1ff91f35d00133c2455301becL116-L123) [[3]](diffhunk://#diff-c8738a4c8da9d120d1bf27add0fa8e3726b8e3a1ff91f35d00133c2455301becL134-L135) [[4]](diffhunk://#diff-c8738a4c8da9d120d1bf27add0fa8e3726b8e3a1ff91f35d00133c2455301becL161-L162) [[5]](diffhunk://#diff-c8738a4c8da9d120d1bf27add0fa8e3726b8e3a1ff91f35d00133c2455301becL192-L193)
* Cleaned up unused imports and simplified import statements in `AlarmJobConfig.java`.

**MyBatis registry and type handler improvements:**

* Refactored `BatchRegistryHandler` to accept an `ObjectMapper` via constructor injection, ensuring all custom type handlers have access to JSON serialization/deserialization. [[1]](diffhunk://#diff-98494995577caa743904afa40fcd61b9990e1f1ff970b4746d00a753b70677d0R19) [[2]](diffhunk://#diff-98494995577caa743904afa40fcd61b9990e1f1ff970b4746d00a753b70677d0R29-R52)
* Added a `registerHandlers` method to `BatchRegistryHandler` for unified registration of type aliases and type handlers, and updated the batch configuration to use this method instead of a local helper. [[1]](diffhunk://#diff-98494995577caa743904afa40fcd61b9990e1f1ff970b4746d00a753b70677d0R29-R52) [[2]](diffhunk://#diff-09450889b0137f975afbb70bbb1f1368232f529a6835790122c864df462bd242L57-R59)
* Registered a new type handler for `List<Tag>` using Jackson in `BatchRegistryHandler`, improving support for complex types in MyBatis mappings.

**Pinot DAO configuration updates:**

* Updated `BatchPinotDaoConfiguration` to inject and use the new `BatchRegistryHandler` bean, ensuring consistent type handler setup for batch-related MyBatis sessions. [[1]](diffhunk://#diff-09450889b0137f975afbb70bbb1f1368232f529a6835790122c864df462bd242R19-L20) [[2]](diffhunk://#diff-09450889b0137f975afbb70bbb1f1368232f529a6835790122c864df462bd242R48) [[3]](diffhunk://#diff-09450889b0137f975afbb70bbb1f1368232f529a6835790122c864df462bd242L57-R59) [[4]](diffhunk://#diff-09450889b0137f975afbb70bbb1f1368232f529a6835790122c864df462bd242L74-R78)