### PR TITLE
[#noissue] Add NodeList.isEmpty() method and refactor appenders to simplify null and empty checks

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/DefaultNodeHistogramAppender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/histogram/DefaultNodeHistogramAppender.java
@@ -56,7 +56,7 @@ public class DefaultNodeHistogramAppender implements NodeHistogramAppender {
 
     @Override
     public void appendNodeHistogram(final TimeWindow timeWindow, final NodeList nodeList, final LinkList linkList, final long timeoutMillis) {
-        if (nodeList == null || nodeList.isEmpty()) {
+        if (NodeList.isEmpty(nodeList)) {
             return;
         }
         final Collection<Node> nodes = nodeList.getNodeList();

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/DefaultServerInfoAppender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/DefaultServerInfoAppender.java
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataDuplexMap;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,14 +54,11 @@ public class DefaultServerInfoAppender implements ServerInfoAppender {
 
     @Override
     public void appendServerInfo(final Range range, final NodeList source, final LinkDataDuplexMap linkDataDuplexMap, long timeoutMillis) {
-        if (source == null) {
+        if (NodeList.isEmpty(source)) {
             return;
         }
 
         Collection<Node> nodes = source.getNodeList();
-        if (CollectionUtils.isEmpty(nodes)) {
-            return;
-        }
 
         final List<ServerGroupRequest> serverGroupRequest = getServerGroupListFutures(range, nodes, linkDataDuplexMap);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/NodeList.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/NodeList.java
@@ -37,6 +37,10 @@ public class NodeList {
         return new NodeList(Map.of(node.getApplication(), node));
     }
 
+    public static boolean isEmpty(NodeList nodeList) {
+        return nodeList == null || nodeList.isEmpty();
+    }
+
     public static NodeList of() {
         return EMPTY;
     }


### PR DESCRIPTION
…mplify null and empty checks

This pull request refactors how node list emptiness checks are performed across the application map appender modules. The main change is the introduction and adoption of a new static utility method, `NodeList.isEmpty`, to consistently check for empty or null `NodeList` instances, replacing previous ad-hoc or external utility checks.

**Refactoring and Consistency Improvements:**

* Added a static `isEmpty` method to the `NodeList` class to encapsulate the null and emptiness check for `NodeList` objects.
* Updated `DefaultNodeHistogramAppender.appendNodeHistogram` and `DefaultServerInfoAppender.appendServerInfo` to use `NodeList.isEmpty` for checking if the node list is empty, improving code readability and consistency. [[1]](diffhunk://#diff-be55c3910e8a30017f138675f86100bba66bdd2e76acf55e4a00a4b7856889bcL59-R59) [[2]](diffhunk://#diff-284651c342c7aecb97f58c23c018333d129d31e0b3ff45ce65e80949a9456e52L58-L65)
* Removed the use of `CollectionUtils.isEmpty` and the associated import from `DefaultServerInfoAppender`, as the new utility method supersedes its usage.