### PR TITLE
[#13430] Performance Improvements to the Application List Menu

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/mapper/ApplicationNameMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/mapper/ApplicationNameMapper.java
@@ -16,13 +16,16 @@
 
 package com.navercorp.pinpoint.web.mapper;
 
+import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.util.CellUtils;
+import com.navercorp.pinpoint.common.util.BytesUtils;
 import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.Service;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
 import org.eclipse.collections.api.factory.primitive.IntSets;
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
 import org.springframework.stereotype.Component;
@@ -31,12 +34,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  *
  */
 @Component
-public class ApplicationNameMapper implements RowMapper<List<Application>> {
+public class ApplicationNameMapper implements RowMapper<List<Application>>, ResultsExtractor<List<Application>> {
 
     private final ApplicationFactory applicationFactory;
 
@@ -49,20 +53,38 @@ public class ApplicationNameMapper implements RowMapper<List<Application>> {
         if (result.isEmpty()) {
             return Collections.emptyList();
         }
+        List<Application> applicationList = new ArrayList<>();
+
+        readApplication(result.rawCells(), applicationList::add);
+
+        return applicationList;
+    }
+
+    public void readApplication(Cell[] cells, Consumer<Application> consumer) {
         MutableIntSet uniqueTypeCodes = IntSets.mutable.of();
-        String applicationName = CellUtils.rowToString(result);
-        
-        Cell[] rawCells = result.rawCells();
-        for (Cell cell : rawCells) {
+        String applicationName = null;
+        for (Cell cell : cells) {
+            if (applicationName == null) {
+                applicationName = BytesUtils.toString(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength());
+            }
             int serviceTypeCode = CellUtils.valueToShort(cell);
-            uniqueTypeCodes.add(serviceTypeCode);
+            if (uniqueTypeCodes.add(serviceTypeCode)) {
+                Application application = applicationFactory.createApplication(Service.DEFAULT, applicationName, serviceTypeCode);
+                consumer.accept(application);
+            }
+        }
+    }
+
+    @Override
+    public List<Application> extractData(ResultScanner results) throws Exception {
+        List<Application> applications = new ArrayList<>(256);
+        for (Result result : results) {
+            if (result.isEmpty()) {
+                continue;
+            }
+            readApplication(result.rawCells(), applications::add);
         }
 
-        List<Application> applicationList = new ArrayList<>();
-        uniqueTypeCodes.forEach(serviceTypeCode -> {
-            final Application application = applicationFactory.createApplication(Service.DEFAULT.getUid(), applicationName, serviceTypeCode);
-            applicationList.add(application);
-        });
-        return applicationList;
+        return applications;
     }
 }


### PR DESCRIPTION
This pull request refactors how application names are retrieved from HBase, improving both performance and code organization. The main change is the introduction of a new `ResultsExtractor` implementation to efficiently flatten and extract application data, replacing the previous approach that required post-processing of nested lists.

**Refactoring and performance improvements:**

* Introduced a new `ApplicationNameResultExtractor` class implementing `ResultsExtractor<List<Application>>`, which efficiently flattens results from HBase scans and eliminates the need for `ListListUtils.toList`. (`web/src/main/java/com/navercorp/pinpoint/web/mapper/ApplicationNameResultExtractor.java`)
* Updated `HbaseApplicationIndexDao` to use the new `ResultsExtractor` for retrieving all application names, increased scan caching for better performance, and removed the now-unnecessary `ListListUtils` dependency. (`web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseApplicationIndexDao.java`) [[1]](diffhunk://#diff-298bdd033b5338787d44ee9ed0a737ccc2e7b2768d72aed3ec1d69fdd71390b1R22-L27) [[2]](diffhunk://#diff-298bdd033b5338787d44ee9ed0a737ccc2e7b2768d72aed3ec1d69fdd71390b1R58-R86)

**Code reuse and maintainability:**

* Refactored `ApplicationNameMapper` to extract a reusable `writeApplication` method, allowing both the mapper and the new extractor to share application creation logic. (`web/src/main/java/com/navercorp/pinpoint/web/mapper/ApplicationNameMapper.java`)

**Dependency and import updates:**

* Added necessary imports for `ResultsExtractor`, utility classes, and functional interfaces to support the refactoring. (`web/src/main/java/com/navercorp/pinpoint/web/mapper/ApplicationNameMapper.java`) [[1]](diffhunk://#diff-fff69f3690522c64a2174cedcd643a974fb2a5773a37f55f7ddec02d94aabdcdR21) [[2]](diffhunk://#diff-fff69f3690522c64a2174cedcd643a974fb2a5773a37f55f7ddec02d94aabdcdR35)