### PR TITLE
[#noissue] Refactor deserializers to improve JSON parsing and error handling

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/FilterHint.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/FilterHint.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.filter;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.web.filter.deserializer.FilterHintListJsonDeserializer;
 
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ public class FilterHint {
 
 
     public FilterHint(List<RpcHint> rpcHintList) {
-        if (rpcHintList == null) {
+        if (CollectionUtils.isEmpty(rpcHintList)) {
             rpcHintList = Collections.emptyList();
         }
         this.rpcHintList = rpcHintList;

--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/deserializer/FilterHintListJsonDeserializer.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/deserializer/FilterHintListJsonDeserializer.java
@@ -39,20 +39,15 @@ public class FilterHintListJsonDeserializer extends JsonDeserializer<FilterHint>
             ctxt.handleUnexpectedToken(RpcHint.class, jp);
         }
         // skip json start
-        final JsonToken jsonToken = jp.nextToken();
-        if (jsonToken == JsonToken.END_OBJECT) {
+        if (jp.nextToken() == JsonToken.END_OBJECT) {
             return new FilterHint(Collections.emptyList());
         }
 
-
         List<RpcHint> rpcHintList = new ArrayList<>();
-        while (true) {
+        do {
             final RpcHint rpcHint = jp.readValueAs(RpcHint.class);
             rpcHintList.add(rpcHint);
-            if (jp.nextToken() == JsonToken.END_OBJECT) {
-                break;
-            }
-        }
+        } while (jp.nextToken() != JsonToken.END_OBJECT);
         return new FilterHint(rpcHintList);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/deserializer/RpcHintJsonDeserializer.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/deserializer/RpcHintJsonDeserializer.java
@@ -44,19 +44,15 @@ public class RpcHintJsonDeserializer extends JsonDeserializer<RpcHint> {
             ctxt.handleUnexpectedToken(RpcHint.class, jp);
         }
         // skip start array
-        final JsonToken token = jp.nextToken();
         // [] empty array
-        if (token == JsonToken.END_ARRAY) {
+        if (jp.nextToken() == JsonToken.END_ARRAY) {
             return new RpcHint(applicationName, Collections.emptyList());
         }
         final List<RpcType> rpcHintList = new ArrayList<>();
-        while (true) {
-            RpcType rpcType =  jp.readValueAs(RpcType.class);
+        do {
+            RpcType rpcType = jp.readValueAs(RpcType.class);
             rpcHintList.add(rpcType);
-            if (jp.nextToken() == JsonToken.END_ARRAY) {
-                break;
-            }
-        }
+        } while (jp.nextToken() != JsonToken.END_ARRAY);
         return new RpcHint(applicationName, rpcHintList);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/deserializer/RpcTypeJsonDeserializer.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/deserializer/RpcTypeJsonDeserializer.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.filter.deserializer;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.navercorp.pinpoint.web.filter.RpcType;
@@ -34,8 +35,13 @@ public class RpcTypeJsonDeserializer extends JsonDeserializer<RpcType> {
 
     @Override
     public RpcType deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        if (jp.getCurrentToken() != JsonToken.VALUE_STRING) {
+            ctxt.handleUnexpectedToken(RpcType.class, jp);
+        }
         String address = jp.getText();
-        jp.nextToken();
+        if (jp.nextToken() != JsonToken.VALUE_NUMBER_INT) {
+            ctxt.handleUnexpectedToken(RpcType.class, jp);
+        }
         int serviceCode = jp.getIntValue();
         return new RpcType(address, serviceCode);
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/filter/FilterHintTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/filter/FilterHintTest.java
@@ -39,7 +39,8 @@ public class FilterHintTest {
     @Test
     public void convert() throws IOException {
 
-        String json = "{ \"TO_APPLICATION\" : [\"IP1\", 1,\"IP2\", 2], \"TO_APPLICATION2\" : [\"IP3\", 3,\"IP4\", 4] }";
+        String json = """
+                { "TO_APPLICATION" : ["IP1", 1, "IP2", 2], "TO_APPLICATION2" : ["IP3", 3, "IP4", 4] }""";
 
         final FilterHint hint = mapper.readValue(json, FilterHint.class);
 
@@ -60,7 +61,8 @@ public class FilterHintTest {
     @Test
     public void convert_duplicate_applicationName_filter() throws IOException {
 
-        String json = "{ \"TO_APPLICATION\" : [\"IP1\", 1,\"IP2\", 2], \"TO_APPLICATION\" : [\"IP3\", 3,\"IP4\", 4] }";
+        String json = """
+                { "TO_APPLICATION" : ["IP1", 1, "IP2", 2], "TO_APPLICATION" : ["IP3", 3, "IP4", 4] }""";
 
 
         final FilterHint hint = mapper.readValue(json, FilterHint.class);
@@ -92,7 +94,8 @@ public class FilterHintTest {
     @Test
     public void empty_array() throws IOException {
 
-        String json = "{ \"TO_APPLICATION\" : [] }";
+        String json = """
+                { "TO_APPLICATION" : [] }""";
 
 
         final FilterHint hint = mapper.readValue(json, FilterHint.class);
@@ -111,7 +114,8 @@ public class FilterHintTest {
     @Test
     public void empty_array2() throws IOException {
 
-        String json = "{ \"TO_APPLICATION\" : [], \"TO_APPLICATION2\" : [\"IP3\", 3,\"IP4\", 4] }";
+        String json = """
+                { "TO_APPLICATION" : [], "TO_APPLICATION2" : ["IP3", 3, "IP4", 4] }""";
 
         final FilterHint hint = mapper.readValue(json, FilterHint.class);
 


### PR DESCRIPTION
This pull request refactors and improves the deserialization logic for `FilterHint` objects, making the code more robust and easier to maintain. The main changes involve switching to a tree-based approach for JSON parsing, improving null and empty handling, and simplifying the construction of `RpcHint` and `RpcType` objects.

**Deserialization logic improvements:**

* Changed the deserialization in `FilterHintListJsonDeserializer` to use Jackson's `JsonNode` tree model, replacing manual token parsing for better readability and maintainability.
* Introduced a new helper method `readRpcTypeList` to cleanly extract `RpcType` objects from the parsed JSON array nodes.

**Null and collection handling:**

* Updated the constructor of `FilterHint` to use `CollectionUtils.isEmpty` for null/empty checks, ensuring consistent handling of empty lists.

**Imports and dependencies:**

* Added and removed import statements in `FilterHint` and `FilterHintListJsonDeserializer` to support the new deserialization logic and utility usage. [[1]](diffhunk://#diff-42c1eb389d1dbb8e573a5a4fee3a9cb23758efe4cfa50598bf35b41b6b77b4bbR20) [[2]](diffhunk://#diff-5f27fdfc43a12c373a3af0833360bb6ac2ee2039528bc64e3de16233f43c318bL20-R31)