### PR TITLE
[#noissue] Replace BytesUtils.toBytes in scanKey

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapAgentScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapAgentScanKeyFactoryV3.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidPrefix;
+import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.web.applicationmap.dao.hbase.MapScanKeyFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -29,7 +30,7 @@ public class MapAgentScanKeyFactoryV3 implements MapScanKeyFactory {
     public byte[] scanKey(int serviceUid, Application application, long timestamp) {
         final Buffer buffer = new AutomaticBuffer(64);
         buffer.skip(saltKeySize);
-        UidPrefix.writePrefix(buffer, serviceUid, application.getName().getBytes(), application.getServiceTypeCode(), timestamp);
+        UidPrefix.writePrefix(buffer, serviceUid, BytesUtils.toBytes(application.getName()), application.getServiceTypeCode(), timestamp);
         return buffer.getBuffer();
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapAppScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapAppScanKeyFactoryV3.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidPrefix;
+import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.web.applicationmap.dao.hbase.MapScanKeyFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -29,7 +30,7 @@ public class MapAppScanKeyFactoryV3 implements MapScanKeyFactory {
     public byte[] scanKey(int serviceUid, Application application, long timestamp) {
         final Buffer buffer = new AutomaticBuffer(64);
         buffer.skip(saltKeySize);
-        UidPrefix.writePrefix(buffer, serviceUid, application.getName().getBytes(), application.getServiceTypeCode(), timestamp);
+        UidPrefix.writePrefix(buffer, serviceUid, BytesUtils.toBytes(application.getName()), application.getServiceTypeCode(), timestamp);
         return buffer.getBuffer();
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapLinkScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapLinkScanKeyFactoryV3.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidPrefix;
+import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.web.applicationmap.dao.hbase.MapScanKeyFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -29,7 +30,7 @@ public class MapLinkScanKeyFactoryV3 implements MapScanKeyFactory {
     public byte[] scanKey(int serviceUid, Application application, long timestamp) {
         final Buffer buffer = new AutomaticBuffer(64);
         buffer.skip(saltKeySize);
-        UidPrefix.writePrefix(buffer, serviceUid, application.getName().getBytes(), application.getServiceTypeCode(), timestamp);
+        UidPrefix.writePrefix(buffer, serviceUid, BytesUtils.toBytes(application.getName()), application.getServiceTypeCode(), timestamp);
         return buffer.getBuffer();
     }
 }


### PR DESCRIPTION
This pull request updates the way application names are converted to byte arrays in three scan key factory classes. Instead of using the default `getBytes()` method, the code now uses the `BytesUtils.toBytes()` utility method, which likely provides more consistent or efficient byte conversions. This change is applied across agent, application, and link scan key factories for improved reliability and maintainability.

**Key changes:**

_Byte conversion improvements:_

* Replaced `application.getName().getBytes()` with `BytesUtils.toBytes(application.getName())` in the `scanKey` method of `MapAgentScanKeyFactoryV3`, `MapAppScanKeyFactoryV3`, and `MapLinkScanKeyFactoryV3` to standardize string-to-byte conversion. [[1]](diffhunk://#diff-653ccf8eb587b57d394cb1d322f4bf6cd7334a2210696f9d8a4b7784dba894c9L32-R33) [[2]](diffhunk://#diff-cc826dff91e03cebcdaaa4d94dc163b238aa032abc249978a28cecbd3d91bd1fL32-R33) [[3]](diffhunk://#diff-72c1ae160fe8e8d40d2619533d3dee72bf5b4bd2c0cff4685e612c2ccbf2b3b4L32-R33)
* Added import of `com.navercorp.pinpoint.common.util.BytesUtils` in all three affected classes to support the new conversion method. [[1]](diffhunk://#diff-653ccf8eb587b57d394cb1d322f4bf6cd7334a2210696f9d8a4b7784dba894c9R23) [[2]](diffhunk://#diff-cc826dff91e03cebcdaaa4d94dc163b238aa032abc249978a28cecbd3d91bd1fR23) [[3]](diffhunk://#diff-72c1ae160fe8e8d40d2619533d3dee72bf5b4bd2c0cff4685e612c2ccbf2b3b4R23)