### PR TITLE
[#noissue] Change crashKey collection to HashSet in recursiveCallFilter

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/CollisionReporter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/CollisionReporter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.applicationmap.service;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CollisionReporter<T> {
+
+    private final boolean detail;
+    private int collisionCount;
+    private int uniqueCollisionCount;
+    private Set<T> collisionKeys;
+
+    public CollisionReporter() {
+        this(false);
+    }
+
+    public CollisionReporter(boolean detail) {
+        this.detail = detail;
+        if (detail) {
+            this.collisionKeys = new HashSet<>();
+        }
+    }
+
+    public void report(T key) {
+        if (detail) {
+            if (collisionKeys.add(key)) {
+                uniqueCollisionCount++;
+            }
+        }
+        collisionCount++;
+    }
+
+    public boolean hasCollision() {
+        return collisionCount > 0;
+    }
+
+    public int getCollisionCount() {
+        return collisionCount;
+    }
+
+    public int getUniqueCollisionCount() {
+        return uniqueCollisionCount;
+    }
+
+    public Set<T> getCollisionKeys() {
+        if (collisionKeys == null) {
+            return Collections.emptySet();
+        }
+        return collisionKeys;
+    }
+
+    @Override
+    public String toString() {
+        if (detail) {
+            return "CollisionReporter{" +
+                    "collisionCount=" + collisionCount +
+                    ", uniqueCollisionCount=" + uniqueCollisionCount +
+                    ", collisionKeys=" + collisionKeys +
+                    '}';
+        }
+        return "CollisionReporter{" +
+                "collisionCount=" + collisionCount +
+                '}';
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/FilteredMapServiceImpl.java
@@ -198,15 +198,15 @@ public class FilteredMapServiceImpl implements FilteredMapService {
     private Collection<ServerTraceId> recursiveCallFilter(Collection<ServerTraceId> transactionIdList) {
         Objects.requireNonNull(transactionIdList, "transactionIdList");
 
-        List<ServerTraceId> crashKey = new ArrayList<>();
+        CollisionReporter<ServerTraceId> reporter = new CollisionReporter<>(logger.isTraceEnabled());
         Set<ServerTraceId> filterSet = new LinkedHashSet<>(transactionIdList.size());
         for (ServerTraceId transactionId : transactionIdList) {
             if (!filterSet.add(transactionId)) {
-                crashKey.add(transactionId);
+                reporter.report(transactionId);
             }
         }
-        if (!crashKey.isEmpty()) {
-            logger.info("transactionId crash found. original:{} filter:{} crashKey:{}", transactionIdList.size(), filterSet.size(), crashKey);
+        if (reporter.hasCollision()) {
+            logger.info("transactionId crash found. original:{} filter:{} {}", transactionIdList.size(), filterSet.size(), reporter);
             return filterSet;
         }
         return transactionIdList;


### PR DESCRIPTION
This pull request makes a small change to the `FilteredMapServiceImpl.java` file to improve the efficiency of the `recursiveCallFilter` method by replacing a `List` with a `Set` for storing `crashKey`. Additionally, it adds the `HashSet` import to support this change.

- Improved data structure usage:
  * Changed the type of `crashKey` from `List<ServerTraceId>` to `Set<ServerTraceId>` in the `recursiveCallFilter` method for better performance and to avoid duplicate entries.
  * Added the `HashSet` import to the file to support the new data structure.