### PR TITLE
[#noissue] Add methods to add annotations and span events in SpanBo and SpanChunkBo

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
@@ -223,6 +223,12 @@ public class SpanBo implements BasicSpan {
         return annotationBoList;
     }
 
+    public void addAnnotation(AnnotationBo annotationBo) {
+        if (annotationBo == null) {
+            return;
+        }
+        this.annotationBoList.add(annotationBo);
+    }
 
     public void setAnnotationBoList(List<AnnotationBo> anoList) {
         if (anoList == null) {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
@@ -176,6 +176,13 @@ public class SpanChunkBo implements BasicSpan {
         this.spanEventBoList.addAll(spanEventBoList);
     }
 
+    public void addSpanEvent(SpanEventBo spanEvent) {
+        if (spanEvent == null) {
+            return;
+        }
+        this.spanEventBoList.add(spanEvent);
+    }
+
     public boolean isAsyncSpanChunk() {
         return localAsyncId != null;
     }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanEventBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanEventBo.java
@@ -151,6 +151,17 @@ public class SpanEventBo {
         this.annotationBoList = annotationList;
     }
 
+    public void addAnnotation(AnnotationBo annotation) {
+        if (annotation == null) {
+            return;
+        }
+        if (this.annotationBoList == null) {
+            this.annotationBoList = new ArrayList<>();
+        }
+        this.annotationBoList.add(annotation);
+    }
+
+
     public boolean hasException() {
         return exceptionInfo != null;
     }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/AnnotationWriter.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/AnnotationWriter.java
@@ -1,0 +1,7 @@
+package com.navercorp.pinpoint.common.server.bo.grpc;
+
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+
+public interface AnnotationWriter {
+    void write(AnnotationBo annotationBo);
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/SpanEventWriter.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/grpc/SpanEventWriter.java
@@ -1,0 +1,7 @@
+package com.navercorp.pinpoint.common.server.bo.grpc;
+
+import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+
+public interface SpanEventWriter {
+    void write(SpanEventBo spanEvent);
+}


### PR DESCRIPTION
…nd SpanChunkBo

This pull request refactors how annotations and span events are read and added to `SpanBo`, `SpanChunkBo`, and `SpanEventBo` objects in the trace serialization code. The changes improve code clarity and extensibility by introducing writer interfaces and switching from bulk list operations to per-item addition via functional interfaces.

### API and Interface Improvements

* Introduced new interfaces `AnnotationWriter` and `SpanEventWriter` for writing individual `AnnotationBo` and `SpanEventBo` objects, respectively. This enables more flexible and functional-style processing when reading data. [[1]](diffhunk://#diff-d9f4a31a95fab635fc87b34e7589a83737ca12bc4f33f21b6664f0ea36ff3d1fR1-R7) [[2]](diffhunk://#diff-3193cdcee7e218f2ea3658fb6f1010092fdceffcb5e97ca6fd9d55e3ff174705R1-R7)

### Refactoring of Data Reading Logic

* Refactored the annotation and span event reading methods in `SpanDecoderV0.java` to use the new writer interfaces and per-item addition, replacing bulk list creation and assignment. This affects how annotations and span events are added to `SpanBo`, `SpanChunkBo`, and `SpanEventBo`. [[1]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L105-R104) [[2]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L169-L182) [[3]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L194-L198) [[4]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L278-R271) [[5]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L321-R313) [[6]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L332-L351)

### Addition of Per-Item Add Methods

* Added `addAnnotation` methods to `SpanBo` and `SpanEventBo`, and an `addSpanEvent` method to `SpanChunkBo`, allowing for safe, incremental addition of individual items. These methods handle null values and lazy initialization of internal lists. [[1]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bR226-R234) [[2]](diffhunk://#diff-f6f9636234f326690b5e8c0c7d92e249ba7d5388e9abdd8fb41c3cd5797a72e7R154-R164) [[3]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cR179-R185)

### Minor Code Cleanups

* Removed unused imports and unnecessary code in `SpanDecoderV0.java` for better readability.
* Fixed a minor typo by removing a redundant semicolon in `readQualifier`.
* Improved logging for sequence overflow scenarios in `readQualifier`.