### PR TITLE
[#noissue] Add mappers for OpenTelemetry attributes, events, and links

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceAttributeMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceAttributeMapper.java
@@ -1,0 +1,40 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import io.opentelemetry.proto.common.v1.KeyValue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperUtils.getAttributeToMap;
+
+public class OtlpTraceAttributeMapper {
+
+    private final ObjectWriter mapWriter;
+
+    public OtlpTraceAttributeMapper(ObjectMapper objectMapper) {
+        Objects.requireNonNull(objectMapper, "objectMapper");
+        this.mapWriter = objectMapper.writerFor(new TypeReference<Map<String, Object>>() {});
+    }
+
+    public void addAttributesToAnnotation(List<KeyValue> keyValueList, AnnotationWriter annotationWriter) {
+        try {
+            Map<String, Object> map = getAttributeToMap(keyValueList, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY);
+            if (!map.isEmpty()) {
+                map.entrySet().removeIf(entry -> OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY_MAP.containsKey(entry.getKey()));
+                final String value = mapWriter.writeValueAsString(map);
+                annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_ATTRIBUTE.getCode(), value));
+            }
+        } catch (JsonProcessingException e) {
+            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_ATTRIBUTE.getCode(), "json processing error"));
+        }
+    }
+
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -17,8 +17,7 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.function.Predicate;
 
 public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_CLIENT_ADDRESS = "client.address";
@@ -34,17 +33,22 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_DB_STATEMENT = "db.statement";
     public static final String ATTRIBUTE_KEY_DB_SYSTEM = "db.system";
 
-    public static final Map<String, Boolean> FILTERED_ATTRIBUTE_KEY_MAP = Stream.of(
-            ATTRIBUTE_KEY_CLIENT_ADDRESS,
-            ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE,
-            ATTRIBUTE_KEY_MESSAGING_KAFKA_MESSAGE_OFFSET,
-            ATTRIBUTE_KEY_MESSAGING_DESTINATION_PARTITION_ID,
-            ATTRIBUTE_KEY_MESSAGING_DESTINATION_NAME,
-            ATTRIBUTE_KEY_URL_PATH,
-            ATTRIBUTE_KEY_MESSAGING_CLIENT_ID,
-            ATTRIBUTE_KEY_SERVER_PORT,
-            ATTRIBUTE_KEY_SERVER_ADDRESS,
-            ATTRIBUTE_KEY_DB_NAME,
-            ATTRIBUTE_KEY_DB_STATEMENT,
-            ATTRIBUTE_KEY_DB_SYSTEM).collect(Collectors.toUnmodifiableMap(key -> key, value -> Boolean.TRUE));
+    public static final Map<String, Boolean> FILTERED_ATTRIBUTE_KEY_MAP = Map.ofEntries(
+            Map.entry(ATTRIBUTE_KEY_CLIENT_ADDRESS, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_MESSAGING_KAFKA_MESSAGE_OFFSET, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_MESSAGING_DESTINATION_PARTITION_ID, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_MESSAGING_DESTINATION_NAME, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_URL_PATH, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_MESSAGING_CLIENT_ID, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_SERVER_PORT, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_SERVER_ADDRESS, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_DB_NAME, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_DB_STATEMENT, Boolean.TRUE),
+            Map.entry(ATTRIBUTE_KEY_DB_SYSTEM, Boolean.TRUE)
+    );
+
+    public static final Predicate<String> FILTERED_ATTRIBUTE_KEY = FILTERED_ATTRIBUTE_KEY_MAP::containsKey;
+
+
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapper.java
@@ -1,0 +1,45 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import io.opentelemetry.proto.trace.v1.Span;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperUtils.getAttributeToMap;
+
+public class OtlpTraceEventMapper {
+
+    private final ObjectWriter mapWriter;
+
+    public OtlpTraceEventMapper(ObjectMapper objectMapper) {
+        Objects.requireNonNull(objectMapper, "objectMapper");
+        this.mapWriter = objectMapper.writerFor(new TypeReference<Map<String, Object>>() {});
+    }
+
+    public void addEventToAnnotation(Span.Event event, AnnotationWriter annotationWriter) {
+        // empty event name??
+//        if (StringUtils.isEmpty(event.getName())) {
+//            return;
+//        }
+        try {
+            Map<String, Object> map;
+            if (event.getAttributesCount() > 0) {
+                map = Map.of(event.getName(), getAttributeToMap(event.getAttributesList()));
+            } else {
+                map = Map.of(event.getName(), "");
+            }
+            final String value = mapWriter.writeValueAsString(map);
+            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), value));
+        } catch (JsonProcessingException e) {
+            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), "json processing error"));
+        }
+    }
+
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
@@ -1,0 +1,47 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
+import com.navercorp.pinpoint.common.server.util.Base16Utils;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import io.opentelemetry.proto.trace.v1.Span;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperUtils.getAttributeToMap;
+
+public class OtlpTraceLinkMapper {
+
+    private final ObjectWriter mapWriter;
+
+    public OtlpTraceLinkMapper(ObjectMapper objectMapper) {
+        Objects.requireNonNull(objectMapper, "objectMapper");
+        this.mapWriter = objectMapper.writerFor(new TypeReference<Map<String, Object>>() {});
+    }
+
+
+    public void addLinkToAnnotation(Span.Link link, AnnotationWriter annotationWriter) {
+        try {
+            Map<String, Object> map = new HashMap<>();
+            if (!link.getTraceId().isEmpty()) {
+                map.put("traceId", Base16Utils.encodeToString(link.getTraceId().toByteArray()));
+            }
+            if (!link.getSpanId().isEmpty()) {
+                map.put("spanId", Base16Utils.encodeToString(link.getSpanId().toByteArray()));
+            }
+            if (link.getAttributesCount() > 0) {
+                map.put("attributes", getAttributeToMap(link.getAttributesList()));
+            }
+            final String value = mapWriter.writeValueAsString(map);
+            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), value));
+        } catch (JsonProcessingException e) {
+            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), "json processing error"));
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -16,27 +16,21 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.profiler.name.Base64Utils;
-import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
-import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
-import com.navercorp.pinpoint.common.server.util.Base16Utils;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
-import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.ArrayValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
-import io.opentelemetry.proto.trace.v1.Span;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 public class OtlpTraceMapperUtils {
     private static final String KEY_AGENT_ID = "pinpoint.agentId";
@@ -101,37 +95,48 @@ public class OtlpTraceMapperUtils {
         return ByteStringUtils.parseLong(bytes);
     }
 
-    public static void addAttributesToAnnotation(ObjectMapper objectMapper, List<KeyValue> keyValueList, AnnotationWriter annotationWriter) {
-        try {
-            final Map<String, Object> map = getAttributeToMap(keyValueList);
-            if (!map.isEmpty()) {
-                map.entrySet().removeIf(entry -> OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY_MAP.containsKey(entry.getKey()));
-                final String value = objectMapper.writeValueAsString(map);
-                annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_ATTRIBUTE.getCode(), value));
-            }
-        } catch (JsonProcessingException e) {
-            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_ATTRIBUTE.getCode(), "json processing error"));
+    public static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList) {
+        final int size = keyValueList.size();
+        if (size == 0) {
+            return Map.of();
         }
-    }
-
-
-    static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList) {
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new HashMap<>(size);
         for (KeyValue kv : keyValueList) {
             map.put(kv.getKey(), getAttributeValueToValue(kv.getValue()));
         }
         return map;
     }
 
-    static List<Object> getArrayValueToList(ArrayValue arrayValue) {
-        List<Object> list = new ArrayList<>();
+    public static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList, Predicate<String> excludeFilter) {
+        final int size = keyValueList.size();
+        if (size == 0) {
+            return Map.of();
+        }
+        Map<String, Object> map = new HashMap<>(size);
+        for (KeyValue kv : keyValueList) {
+            String key = kv.getKey();
+            if (excludeFilter.test(key)) {
+                continue;
+            }
+            map.put(key, getAttributeValueToValue(kv.getValue()));
+        }
+        return map;
+    }
+
+    public static List<Object> getArrayValueToList(ArrayValue arrayValue) {
+        final int size = arrayValue.getValuesCount();
+        if (size == 0) {
+            return List.of();
+        }
+
+        List<Object> list = new ArrayList<>(size);
         for (AnyValue anyValue : arrayValue.getValuesList()) {
             list.add(getAttributeValueToValue(anyValue));
         }
         return list;
     }
 
-    static Object getAttributeValueToValue(AnyValue anyValue) {
+    public static Object getAttributeValueToValue(AnyValue anyValue) {
         if (anyValue.hasIntValue()) {
             return anyValue.getIntValue();
         } else if (anyValue.hasDoubleValue()) {
@@ -152,41 +157,4 @@ public class OtlpTraceMapperUtils {
         }
     }
 
-    public static void addEventToAnnotation(ObjectMapper objectMapper, Span.Event event, AnnotationWriter annotationWriter) {
-        if (event.getName() == null) {
-            return;
-        }
-
-        try {
-            Map<String, Object> map = new HashMap<>();
-            if (event.getAttributesCount() > 0) {
-                map.put(event.getName(), getAttributeToMap(event.getAttributesList()));
-            } else {
-                map.put(event.getName(), "");
-            }
-            final String value = objectMapper.writeValueAsString(map);
-            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), value));
-        } catch (JsonProcessingException e) {
-            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), "json processing error"));
-        }
-    }
-
-    public static void addLinkToAnnotation(ObjectMapper objectMapper, Span.Link link, AnnotationWriter annotationWriter) {
-        try {
-            Map<String, Object> map = new HashMap<>();
-            if (!link.getTraceId().isEmpty()) {
-                map.put("traceId", Base16Utils.encodeToString(link.getTraceId().toByteArray()));
-            }
-            if (!link.getSpanId().isEmpty()) {
-                map.put("spanId", Base16Utils.encodeToString(link.getSpanId().toByteArray()));
-            }
-            if (link.getAttributesCount() > 0) {
-                map.put("attributes", getAttributeToMap(link.getAttributesList()));
-            }
-            final String value = objectMapper.writeValueAsString(map);
-            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), value));
-        } catch (JsonProcessingException e) {
-            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), "json processing error"));
-        }
-    }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -23,8 +23,8 @@ import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import com.navercorp.pinpoint.io.SpanVersion;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import io.opentelemetry.proto.trace.v1.Span;
 import org.springframework.stereotype.Component;
 
@@ -35,10 +35,14 @@ import java.util.concurrent.TimeUnit;
 
 @Component
 public class OtlpTraceSpanEventMapper {
-    private final ObjectMapper objectMapper;
+
+    private final OtlpTraceAttributeMapper attributeMapper;
+    private final OtlpTraceEventMapper eventMapper;
 
     public OtlpTraceSpanEventMapper(ObjectMapper objectMapper) {
-        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+        Objects.requireNonNull(objectMapper, "objectMapper");
+        this.attributeMapper = new OtlpTraceAttributeMapper(objectMapper);
+        this.eventMapper = new OtlpTraceEventMapper(objectMapper);
     }
 
     List<SpanEventBo> map(long spanStartTime, Span span) {
@@ -80,13 +84,13 @@ public class OtlpTraceSpanEventMapper {
         spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_START_TIME.getCode(), span.getStartTimeUnixNano()));
         // attributes
         if (span.getAttributesCount() > 0) {
-            OtlpTraceMapperUtils.addAttributesToAnnotation(objectMapper, span.getAttributesList(), spanEventBo::addAnnotation);
+            attributeMapper.addAttributesToAnnotation(span.getAttributesList(), spanEventBo::addAnnotation);
         }
         // argument
         spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.ARGS0.getCode(), span.getName()));
         // event
         for (Span.Event event : span.getEventsList()) {
-            OtlpTraceMapperUtils.addEventToAnnotation(objectMapper, event, spanEventBo::addAnnotation);
+            eventMapper.addEventToAnnotation(event, spanEventBo::addAnnotation);
         }
 
         spanEventBo.setDepth(1);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -39,10 +39,16 @@ import java.util.concurrent.TimeUnit;
 
 @Component
 public class OtlpTraceSpanMapper {
-    private final ObjectMapper objectMapper;
+    private final OtlpTraceAttributeMapper attributeMapper;
+    private final OtlpTraceEventMapper eventMapper;
+    private final OtlpTraceLinkMapper linkMapper;
+
 
     public OtlpTraceSpanMapper(ObjectMapper objectMapper) {
-        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+        Objects.requireNonNull(objectMapper, "objectMapper");
+        this.attributeMapper = new OtlpTraceAttributeMapper(objectMapper);
+        this.eventMapper = new OtlpTraceEventMapper(objectMapper);
+        this.linkMapper = new OtlpTraceLinkMapper(objectMapper);
     }
 
     SpanBo map(IdAndName idAndName, Span span) {
@@ -102,16 +108,16 @@ public class OtlpTraceSpanMapper {
         }
         // attributes
         if (span.getAttributesCount() > 0) {
-            OtlpTraceMapperUtils.addAttributesToAnnotation(objectMapper, span.getAttributesList(), spanBo::addAnnotation);
+            attributeMapper.addAttributesToAnnotation(span.getAttributesList(), spanBo::addAnnotation);
         }
 
         // event
         for (Span.Event event : span.getEventsList()) {
-            OtlpTraceMapperUtils.addEventToAnnotation(objectMapper, event, spanBo::addAnnotation);
+            eventMapper.addEventToAnnotation(event, spanBo::addAnnotation);
         }
         // link
         for (Span.Link link : span.getLinksList()) {
-            OtlpTraceMapperUtils.addLinkToAnnotation(objectMapper, link, spanBo::addAnnotation);
+            linkMapper.addLinkToAnnotation(link, spanBo::addAnnotation);
         }
 
         final List<SpanEventBo> spanEventBoList = new ArrayList<>();

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAnyValueFactory.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAnyValueFactory.java
@@ -1,0 +1,30 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+
+public final class OtlpAnyValueFactory {
+
+    private OtlpAnyValueFactory() {
+    }
+
+    public static KeyValue kv(String key, AnyValue value) {
+        return KeyValue.newBuilder().setKey(key).setValue(value).build();
+    }
+
+    public static AnyValue strVal(String s) {
+        return AnyValue.newBuilder().setStringValue(s).build();
+    }
+
+    public static AnyValue intVal(long v) {
+        return AnyValue.newBuilder().setIntValue(v).build();
+    }
+
+    public static AnyValue boolVal(boolean v) {
+        return AnyValue.newBuilder().setBoolValue(v).build();
+    }
+
+    public static AnyValue doubleVal(double v) {
+        return AnyValue.newBuilder().setDoubleValue(v).build();
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceAttributeMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceAttributeMapperTest.java
@@ -1,0 +1,176 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.ArrayValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.boolVal;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.doubleVal;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.intVal;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.kv;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.strVal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpTraceAttributeMapperTest {
+
+    private OtlpTraceAttributeMapper mapper;
+    private List<AnnotationBo> annotations;
+    private AnnotationWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new OtlpTraceAttributeMapper(new ObjectMapper());
+        annotations = new ArrayList<>();
+        writer = annotations::add;
+    }
+
+    // -----------------------------------------------------------------------
+    // empty list -> skip
+    // -----------------------------------------------------------------------
+
+    @Test
+    void emptyList_skipsWrite() {
+        mapper.addAttributesToAnnotation(List.of(), writer);
+
+        assertThat(annotations).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // only filtered keys -> all removed, skip write
+    // -----------------------------------------------------------------------
+
+    @Test
+    void onlyFilteredKeys_skipsWrite() {
+        List<KeyValue> attrs = List.of(
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE, strVal("200")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH, strVal("/api/hello"))
+        );
+
+        mapper.addAttributesToAnnotation(attrs, writer);
+
+        Assertions.assertThat(annotations).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // write string attribute
+    // -----------------------------------------------------------------------
+
+    @Test
+    void withStringAttribute_writesJson() {
+        List<KeyValue> attrs = List.of(
+                kv("http.method", strVal("GET"))
+        );
+
+        mapper.addAttributesToAnnotation(attrs, writer);
+
+        assertThat(annotations).hasSize(1);
+        AnnotationBo bo = annotations.get(0);
+        assertThat(bo.getKey()).isEqualTo(AnnotationKey.OPENTELEMETRY_ATTRIBUTE.getCode());
+
+        String json = (String) bo.getValue();
+        assertThat(json).isEqualTo("{\"http.method\":\"GET\"}");
+    }
+
+    // -----------------------------------------------------------------------
+    // int / bool / double attribute
+    // -----------------------------------------------------------------------
+
+    @Test
+    void withMultipleAttributeTypes_writesCorrectJson() throws Exception {
+        List<KeyValue> attrs = List.of(
+                kv("count", intVal(42L)),
+                kv("flag", boolVal(true)),
+                kv("ratio", doubleVal(0.5))
+        );
+
+        mapper.addAttributesToAnnotation(attrs, writer);
+
+        assertThat(annotations).hasSize(1);
+        String json = (String) annotations.get(0).getValue();
+
+        ObjectMapper om = new ObjectMapper();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = om.readValue(json, Map.class);
+
+        assertThat(map).containsEntry("count", 42);
+        assertThat(map).containsEntry("flag", true);
+        assertThat(map).containsEntry("ratio", 0.5);
+    }
+
+    // -----------------------------------------------------------------------
+    // array attribute
+    // -----------------------------------------------------------------------
+
+    @Test
+    void withArrayAttribute_writesArray() throws Exception {
+        ArrayValue arrayValue = ArrayValue.newBuilder()
+                .addValues(strVal("x"))
+                .addValues(strVal("y"))
+                .build();
+        List<KeyValue> attrs = List.of(
+                kv("tags", AnyValue.newBuilder().setArrayValue(arrayValue).build())
+        );
+
+        mapper.addAttributesToAnnotation(attrs, writer);
+
+        assertThat(annotations).hasSize(1);
+        String json2 = (String) annotations.get(0).getValue();
+
+        ObjectMapper om2 = new ObjectMapper();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map2 = om2.readValue(json2, Map.class);
+
+        assertThat(map2.get("tags")).isInstanceOf(List.class)
+                .asList().containsExactly("x", "y");
+    }
+
+    // -----------------------------------------------------------------------
+    // mixed keys -> filtered keys are removed, others are preserved
+    // -----------------------------------------------------------------------
+
+    @Test
+    void mixedKeys_filteredKeysAreRemoved() throws Exception {
+        List<KeyValue> attrs = List.of(
+                kv("http.method", strVal("POST")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH, strVal("/api/save")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_DB_STATEMENT, strVal("SELECT 1"))
+        );
+
+        mapper.addAttributesToAnnotation(attrs, writer);
+
+        assertThat(annotations).hasSize(1);
+        String json = (String) annotations.get(0).getValue();
+
+        ObjectMapper om = new ObjectMapper();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = om.readValue(json, Map.class);
+
+        assertThat(map).containsOnlyKeys("http.method");
+        assertThat(map).containsEntry("http.method", "POST");
+    }
+
+    // -----------------------------------------------------------------------
+    // verify annotation key code
+    // -----------------------------------------------------------------------
+
+    @Test
+    void annotationKey_isOpentelemetryAttribute() {
+        mapper.addAttributesToAnnotation(List.of(kv("k", strVal("v"))), writer);
+
+        assertThat(annotations.get(0).getKey())
+                .isEqualTo(AnnotationKey.OPENTELEMETRY_ATTRIBUTE.getCode());
+    }
+
+}
+

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapperTest.java
@@ -1,0 +1,169 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.ArrayValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.trace.v1.Span;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.boolVal;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.doubleVal;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.intVal;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.kv;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.strVal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpTraceEventMapperTest {
+
+    private OtlpTraceEventMapper mapper;
+    private List<AnnotationBo> annotations;
+    private AnnotationWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new OtlpTraceEventMapper(new ObjectMapper());
+        annotations = new ArrayList<>();
+        writer = annotations::add;
+    }
+
+    // -----------------------------------------------------------------------
+    // empty name -> skip
+    // -----------------------------------------------------------------------
+
+    @Test
+    void emptyName() {
+        Span.Event event = Span.Event.newBuilder().setName("").build();
+
+        mapper.addEventToAnnotation(event, writer);
+
+        assertThat(annotations).hasSize(1);
+    }
+
+    // -----------------------------------------------------------------------
+    // name only (no attributes)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void nameOnly_writesEmptyStringValue() {
+        Span.Event event = Span.Event.newBuilder()
+                .setName("exception")
+                .build();
+
+        mapper.addEventToAnnotation(event, writer);
+
+        assertThat(annotations).hasSize(1);
+        AnnotationBo bo = annotations.get(0);
+        assertThat(bo.getKey()).isEqualTo(AnnotationKey.OPENTELEMETRY_EVENT.getCode());
+        assertThat(bo.getValue()).isEqualTo("{\"exception\":\"\"}");
+    }
+
+    // -----------------------------------------------------------------------
+    // name + string attribute
+    // -----------------------------------------------------------------------
+
+    @Test
+    void withStringAttribute_writesAttributeMap() {
+        List<KeyValue> attrs = List.of(
+                kv("exception.type", strVal("java.lang.RuntimeException"))
+        );
+        Span.Event event = Span.Event.newBuilder()
+                .setName("exception")
+                .addAllAttributes(attrs)
+                .build();
+
+        mapper.addEventToAnnotation(event, writer);
+
+        assertThat(annotations).hasSize(1);
+        assertThat(annotations.get(0).getValue())
+                .isEqualTo("{\"exception\":{\"exception.type\":\"java.lang.RuntimeException\"}}");
+    }
+
+    // -----------------------------------------------------------------------
+    // name + multiple attribute types (int, bool, double)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void withMultipleAttributeTypes_writesCorrectJson() throws Exception {
+        List<KeyValue> attrs = List.of(
+                kv("count", intVal(42L)),
+                kv("flag", boolVal(true)),
+                kv("ratio", doubleVal(0.5))
+        );
+        Span.Event event = Span.Event.newBuilder()
+                .setName("my-event")
+                .addAllAttributes(attrs)
+                .build();
+
+        mapper.addEventToAnnotation(event, writer);
+
+        assertThat(annotations).hasSize(1);
+        String json = (String) annotations.get(0).getValue();
+
+        ObjectMapper om = new ObjectMapper();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> root = om.readValue(json, Map.class);
+        assertThat(root).containsKey("my-event");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> inner = (Map<String, Object>) root.get("my-event");
+        assertThat(inner).containsEntry("count", 42);
+        assertThat(inner).containsEntry("flag", true);
+        assertThat(inner).containsEntry("ratio", 0.5);
+    }
+
+    // -----------------------------------------------------------------------
+    // name + array attribute
+    // -----------------------------------------------------------------------
+
+    @Test
+    void withArrayAttribute_writesArray() throws Exception {
+        ArrayValue arrayValue = ArrayValue.newBuilder()
+                .addValues(strVal("a"))
+                .addValues(strVal("b"))
+                .build();
+        Span.Event event = Span.Event.newBuilder()
+                .setName("tagged")
+                .addAttributes(kv("tags", AnyValue.newBuilder().setArrayValue(arrayValue).build()))
+                .build();
+
+        mapper.addEventToAnnotation(event, writer);
+
+        assertThat(annotations).hasSize(1);
+        String json = (String) annotations.get(0).getValue();
+
+        ObjectMapper om = new ObjectMapper();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> root = om.readValue(json, Map.class);
+
+        assertThat(root.get("tagged")).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> inner = (Map<String, Object>) root.get("tagged");
+        assertThat(inner.get("tags")).isInstanceOf(List.class)
+                .asList().containsExactly("a", "b");
+    }
+
+    // -----------------------------------------------------------------------
+    // verify annotation key code
+    // -----------------------------------------------------------------------
+
+    @Test
+    void annotationKey_isOpentelemetryEvent() {
+        Span.Event event = Span.Event.newBuilder().setName("check").build();
+
+        mapper.addEventToAnnotation(event, writer);
+
+        assertThat(annotations.get(0).getKey())
+                .isEqualTo(AnnotationKey.OPENTELEMETRY_EVENT.getCode());
+    }
+
+}
+

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -1,0 +1,148 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.ArrayValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.boolVal;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.doubleVal;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.intVal;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.kv;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.strVal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpTraceMapperUtilsTest {
+
+    // -----------------------------------------------------------------------
+    // empty list -> empty map
+    // -----------------------------------------------------------------------
+
+    @Test
+    void emptyList_returnsEmptyMap() {
+        Map<String, Object> result = OtlpTraceMapperUtils.getAttributeToMap(List.of(), key -> false);
+
+        assertThat(result).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // no keys excluded -> all entries present
+    // -----------------------------------------------------------------------
+
+    @Test
+    void noExclusion_returnsAllEntries() {
+        List<KeyValue> attrs = List.of(
+                kv("a", strVal("1")),
+                kv("b", strVal("2"))
+        );
+
+        Map<String, Object> result = OtlpTraceMapperUtils.getAttributeToMap(attrs, key -> false);
+
+        assertThat(result).containsOnlyKeys("a", "b");
+    }
+
+    // -----------------------------------------------------------------------
+    // all keys excluded -> empty map
+    // -----------------------------------------------------------------------
+
+    @Test
+    void allKeysExcluded_returnsEmptyMap() {
+        List<KeyValue> attrs = List.of(
+                kv("x", strVal("v1")),
+                kv("y", strVal("v2"))
+        );
+
+        Map<String, Object> result = OtlpTraceMapperUtils.getAttributeToMap(attrs, key -> true);
+
+        assertThat(result).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // partial exclusion -> excluded keys are absent
+    // -----------------------------------------------------------------------
+
+    @Test
+    void partialExclusion_excludedKeysAbsent() {
+        Set<String> excluded = Set.of("url.path", "db.statement");
+        List<KeyValue> attrs = List.of(
+                kv("http.method", strVal("GET")),
+                kv("url.path", strVal("/api")),
+                kv("db.statement", strVal("SELECT 1"))
+        );
+
+        Map<String, Object> result = OtlpTraceMapperUtils.getAttributeToMap(attrs, excluded::contains);
+
+        assertThat(result).containsOnlyKeys("http.method");
+        assertThat(result).containsEntry("http.method", "GET");
+    }
+
+    // -----------------------------------------------------------------------
+    // FILTERED_ATTRIBUTE_KEY_MAP as excludeFilter
+    // -----------------------------------------------------------------------
+
+    @Test
+    void filteredAttributeKeyMap_removesKnownKeys() {
+        List<KeyValue> attrs = List.of(
+                kv("http.method", strVal("POST")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH, strVal("/save")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_DB_STATEMENT, strVal("INSERT INTO t")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE, strVal("201"))
+        );
+
+        Map<String, Object> result = OtlpTraceMapperUtils.getAttributeToMap(
+                attrs, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY);
+
+        assertThat(result).containsOnlyKeys("http.method");
+    }
+
+    // -----------------------------------------------------------------------
+    // value types are preserved through the filter
+    // -----------------------------------------------------------------------
+
+    @Test
+    void valueTypes_preservedAfterFilter() {
+        List<KeyValue> attrs = List.of(
+                kv("count", intVal(7L)),
+                kv("flag", boolVal(true)),
+                kv("ratio", doubleVal(3.14)),
+                kv("excluded", strVal("drop me"))
+        );
+
+        Map<String, Object> result = OtlpTraceMapperUtils.getAttributeToMap(
+                attrs, key -> key.equals("excluded"));
+
+        assertThat(result).containsEntry("count", 7L);
+        assertThat(result).containsEntry("flag", true);
+        assertThat(result).containsEntry("ratio", 3.14);
+        assertThat(result).doesNotContainKey("excluded");
+    }
+
+    // -----------------------------------------------------------------------
+    // array value is preserved through the filter
+    // -----------------------------------------------------------------------
+
+    @Test
+    void arrayValue_preservedAfterFilter() {
+        ArrayValue arrayValue = ArrayValue.newBuilder()
+                .addValues(strVal("x"))
+                .addValues(strVal("y"))
+                .build();
+        List<KeyValue> attrs = List.of(
+                kv("tags", AnyValue.newBuilder().setArrayValue(arrayValue).build()),
+                kv("excluded", strVal("drop me"))
+        );
+
+        Map<String, Object> result = OtlpTraceMapperUtils.getAttributeToMap(
+                attrs, key -> key.equals("excluded"));
+
+        assertThat(result).containsOnlyKeys("tags");
+        assertThat(result.get("tags")).isInstanceOf(List.class)
+                .asList().containsExactly("x", "y");
+    }
+
+}
+


### PR DESCRIPTION
This pull request refactors and modularizes the code responsible for mapping OpenTelemetry trace attributes, events, and links to Pinpoint annotations. The main changes involve extracting previously static utility methods into dedicated mapper classes, improving code organization and maintainability, and updating usage throughout the codebase.

### Refactoring and Modularization

* Extracted attribute, event, and link mapping logic from `OtlpTraceMapperUtils` into new dedicated classes: `OtlpTraceAttributeMapper`, `OtlpTraceEventMapper`, and `OtlpTraceLinkMapper`. These classes encapsulate the mapping logic and handle JSON serialization errors internally. [[1]](diffhunk://#diff-2f057fb15b402fcf03134c7cc67f3ad1205f97448432aaa4d39bc010eab0b9ebR1-R40) [[2]](diffhunk://#diff-3ab15f154577f362e1dadd3ec5dda4000f23e367a721a75e6109c1e6beb2a4d3R1-R45) [[3]](diffhunk://#diff-f20b0368bc14cf2f8b25671ed4ee5b505bb1485e4d3c13c38f144ce38dece9e5R1-R47)

* Updated `OtlpTraceSpanMapper` and `OtlpTraceSpanEventMapper` to use the new mapper classes instead of static methods, improving separation of concerns and making the code easier to test and maintain. [[1]](diffhunk://#diff-f1683c8479f9580f34253e55979333a4e2c6fe3665660e2698d92a1629617195L38-R45) [[2]](diffhunk://#diff-b905d913fa453efe31e279b2cc1f810314b54fe8dc3871146a9ef8505bf14edaL42-R51) [[3]](diffhunk://#diff-f1683c8479f9580f34253e55979333a4e2c6fe3665660e2698d92a1629617195L83-R93) [[4]](diffhunk://#diff-b905d913fa453efe31e279b2cc1f810314b54fe8dc3871146a9ef8505bf14edaL105-R120)

### Utility Method Improvements

* Simplified and optimized `getAttributeToMap` and `getArrayValueToList` methods in `OtlpTraceMapperUtils` by handling empty input cases more efficiently and pre-sizing collections for performance.

* Removed obsolete static methods for adding attributes, events, and links to annotations from `OtlpTraceMapperUtils`, as their functionality has been moved to the new mapper classes.

### Code Clean-up

* Minor import reordering and clean-up in `OtlpTraceSpanEventMapper` for consistency.

These changes collectively improve the structure, readability, and maintainability of the trace mapping code.