### PR TITLE
[#noissue] Refactor annotation handling in OtlpTraceMapperUtils and related classes to use AnnotationWriter

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
 import com.navercorp.pinpoint.common.profiler.name.Base64Utils;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.server.bo.grpc.AnnotationWriter;
 import com.navercorp.pinpoint.common.server.util.Base16Utils;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.util.ArrayUtils;
@@ -92,16 +93,16 @@ public class OtlpTraceMapperUtils {
         return ByteArrayUtils.bytesToLong(bytes, 0);
     }
 
-    public static void addAttributesToAnnotation(ObjectMapper objectMapper, List<KeyValue> keyValueList, List<AnnotationBo> annotationBoList) {
+    public static void addAttributesToAnnotation(ObjectMapper objectMapper, List<KeyValue> keyValueList, AnnotationWriter annotationWriter) {
         try {
             final Map<String, Object> map = getAttributeToMap(keyValueList);
             if (!map.isEmpty()) {
                 map.entrySet().removeIf(entry -> OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY_MAP.containsKey(entry.getKey()));
                 final String value = objectMapper.writeValueAsString(map);
-                annotationBoList.add(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_ATTRIBUTE.getCode(), value));
+                annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_ATTRIBUTE.getCode(), value));
             }
         } catch (JsonProcessingException e) {
-            annotationBoList.add(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_ATTRIBUTE.getCode(), "json processing error"));
+            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_ATTRIBUTE.getCode(), "json processing error"));
         }
     }
 
@@ -142,7 +143,7 @@ public class OtlpTraceMapperUtils {
         }
     }
 
-    public static void addEventToAnnotation(ObjectMapper objectMapper, Span.Event event, List<AnnotationBo> annotationBoList) {
+    public static void addEventToAnnotation(ObjectMapper objectMapper, Span.Event event, AnnotationWriter annotationWriter) {
         if (event.getName() == null) {
             return;
         }
@@ -155,13 +156,13 @@ public class OtlpTraceMapperUtils {
                 map.put(event.getName(), "");
             }
             final String value = objectMapper.writeValueAsString(map);
-            annotationBoList.add(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), value));
+            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), value));
         } catch (JsonProcessingException e) {
-            annotationBoList.add(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), "json processing error"));
+            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), "json processing error"));
         }
     }
 
-    public static void addLinkToAnnotation(ObjectMapper objectMapper, Span.Link link, List<AnnotationBo> annotationBoList) {
+    public static void addLinkToAnnotation(ObjectMapper objectMapper, Span.Link link, AnnotationWriter annotationWriter) {
         try {
             Map<String, Object> map = new HashMap<>();
             if (!link.getTraceId().isEmpty()) {
@@ -174,9 +175,9 @@ public class OtlpTraceMapperUtils {
                 map.put("attributes", getAttributeToMap(link.getAttributesList()));
             }
             final String value = objectMapper.writeValueAsString(map);
-            annotationBoList.add(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), value));
+            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), value));
         } catch (JsonProcessingException e) {
-            annotationBoList.add(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), "json processing error"));
+            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), "json processing error"));
         }
     }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -49,7 +49,7 @@ public class OtlpTraceSpanMapper {
 
     SpanBo map(List<KeyValue> resourceAttributesList, Span span) {
         // annotations
-        final List<AnnotationBo> annotationBoList = new ArrayList<>();
+
         SpanBo spanBo = new SpanBo();
 
         spanBo.setVersion(1); // TODO ?
@@ -97,28 +97,27 @@ public class OtlpTraceSpanMapper {
         // api
         spanBo.setApiId(0);
         if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_CONSUMER_VALUE) {
-            annotationBoList.add(AnnotationBo.of(AnnotationKey.API.getCode(), OtlpTraceMapper.CONSUMER_METHOD_NAME));
+            spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.API.getCode(), OtlpTraceMapper.CONSUMER_METHOD_NAME));
         } else {
-            annotationBoList.add(AnnotationBo.of(AnnotationKey.API.getCode(), OtlpTraceMapper.SERVER_METHOD_NAME));
+            spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.API.getCode(), OtlpTraceMapper.SERVER_METHOD_NAME));
         }
         // response
         final int responseStatusCode = (int) getServerSpanToResponseStatusCode(span);
         if (responseStatusCode != -1) {
-            annotationBoList.add(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatusCode));
+            spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatusCode));
         }
         // attributes
         if (span.getAttributesCount() > 0) {
-            OtlpTraceMapperUtils.addAttributesToAnnotation(objectMapper, span.getAttributesList(), annotationBoList);
+            OtlpTraceMapperUtils.addAttributesToAnnotation(objectMapper, span.getAttributesList(), spanBo::addAnnotation);
         }
         // event
         for (Span.Event event : span.getEventsList()) {
-            OtlpTraceMapperUtils.addEventToAnnotation(objectMapper, event, annotationBoList);
+            OtlpTraceMapperUtils.addEventToAnnotation(objectMapper, event, spanBo::addAnnotation);
         }
         // link
         for (Span.Link link : span.getLinksList()) {
-            OtlpTraceMapperUtils.addLinkToAnnotation(objectMapper, link, annotationBoList);
+            OtlpTraceMapperUtils.addLinkToAnnotation(objectMapper, link, spanBo::addAnnotation);
         }
-        spanBo.setAnnotationBoList(annotationBoList);
 
         final List<SpanEventBo> spanEventBoList = new ArrayList<>();
         spanBo.addSpanEventBoList(spanEventBoList);


### PR DESCRIPTION
…elated classes to use AnnotationWriter


This pull request refactors how annotations are handled in the OTLP trace mapping logic to improve code clarity and flexibility. The main change is the replacement of explicit `List<AnnotationBo>` manipulation with the use of an `AnnotationWriter` interface, allowing annotations to be added directly to domain objects (`SpanBo` and `SpanEventBo`) via method references. This removes the need for temporary annotation lists and streamlines the annotation process.

**Refactoring annotation handling:**

* Updated `OtlpTraceMapperUtils` methods (`addAttributesToAnnotation`, `addEventToAnnotation`, and `addLinkToAnnotation`) to accept an `AnnotationWriter` instead of a `List<AnnotationBo>`, enabling direct annotation writing and improving code flexibility. [[1]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1R25) [[2]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L95-R105) [[3]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L145-R146) [[4]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L158-R165) [[5]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L177-R180)

**Code simplification in mappers:**

* Removed temporary `annotationBoList` variables in both `OtlpTraceSpanMapper` and `OtlpTraceSpanEventMapper`, and replaced all usages with direct calls to `addAnnotation` on `SpanBo` and `SpanEventBo` using method references. [[1]](diffhunk://#diff-f1683c8479f9580f34253e55979333a4e2c6fe3665660e2698d92a1629617195L55-L56) [[2]](diffhunk://#diff-f1683c8479f9580f34253e55979333a4e2c6fe3665660e2698d92a1629617195L66-L93) [[3]](diffhunk://#diff-b905d913fa453efe31e279b2cc1f810314b54fe8dc3871146a9ef8505bf14edaL52-R52) [[4]](diffhunk://#diff-b905d913fa453efe31e279b2cc1f810314b54fe8dc3871146a9ef8505bf14edaL100-L121)

These changes make the annotation process more idiomatic and reduce the risk of errors from manual list management, while also preparing the codebase for future extensibility.