### PR TITLE
[#noissue] Refactor span kind handling

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
@@ -67,25 +67,26 @@ public class OtlpTraceMapper {
                 int errorCount = 0;
                 for (Span span : spansList) {
                     try {
-                        if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE) {
-                            final SpanBo spanBo = spanMapper.map(idAndName, span);
-                            mapperData.addSpanBo(spanBo);
-                            final AgentInfoBo agentInfoBo = agentInfoMapper.map(spanBo, attributesList);
-                            mapperData.addAgentInfoBo(agentInfoBo);
-                        } else if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_CONSUMER_VALUE) {
-                            final SpanBo spanBo = spanMapper.map(idAndName, span);
-                            mapperData.addSpanBo(spanBo);
-                            final AgentInfoBo agentInfoBo = agentInfoMapper.map(spanBo, attributesList);
-                            mapperData.addAgentInfoBo(agentInfoBo);
-                        } else if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_CLIENT_VALUE) {
-                            final SpanChunkBo spanChunkBo = spanChunkMapper.map(idAndName, span);
-                            mapperData.addSpanChunkBo(spanChunkBo);
-                        } else if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_PRODUCER_VALUE) {
-                            final SpanChunkBo spanChunkBo = spanChunkMapper.map(idAndName, span);
-                            mapperData.addSpanChunkBo(spanChunkBo);
-                        } else {
-                            final SpanChunkBo spanChunkBo = spanChunkMapper.map(idAndName, span);
-                            mapperData.addSpanChunkBo(spanChunkBo);
+                        switch (span.getKind().getNumber()) {
+                            case Span.SpanKind.SPAN_KIND_SERVER_VALUE,
+                                 Span.SpanKind.SPAN_KIND_CONSUMER_VALUE -> {
+                                final SpanBo spanBo = spanMapper.map(idAndName, span);
+                                mapperData.addSpanBo(spanBo);
+                                final AgentInfoBo agentInfoBo = agentInfoMapper.map(spanBo, attributesList);
+                                mapperData.addAgentInfoBo(agentInfoBo);
+                            }
+                            case Span.SpanKind.SPAN_KIND_CLIENT_VALUE -> {
+                                final SpanChunkBo spanChunkBo = spanChunkMapper.map(idAndName, span);
+                                mapperData.addSpanChunkBo(spanChunkBo);
+                            }
+                            case Span.SpanKind.SPAN_KIND_PRODUCER_VALUE -> {
+                                final SpanChunkBo spanChunkBo = spanChunkMapper.map(idAndName, span);
+                                mapperData.addSpanChunkBo(spanChunkBo);
+                            }
+                            default -> {
+                                final SpanChunkBo spanChunkBo = spanChunkMapper.map(idAndName, span);
+                                mapperData.addSpanChunkBo(spanChunkBo);
+                            }
                         }
                     } catch (Exception e) {
                         errorCount++;


### PR DESCRIPTION
This pull request refactors the logic for mapping span kinds in the `OtlpTraceMapper` class to improve readability and maintainability. The main change is replacing a series of `if-else` statements with a `switch` expression, making the code easier to follow and less error-prone.

Refactoring for clarity and maintainability:

* Replaced multiple `if-else` statements with a `switch` expression for handling different span kinds in the `map` method of `OtlpTraceMapper.java`. This change groups mapping logic by span kind, improving readability and reducing potential mistakes when adding or modifying span handling.