### PR TITLE
[#noissue] Replace BytesUtils.toBytes

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/cache/UidGenerator.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/cache/UidGenerator.java
@@ -2,6 +2,7 @@ package com.navercorp.pinpoint.profiler.cache;
 
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+import com.navercorp.pinpoint.common.util.BytesUtils;
 
 import java.util.function.Function;
 
@@ -10,8 +11,8 @@ public interface UidGenerator extends Function<String, byte[]> {
         private static final HashFunction hashFunction = Hashing.murmur3_128();
 
         @Override
-        public byte[] apply(String s) {
-            return hashFunction.hashBytes(s.getBytes()).asBytes();
+        public byte[] apply(String uid) {
+            return hashFunction.hashBytes(BytesUtils.toBytes(uid)).asBytes();
         }
     }
 }

--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/JwtService.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/JwtService.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.login.basic.service;
 
+import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.login.basic.config.BasicLoginProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -56,7 +57,7 @@ public class JwtService {
         Assert.isTrue(basicLoginProperties.getExpirationTimeSeconds() > 0, "expirationTimeSeconds must be '>= 0'");
         this.expirationTimeMillis = TimeUnit.SECONDS.toMillis(basicLoginProperties.getExpirationTimeSeconds());
 
-        byte[] keyBytes = Base64.getEncoder().encode(secretKeyStr.getBytes());
+        byte[] keyBytes = Base64.getEncoder().encode(BytesUtils.toBytes(secretKeyStr));
         this.secretKey = Keys.hmacShaKeyFor(keyBytes);
 
         JwtParserBuilder jwtParser = Jwts.parser();


### PR DESCRIPTION
This pull request updates how string-to-byte conversions are handled in both the UID generation and JWT service logic. The changes ensure consistent encoding by using `BytesUtils.toBytes()` instead of the default `String.getBytes()` method, which can help avoid platform-dependent encoding issues.

**String-to-byte conversion improvements:**

* Updated the `Murmur` implementation of `UidGenerator` to use `BytesUtils.toBytes(uid)` instead of `uid.getBytes()` for hashing, ensuring consistent byte encoding.
* In `JwtService`, replaced `secretKeyStr.getBytes()` with `BytesUtils.toBytes(secretKeyStr)` before Base64 encoding the secret key, improving encoding reliability.

**Dependency management:**

* Added import of `BytesUtils` in both `UidGenerator.java` and `JwtService.java` to support the new string-to-byte conversion method. [[1]](diffhunk://#diff-25270430b3f89d9155d2215720b218f68a50a35f58eaf63859506b9da29b8109R5) [[2]](diffhunk://#diff-99ca15656f13445ec07c30a0c325b4e1dadb44745fd5e4806c7bec63edc2c2cbR19)