### PR TITLE
[#noissue] Refactor recursiveCallFilter to use LinkedHashSet

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImpl.java
@@ -46,7 +46,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StopWatch;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -75,8 +76,6 @@ public class FilteredMapServiceImpl implements FilteredMapService {
 
     private final ApplicationMapBuilderFactory applicationMapBuilderFactory;
     private final NodeHistogramService nodeHistogramService;
-
-    private static final Object V = new Object();
 
     @Value("${web.servermap.build.timeout:600000}")
     private long buildTimeoutMillis;
@@ -170,7 +169,7 @@ public class FilteredMapServiceImpl implements FilteredMapService {
     private List<List<SpanBo>> selectFilteredSpan(List<ServerTraceId> transactionIdList, Filter<List<SpanBo>> filter, ColumnGetCount columnGetCount) {
         // filters out recursive calls by looking at each objects
         // do not filter here if we change to a tree-based collision check in the future.
-        final List<ServerTraceId> recursiveFilterList = recursiveCallFilter(transactionIdList);
+        final Collection<ServerTraceId> recursiveFilterList = recursiveCallFilter(transactionIdList);
 
         // FIXME might be better to simply traverse the List<Span> and create a process chain for execution
         final List<List<SpanBo>> originalList = this.traceDao.selectAllSpans(recursiveFilterList, columnGetCount);
@@ -196,21 +195,19 @@ public class FilteredMapServiceImpl implements FilteredMapService {
         return map;
     }
 
-    private List<ServerTraceId> recursiveCallFilter(List<ServerTraceId> transactionIdList) {
+    private Collection<ServerTraceId> recursiveCallFilter(Collection<ServerTraceId> transactionIdList) {
         Objects.requireNonNull(transactionIdList, "transactionIdList");
 
         List<ServerTraceId> crashKey = new ArrayList<>();
-        Map<ServerTraceId, Object> filterMap = new LinkedHashMap<>(transactionIdList.size());
+        Set<ServerTraceId> filterSet = new LinkedHashSet<>(transactionIdList.size());
         for (ServerTraceId transactionId : transactionIdList) {
-            Object old = filterMap.put(transactionId, V);
-            if (old != null) {
+            if (!filterSet.add(transactionId)) {
                 crashKey.add(transactionId);
             }
         }
         if (!crashKey.isEmpty()) {
-            Set<ServerTraceId> filteredTransactionId = filterMap.keySet();
-            logger.info("transactionId crash found. original:{} filter:{} crashKey:{}", transactionIdList.size(), filteredTransactionId.size(), crashKey);
-            return new ArrayList<>(filteredTransactionId);
+            logger.info("transactionId crash found. original:{} filter:{} crashKey:{}", transactionIdList.size(), filterSet.size(), crashKey);
+            return filterSet;
         }
         return transactionIdList;
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/TraceDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/TraceDao.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.service.FetchResult;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -36,9 +37,9 @@ public interface TraceDao {
 
     List<List<SpanBo>> selectSpans(List<GetTraceInfo> getTraceInfoList);
     
-    List<List<SpanBo>> selectAllSpans(List<ServerTraceId> transactionIdList);
+    List<List<SpanBo>> selectAllSpans(Collection<ServerTraceId> transactionIdList);
 
-    List<List<SpanBo>> selectAllSpans(List<ServerTraceId> transactionIdList, ColumnGetCount columnGetCount);
+    List<List<SpanBo>> selectAllSpans(Collection<ServerTraceId> transactionIdList, ColumnGetCount columnGetCount);
 
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/hbase/HbaseTraceDaoV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/hbase/HbaseTraceDaoV2.java
@@ -52,6 +52,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -146,17 +147,17 @@ public class HbaseTraceDaoV2 implements TraceDao {
     }
 
     @Override
-    public List<List<SpanBo>> selectAllSpans(List<ServerTraceId> transactionIdList) {
+    public List<List<SpanBo>> selectAllSpans(Collection<ServerTraceId> transactionIdList) {
         return selectAllSpans(transactionIdList, selectAllSpansLimit, null);
     }
 
     @Override
-    public List<List<SpanBo>> selectAllSpans(List<ServerTraceId> transactionIdList, ColumnGetCount columnGetCount) {
+    public List<List<SpanBo>> selectAllSpans(Collection<ServerTraceId> transactionIdList, ColumnGetCount columnGetCount) {
         Filter filter = ColumnGetCount.toFilter(columnGetCount);
         return selectAllSpans(transactionIdList, selectAllSpansLimit, filter);
     }
 
-    List<List<SpanBo>> selectAllSpans(List<ServerTraceId> transactionIdList, int eachPartitionSize, Filter filter) {
+    List<List<SpanBo>> selectAllSpans(Collection<ServerTraceId> transactionIdList, int eachPartitionSize, Filter filter) {
         if (CollectionUtils.isEmpty(transactionIdList)) {
             return Collections.emptyList();
         }


### PR DESCRIPTION
This pull request refactors the handling of transaction ID collections in the application map and trace DAO layers to use `Collection<ServerTraceId>` instead of `List<ServerTraceId>`. This change improves code flexibility and efficiency, particularly in duplicate filtering, and ensures consistency across interfaces and implementations.

**Refactoring and API consistency:**

* Changed method signatures in `TraceDao` and its implementation (`HbaseTraceDaoV2`) to accept `Collection<ServerTraceId>` instead of `List<ServerTraceId>`, allowing for more flexible and efficient processing of transaction IDs. [[1]](diffhunk://#diff-d8974fd9001f5ba01316caba045cd15bd7196cf4759719a6cf42c91108e84606L39-R42) [[2]](diffhunk://#diff-d99eefb14179e88e9d9e80f4bc27b51903452e4e4aa2d12a9e6429e6e9f81b5dL149-R160)
* Updated imports and internal variable types in `FilteredMapServiceImpl` to use `Collection` and `LinkedHashSet` instead of `List` and `LinkedHashMap`, aligning with the new method signatures and improving duplicate detection. [[1]](diffhunk://#diff-154c8813f020a7214570caaef085d59e121e0f171eaeb3310343627782747fb2L49-R50) [[2]](diffhunk://#diff-154c8813f020a7214570caaef085d59e121e0f171eaeb3310343627782747fb2L173-R172) [[3]](diffhunk://#diff-154c8813f020a7214570caaef085d59e121e0f171eaeb3310343627782747fb2L199-R210)

**Duplicate filtering improvements:**

* Refactored the recursive call filtering logic in `FilteredMapServiceImpl` to use a `LinkedHashSet` for efficient duplicate detection, removing the need for a placeholder object and simplifying the code.

**General code cleanup:**

* Removed an unused static object (`V`) from `FilteredMapServiceImpl` as it is no longer needed after the refactor.

These changes collectively improve the maintainability and efficiency of transaction ID processing throughout the codebase.