### PR TITLE
[#noissue] Cleanup

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ServiceGroupRowKeyPrefixUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ServiceGroupRowKeyPrefixUtils.java
@@ -2,7 +2,8 @@ package com.navercorp.pinpoint.common.server.util;
 
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
-import com.navercorp.pinpoint.common.buffer.FixedBuffer;
+import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
+import com.navercorp.pinpoint.common.util.BytesUtils;
 
 public class ServiceGroupRowKeyPrefixUtils {
 
@@ -10,20 +11,20 @@ public class ServiceGroupRowKeyPrefixUtils {
     }
 
     public static byte[] createRowKey(int serviceUid) {
-        Buffer buffer = new FixedBuffer(4);
-        buffer.putInt(serviceUid);
-        return buffer.getBuffer();
+        byte[] serviceUidBytes = new byte[BytesUtils.INT_BYTE_LENGTH];
+        ByteArrayUtils.writeInt(serviceUid, serviceUidBytes, 0);
+        return serviceUidBytes;
     }
 
     public static byte[] createRowKey(int serviceUid, String applicationName) {
-        Buffer buffer = new AutomaticBuffer(4 + applicationName.length() + 1);
+        Buffer buffer = new AutomaticBuffer(BytesUtils.INT_BYTE_LENGTH + applicationName.length() + 1);
         buffer.putInt(serviceUid);
         buffer.putNullTerminatedString(applicationName);
         return buffer.getBuffer();
     }
 
     public static byte[] createRowKey(int serviceUid, String applicationName, int serviceTypeCode) {
-        Buffer buffer = new AutomaticBuffer(4 + applicationName.length() + 1 + 4);
+        Buffer buffer = new AutomaticBuffer(BytesUtils.INT_BYTE_LENGTH + applicationName.length() + 1 + BytesUtils.INT_BYTE_LENGTH);
         buffer.putInt(serviceUid);
         buffer.putNullTerminatedString(applicationName);
         buffer.putInt(serviceTypeCode);


### PR DESCRIPTION
This pull request refactors the way row keys are created in the `ServiceGroupRowKeyPrefixUtils` utility class to improve clarity and maintainability. The changes standardize the use of integer byte length constants and utility methods for byte array operations.

Key improvements to row key creation:

* Replaced the use of `FixedBuffer` and manual buffer sizing with direct use of `BytesUtils.INT_BYTE_LENGTH` and `ByteArrayUtils.writeInt` for creating row keys from integers, improving clarity and consistency.
* Updated buffer size calculations in overloaded `createRowKey` methods to use `BytesUtils.INT_BYTE_LENGTH` instead of hardcoded values, ensuring correctness and maintainability.