### PR TITLE
[#noissue] Remove unused simpleResponseHistogram field and related bu…

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/MapOutLinkDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/MapOutLinkDataCollector.java
@@ -62,7 +62,7 @@ public class MapOutLinkDataCollector extends DataCollector {
 
         Range between = Range.between(timeSlotEndTime - slotInterval, timeSlotEndTime);
         TimeWindow timeWindow = new TimeWindow(between);
-        LinkDataMap outLinkDataMap = mapOutLinkDao.selectOutLink(application, timeWindow, false);
+        LinkDataMap outLinkDataMap = mapOutLinkDao.selectOutLink(application, timeWindow);
 
         for (LinkData linkData : outLinkDataMap.getLinkDataList()) {
             LinkCallDataMap linkCallDataMap = linkData.getLinkCallDataMap();

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorCountToCalleCheckerTest.java
@@ -53,7 +53,7 @@ public class ErrorCountToCalleCheckerTest {
         dao = new MapOutLinkDao() {
 
             @Override
-            public LinkDataMap selectOutLink(Application outApplication, TimeWindow timeWindow, boolean timeAggregated) {
+            public LinkDataMap selectOutLink(Application outApplication, TimeWindow timeWindow) {
                 long timeStamp = 1409814914298L;
                 LinkDataMap linkDataMap = new LinkDataMap();
                 Application fromApplication = new Application(FROM_SERVICE_NAME, ServiceType.STAND_ALONE);

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/ErrorRateToCalleCheckerTest.java
@@ -50,7 +50,7 @@ public class ErrorRateToCalleCheckerTest {
         dao = new MapOutLinkDao() {
 
             @Override
-            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range, boolean timeAggregated) {
+            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range) {
                 long timeStamp = 1409814914298L;
                 LinkDataMap linkDataMap = new LinkDataMap();
                 Application fromApplication = new Application(FROM_SERVICE_NAME, ServiceType.STAND_ALONE);

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowCountToCalleCheckerTest.java
@@ -49,7 +49,7 @@ public class SlowCountToCalleCheckerTest {
         dao = new MapOutLinkDao() {
 
             @Override
-            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range, boolean timeAggregated) {
+            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range) {
                 long timeStamp = 1409814914298L;
                 LinkDataMap linkDataMap = new LinkDataMap();
                 Application fromApplication = new Application(FROM_SERVICE_NAME, ServiceType.STAND_ALONE);

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateToCalleCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/SlowRateToCalleCheckerTest.java
@@ -49,7 +49,7 @@ public class SlowRateToCalleCheckerTest {
         dao = new MapOutLinkDao() {
 
             @Override
-            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range, boolean timeAggregated) {
+            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range) {
                 long timeStamp = 1409814914298L;
                 LinkDataMap linkDataMap = new LinkDataMap();
                 Application fromApplication = new Application(FROM_SERVICE_NAME, ServiceType.STAND_ALONE);

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/TotalCountToCalleeCheckerTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/checker/TotalCountToCalleeCheckerTest.java
@@ -49,7 +49,7 @@ public class TotalCountToCalleeCheckerTest {
         dao = new MapOutLinkDao() {
 
             @Override
-            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range, boolean timeAggregated) {
+            public LinkDataMap selectOutLink(Application outApplication, TimeWindow range) {
                 long timeStamp = 1409814914298L;
                 LinkDataMap linkDataMap = new LinkDataMap();
                 Application fromApplication = new Application(FROM_SERVICE_NAME, ServiceType.STAND_ALONE);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapInLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapInLinkDao.java
@@ -27,6 +27,6 @@ import com.navercorp.pinpoint.web.vo.Application;
  * 
  */
 public interface MapInLinkDao {
-    LinkDataMap selectInLink(Application inApplication, TimeWindow timeWindow, boolean timeAggregated);
+    LinkDataMap selectInLink(Application inApplication, TimeWindow timeWindow);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapOutLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/MapOutLinkDao.java
@@ -27,6 +27,6 @@ import com.navercorp.pinpoint.web.vo.Application;
  * 
  */
 public interface MapOutLinkDao {
-   LinkDataMap selectOutLink(Application outApplication, TimeWindow timeWindow, boolean timeAggregated);
+   LinkDataMap selectOutLink(Application outApplication, TimeWindow timeWindow);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java
@@ -80,11 +80,11 @@ public class HbaseMapInLinkDao implements MapInLinkDao {
     }
 
     @Override
-    public LinkDataMap selectInLink(Application inApplication, TimeWindow timeWindow, boolean timeAggregated) {
+    public LinkDataMap selectInLink(Application inApplication, TimeWindow timeWindow) {
         Objects.requireNonNull(inApplication, "inApplication");
         Objects.requireNonNull(timeWindow, "timeWindow");
 
-        TimeWindowFunction mapperWindow = TimeWindowFunction.newTimeWindow(timeAggregated);
+        TimeWindowFunction mapperWindow = TimeWindowFunction.identity();
 
         RowMapper<LinkDataMap> rowMapper = this.inLinkMapperFactory.newMapper(mapperWindow, inApplication);
         ResultsExtractor<LinkDataMap> resultExtractor = new RowMapReduceResultExtractor<>(rowMapper, new LinkTimeWindowReducer(timeWindow));

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -80,9 +80,9 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
     }
 
     @Override
-    public LinkDataMap selectOutLink(Application outApplication, TimeWindow timeWindow, boolean timeAggregated) {
+    public LinkDataMap selectOutLink(Application outApplication, TimeWindow timeWindow) {
 
-        TimeWindowFunction mapperWindow = TimeWindowFunction.newTimeWindow(timeAggregated);
+        TimeWindowFunction mapperWindow = TimeWindowFunction.identity();
 
         RowMapper<LinkDataMap> rowMapper = this.outMapperFactory.newMapper(mapperWindow, outApplication);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/BidirectionalLinkSelector.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/BidirectionalLinkSelector.java
@@ -60,18 +60,13 @@ public class BidirectionalLinkSelector implements LinkSelector {
 
     @Override
     public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth) {
-        return select(sourceApplications, timeWindow, outSearchDepth, inSearchDepth, false);
-    }
-
-    @Override
-    public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth, boolean timeAggregated) {
         logger.debug("Creating link data map for {}", sourceApplications);
         final SearchDepth outDepth = new SearchDepth(outSearchDepth);
         final SearchDepth inDepth = new SearchDepth(inSearchDepth);
 
         LinkDataDuplexMap linkDataDuplexMap = new LinkDataDuplexMap();
         List<Application> applications = filterApplications(sourceApplications);
-        LinkSelectContext linkSelectContext = new LinkSelectContext(timeWindow, outDepth, inDepth, linkVisitChecker, timeAggregated);
+        LinkSelectContext linkSelectContext = new LinkSelectContext(timeWindow, outDepth, inDepth, linkVisitChecker);
 
         while (!applications.isEmpty()) {
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/DefaultApplicationMapCreator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/DefaultApplicationMapCreator.java
@@ -60,7 +60,7 @@ public class DefaultApplicationMapCreator implements ApplicationMapCreator {
         LinkDataDuplexMap searchResult = new LinkDataDuplexMap();
 
         if (linkSelectContext.checkNextOut(application)) {
-            final LinkDataMap outLinkDataMap = linkDataMapService.selectOutLinkDataMap(application, timeWindow, linkSelectContext.isTimeAggregated());
+            final LinkDataMap outLinkDataMap = linkDataMapService.selectOutLinkDataMap(application, timeWindow);
             logger.debug("Found {}. node={}, depth={}, count={}", LinkDirection.OUT_LINK, application, linkSelectContext.getOutDepth(), outLinkDataMap.size());
 
             final LinkDataMap processedOutLinkDataMap = outLinkDataMapProcessor.processLinkDataMap(LinkDirection.OUT_LINK, outLinkDataMap, timeWindow);
@@ -78,7 +78,7 @@ public class DefaultApplicationMapCreator implements ApplicationMapCreator {
         }
 
         if (linkSelectContext.checkNextIn(application)) {
-            final LinkDataMap inLinkDataMap = linkDataMapService.selectInLinkDataMap(application, timeWindow, linkSelectContext.isTimeAggregated());
+            final LinkDataMap inLinkDataMap = linkDataMapService.selectInLinkDataMap(application, timeWindow);
             logger.debug("Found {}. node={}, depth={}, count={}", LinkDirection.IN_LINK, application, linkSelectContext.getInDepth(), inLinkDataMap.size());
 
             final LinkDataMap processedInLinkDataMap = inLinkDataMapProcessor.processLinkDataMap(LinkDirection.IN_LINK, inLinkDataMap, timeWindow);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelectContext.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelectContext.java
@@ -43,17 +43,15 @@ public class LinkSelectContext {
     private final SearchDepth inDepth;
 
     private final LinkVisitChecker linkVisitChecker;
-    private final boolean timeAggregated;
 
     private final Set<Application> nextApplications = ConcurrentHashMap.newKeySet();
 
     public LinkSelectContext(TimeWindow timeWindow, SearchDepth outDepth, SearchDepth inDepth,
-                             LinkVisitChecker linkVisitChecker, boolean timeAggregated) {
+                             LinkVisitChecker linkVisitChecker) {
         this.timeWindow = Objects.requireNonNull(timeWindow, "timeWindow");
         this.outDepth = Objects.requireNonNull(outDepth, "outDepth");
         this.inDepth = Objects.requireNonNull(inDepth, "inDepth");
         this.linkVisitChecker = Objects.requireNonNull(linkVisitChecker, "linkVisitChecker");
-        this.timeAggregated = timeAggregated;
     }
 
     public TimeWindow getTimeWindow() {
@@ -66,10 +64,6 @@ public class LinkSelectContext {
 
     public int getInDepth() {
         return inDepth.getDepth();
-    }
-
-    public boolean isTimeAggregated() {
-        return timeAggregated;
     }
 
     public boolean checkNextOut(Application application) {
@@ -106,6 +100,6 @@ public class LinkSelectContext {
     public LinkSelectContext advance() {
         SearchDepth nextOutDepth = outDepth.nextDepth();
         SearchDepth nextInDepth = inDepth.nextDepth();
-        return new LinkSelectContext(timeWindow, nextOutDepth, nextInDepth, linkVisitChecker, timeAggregated);
+        return new LinkSelectContext(timeWindow, nextOutDepth, nextInDepth, linkVisitChecker);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelector.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelector.java
@@ -28,6 +28,4 @@ import java.util.List;
  */
 public interface LinkSelector {
     LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth);
-
-    LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth, boolean timeAggregated);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/UnidirectionalLinkSelector.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/UnidirectionalLinkSelector.java
@@ -57,11 +57,6 @@ public class UnidirectionalLinkSelector implements LinkSelector {
 
     @Override
     public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth) {
-        return select(sourceApplications, timeWindow, outSearchDepth, inSearchDepth, false);
-    }
-
-    @Override
-    public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int outSearchDepth, int inSearchDepth, boolean timeAggregated) {
         logger.debug("Creating link data map for {}", sourceApplications);
         final SearchDepth outDepth = new SearchDepth(outSearchDepth);
         final SearchDepth inDepth = new SearchDepth(inSearchDepth);
@@ -70,9 +65,9 @@ public class UnidirectionalLinkSelector implements LinkSelector {
         List<Application> applications = filterApplications(sourceApplications);
 
         List<Application> outboundApplications = Collections.unmodifiableList(applications);
-        LinkSelectContext outboundLinkSelectContext = new LinkSelectContext(timeWindow, outDepth, new SearchDepth(0), linkVisitChecker, timeAggregated);
+        LinkSelectContext outboundLinkSelectContext = new LinkSelectContext(timeWindow, outDepth, new SearchDepth(0), linkVisitChecker);
         List<Application> inboundApplications = Collections.unmodifiableList(applications);
-        LinkSelectContext inboundLinkSelectContext = new LinkSelectContext(timeWindow, new SearchDepth(0), inDepth, linkVisitChecker, timeAggregated);
+        LinkSelectContext inboundLinkSelectContext = new LinkSelectContext(timeWindow, new SearchDepth(0), inDepth, linkVisitChecker);
 
         while (!outboundApplications.isEmpty() || !inboundApplications.isEmpty()) {
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkHandler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkHandler.java
@@ -87,7 +87,7 @@ public class VirtualLinkHandler {
     }
 
     private Collection<LinkData> getEmulatedNodeInLinkData(LinkVisitChecker linkVisitChecker, Application emulatedNode, TimeWindow timeWindow) {
-        LinkDataMap inLinkDataMap = linkDataMapService.selectInLinkDataMap(emulatedNode, timeWindow, false);
+        LinkDataMap inLinkDataMap = linkDataMapService.selectInLinkDataMap(emulatedNode, timeWindow);
         logger.debug("emulated node [{}] in LinkDataMap:{}", emulatedNode, inLinkDataMap);
 
         LinkDataMap filteredInLinkDataMap = new LinkDataMap();

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/HistogramServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/HistogramServiceImpl.java
@@ -75,7 +75,6 @@ public class HistogramServiceImpl implements HistogramService {
         LinkSelectorType linkSelectorType = searchOption.getLinkSelectorType();
         int outSearchDepth = searchOption.getOutSearchDepth();
         int inSearchDepth = searchOption.getInSearchDepth();
-        boolean timeAggregate = option.isSimpleResponseHistogram();
 
         LinkDataMapProcessor outLinkProcessor = LinkDataMapProcessor.NO_OP;
         if (searchOption.isWasOnly()) {
@@ -86,9 +85,7 @@ public class HistogramServiceImpl implements HistogramService {
 
         TimeWindow timeWindow = option.getTimeWindow();
         LinkDataDuplexMap linkDataDuplexMap = linkSelector.select(
-                Collections.singletonList(
-                        option.getSourceApplication()
-                ), timeWindow, outSearchDepth, inSearchDepth, timeAggregate);
+                List.of(option.getSourceApplication()), timeWindow, outSearchDepth, inSearchDepth);
         watch.stop();
         logger.debug("LinkDataDuplexMap selected in {} ms. node={}, outDepth={}, inDepth={}, count={}",
                 watch.getTotalTimeMillis(), option.getSourceApplication(), outSearchDepth, inSearchDepth, linkDataDuplexMap.size());

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/LinkDataMapService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/LinkDataMapService.java
@@ -26,7 +26,7 @@ import com.navercorp.pinpoint.web.vo.Application;
  */
 public interface LinkDataMapService {
 
-    LinkDataMap selectOutLinkDataMap(Application outApplication, TimeWindow timeWindow, boolean timeAggregated);
+    LinkDataMap selectOutLinkDataMap(Application outApplication, TimeWindow timeWindow);
 
-    LinkDataMap selectInLinkDataMap(Application inApplication, TimeWindow timeWindow, boolean timeAggregated);
+    LinkDataMap selectInLinkDataMap(Application inApplication, TimeWindow timeWindow);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/LinkDataMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/LinkDataMapServiceImpl.java
@@ -42,12 +42,12 @@ public class LinkDataMapServiceImpl implements LinkDataMapService {
     }
 
     @Override
-    public LinkDataMap selectOutLinkDataMap(Application outApplication, TimeWindow timeWindow, boolean timeAggregated) {
-        return mapOutLinkDao.selectOutLink(outApplication, timeWindow, timeAggregated);
+    public LinkDataMap selectOutLinkDataMap(Application outApplication, TimeWindow timeWindow) {
+        return mapOutLinkDao.selectOutLink(outApplication, timeWindow);
     }
 
     @Override
-    public LinkDataMap selectInLinkDataMap(Application inApplication, TimeWindow timeWindow, boolean timeAggregated) {
-        return mapInLinkDao.selectInLink(inApplication, timeWindow, timeAggregated);
+    public LinkDataMap selectInLinkDataMap(Application inApplication, TimeWindow timeWindow) {
+        return mapInLinkDao.selectInLink(inApplication, timeWindow);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceOption.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceOption.java
@@ -32,14 +32,12 @@ public class MapServiceOption {
     private final TimeWindow timeWindow;
     private final SearchOption searchOption;
 
-    private final boolean simpleResponseHistogram;
     private final boolean useStatisticsAgentState;
 
     private MapServiceOption(Builder builder) {
         this.sourceApplication = builder.sourceApplication;
         this.timeWindow = builder.timeWindow;
         this.searchOption = builder.searchOption;
-        this.simpleResponseHistogram = builder.simpleResponseHistogram;
         this.useStatisticsAgentState = builder.useStatisticsAgentState;
     }
 
@@ -59,10 +57,6 @@ public class MapServiceOption {
         return searchOption;
     }
 
-    public boolean isSimpleResponseHistogram() {
-        return simpleResponseHistogram;
-    }
-
     public boolean isUseStatisticsAgentState() {
         return useStatisticsAgentState;
     }
@@ -73,7 +67,6 @@ public class MapServiceOption {
                 "sourceApplication=" + sourceApplication +
                 ", timeWindow=" + timeWindow +
                 ", searchOption=" + searchOption +
-                ", simpleResponseHistogram=" + simpleResponseHistogram +
                 ", useStatisticsAgentState=" + useStatisticsAgentState +
                 '}';
     }
@@ -83,7 +76,6 @@ public class MapServiceOption {
         private final TimeWindow timeWindow;
         private final SearchOption searchOption;
 
-        private boolean simpleResponseHistogram;
         // option
         private boolean useStatisticsAgentState;
 
@@ -93,10 +85,6 @@ public class MapServiceOption {
             this.searchOption = Objects.requireNonNull(searchOption, "searchOption");
         }
 
-        public Builder setSimpleResponseHistogram(boolean simpleResponseHistogram) {
-            this.simpleResponseHistogram = simpleResponseHistogram;
-            return this;
-        }
 
         public Builder setUseStatisticsAgentState(boolean useStatisticsAgentState) {
             this.useStatisticsAgentState = useStatisticsAgentState;

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/NodeHistogramService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/NodeHistogramService.java
@@ -20,7 +20,6 @@ import com.navercorp.pinpoint.web.applicationmap.appender.histogram.NodeHistogra
 import com.navercorp.pinpoint.web.vo.ResponseHistograms;
 
 public interface NodeHistogramService {
-    NodeHistogramFactory getSimpleHistogram();
 
     NodeHistogramFactory getApplicationHistogram();
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/NodeHistogramServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/NodeHistogramServiceImpl.java
@@ -18,10 +18,8 @@ package com.navercorp.pinpoint.web.applicationmap.service;
 
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.DefaultNodeHistogramFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.NodeHistogramFactory;
-import com.navercorp.pinpoint.web.applicationmap.appender.histogram.SimplifiedNodeHistogramFactory;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.MapApplicationResponseNodeHistogramDataSource;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.MapResponseNodeHistogramDataSource;
-import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.MapResponseSimplifiedNodeHistogramDataSource;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.ResponseHistogramsNodeHistogramDataSource;
 import com.navercorp.pinpoint.web.applicationmap.appender.histogram.datasource.WasNodeHistogramDataSource;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapAgentResponseDao;
@@ -40,12 +38,6 @@ public class NodeHistogramServiceImpl implements NodeHistogramService {
     public NodeHistogramServiceImpl(MapAgentResponseDao mapAgentResponseDao, MapResponseDao mapResponseDao) {
         this.mapAgentResponseDao = Objects.requireNonNull(mapAgentResponseDao, "mapAgentResponseDao");
         this.mapResponseDao = Objects.requireNonNull(mapResponseDao, "mapResponseDao");
-    }
-
-    @Override
-    public NodeHistogramFactory getSimpleHistogram() {
-        WasNodeHistogramDataSource dataSource = new MapResponseSimplifiedNodeHistogramDataSource(mapAgentResponseDao);
-        return new SimplifiedNodeHistogramFactory(dataSource);
     }
 
     @Override

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/BidirectionalLinkSelectorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/BidirectionalLinkSelectorTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.when;
 
 /**
@@ -77,7 +76,7 @@ public class BidirectionalLinkSelectorTest extends LinkSelectorTestBase {
         LinkDataMap link_OUT_IN_to_OUT = new LinkDataMap();
         link_OUT_IN_to_OUT.addLinkData(APP_OUT_IN, "agentOutIn", APP_OUT, "agentOut", 1000, ServiceType.STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount);
 
-        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
+        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class))).thenAnswer(new Answer<LinkDataMap>() {
             @Override
             public LinkDataMap answer(InvocationOnMock invocation) throws Throwable {
                 Application callerApplication = invocation.getArgument(0);
@@ -98,7 +97,7 @@ public class BidirectionalLinkSelectorTest extends LinkSelectorTestBase {
                 return newEmptyLinkDataMap();
             }
         });
-        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
+        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class))).thenAnswer(new Answer<LinkDataMap>() {
             @Override
             public LinkDataMap answer(InvocationOnMock invocation) throws Throwable {
                 Application calleeApplication = invocation.getArgument(0);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelectorTestBase.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelectorTestBase.java
@@ -47,7 +47,6 @@ import java.util.concurrent.Executors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -94,8 +93,8 @@ public abstract class LinkSelectorTestBase {
     @Test
     public void testEmpty() {
         Application APP_A = new Application("APP_A", ServiceType.TEST_STAND_ALONE);
-        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
-        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(Set.of());
 
         LinkSelector linkSelector = linkSelectorFactory.createLinkSelector(getLinkSelectorType());
@@ -117,8 +116,8 @@ public abstract class LinkSelectorTestBase {
                 APP_B, "agentB",
                 1000, ServiceType.TEST_STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_A_B);
 
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class), anyBoolean())).thenReturn(linkDataMap);
-        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class))).thenReturn(linkDataMap);
+        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(Set.of());
 
         LinkSelector linkSelector = linkSelectorFactory.createLinkSelector(getLinkSelectorType());
@@ -149,8 +148,8 @@ public abstract class LinkSelectorTestBase {
                     targetApp, targetAppAgentId,
                     1000, ServiceType.TEST_STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_A_APP);
         }
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class), anyBoolean())).thenReturn(linkDataMap);
-        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class))).thenReturn(linkDataMap);
+        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(Set.of());
 
         LinkSelector linkSelector = linkSelectorFactory.createLinkSelector(getLinkSelectorType());
@@ -177,7 +176,7 @@ public abstract class LinkSelectorTestBase {
                 APP_A, "agentA",
                 APP_B, "agentB",
                 1000, ServiceType.TEST_STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_A_B);
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class), anyBoolean())).thenReturn(link_A_B);
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class))).thenReturn(link_A_B);
 
         LinkDataMap link_B_C = new LinkDataMap();
         int callCount_B_C = 20;
@@ -185,9 +184,9 @@ public abstract class LinkSelectorTestBase {
                 APP_B, "agentB",
                 APP_C, "agentC",
                 1000, ServiceType.TEST_STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_B_C);
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_B), any(TimeWindow.class), anyBoolean())).thenReturn(link_B_C);
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_B), any(TimeWindow.class))).thenReturn(link_B_C);
 
-        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(Set.of());
 
         // depth 1
@@ -232,8 +231,8 @@ public abstract class LinkSelectorTestBase {
                 RPC_A_B, rpcUri,
                 1000, testRpcServiceType.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_A_B);
 
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class), anyBoolean())).thenReturn(linkDataMap);
-        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class))).thenReturn(linkDataMap);
+        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
         when(hostApplicationMapDao.findAcceptApplicationName(eq(APP_A), any(Range.class))).thenReturn(acceptApplications);
 
         // When
@@ -271,8 +270,8 @@ public abstract class LinkSelectorTestBase {
                 APP_B, "agentB",
                 1000, ServiceType.TEST_STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_A_B);
 
-        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_B), any(TimeWindow.class), anyBoolean())).thenReturn(linkDataMap);
+        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_B), any(TimeWindow.class))).thenReturn(linkDataMap);
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(Set.of());
 
         LinkSelector linkSelector = linkSelectorFactory.createLinkSelector(getLinkSelectorType());
@@ -293,7 +292,7 @@ public abstract class LinkSelectorTestBase {
         final Application APP_A = new Application("APP_A", ServiceType.TEST_STAND_ALONE);
         final Application APP_B = new Application("APP_B", ServiceType.TEST_STAND_ALONE);
         final Application APP_C = new Application("APP_C", ServiceType.TEST_STAND_ALONE);
-        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
 
         int callCount_A_B = 30;
         LinkDataMap linkDataMap_A_B = new LinkDataMap();
@@ -301,7 +300,7 @@ public abstract class LinkSelectorTestBase {
                 APP_A, "agentA",
                 APP_B, "agentB",
                 1000, ServiceType.TEST_STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_A_B);
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_B), any(TimeWindow.class), anyBoolean())).thenReturn(linkDataMap_A_B);
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_B), any(TimeWindow.class))).thenReturn(linkDataMap_A_B);
 
         int callCount_B_C = 40;
         LinkDataMap linkDataMap_B_C = new LinkDataMap();
@@ -309,9 +308,9 @@ public abstract class LinkSelectorTestBase {
                 APP_B, "agentB",
                 APP_C, "agentC",
                 1000, ServiceType.TEST_STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_B_C);
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_C), any(TimeWindow.class), anyBoolean())).thenReturn(linkDataMap_B_C);
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_C), any(TimeWindow.class))).thenReturn(linkDataMap_B_C);
 
-        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
         when(hostApplicationMapDao.findAcceptApplicationName(any(Application.class), any(Range.class))).thenReturn(Set.of());
 
         LinkSelector linkSelector = linkSelectorFactory.createLinkSelector(getLinkSelectorType());
@@ -368,12 +367,12 @@ public abstract class LinkSelectorTestBase {
                 APP_C, "agentC",
                 1000, ServiceType.TEST_STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_A_C);
 
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class), anyBoolean())).thenReturn(linkDataMap);
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_A), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_B), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_B), any(TimeWindow.class), anyBoolean())).thenReturn(rpc_A_B_calleeLinkDataMap);
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_C), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_C), any(TimeWindow.class), anyBoolean())).thenReturn(rpc_A_C_calleeLinkDataMap);
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class))).thenReturn(linkDataMap);
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_A), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_B), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_B), any(TimeWindow.class))).thenReturn(rpc_A_B_calleeLinkDataMap);
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_C), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_C), any(TimeWindow.class))).thenReturn(rpc_A_C_calleeLinkDataMap);
         when(hostApplicationMapDao.findAcceptApplicationName(eq(APP_A), any(Range.class))).thenReturn(acceptApplications);
 
         // When
@@ -449,12 +448,12 @@ public abstract class LinkSelectorTestBase {
                 APP_C, "agentC",
                 1000, ServiceType.TEST_STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_proxy_C + callCount_C);
 
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class), anyBoolean())).thenReturn(linkDataMap);
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_A), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_B), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_B), any(TimeWindow.class), anyBoolean())).thenReturn(calleeLinkDataMap_B);
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_C), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_C), any(TimeWindow.class), anyBoolean())).thenReturn(calleeLinkDataMap_C);
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class))).thenReturn(linkDataMap);
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_A), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_B), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_B), any(TimeWindow.class))).thenReturn(calleeLinkDataMap_B);
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_C), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_C), any(TimeWindow.class))).thenReturn(calleeLinkDataMap_C);
         when(hostApplicationMapDao.findAcceptApplicationName(eq(APP_A), any(Range.class))).thenReturn(acceptApplications);
 
         // When
@@ -525,14 +524,14 @@ public abstract class LinkSelectorTestBase {
                 APP_D, "agentD",
                 1000, ServiceType.TEST_STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount_C_D);
 
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class), anyBoolean())).thenReturn(callerlinkDataMap_A);
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_A), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_B), any(TimeWindow.class), anyBoolean())).thenReturn(callerLinkDataMap_B);
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_B), any(TimeWindow.class), anyBoolean())).thenReturn(calleeLinkDataMap_B);
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_C), any(TimeWindow.class), anyBoolean())).thenReturn(callerLinkDataMap_C);
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_C), any(TimeWindow.class), anyBoolean())).thenReturn(calleeLinkDataMap_C);
-        when(linkDataMapService.selectOutLinkDataMap(eq(APP_D), any(TimeWindow.class), anyBoolean())).thenReturn(newEmptyLinkDataMap());
-        when(linkDataMapService.selectInLinkDataMap(eq(APP_D), any(TimeWindow.class), anyBoolean())).thenReturn(calleeLinkDataMap_D);
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_A), any(TimeWindow.class))).thenReturn(callerlinkDataMap_A);
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_A), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_B), any(TimeWindow.class))).thenReturn(callerLinkDataMap_B);
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_B), any(TimeWindow.class))).thenReturn(calleeLinkDataMap_B);
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_C), any(TimeWindow.class))).thenReturn(callerLinkDataMap_C);
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_C), any(TimeWindow.class))).thenReturn(calleeLinkDataMap_C);
+        when(linkDataMapService.selectOutLinkDataMap(eq(APP_D), any(TimeWindow.class))).thenReturn(newEmptyLinkDataMap());
+        when(linkDataMapService.selectInLinkDataMap(eq(APP_D), any(TimeWindow.class))).thenReturn(calleeLinkDataMap_D);
         when(hostApplicationMapDao.findAcceptApplicationName(eq(APP_A), any(Range.class))).thenReturn(gwAcceptApplications);
         when(hostApplicationMapDao.findAcceptApplicationName(eq(APP_B), any(Range.class))).thenReturn(apiAcceptApplications);
         when(hostApplicationMapDao.findAcceptApplicationName(eq(APP_C), any(Range.class))).thenReturn(apiAcceptApplications);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/UnidirectionalLinkSelectorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/UnidirectionalLinkSelectorTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.when;
 
 /**
@@ -77,7 +76,7 @@ public class UnidirectionalLinkSelectorTest extends LinkSelectorTestBase {
         LinkDataMap link_OUT_IN_to_OUT = new LinkDataMap();
         link_OUT_IN_to_OUT.addLinkData(APP_OUT_IN, "agentOutIn", APP_OUT, "agentOut", 1000, ServiceType.STAND_ALONE.getHistogramSchema().getNormalSlot().getSlotTime(), callCount);
 
-        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
+        when(linkDataMapService.selectOutLinkDataMap(any(Application.class), any(TimeWindow.class))).thenAnswer(new Answer<LinkDataMap>() {
             @Override
             public LinkDataMap answer(InvocationOnMock invocation) throws Throwable {
                 Application callerApplication = invocation.getArgument(0);
@@ -98,7 +97,7 @@ public class UnidirectionalLinkSelectorTest extends LinkSelectorTestBase {
                 return newEmptyLinkDataMap();
             }
         });
-        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class), anyBoolean())).thenAnswer(new Answer<LinkDataMap>() {
+        when(linkDataMapService.selectInLinkDataMap(any(Application.class), any(TimeWindow.class))).thenAnswer(new Answer<LinkDataMap>() {
             @Override
             public LinkDataMap answer(InvocationOnMock invocation) throws Throwable {
                 Application calleeApplication = invocation.getArgument(0);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
@@ -580,14 +580,6 @@ public class ResponseTimeHistogramServiceImplTest {
                 }
                 return linkDataDuplexMap;
             }
-
-            @Override
-            public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int callerSearchDepth, int calleeSearchDepth, boolean timeAggregated) {
-                if (timeAggregated) {
-                    throw new IllegalArgumentException("link histogram data require timeSeries data");
-                }
-                return select(sourceApplications, timeWindow, callerSearchDepth, calleeSearchDepth);
-            }
         };
     }
 
@@ -604,14 +596,6 @@ public class ResponseTimeHistogramServiceImplTest {
                     linkDataDuplexMap.addSourceLinkData(createLinkData(linkKey.getFrom(), linkKey.getTo(), timestamp));
                 }
                 return linkDataDuplexMap;
-            }
-
-            @Override
-            public LinkDataDuplexMap select(List<Application> sourceApplications, TimeWindow timeWindow, int callerSearchDepth, int calleeSearchDepth, boolean timeAggregated) {
-                if (timeAggregated) {
-                    throw new IllegalArgumentException("link histogram data require timeSeries data");
-                }
-                return select(sourceApplications, timeWindow, callerSearchDepth, calleeSearchDepth);
             }
         };
     }


### PR DESCRIPTION
…ilder method from MapServiceOption

This pull request simplifies the `MapServiceOption` class by removing the `simpleResponseHistogram` property and all related code. This reduces complexity and eliminates an unused or unnecessary option from the class and its builder.

**Refactoring and code cleanup:**

* Removed the `simpleResponseHistogram` field from the `MapServiceOption` class, its builder, and the constructor. [[1]](diffhunk://#diff-5f4b5ef4fe2c67502449231e31faf3fb380387ec23838e5c79e0c310b99af293L35-L42) [[2]](diffhunk://#diff-5f4b5ef4fe2c67502449231e31faf3fb380387ec23838e5c79e0c310b99af293L86)
* Deleted the `isSimpleResponseHistogram()` getter method.
* Removed the `setSimpleResponseHistogram` method from the builder.
* Updated the `toString()` method to exclude the `simpleResponseHistogram` field.