### PR TITLE
[#noissue] Add isEmpty method to NodeList and simplify DefaultNodeHis…

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/DefaultNodeHistogramAppender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/DefaultNodeHistogramAppender.java
@@ -26,7 +26,6 @@ import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.nodes.NodeList;
 import com.navercorp.pinpoint.web.applicationmap.util.CancellableHistogramFactory;
 import com.navercorp.pinpoint.web.vo.Application;
-import org.springframework.util.CollectionUtils;
 
 import java.util.Collection;
 import java.util.List;
@@ -57,13 +56,10 @@ public class DefaultNodeHistogramAppender implements NodeHistogramAppender {
 
     @Override
     public void appendNodeHistogram(final TimeWindow timeWindow, final NodeList nodeList, final LinkList linkList, final long timeoutMillis) {
-        if (nodeList == null) {
+        if (nodeList == null || nodeList.isEmpty()) {
             return;
         }
         final Collection<Node> nodes = nodeList.getNodeList();
-        if (CollectionUtils.isEmpty(nodes)) {
-            return;
-        }
         final Node[] nodeArray = nodes.toArray(new Node[0]);
         final CompletableFuture<List<NodeHistogram>> future = getNodeHistogramList(timeWindow, nodeArray, linkList);
         List<NodeHistogram> result = allOf(future, timeoutMillis, nodeHistogramFactory::cancel);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/NodeList.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/NodeList.java
@@ -63,6 +63,10 @@ public class NodeList {
         return this.nodeMap.size();
     }
 
+    public boolean isEmpty() {
+        return this.nodeMap.isEmpty();
+    }
+
     public static NodeList.Builder newBuilder() {
         return newBuilder(16);
     }


### PR DESCRIPTION
…togramAppender logic

This pull request refactors how empty node lists are handled in the `DefaultNodeHistogramAppender` class by simplifying the logic and removing unnecessary dependencies. The main changes include adding an `isEmpty()` method to the `NodeList` class and updating the histogram appender to use this method instead of relying on Spring's `CollectionUtils`.

Node list handling improvements:

* Added a new `isEmpty()` method to the `NodeList` class to directly check if the node map is empty. (`NodeList.java`)
* Updated the `appendNodeHistogram` method in `DefaultNodeHistogramAppender` to use `nodeList.isEmpty()` for early return, replacing previous checks and removing the dependency on `CollectionUtils`. (`DefaultNodeHistogramAppender.java`)

Dependency cleanup:

* Removed the import of `CollectionUtils` from `DefaultNodeHistogramAppender.java` since it is no longer needed.