### PR TITLE
[#noissue] Add ServiceKey for ServiceMap

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/Link.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/Link.java
@@ -94,6 +94,10 @@ public class Link {
         return range;
     }
 
+    public ServiceLinkName getServiceLinkName() {
+        return ServiceLinkName.of(fromNode.getApplication(), toNode.getApplication());
+    }
+
     public LinkName getLinkName() {
         return LinkName.of(fromNode.getApplication(), toNode.getApplication());
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/ServiceLinkName.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/ServiceLinkName.java
@@ -1,0 +1,65 @@
+package com.navercorp.pinpoint.web.applicationmap.link;
+
+import com.navercorp.pinpoint.web.applicationmap.nodes.ServiceNodeName;
+import com.navercorp.pinpoint.web.vo.Application;
+
+import java.util.Objects;
+
+/**
+ * @author Woonduk Kang(emeroad)
+ */
+public class ServiceLinkName {
+    public static final String LINK_DELIMITER = "~";
+
+    private final Application from;
+    private final Application to;
+
+    public static ServiceLinkName of(Application from, Application to) {
+        return new ServiceLinkName(from, to);
+    }
+
+    public ServiceLinkName(Application from, Application to) {
+        this.from = Objects.requireNonNull(from, "from");
+        this.to = Objects.requireNonNull(to, "to");
+    }
+
+    public String getName() {
+        return toNodeName(from) + LINK_DELIMITER + toNodeName(to);
+    }
+
+    private String toNodeName(Application node) {
+        return ServiceNodeName.toServiceNodeName(node.getService().getServiceName(), node.getApplicationName(), node.getServiceType());
+    }
+
+    public String getLinkKey() {
+        return toNodeKey(from) + LINK_DELIMITER + toNodeKey(to);
+    }
+
+    private String toNodeKey(Application node) {
+        return ServiceNodeName.toServiceNodeKey(node.getService().getServiceName(), node.getApplicationName(), node.getServiceType());
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ServiceLinkName linkName = (ServiceLinkName) o;
+
+        if (!from.equals(linkName.from)) return false;
+        return to.equals(linkName.to);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = from.hashCode();
+        result = 31 * result + to.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/Node.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/Node.java
@@ -79,6 +79,10 @@ public class Node {
         return NodeName.toNodeKey(application.getApplicationName(), application.getServiceType());
     }
 
+    public ServiceNodeName getServiceNodeName() {
+        return ServiceNodeName.of(application);
+    }
+
     public ServiceType getServiceType() {
         return application.getServiceType();
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/ServiceNodeName.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/ServiceNodeName.java
@@ -1,0 +1,62 @@
+package com.navercorp.pinpoint.web.applicationmap.nodes;
+
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.web.vo.Application;
+
+import java.util.Objects;
+
+/**
+ * @author Woonduk Kang(emeroad)
+ */
+public class ServiceNodeName {
+    public static final String SERVICE_DELIMITER = ":";
+    public static final String NODE_DELIMITER = NodeName.NODE_DELIMITER;
+
+    private final String serviceName;
+    private final String applicationName;
+    private final ServiceType serviceType;
+
+    public static ServiceNodeName of(Application application) {
+        Objects.requireNonNull(application, "application");
+        return new ServiceNodeName(application.getService().getServiceName(), application.getApplicationName(), application.getServiceType());
+    }
+
+    public ServiceNodeName(String serviceName, String applicationName, ServiceType serviceType) {
+        this.serviceName = Objects.requireNonNull(serviceName, "serviceName");
+        this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
+        this.serviceType = Objects.requireNonNull(serviceType, "serviceType");
+    }
+
+    public String getName() {
+        return toServiceNodeName(serviceName, applicationName, serviceType);
+    }
+
+    public static String toServiceNodeName(String serviceName, String applicationName, ServiceType serviceType) {
+        return serviceName + SERVICE_DELIMITER + applicationName + NODE_DELIMITER + serviceType.getDesc();
+    }
+
+    public static String toServiceNodeKey(String serviceName, String applicationName, ServiceType serviceType) {
+        return serviceName + SERVICE_DELIMITER + applicationName + NODE_DELIMITER + serviceType.getName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ServiceNodeName that = (ServiceNodeName) o;
+        return serviceName.equals(that.serviceName) && applicationName.equals(that.applicationName) && serviceType.equals(that.serviceType);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = serviceName.hashCode();
+        result = 31 * result + applicationName.hashCode();
+        result = 31 * result + serviceType.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
@@ -79,6 +79,7 @@ public class LinkView {
 
             jgen.writeObjectField("key", link.getLinkName());  // for servermap
             jgen.writeStringField("linkKey", link.getLinkNameKey());
+            jgen.writeObjectField("serviceKey", link.getServiceLinkName().toString());
 
             jgen.writeObjectField("from", link.getFrom().getNodeName());  // necessary for go.js
             jgen.writeObjectField("to", link.getTo().getNodeName()); // necessary for go.js

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java
@@ -104,6 +104,8 @@ public class NodeView {
             jgen.writeObjectField("key", node.getNodeName()); // necessary for go.js
             jgen.writeStringField("nodeKey", node.getNodeKey());
 
+            jgen.writeObjectField("serviceKey", node.getServiceNodeName().toString());
+
             Application application = node.getApplication();
             jgen.writeStringField("serviceName", application.getService().getServiceName());
             jgen.writeStringField("applicationName", node.getApplicationTextName()); // for go.js


### PR DESCRIPTION
This pull request introduces new classes and methods to improve the representation and serialization of service-level node and link identifiers within the application map. The changes enhance how service-related keys and names are handled and exposed in the API, making it easier to distinguish and reference service nodes and links.

Service-level identifier enhancements:

* Added the `ServiceNodeName` class to encapsulate service-level node names and keys, including serialization logic and equality/hash methods. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/ServiceNodeName.java`)
* Added the `ServiceLinkName` class to encapsulate service-level link names and keys, including serialization logic and equality/hash methods. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/ServiceLinkName.java`)

API and serialization improvements:

* Modified `Node` to expose `getServiceNodeName()` for retrieving the service-level node name. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/Node.java`)
* Modified `Link` to expose `getServiceLinkName()` for retrieving the service-level link name. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/link/Link.java`)
* Updated `NodeView` and `LinkView` serialization to include the new service-level keys in their JSON output. (`web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeView.java`, `web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java`) [[1]](diffhunk://#diff-283e153fc2bfe9495312ec388b0570be6d8dfdcb230261ad8429607a4fdc0cc9R107-R108) [[2]](diffhunk://#diff-dca5fb204dd0eac17e825757bec2e12863515e3dd93782c1a06c0e23a0aac03dR82)