### PR TITLE
[#noissue] Remove unused method from ActiveAgentValidator

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/service/component/ActiveAgentValidator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/component/ActiveAgentValidator.java
@@ -3,16 +3,12 @@ package com.navercorp.pinpoint.web.service.component;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.vo.Application;
 
-import java.util.List;
-
 public interface ActiveAgentValidator {
     boolean isActiveAgent(String agentId, Range range);
 
     boolean isActiveAgent(Application agent, Range range);
 
     boolean isActiveAgent(Application agent, String version, Range range);
-
-    boolean isActiveAgent(Application agent, String version, List<Range> ranges);
 
     boolean isActiveAgentByEvent(String agentId, Range range);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/component/DefaultActiveAgentValidator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/component/DefaultActiveAgentValidator.java
@@ -55,16 +55,6 @@ public class DefaultActiveAgentValidator implements ActiveAgentValidator {
         return false;
     }
 
-    @Override
-    public boolean isActiveAgent(Application agent, String version, List<Range> ranges) {
-        for (Range range : ranges) {
-            if (isActiveAgent(agent, version, range)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 
     @Override
     public boolean isActiveAgentByEvent(String agentId, Range range) {


### PR DESCRIPTION
This pull request simplifies the `ActiveAgentValidator` interface and its implementation by removing an unused method that checked agent activity across multiple time ranges. This reduces code complexity and potential maintenance overhead.

Removed unused multi-range agent validation:

* `ActiveAgentValidator` interface: Removed the `isActiveAgent(Application agent, String version, List<Range> ranges)` method declaration.
* `DefaultActiveAgentValidator` implementation: Removed the corresponding `isActiveAgent(Application agent, String version, List<Range> ranges)` method implementation.