### PR TITLE
[#noissue] Refactor active agent validation to use agent ID and service type

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmProcessor.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmProcessor.java
@@ -101,13 +101,15 @@ public class AlarmProcessor implements ItemProcessor<Application, AppAlarmChecke
 
     private List<String> fetchActiveAgents(Application application, Range activeRange) {
         List<String> agentList = batchAgentService.getIds(application.getName());
-        return agentList
-                .stream()
-                .filter(id -> {
-                    Application agent = new Application(id, application.getServiceType());
-                    return batchAgentService.isActive(agent, activeRange);
-                })
-                .toList();
+
+        int code = application.getServiceType().getCode();
+        List<String> list = new ArrayList<>();
+        for (String agentId : agentList) {
+            if (batchAgentService.isActive(agentId, code, activeRange)) {
+                list.add(agentId);
+            }
+        }
+        return list;
     }
 
     private static class AlarmCheckerFactory {

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/service/BatchAgentService.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/service/BatchAgentService.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.batch.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
-import com.navercorp.pinpoint.web.vo.Application;
 
 import java.util.List;
 
@@ -30,6 +29,6 @@ public interface BatchAgentService {
 
     boolean isActive(String agentId, Range range);
 
-    boolean isActive(Application agent, Range range);
+    boolean isActive(String agentId, int agentServiceType, Range range);
 
 }

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/service/BatchAgentServiceImpl.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/service/BatchAgentServiceImpl.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.batch.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.service.component.ActiveAgentValidator;
-import com.navercorp.pinpoint.web.vo.Application;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -51,7 +50,7 @@ public class BatchAgentServiceImpl implements BatchAgentService {
     }
 
     @Override
-    public boolean isActive(Application agent, Range range) {
-        return this.activeAgentValidator.isActiveAgent(agent, range);
+    public boolean isActive(String agentId, int agentServiceType, Range range) {
+        return this.activeAgentValidator.isActiveAgent(agentId, agentServiceType, range);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/component/ActiveAgentValidator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/component/ActiveAgentValidator.java
@@ -1,14 +1,13 @@
 package com.navercorp.pinpoint.web.service.component;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
-import com.navercorp.pinpoint.web.vo.Application;
 
 public interface ActiveAgentValidator {
     boolean isActiveAgent(String agentId, Range range);
 
-    boolean isActiveAgent(Application agent, Range range);
+    boolean isActiveAgent(String agentId, int agentServiceType, Range range);
 
-    boolean isActiveAgent(Application agent, String version, Range range);
+    boolean isActiveAgent(String agentId, int agentServiceType, String version, Range range);
 
     boolean isActiveAgentByEvent(String agentId, Range range);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/component/DefaultActiveAgentValidator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/component/DefaultActiveAgentValidator.java
@@ -4,7 +4,6 @@ import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.web.service.AgentEventService;
 import com.navercorp.pinpoint.web.vo.AgentEvent;
-import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
@@ -36,15 +35,15 @@ public class DefaultActiveAgentValidator implements ActiveAgentValidator {
     }
 
     @Override
-    public boolean isActiveAgent(Application agent, Range range) {
-        return isActiveAgent(agent, null, range);
+    public boolean isActiveAgent(String agentId, int agentServiceType, Range range) {
+        return isActiveAgent(agentId, agentServiceType, null, range);
     }
 
     @Override
-    public boolean isActiveAgent(Application agent, String version, Range range) {
-        Objects.requireNonNull(agent, "agent");
-        String agentId = agent.getName();
-        if (!agentCompatibility.isLegacyAgent(agent.getServiceTypeCode(), version)) {
+    public boolean isActiveAgent(String agentId, int agentServiceType, String version, Range range) {
+        Objects.requireNonNull(agentId, "agentId");
+
+        if (!agentCompatibility.isLegacyAgent(agentServiceType, version)) {
             logger.trace("isActiveAgentByPing");
 
             if (isActiveAgentByEvent(agentId, range)) {

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/component/DefaultActiveAgentValidatorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/component/DefaultActiveAgentValidatorTest.java
@@ -2,10 +2,10 @@ package com.navercorp.pinpoint.web.service.component;
 
 import com.navercorp.pinpoint.common.server.util.AgentEventType;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
 import com.navercorp.pinpoint.web.service.AgentEventService;
 import com.navercorp.pinpoint.web.vo.AgentEvent;
-import com.navercorp.pinpoint.web.vo.Application;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,7 +24,8 @@ class DefaultActiveAgentValidatorTest {
     @Mock
     AgentEventService agentEventService;
 
-    Application node = new Application("testNodeApp", ServiceTypeFactory.of(1400, "node"));
+    String agentId = "testNodeApp";
+    ServiceType node = ServiceTypeFactory.of(1400, "node");
 //    Application java = new Application("testJavaApp", ServiceTypeFactory.of(1010, "java"));
 
     @Test
@@ -32,7 +33,7 @@ class DefaultActiveAgentValidatorTest {
         LegacyAgentCompatibility agentCompatibility = new DefaultLegacyAgentCompatibility();
         ActiveAgentValidator validator = new DefaultActiveAgentValidator(agentEventService, agentCompatibility);
 
-        Assertions.assertFalse(validator.isActiveAgent(node, "0.7.0", Range.between(0, 1)));
+        Assertions.assertFalse(validator.isActiveAgent(agentId, node.getCode(), "0.7.0", Range.between(0, 1)));
     }
 
     @Test
@@ -43,7 +44,7 @@ class DefaultActiveAgentValidatorTest {
         AgentEvent gc = new AgentEvent("test", 1, 1, AgentEventType.AGENT_PING);
         when(agentEventService.getAgentEvents(any(), any(), any())).thenReturn(List.of(gc));
 
-        Assertions.assertTrue(validator.isActiveAgent(node, "5.0.0", Range.between(0, 1)));
+        Assertions.assertTrue(validator.isActiveAgent(agentId, node.getCode(), "5.0.0", Range.between(0, 1)));
     }
 
     @Test
@@ -51,7 +52,7 @@ class DefaultActiveAgentValidatorTest {
         LegacyAgentCompatibility agentCompatibility = new DefaultLegacyAgentCompatibility();
         ActiveAgentValidator validator = new DefaultActiveAgentValidator(agentEventService, agentCompatibility);
 
-        Assertions.assertFalse(validator.isActiveAgent(node, "0.8.0", Range.between(0, 1)));
+        Assertions.assertFalse(validator.isActiveAgent(agentId, node.getCode(), "0.8.0", Range.between(0, 1)));
 
         verify(agentEventService).getAgentEvents(any(), any(), any());
     }
@@ -64,6 +65,6 @@ class DefaultActiveAgentValidatorTest {
         LegacyAgentCompatibility agentCompatibility = new DefaultLegacyAgentCompatibility();
         ActiveAgentValidator validator = new DefaultActiveAgentValidator(agentEventService, agentCompatibility);
 
-        Assertions.assertTrue(validator.isActiveAgent(node, "0.8.0", Range.between(0, 1)));
+        Assertions.assertTrue(validator.isActiveAgent(agentId, node.getCode(), "0.8.0", Range.between(0, 1)));
     }
 }


### PR DESCRIPTION
…ce type

This pull request refactors how agent activity is checked by removing the dependency on the `Application` object and instead using primitive parameters (`agentId` and `agentServiceType`). This simplifies method signatures and improves clarity in the agent activity validation logic across the batch and web modules.

**Refactoring agent activity validation:**

* Changed `BatchAgentService.isActive` and its implementations to accept `agentId` and `agentServiceType` as parameters instead of an `Application` object, updating all usages accordingly (`BatchAgentService.java`, `BatchAgentServiceImpl.java`, `AlarmProcessor.java`). [[1]](diffhunk://#diff-c3809310411cfd9ac4965e8e119e66a80c0955dbb1d9a7ac89cf9d3629ec60e7L33-R32) [[2]](diffhunk://#diff-dea4264e136837279ba00057b724a1fffb501eb0672fc107b1a80f7f6930e6dfL54-R54) [[3]](diffhunk://#diff-230add387063a918e442acb8765a7456671e9a1188ff00efc03e313a609f4e21L104-R112)
* Updated `ActiveAgentValidator` interface and its implementation to replace methods using `Application` with methods using `agentId` and `agentServiceType`, and adjusted the validation logic to match (`ActiveAgentValidator.java`, `DefaultActiveAgentValidator.java`). [[1]](diffhunk://#diff-2aad6ed52f52b62d1b2236828eb6d59a5713adaf344bc9e301217ea4b7cf1a96L4-R10) [[2]](diffhunk://#diff-07dab0bd934ce3c8531a3fb5c7235c2333578144f16ffd33e9d186f9ccf2654fL39-R46)

**Code cleanup:**

* Removed unnecessary imports of `Application` from affected files, reflecting the updated method signatures. [[1]](diffhunk://#diff-c3809310411cfd9ac4965e8e119e66a80c0955dbb1d9a7ac89cf9d3629ec60e7L20) [[2]](diffhunk://#diff-dea4264e136837279ba00057b724a1fffb501eb0672fc107b1a80f7f6930e6dfL21) [[3]](diffhunk://#diff-07dab0bd934ce3c8531a3fb5c7235c2333578144f16ffd33e9d186f9ccf2654fL7)