### PR TITLE
[#noissue] Replace `getName()` with `getApplicationName()`

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmProcessor.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmProcessor.java
@@ -79,7 +79,7 @@ public class AlarmProcessor implements ItemProcessor<Application, AppAlarmChecke
     }
 
     private List<AlarmChecker<?>> getAlarmCheckers(Application application) {
-        List<Rule> rules = alarmService.selectRuleByApplicationName(application.getName());
+        List<Rule> rules = alarmService.selectRuleByApplicationName(application.getApplicationName());
 
         long now = System.currentTimeMillis();
         Supplier<List<String>> agentIds = getAgentIdsSupplier(application, now);
@@ -100,7 +100,7 @@ public class AlarmProcessor implements ItemProcessor<Application, AppAlarmChecke
     }
 
     private List<String> fetchActiveAgents(Application application, Range activeRange) {
-        List<String> agentList = batchAgentService.getIds(application.getName());
+        List<String> agentList = batchAgentService.getIds(application.getApplicationName());
 
         int code = application.getServiceType().getCode();
         List<String> list = new ArrayList<>();

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmReader.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/AlarmReader.java
@@ -61,7 +61,7 @@ public class AlarmReader implements ItemReader<Application>, StepExecutionListen
 
         List<Application> validApplications = new ArrayList<>(applications.size());
         for (Application application: applications) {
-            if (validApplicationNames.contains(application.getName())) {
+            if (validApplicationNames.contains(application.getApplicationName())) {
                 validApplications.add(application);
             }
         }

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/MapOutLinkDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/MapOutLinkDataCollector.java
@@ -68,7 +68,7 @@ public class MapOutLinkDataCollector extends DataCollector {
             LinkCallDataMap linkCallDataMap = linkData.getLinkCallDataMap();
 
             for (LinkCallData linkCallData : linkCallDataMap.getLinkDataList()) {
-                inLinkStatMap.put(linkCallData.getTarget().getName(), linkCallData);
+                inLinkStatMap.put(linkCallData.getTarget().getApplicationName(), linkCallData);
             }
         }
 

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/DataSourceDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/DataSourceDataCollector.java
@@ -84,7 +84,7 @@ public class DataSourceDataCollector extends DataCollector implements DataSource
 
                 for (TagInformation tagInformation : tagInformationList) {
                     CompletableFuture<List<AgentFieldUsage>> futureAgent = alarmDao
-                            .selectAvgGroupByField(application.getName(), agentId, METRIC_NAME, fieldList, tagInformation.tags(), range);
+                            .selectAvgGroupByField(application.getApplicationName(), agentId, METRIC_NAME, fieldList, tagInformation.tags(), range);
                     queryResults.add(new QueryResult<>(futureAgent, tagInformation));
                 }
             }
@@ -123,11 +123,11 @@ public class DataSourceDataCollector extends DataCollector implements DataSource
                 agentDataSourceConnectionUsageRateMap.add(tagInformation.agentId(), dataSourceAlarmVO);
             }
         } catch (RuntimeException e) {
-            logger.error("Fail to get agent datasource data. applicationName : {}", application.getName(), e);
+            logger.error("Fail to get agent datasource data. applicationName : {}", application.getApplicationName(), e);
         } catch (ExecutionException e) {
-            logger.error("Fail to get agent datasource data with ExecutionException. applicationName : {}", application.getName(), e);
+            logger.error("Fail to get agent datasource data with ExecutionException. applicationName : {}", application.getApplicationName(), e);
         } catch (InterruptedException e) {
-            logger.error("Fail to get agent datasource data with InterruptedException. applicationName : {}", application.getName(), e);
+            logger.error("Fail to get agent datasource data with InterruptedException. applicationName : {}", application.getApplicationName(), e);
         }
     }
 
@@ -141,7 +141,7 @@ public class DataSourceDataCollector extends DataCollector implements DataSource
 
             for (Tag jdbcUrlTag : jdbcUrlList) {
                 List<Tag> tagList = List.of(jdbcUrlTag);
-                CompletableFuture<List<TagInformation>> futureTagInformation = alarmDao.getTagInfoContainedSpecificTag(application.getName(), agentId, METRIC_NAME, FIELD_ACTIVE_CONNECTION, tagList, range);
+                CompletableFuture<List<TagInformation>> futureTagInformation = alarmDao.getTagInfoContainedSpecificTag(application.getApplicationName(), agentId, METRIC_NAME, FIELD_ACTIVE_CONNECTION, tagList, range);
                 queryResults.add(new QueryResult<>(futureTagInformation, agentId));
             }
         }
@@ -163,7 +163,7 @@ public class DataSourceDataCollector extends DataCollector implements DataSource
                 errorCount++;
 
                 if (errorCount > 2) {
-                    logger.error("Fail to get agent tag information. applicationName : {}, agentId : {}", application.getName(), agentId, e);
+                    logger.error("Fail to get agent tag information. applicationName : {}, agentId : {}", application.getApplicationName(), agentId, e);
                     throw e;
                 }
             }
@@ -176,7 +176,7 @@ public class DataSourceDataCollector extends DataCollector implements DataSource
         List<QueryResult<Tag, String>> queryResults = new ArrayList<>();
 
         for (String agentId : agentIds) {
-            CompletableFuture<List<Tag>> future = alarmDao.selectTagInfo(application.getName(), agentId, METRIC_NAME, FIELD_ACTIVE_CONNECTION, range);
+            CompletableFuture<List<Tag>> future = alarmDao.selectTagInfo(application.getApplicationName(), agentId, METRIC_NAME, FIELD_ACTIVE_CONNECTION, range);
             queryResults.add(new QueryResult<>(future, agentId));
         }
 
@@ -201,7 +201,7 @@ public class DataSourceDataCollector extends DataCollector implements DataSource
             } catch (Exception e) {
                 errorCount++;
                 if (errorCount > 2) {
-                    logger.error("Fail to get agent jdbcUrl. applicationName : {}, agentId : {}", application.getName(), agentId, e);
+                    logger.error("Fail to get agent jdbcUrl. applicationName : {}, agentId : {}", application.getApplicationName(), agentId, e);
                     throw e;
                 }
             }

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/FileDescriptorDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/FileDescriptorDataCollector.java
@@ -53,7 +53,7 @@ public class FileDescriptorDataCollector extends DataCollector implements FileDe
     @Override
     public void collect() {
         Range range = Range.between(timeSlotEndTime - slotInterval, timeSlotEndTime);
-        List<AgentUsage> agentUsageList = alarmDao.selectAvg(application.getName(), METRIC_NAME, FIELD_NAME, range);
+        List<AgentUsage> agentUsageList = alarmDao.selectAvg(application.getApplicationName(), METRIC_NAME, FIELD_NAME, range);
 
         for (AgentUsage agentUsage : agentUsageList) {
             agentFileDescriptorCount.put(agentUsage.getAgentId(), agentUsage.getValue().longValue());

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/HeapDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/HeapDataCollector.java
@@ -56,7 +56,7 @@ public class HeapDataCollector extends DataCollector implements HeapDataGetter {
     @Override
     public void collect() {
         Range range = Range.between(timeSlotEndTime - slotInterval, timeSlotEndTime);
-        List<AgentFieldUsage> agentFieldUsageList = alarmDao.selectSumGroupByField(application.getName(), METRIC_NAME, fieldList, range);
+        List<AgentFieldUsage> agentFieldUsageList = alarmDao.selectSumGroupByField(application.getApplicationName(), METRIC_NAME, fieldList, range);
         Map<String, AgentHeapUsage> agentHeapUsageMap = new HashMap<>();
 
         for(AgentFieldUsage agentFieldUsage : agentFieldUsageList) {

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/JvmCpuDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/JvmCpuDataCollector.java
@@ -55,7 +55,7 @@ public class JvmCpuDataCollector extends DataCollector implements JvmCpuDataGett
     @Override
     public void collect() {
         Range range = Range.between(timeSlotEndTime - slotInterval, timeSlotEndTime);
-        List<AgentUsageCount> agentUsageCountList = alarmDao.selectSumCount(application.getName(), METRIC_NAME, FIELD_NAME, range);
+        List<AgentUsageCount> agentUsageCountList = alarmDao.selectSumCount(application.getApplicationName(), METRIC_NAME, FIELD_NAME, range);
 
         for (AgentUsageCount agentUsageCount : agentUsageCountList) {
             long jvmCpuUsagePercent = calculatePercent(agentUsageCount.getValue().longValue(), 100L * agentUsageCount.getCountValue().longValue());

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/SystemCpuDataCollector.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/SystemCpuDataCollector.java
@@ -53,7 +53,7 @@ public class SystemCpuDataCollector extends DataCollector implements SystemCpuDa
     @Override
     public void collect() {
         Range range = Range.between(timeSlotEndTime - slotInterval, timeSlotEndTime);
-        List<AgentUsageCount> agentUsageCountList = alarmDao.selectSumCount(application.getName(), METRIC_NAME, FIELD_NAME, range);
+        List<AgentUsageCount> agentUsageCountList = alarmDao.selectSumCount(application.getApplicationName(), METRIC_NAME, FIELD_NAME, range);
 
         for (AgentUsageCount agentUsageCount : agentUsageCountList) {
             long jvmCpuUsagePercent = calculatePercent(agentUsageCount.getValue().longValue(), 100L * agentUsageCount.getCountValue().longValue());

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/job/ApplicationCleaningProcessor.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/job/ApplicationCleaningProcessor.java
@@ -93,11 +93,11 @@ public class ApplicationCleaningProcessor implements ItemProcessor<Application, 
     }
 
     private List<String> getOldAgents(Application application, long maxTimestamp) {
-        return this.batchApplicationIndexService.selectAgentIds(application.getName(), application.getServiceTypeCode(), maxTimestamp);
+        return this.batchApplicationIndexService.selectAgentIds(application.getApplicationName(), application.getServiceTypeCode(), maxTimestamp);
     }
 
     private List<String> getAllAgents(Application application) {
-        return this.batchApplicationIndexService.selectAgentIds(application.getName(), application.getServiceTypeCode());
+        return this.batchApplicationIndexService.selectAgentIds(application.getApplicationName(), application.getServiceTypeCode());
     }
 
     private Range getRange() {

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/job/ApplicationRemover.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/job/ApplicationRemover.java
@@ -45,7 +45,7 @@ public class ApplicationRemover implements ItemWriter<CleanTarget.TypeApplicatio
             Application application = target.application();
             logger.info("Removing application: {}", application);
             try {
-                this.batchApplicationIndexService.remove(application.getName(), application.getServiceTypeCode());
+                this.batchApplicationIndexService.remove(application.getApplicationName(), application.getServiceTypeCode());
             } catch (Exception e) {
                 logger.error("Failed to remove application: {}", target, e);
             }

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/service/BatchApplicationIndexServiceImpl.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/service/BatchApplicationIndexServiceImpl.java
@@ -80,12 +80,12 @@ public class BatchApplicationIndexServiceImpl implements BatchApplicationIndexSe
     public List<String> selectAllApplicationNames() {
         if (isReadV2()) {
             return this.applicationDao.getApplications(ServiceUid.DEFAULT_SERVICE_UID_CODE).stream()
-                    .map(Application::getName)
+                    .map(Application::getApplicationName)
                     .toList();
         }
         return this.applicationIndexDao.selectAllApplicationNames()
                 .stream()
-                .map(Application::getName)
+                .map(Application::getApplicationName)
                 .toList();
     }
 

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/AlarmReaderTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/AlarmReaderTest.java
@@ -52,7 +52,7 @@ public class AlarmReaderTest {
     );
 
     private static final List<String> applicationIds = mockApplications.stream()
-            .map(Application::getName)
+            .map(Application::getApplicationName)
             .toList();
 
     @Test

--- a/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/FileDescriptorDataCollectorTest.java
+++ b/batch/src/test/java/com/navercorp/pinpoint/batch/alarm/collector/pinot/FileDescriptorDataCollectorTest.java
@@ -58,7 +58,7 @@ class FileDescriptorDataCollectorTest {
                 new AgentUsage("testAgent5", 300D),
                 new AgentUsage("testAgent6", 400D)
         );
-        when(alarmDao.selectAvg(application.getName(), FileDescriptorDataCollector.METRIC_NAME, FileDescriptorDataCollector.FIELD_NAME, range)).thenReturn(agentUsageList);
+        when(alarmDao.selectAvg(application.getApplicationName(), FileDescriptorDataCollector.METRIC_NAME, FileDescriptorDataCollector.FIELD_NAME, range)).thenReturn(agentUsageList);
         fileDescriptorDataCollector.collect();
 
         Map<String, Long> fileDescriptorCount = fileDescriptorDataCollector.getFileDescriptorCount();

--- a/web/src/main/java/com/navercorp/pinpoint/web/agentlist/service/AgentsServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/agentlist/service/AgentsServiceImpl.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.agentlist.service;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.web.agentlist.AgentsFactory;
 import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
 import com.navercorp.pinpoint.web.service.ApplicationAgentListQueryRule;
 import com.navercorp.pinpoint.web.service.ApplicationAgentListService;
@@ -25,7 +26,6 @@ import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilter;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatusAndLink;
-import com.navercorp.pinpoint.web.agentlist.AgentsFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -79,7 +79,7 @@ public class AgentsServiceImpl implements AgentsService {
             ApplicationAgentListQueryRule applicationAgentListQueryRule,
             AgentInfoFilter agentInfoFilter
     ) {
-        final String applicationName = application.getName();
+        final String applicationName = application.getApplicationName();
         final ServiceType serviceType = application.getServiceType();
         final Range windowRange = timeWindow.getWindowRange();
         return switch (applicationAgentListQueryRule) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/datasource/AgentInfoServerGroupListDataSource.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/datasource/AgentInfoServerGroupListDataSource.java
@@ -62,7 +62,7 @@ public class AgentInfoServerGroupListDataSource implements ServerGroupListDataSo
         }
 
         Application application = node.getApplication();
-        Set<AgentInfo> agentInfos = agentInfoService.getAgentsByApplicationNameWithoutStatus(application.getName(), timestamp);
+        Set<AgentInfo> agentInfos = agentInfoService.getAgentsByApplicationNameWithoutStatus(application.getApplicationName(), timestamp);
         if (CollectionUtils.isEmpty(agentInfos)) {
             logger.info("agentInfo not found. application:{}", application);
             return ServerGroupList.empty();

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/ApplicationResponse.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/ApplicationResponse.java
@@ -99,7 +99,7 @@ public class ApplicationResponse {
         }
 
         public String getApplicationName() {
-            return application.getName();
+            return application.getApplicationName();
         }
 
         public ServiceType getApplicationServiceType() {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/MapScanKeyFactoryV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/MapScanKeyFactoryV2.java
@@ -22,6 +22,6 @@ import com.navercorp.pinpoint.web.vo.Application;
 
 public class MapScanKeyFactoryV2 implements MapScanKeyFactory {
     public byte[] scanKey(int serviceUid, Application application, long timestamp) {
-        return LinkRowKey.makeRowKey(ByteSaltKey.NONE.size(), application.getName(), (short) application.getServiceTypeCode(), timestamp);
+        return LinkRowKey.makeRowKey(ByteSaltKey.NONE.size(), application.getApplicationName(), (short) application.getServiceTypeCode(), timestamp);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ApplicationResponseTimeResultExtractor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/ApplicationResponseTimeResultExtractor.java
@@ -92,7 +92,7 @@ public class ApplicationResponseTimeResultExtractor implements ResultsExtractor<
             builder = ApplicationResponse.newBuilder(application);
         } else {
             Application builderApp = builder.getApplication();
-            if (!builderApp.getName().equals(applicationName)) {
+            if (!builderApp.getApplicationName().equals(applicationName)) {
                 throw new IllegalStateException("applicationName must match");
             }
             if (builderApp.getServiceType().getCode() != serviceTypeCode) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/DefaultLinkFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/DefaultLinkFilter.java
@@ -52,7 +52,7 @@ public class DefaultLinkFilter implements LinkFilter {
         } else if (this.outApplication.getServiceType().isUser()) {
             logger.debug("check client to was");
             // if dest not equals to that WAS, drop
-            if (!this.inApplication.getName().equals(foundApplication.getName())) {
+            if (!this.inApplication.getApplicationName().equals(foundApplication.getApplicationName())) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("  DROP THE ROW,2, DIFFERENT DEST. fetched={}, params={}", foundApplication, this.inApplication);
                 }
@@ -63,7 +63,7 @@ public class DefaultLinkFilter implements LinkFilter {
             if (this.inApplication.getServiceType().isUnknown()) {
                 //  compare just only application name when dest is unknown.
                 // TODO need more nice way to compare
-                if (!this.inApplication.getName().equals(foundApplication.getName())) {
+                if (!this.inApplication.getApplicationName().equals(foundApplication.getApplicationName())) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("  DROP THE ROW,3, DIFFERENT DEST. fetched={}, params={}", foundApplication, inApplication);
                     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/HostScanKeyFactoryV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/HostScanKeyFactoryV2.java
@@ -26,7 +26,7 @@ public class HostScanKeyFactoryV2 implements HostScanKeyFactory {
     @Override
     public byte[] scanKey(Application parentApplication, long timestamp) {
         Buffer buffer = new AutomaticBuffer();
-        buffer.putPadString(parentApplication.getName(), HbaseTableConstants.APPLICATION_NAME_MAX_LEN);
+        buffer.putPadString(parentApplication.getApplicationName(), HbaseTableConstants.APPLICATION_NAME_MAX_LEN);
         buffer.putShort((short) parentApplication.getServiceTypeCode());
         long reverseTimestamp = LongInverter.invert(timestamp);
         buffer.putLong(reverseTimestamp);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/InLinkMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/InLinkMapper.java
@@ -115,7 +115,7 @@ public class InLinkMapper implements RowMapper<LinkDataMap> {
                         self, selfHost, inApplication, histogramSlot, requestCount);
             }
 
-            linkDataMap.addLinkData(self, self.getName(), inApplication, selfHost, timestamp, histogramSlot, requestCount);
+            linkDataMap.addLinkData(self, self.getApplicationName(), inApplication, selfHost, timestamp, histogramSlot, requestCount);
 
             if (logger.isTraceEnabled()) {
                 logger.trace("    Fetched IN_LINK inLink:{}", linkDataMap);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/OutLinkMapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/mapper/OutLinkMapper.java
@@ -102,7 +102,7 @@ public class OutLinkMapper implements RowMapper<LinkDataMap> {
             }
 
             if (StringUtils.isEmpty(inHost)) {
-                inHost = inApplication.getName();
+                inHost = inApplication.getApplicationName();
             }
             linkDataMap.addLinkData(outApplication, outAgentId, inApplication, inHost, timestamp, histogramSlot, requestCount);
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostScanKeyFactoryV3.java
@@ -28,7 +28,7 @@ public class HostScanKeyFactoryV3 implements HostScanKeyFactory {
     @Override
     public byte[] scanKey(Application parentApplication, long timestamp) {
         return UidAppRowKey.makeRowKey(saltKeySize, ServiceUid.DEFAULT_SERVICE_UID_CODE,
-                parentApplication.getName(), parentApplication.getServiceTypeCode(),
+                parentApplication.getApplicationName(), parentApplication.getServiceTypeCode(),
                 timestamp);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/InLinkV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/InLinkV3Mapper.java
@@ -119,7 +119,7 @@ public class InLinkV3Mapper implements RowMapper<LinkDataMap> {
                         self, selfHost, inApplication, slotCode, requestCount);
             }
 
-            linkDataMap.addLinkDataByCode(self, self.getName(), inApplication, selfHost, timestamp, slotCode, requestCount);
+            linkDataMap.addLinkDataByCode(self, self.getApplicationName(), inApplication, selfHost, timestamp, slotCode, requestCount);
 
             if (logger.isTraceEnabled()) {
                 logger.trace("    Fetched IN_LINK inLink:{}", linkDataMap);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapAgentScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapAgentScanKeyFactoryV3.java
@@ -30,7 +30,7 @@ public class MapAgentScanKeyFactoryV3 implements MapScanKeyFactory {
     public byte[] scanKey(int serviceUid, Application application, long timestamp) {
         final Buffer buffer = new AutomaticBuffer(64);
         buffer.skip(saltKeySize);
-        UidPrefix.writePrefix(buffer, serviceUid, BytesUtils.toBytes(application.getName()), application.getServiceTypeCode(), timestamp);
+        UidPrefix.writePrefix(buffer, serviceUid, BytesUtils.toBytes(application.getApplicationName()), application.getServiceTypeCode(), timestamp);
         return buffer.getBuffer();
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapAppScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapAppScanKeyFactoryV3.java
@@ -30,7 +30,7 @@ public class MapAppScanKeyFactoryV3 implements MapScanKeyFactory {
     public byte[] scanKey(int serviceUid, Application application, long timestamp) {
         final Buffer buffer = new AutomaticBuffer(64);
         buffer.skip(saltKeySize);
-        UidPrefix.writePrefix(buffer, serviceUid, BytesUtils.toBytes(application.getName()), application.getServiceTypeCode(), timestamp);
+        UidPrefix.writePrefix(buffer, serviceUid, BytesUtils.toBytes(application.getApplicationName()), application.getServiceTypeCode(), timestamp);
         return buffer.getBuffer();
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapLinkScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/MapLinkScanKeyFactoryV3.java
@@ -30,7 +30,7 @@ public class MapLinkScanKeyFactoryV3 implements MapScanKeyFactory {
     public byte[] scanKey(int serviceUid, Application application, long timestamp) {
         final Buffer buffer = new AutomaticBuffer(64);
         buffer.skip(saltKeySize);
-        UidPrefix.writePrefix(buffer, serviceUid, BytesUtils.toBytes(application.getName()), application.getServiceTypeCode(), timestamp);
+        UidPrefix.writePrefix(buffer, serviceUid, BytesUtils.toBytes(application.getApplicationName()), application.getServiceTypeCode(), timestamp);
         return buffer.getBuffer();
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/OutLinkV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/OutLinkV3Mapper.java
@@ -105,7 +105,7 @@ public class OutLinkV3Mapper implements RowMapper<LinkDataMap> {
             }
 
             if (StringUtils.isEmpty(outSubLink)) {
-                outSubLink = inApplication.getName();
+                outSubLink = inApplication.getApplicationName();
             }
             Application selfApplication = getApplication(selfRowKey);
             linkDataMap.addLinkDataByCode(selfApplication, MERGE_AGENT, inApplication, outSubLink, timestamp, slotCode, requestCount);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogram.java
@@ -72,7 +72,7 @@ public class AgentTimeHistogram {
         Map<String, List<TimeHistogram>> result = new LinkedHashMap<>();
 
         for (AgentHistogram agentHistogram : agentHistogramList.getAgentHistogramList()) {
-            result.put(agentHistogram.getAgentId().getName(), agentHistogram.getTimeHistogram());
+            result.put(agentHistogram.getAgentId().getApplicationName(), agentHistogram.getTimeHistogram());
         }
         return result;
     }
@@ -108,7 +108,7 @@ public class AgentTimeHistogram {
     private AgentHistogram selectAgentHistogram(String agentName) {
         for (AgentHistogram agentHistogram : agentHistogramList.getAgentHistogramList()) {
             Application agentId = agentHistogram.getAgentId();
-            if (agentId.getName().equals(agentName)) {
+            if (agentId.getApplicationName().equals(agentName)) {
                 return agentHistogram;
             }
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/LinkName.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/LinkName.java
@@ -30,7 +30,7 @@ public class LinkName {
     }
 
     private String toNodeName(Application node) {
-        return NodeName.toNodeName(node.getName(), node.getServiceType());
+        return NodeName.toNodeName(node.getApplicationName(), node.getServiceType());
     }
 
     public String getLinkKey() {
@@ -38,7 +38,7 @@ public class LinkName {
     }
 
     private String toNodeKey(Application node) {
-        return NodeName.toNodeKey(node.getName(), node.getServiceType());
+        return NodeName.toNodeKey(node.getApplicationName(), node.getServiceType());
     }
 
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java
@@ -338,7 +338,7 @@ public class FilteredMapBuilder {
                     //replace with alias instead of Unkown when exists
                     logger.debug("replace with alias {}", replacedApplication.getServiceType());
                     destServiceType = replacedApplication.getServiceType();
-                    dest = replacedApplication.getName();
+                    dest = replacedApplication.getApplicationName();
                 }
             }
         }
@@ -354,7 +354,7 @@ public class FilteredMapBuilder {
             logger.trace("spanEvent  src:{} {} -> dest:{} {}", srcApplication, span.getAgentId(), destApplication, spanEvent.getEndPoint());
         }
         // endPoint may be null
-        final String destinationAgentId = Objects.toString(spanEvent.getEndPoint(), destApplication.getName());
+        final String destinationAgentId = Objects.toString(spanEvent.getEndPoint(), destApplication.getApplicationName());
         sourceLinkDataMap.addLinkData(srcApplication, span.getAgentId(), destApplication, destinationAgentId, spanEventTimeStamp, slotTime, 1);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkMarker.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/VirtualLinkMarker.java
@@ -42,7 +42,7 @@ public class VirtualLinkMarker {
     }
 
     public List<LinkData> createVirtualLink(LinkData linkData, Application toApplication, AcceptApplicationSet acceptApplicationList) {
-        logger.info("one to N replaced. node:{}->host:{} accept:{}", linkData.getFromApplication(), toApplication.getName(), acceptApplicationList);
+        logger.info("one to N replaced. node:{}->host:{} accept:{}", linkData.getFromApplication(), toApplication.getApplicationName(), acceptApplicationList);
         List<LinkData> virtualLinkDataList = new ArrayList<>();
         logger.debug("acceptApplicationList:{}", acceptApplicationList);
         for (AcceptApplication acceptApplication : acceptApplicationList) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/RpcCallProcessor.java
@@ -78,7 +78,7 @@ public class RpcCallProcessor implements LinkDataMapProcessor {
             // rpc client's destination could have an agent installed in which case the link data must be replaced to point
             // to the destination application.
             logger.debug("Finding {} accept applications for {}, {}", direction, toApplication, range);
-            final AcceptApplicationSet acceptApplicationList = findAcceptApplications(linkData.getFromApplication(), toApplication.getName(), range);
+            final AcceptApplicationSet acceptApplicationList = findAcceptApplications(linkData.getFromApplication(), toApplication.getApplicationName(), range);
             logger.debug("Found {} accept applications: {}", direction, acceptApplicationList);
             final int size = AcceptApplicationSet.size(acceptApplicationList);
             if (size > 0) {
@@ -100,7 +100,7 @@ public class RpcCallProcessor implements LinkDataMapProcessor {
                 if (toApplication.getServiceType().isQueue()) {
                     return Collections.singletonList(linkData);
                 } else {
-                    final Application unknown = new Application(toApplication.getService(), toApplication.getName(), ServiceType.UNKNOWN);
+                    final Application unknown = new Application(toApplication.getService(), toApplication.getApplicationName(), ServiceType.UNKNOWN);
                     final LinkData unknownLinkData = LinkData.copyOf(linkData.getFromApplication(), unknown, linkData.getLinkCallDataMap());
                     return Collections.singletonList(unknownLinkData);
                 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/Node.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/Node.java
@@ -51,7 +51,7 @@ public class Node {
         if (application.getServiceType().isUser()) {
             return "USER";
         } else {
-            return application.getName();
+            return application.getApplicationName();
         }
     }
 
@@ -76,7 +76,7 @@ public class Node {
     }
 
     public String getNodeKey() {
-        return NodeName.toNodeKey(application.getName(), application.getServiceType());
+        return NodeName.toNodeKey(application.getApplicationName(), application.getServiceType());
     }
 
     public ServiceType getServiceType() {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/NodeName.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/NodeName.java
@@ -17,7 +17,7 @@ public class NodeName {
 
     public static NodeName of(Application application) {
         Objects.requireNonNull(application, "application");
-        return new NodeName(application.getName(), application.getServiceType());
+        return new NodeName(application.getApplicationName(), application.getServiceType());
     }
 
     public NodeName(String name, ServiceType serviceType) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/AgentHistogram.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/AgentHistogram.java
@@ -50,7 +50,7 @@ public class AgentHistogram {
 
     @JsonProperty("name")
     public String getId() {
-        return agentId.getName();
+        return agentId.getApplicationName();
     }
 
     @JsonIgnore
@@ -116,7 +116,7 @@ public class AgentHistogram {
     @Override
     public String toString() {
         return "AgentHistogram{" +
-                "agent='" + agentId.getName() + '\'' +
+                "agent='" + agentId.getApplicationName() + '\'' +
                 ", serviceType=" + agentId.getServiceType() +
                 ", " + timeHistogramList +
                 '}';

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/AgentHistogramList.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/AgentHistogramList.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  */
 public class AgentHistogramList {
     public static final Comparator<AgentHistogram> AGENT_HISTOGRAM_COMPARATOR
-            = Comparator.comparing((e) -> e.getAgentId().getName());
+            = Comparator.comparing((e) -> e.getAgentId().getApplicationName());
 
     // stores times series data per agent
     private final List<AgentHistogram> agentHistogramList;

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkCallDataMap.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/rawdata/LinkCallDataMap.java
@@ -125,7 +125,7 @@ public class LinkCallDataMap {
             // need target (to) ServiceType
             // the definition of source is data from the source when the source sends a request to a target.
             // Thus ServiceType is the target's ServiceType
-            sourceBuilder.addAgentHistogram(key.getFrom().getName(), key.getTo().getServiceType(), linkCallData.getTimeHistogram());
+            sourceBuilder.addAgentHistogram(key.getFrom().getApplicationName(), key.getTo().getServiceType(), linkCallData.getTimeHistogram());
         }
         return sourceBuilder.build();
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
@@ -122,7 +122,7 @@ public class LinkView {
             Application filterApplication = link.getFilterApplication();
             jgen.writeFieldName("filter");
             jgen.writeStartObject();
-            jgen.writeStringField("applicationName", filterApplication.getName());
+            jgen.writeStringField("applicationName", filterApplication.getApplicationName());
             ServiceType serviceType = filterApplication.getServiceType();
             jgen.writeNumberField("serviceTypeCode", serviceType.getCode());
             jgen.writeStringField("serviceTypeName", serviceType.getName());
@@ -146,7 +146,7 @@ public class LinkView {
             Collection<Application> sourceLinkTargetAgentList = link.getSourceLinkTargetAgentList();
             for (Application application : sourceLinkTargetAgentList) {
                 jgen.writeStartObject();
-                jgen.writeStringField("rpc", application.getName());
+                jgen.writeStringField("rpc", application.getApplicationName());
                 jgen.writeNumberField("rpcServiceTypeCode", application.getServiceTypeCode());
                 jgen.writeEndObject();
             }
@@ -159,7 +159,7 @@ public class LinkView {
 
             jgen.writeStartObject();
             Application application = node.getApplication();
-            jgen.writeStringField("applicationName", application.getName());
+            jgen.writeStringField("applicationName", application.getApplicationName());
             ServiceType serviceType = application.getServiceType();
             jgen.writeStringField("serviceType", serviceType.toString());
             jgen.writeNumberField("serviceTypeCode", serviceType.getCode());

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/TimeHistogramView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/TimeHistogramView.java
@@ -39,7 +39,7 @@ public interface TimeHistogramView {
         for (AgentHistogram agentHistogram : histogram.getAgentHistogramList()) {
             List<TimeHistogram> timeHistogram = agentHistogram.getTimeHistogram();
             List<TimeHistogramViewModel> responseTimeViewModel = this.build(histogram.getApplication(), timeHistogram);
-            builder.addField(new AgentNameView(agentHistogram.getAgentId().getName()), responseTimeViewModel);
+            builder.addField(new AgentNameView(agentHistogram.getAgentId().getApplicationName()), responseTimeViewModel);
         }
         return builder.build();
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AdminServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AdminServiceImpl.java
@@ -136,7 +136,7 @@ public class AdminServiceImpl implements AdminService {
         Map<String, List<Application>> agentIdMap = new TreeMap<>();
         List<Application> applications = this.applicationIndexService.selectAllApplications();
         for (Application application : applications) {
-            List<String> agentIds = this.applicationIndexService.selectAgentIds(application.getName());
+            List<String> agentIds = this.applicationIndexService.selectAgentIds(application.getApplicationName());
             for (String agentId : agentIds) {
                 List<Application> applicationList = agentIdMap.computeIfAbsent(agentId, k -> new ArrayList<>());
                 applicationList.add(application);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
@@ -153,7 +153,7 @@ public class AgentInfoServiceImpl implements AgentInfoService {
 
     private List<String> getApplicationNameList(List<Application> applications) {
         return applications.stream()
-                .map(Application::getName)
+                .map(Application::getApplicationName)
                 .distinct()
                 .sorted(Comparator.naturalOrder())
                 .collect(Collectors.toList());

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/ApplicationScatterScanResultSerializer.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/ApplicationScatterScanResultSerializer.java
@@ -19,8 +19,8 @@ package com.navercorp.pinpoint.web.view;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.scatter.vo.ApplicationScatterScanResult;
+import com.navercorp.pinpoint.web.vo.Application;
 
 import java.io.IOException;
 
@@ -32,7 +32,7 @@ public class ApplicationScatterScanResultSerializer extends JsonSerializer<Appli
     public void serialize(ApplicationScatterScanResult value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
         jgen.writeStartObject();
         Application application = value.getApplication();
-        jgen.writeStringField("applicationName", application.getName());
+        jgen.writeStringField("applicationName", application.getApplicationName());
         jgen.writeNumberField("applicationServiceType", application.getServiceTypeCode());
 
         jgen.writeFieldName("scatter");

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/ApplicationSerializer.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/ApplicationSerializer.java
@@ -31,7 +31,7 @@ public class ApplicationSerializer extends JsonSerializer<Application> {
     @Override
     public void serialize(Application application, JsonGenerator jgen, SerializerProvider provider) throws IOException {
         jgen.writeStartObject();
-        jgen.writeStringField("applicationName", application.getName());
+        jgen.writeStringField("applicationName", application.getApplicationName());
         jgen.writeStringField("serviceType", application.getServiceType().getDesc());
         jgen.writeNumberField("code", application.getServiceTypeCode());
         jgen.writeEndObject();

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/histogram/HistogramView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/histogram/HistogramView.java
@@ -91,7 +91,7 @@ public class HistogramView {
 
     public static HistogramView view(NodeHistogramSummary summary) {
         Application application = summary.getApplication();
-        String nodeName = NodeName.toNodeName(application.getName(), application.getServiceType());
+        String nodeName = NodeName.toNodeName(application.getApplicationName(), application.getServiceType());
         Histogram applicationHistogram = summary.getNodeHistogram().getApplicationHistogram();
         List<TimeHistogram> histogramList = summary.getNodeHistogram().getApplicationTimeHistogram().getHistogramList();
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/histogram/ServerHistogramView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/histogram/ServerHistogramView.java
@@ -35,7 +35,7 @@ public class ServerHistogramView {
 
     public static ServerHistogramView view(NodeHistogramSummary summary, HyperLinkFactory hyperLinkFactory) {
         Application application = summary.getApplication();
-        String key = NodeName.toNodeName(application.getName(), application.getServiceType());
+        String key = NodeName.toNodeName(application.getApplicationName(), application.getServiceType());
         List<HistogramView> agentHistogramList = summary.getNodeHistogram().createAgentHistogramViewList();
         ServerGroupList serverGroupList = summary.getServerGroupList();
         ServerGroupListView serverGroupListView = new ServerGroupListView(serverGroupList, hyperLinkFactory);

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/id/AgentNameView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/id/AgentNameView.java
@@ -8,7 +8,7 @@ public record AgentNameView(String agentName) {
 
     public static AgentNameView of(Application application) {
         Objects.requireNonNull(application, "application");
-        return new AgentNameView(application.getName());
+        return new AgentNameView(application.getApplicationName());
     }
 
     public AgentNameView(String agentName) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/ResponseHistograms.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/ResponseHistograms.java
@@ -89,7 +89,7 @@ public class ResponseHistograms {
             Map<Application, ResponseTime.Builder> responseTimeMap = map.getIfAbsentPutWithKey(timestamp, (k) -> new HashMap<>());
             ResponseTime.Builder responseTime = responseTimeMap.get(application);
             if (responseTime == null) {
-                responseTime = ResponseTime.newBuilder(application.getName(), application.getServiceType(), timestamp);
+                responseTime = ResponseTime.newBuilder(application.getApplicationName(), application.getServiceType(), timestamp);
                 responseTimeMap.put(application, responseTime);
             }
             return responseTime;

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
@@ -99,10 +99,10 @@ public class ApplicationMapBuilderTest {
             @Override
             public List<ResponseTime> answer(InvocationOnMock invocation) {
                 Application application = invocation.getArgument(0);
-                String applicationName = application.getName();
+                String applicationName = application.getApplicationName();
                 ServiceType applicationServiceType = application.getServiceType();
                 int depth = ApplicationMapBuilderTestHelper.getDepthFromApplicationName(applicationName);
-                ResponseTime.Builder responseTimeBuilder = ResponseTime.newBuilder(application.getName(), application.getServiceType(), timestamp);
+                ResponseTime.Builder responseTimeBuilder = ResponseTime.newBuilder(application.getApplicationName(), application.getServiceType(), timestamp);
                 responseTimeBuilder.addResponseTime(ApplicationMapBuilderTestHelper.createAgentIdFromDepth(depth), applicationServiceType.getHistogramSchema().getNormalSlot().getSlotTime(), 1);
                 return List.of(responseTimeBuilder.build());
             }

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTestHelper.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTestHelper.java
@@ -97,7 +97,7 @@ public class ApplicationMapBuilderTestHelper {
         Application toApplication = createApplicationFromDepth(toDepth);
         LinkData targetLinkData = new LinkData(fromApplication, toApplication);
         targetLinkData.addLinkData(
-                fromApplication.getName(), WAS_TYPE,
+                fromApplication.getApplicationName(), WAS_TYPE,
                 createAgentIdFromDepth(toDepth), WAS_TYPE,
                 System.currentTimeMillis(), WAS_TYPE.getHistogramSchema().getNormalSlot().getSlotTime(), 1);
         return targetLinkData;
@@ -109,7 +109,7 @@ public class ApplicationMapBuilderTestHelper {
         Application fromApplication = createUserApplication(toApplication);
         LinkData targetLinkData = new LinkData(fromApplication, toApplication);
         targetLinkData.addLinkData(
-                fromApplication.getName(), USER_TYPE,
+                fromApplication.getApplicationName(), USER_TYPE,
                 createAgentIdFromDepth(toDepth), WAS_TYPE,
                 System.currentTimeMillis(), WAS_TYPE.getHistogramSchema().getNormalSlot().getSlotTime(), 1);
         return targetLinkData;
@@ -158,18 +158,18 @@ public class ApplicationMapBuilderTestHelper {
     }
 
     public static Application createUserApplication(Application toApplication) {
-        String userApplicationName = toApplication.getName() + "_" + toApplication.getServiceType().getName();
+        String userApplicationName = toApplication.getApplicationName() + "_" + toApplication.getServiceType().getName();
         return new Application(userApplicationName, USER_TYPE);
     }
 
     public static Application createTerminalApplication(Application fromApplication) {
-        int depth = getDepthFromApplicationName(fromApplication.getName());
+        int depth = getDepthFromApplicationName(fromApplication.getApplicationName());
         String terminalApplicationName = "destinationId_" + depth;
         return new Application(terminalApplicationName, TERMINAL_TYPE);
     }
 
     public static Application createUnknownApplication(Application fromApplication) {
-        int depth = getDepthFromApplicationName(fromApplication.getName());
+        int depth = getDepthFromApplicationName(fromApplication.getApplicationName());
         return new Application(createHostnameFromDepth(depth), UNKNOWN_TYPE);
     }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogramTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/AgentTimeHistogramTest.java
@@ -108,16 +108,16 @@ public class AgentTimeHistogramTest {
 
     private List<ResponseTime> createResponseTime(Application app, String agentName1, String agentName2) {
 
-        ResponseTime.Builder one = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 0);
+        ResponseTime.Builder one = ResponseTime.newBuilder(app.getApplicationName(), app.getServiceType(), 0);
         one.addResponseTime(agentName1, (short) 1000, 1);
 
-        ResponseTime.Builder two = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 1000 * 60);
+        ResponseTime.Builder two = ResponseTime.newBuilder(app.getApplicationName(), app.getServiceType(), 1000 * 60);
         two.addResponseTime(agentName1, (short) 3000, 1);
 
-        ResponseTime.Builder three = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 0);
+        ResponseTime.Builder three = ResponseTime.newBuilder(app.getApplicationName(), app.getServiceType(), 0);
         three.addResponseTime(agentName2, (short) 1000, 1);
 
-        ResponseTime.Builder four = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 1000 * 60);
+        ResponseTime.Builder four = ResponseTime.newBuilder(app.getApplicationName(), app.getServiceType(), 1000 * 60);
         four.addResponseTime(agentName2, (short) 3000, 1);
 
         return List.of(one.build(), two.build(), three.build(), four.build());

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogramTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/histogram/ApplicationTimeHistogramTest.java
@@ -65,10 +65,10 @@ public class ApplicationTimeHistogramTest {
 
     private List<ResponseTime> createResponseTime(Application app) {
 
-        ResponseTime.Builder one = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 0);
+        ResponseTime.Builder one = ResponseTime.newBuilder(app.getApplicationName(), app.getServiceType(), 0);
         one.addResponseTime("test", (short) 1000, 1);
 
-        ResponseTime.Builder two = ResponseTime.newBuilder(app.getName(), app.getServiceType(), 1000 * 60);
+        ResponseTime.Builder two = ResponseTime.newBuilder(app.getApplicationName(), app.getServiceType(), 1000 * 60);
         two.addResponseTime("test", (short) 3000, 1);
 
         return List.of(one.build(), two.build());
@@ -82,7 +82,7 @@ public class ApplicationTimeHistogramTest {
 
         ApplicationTimeHistogramBuilder builder = new ApplicationTimeHistogramBuilder(app, range);
 
-        ResponseTime.Builder responseTime = new ResponseTime.Builder(app.getName(), app.getServiceType(), timestamp);
+        ResponseTime.Builder responseTime = new ResponseTime.Builder(app.getApplicationName(), app.getServiceType(), timestamp);
         responseTime.addResponseTime("test", (short) 1000, 1);
 
         List<ResponseTime> responseHistogramList = List.of(responseTime.build());

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelectorTestBase.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/LinkSelectorTestBase.java
@@ -254,7 +254,7 @@ public abstract class LinkSelectorTestBase {
         List<LinkCallData> callDatas = List.copyOf(linkData_A_B.getLinkCallDataMap().getLinkDataList());
         assertThat(callDatas).hasSize(1);
         LinkCallData callData = callDatas.get(0);
-        assertEquals(rpcUri, callData.getTarget().getName());
+        assertEquals(rpcUri, callData.getTarget().getApplicationName());
         assertEquals(testRpcServiceType, callData.getTarget().getServiceType());
     }
 
@@ -388,13 +388,13 @@ public abstract class LinkSelectorTestBase {
         List<LinkCallData> callData_A_Bs = List.copyOf(linkData_A_B.getLinkCallDataMap().getLinkDataList());
         assertThat(callData_A_Bs).hasSize(1);
         LinkCallData callData_A_B = callData_A_Bs.get(0);
-        assertEquals(rpcUri, callData_A_B.getTarget().getName());
+        assertEquals(rpcUri, callData_A_B.getTarget().getApplicationName());
         assertEquals(testRpcServiceType, callData_A_B.getTarget().getServiceType());
 
         List<LinkCallData> callData_A_Cs = List.copyOf(linkData_A_C.getLinkCallDataMap().getLinkDataList());
         assertThat(callData_A_Cs).hasSize(1);
         LinkCallData callData_A_C = callData_A_Cs.get(0);
-        assertEquals(rpcUri, callData_A_C.getTarget().getName());
+        assertEquals(rpcUri, callData_A_C.getTarget().getApplicationName());
         assertEquals(testRpcServiceType, callData_A_C.getTarget().getServiceType());
     }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImplTest.java
@@ -182,7 +182,7 @@ public class FilteredMapServiceImplTest {
         assertThat(nodes).hasSize(4);
         for (Node node : nodes) {
             Application application = node.getApplication();
-            if (application.getName().equals(UserNodeUtils.newUserNodeName("ROOT_APP", ServiceType.TEST_STAND_ALONE)) && application.getServiceType().getCode() == TestTraceUtils.USER_TYPE_CODE) {
+            if (application.getApplicationName().equals(UserNodeUtils.newUserNodeName("ROOT_APP", ServiceType.TEST_STAND_ALONE)) && application.getServiceType().getCode() == TestTraceUtils.USER_TYPE_CODE) {
                 // USER node
                 NodeHistogram nodeHistogram = node.getNodeHistogram();
                 // histogram
@@ -201,7 +201,7 @@ public class FilteredMapServiceImplTest {
                 JsonFields<AgentNameView, List<TimeHistogramViewModel>> agentTimeHistogram = getAgentTimeHistogram(nodeHistogram);
 //                AgentResponseTimeViewModelList agentTimeHistogram = agentTimeHistogram;
                 Assertions.assertTrue(agentTimeHistogram.isEmpty());
-            } else if (application.getName().equals("ROOT_APP") && application.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE) {
+            } else if (application.getApplicationName().equals("ROOT_APP") && application.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE) {
                 // ROOT_APP node
                 NodeHistogram nodeHistogram = node.getNodeHistogram();
                 // histogram
@@ -219,7 +219,7 @@ public class FilteredMapServiceImplTest {
                 JsonFields<AgentNameView, List<TimeHistogramViewModel>> agentTimeHistogram = getAgentTimeHistogram(nodeHistogram);
 //                AgentResponseTimeViewModelList agentTimeHistogram = nodeHistogram.getAgentTimeHistogram(TimeHistogramFormat.V1);
                 assertAgentTimeHistogram(agentTimeHistogram, "root-agent", histogramSchema.getFastSlot(), expectedTimeCounts);
-            } else if (application.getName().equals("APP_A") && application.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE) {
+            } else if (application.getApplicationName().equals("APP_A") && application.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE) {
                 // APP_A node
                 NodeHistogram nodeHistogram = node.getNodeHistogram();
                 // histogram
@@ -237,7 +237,7 @@ public class FilteredMapServiceImplTest {
                 JsonFields<AgentNameView, List<TimeHistogramViewModel>> agentTimeHistogram = getAgentTimeHistogram(nodeHistogram);
 //                AgentResponseTimeViewModelList agentTimeHistogram = nodeHistogram.getAgentTimeHistogram(TimeHistogramFormat.V1);
                 assertAgentTimeHistogram(agentTimeHistogram, "app-a", histogramSchema.getFastSlot(), expectedTimeCounts);
-            } else if (application.getName().equals("CacheName") && application.getServiceType().getCode() == TestTraceUtils.CACHE_TYPE_CODE) {
+            } else if (application.getApplicationName().equals("CacheName") && application.getServiceType().getCode() == TestTraceUtils.CACHE_TYPE_CODE) {
                 // CACHE node
                 NodeHistogram nodeHistogram = node.getNodeHistogram();
                 // histogram
@@ -265,8 +265,8 @@ public class FilteredMapServiceImplTest {
         for (Link link : links) {
             Application fromApplication = link.getFrom().getApplication();
             Application toApplication = link.getTo().getApplication();
-            if ((fromApplication.getName().equals(UserNodeUtils.newUserNodeName("ROOT_APP", ServiceType.TEST_STAND_ALONE)) && fromApplication.getServiceType().getCode() == TestTraceUtils.USER_TYPE_CODE) &&
-                    (toApplication.getName().equals("ROOT_APP") && toApplication.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE)) {
+            if ((fromApplication.getApplicationName().equals(UserNodeUtils.newUserNodeName("ROOT_APP", ServiceType.TEST_STAND_ALONE)) && fromApplication.getServiceType().getCode() == TestTraceUtils.USER_TYPE_CODE) &&
+                    (toApplication.getApplicationName().equals("ROOT_APP") && toApplication.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE)) {
                 // histogram
                 Histogram histogram = link.getHistogram();
                 assertHistogram(histogram, 1, 0, 0, 0, 0);
@@ -277,8 +277,8 @@ public class FilteredMapServiceImplTest {
                         new TimeCount(timeWindow.refineTimestamp(rootSpanCollectorAcceptTime), 1)
                 );
                 assertTimeHistogram(histogramViewModels, targetHistogramSchema.getFastSlot(), expectedTimeCounts);
-            } else if ((fromApplication.getName().equals("ROOT_APP") && fromApplication.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE) &&
-                    (toApplication.getName().equals("APP_A") && toApplication.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE)) {
+            } else if ((fromApplication.getApplicationName().equals("ROOT_APP") && fromApplication.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE) &&
+                    (toApplication.getApplicationName().equals("APP_A") && toApplication.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE)) {
                 // histogram
                 Histogram histogram = link.getHistogram();
                 assertHistogram(histogram, 1, 0, 0, 0, 0);
@@ -289,8 +289,8 @@ public class FilteredMapServiceImplTest {
                         new TimeCount(timeWindow.refineTimestamp(appASpanCollectorAcceptTime), 1)
                 );
                 assertTimeHistogram(linkApplicationTimeSeriesHistogram, targetHistogramSchema.getFastSlot(), expectedTimeCounts);
-            } else if ((fromApplication.getName().equals("APP_A") && fromApplication.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE) &&
-                    (toApplication.getName().equals("CacheName") && toApplication.getServiceType().getCode() == TestTraceUtils.CACHE_TYPE_CODE
+            } else if ((fromApplication.getApplicationName().equals("APP_A") && fromApplication.getServiceType().getCode() == TestTraceUtils.TEST_STAND_ALONE_TYPE_CODE) &&
+                    (toApplication.getApplicationName().equals("CacheName") && toApplication.getServiceType().getCode() == TestTraceUtils.CACHE_TYPE_CODE
                     )) {
                 // histogram
                 Histogram histogram = link.getHistogram();

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/service/ResponseTimeHistogramServiceImplTest.java
@@ -159,7 +159,7 @@ public class ResponseTimeHistogramServiceImplTest {
     }
 
     private ResponseTime createResponseTime(Application application, long timestamp) {
-        ResponseTime.Builder responseTimeBuilder = ResponseTime.newBuilder(application.getName(), application.getServiceType(), timestamp);
+        ResponseTime.Builder responseTimeBuilder = ResponseTime.newBuilder(application.getApplicationName(), application.getServiceType(), timestamp);
         HistogramSchema schema = application.getServiceType().getHistogramSchema();
         responseTimeBuilder.addResponseTime("agentId", schema.getFastSlot().getSlotTime(), 1L);
         responseTimeBuilder.addResponseTime("agentId", schema.getNormalSlot().getSlotTime(), 2L);

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/AdminServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/AdminServiceImplTest.java
@@ -117,13 +117,13 @@ public class AdminServiceImplTest {
         assertThat(duplicateAgentIdMap.get(AGENT_ID3)).hasSize(2);
 
         // check the application names
-        List<String> applicationNamesOfAgentId1 = duplicateAgentIdMap.get(AGENT_ID1).stream().map(Application::getName).collect(Collectors.toList());
+        List<String> applicationNamesOfAgentId1 = duplicateAgentIdMap.get(AGENT_ID1).stream().map(Application::getApplicationName).collect(Collectors.toList());
         assertThat(applicationNamesOfAgentId1).containsAll(List.of(APPLICATION_NAME1, APPLICATION_NAME3));
 
-        List<String> applicationNamesOfAgentId2 = duplicateAgentIdMap.get(AGENT_ID2).stream().map(Application::getName).collect(Collectors.toList());
+        List<String> applicationNamesOfAgentId2 = duplicateAgentIdMap.get(AGENT_ID2).stream().map(Application::getApplicationName).collect(Collectors.toList());
         assertThat(applicationNamesOfAgentId2).containsAll(List.of(APPLICATION_NAME1, APPLICATION_NAME2));
 
-        List<String> applicationNamesOfAgentId3 = duplicateAgentIdMap.get(AGENT_ID3).stream().map(Application::getName).collect(Collectors.toList());
+        List<String> applicationNamesOfAgentId3 = duplicateAgentIdMap.get(AGENT_ID3).stream().map(Application::getApplicationName).collect(Collectors.toList());
         assertThat(applicationNamesOfAgentId3).containsAll(List.of(APPLICATION_NAME1, APPLICATION_NAME2));
     }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ApdexScoreServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ApdexScoreServiceImplTest.java
@@ -92,7 +92,7 @@ public class ApdexScoreServiceImplTest {
     }
 
     private ResponseTime createResponseTime(long timeStamp) {
-        ResponseTime.Builder responseTimeBuilder = ResponseTime.newBuilder(testApplication.getName(), testApplication.getServiceType(), timeStamp);
+        ResponseTime.Builder responseTimeBuilder = ResponseTime.newBuilder(testApplication.getApplicationName(), testApplication.getServiceType(), timeStamp);
         for (String agentId : agentIdList) {
             responseTimeBuilder.addResponseTime(agentId, createTestHistogram(1, 2, 3, 4, 5));
         }


### PR DESCRIPTION
This pull request standardizes the usage of the `Application` class's application name accessor throughout the codebase. Specifically, it replaces calls to the deprecated or legacy `getName()` method with the preferred `getApplicationName()` method. This change improves code consistency and prepares the codebase for future changes where `getName()` may be removed or its behavior altered.

**Refactoring for consistent application name access:**

* Replaced all instances of `application.getName()` with `application.getApplicationName()` in alarm processing, data collection, logging, and agent management logic across multiple files, including `AlarmProcessor.java`, `AlarmReader.java`, various collectors (e.g., `DataSourceDataCollector.java`, `FileDescriptorDataCollector.java`, `HeapDataCollector.java`, `JvmCpuDataCollector.java`, `SystemCpuDataCollector.java`), and application/job management classes (e.g., `ApplicationCleaningProcessor.java`, `ApplicationRemover.java`, `BatchApplicationIndexServiceImpl.java`). [[1]](diffhunk://#diff-230add387063a918e442acb8765a7456671e9a1188ff00efc03e313a609f4e21L82-R82) [[2]](diffhunk://#diff-230add387063a918e442acb8765a7456671e9a1188ff00efc03e313a609f4e21L103-R103) [[3]](diffhunk://#diff-550709ac544d79e51e5fd237bfaa43d2969d27a37b08ec2883dd6df41f7e09d7L64-R64) [[4]](diffhunk://#diff-55bae80948938d4edcdc1a23f1a8de66e0badb7a29dc5588cef2dc7f64ce671fL71-R71) [[5]](diffhunk://#diff-ef99f2f378f9030296b3f947b0b238dc2363bccdaa5f63c932943ac03c72b420L87-R87) [[6]](diffhunk://#diff-ef99f2f378f9030296b3f947b0b238dc2363bccdaa5f63c932943ac03c72b420L126-R130) [[7]](diffhunk://#diff-ef99f2f378f9030296b3f947b0b238dc2363bccdaa5f63c932943ac03c72b420L144-R144) [[8]](diffhunk://#diff-ef99f2f378f9030296b3f947b0b238dc2363bccdaa5f63c932943ac03c72b420L166-R166) [[9]](diffhunk://#diff-ef99f2f378f9030296b3f947b0b238dc2363bccdaa5f63c932943ac03c72b420L179-R179) [[10]](diffhunk://#diff-ef99f2f378f9030296b3f947b0b238dc2363bccdaa5f63c932943ac03c72b420L204-R204) [[11]](diffhunk://#diff-092e4cc90313dec7bb90ccaa0556d5d69967f214b69297d3da3b4ccaa1c6d07aL56-R56) [[12]](diffhunk://#diff-df12bee16bda5f772b06afb4371213efdc7a24ab95e356d7a3fdeaef210129faL59-R59) [[13]](diffhunk://#diff-836cc73207246b2c0c9e198494a940ce7ff9c799be1675592d7d129ac460ba41L58-R58) [[14]](diffhunk://#diff-8ef0e4175a4cb6daa5a493d9a0bafddae1df13d66034687ed8e3ebf1ab680298L56-R56) [[15]](diffhunk://#diff-f3f2093546754551a5595b08f7b1a2d1706cab6611f538d6c40ea0188a8bff80L96-R100) [[16]](diffhunk://#diff-f807e352e511583f8826a83caecdb553e6f1f78b5aac7c2351901a6b96883bc6L48-R48) [[17]](diffhunk://#diff-eaaaa223d360976b988d59e877aaa72c0b6acecd83798b6f318469001c593e9bL83-R88) [[18]](diffhunk://#diff-15871556448e8a83278c8f7ceb8c4824ac45408c15b15b680aee6f724ae71509L55-R55) [[19]](diffhunk://#diff-78be99e91c3c89e1311d7f378b994541d3689df200e6b91392bd6bf1ffbc8c08L61-R61)
* Updated web layer and related service/DAO classes to use `getApplicationName()` for all application name retrievals, ensuring consistency in agent queries, application mapping, and key generation. [[1]](diffhunk://#diff-ec74c5d215e8a4bf087b1500481b46b894f992fe54e459c3667a4b958b7a2296R21-L28) [[2]](diffhunk://#diff-ec74c5d215e8a4bf087b1500481b46b894f992fe54e459c3667a4b958b7a2296L82-R82) [[3]](diffhunk://#diff-25617e0baac539c8c92da6d22ee66b7879961dd59785ac40d6435520b49826b0L65-R65) [[4]](diffhunk://#diff-6359aee70ea42a8dd88eb310e58c4245efd7bf1b392cffe27bbf8045636e2039L102-R102) [[5]](diffhunk://#diff-bfcfd11915db91f367237d3fecae63a6c608d02758cfaa6023c8979db44e3dceL25-R25) [[6]](diffhunk://#diff-44e6f5a7305106d10542530e1219b59a27792810aa5687859a836bd5cbe1589cL95-R95)

No functional changes are introduced; this is a pure refactor to unify the method used for retrieving application names.