### PR TITLE
[#noissue] Simplify ColumnGetCount by removing UnlimitedColumnGetCount subclass

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/bo/ColumnGetCount.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/bo/ColumnGetCount.java
@@ -25,16 +25,19 @@ import org.apache.hadoop.hbase.filter.Filter;
  */
 public class ColumnGetCount {
 
-    public static final ColumnGetCount UNLIMITED_COLUMN_GET_COUNT = new UnlimitedColumnGetCount();
+    public static final int UNLIMITED_COUNT = Integer.MAX_VALUE;
+    public static final ColumnGetCount UNLIMITED_COLUMN_GET_COUNT = new ColumnGetCount(UNLIMITED_COUNT);
 
     private final int limit;
 
     public static ColumnGetCount of(int limit) {
-        if (limit == -1 || limit == Integer.MAX_VALUE) {
+        if (limit == -1 || limit == UNLIMITED_COUNT) {
             return ColumnGetCount.UNLIMITED_COLUMN_GET_COUNT;
-        } else {
-            return new ColumnGetCount(limit);
         }
+        if (limit <= 0) {
+            throw new IllegalArgumentException("limit must be positive or -1(unlimited): " + limit);
+        }
+        return new ColumnGetCount(limit);
     }
 
     ColumnGetCount(int limit) {
@@ -47,6 +50,9 @@ public class ColumnGetCount {
     }
 
     public boolean isReachedLimit(int resultSize) {
+        if (limit == UNLIMITED_COUNT) {
+            return false;
+        }
         return resultSize >= limit;
     }
 
@@ -54,7 +60,7 @@ public class ColumnGetCount {
         if (columnGetCount == null) {
             return null;
         }
-        if (columnGetCount.getLimit() != Integer.MAX_VALUE) {
+        if (columnGetCount.getLimit() != UNLIMITED_COUNT) {
             return new ColumnCountGetFilter(columnGetCount.getLimit());
         }
         return null;
@@ -73,19 +79,6 @@ public class ColumnGetCount {
     @Override
     public int hashCode() {
         return limit;
-    }
-
-    private static class UnlimitedColumnGetCount extends ColumnGetCount {
-
-        private UnlimitedColumnGetCount() {
-            super(Integer.MAX_VALUE);
-        }
-
-        @Override
-        public boolean isReachedLimit(int resultSize) {
-            return false;
-        }
-
     }
 
 }


### PR DESCRIPTION
…t subclass

This pull request refactors the handling of unlimited column get counts in the `ColumnGetCount` class to simplify the implementation and improve maintainability. The main change is the removal of the `UnlimitedColumnGetCount` subclass, replaced by a constant for the unlimited count value. The logic now consistently uses this constant throughout the class.

**Refactoring and simplification:**

* Removed the `UnlimitedColumnGetCount` subclass and replaced it with a constant `UNLIMITED_COUNT` set to `Integer.MAX_VALUE`, and updated the `UNLIMITED_COLUMN_GET_COUNT` instance to use this constant.
* Updated all checks and references for unlimited column get counts to use the new `UNLIMITED_COUNT` constant instead of `Integer.MAX_VALUE` directly. [[1]](diffhunk://#diff-16e7b9ad706245b126cd73c8229429ada5a110bdf0bf49dd5be9715f916edf76L28-R34) [[2]](diffhunk://#diff-16e7b9ad706245b126cd73c8229429ada5a110bdf0bf49dd5be9715f916edf76L57-R58)
* Removed the now-unnecessary `UnlimitedColumnGetCount` inner class definition.