### PR TITLE
[#noissue] Add serviceName field to LinkView and NodeView JSON output

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
@@ -122,6 +122,7 @@ public class LinkView {
             Application filterApplication = link.getFilterApplication();
             jgen.writeFieldName("filter");
             jgen.writeStartObject();
+            jgen.writeStringField("serviceName", filterApplication.getService().getServiceName());
             jgen.writeStringField("applicationName", filterApplication.getApplicationName());
             ServiceType serviceType = filterApplication.getServiceType();
             jgen.writeNumberField("serviceTypeCode", serviceType.getCode());
@@ -146,7 +147,9 @@ public class LinkView {
             Collection<Application> sourceLinkTargetAgentList = link.getSourceLinkTargetAgentList();
             for (Application application : sourceLinkTargetAgentList) {
                 jgen.writeStartObject();
+                jgen.writeStringField("rpcServiceName", application.getService().getServiceName());
                 jgen.writeStringField("rpc", application.getApplicationName());
+                jgen.writeStringField("rpcApplicationName", application.getApplicationName());
                 jgen.writeNumberField("rpcServiceTypeCode", application.getServiceTypeCode());
                 jgen.writeEndObject();
             }
@@ -159,6 +162,7 @@ public class LinkView {
 
             jgen.writeStartObject();
             Application application = node.getApplication();
+            jgen.writeStringField("serviceName", application.getService().getServiceName());
             jgen.writeStringField("applicationName", application.getApplicationName());
             ServiceType serviceType = application.getServiceType();
             jgen.writeStringField("serviceType", serviceType.toString());

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.web.applicationmap.nodes.AgentServerGroupListWrite
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.nodes.ServerGroupList;
 import com.navercorp.pinpoint.web.applicationmap.service.AlertViewService;
+import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseTimeStatics;
 import org.springframework.boot.jackson.JsonComponent;
 
@@ -103,6 +104,8 @@ public class NodeView {
             jgen.writeObjectField("key", node.getNodeName()); // necessary for go.js
             jgen.writeStringField("nodeKey", node.getNodeKey());
 
+            Application application = node.getApplication();
+            jgen.writeStringField("serviceName", application.getService().getServiceName());
             jgen.writeStringField("applicationName", node.getApplicationTextName()); // for go.js
 
             final ServiceType serviceType = node.getServiceType();


### PR DESCRIPTION
This pull request enhances the JSON serialization of application map views by including additional service name fields in the output. These changes improve clarity and consistency in the data provided to the frontend, making it easier to identify services associated with applications and links.

**Application and Service Name Serialization Enhancements:**

* Added `serviceName` to the filter section in `LinkView`, providing the service name for the filtered application.
* Added `serviceName` to the node serialization in `LinkView`, ensuring each node includes its associated service name.
* Added `serviceName` to the node serialization in `NodeView`, making service names available alongside application names.

**RPC Link Serialization Improvements:**

* Added `rpcServiceName` and `rpcApplicationName` fields to the target agent list in `LinkView`, improving the detail and clarity of RPC link data.

**Imports Update:**

* Imported `Application` in `NodeView` to support the new serialization fields.