### PR TITLE
[#12883] Test: cover jdk branch in UnmodifiableClassFilter

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/transformer/UnmodifiableClassFilter.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/transformer/UnmodifiableClassFilter.java
@@ -64,6 +64,15 @@ public class UnmodifiableClassFilter implements ClassFileFilter {
             }
         }
 
+        if (className.startsWith("jdk")) {
+            if (className.startsWith("/", 3)) {
+                if (allowJdkClassName(className)) {
+                    return CONTINUE;
+                }
+                return SKIP;
+            }
+        }
+
         return CONTINUE;
     }
 

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/transformer/UnmodifiableClassFilterTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/transformer/UnmodifiableClassFilterTest.java
@@ -31,6 +31,7 @@ public class UnmodifiableClassFilterTest {
 
         Assertions.assertSame(filter.accept(null, "java/test", null, null, null), ClassFileFilter.SKIP);
         Assertions.assertSame(filter.accept(null, "javax/test", null, null, null), ClassFileFilter.SKIP);
+        Assertions.assertSame(filter.accept(null, "jdk/test", null, null, null), ClassFileFilter.SKIP);
 
 
         Assertions.assertSame(filter.accept(null, "com/navercorp/pinpoint/", null, null, null), ClassFileFilter.CONTINUE);


### PR DESCRIPTION
### What
Add a minimal unit test to cover the newly added `jdk/*` branch in
`UnmodifiableClassFilter`.

### Why
The Codecov patch check was failing because the `jdk/*` branch
introduced in #12883 was not exercised by tests.

### Scope
- Test only
- No production code or configuration changes