### PR TITLE
[#noissue] Add ByteStringUtils for ByteString operations

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ByteStringUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ByteStringUtils.java
@@ -1,0 +1,55 @@
+package com.navercorp.pinpoint.common.server.util;
+
+import com.google.protobuf.ByteString;
+import com.navercorp.pinpoint.common.util.BytesUtils;
+
+import java.util.Objects;
+
+public final class ByteStringUtils {
+    private ByteStringUtils() {
+    }
+
+    public static boolean isEmpty(ByteString buf) {
+        return buf == null || buf.isEmpty();
+    }
+
+    public static long parseLong(final ByteString buf) {
+        return parseLong(buf, 0);
+    }
+
+    public static long parseLong(final ByteString buf, final int offset) {
+        if (buf == null) {
+            throw new NullPointerException("buf");
+        }
+        checkBounds(buf, offset, BytesUtils.LONG_BYTE_LENGTH);
+
+        return (((long) buf.byteAt(offset) & 0xff) << 56)
+                | (((long) buf.byteAt(offset + 1) & 0xff) << 48)
+                | (((long) buf.byteAt(offset + 2) & 0xff) << 40)
+                | (((long) buf.byteAt(offset + 3) & 0xff) << 32)
+                | (((long) buf.byteAt(offset + 4) & 0xff) << 24)
+                | (((long) buf.byteAt(offset + 5) & 0xff) << 16)
+                | (((long) buf.byteAt(offset + 6) & 0xff) << 8)
+                | (((long) buf.byteAt(offset + 7) & 0xff));
+    }
+
+    public static int parseInt(final ByteString buf) {
+        return parseInt(buf, 0);
+    }
+
+    public static int parseInt(final ByteString buf, final int offset) {
+        if (buf == null) {
+            throw new NullPointerException("buf");
+        }
+        checkBounds(buf, offset, BytesUtils.INT_BYTE_LENGTH);
+
+        return ((buf.byteAt(offset) & 0xff) << 24)
+                | ((buf.byteAt(offset + 1) & 0xff) << 16)
+                | ((buf.byteAt(offset + 2) & 0xff) << 8)
+                | ((buf.byteAt(offset + 3) & 0xff));
+    }
+
+    public static void checkBounds(ByteString bytes, int offset, int length) {
+        Objects.checkFromIndexSize(offset, length, bytes.size());
+    }
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/util/ByteStringUtilsTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/util/ByteStringUtilsTest.java
@@ -1,0 +1,57 @@
+package com.navercorp.pinpoint.common.util;
+
+import com.google.protobuf.ByteString;
+import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ByteStringUtilsTest {
+
+
+    @Test
+    void testParseLongValidInput() {
+        byte[] bytes = writeLong(Long.MAX_VALUE);
+        ByteString byteString = ByteString.copyFrom(bytes);
+
+        long result = ByteStringUtils.parseLong(byteString, 0);
+        Assertions.assertEquals(Long.MAX_VALUE, result);
+    }
+
+    private byte[] writeLong(long value) {
+        byte[] bytes = new byte[BytesUtils.LONG_BYTE_LENGTH];
+        BytesUtils.writeLong(value, bytes, 0);
+        return bytes;
+    }
+
+    @Test
+    void testParseLong_invalidOffset() {
+        byte[] bytes = writeLong(Long.MAX_VALUE);
+        ByteString byteString = ByteString.copyFrom(bytes);
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> ByteStringUtils.parseLong(byteString, 1));
+    }
+
+    @Test
+    void testParseIntValidInput() {
+        byte[] bytes = writeInt(Integer.MAX_VALUE);
+        ByteString byteString = ByteString.copyFrom(bytes);
+
+        long result = ByteStringUtils.parseInt(byteString, 0);
+        Assertions.assertEquals(Integer.MAX_VALUE, result);
+    }
+
+    private byte[] writeInt(int value) {
+        byte[] bytes = new byte[BytesUtils.INT_BYTE_LENGTH];
+        BytesUtils.writeInt(value, bytes, 0);
+        return bytes;
+    }
+
+    @Test
+    void testParseInt_invalidOffset() {
+        byte[] bytes = writeInt(Integer.MAX_VALUE);
+        ByteString byteString = ByteString.copyFrom(bytes);
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> ByteStringUtils.parseInt(byteString, 1));
+    }
+
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentInfoMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentInfoMapper.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import org.springframework.stereotype.Component;
 
@@ -36,15 +37,15 @@ public class OtlpAgentInfoMapper {
         builder.setServiceTypeCode(spanBo.getServiceType());
         builder.setStartTime(spanBo.getAgentStartTime());
 
-        final String hostName = attributesList.stream().filter(kv -> kv.getKey().equals("host.name")).findFirst().map(kv -> kv.getValue().getStringValue()).orElse(null);
+        final String hostName = AttributeUtils.getStringValue(attributesList, "host.name", null);
         if (hostName != null) {
             builder.setHostName(hostName);
         }
-        final long pid = attributesList.stream().filter(kv -> kv.getKey().equals("process.pid")).findFirst().map(kv -> kv.getValue().getIntValue()).orElse(0L);
+        final long pid = AttributeUtils.getIntValue(attributesList, "process.pid", 0L);
         builder.setPid((int) pid);
-        final String vmVersion = attributesList.stream().filter(kv -> kv.getKey().equals("process.runtime.description")).findFirst().map(kv -> kv.getValue().getStringValue()).orElse(null);
+        final String vmVersion = AttributeUtils.getStringValue(attributesList, "process.runtime.description", null);
         builder.setVmVersion(vmVersion);
-        final String agentVersion = attributesList.stream().filter(kv -> kv.getKey().equals("telemetry.sdk.version")).findFirst().map(kv -> kv.getValue().getStringValue()).orElse(null);
+        final String agentVersion = AttributeUtils.getStringValue(attributesList, "telemetry.sdk.version", null);
         if (agentVersion != null) {
             builder.setAgentVersion(agentVersion);
         }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanChunkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanChunkMapper.java
@@ -25,15 +25,16 @@ import io.opentelemetry.proto.trace.v1.Span;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 @Component
 public class OtlpTraceSpanChunkMapper {
 
-    private OtlpTraceSpanEventMapper spanEventMapper;
+    private final OtlpTraceSpanEventMapper spanEventMapper;
 
     public OtlpTraceSpanChunkMapper(OtlpTraceSpanEventMapper spanEventMapper) {
-        this.spanEventMapper = spanEventMapper;
+        this.spanEventMapper = Objects.requireNonNull(spanEventMapper, "spanEventMapper");
     }
 
     SpanChunkBo map(List<KeyValue> resourceAttributesList, Span span) {
@@ -49,7 +50,7 @@ public class OtlpTraceSpanChunkMapper {
         final long startTime = TimeUnit.NANOSECONDS.toMillis(span.getStartTimeUnixNano());
         spanChunkBo.setAgentStartTime(startTime);
         spanChunkBo.setTransactionId(new OtelServerTraceId(span.getTraceId().toByteArray()));
-        spanChunkBo.setSpanId(OtlpTraceMapperUtils.getSpanId(span.getParentSpanId().toByteArray()));
+        spanChunkBo.setSpanId(OtlpTraceMapperUtils.getSpanId(span.getParentSpanId()));
         // spanChunkBo.setEndPoint();
         spanChunkBo.setApplicationServiceType(ServiceType.OPENTELEMETRY_SERVER.getCode());
         final List<SpanEventBo> spanEventBoList = spanEventMapper.map(startTime, span);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -17,10 +17,10 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
 import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
@@ -91,7 +91,7 @@ public class OtlpTraceSpanEventMapper {
         spanEventBo.setDepth(1);
 
         if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_CLIENT_VALUE || span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_PRODUCER_VALUE) {
-            final long nextSpanId = ByteArrayUtils.bytesToLong(span.getSpanId().toByteArray(), 0);
+            final long nextSpanId = ByteStringUtils.parseLong(span.getSpanId());
             spanEventBo.setNextSpanId(nextSpanId);
         }
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -67,8 +67,8 @@ public class OtlpTraceSpanMapper {
         spanBo.setEndPoint(getServerSpanToEndPoint(span));
         spanBo.setRemoteAddr(getServerSpanToRemoteAddress(span));
 
-        spanBo.setSpanId(OtlpTraceMapperUtils.getSpanId(span.getSpanId().toByteArray()));
-        spanBo.setParentSpanId(OtlpTraceMapperUtils.getParentSpanId(span.getParentSpanId().toByteArray()));
+        spanBo.setSpanId(OtlpTraceMapperUtils.getSpanId(span.getSpanId()));
+        spanBo.setParentSpanId(OtlpTraceMapperUtils.getParentSpanId(span.getParentSpanId()));
         if (spanBo.getParentSpanId() != -1) {
             spanBo.setAcceptorHost(spanBo.getEndPoint());
         }


### PR DESCRIPTION
This pull request introduces a new utility class, `ByteStringUtils`, for handling `ByteString` conversions and parsing, and refactors the OTLP trace collector mappers to use this new utility. It also improves attribute extraction by centralizing logic in `AttributeUtils`, and adds corresponding unit tests for the new utility. The changes enhance code readability, reliability, and consistency when working with protocol buffer byte arrays and attribute lists.

**Core utility and refactoring:**

* Added `ByteStringUtils` class to encapsulate common operations for parsing `ByteString` to primitive types, including methods for checking emptiness, parsing `long` and `int` values, and validating bounds.
* Refactored `OtlpTraceMapperUtils`, `OtlpTraceSpanChunkMapper`, `OtlpTraceSpanEventMapper`, and `OtlpTraceSpanMapper` to use `ByteStringUtils` for parsing span IDs and parent span IDs, replacing previous usage of raw byte array utilities. [[1]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L80-R93) [[2]](diffhunk://#diff-0d91c83c70e03d341ab44f74f43a0793f7ae69defafd33e993fb92e421045630L52-R53) [[3]](diffhunk://#diff-f1683c8479f9580f34253e55979333a4e2c6fe3665660e2698d92a1629617195L94-R94) [[4]](diffhunk://#diff-b905d913fa453efe31e279b2cc1f810314b54fe8dc3871146a9ef8505bf14edaL70-R71)

**Attribute extraction improvements:**

* Replaced in-line attribute extraction logic with centralized calls to `AttributeUtils.getStringValue` and `AttributeUtils.getIntValue` in mapper classes, improving maintainability and reducing code duplication. [[1]](diffhunk://#diff-305e7188aaceab95b7a7aec666bce70602bdc0e9f2df9f818c990e0d6842304bL39-R48) [[2]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L42-R45) [[3]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L66-R69)

**Testing:**

* Added comprehensive unit tests for `ByteStringUtils`, covering valid and invalid cases for parsing `long` and `int` values from `ByteString`.

**Dependency and code hygiene:**

* Removed unused imports and replaced direct usages of byte array utilities with the new `ByteStringUtils` where applicable. [[1]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1R21-R30) [[2]](diffhunk://#diff-f1683c8479f9580f34253e55979333a4e2c6fe3665660e2698d92a1629617195L20-R23)

**Constructor safety:**

* Updated `OtlpTraceSpanChunkMapper` to ensure its dependency is non-null using `Objects.requireNonNull`, improving robustness.