### PR TITLE
[#noissue] Fix route loaders to handle configuration fetch failure gr…

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/loader/errorAnalysis.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/errorAnalysis.ts
@@ -15,51 +15,53 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const errorAnalysisRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
+  const application = getApplicationTypeAndName(params.application!);
+
+  let config: Configuration | undefined;
   try {
-    const application = getApplicationTypeAndName(params.application!);
-    const config = await getConfiguration<Configuration>();
-    const timezone = getTimezone();
+    config = await getConfiguration<Configuration>();
+  } catch {
+    // Continue with defaults so that date params are still redirected.
+  }
 
-    if (application?.applicationName && application.serviceType) {
-      const basePath = `${APP_PATH.ERROR_ANALYSIS}/${params.application}`;
-      const queryParam = Object.fromEntries(new URL(request.url).searchParams);
-      const conditions = Object.keys(queryParam);
+  const timezone = getTimezone();
 
-      const from = queryParam?.from as string;
-      const to = queryParam?.to as string;
+  if (application?.applicationName && application.serviceType) {
+    const basePath = `${APP_PATH.ERROR_ANALYSIS}/${params.application}`;
+    const queryParam = Object.fromEntries(new URL(request.url).searchParams);
+    const conditions = Object.keys(queryParam);
 
-      const currentDate = new Date();
-      const parsedDateRange = {
-        from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-        to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-      };
-      const validateDateRange = isValidDateRange(config?.['periodMax.exceptionTrace'] || 7);
-      const defaultParsedDateRange = getParsedDateRange({ from, to }, validateDateRange);
-      const defaultFormattedDateRange = {
-        from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-        to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-      };
-      const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
-      const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+    const from = queryParam?.from as string;
+    const to = queryParam?.to as string;
 
-      if (conditions.length === 0) {
-        return redirect(defaultDestination);
+    const currentDate = new Date();
+    const parsedDateRange = {
+      from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+      to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+    };
+    const validateDateRange = isValidDateRange(config?.['periodMax.exceptionTrace'] || 7);
+    const defaultParsedDateRange = getParsedDateRange({ from, to }, validateDateRange);
+    const defaultFormattedDateRange = {
+      from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+      to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+    };
+    const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
+    const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+
+    if (conditions.length === 0) {
+      return redirect(defaultDestination);
+    } else {
+      if (
+        conditions.includes('from') &&
+        conditions.includes('to') &&
+        validateDateRange(parsedDateRange)
+      ) {
+        return application;
       } else {
-        if (
-          conditions.includes('from') &&
-          conditions.includes('to') &&
-          validateDateRange(parsedDateRange)
-        ) {
-          return application;
-        } else {
-          return redirect(defaultDestination);
-        }
+        return redirect(defaultDestination);
       }
     }
-
-    return application;
-  } catch (err) {
-    console.error('Error in errorAnalysisRouteLoader:', err);
-    return null;
   }
+
+  return application;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/loader/inspector.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/inspector.ts
@@ -15,53 +15,55 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const inspectorRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
+  const application = getApplicationTypeAndName(params.application!);
+
+  let configuration: Configuration | undefined;
   try {
-    const application = getApplicationTypeAndName(params.application!);
-    const configuration = await getConfiguration<Configuration>();
-    const timezone = getTimezone();
+    configuration = await getConfiguration<Configuration>();
+  } catch {
+    // Continue with defaults so that date params are still redirected.
+  }
 
-    if (application?.applicationName && application.serviceType) {
-      const basePath = `${APP_PATH.INSPECTOR}/${params.application}`;
-      const queryParam = Object.fromEntries(new URL(request.url).searchParams);
-      const conditions = Object.keys(queryParam);
+  const timezone = getTimezone();
 
-      const from = queryParam?.from as string;
-      const to = queryParam?.to as string;
+  if (application?.applicationName && application.serviceType) {
+    const basePath = `${APP_PATH.INSPECTOR}/${params.application}`;
+    const queryParam = Object.fromEntries(new URL(request.url).searchParams);
+    const conditions = Object.keys(queryParam);
 
-      const currentDate = new Date();
-      const parsedDateRange = {
-        from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-        to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-      };
-      const validateDateRange = isValidDateRange(configuration?.['periodMax.inspector'] || 42);
-      const defaultParsedDateRange = getParsedDateRange({ from, to }, validateDateRange);
-      const defaultFormattedDateRange = {
-        from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-        to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-      };
-      const defaultDestination = `${basePath}?${convertParamsToQueryString({
-        ...queryParam,
-        ...defaultFormattedDateRange,
-      })}`;
+    const from = queryParam?.from as string;
+    const to = queryParam?.to as string;
 
-      if (conditions.length === 0) {
-        return redirect(defaultDestination);
+    const currentDate = new Date();
+    const parsedDateRange = {
+      from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+      to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+    };
+    const validateDateRange = isValidDateRange(configuration?.['periodMax.inspector'] || 42);
+    const defaultParsedDateRange = getParsedDateRange({ from, to }, validateDateRange);
+    const defaultFormattedDateRange = {
+      from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+      to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+    };
+    const defaultDestination = `${basePath}?${convertParamsToQueryString({
+      ...queryParam,
+      ...defaultFormattedDateRange,
+    })}`;
+
+    if (conditions.length === 0) {
+      return redirect(defaultDestination);
+    } else {
+      if (
+        conditions.includes('from') &&
+        conditions.includes('to') &&
+        validateDateRange(parsedDateRange)
+      ) {
+        return application;
       } else {
-        if (
-          conditions.includes('from') &&
-          conditions.includes('to') &&
-          validateDateRange(parsedDateRange)
-        ) {
-          return application;
-        } else {
-          return redirect(defaultDestination);
-        }
+        return redirect(defaultDestination);
       }
     }
-
-    return application;
-  } catch (err) {
-    console.error('Error in inspectorRouteLoader:', err);
-    return null;
   }
+
+  return application;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/loader/openTelemetry.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/openTelemetry.ts
@@ -15,51 +15,53 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const openTelemetryRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
+  const application = getApplicationTypeAndName(params.application!);
+
+  let configuration: Configuration | undefined;
   try {
-    const application = getApplicationTypeAndName(params.application!);
-    const configuration = await getConfiguration<Configuration>();
-    const timezone = getTimezone();
+    configuration = await getConfiguration<Configuration>();
+  } catch {
+    // Continue with defaults so that date params are still redirected.
+  }
 
-    if (application?.applicationName && application.serviceType) {
-      const basePath = `${APP_PATH.OPEN_TELEMETRY_METRIC}/${params.application}`;
-      const queryParam = Object.fromEntries(new URL(request.url).searchParams);
-      const conditions = Object.keys(queryParam);
+  const timezone = getTimezone();
 
-      const from = queryParam?.from as string;
-      const to = queryParam?.to as string;
+  if (application?.applicationName && application.serviceType) {
+    const basePath = `${APP_PATH.OPEN_TELEMETRY_METRIC}/${params.application}`;
+    const queryParam = Object.fromEntries(new URL(request.url).searchParams);
+    const conditions = Object.keys(queryParam);
 
-      const currentDate = new Date();
-      const parsedDateRange = {
-        from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-        to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-      };
-      const validateDateRange = isValidDateRange(configuration?.['periodMax.otlpMetric'] || 28);
-      const defaultParsedDateRange = getParsedDateRange({ from, to }, validateDateRange);
-      const defaultFormattedDateRange = {
-        from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-        to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-      };
-      const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
-      const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+    const from = queryParam?.from as string;
+    const to = queryParam?.to as string;
 
-      if (conditions.length === 0) {
-        return redirect(defaultDestination);
+    const currentDate = new Date();
+    const parsedDateRange = {
+      from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+      to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+    };
+    const validateDateRange = isValidDateRange(configuration?.['periodMax.otlpMetric'] || 28);
+    const defaultParsedDateRange = getParsedDateRange({ from, to }, validateDateRange);
+    const defaultFormattedDateRange = {
+      from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+      to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+    };
+    const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
+    const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+
+    if (conditions.length === 0) {
+      return redirect(defaultDestination);
+    } else {
+      if (
+        conditions.includes('from') &&
+        conditions.includes('to') &&
+        validateDateRange(parsedDateRange)
+      ) {
+        return application;
       } else {
-        if (
-          conditions.includes('from') &&
-          conditions.includes('to') &&
-          validateDateRange(parsedDateRange)
-        ) {
-          return application;
-        } else {
-          return redirect(defaultDestination);
-        }
+        return redirect(defaultDestination);
       }
     }
-
-    return application;
-  } catch (err) {
-    console.error('Error in openTelemetryRouteLoader:', err);
-    return null;
   }
+
+  return application;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/loader/scatterFullScreen.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/scatterFullScreen.ts
@@ -15,53 +15,55 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const scatterFullScreenLoader = async ({ params, request }: LoaderFunctionArgs) => {
+  const application = getApplicationTypeAndName(params.application);
+
+  let configuration: Configuration | undefined;
   try {
-    const application = getApplicationTypeAndName(params.application);
-    const configuration = await getConfiguration<Configuration>();
-    const timezone = getTimezone();
-
-    if (application?.applicationName && application.serviceType) {
-      const basePath = `${APP_PATH.SCATTER_FULL_SCREEN}/${params.application}`;
-      const queryParam = Object.fromEntries(new URL(request.url).searchParams);
-      const conditions = Object.keys(queryParam);
-
-      const from = queryParam?.from as string;
-      const to = queryParam?.to as string;
-
-      const currentDate = new Date();
-      const parsedDateRange = {
-        from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-        to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-      };
-      const defaultParsedDateRange = getParsedDateRange({ from, to });
-      const defaultFormattedDateRange = {
-        from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-        to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-      };
-      const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
-      const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
-
-      if (conditions.length === 0) {
-        return redirect(defaultDestination);
-      } else if (conditions.includes('from')) {
-        if (
-          conditions.includes('to') &&
-          isValidDateRange(configuration?.['periodMax.serverMap'] || 2)(parsedDateRange)
-        ) {
-          return application;
-        } else {
-          return redirect(defaultDestination);
-        }
-      }
-    } else {
-      return redirect('/');
-    }
-
-    return application;
-  } catch (err) {
-    console.error('Error in scatterFullScreenLoader:', err);
-    return null;
+    configuration = await getConfiguration<Configuration>();
+  } catch {
+    // Continue with defaults so that date params are still redirected.
   }
+
+  const timezone = getTimezone();
+
+  if (application?.applicationName && application.serviceType) {
+    const basePath = `${APP_PATH.SCATTER_FULL_SCREEN}/${params.application}`;
+    const queryParam = Object.fromEntries(new URL(request.url).searchParams);
+    const conditions = Object.keys(queryParam);
+
+    const from = queryParam?.from as string;
+    const to = queryParam?.to as string;
+
+    const currentDate = new Date();
+    const parsedDateRange = {
+      from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+      to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+    };
+    const defaultParsedDateRange = getParsedDateRange({ from, to });
+    const defaultFormattedDateRange = {
+      from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+      to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+    };
+    const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
+    const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+
+    if (conditions.length === 0) {
+      return redirect(defaultDestination);
+    } else if (conditions.includes('from')) {
+      if (
+        conditions.includes('to') &&
+        isValidDateRange(configuration?.['periodMax.serverMap'] || 2)(parsedDateRange)
+      ) {
+        return application;
+      } else {
+        return redirect(defaultDestination);
+      }
+    }
+  } else {
+    return redirect('/');
+  }
+
+  return application;
 };
 
 export const scatterFullScreenRealtimeLoader = ({ params, request }: LoaderFunctionArgs) => {

--- a/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.ts
@@ -15,55 +15,57 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const scatterOrHeatmapFullScreenLoader = async ({ params, request }: LoaderFunctionArgs) => {
+  const application = getApplicationTypeAndName(params.application);
+
+  let configuration: Configuration | undefined;
   try {
-    const application = getApplicationTypeAndName(params.application);
-    const configuration = await getConfiguration<Configuration>();
-    const timezone = getTimezone();
-    const url = new URL(request.url);
-    const pathname = url?.pathname?.split('/')?.[1] || '';
-
-    if (pathname && application?.applicationName && application.serviceType) {
-      const basePath = `/${pathname}/${params.application}`;
-      const queryParam = Object.fromEntries(url?.searchParams);
-      const conditions = Object.keys(queryParam);
-
-      const from = queryParam?.from as string;
-      const to = queryParam?.to as string;
-
-      const currentDate = new Date();
-      const parsedDateRange = {
-        from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-        to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-      };
-      const defaultParsedDateRange = getParsedDateRange({ from, to });
-      const defaultFormattedDateRange = {
-        from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-        to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-      };
-      const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
-      const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
-
-      if (conditions.length === 0) {
-        return redirect(defaultDestination);
-      } else if (conditions.includes('from')) {
-        if (
-          conditions.includes('to') &&
-          isValidDateRange(configuration?.['periodMax.serverMap'] || 2)(parsedDateRange)
-        ) {
-          return application;
-        } else {
-          return redirect(defaultDestination);
-        }
-      }
-    } else {
-      return redirect('/');
-    }
-
-    return application;
-  } catch (err) {
-    console.error('Error in scatterOrHeatmapFullScreenLoader:', err);
-    return null;
+    configuration = await getConfiguration<Configuration>();
+  } catch {
+    // Continue with defaults so that date params are still redirected.
   }
+
+  const timezone = getTimezone();
+  const url = new URL(request.url);
+  const pathname = url?.pathname?.split('/')?.[1] || '';
+
+  if (pathname && application?.applicationName && application.serviceType) {
+    const basePath = `/${pathname}/${params.application}`;
+    const queryParam = Object.fromEntries(url?.searchParams);
+    const conditions = Object.keys(queryParam);
+
+    const from = queryParam?.from as string;
+    const to = queryParam?.to as string;
+
+    const currentDate = new Date();
+    const parsedDateRange = {
+      from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+      to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+    };
+    const defaultParsedDateRange = getParsedDateRange({ from, to });
+    const defaultFormattedDateRange = {
+      from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+      to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+    };
+    const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
+    const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+
+    if (conditions.length === 0) {
+      return redirect(defaultDestination);
+    } else if (conditions.includes('from')) {
+      if (
+        conditions.includes('to') &&
+        isValidDateRange(configuration?.['periodMax.serverMap'] || 2)(parsedDateRange)
+      ) {
+        return application;
+      } else {
+        return redirect(defaultDestination);
+      }
+    }
+  } else {
+    return redirect('/');
+  }
+
+  return application;
 };
 
 export const scatterOrHeatmapFullScreenRealtimeLoader = ({

--- a/web-frontend/src/main/v3/packages/ui/src/loader/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/serverMap.ts
@@ -17,69 +17,72 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const serverMapRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
+  const application = getApplicationTypeAndName(params.application!);
+
+  let configuration: Configuration | undefined;
   try {
-    const application = getApplicationTypeAndName(params.application!);
-    const configuration = await getConfiguration<Configuration>();
-    const timezone = getTimezone();
-
-    if (application?.applicationName && application.serviceType) {
-      const basePath = `/serverMap/${params.application}`;
-      const queryParam = Object.fromEntries(new URL(request.url).searchParams);
-      const conditions = Object.keys(queryParam);
-
-      const from = queryParam?.from as string;
-      const to = queryParam?.to as string;
-
-      const currentDate = new Date();
-      const validationRange = isValidDateRange(configuration?.['periodMax.serverMap'] || 2);
-      const defaultParsedDateRange = getParsedDateRange({ from, to });
-      const defaultFormattedDateRange = {
-        from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-        to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-      };
-      const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
-      const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
-
-      if (conditions.length === 0) {
-        return redirect(defaultDestination);
-      } else if (conditions.includes('from')) {
-        if (!conditions.includes('to')) {
-          return redirect(defaultDestination);
-        }
-
-        const matchedFormat = SEARCH_PARAMETER_DATE_FORMAT_WHITE_LIST.find((dateFormat) => {
-          const parsedDateRange = {
-            from: parse(from, dateFormat, currentDate),
-            to: parse(to, dateFormat, currentDate),
-          };
-
-          return validationRange(parsedDateRange);
-        });
-
-        if (!matchedFormat) {
-          return redirect(defaultDestination);
-        }
-
-        if (matchedFormat !== SEARCH_PARAMETER_DATE_FORMAT) {
-          const parsedDateRange = {
-            from: parse(from, matchedFormat, currentDate),
-            to: parse(to, matchedFormat, currentDate),
-          };
-          const formattedDataRange = getFormattedDateRange(parsedDateRange);
-          const destination = `${basePath}?${convertParamsToQueryString({
-            ...queryParam,
-            ...formattedDataRange,
-          })}`;
-          return redirect(destination);
-        }
-
-        return application;
-      }
-    }
-
-    return application;
-  } catch (error) {
-    console.error('Error in serverMapRouteLoader:', error);
-    return null;
+    configuration = await getConfiguration<Configuration>();
+  } catch {
+    // Configuration fetch may fail when the backend is down.
+    // Continue with defaults so that date params are still redirected.
   }
+
+  const timezone = getTimezone();
+
+  if (application?.applicationName && application.serviceType) {
+    const basePath = `/serverMap/${params.application}`;
+    const queryParam = Object.fromEntries(new URL(request.url).searchParams);
+    const conditions = Object.keys(queryParam);
+
+    const from = queryParam?.from as string;
+    const to = queryParam?.to as string;
+
+    const currentDate = new Date();
+    const validationRange = isValidDateRange(configuration?.['periodMax.serverMap'] || 2);
+    const defaultParsedDateRange = getParsedDateRange({ from, to });
+    const defaultFormattedDateRange = {
+      from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+      to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+    };
+    const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
+    const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+
+    if (conditions.length === 0) {
+      return redirect(defaultDestination);
+    } else if (conditions.includes('from')) {
+      if (!conditions.includes('to')) {
+        return redirect(defaultDestination);
+      }
+
+      const matchedFormat = SEARCH_PARAMETER_DATE_FORMAT_WHITE_LIST.find((dateFormat) => {
+        const parsedDateRange = {
+          from: parse(from, dateFormat, currentDate),
+          to: parse(to, dateFormat, currentDate),
+        };
+
+        return validationRange(parsedDateRange);
+      });
+
+      if (!matchedFormat) {
+        return redirect(defaultDestination);
+      }
+
+      if (matchedFormat !== SEARCH_PARAMETER_DATE_FORMAT) {
+        const parsedDateRange = {
+          from: parse(from, matchedFormat, currentDate),
+          to: parse(to, matchedFormat, currentDate),
+        };
+        const formattedDataRange = getFormattedDateRange(parsedDateRange);
+        const destination = `${basePath}?${convertParamsToQueryString({
+          ...queryParam,
+          ...formattedDataRange,
+        })}`;
+        return redirect(destination);
+      }
+
+      return application;
+    }
+  }
+
+  return application;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/loader/systemMetric.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/systemMetric.ts
@@ -11,51 +11,53 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const systemMetricRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
+  const hostGroup = params.hostGroup || null;
+
+  let configuration: Configuration | undefined;
   try {
-    const hostGroup = params.hostGroup || null;
-    const configuration = await getConfiguration<Configuration>();
-    const timezone = getTimezone();
+    configuration = await getConfiguration<Configuration>();
+  } catch {
+    // Continue with defaults so that date params are still redirected.
+  }
 
-    if (hostGroup) {
-      const basePath = `${APP_PATH.SYSTEM_METRIC}/${hostGroup}`;
-      const queryParam = Object.fromEntries(new URL(request.url).searchParams);
-      const conditions = Object.keys(queryParam);
+  const timezone = getTimezone();
 
-      const from = queryParam?.from as string;
-      const to = queryParam?.to as string;
+  if (hostGroup) {
+    const basePath = `${APP_PATH.SYSTEM_METRIC}/${hostGroup}`;
+    const queryParam = Object.fromEntries(new URL(request.url).searchParams);
+    const conditions = Object.keys(queryParam);
 
-      const currentDate = new Date();
-      const parsedDateRange = {
-        from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-        to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-      };
-      const defaultParsedDateRange = getParsedDateRange({ from, to });
-      const defaultFormattedDateRange = {
-        from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-        to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-      };
-      const validateDateRange = isValidDateRange(configuration?.['periodMax.systemMetric'] || 28);
-      const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
-      const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+    const from = queryParam?.from as string;
+    const to = queryParam?.to as string;
 
-      if (conditions.length === 0) {
-        return redirect(defaultDestination);
+    const currentDate = new Date();
+    const parsedDateRange = {
+      from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+      to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+    };
+    const defaultParsedDateRange = getParsedDateRange({ from, to });
+    const defaultFormattedDateRange = {
+      from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+      to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+    };
+    const validateDateRange = isValidDateRange(configuration?.['periodMax.systemMetric'] || 28);
+    const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
+    const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+
+    if (conditions.length === 0) {
+      return redirect(defaultDestination);
+    } else {
+      if (
+        conditions.includes('from') &&
+        conditions.includes('to') &&
+        validateDateRange(parsedDateRange)
+      ) {
+        return hostGroup;
       } else {
-        if (
-          conditions.includes('from') &&
-          conditions.includes('to') &&
-          validateDateRange(parsedDateRange)
-        ) {
-          return hostGroup;
-        } else {
-          return redirect(defaultDestination);
-        }
+        return redirect(defaultDestination);
       }
     }
-
-    return hostGroup;
-  } catch (err) {
-    console.error('Error in systemMetricRouteLoader:', err);
-    return null;
   }
+
+  return hostGroup;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transaction.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transaction.ts
@@ -15,51 +15,53 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const transactionRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
+  const application = getApplicationTypeAndName(params.application!);
+
+  let configuration: Configuration | undefined;
   try {
-    const application = getApplicationTypeAndName(params.application!);
-    const configuration = await getConfiguration<Configuration>();
-    const timezone = getTimezone();
+    configuration = await getConfiguration<Configuration>();
+  } catch {
+    // Continue with defaults so that date params are still redirected.
+  }
 
-    if (application?.applicationName && application.serviceType) {
-      const basePath = `${APP_PATH.TRANSACTION_LIST}/${params.application}`;
-      const queryParam = Object.fromEntries(new URL(request.url).searchParams);
-      const conditions = Object.keys(queryParam);
+  const timezone = getTimezone();
 
-      const from = queryParam?.from as string;
-      const to = queryParam?.to as string;
+  if (application?.applicationName && application.serviceType) {
+    const basePath = `${APP_PATH.TRANSACTION_LIST}/${params.application}`;
+    const queryParam = Object.fromEntries(new URL(request.url).searchParams);
+    const conditions = Object.keys(queryParam);
 
-      const currentDate = new Date();
-      const parsedDateRange = {
-        from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-        to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-      };
-      const validateDateRange = isValidDateRange(configuration?.['periodMax.serverMap'] || 2);
-      const defaultParsedDateRange = getParsedDateRange({ from, to }, validateDateRange);
-      const defaultFormattedDateRange = {
-        from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-        to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-      };
-      const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
-      const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+    const from = queryParam?.from as string;
+    const to = queryParam?.to as string;
 
-      if (conditions.length === 0) {
-        return redirect(defaultDestination);
+    const currentDate = new Date();
+    const parsedDateRange = {
+      from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+      to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+    };
+    const validateDateRange = isValidDateRange(configuration?.['periodMax.serverMap'] || 2);
+    const defaultParsedDateRange = getParsedDateRange({ from, to }, validateDateRange);
+    const defaultFormattedDateRange = {
+      from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+      to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+    };
+    const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
+    const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+
+    if (conditions.length === 0) {
+      return redirect(defaultDestination);
+    } else {
+      if (
+        conditions.includes('from') &&
+        conditions.includes('to') &&
+        validateDateRange(parsedDateRange)
+      ) {
+        return application;
       } else {
-        if (
-          conditions.includes('from') &&
-          conditions.includes('to') &&
-          validateDateRange(parsedDateRange)
-        ) {
-          return application;
-        } else {
-          return redirect(defaultDestination);
-        }
+        return redirect(defaultDestination);
       }
     }
-
-    return application;
-  } catch (err) {
-    console.error('Error in transactionRouteLoader:', err);
-    return null;
   }
+
+  return application;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/loader/urlStatistic.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/urlStatistic.ts
@@ -15,51 +15,53 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const urlStatisticRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
+  const application = getApplicationTypeAndName(params.application!);
+
+  let configuration: Configuration | undefined;
   try {
-    const application = getApplicationTypeAndName(params.application!);
-    const configuration = await getConfiguration<Configuration>();
-    const timezone = getTimezone();
+    configuration = await getConfiguration<Configuration>();
+  } catch {
+    // Continue with defaults so that date params are still redirected.
+  }
 
-    if (application?.applicationName && application.serviceType) {
-      const basePath = `${APP_PATH.URL_STATISTIC}/${params.application}`;
-      const queryParam = Object.fromEntries(new URL(request.url).searchParams);
-      const conditions = Object.keys(queryParam);
+  const timezone = getTimezone();
 
-      const from = queryParam?.from as string;
-      const to = queryParam?.to as string;
+  if (application?.applicationName && application.serviceType) {
+    const basePath = `${APP_PATH.URL_STATISTIC}/${params.application}`;
+    const queryParam = Object.fromEntries(new URL(request.url).searchParams);
+    const conditions = Object.keys(queryParam);
 
-      const currentDate = new Date();
-      const parsedDateRange = {
-        from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-        to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
-      };
-      const validateDateRange = isValidDateRange(configuration?.['periodMax.uriStat'] || 28);
-      const defaultParsedDateRange = getParsedDateRange({ from, to }, validateDateRange);
-      const defaultFormattedDateRange = {
-        from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-        to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
-      };
-      const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
-      const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+    const from = queryParam?.from as string;
+    const to = queryParam?.to as string;
 
-      if (conditions.length === 0) {
-        return redirect(defaultDestination);
+    const currentDate = new Date();
+    const parsedDateRange = {
+      from: parse(from, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+      to: parse(to, SEARCH_PARAMETER_DATE_FORMAT, currentDate),
+    };
+    const validateDateRange = isValidDateRange(configuration?.['periodMax.uriStat'] || 28);
+    const defaultParsedDateRange = getParsedDateRange({ from, to }, validateDateRange);
+    const defaultFormattedDateRange = {
+      from: formatInTimeZone(defaultParsedDateRange.from, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+      to: formatInTimeZone(defaultParsedDateRange.to, timezone, SEARCH_PARAMETER_DATE_FORMAT),
+    };
+    const defaultDatesQueryString = new URLSearchParams(defaultFormattedDateRange).toString();
+    const defaultDestination = `${basePath}?${defaultDatesQueryString}`;
+
+    if (conditions.length === 0) {
+      return redirect(defaultDestination);
+    } else {
+      if (
+        conditions.includes('from') &&
+        conditions.includes('to') &&
+        validateDateRange(parsedDateRange)
+      ) {
+        return application;
       } else {
-        if (
-          conditions.includes('from') &&
-          conditions.includes('to') &&
-          validateDateRange(parsedDateRange)
-        ) {
-          return application;
-        } else {
-          return redirect(defaultDestination);
-        }
+        return redirect(defaultDestination);
       }
     }
-
-    return application;
-  } catch (err) {
-    console.error('Error in urlStatisticRouteLoader:', err);
-    return null;
   }
+
+  return application;
 };


### PR DESCRIPTION
…acefully

Narrow try-catch scope to only wrap getConfiguration() so that date parameter validation and redirect logic continues to work even when the backend is unavailable.