### PR TITLE
[#13408] Close JarFiles opened during bootstrap classloader append

### DIFF
--- a/agent-module/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointBootStrap.java
+++ b/agent-module/bootstraps/bootstrap/src/main/java/com/navercorp/pinpoint/bootstrap/PinpointBootStrap.java
@@ -146,10 +146,20 @@ public class PinpointBootStrap {
 
     private void appendToBootstrapClassLoader(Instrumentation instrumentation, BootDir bootDir) {
         List<JarFile> jarFiles = bootDir.openJarFiles();
-        for (JarFile jarFile : jarFiles) {
-            Path path = FileUtils.subpathAfterLast(Paths.get(jarFile.getName()), 2);
-            logger.info("appendToBootstrapClassLoader:" + path);
-            instrumentation.appendToBootstrapClassLoaderSearch(jarFile);
+        try {
+            for (JarFile jarFile : jarFiles) {
+                Path path = FileUtils.subpathAfterLast(Paths.get(jarFile.getName()), 2);
+                logger.info("appendToBootstrapClassLoader:" + path);
+                instrumentation.appendToBootstrapClassLoaderSearch(jarFile);
+            }
+        } finally {
+            for (JarFile jarFile : jarFiles) {
+                try {
+                    jarFile.close();
+                } catch (Exception e) {
+                    logger.warn("Failed to close JarFile:" + jarFile.getName(), e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This changes `PinpointBootStrap.appendToBootstrapClassLoader(...)` to always close the `JarFile`s returned by `bootDir.openJarFiles()`.

The method appends each jar to the bootstrap classloader search path, but the opened `JarFile` instances weren’t closed. This can keep `JarFile` resources open indefinitely. The `JarFile`s are only used to register the JARs via `appendToBootstrapClassLoaderSearch` and aren’t needed afterward.

**Changes:*
Wrap the append loop in a try/finally and close every JarFile in finally. If a close fails, log it and continue closing the rest.