### PR TITLE
[#noissue] Remove deprecated selectAllApplicationNames method and ref…

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AdminServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AdminServiceImpl.java
@@ -42,6 +42,8 @@ public class AdminServiceImpl implements AdminService {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
+    private static final Integer SERVICE_TYPE_EMPTY = null;
+
     private final ActiveAgentValidator activeAgentValidator;
 
     private final ApplicationIndexService applicationIndexService;
@@ -80,33 +82,40 @@ public class AdminServiceImpl implements AdminService {
             throw new IllegalArgumentException("duration may not be less than " + MIN_DURATION_DAYS_FOR_INACTIVITY + " days");
         }
 
-        List<String> applicationNames = this.applicationIndexService.selectAllApplicationNames().stream()
-                .distinct()
-                .collect(Collectors.toList());
-        Collections.shuffle(applicationNames);
+        List<Application> applications = this.applicationIndexService.selectAllApplications();
+
 
         int index = 1;
-        for (String applicationName : applicationNames) {
-            logger.info("Cleaning {} ({}/{})", applicationName, index++, applicationNames.size());
-            removeInactiveAgentInApplication(applicationName, durationDays);
+        for (Application application : applications) {
+            logger.info("Cleaning {} ({}/{})", application, index++, applications.size());
+            removeInactiveAgentInApplication(application.getApplicationName(), application.getServiceTypeCode(), durationDays);
         }
     }
 
-    @Override
-    public int removeInactiveAgentInApplication(String applicationName, int durationDays) {
+    public int removeInactiveAgentInApplication(String applicationName, Integer serviceType, int durationDays) {
         try {
-            return removeInactiveAgentInApplication0(applicationName, durationDays);
+            return removeInactiveAgentInApplication0(applicationName, serviceType, durationDays);
         } catch (Exception e) {
             logger.error("Backoff to remove inactive agents in application {}", applicationName, e);
         }
         return 0;
     }
 
-    private int removeInactiveAgentInApplication0(String applicationName, int durationDays) {
+    @Override
+    public int removeInactiveAgentInApplication(String applicationName, int durationDays) {
+        try {
+            return removeInactiveAgentInApplication0(applicationName, SERVICE_TYPE_EMPTY, durationDays);
+        } catch (Exception e) {
+            logger.error("Backoff to remove inactive agents in application {}", applicationName, e);
+        }
+        return 0;
+    }
+
+    private int removeInactiveAgentInApplication0(String applicationName, Integer serviceTypeCode, int durationDays) {
         final List<String> agentsToDelete = new ArrayList<>(100);
         int deleteCount = 0;
 
-        final List<String> agentIds = this.applicationIndexService.selectAgentIds(applicationName);
+        final List<String> agentIds = selectAgentIds(applicationName, serviceTypeCode);
         for (String agentId : agentIds) {
             if (!isInactiveAgent(agentId, durationDays)) {
                 continue;
@@ -117,18 +126,34 @@ public class AdminServiceImpl implements AdminService {
 
             if (agentsToDelete.size() >= 100) {
                 logger.info("Delete {} of {}", agentsToDelete, applicationName);
-                applicationIndexService.deleteAgentIds(applicationName, agentsToDelete);
+                deleteAgentInfos(applicationName, serviceTypeCode, agentsToDelete);
                 agentsToDelete.clear();
             }
         }
 
         if (!agentsToDelete.isEmpty()) {
             logger.info("Delete {} of {}", agentsToDelete, applicationName);
-            applicationIndexService.deleteAgentIds(applicationName, agentsToDelete);
+            deleteAgentInfos(applicationName, serviceTypeCode, agentsToDelete);
         }
 
         logger.info("({}/{}) agents of {} had been cleaned up", deleteCount, agentIds.size(), applicationName);
         return deleteCount;
+    }
+
+    private List<String> selectAgentIds(String applicationName, Integer serviceTypeCode) {
+        if (serviceTypeCode == null) {
+            return this.applicationIndexService.selectAgentIds(applicationName);
+        } else {
+            return this.applicationIndexService.selectAgentIds(applicationName, serviceTypeCode);
+        }
+    }
+
+    private void deleteAgentInfos(String applicationName, Integer serviceTypeCode, List<String> agentsToDelete) {
+        if (serviceTypeCode == null) {
+            applicationIndexService.deleteAgentIds(applicationName, agentsToDelete);
+        } else {
+            applicationIndexService.deleteAgentIds(applicationName, serviceTypeCode, agentsToDelete);
+        }
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
@@ -95,7 +95,12 @@ public class AgentInfoServiceImpl implements AgentInfoService {
     public List<DetailedAgentAndStatus> getAllAgentsStatisticsList(AgentStatusFilter filter, Range range) {
         Objects.requireNonNull(filter, "filter");
 
-        List<String> applicationNameList = applicationIndexService.selectAllApplicationNames();
+        List<Application> applicationList = applicationIndexService.selectAllApplications();
+        List<String> applicationNameList = applicationList.stream()
+                .map(Application::getApplicationName)
+                .distinct()
+                .collect(Collectors.toList());
+
         List<DetailedAgentAndStatus> agents = new ArrayList<>();
         for (String applicationName : applicationNameList) {
             Set<DetailedAgentAndStatus> detailedAgents = getDetailedAgentsByApplicationName(applicationName, range.getTo());

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexService.java
@@ -29,9 +29,6 @@ public interface ApplicationIndexService {
 
     List<Application> selectAllApplications();
 
-    @Deprecated
-    List<String> selectAllApplicationNames();
-
     List<Application> selectApplication(String applicationName);
 
     void deleteApplicationName(String applicationName);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexServiceImpl.java
@@ -73,22 +73,6 @@ public class ApplicationIndexServiceImpl implements ApplicationIndexService {
     }
 
     @Override
-    @Deprecated
-    public List<String> selectAllApplicationNames() {
-        if (v2TableEnabled && applicationReadV2) {
-            return this.applicationDao.getApplications(ServiceUid.DEFAULT_SERVICE_UID_CODE).stream()
-                    .map(Application::getApplicationName)
-                    .distinct()
-                    .toList();
-        }
-        return this.applicationIndexDao.selectAllApplicationNames()
-                .stream()
-                .map(Application::getApplicationName)
-                .distinct()
-                .toList();
-    }
-
-    @Override
     public List<Application> selectApplication(String applicationName) {
         if (v2TableEnabled && applicationReadV2) {
             return this.applicationDao.getApplications(ServiceUid.DEFAULT_SERVICE_UID_CODE, applicationName);


### PR DESCRIPTION
This pull request refactors how applications are retrieved and handled in the admin and agent info services, moving from using application names (strings) to using the full `Application` object. It also updates deletion logic to support service type codes and removes deprecated methods. These changes improve code clarity and future extensibility.

**Refactoring application retrieval and usage:**

* Replaced usage of `selectAllApplicationNames()` (which returned a list of strings) with `selectAllApplications()` (which returns a list of `Application` objects) in both `AdminServiceImpl` and `AgentInfoServiceImpl`, updating the logic to utilize the `Application` object and its properties. [[1]](diffhunk://#diff-33d8dad04743eb181b1f61c61bc34bc980b22cc675db9661a61a915bbd2bc04fL83-R114) [[2]](diffhunk://#diff-5224732e188ccfd835e0021738148eedbb79cf63d5c47f19c3a9cfbce0f95a8eL98-R103)

**Deletion logic improvements:**

* Enhanced agent deletion logic in `AdminServiceImpl` to support deletion by both application name and service type code, including a new helper method `deleteAgentInfoos()` that delegates to the appropriate delete method based on presence of service type.
* Updated `removeInactiveAgentInApplication` and related methods to accept and use service type codes, improving granularity of agent removal.

**API and codebase cleanup:**

* Removed the deprecated `selectAllApplicationNames()` method from `ApplicationIndexService` and its implementation, consolidating to the newer, more robust `selectAllApplications()` API. [[1]](diffhunk://#diff-d1bdec2035b20da003deeaddcff1b22d5e027e82bb6f2233eb2526bd4ef8f904L32-L34) [[2]](diffhunk://#diff-4848edec56e68a9e4c4456af3e145202237c675004f4033abcd1e5f6d9dc82e0L75-L90)

**Minor improvements:**

* Added a constant `SERVICE_TYPE_EMPTY` for clarity in handling cases where service type is not specified.