### PR TITLE
[#noissue] Update .claude docs to reflect nested layout route pattern

### DIFF
--- a/web-frontend/src/main/v3/packages/.claude/CLAUDE.md
+++ b/web-frontend/src/main/v3/packages/.claude/CLAUDE.md
@@ -59,10 +59,13 @@ Pages in `apps/web/src/pages/` are thin wrappers. Almost all logic lives in `pac
 
 ```
 apps/web/src/pages/Inspector.tsx  →  wraps InspectorPage from @pinpoint-fe/ui
-                                     via withInitialFetch HOC
+                                     reads configuration from configurationAtom
 ```
 
-**`withInitialFetch` HOC** (`packages/ui/src/components/HOC/`): Fetches configuration, syncs URL search params to Jotai atoms, and redirects to `/apiCheck` on error. All routed pages use this.
+**Nested Layout Routes** (`apps/web/src/components/Layout/`): The routing uses React Router nested `<Outlet />` components to handle cross-cutting concerns:
+- `SideNavigationOutlet` — wraps pages with the side navigation layout
+- `InitialFetchOutlet` — fetches configuration, syncs URL search params to Jotai atoms, and redirects to `/apiCheck` on error
+- `ConfigurationOutlet` — wraps configuration pages with the configuration layout
 
 **Route loaders** (`packages/ui/src/loader/`): React Router loaders validate/normalize URL date params (from/to) before rendering. They redirect with corrected date formats when needed.
 
@@ -70,7 +73,7 @@ apps/web/src/pages/Inspector.tsx  →  wraps InspectorPage from @pinpoint-fe/ui
 
 - **Jotai** atoms in `packages/ui/src/atoms/` — global state for search parameters, server map data, scatter data, configuration, transactions, toasts, etc.
 - **React Query** (`@tanstack/react-query`) — all server data fetching. Custom hooks in `packages/ui/src/hooks/api/` follow pattern: `useGetXxx` wraps `useQuery` with endpoint from `END_POINTS` and shared `queryFn`.
-- URL search params (`from`, `to`, application) are the source of truth for time ranges and selected application, synced to atoms via `withInitialFetch`.
+- URL search params (`from`, `to`, application) are the source of truth for time ranges and selected application, synced to atoms via `InitialFetchOutlet`.
 
 ### API Layer
 

--- a/web-frontend/src/main/v3/packages/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/web-frontend/src/main/v3/packages/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -2,14 +2,11 @@
 
 ## Key Architectural Patterns (Confirmed)
 
-### withInitialFetch HOC
-- `packages/ui/src/components/HOC/withInitialFetch.tsx`
-- 역할: configuration 조회, searchParameters 동기화, error 시 /apiCheck 리다이렉트
-- 현재 커밋(4e4bbdbf55)에서 `InitialFetchOutlet`으로 대체됨
-- HOC 자체는 아직 삭제되지 않음 (dead code)
-
-### 새로운 레이아웃 라우트 패턴 (4e4bbdbf55 이후)
-- SideNavigationOutlet > InitialFetchOutlet > (errorElement wrapper) > 개별 페이지
+### Nested Layout Route Pattern
+- `apps/web/src/components/Layout/InitialFetchOutlet.tsx` — configuration 조회, searchParameters 동기화, error 시 /apiCheck 리다이렉트
+- `apps/web/src/components/Layout/SideNavigationOutlet.tsx` — 사이드 네비게이션 레이아웃
+- `apps/web/src/components/Layout/ConfigurationOutlet.tsx` — 설정 페이지 레이아웃
+- 라우트 구조: SideNavigationOutlet > InitialFetchOutlet > (errorElement wrapper) > 개별 페이지
 - Configuration 필요 페이지는 추가로 ConfigurationOutlet 중첩
 - 각 페이지 컴포넌트는 useAtomValue(configurationAtom)으로 직접 atom 읽기
 
@@ -22,11 +19,10 @@
 ### navigate()를 render 중 호출하는 패턴
 - React Router v6에서 render 단계에서 navigate()를 직접 호출하면 경고 발생
 - `useEffect` 안에서 navigate를 호출해야 안전
-- InitialFetchOutlet이 이 문제를 가지고 있음
+- InitialFetchOutlet에서는 useEffect로 처리됨
 
 ## 주요 파일 경로
 - `apps/web/src/routes/index.tsx` - 라우팅 설정
 - `apps/web/src/components/Layout/InitialFetchOutlet.tsx` - 핵심 초기화 로직
-- `packages/ui/src/components/HOC/withInitialFetch.tsx` - 구 HOC (현재 dead code)
 - `packages/ui/src/atoms/searchParameters.ts` - 검색 파라미터 atom
 - `apps/web/src/hooks/useMenuItems.tsx` - 사이드 네비게이션 메뉴

--- a/web-frontend/src/main/v3/packages/.claude/agents/code-reviewer/code-reviewer.md
+++ b/web-frontend/src/main/v3/packages/.claude/agents/code-reviewer/code-reviewer.md
@@ -20,7 +20,7 @@ You are an expert code reviewer for the Pinpoint Web Frontend v3 monorepo — a 
 - `packages/datetime-picker/`: Date/time picker
 
 ### Key Patterns
-1. **Page Pattern**: `withInitialFetch` HOC → Layout wrapper → Page component from `@pinpoint-fe/ui`
+1. **Page Pattern**: Nested layout routes (`SideNavigationOutlet` → `InitialFetchOutlet` → page) → Page reads `configurationAtom` → Page component from `@pinpoint-fe/ui`
 2. **API Hook Pattern**: `useGetXxx` → `useQuery` with `queryFn` from `reactQueryHelper.ts` → endpoint from `END_POINTS`
 3. **State**: URL params (source of truth) → Jotai atoms (global) → React Query (server)
 4. **UI Components**: shadcn/ui pattern (Radix + CVA + Tailwind + `cn()` utility)

--- a/web-frontend/src/main/v3/packages/.claude/agents/debugger/debugger.md
+++ b/web-frontend/src/main/v3/packages/.claude/agents/debugger/debugger.md
@@ -21,7 +21,7 @@ You are a frontend debugging specialist for the Pinpoint Web Frontend v3 monorep
 ### Common Error Sources
 1. **API Errors**: ProblemDetail (RFC 7807) responses from backend — check `reactQueryHelper.ts`
 2. **Route Loader Failures**: Date validation/redirect in `packages/ui/src/loader/`
-3. **Atom Sync Issues**: `withInitialFetch` HOC syncing URL params → atoms
+3. **Atom Sync Issues**: `InitialFetchOutlet` syncing URL params → atoms
 4. **React Query Stale Data**: Check `enabled`, `gcTime`, `staleTime`, query keys
 5. **Build Errors**: TypeScript strict mode violations, missing exports, circular deps
 6. **Test Failures**: Module alias mismatch, missing jsdom setup, async timing
@@ -29,7 +29,7 @@ You are a frontend debugging specialist for the Pinpoint Web Frontend v3 monorep
 ### Key Files for Investigation
 - Error handling: `packages/ui/src/hooks/api/reactQueryHelper.ts`
 - Configuration: `packages/ui/src/atoms/configuration.ts`
-- URL sync: `packages/ui/src/components/HOC/withInitialFetch.tsx`
+- URL sync: `apps/web/src/components/Layout/InitialFetchOutlet.tsx`
 - Route validation: `packages/ui/src/loader/*.ts`
 - Endpoints: `packages/ui/src/constants/EndPoints.ts`
 

--- a/web-frontend/src/main/v3/packages/.claude/agents/explorer/explorer.md
+++ b/web-frontend/src/main/v3/packages/.claude/agents/explorer/explorer.md
@@ -25,14 +25,14 @@ You are a codebase exploration specialist for the Pinpoint Web Frontend v3 monor
 
 ### Data Flow
 ```
-URL params → Route Loader (validate dates) → withInitialFetch (sync to atoms)
+URL params → Route Loader (validate dates) → InitialFetchOutlet (sync to atoms)
   → Page Component → API Hooks (React Query) → Backend (/api/*)
   → Response → Component renders
 ```
 
 ### Key Architecture Decisions
 - URL is source of truth for application + date range
-- withInitialFetch HOC bridges URL → Jotai atoms → component props
+- InitialFetchOutlet bridges URL → Jotai atoms; pages read atoms directly via `useAtomValue`
 - All API calls go through shared queryFn in reactQueryHelper.ts
 - Types use namespace pattern (namespace GetXxx { ... })
 

--- a/web-frontend/src/main/v3/packages/.claude/rules/code-review-policy.md
+++ b/web-frontend/src/main/v3/packages/.claude/rules/code-review-policy.md
@@ -33,7 +33,7 @@ Every time code is modified, the following review must be performed:
 - [ ] No exports were accidentally removed or renamed
 - [ ] No query keys were changed in a way that breaks cache invalidation
 - [ ] Route loaders still validate and redirect correctly
-- [ ] withInitialFetch HOC still receives expected data shape
+- [ ] InitialFetchOutlet correctly syncs URL params to atoms and handles configuration errors
 
 ### 5. Test Awareness
 - If modifying code that has tests, run the relevant tests: `yarn workspace @pinpoint-fe/ui test`

--- a/web-frontend/src/main/v3/packages/.claude/rules/components.md
+++ b/web-frontend/src/main/v3/packages/.claude/rules/components.md
@@ -8,15 +8,19 @@ paths:
 # React Component Rules
 
 ## Page Components (apps/web/src/pages/)
-- Pages are thin wrappers: import page component from `@pinpoint-fe/ui` and wrap with `withInitialFetch` HOC
-- Always wrap with a layout component (`getLayoutWithSideNavigation` or `getLayoutWithConfiguration`)
+- Pages are thin wrappers: import page component from `@pinpoint-fe/ui` and render it
+- Layout wrapping is handled by nested layout routes (`SideNavigationOutlet`, `InitialFetchOutlet`, `ConfigurationOutlet`) in `apps/web/src/routes/index.tsx`
+- Pages that need configuration read it from `configurationAtom` via `useAtomValue`
 - Pattern:
   ```tsx
-  import { withInitialFetch, SomePageComponent } from '@pinpoint-fe/ui';
-  import { getLayoutWithSideNavigation } from '@pinpoint-fe/web/src/components/Layout/LayoutWithSideNavigation';
-  export default withInitialFetch((props) =>
-    getLayoutWithSideNavigation(<SomePageComponent {...props} />),
-  );
+  import { useAtomValue } from 'jotai';
+  import { SomePageComponent } from '@pinpoint-fe/ui';
+  import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
+
+  export default function SomePage() {
+    const configuration = useAtomValue(configurationAtom);
+    return <SomePageComponent configuration={configuration} />;
+  }
   ```
 
 ## Domain Components (packages/ui/src/components/)

--- a/web-frontend/src/main/v3/packages/.claude/rules/routing.md
+++ b/web-frontend/src/main/v3/packages/.claude/rules/routing.md
@@ -16,10 +16,22 @@ paths:
 ## Adding a New Route
 1. Define path constant in `packages/ui/src/constants/path.ts` under `APP_PATH`
 2. Create page component in `packages/ui/src/pages/`
-3. Create page wrapper in `apps/web/src/pages/` using `withInitialFetch`
+3. Create thin page wrapper in `apps/web/src/pages/` (read `configurationAtom` via `useAtomValue` if needed)
 4. Create route loader in `packages/ui/src/loader/` if date validation needed
-5. Add route to `apps/web/src/routes/index.tsx`
+5. Add route to `apps/web/src/routes/index.tsx` inside the `InitialFetchOutlet` children (or `ConfigurationOutlet` for config pages)
 6. Use `React.lazy()` for code splitting (except default route)
+
+## Nested Layout Route Structure
+Routes use nested `<Outlet />` components for cross-cutting concerns:
+```
+SideNavigationOutlet
+  ├── /apiCheck (outside InitialFetchOutlet)
+  └── InitialFetchOutlet (fetches config, syncs URL → atoms)
+       ├── Page routes (with loaders)
+       ├── ConfigurationOutlet (wraps config pages with config layout)
+       │    └── Config page routes
+       └── * (NotFound)
+```
 
 ## Route Loaders (`packages/ui/src/loader/`)
 - Validate URL date parameters (from/to)

--- a/web-frontend/src/main/v3/packages/.claude/rules/state-management.md
+++ b/web-frontend/src/main/v3/packages/.claude/rules/state-management.md
@@ -9,14 +9,14 @@ paths:
 
 ## Architecture (Three Layers)
 1. **URL State (Source of Truth)**: Application name, date range (from/to), query filters
-2. **Jotai Atoms (Global State)**: Synced from URL via `withInitialFetch`, plus UI state
+2. **Jotai Atoms (Global State)**: Synced from URL via `InitialFetchOutlet`, plus UI state
 3. **React Query (Server State)**: All API data fetching with caching
 
 ## Jotai Atoms (`packages/ui/src/atoms/`)
 - Atom naming: camelCase with `Atom` suffix (e.g., `serverMapDataAtom`)
 - Derived atoms use `atom((get) => ...)` pattern
 - Keep atoms minimal — store only what multiple components need
-- Atoms are synced from URL search params via `withInitialFetch` HOC
+- Atoms are synced from URL search params via `InitialFetchOutlet` layout route
 - Key atoms: `searchParametersAtom`, `configurationAtom`, `serverMapDataAtom`, `serverMapCurrentTargetAtom`
 
 ## React Query Hooks (`packages/ui/src/hooks/api/`)
@@ -37,4 +37,4 @@ paths:
 ## Do NOT
 - Store derived state in atoms — compute it in components or derived atoms
 - Duplicate server data in atoms — let React Query manage it
-- Manually sync URL params — use `withInitialFetch` and search parameter hooks
+- Manually sync URL params — use `InitialFetchOutlet` and search parameter hooks

--- a/web-frontend/src/main/v3/packages/.claude/skills/create-page/SKILL.md
+++ b/web-frontend/src/main/v3/packages/.claude/skills/create-page/SKILL.md
@@ -24,7 +24,7 @@ Add the new path constant to `APP_PATH` in `packages/ui/src/constants/path.ts`.
 ### 2b. Create Page Component
 Create `packages/ui/src/pages/{PageName}.tsx`:
 - Import hooks and components from `@pinpoint-fe/ui`
-- Accept `configuration` prop from `withInitialFetch`
+- Accept `configuration` prop (read from `configurationAtom` in the page wrapper)
 - Use appropriate search parameter hook
 - Use React Query hooks for data fetching
 
@@ -41,18 +41,21 @@ Create `packages/ui/src/loader/{pageName}.ts` following the pattern in existing 
 Create `apps/web/src/pages/<PageName>.tsx`:
 ```tsx
 // Replace <PageName> with the actual page name (e.g., Inspector, ErrorAnalysis)
-import { withInitialFetch, <PageName>Page } from '@pinpoint-fe/ui';
-import { getLayoutWithSideNavigation } from '@pinpoint-fe/web/src/components/Layout/LayoutWithSideNavigation';
+import { useAtomValue } from 'jotai';
+import { <PageName>Page } from '@pinpoint-fe/ui';
+import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
 
-export default withInitialFetch((props) =>
-  getLayoutWithSideNavigation(<<PageName>Page {...props} />),
-);
+export default function <PageName>() {
+  const configuration = useAtomValue(configurationAtom);
+  return <<PageName>Page configuration={configuration} />;
+}
 ```
 
 ### 2f. Add Route
 Add the route to `apps/web/src/routes/index.tsx`:
 - Add lazy import at the top
-- Add route entry with loader and element
+- Add route entry inside the `InitialFetchOutlet` children (or `ConfigurationOutlet` for config pages)
+- Include loader and element
 
 ## 3. Add i18n Keys
 Add any user-facing strings to both `en.json` and `ko.json` in `packages/ui/src/constants/locales/`.
@@ -60,4 +63,4 @@ Add any user-facing strings to both `en.json` and `ko.json` in `packages/ui/src/
 ## 4. Verify
 - Check that the route path is unique
 - Confirm all imports are correct
-- Verify the page follows withInitialFetch pattern
+- Verify the page is placed inside the correct layout outlet in the route tree

--- a/web-frontend/src/main/v3/packages/.claude/skills/review-code/SKILL.md
+++ b/web-frontend/src/main/v3/packages/.claude/skills/review-code/SKILL.md
@@ -15,7 +15,7 @@ Review the code at `$ARGUMENTS` (or recent git changes if no path given).
 
 ### 1. Architecture
 - [ ] Code in correct package (apps/web for routing, packages/ui for everything else)
-- [ ] Page follows withInitialFetch + Layout wrapper pattern
+- [ ] Page is placed inside correct nested layout outlet (InitialFetchOutlet / ConfigurationOutlet)
 - [ ] API hooks use shared queryFn from reactQueryHelper
 - [ ] State management uses correct layer (URL → Jotai → React Query)
 


### PR DESCRIPTION
Replace all withInitialFetch HOC references with the new InitialFetchOutlet / SideNavigationOutlet / ConfigurationOutlet nested layout route pattern across rules, skills, agents, and agent-memory documentation.