### PR TITLE
[#noissue] /servermap 페이지 헤더를 Servermap2로 변경

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
@@ -161,7 +161,7 @@ export const ServerMapPage = ({
           <div className="flex items-center gap-2">
             <PiTreeStructureDuotone />
             <div className="flex items-center gap-1">
-              Servermap
+              Servermap2
               <HelpPopover helpKey="HELP_VIEWER.SERVER_MAP" />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- `/servermap` 페이지의 `MainHeader` 타이틀 텍스트를 `Servermap`에서 `Servermap2`로 변경합니다.
- 사이드바 메뉴명은 변경하지 않습니다.

## Test plan
- [ ] `/servermap` 페이지에 접속하여 헤더가 `Servermap2`로 표시되는지 확인
- [ ] 사이드바의 메뉴명이 변경되지 않았는지 확인

🤖 Generated with Claude Code