### PR TITLE
[#noissue] Remove unnecessary service field

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkView.java
@@ -148,9 +148,7 @@ public class LinkView {
             Collection<Application> sourceLinkTargetAgentList = link.getSourceLinkTargetAgentList();
             for (Application application : sourceLinkTargetAgentList) {
                 jgen.writeStartObject();
-                jgen.writeStringField("rpcServiceName", application.getService().getServiceName());
                 jgen.writeStringField("rpc", application.getApplicationName());
-                jgen.writeStringField("rpcApplicationName", application.getApplicationName());
                 jgen.writeNumberField("rpcServiceTypeCode", application.getServiceTypeCode());
                 jgen.writeEndObject();
             }


### PR DESCRIPTION
This pull request makes a small change to the serialization logic in `LinkView.java` by removing two fields from the JSON output for each application in the source link target agent list. The change simplifies the JSON structure for these objects.