### PR TITLE
[#noissue] Refactor FilterDescriptor to use JsonNode directly instead of readValueAs

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/ApplicationFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/ApplicationFilter.java
@@ -45,7 +45,7 @@ public class ApplicationFilter implements Filter<List<SpanBo>> {
 
     private final List<ServiceType> serviceDescList;
 
-    private final FilterDescriptor.SelfNode selfNode;
+    private final FilterDescriptor.Node selfNode;
 
     private final Filter<SpanBo> spanResponseConditionFilter;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/FilterDescriptor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/FilterDescriptor.java
@@ -16,16 +16,13 @@
 
 package com.navercorp.pinpoint.web.filter;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.navercorp.pinpoint.common.util.StringUtils;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -40,9 +37,9 @@ import java.util.Objects;
 @JsonDeserialize(using = FilterDescriptor.FilterDescriptorDeserializer.class)
 public class FilterDescriptor {
 
-    private final FromNode fromNode;
-    private final ToNode toNode;
-    private final SelfNode selfNode;
+    private final Node fromNode;
+    private final Node toNode;
+    private final Node selfNode;
     private final ResponseTime responseTime;
     private final Option option;
 
@@ -52,22 +49,25 @@ public class FilterDescriptor {
         public FilterDescriptor deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
             JsonNode jsonNode = p.readValueAsTree();
 
-            FromNode fromNode = readValueAs(FromNode.class, jsonNode, p);
-            ToNode toNode = readValueAs(ToNode.class, jsonNode, p);
-            SelfNode selfNode = readValueAs(SelfNode.class, jsonNode, p);
-            ResponseTime responseTime= readValueAs(ResponseTime.class, jsonNode, p);
-            Option option = readValueAs(Option.class, jsonNode, p);
+            Node fromNode = readNode(jsonNode, Node.NodeType.FROM, "fa", "fst", "fan");
+            Node toNode = readNode(jsonNode, Node.NodeType.TO, "ta", "tst", "tan");
+            Node selfNode = readNode(jsonNode, Node.NodeType.SELF, "a", "st", "an");
+
+            ResponseTime responseTime = ResponseTime.of(JsonNodeUtils.longValue(jsonNode, "rf"), JsonNodeUtils.textValue(jsonNode, "rt"));
+
+            Option option = new Option(JsonNodeUtils.textValue(jsonNode, "url"), JsonNodeUtils.booleanValue(jsonNode, "ie"));
             return new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
         }
 
-        private <T> T readValueAs(Class<T> valueType, JsonNode jsonNode, JsonParser p) throws IOException {
-            try (JsonParser traverse = jsonNode.traverse(p.getCodec())) {
-                return traverse.readValueAs(valueType);
-            }
+        private static Node readNode(JsonNode jsonNode, Node.NodeType type, String applicationNameField, String serviceTypeField, String agentIdField) {
+            String applicationName = JsonNodeUtils.textValue(jsonNode, applicationNameField);
+            String serviceType = JsonNodeUtils.textValue(jsonNode, serviceTypeField);
+            String agentId = JsonNodeUtils.textValue(jsonNode, agentIdField);
+            return new Node(type, applicationName, serviceType, agentId);
         }
     }
 
-    public FilterDescriptor(FromNode fromNode, ToNode toNode, SelfNode selfNode, ResponseTime responseTime, Option option) {
+    public FilterDescriptor(Node fromNode, Node toNode, Node selfNode, ResponseTime responseTime, Option option) {
         this.fromNode = Objects.requireNonNull(fromNode, "fromNode");
         this.toNode = Objects.requireNonNull(toNode, "toNode");
         this.selfNode = Objects.requireNonNull(selfNode, "self");
@@ -75,22 +75,32 @@ public class FilterDescriptor {
         this.option = Objects.requireNonNull(option, "option");
     }
 
-    @JsonIgnoreProperties(ignoreUnknown=true)
     public static class Node {
+        private final NodeType type;
+
+        enum NodeType {
+            FROM, TO, SELF
+        }
+
+        @Nullable
         private final String applicationName;
+        @Nullable
         private final String serviceType ;
         private final String agentId;
 
-        public Node(String applicationName, String serviceType, String agentId) {
+        public Node(NodeType type, String applicationName, String serviceType, String agentId) {
+            this.type = Objects.requireNonNull(type, "type");
             this.applicationName = applicationName;
             this.serviceType = serviceType;
             this.agentId = agentId;
         }
 
+        @Nullable
         public String getApplicationName() {
             return applicationName;
         }
 
+        @Nullable
         public String getServiceType() {
             return serviceType;
         }
@@ -105,7 +115,7 @@ public class FilterDescriptor {
 
         @Override
         public String toString() {
-            return this.getClass().getSimpleName()  + "{" +
+            return type  + "{" +
                     "applicationName='" + applicationName + '\'' +
                     ", serviceType='" + serviceType + '\'' +
                     ", agentId='" + agentId + '\'' +
@@ -113,47 +123,18 @@ public class FilterDescriptor {
         }
     }
 
-    public static class FromNode extends Node {
-        @JsonCreator
-        public FromNode(@JsonProperty("fa") String applicationName,
-                        @JsonProperty("fst") String serviceType,
-                        @JsonProperty("fan") String agentId) {
-            super(applicationName, serviceType, agentId);
-        }
-    }
 
-    public static class ToNode extends Node {
-        /**
-         * to application
-         */
-        @JsonCreator
-        public ToNode(@JsonProperty("ta") String applicationName,
-                      @JsonProperty("tst") String serviceType,
-                      @JsonProperty("tan") String agentId) {
-            super(applicationName, serviceType, agentId);
-        }
-    }
-
-    public static class SelfNode extends Node {
-        /**
-         * self application
-         */
-        @JsonCreator
-        public SelfNode(@JsonProperty("a") String applicationName,
-                      @JsonProperty("st") String serviceType,
-                      @JsonProperty("an") String agentId) {
-            super(applicationName, serviceType, agentId);
-        }
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown=true)
     public static class ResponseTime {
 
         private final Long fromResponseTime;
-        private final String toResponseTime;
+        private final Long toResponseTime;
 
-        public ResponseTime(@JsonProperty("rf") Long fromResponseTime,
-                            @JsonProperty("rt") String toResponseTime) {
+        public static ResponseTime of(Long fromResponseTime, String rawToResponseTime) {
+            Long toResponseTime = parseLongResponseTime(rawToResponseTime);
+            return new ResponseTime(fromResponseTime, toResponseTime);
+        }
+
+        public ResponseTime(Long fromResponseTime, Long toResponseTime) {
             this.fromResponseTime = fromResponseTime;
             this.toResponseTime = toResponseTime;
         }
@@ -163,22 +144,22 @@ public class FilterDescriptor {
         }
 
         public Long getToResponseTime() {
-            if (toResponseTime == null) {
-                return null;
-            } else if ("max".equals(toResponseTime)) {
-                return Long.MAX_VALUE;
-            } else {
-                return Long.valueOf(toResponseTime);
-            }
+            return this.toResponseTime;
         }
 
-        public String getRawToResponseTime() {
-            return toResponseTime;
+        private static Long parseLongResponseTime(String responseTime) {
+            if (responseTime == null) {
+                return null;
+            } else if ("max".equals(responseTime)) {
+                return Long.MAX_VALUE;
+            } else {
+                return Long.parseLong(responseTime);
+            }
         }
 
 
         public boolean isValid() {
-            return !((fromResponseTime == null && StringUtils.hasLength(toResponseTime)) || (fromResponseTime != null && StringUtils.isEmpty(toResponseTime)));
+            return !((fromResponseTime == null && toResponseTime != null) || (fromResponseTime != null && toResponseTime == null));
         }
 
         @Override
@@ -190,21 +171,19 @@ public class FilterDescriptor {
         }
     }
 
-    @JsonIgnoreProperties(ignoreUnknown=true)
     public static class Option {
 
         /**
          * requested url
          */
-        private String urlPattern = null;
+        private String urlPattern;
 
         /**
          * include exception
          */
-        private Boolean includeException = null;
+        private Boolean includeException;
 
-        public Option(@JsonSetter(value = "url") String urlPattern,
-                      @JsonSetter(value = "ie") Boolean includeException) {
+        public Option(String urlPattern, Boolean includeException) {
             this.urlPattern = decodeBase64(urlPattern);
             this.includeException = includeException;
         }
@@ -236,15 +215,15 @@ public class FilterDescriptor {
         return this.fromNode.isValid() || this.toNode.isValid() || this.selfNode.isValid();
     }
 
-    public FromNode getFromNode() {
+    public Node getFromNode() {
         return fromNode;
     }
 
-    public ToNode getToNode() {
+    public Node getToNode() {
         return toNode;
     }
 
-    public SelfNode getSelfNode() {
+    public Node getSelfNode() {
         return selfNode;
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/JsonNodeUtils.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/JsonNodeUtils.java
@@ -1,0 +1,37 @@
+package com.navercorp.pinpoint.web.filter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public final class JsonNodeUtils {
+
+    private JsonNodeUtils() {
+    }
+
+    public static String textValue(JsonNode jsonNode, String fieldName) {
+        JsonNode node = jsonNode.get(fieldName);
+        if (isNull(node)) {
+            return null;
+        }
+        return node.asText();
+    }
+
+    public static Long longValue(JsonNode jsonNode, String fieldName) {
+        JsonNode node = jsonNode.get(fieldName);
+        if (isNull(node)) {
+            return null;
+        }
+        return node.asLong();
+    }
+
+    public static Boolean booleanValue(JsonNode jsonNode, String fieldName) {
+        JsonNode node = jsonNode.get(fieldName);
+        if (isNull(node)) {
+            return null;
+        }
+        return node.asBoolean();
+    }
+
+    private static boolean isNull(JsonNode node) {
+        return node == null || node.isNull();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/LinkFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/LinkFilter.java
@@ -54,10 +54,10 @@ public class LinkFilter implements Filter<List<SpanBo>> {
     private final Logger logger = LogManager.getLogger(this.getClass());
 
     private final List<ServiceType> fromServiceDescList;
-    private final FilterDescriptor.FromNode fromNode;
+    private final FilterDescriptor.Node fromNode;
 
     private final List<ServiceType> toServiceDescList;
-    private final FilterDescriptor.ToNode toNode;
+    private final FilterDescriptor.Node toNode;
 
     private final Filter<SpanBo> spanResponseConditionFilter;
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/filter/FilterDescriptorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/filter/FilterDescriptorTest.java
@@ -49,13 +49,13 @@ public class FilterDescriptorTest {
         FilterDescriptor descriptor = mapper.readValue(jsonString, FilterDescriptor.class);
 
         FilterDescriptor.ResponseTime responseTime = descriptor.getResponseTime();
-        FilterDescriptor.FromNode fromNode = descriptor.getFromNode();
+        FilterDescriptor.Node fromNode = descriptor.getFromNode();
         Assertions.assertEquals("FROM_APPLICATION", fromNode.getApplicationName());
         Assertions.assertEquals("FROM_SERVICE_TYPE", fromNode.getServiceType());
         Assertions.assertEquals("FROM_AGENT_ID", fromNode.getAgentId());
         Assertions.assertEquals((Long) 0L, descriptor.getResponseTime().getFromResponseTime());
 
-        FilterDescriptor.ToNode toNode = descriptor.getToNode();
+        FilterDescriptor.Node toNode = descriptor.getToNode();
         Assertions.assertEquals("TO_APPLICATION", toNode.getApplicationName());
         Assertions.assertEquals("TO_SERVICE_TYPE", toNode.getServiceType());
         Assertions.assertEquals("TO_AGENT_ID", toNode.getAgentId());

--- a/web/src/test/java/com/navercorp/pinpoint/web/filter/LinkFilterTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/filter/LinkFilterTest.java
@@ -61,10 +61,11 @@ public class LinkFilterTest {
         ServiceType tomcat = serviceTypeRegistryService.findServiceTypeByName(TOMCAT_TYPE_NAME);
         final int tomcatServiceType = tomcat.getCode();
 
-        FilterDescriptor.FromNode fromNode = new FilterDescriptor.FromNode("APP_A", tomcat.getName(), null);
-        FilterDescriptor.ToNode toNode = new FilterDescriptor.ToNode("APP_B", tomcat.getName(), null);
-        FilterDescriptor.SelfNode selfNode = new FilterDescriptor.SelfNode(null, null, null);
+        FilterDescriptor.Node fromNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.FROM, "APP_A", tomcat.getName(), null);
+        FilterDescriptor.Node toNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.TO, "APP_B", tomcat.getName(), null);
+        FilterDescriptor.Node selfNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, null, null, null);
         FilterDescriptor.ResponseTime responseTime = new FilterDescriptor.ResponseTime(null, null);
+
         FilterDescriptor.Option option = new FilterDescriptor.Option(null, null);
         FilterDescriptor descriptor = new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
 
@@ -102,10 +103,10 @@ public class LinkFilterTest {
         final ServiceType tomcat = serviceTypeRegistryService.findServiceTypeByName(TOMCAT_TYPE_NAME);
         final int tomcatServiceType = tomcat.getCode();
 
-        FilterDescriptor.FromNode fromNode = new FilterDescriptor.FromNode("APP_A", tomcat.getName(), "AGENT_A");
-        FilterDescriptor.ToNode toNode = new FilterDescriptor.ToNode("APP_B", tomcat.getName(), "AGENT_B");
-        FilterDescriptor.SelfNode selfNode = new FilterDescriptor.SelfNode(null, null, null);
-        FilterDescriptor.ResponseTime responseTime = new FilterDescriptor.ResponseTime(null, null);
+        FilterDescriptor.Node fromNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.FROM, "APP_A", tomcat.getName(), "AGENT_A");
+        FilterDescriptor.Node toNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.TO, "APP_B", tomcat.getName(), "AGENT_B");
+        FilterDescriptor.Node selfNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, null, null, null);
+        FilterDescriptor.ResponseTime responseTime = FilterDescriptor.ResponseTime.of(null, null);
         FilterDescriptor.Option option = new FilterDescriptor.Option(null, null);
         FilterDescriptor descriptor = new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
 
@@ -141,11 +142,11 @@ public class LinkFilterTest {
         final ServiceType user = serviceTypeRegistryService.findServiceTypeByName(USER_TYPE_NAME);
         final ServiceType tomcat = serviceTypeRegistryService.findServiceTypeByName(TOMCAT_TYPE_NAME);
 
-        FilterDescriptor.FromNode fromNode = new FilterDescriptor.FromNode("USER", user.getName(), null);
-        FilterDescriptor.ToNode toNode = new FilterDescriptor.ToNode("APP_A", tomcat.getName(), null);
-        FilterDescriptor.SelfNode selfNode = new FilterDescriptor.SelfNode(null, null, null);
+        FilterDescriptor.Node fromNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.FROM, "USER", user.getName(), null);
+        FilterDescriptor.Node toNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.TO, "APP_A", tomcat.getName(), null);
+        FilterDescriptor.Node selfNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, null, null, null);
         FilterDescriptor.Option option = new FilterDescriptor.Option(null, null);
-        FilterDescriptor.ResponseTime responseTime = new FilterDescriptor.ResponseTime(null, null);
+        FilterDescriptor.ResponseTime responseTime = FilterDescriptor.ResponseTime.of(null, null);
         FilterDescriptor descriptor = new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
 
         FilterHint hint = new FilterHint(Collections.emptyList());
@@ -188,11 +189,11 @@ public class LinkFilterTest {
         final String rpcUrl = "http://" + rpcHost + "/some/test/path";
         final String urlPattern = "/some/test/**";
 
-        FilterDescriptor.FromNode fromNode = new FilterDescriptor.FromNode("APP_A", tomcat.getName(), null);
-        FilterDescriptor.ToNode toNode = new FilterDescriptor.ToNode(rpcHost, unknown.getName(), null);
-        FilterDescriptor.SelfNode selfNode = new FilterDescriptor.SelfNode(null, null, null);
+        FilterDescriptor.Node fromNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.FROM, "APP_A", tomcat.getName(), null);
+        FilterDescriptor.Node toNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.TO, rpcHost, unknown.getName(), null);
+        FilterDescriptor.Node selfNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, null, null, null);
         FilterDescriptor.Option option = new FilterDescriptor.Option(encodeUrl(urlPattern), null);
-        FilterDescriptor.ResponseTime responseTime = new FilterDescriptor.ResponseTime(null, null);
+        FilterDescriptor.ResponseTime responseTime = FilterDescriptor.ResponseTime.of(null, null);
         FilterDescriptor descriptor = new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
 
         FilterHint hint = new FilterHint(Collections.emptyList());
@@ -222,10 +223,10 @@ public class LinkFilterTest {
     public void wasToWasFilter_perfectMatch() {
         final ServiceType tomcat = serviceTypeRegistryService.findServiceTypeByName(TOMCAT_TYPE_NAME);
 
-        FilterDescriptor.FromNode fromNode = new FilterDescriptor.FromNode("APP_A", tomcat.getName(), null);
-        FilterDescriptor.ToNode toNode = new FilterDescriptor.ToNode("APP_B", tomcat.getName(), null);
-        FilterDescriptor.SelfNode selfNode = new FilterDescriptor.SelfNode(null, null, null);
-        FilterDescriptor.ResponseTime responseTime = new FilterDescriptor.ResponseTime(null, null);
+        FilterDescriptor.Node fromNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.FROM, "APP_A", tomcat.getName(), null);
+        FilterDescriptor.Node toNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.TO, "APP_B", tomcat.getName(), null);
+        FilterDescriptor.Node selfNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, null, null, null);
+        FilterDescriptor.ResponseTime responseTime = FilterDescriptor.ResponseTime.of(null, null);
         FilterDescriptor.Option option = new FilterDescriptor.Option(null, null);
         FilterDescriptor descriptor = new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
 
@@ -252,10 +253,10 @@ public class LinkFilterTest {
     public void wasToWasFilter_noMatch() {
         final ServiceType tomcat = serviceTypeRegistryService.findServiceTypeByName(TOMCAT_TYPE_NAME);
 
-        FilterDescriptor.FromNode fromNode = new FilterDescriptor.FromNode("APP_A", tomcat.getName(), null);
-        FilterDescriptor.ToNode toNode = new FilterDescriptor.ToNode("APP_B", tomcat.getName(), null);
-        FilterDescriptor.SelfNode selfNode = new FilterDescriptor.SelfNode(null, null, null);
-        FilterDescriptor.ResponseTime responseTime = new FilterDescriptor.ResponseTime(null, null);
+        FilterDescriptor.Node fromNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.FROM, "APP_A", tomcat.getName(), null);
+        FilterDescriptor.Node toNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.TO, "APP_B", tomcat.getName(), null);
+        FilterDescriptor.Node selfNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, null, null, null);
+        FilterDescriptor.ResponseTime responseTime = FilterDescriptor.ResponseTime.of(null, null);
         FilterDescriptor.Option option = new FilterDescriptor.Option(null, null);
         FilterDescriptor descriptor = new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
 
@@ -298,10 +299,10 @@ public class LinkFilterTest {
         final String rpcHost = "some.domain.name";
         final String rpcUrl = "http://" + rpcHost + "/some/test/path";
 
-        FilterDescriptor.FromNode fromNode = new FilterDescriptor.FromNode("APP_A", tomcat.getName(), null);
-        FilterDescriptor.ToNode toNode = new FilterDescriptor.ToNode("APP_B", tomcat.getName(), null);
-        FilterDescriptor.SelfNode selfNode = new FilterDescriptor.SelfNode(null, null, null);
-        FilterDescriptor.ResponseTime responseTime = new FilterDescriptor.ResponseTime(null, null);
+        FilterDescriptor.Node fromNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.FROM, "APP_A", tomcat.getName(), null);
+        FilterDescriptor.Node toNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.TO, "APP_B", tomcat.getName(), null);
+        FilterDescriptor.Node selfNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, null, null, null);
+        FilterDescriptor.ResponseTime responseTime = FilterDescriptor.ResponseTime.of(null, null);
         FilterDescriptor.Option option = mock(FilterDescriptor.Option.class);
         FilterDescriptor descriptor = new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
 
@@ -360,10 +361,10 @@ public class LinkFilterTest {
         final String destinationA = "BACKEND_A";
         final String destinationB = "BACKEND_B";
 
-        FilterDescriptor.FromNode fromNode = new FilterDescriptor.FromNode("APP_A", tomcat.getName(), null);
-        FilterDescriptor.ToNode toNode = new FilterDescriptor.ToNode(destinationA, backend.getName(), null);
-        FilterDescriptor.SelfNode selfNode = new FilterDescriptor.SelfNode(null, null, null);
-        FilterDescriptor.ResponseTime responseTime = new FilterDescriptor.ResponseTime(null, null);
+        FilterDescriptor.Node fromNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.FROM, "APP_A", tomcat.getName(), null);
+        FilterDescriptor.Node toNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.TO, destinationA, backend.getName(), null);
+        FilterDescriptor.Node selfNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, null, null, null);
+        FilterDescriptor.ResponseTime responseTime = FilterDescriptor.ResponseTime.of(null, null);
         FilterDescriptor.Option option = mock(FilterDescriptor.Option.class);
         FilterDescriptor descriptor = new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
 
@@ -407,10 +408,10 @@ public class LinkFilterTest {
         final String messageQueueA = "QUEUE_A";
         final String messageQueueB = "QUEUE_B";
 
-        FilterDescriptor.FromNode fromNode = new FilterDescriptor.FromNode("APP_A", tomcat.getName(), null);
-        FilterDescriptor.ToNode toNode = new FilterDescriptor.ToNode(messageQueueA, messageQueue.getName(), null);
-        FilterDescriptor.SelfNode selfNode = new FilterDescriptor.SelfNode(null, null, null);
-        FilterDescriptor.ResponseTime responseTime = new FilterDescriptor.ResponseTime(null, null);
+        FilterDescriptor.Node fromNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.FROM, "APP_A", tomcat.getName(), null);
+        FilterDescriptor.Node toNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.TO, messageQueueA, messageQueue.getName(), null);
+        FilterDescriptor.Node selfNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, null, null, null);
+        FilterDescriptor.ResponseTime responseTime = FilterDescriptor.ResponseTime.of(null, null);
         FilterDescriptor.Option option = mock(FilterDescriptor.Option.class);
         FilterDescriptor descriptor = new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
 
@@ -454,10 +455,10 @@ public class LinkFilterTest {
         final String messageQueueA = "QUEUE_A";
         final String messageQueueB = "QUEUE_B";
 
-        FilterDescriptor.FromNode fromNode = new FilterDescriptor.FromNode(messageQueueA, messageQueue.getName(), null);
-        FilterDescriptor.ToNode toNode = new FilterDescriptor.ToNode("APP_A", tomcat.getName(), null);
-        FilterDescriptor.SelfNode selfNode = new FilterDescriptor.SelfNode(null, null, null);
-        FilterDescriptor.ResponseTime responseTime = new FilterDescriptor.ResponseTime(null, null);
+        FilterDescriptor.Node fromNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.FROM, messageQueueA, messageQueue.getName(), null);
+        FilterDescriptor.Node toNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.TO, "APP_A", tomcat.getName(), null);
+        FilterDescriptor.Node selfNode = new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, null, null, null);
+        FilterDescriptor.ResponseTime responseTime = FilterDescriptor.ResponseTime.of(null, null);
         FilterDescriptor.Option option = mock(FilterDescriptor.Option.class);
         FilterDescriptor descriptor = new FilterDescriptor(fromNode, toNode, selfNode, responseTime, option);
 


### PR DESCRIPTION
This pull request refactors the `FilterDescriptor` and related classes to simplify and unify the handling of node types (`from`, `to`, `self`) in the filtering logic. The previous specialized node classes are replaced with a single `Node` class that uses an enum to distinguish node types. The deserialization logic and related usages are updated accordingly. Additionally, a utility class is introduced to streamline JSON node parsing.

Key changes:

### Refactoring Node Representation

* Replaced the specialized node classes (`FromNode`, `ToNode`, `SelfNode`) in `FilterDescriptor` with a single `Node` class, distinguished by a `NodeType` enum (`FROM`, `TO`, `SELF`). This change affects the core data model and all usages of these node types. [[1]](diffhunk://#diff-f39597f7e8e2fa05c1b0c2cb93269cd7cf353c17255b23679294c5632c8562c4L43-R42) [[2]](diffhunk://#diff-f39597f7e8e2fa05c1b0c2cb93269cd7cf353c17255b23679294c5632c8562c4L108-R137)
* Updated constructors, getters, and usages throughout the codebase (including `ApplicationFilter`, `LinkFilter`, and test classes) to use the unified `Node` class instead of the specialized node classes. [[1]](diffhunk://#diff-6c7efee692f3a42ecef9f1d7ea65dc86c54e37a7427d620b2c98e34efc387e8eL48-R48) [[2]](diffhunk://#diff-87c8a1d8d7e1be05b34b61c0e19eeeea06d8961121245c39320c09fa1e9ddbccL57-R60) [[3]](diffhunk://#diff-31890513ec044bb08e0e74eb8bf3c150ff4b4e261cc5f4bcd2fd54184571655fL52-R58) [[4]](diffhunk://#diff-9127f373f2080a4e59c29ff0ca6444ee062d99fc4571c080d2d6d2f29819722cL64-R68) [[5]](diffhunk://#diff-9127f373f2080a4e59c29ff0ca6444ee062d99fc4571c080d2d6d2f29819722cL105-R109) [[6]](diffhunk://#diff-9127f373f2080a4e59c29ff0ca6444ee062d99fc4571c080d2d6d2f29819722cL144-R149) [[7]](diffhunk://#diff-9127f373f2080a4e59c29ff0ca6444ee062d99fc4571c080d2d6d2f29819722cL191-R196) [[8]](diffhunk://#diff-9127f373f2080a4e59c29ff0ca6444ee062d99fc4571c080d2d6d2f29819722cL225-R229) [[9]](diffhunk://#diff-9127f373f2080a4e59c29ff0ca6444ee062d99fc4571c080d2d6d2f29819722cL255-R259) [[10]](diffhunk://#diff-f39597f7e8e2fa05c1b0c2cb93269cd7cf353c17255b23679294c5632c8562c4L239-R226)

### Deserialization and Utility Improvements

* Refactored the deserialization logic in `FilterDescriptorDeserializer` to construct `Node` objects using a new helper method and the `NodeType` enum, instead of deserializing to specific node subclasses.
* Introduced a new utility class `JsonNodeUtils` to simplify and centralize JSON field extraction for text, long, and boolean values.

### ResponseTime Handling

* Changed `FilterDescriptor.ResponseTime` to store both `from` and `to` response times as `Long` values, with a static factory method `of` to handle parsing (including the `"max"` string case). [[1]](diffhunk://#diff-f39597f7e8e2fa05c1b0c2cb93269cd7cf353c17255b23679294c5632c8562c4L108-R137) [[2]](diffhunk://#diff-f39597f7e8e2fa05c1b0c2cb93269cd7cf353c17255b23679294c5632c8562c4L166-R162)
* Updated `isValid()` and related logic to reflect the new types and validation rules.

### Option Class Simplification

* Simplified the `Option` class by removing Jackson annotations and making the constructor accept plain values, with internal base64 decoding for the URL pattern.

These changes modernize and simplify the filter descriptor logic, making it easier to maintain and extend.