### PR TITLE
[#13464] Bump org.apache.zookeeper:zookeeper from 3.8.4 to 3.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <jakarta.jaxb-api.version>4.0.4</jakarta.jaxb-api.version>
         <jaxb-impl.version>4.0.6</jaxb-impl.version>
 
-        <zookeeper.version>3.8.4</zookeeper.version>
+        <zookeeper.version>3.8.6</zookeeper.version>
 
         <mockito.version>4.11.0</mockito.version>
         <bytebuddy.version>1.12.23</bytebuddy.version>


### PR DESCRIPTION
Bumps org.apache.zookeeper:zookeeper from 3.8.4 to 3.8.6.

---
updated-dependencies:
- dependency-name: org.apache.zookeeper:zookeeper dependency-version: 3.8.6 dependency-type: direct:production ...