### PR TITLE
[#13443] Replace gRPC Span stream with batch unary SendSpanList RPC 

### DIFF
--- a/agent-module/agent/src/main/resources/pinpoint-root.config
+++ b/agent-module/agent/src/main/resources/pinpoint-root.config
@@ -127,6 +127,15 @@ profiler.transport.grpc.span.sender.maxtraceevent=8
 profiler.transport.grpc.span.sender.limitcount=100
 profiler.transport.grpc.span.sender.limittime=60000
 
+# Span sender type: BATCH (unary SendSpanList RPC) or STREAM (gRPC bidirectional stream)
+# Supported since 3.1.0 collector
+profiler.transport.grpc.span.sender.type=BATCH
+profiler.transport.grpc.span.batch-sender.size=20
+profiler.transport.grpc.span.batch-sender.flush.interval.millis=1000
+profiler.transport.grpc.span.batch-sender.collect.deadline.time.millis=500
+# Backpressure: limits concurrent in-flight batch RPC requests
+profiler.transport.grpc.span.batch-sender.max-concurrent-requests=10
+
 profiler.transport.grpc.stats.logging.period=PT1M
 profiler.transport.grpc.span.stats.logging.enabled=false
 

--- a/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
@@ -21,6 +21,8 @@ profiler.transport.module=GRPC
 # gRPC Configuration                                      #
 ###########################################################
 profiler.transport.grpc.collector.ip=127.0.0.1
+# Supported since 3.1.0 collector
+profiler.transport.grpc.span.sender.type=BATCH
 
 
 ###########################################################

--- a/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
@@ -21,6 +21,8 @@ profiler.transport.module=GRPC
 # gRPC Configuration                                      #
 ###########################################################
 profiler.transport.grpc.collector.ip=127.0.0.1
+# Supported since 3.1.0 collector
+profiler.transport.grpc.span.sender.type=BATCH
 
 ###########################################################
 # Profiler Global Configuration                           #

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/config/GrpcTransportConfig.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/config/GrpcTransportConfig.java
@@ -155,6 +155,11 @@ public class GrpcTransportConfig {
     @Value("${profiler.transport.grpc.span.stats.logging.enable}")
     private boolean spanEnableStatLogging = DEFAULT_ENABLE_SPAN_STATS_LOGGING;
 
+    @Value("${profiler.transport.grpc.span.sender.type}")
+    private String spanSenderType;
+
+    private SpanBatchSenderConfig spanBatchSenderConfig = new SpanBatchSenderConfig();
+
     @Value("${profiler.transport.grpc.span.sender.discardpolicy.logger.discard.ratelimit}")
     private int spanDiscardLogRateLimit = DEFAULT_DISCARD_LOG_RATE_LIMIT;
     @Value("${profiler.transport.grpc.span.sender.discardpolicy.maxpendingthreshold}")
@@ -189,6 +194,9 @@ public class GrpcTransportConfig {
         // Span
         this.spanClientOption = readSpanClientOption(properties);
 
+        // Span batch sender
+        this.spanBatchSenderConfig = readSpanBatchSenderConfig(properties);
+
         // Ssl
         this.sslOption = readSslOption(properties);
     }
@@ -207,6 +215,13 @@ public class GrpcTransportConfig {
 
     private ClientOption readSpanClientOption(final Function<String, String> properties) {
         return readClientOption(properties, "profiler.transport.grpc.span.sender.");
+    }
+
+    private SpanBatchSenderConfig readSpanBatchSenderConfig(final Function<String, String> properties) {
+        SpanBatchSenderConfig config = new SpanBatchSenderConfig();
+        ValueAnnotationProcessor reader = new ValueAnnotationProcessor();
+        reader.process(config, properties);
+        return config;
     }
 
     private ClientOption readClientOption(final Function<String, String> properties, final String transportName) {
@@ -413,6 +428,14 @@ public class GrpcTransportConfig {
         return spanEnableStatLogging;
     }
 
+    public SpanBatchSenderConfig getSpanBatchSenderConfig() {
+        return spanBatchSenderConfig;
+    }
+
+    public SpanSenderType getSpanSenderType() {
+        return SpanSenderType.fromValue(spanSenderType);
+    }
+
     public boolean isNettySystemPropertyTryReflectiveSetAccessible() {
         return nettySystemPropertyTryReflectiveSetAccessible;
     }
@@ -451,6 +474,8 @@ public class GrpcTransportConfig {
                 ", metadataRetryMaxCount=" + metadataRetryMaxCount +
                 ", metadataRetryDelayMillis=" + metadataRetryDelayMillis +
                 ", nettySystemPropertyTryReflectiveSetAccessible=" + nettySystemPropertyTryReflectiveSetAccessible +
+                ", spanSenderType=" + getSpanSenderType() +
+                ", spanBatchSenderConfig=" + spanBatchSenderConfig +
                 ", spanDiscardLogRateLimit=" + spanDiscardLogRateLimit +
                 ", spanDiscardMaxPendingThreshold=" + spanDiscardMaxPendingThreshold +
                 '}';

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/config/SpanBatchSenderConfig.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/config/SpanBatchSenderConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.context.grpc.config;
+
+import com.navercorp.pinpoint.common.config.Value;
+
+/**
+ * @author emeroad
+ */
+public class SpanBatchSenderConfig {
+
+    private static final int DEFAULT_SIZE = 50;
+    private static final long DEFAULT_FLUSH_INTERVAL_MILLIS = 1000;
+    private static final long DEFAULT_COLLECT_DEADLINE_TIME_MILLIS = 500;
+    private static final int DEFAULT_MAX_CONCURRENT_REQUESTS = 10;
+
+    @Value("${profiler.transport.grpc.span.batch-sender.size}")
+    private int size = DEFAULT_SIZE;
+    @Value("${profiler.transport.grpc.span.batch-sender.flush.interval.millis}")
+    private long flushIntervalMillis = DEFAULT_FLUSH_INTERVAL_MILLIS;
+    @Value("${profiler.transport.grpc.span.batch-sender.collect.deadline.time.millis}")
+    private long collectDeadlineTimeMillis = DEFAULT_COLLECT_DEADLINE_TIME_MILLIS;
+    @Value("${profiler.transport.grpc.span.batch-sender.max-concurrent-requests}")
+    private int maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS;
+
+    public int getSize() {
+        return size;
+    }
+
+    public long getFlushIntervalMillis() {
+        return flushIntervalMillis;
+    }
+
+    public long getCollectDeadlineTimeMillis() {
+        return collectDeadlineTimeMillis;
+    }
+
+    public int getMaxConcurrentRequests() {
+        return maxConcurrentRequests;
+    }
+
+    @Override
+    public String toString() {
+        return "SpanBatchSenderConfig{" +
+                "size=" + size +
+                ", flushIntervalMillis=" + flushIntervalMillis +
+                ", collectDeadlineTimeMillis=" + collectDeadlineTimeMillis +
+                ", maxConcurrentRequests=" + maxConcurrentRequests +
+                '}';
+    }
+}

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/config/SpanSenderType.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/config/SpanSenderType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.context.grpc.config;
+
+/**
+ * @author emeroad
+ */
+public enum SpanSenderType {
+    BATCH,
+    STREAM;
+
+    public static SpanSenderType defaultType() {
+        return BATCH;
+    }
+
+    public static SpanSenderType fromValue(String value) {
+        if (value == null) {
+            return defaultType();
+        }
+        for (SpanSenderType type : values()) {
+            if (type.name().equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown SpanSenderType: " + value);
+    }
+}

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/GrpcModule.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/module/GrpcModule.java
@@ -36,6 +36,7 @@ import com.navercorp.pinpoint.profiler.context.grpc.GrpcMetadataMessageConverter
 import com.navercorp.pinpoint.profiler.context.grpc.GrpcSpanMessageConverterProvider;
 import com.navercorp.pinpoint.profiler.context.grpc.GrpcStatMessageConverterProvider;
 import com.navercorp.pinpoint.profiler.context.grpc.config.GrpcTransportConfig;
+import com.navercorp.pinpoint.profiler.context.grpc.config.SpanSenderType;
 import com.navercorp.pinpoint.profiler.context.grpc.config.SpanUriGetter;
 import com.navercorp.pinpoint.profiler.context.grpc.config.SpanUriGetterProvider;
 import com.navercorp.pinpoint.profiler.context.grpc.mapper.AgentInfoMapper;
@@ -57,6 +58,7 @@ import com.navercorp.pinpoint.profiler.context.provider.grpc.MetadataGrpcDataSen
 import com.navercorp.pinpoint.profiler.context.provider.grpc.ReconnectExecutorProvider;
 import com.navercorp.pinpoint.profiler.context.provider.grpc.ReconnectSchedulerProvider;
 import com.navercorp.pinpoint.profiler.context.provider.grpc.SSLContextProvider;
+import com.navercorp.pinpoint.profiler.context.provider.grpc.SpanBatchGrpcDataSenderProvider;
 import com.navercorp.pinpoint.profiler.context.provider.grpc.SpanGrpcDataSenderProvider;
 import com.navercorp.pinpoint.profiler.context.provider.grpc.StatGrpcDataSenderProvider;
 import com.navercorp.pinpoint.profiler.metadata.MetaDataType;
@@ -124,7 +126,7 @@ public class GrpcModule extends PrivateModule {
 
         bindAgentDataSender();
 
-        bindSpanDataSender();
+        bindSpanDataSender(grpcTransportConfig);
 
         bindStatDataSender();
 
@@ -194,7 +196,7 @@ public class GrpcModule extends PrivateModule {
         expose(statDataSender);
     }
 
-    private void bindSpanDataSender() {
+    private void bindSpanDataSender(GrpcTransportConfig grpcTransportConfig) {
         // Span
         TypeLiteral<MessageConverter<SpanType, GeneratedMessageV3>> protoMessageConverter = new TypeLiteral<MessageConverter<SpanType, GeneratedMessageV3>>() {
         };
@@ -209,7 +211,19 @@ public class GrpcModule extends PrivateModule {
         TypeLiteral<DataSender<SpanType>> spanDataSenderType = new TypeLiteral<DataSender<SpanType>>() {
         };
         Key<DataSender<SpanType>> spanDataSender = Key.get(spanDataSenderType, SpanDataSender.class);
-        bind(spanDataSender).toProvider(SpanGrpcDataSenderProvider.class).in(Scopes.SINGLETON);
+
+        SpanSenderType spanSenderType = grpcTransportConfig.getSpanSenderType();
+        logger.info("SpanSenderType: {}", spanSenderType);
+        switch (spanSenderType) {
+            case BATCH:
+                bind(spanDataSender).toProvider(SpanBatchGrpcDataSenderProvider.class).in(Scopes.SINGLETON);
+                break;
+            case STREAM:
+                bind(spanDataSender).toProvider(SpanGrpcDataSenderProvider.class).in(Scopes.SINGLETON);
+                break;
+            default:
+                throw new IllegalStateException("Unknown SpanSenderType: " + spanSenderType);
+        }
         expose(spanDataSender);
     }
 

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/grpc/SpanBatchGrpcDataSenderProvider.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/grpc/SpanBatchGrpcDataSenderProvider.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.context.provider.grpc;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.protobuf.GeneratedMessageV3;
+import com.navercorp.pinpoint.common.profiler.message.DataSender;
+import com.navercorp.pinpoint.common.profiler.message.MessageConverter;
+import com.navercorp.pinpoint.grpc.client.ChannelFactory;
+import com.navercorp.pinpoint.grpc.client.ChannelFactoryBuilder;
+import com.navercorp.pinpoint.grpc.client.DefaultChannelFactoryBuilder;
+import com.navercorp.pinpoint.grpc.client.HeaderFactory;
+import com.navercorp.pinpoint.grpc.client.UnaryCallDeadlineInterceptor;
+import com.navercorp.pinpoint.grpc.client.config.ClientOption;
+import com.navercorp.pinpoint.profiler.context.SpanType;
+import com.navercorp.pinpoint.profiler.context.grpc.config.GrpcTransportConfig;
+import com.navercorp.pinpoint.profiler.context.grpc.config.SpanBatchSenderConfig;
+import com.navercorp.pinpoint.profiler.context.module.SpanDataSender;
+import com.navercorp.pinpoint.profiler.sender.grpc.SpanBatchGrpcDataSender;
+import com.navercorp.pinpoint.profiler.sender.grpc.metric.ChannelzReporter;
+import com.navercorp.pinpoint.profiler.sender.grpc.metric.ChannelzScheduledReporter;
+import com.navercorp.pinpoint.profiler.sender.grpc.metric.DefaultChannelzReporter;
+import io.grpc.ClientInterceptor;
+import io.grpc.NameResolverProvider;
+import io.netty.handler.ssl.SslContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author emeroad
+ */
+public class SpanBatchGrpcDataSenderProvider implements Provider<DataSender<SpanType>> {
+
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    private final GrpcTransportConfig grpcTransportConfig;
+    private final MessageConverter<SpanType, GeneratedMessageV3> messageConverter;
+    private final HeaderFactory headerFactory;
+    private final NameResolverProvider nameResolverProvider;
+    private final ChannelzScheduledReporter reporter;
+    private final Provider<SslContext> sslContextProvider;
+
+    private List<ClientInterceptor> clientInterceptorList;
+
+    public static final String SPAN_CHANNELZ = "com.navercorp.pinpoint.metric.SpanChannel";
+
+    @Inject
+    public SpanBatchGrpcDataSenderProvider(GrpcTransportConfig grpcTransportConfig,
+                                          @SpanDataSender MessageConverter<SpanType, GeneratedMessageV3> messageConverter,
+                                          HeaderFactory headerFactory,
+                                          NameResolverProvider nameResolverProvider,
+                                          ChannelzScheduledReporter reporter,
+                                          Provider<SslContext> sslContextProvider) {
+        this.grpcTransportConfig = Objects.requireNonNull(grpcTransportConfig, "grpcTransportConfig");
+        this.messageConverter = Objects.requireNonNull(messageConverter, "messageConverter");
+        this.headerFactory = Objects.requireNonNull(headerFactory, "headerFactory");
+        this.nameResolverProvider = Objects.requireNonNull(nameResolverProvider, "nameResolverProvider");
+        this.reporter = Objects.requireNonNull(reporter, "reporter");
+        this.sslContextProvider = Objects.requireNonNull(sslContextProvider, "sslContextProvider");
+    }
+
+    @Inject(optional = true)
+    public void setClientInterceptor(@SpanDataSender List<ClientInterceptor> clientInterceptorList) {
+        this.clientInterceptorList = Objects.requireNonNull(clientInterceptorList, "clientInterceptorList");
+    }
+
+    @Override
+    public DataSender<SpanType> get() {
+        final String collectorIp = grpcTransportConfig.getSpanCollectorIp();
+        final int collectorPort = grpcTransportConfig.getSpanCollectorPort();
+        final boolean sslEnable = grpcTransportConfig.isSpanSslEnable();
+        final int senderExecutorQueueSize = grpcTransportConfig.getSpanSenderExecutorQueueSize();
+        final SpanBatchSenderConfig batchConfig = grpcTransportConfig.getSpanBatchSenderConfig();
+        final int batchSize = batchConfig.getSize();
+        final long flushIntervalMillis = batchConfig.getFlushIntervalMillis();
+        final long batchCollectDeadLineTimeMillis = batchConfig.getCollectDeadlineTimeMillis();
+        final int maxConcurrentRequests = batchConfig.getMaxConcurrentRequests();
+
+        final ChannelFactoryBuilder channelFactoryBuilder = newChannelFactoryBuilder(sslEnable);
+        final ChannelFactory channelFactory = channelFactoryBuilder.build();
+
+        final SpanBatchGrpcDataSender spanListGrpcDataSender = new SpanBatchGrpcDataSender(
+                collectorIp, collectorPort,
+                senderExecutorQueueSize, messageConverter,
+                channelFactory, batchSize, flushIntervalMillis, batchCollectDeadLineTimeMillis,
+                maxConcurrentRequests);
+
+        logger.info("SpanBatchGrpcDataSender={}", spanListGrpcDataSender);
+
+        if (grpcTransportConfig.isSpanEnableStatLogging()) {
+            registerChannelzReporter(spanListGrpcDataSender);
+        }
+
+        return spanListGrpcDataSender;
+    }
+
+    private void registerChannelzReporter(SpanBatchGrpcDataSender sender) {
+        final Logger statChannelLogger = LogManager.getLogger(SPAN_CHANNELZ);
+        ChannelzReporter statReporter = new DefaultChannelzReporter(statChannelLogger);
+        reporter.registerRootChannel(sender.getLogId(), statReporter);
+    }
+
+    private ChannelFactoryBuilder newChannelFactoryBuilder(boolean sslEnable) {
+        final int channelExecutorQueueSize = grpcTransportConfig.getSpanChannelExecutorQueueSize();
+        final ClientOption clientOption = grpcTransportConfig.getSpanClientOption();
+
+        ChannelFactoryBuilder channelFactoryBuilder = new DefaultChannelFactoryBuilder("SpanBatchGrpcDataSender");
+        channelFactoryBuilder.setHeaderFactory(headerFactory);
+        channelFactoryBuilder.setNameResolverProvider(nameResolverProvider);
+
+        final ClientInterceptor unaryCallDeadlineInterceptor = new UnaryCallDeadlineInterceptor(grpcTransportConfig.getSpanRequestTimeout());
+        channelFactoryBuilder.addClientInterceptor(unaryCallDeadlineInterceptor);
+
+        if (clientInterceptorList != null) {
+            for (ClientInterceptor clientInterceptor : clientInterceptorList) {
+                logger.info("addClientInterceptor:{}", clientInterceptor);
+                channelFactoryBuilder.addClientInterceptor(clientInterceptor);
+            }
+        }
+
+        channelFactoryBuilder.setExecutorQueueSize(channelExecutorQueueSize);
+        channelFactoryBuilder.setClientOption(clientOption);
+
+        if (sslEnable) {
+            SslContext sslContext = sslContextProvider.get();
+            channelFactoryBuilder.setSslContext(sslContext);
+        }
+
+        return channelFactoryBuilder;
+    }
+}

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/sender/grpc/SpanBatchGrpcDataSender.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/sender/grpc/SpanBatchGrpcDataSender.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.sender.grpc;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.GeneratedMessageV3;
+import com.navercorp.pinpoint.common.profiler.message.MessageConverter;
+import com.navercorp.pinpoint.common.util.CollectionUtils;
+import com.navercorp.pinpoint.common.util.ErrorId;
+import com.navercorp.pinpoint.grpc.client.ChannelFactory;
+import com.navercorp.pinpoint.grpc.trace.PPartialSuccess;
+import com.navercorp.pinpoint.grpc.trace.PSpanMessageBatch;
+import com.navercorp.pinpoint.grpc.trace.PSpanResultBatch;
+import com.navercorp.pinpoint.grpc.trace.SpanGrpc;
+import com.navercorp.pinpoint.profiler.context.SpanType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Sends spans in batches via a unary RPC (SendSpanBatch), replacing the long-lived streaming approach.
+ * <p>
+ * Benefits over streaming:
+ * <ul>
+ *   <li>No complex stream state management or re-initialization for load balancing</li>
+ *   <li>A single invalid span does not terminate the entire connection</li>
+ *   <li>No sequence overflow concerns; each batch is an independent request</li>
+ * </ul>
+ *
+ * @author emeroad
+ */
+public class SpanBatchGrpcDataSender extends AbstractGrpcDataSender<SpanType> {
+
+    private final SpanGrpc.SpanFutureStub spanFutureStub;
+    private final BlockingQueue<SpanType> queue;
+    private final Thread sendThread;
+    private final int batchSize;
+    private final long flushTimeoutMillis;
+    private final long batchCollectDeadLineTimeMillis;
+    private final int maxConcurrentRequests;
+    private final Semaphore concurrentRequestPermit;
+
+    private final FutureCallback<PSpanResultBatch> sendCallback;
+
+    // Reusable — safe because sendLoop runs on a single thread
+    private final List<SpanType> batchBuffer;
+    private final SpanMessageBatchBuilder batchMessageBuilder;
+
+    public SpanBatchGrpcDataSender(String host, int port,
+                                  int executorQueueSize,
+                                  MessageConverter<SpanType, GeneratedMessageV3> messageConverter,
+                                  ChannelFactory channelFactory,
+                                  int batchSize,
+                                  long flushTimeoutMillis,
+                                  long batchCollectDeadLineTimeMillis,
+                                  int maxConcurrentRequests) {
+        super(host, port, messageConverter, channelFactory);
+        this.spanFutureStub = SpanGrpc.newFutureStub(managedChannel);
+        this.queue = new LinkedBlockingQueue<>(executorQueueSize);
+        this.batchSize = batchSize;
+        this.flushTimeoutMillis = flushTimeoutMillis;
+        this.batchCollectDeadLineTimeMillis = batchCollectDeadLineTimeMillis;
+        this.maxConcurrentRequests = maxConcurrentRequests;
+        this.concurrentRequestPermit = new Semaphore(maxConcurrentRequests);
+        this.sendCallback = newSendCallback(this.concurrentRequestPermit);
+        this.batchBuffer = new ArrayList<>(batchSize);
+        this.batchMessageBuilder = new SpanMessageBatchBuilder(messageConverter);
+        this.sendThread = new Thread(this::sendLoop, "Pinpoint-SpanBatch-Sender");
+        this.sendThread.setDaemon(true);
+        this.sendThread.start();
+    }
+
+    @Override
+    public boolean send(SpanType data) {
+        if (shutdown) {
+            return false;
+        }
+        if (queue.offer(data)) {
+            return true;
+        }
+        final SpanType discarded = queue.poll();
+        if (discarded != null) {
+            if (isDebug) {
+                logger.debug("discard oldest message queue size:{}", queue.size());
+            } else {
+                tLogger.info("discard oldest message queue size:{}", queue.size());
+            }
+        }
+        return queue.offer(data);
+    }
+
+    private void sendLoop() {
+        while (!shutdown) {
+            final List<SpanType> buffer = this.batchBuffer;
+            try {
+                collectBatch(buffer);
+                if (CollectionUtils.hasLength(buffer)) {
+                    sendBatchAsync(buffer);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Throwable e) {
+                logger.warn("Error in SpanList send loop", e);
+            } finally {
+                buffer.clear();
+            }
+        }
+        flushRemaining();
+    }
+
+    private void collectBatch(List<SpanType> buffer) throws InterruptedException {
+        // Block until the first item arrives
+        final SpanType first = queue.poll(flushTimeoutMillis, TimeUnit.MILLISECONDS);
+        if (first == null) {
+            return;
+        }
+        buffer.add(first);
+
+        // Gather more items within the collection time window
+        final long deadline = System.currentTimeMillis() + batchCollectDeadLineTimeMillis;
+        while (buffer.size() < batchSize) {
+            final long remaining = deadline - System.currentTimeMillis();
+            if (remaining <= 0) {
+                break;
+            }
+            final SpanType item = queue.poll(remaining, TimeUnit.MILLISECONDS);
+            if (item == null) {
+                break;
+            }
+            buffer.add(item);
+        }
+    }
+
+    private void flushRemaining() {
+        final List<SpanType> remaining = new ArrayList<>();
+        queue.drainTo(remaining);
+        if (!remaining.isEmpty()) {
+            logger.info("Flushing {} remaining spans on shutdown", remaining.size());
+            sendBatchAsync(remaining);
+        }
+        awaitInFlightRequests();
+    }
+
+    private void awaitInFlightRequests() {
+        try {
+            if (!concurrentRequestPermit.tryAcquire(maxConcurrentRequests, 3, TimeUnit.SECONDS)) {
+                logger.warn("Timed out waiting for in-flight span requests to complete");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void sendBatchAsync(List<SpanType> batch) {
+        final PSpanMessageBatch spanMessageBatch = batchMessageBuilder.buildBatch(batch);
+        if (spanMessageBatch.getSpanCount() == 0) {
+            return;
+        }
+
+        if (isDebug) {
+            logger.debug("SendSpanBatch size={}", spanMessageBatch.getSpanCount());
+        }
+
+        try {
+            if (!concurrentRequestPermit.tryAcquire(flushTimeoutMillis, TimeUnit.MILLISECONDS)) {
+                tLogger.info("SendSpanBatch skipped: no available permits within {}ms concurrentRequests:{}/{}", flushTimeoutMillis, concurrentRequestPermit.availablePermits(), maxConcurrentRequests);
+                return;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("SendSpanBatch batchSize={} concurrentRequests={}/{}", spanMessageBatch.getSpanCount(), concurrentRequestPermit.availablePermits(), maxConcurrentRequests);
+        }
+
+        try {
+            final ListenableFuture<PSpanResultBatch> future = spanFutureStub.sendSpanBatch(spanMessageBatch);
+            Futures.addCallback(future, sendCallback, MoreExecutors.directExecutor());
+        } catch (Throwable t) {
+            concurrentRequestPermit.release();
+            tLogger.info("sendSpanBatch failed synchronously", t);
+        }
+
+    }
+
+    private FutureCallback<PSpanResultBatch> newSendCallback(final Semaphore concurrentRequestPermit) {
+        return new FutureCallback<PSpanResultBatch>() {
+            @Override
+            public void onSuccess(PSpanResultBatch response) {
+                concurrentRequestPermit.release();
+                handleResponse(response);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                concurrentRequestPermit.release();
+                tLogger.info("SendSpanBatch failed", t);
+            }
+        };
+    }
+
+    private void handleResponse(PSpanResultBatch response) {
+        if (response.hasPartialSuccess()) {
+            final PPartialSuccess partialSuccess = response.getPartialSuccess();
+            final long rejectedSpans = partialSuccess.getRejectedSpans();
+            final ErrorId errorId = ErrorId.of(partialSuccess.getErrorId());
+            if (rejectedSpans > 0) {
+                tLogger.warn("SendSpanBatch partial success: rejectedSpans={}, errorId={}, errorMessage={}",
+                        rejectedSpans, errorId, partialSuccess.getErrorMessage());
+            } else if (!partialSuccess.getErrorMessage().isEmpty()) {
+                tLogger.info("SendSpanBatch warning: errorId={}, {}", errorId, partialSuccess.getErrorMessage());
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        if (shutdown) {
+            return;
+        }
+        shutdown = true;
+        logger.info("Close SpanBatchGrpcDataSender host={} port={}", host, port);
+        sendThread.interrupt();
+        try {
+            sendThread.join(3000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        releaseChannel();
+    }
+
+    @Override
+    public String toString() {
+        return "SpanBatchGrpcDataSender{" +
+                "name='" + name + '\'' +
+                ", host='" + host + '\'' +
+                ", port=" + port +
+                ", batchSize=" + batchSize +
+                ", flushTimeoutMillis=" + flushTimeoutMillis +
+                ", batchCollectDeadLineTimeMillis=" + batchCollectDeadLineTimeMillis +
+                ", maxConcurrentRequests=" + maxConcurrentRequests +
+                '}';
+    }
+}

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/sender/grpc/SpanMessageBatchBuilder.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/sender/grpc/SpanMessageBatchBuilder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.sender.grpc;
+
+import com.google.protobuf.GeneratedMessageV3;
+import com.navercorp.pinpoint.common.profiler.message.MessageConverter;
+import com.navercorp.pinpoint.grpc.trace.PSpan;
+import com.navercorp.pinpoint.grpc.trace.PSpanChunk;
+import com.navercorp.pinpoint.grpc.trace.PSpanMessage;
+import com.navercorp.pinpoint.grpc.trace.PSpanMessageBatch;
+import com.navercorp.pinpoint.profiler.context.SpanType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.navercorp.pinpoint.grpc.MessageFormatUtils.debugLog;
+
+/**
+ * Reusable protobuf builder for {@link PSpanMessageBatch}.
+ * <p>
+ * This class is NOT thread-safe. It is designed to be used by a single flush thread
+ * to avoid per-batch allocation of protobuf builders.
+ *
+ * @author emeroad
+ */
+class SpanMessageBatchBuilder {
+
+    private final Logger logger = LogManager.getLogger(this.getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final MessageConverter<SpanType, GeneratedMessageV3> messageConverter;
+    // @NotThreadSafe WARNING
+    private final PSpanMessageBatch.Builder batchBuilder = PSpanMessageBatch.newBuilder();
+    // @NotThreadSafe WARNING
+    private final PSpanMessage.Builder spanMessageBuilder = PSpanMessage.newBuilder();
+
+    SpanMessageBatchBuilder(MessageConverter<SpanType, GeneratedMessageV3> messageConverter) {
+        this.messageConverter = Objects.requireNonNull(messageConverter, "messageConverter");
+    }
+
+    PSpanMessageBatch buildBatch(List<SpanType> batch) {
+        if (batch.isEmpty()) {
+            return PSpanMessageBatch.getDefaultInstance();
+        }
+        final PSpanMessageBatch.Builder builder = this.batchBuilder;
+        for (SpanType spanType : batch) {
+            final GeneratedMessageV3 message = messageConverter.toMessage(spanType);
+            if (message == null) {
+                continue;
+            }
+            final PSpanMessage spanMessage = toSpanMessage(message);
+            if (spanMessage != null) {
+                builder.addSpan(spanMessage);
+            }
+        }
+
+        PSpanMessageBatch spanMessageBatch = builder.build();
+        builder.clear();
+        return spanMessageBatch;
+    }
+
+    private PSpanMessage toSpanMessage(GeneratedMessageV3 message) {
+        final PSpanMessage.Builder builder = this.spanMessageBuilder;
+        if (message instanceof PSpan) {
+            final PSpan pSpan = (PSpan) message;
+            if (isDebug) {
+                logger.debug("toSpanMessage PSpan={}", debugLog(pSpan));
+            }
+
+            PSpanMessage spanMessage = builder.setSpan(pSpan).build();
+            builder.clear();
+            return spanMessage;
+        }
+        if (message instanceof PSpanChunk) {
+            final PSpanChunk pSpanChunk = (PSpanChunk) message;
+            if (isDebug) {
+                logger.debug("toSpanMessage PSpanChunk={}", debugLog(pSpanChunk));
+            }
+
+            PSpanMessage spanMessage = builder.setSpanChunk(pSpanChunk).build();
+            builder.clear();
+            return spanMessage;
+        }
+        logger.warn("Unsupported message type: {}", message.getClass());
+        return null;
+    }
+}

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/sender/grpc/SpanBatchGrpcDataSenderTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/sender/grpc/SpanBatchGrpcDataSenderTest.java
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.sender.grpc;
+
+import com.google.protobuf.GeneratedMessageV3;
+import com.navercorp.pinpoint.common.profiler.message.MessageConverter;
+import com.navercorp.pinpoint.grpc.client.ChannelFactory;
+import com.navercorp.pinpoint.grpc.trace.PPartialSuccess;
+import com.navercorp.pinpoint.grpc.trace.PSpan;
+import com.navercorp.pinpoint.grpc.trace.PSpanMessage;
+import com.navercorp.pinpoint.grpc.trace.PSpanMessageBatch;
+import com.navercorp.pinpoint.grpc.trace.PSpanResultBatch;
+import com.navercorp.pinpoint.grpc.trace.SpanGrpc;
+import com.navercorp.pinpoint.profiler.context.SpanType;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class SpanBatchGrpcDataSenderTest {
+
+    private Server server;
+    private String serverName;
+    private TestSpanBatchService service;
+    private SpanBatchGrpcDataSender sender;
+
+    private void setUpServer(TestSpanBatchService service) throws IOException {
+        serverName = InProcessServerBuilder.generateName();
+        this.service = service;
+        server = InProcessServerBuilder
+                .forName(serverName)
+                .addService(service)
+                .build()
+                .start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (sender != null) {
+            sender.close();
+        }
+        if (server != null) {
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void sendSingleSpan_receivedByServer() throws IOException {
+        setUpServer(new TestSpanBatchService());
+        sender = createSender(100, 10, 200, 100, 5);
+
+        boolean result = sender.send(new TestSpan(1));
+
+        assertThat(result).isTrue();
+        await().atMost(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(totalSpanCount()).isEqualTo(1));
+
+        List<Integer> apiIds = collectAllApiIds();
+        assertThat(apiIds).containsExactly(1);
+    }
+
+    @Test
+    void sendMultipleSpans_batchedTogether() throws IOException {
+        setUpServer(new TestSpanBatchService());
+        sender = createSender(100, 10, 500, 300, 5);
+
+        for (int i = 1; i <= 5; i++) {
+            sender.send(new TestSpan(i));
+        }
+
+        await().atMost(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(totalSpanCount()).isEqualTo(5));
+
+        assertThat(service.receivedBatches.size()).isLessThanOrEqualTo(2);
+
+        List<Integer> apiIds = collectAllApiIds();
+        assertThat(apiIds).containsExactlyInAnyOrder(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void batchSizeLimit_doesNotExceedConfiguredSize() throws IOException {
+        setUpServer(new TestSpanBatchService());
+        sender = createSender(100, 3, 200, 100, 5);
+
+        for (int i = 1; i <= 7; i++) {
+            sender.send(new TestSpan(i));
+        }
+
+        await().atMost(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(totalSpanCount()).isEqualTo(7));
+
+        for (PSpanMessageBatch batch : service.receivedBatches) {
+            assertThat(batch.getSpanCount()).isLessThanOrEqualTo(3);
+        }
+        assertThat(service.receivedBatches.size()).isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void queueOverflow_discardsOldestSpan() throws Exception {
+        setUpServer(TestSpanBatchService.blocking());
+
+        sender = createSender(1, 1, 5000, 50, 1);
+
+        sender.send(new TestSpan(1));
+        assertThat(service.getRequestArrivedLatch().await(3, TimeUnit.SECONDS)).isTrue();
+
+        sender.send(new TestSpan(2));
+        Thread.sleep(300);
+
+        sender.send(new TestSpan(3));
+        sender.send(new TestSpan(4));
+        sender.send(new TestSpan(5));
+
+        service.unblock();
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(totalSpanCount()).isGreaterThanOrEqualTo(2));
+
+        List<Integer> apiIds = collectAllApiIds();
+        assertThat(apiIds).contains(1);
+        assertThat(apiIds).doesNotContain(3, 4);
+    }
+
+    @Test
+    void concurrentRequestLimiting() throws Exception {
+        setUpServer(new TestSpanBatchService(false, null, () -> false, 500));
+
+        sender = createSender(100, 1, 200, 50, 2);
+
+        for (int i = 1; i <= 5; i++) {
+            sender.send(new TestSpan(i));
+        }
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(service.totalRequestCount.get()).isGreaterThanOrEqualTo(3));
+
+        assertThat(service.maxConcurrent.get()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void serverError_handledGracefully() throws IOException {
+        AtomicBoolean fail = new AtomicBoolean(true);
+        setUpServer(new TestSpanBatchService(false, null, fail::get, 0));
+
+        sender = createSender(100, 1, 200, 50, 5);
+
+        for (int i = 1; i <= 3; i++) {
+            sender.send(new TestSpan(i));
+        }
+
+        await().atMost(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(service.totalRequestCount.get()).isGreaterThanOrEqualTo(3));
+
+        fail.set(false);
+
+        sender.send(new TestSpan(100));
+
+        await().atMost(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    List<Integer> apiIds = collectAllApiIds();
+                    assertThat(apiIds).contains(100);
+                });
+    }
+
+    @Test
+    void partialSuccess_handledProperly() throws IOException {
+        PSpanResultBatch partialResponse = PSpanResultBatch.newBuilder()
+                .setPartialSuccess(PPartialSuccess.newBuilder()
+                        .setRejectedSpans(2)
+                        .setErrorId(42)
+                        .setErrorMessage("test partial rejection")
+                        .build())
+                .build();
+        AtomicBoolean usePartialResponse = new AtomicBoolean(true);
+        setUpServer(new TestSpanBatchService(false,
+                () -> usePartialResponse.get() ? partialResponse : null,
+                () -> false, 0));
+
+        sender = createSender(100, 5, 200, 100, 5);
+
+        for (int i = 1; i <= 5; i++) {
+            sender.send(new TestSpan(i));
+        }
+
+        await().atMost(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(totalSpanCount()).isEqualTo(5));
+
+        usePartialResponse.set(false);
+        sender.send(new TestSpan(99));
+
+        await().atMost(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    List<Integer> apiIds = collectAllApiIds();
+                    assertThat(apiIds).contains(99);
+                });
+    }
+
+    @Test
+    void close_allSentSpansReceived() throws IOException {
+        setUpServer(new TestSpanBatchService());
+        sender = createSender(100, 5, 200, 100, 5);
+
+        for (int i = 1; i <= 10; i++) {
+            sender.send(new TestSpan(i));
+        }
+
+        await().atMost(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(totalSpanCount()).isEqualTo(10));
+
+        sender.close();
+        sender = null;
+
+        List<Integer> apiIds = collectAllApiIds();
+        assertThat(apiIds).containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    void sendAfterShutdown_returnsFalse() throws IOException {
+        setUpServer(new TestSpanBatchService());
+        sender = createSender(100, 10, 200, 100, 5);
+        sender.close();
+
+        boolean result = sender.send(new TestSpan(1));
+
+        assertThat(result).isFalse();
+        sender = null;
+    }
+
+    // --- Test infrastructure ---
+
+    private SpanBatchGrpcDataSender createSender(int executorQueueSize, int batchSize,
+                                                  long flushTimeoutMillis, long batchCollectDeadLineTimeMillis,
+                                                  int maxConcurrentRequests) {
+        MessageConverter<SpanType, GeneratedMessageV3> converter = message -> {
+            TestSpan span = (TestSpan) message;
+            return PSpan.newBuilder().setApiId(span.id).build();
+        };
+
+        ChannelFactory channelFactory = new ChannelFactory() {
+            @Override
+            public String getFactoryName() {
+                return "test-span-batch";
+            }
+
+            @Override
+            public ManagedChannel build(String channelName, String host, int port) {
+                return InProcessChannelBuilder.forName(serverName).build();
+            }
+
+            @Override
+            public ManagedChannel build(String host, int port) {
+                return build("default", host, port);
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        return new SpanBatchGrpcDataSender("localhost", 0, executorQueueSize,
+                converter, channelFactory, batchSize, flushTimeoutMillis,
+                batchCollectDeadLineTimeMillis, maxConcurrentRequests);
+    }
+
+    private int totalSpanCount() {
+        return service.receivedBatches.stream()
+                .mapToInt(PSpanMessageBatch::getSpanCount)
+                .sum();
+    }
+
+    private List<Integer> collectAllApiIds() {
+        return service.receivedBatches.stream()
+                .flatMap(batch -> batch.getSpanList().stream())
+                .filter(PSpanMessage::hasSpan)
+                .map(msg -> msg.getSpan().getApiId())
+                .collect(Collectors.toList());
+    }
+
+    // --- Test doubles ---
+
+    static class TestSpan implements SpanType {
+        final int id;
+
+        TestSpan(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public String toString() {
+            return "TestSpan{id=" + id + '}';
+        }
+    }
+
+    static class TestSpanBatchService extends SpanGrpc.SpanImplBase {
+        final List<PSpanMessageBatch> receivedBatches = new CopyOnWriteArrayList<>();
+        final AtomicInteger totalRequestCount = new AtomicInteger();
+        final AtomicInteger maxConcurrent = new AtomicInteger();
+        final AtomicInteger currentConcurrent = new AtomicInteger();
+
+        final CountDownLatch requestArrivedLatch = new CountDownLatch(1);
+        final CountDownLatch serverBlockLatch;
+        final Supplier<PSpanResultBatch> responseSupplier;
+        final BooleanSupplier failMode;
+        final long responseDelayMillis;
+
+        TestSpanBatchService() {
+            this(false, null, () -> false, 0);
+        }
+
+        TestSpanBatchService(boolean blockServer,
+                             Supplier<PSpanResultBatch> responseSupplier,
+                             BooleanSupplier failMode,
+                             long responseDelayMillis) {
+            this.serverBlockLatch = new CountDownLatch(blockServer ? 1 : 0);
+            this.responseSupplier = responseSupplier;
+            this.failMode = failMode;
+            this.responseDelayMillis = responseDelayMillis;
+        }
+
+        static TestSpanBatchService blocking() {
+            return new TestSpanBatchService(true, null, () -> false, 0);
+        }
+
+        CountDownLatch getRequestArrivedLatch() {
+            return requestArrivedLatch;
+        }
+
+        void unblock() {
+            serverBlockLatch.countDown();
+        }
+
+        @Override
+        public void sendSpanBatch(PSpanMessageBatch request,
+                                  StreamObserver<PSpanResultBatch> responseObserver) {
+            int concurrent = currentConcurrent.incrementAndGet();
+            maxConcurrent.updateAndGet(prev -> Math.max(prev, concurrent));
+            totalRequestCount.incrementAndGet();
+            receivedBatches.add(request);
+
+            requestArrivedLatch.countDown();
+
+            try {
+                serverBlockLatch.await();
+
+                if (responseDelayMillis > 0) {
+                    Thread.sleep(responseDelayMillis);
+                }
+
+                if (failMode.getAsBoolean()) {
+                    responseObserver.onError(
+                            Status.INTERNAL.withDescription("test error").asException());
+                    return;
+                }
+
+                PSpanResultBatch response = (responseSupplier != null) ? responseSupplier.get() : null;
+                if (response == null) {
+                    response = PSpanResultBatch.getDefaultInstance();
+                }
+                responseObserver.onNext(response);
+                responseObserver.onCompleted();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                responseObserver.onError(Status.CANCELLED.asException());
+            } finally {
+                currentConcurrent.decrementAndGet();
+            }
+        }
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanBatchErrorResult.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanBatchErrorResult.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.receiver.grpc.service;
+
+import com.navercorp.pinpoint.common.util.ErrorId;
+import com.navercorp.pinpoint.grpc.trace.PPartialSuccess;
+import com.navercorp.pinpoint.grpc.trace.PSpanResultBatch;
+
+public class SpanBatchErrorResult {
+
+    private static final int DEFAULT_ERROR_MESSAGE_LIMIT = 3;
+
+    private final int errorMessageLimit;
+    private ErrorId errorId;
+    private long rejectedSpans;
+    private StringBuilder errorMessages;
+
+    public SpanBatchErrorResult() {
+        this(DEFAULT_ERROR_MESSAGE_LIMIT);
+    }
+
+    public SpanBatchErrorResult(int errorMessageLimit) {
+        this.errorMessageLimit = errorMessageLimit;
+    }
+
+    public ErrorId getErrorId() {
+        if (errorId == null) {
+            return ErrorId.EMPTY;
+        }
+        return errorId;
+    }
+
+    public void recordException(Throwable e) {
+        rejectedSpans++;
+        if (errorId == null) {
+            errorId = ErrorId.random();
+        }
+
+        if (rejectedSpans <= errorMessageLimit) {
+            if (errorMessages == null) {
+                errorMessages = new StringBuilder();
+            } else {
+                errorMessages.append(", ");
+            }
+            errorMessages.append(e.getMessage());
+        }
+    }
+
+    public PSpanResultBatch buildResultBatch() {
+        if (rejectedSpans == 0) {
+            return PSpanResultBatch.getDefaultInstance();
+        }
+        final PPartialSuccess.Builder partialSuccess = PPartialSuccess.newBuilder();
+        partialSuccess.setRejectedSpans(rejectedSpans);
+        partialSuccess.setErrorId(errorId.getId());
+
+        if (errorMessages != null) {
+            partialSuccess.setErrorMessage(errorMessages.toString());
+        }
+        return PSpanResultBatch.newBuilder()
+                .setPartialSuccess(partialSuccess)
+                .build();
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanService.java
@@ -26,10 +26,13 @@ import com.navercorp.pinpoint.grpc.server.ServerContext;
 import com.navercorp.pinpoint.grpc.trace.PSpan;
 import com.navercorp.pinpoint.grpc.trace.PSpanChunk;
 import com.navercorp.pinpoint.grpc.trace.PSpanMessage;
+import com.navercorp.pinpoint.grpc.trace.PSpanMessageBatch;
+import com.navercorp.pinpoint.grpc.trace.PSpanResultBatch;
 import com.navercorp.pinpoint.grpc.trace.SpanGrpc;
 import com.navercorp.pinpoint.io.request.UidFetcher;
 import com.navercorp.pinpoint.io.request.UidFetcherStreamService;
 import io.grpc.Context;
+import io.grpc.Status;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
@@ -44,9 +47,11 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author jaehong.kim
  */
 public class SpanService extends SpanGrpc.SpanImplBase {
+    private static final Status EXECUTOR_REJECTED = Status.RESOURCE_EXHAUSTED.withDescription("Executor rejected");
+
     private final Logger logger = LogManager.getLogger(this.getClass());
     private final boolean isDebug = logger.isDebugEnabled();
-    private final ThrottledLogger bandwidthLogger = ThrottledLogger.getLogger(logger, 100);
+    private final ThrottledLogger tLogger = ThrottledLogger.getLogger(logger, 100);
 
     private final AtomicLong serverStreamId = new AtomicLong();
 
@@ -74,6 +79,54 @@ public class SpanService extends SpanGrpc.SpanImplBase {
     }
 
     @Override
+    public void sendSpanBatch(PSpanMessageBatch request, StreamObserver<PSpanResultBatch> responseObserver) {
+        final Context current = Context.current();
+        final Runnable batchTask = current.wrap(() -> handleSpanBatch(current, request, responseObserver));
+        try {
+            executor.execute(batchTask);
+        } catch (RejectedExecutionException e) {
+            logger.warn("Failed to request. Executor rejected. header:{}", ServerContext.getAgentInfo(current));
+            responseObserver.onError(EXECUTOR_REJECTED.asException());
+        }
+    }
+
+    private void handleSpanBatch(Context current, PSpanMessageBatch request, StreamObserver<PSpanResultBatch> responseObserver) {
+        final UidFetcher fetcher = uidFetcherStreamService.newUidFetcher();
+        final SpanBatchErrorResult errorReporter = new SpanBatchErrorResult();
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        for (PSpanMessage spanMessage : request.getSpanList()) {
+            if (isDebug) {
+                logger.debug("SendSpanList PSpanMessage={}", MessageFormatUtils.debugLog(spanMessage));
+            }
+            if (spanMessage.hasSpan()) {
+                final PSpan span = spanMessage.getSpan();
+                final ServerRequest<PSpan> serverRequest = serverRequestFactory.newServerRequest(current, fetcher, MessageTypes.SPAN, span);
+                try {
+                    spanHandler.handleSimple(serverRequest);
+                } catch (Throwable e) {
+                    logger.warn("Failed to handle span. header={} spanErrorId={}", serverRequest.getHeader(), errorReporter.getErrorId(), e);
+                    errorReporter.recordException(e);
+                }
+            } else if (spanMessage.hasSpanChunk()) {
+                final PSpanChunk spanChunk = spanMessage.getSpanChunk();
+                final ServerRequest<PSpanChunk> serverRequest = serverRequestFactory.newServerRequest(current, fetcher, MessageTypes.SPANCHUNK, spanChunk);
+                try {
+                    spanCheckHandler.handleSimple(serverRequest);
+                } catch (Throwable e) {
+                    logger.warn("Failed to handle spanChunk. header={} spanErrorId={}", serverRequest.getHeader(), errorReporter.getErrorId(), e);
+                    errorReporter.recordException(e);
+                }
+            }
+        }
+        responseObserver.onNext(errorReporter.buildResultBatch());
+        responseObserver.onCompleted();
+    }
+
+    @Override
     public StreamObserver<PSpanMessage> sendSpan(final StreamObserver<Empty> responseStream) {
         final ServerCallStreamObserver<Empty> responseObserver = (ServerCallStreamObserver<Empty>) responseStream;
         long streamId = serverStreamId.incrementAndGet();
@@ -89,10 +142,11 @@ public class SpanService extends SpanGrpc.SpanImplBase {
         }
 
         final Context current = Context.current();
+        final Runnable spanTask = current.wrap(() -> spanDispatch(current, spanMessage, call, responseObserver));
         try {
-            executor.execute(current.wrap(() -> spanDispatch(current, spanMessage, call, responseObserver)));
+            executor.execute(spanTask);
         } catch (RejectedExecutionException e) {
-            logger.warn("Failed to request. Executor rejected. header:{}", ServerContext.getAgentInfo(current));
+            tLogger.warn("Failed to request. Executor rejected. header:{}", ServerContext.getAgentInfo(current));
         }
     }
 
@@ -124,7 +178,5 @@ public class SpanService extends SpanGrpc.SpanImplBase {
             responseObserver.onNextError(e);
         }
     }
-
-
 
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/StatService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/StatService.java
@@ -92,8 +92,9 @@ public class StatService extends StatGrpc.StatImplBase {
         }
 
         final Context current = Context.current();
+        final Runnable statTask = current.wrap(() -> statDispatch(current, statMessage, call, response));
         try {
-            executor.execute(current.wrap(() -> statDispatch(current, statMessage, call, response)));
+            executor.execute(statTask);
         } catch (RejectedExecutionException e) {
             logger.warn("Failed to request. Executor rejected. header:{}", ServerContext.getAgentInfo(current));
         }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/ErrorId.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/ErrorId.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.util;
+
+import java.util.Base64;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class ErrorId {
+
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+    private static final long EMPTY_ID = 0;
+
+    public static final ErrorId EMPTY = new ErrorId(EMPTY_ID);
+
+    private final long id;
+
+    private ErrorId(long id) {
+        this.id = id;
+    }
+
+    public static ErrorId of(long id) {
+        if (id == EMPTY_ID) {
+            return EMPTY;
+        }
+        return new ErrorId(id);
+    }
+
+    public static ErrorId random() {
+        long id;
+        do {
+            id = ThreadLocalRandom.current().nextLong();
+        } while (id == EMPTY_ID);
+        return new ErrorId(id);
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String toBase64() {
+        if (id == EMPTY_ID) {
+            return "";
+        }
+        byte[] bytes = new byte[BytesUtils.LONG_BYTE_LENGTH];
+        BytesUtils.writeLong(id, bytes, 0);
+        return ENCODER.encodeToString(bytes);
+    }
+
+    @Override
+    public String toString() {
+        return toBase64();
+    }
+}


### PR DESCRIPTION
This pull request introduces a new batch-based gRPC Span sender to the agent, allowing Spans to be sent in batches via a unary RPC, as an alternative to the existing streaming approach. The batch sender is configurable and disabled by default. The main changes include new configuration options, supporting code to read and apply these options, and the provider for the new batch sender.

**Key changes:**

### Configuration and Properties

* Added new configuration options for the Span batch sender (such as enable flag, batch size, flush interval, deadline, and max concurrent requests) to `pinpoint-root.config` and profile-specific configs, with the batch sender disabled by default. [[1]](diffhunk://#diff-20ae8b0977ce97a7e5f506eca7b7231a570a51523ac9b7b88d231d7bf26ebabcR130-R138) [[2]](diffhunk://#diff-1b874666a72b9059afa192ca19941ffc67c6e4db212614ca09958b5ba3adadcfR24-R25) [[3]](diffhunk://#diff-7b980b4ee645cc825e2ae038ae3cb6e040ba1c93bc1e558badc95ad6686f96c7R24-R25)

### Core Implementation

* Introduced the `SpanBatchSenderConfig` class to encapsulate batch sender settings, including default values and property bindings.
* Updated `GrpcTransportConfig` to include, read, and expose the `SpanBatchSenderConfig` for use throughout the agent. [[1]](diffhunk://#diff-974f5ea4460780d8db8840d043b5b9b265637831b8befdf29a6906b23dcf7037R158-R159) [[2]](diffhunk://#diff-974f5ea4460780d8db8840d043b5b9b265637831b8befdf29a6906b23dcf7037R194-R196) [[3]](diffhunk://#diff-974f5ea4460780d8db8840d043b5b9b265637831b8befdf29a6906b23dcf7037R217-R223) [[4]](diffhunk://#diff-974f5ea4460780d8db8840d043b5b9b265637831b8befdf29a6906b23dcf7037R428-R431) [[5]](diffhunk://#diff-974f5ea4460780d8db8840d043b5b9b265637831b8befdf29a6906b23dcf7037R470)

### Dependency Injection and Sender Selection

* Modified `GrpcModule` to select between the standard and batch span sender providers based on the new configuration, and to bind the new batch sender provider when enabled. [[1]](diffhunk://#diff-87bf61e282d59e8e1f4f8c57355b1d4a851e882029421abf59f52c1d3a7b3228R39) [[2]](diffhunk://#diff-87bf61e282d59e8e1f4f8c57355b1d4a851e882029421abf59f52c1d3a7b3228R61) [[3]](diffhunk://#diff-87bf61e282d59e8e1f4f8c57355b1d4a851e882029421abf59f52c1d3a7b3228L127-R129) [[4]](diffhunk://#diff-87bf61e282d59e8e1f4f8c57355b1d4a851e882029421abf59f52c1d3a7b3228L197-R199) [[5]](diffhunk://#diff-87bf61e282d59e8e1f4f8c57355b1d4a851e882029421abf59f52c1d3a7b3228R214-R221)

### New Batch Sender Provider

* Added the `SpanBatchGrpcDataSenderProvider` class, which constructs and provides the batch-based gRPC Span sender, wiring up all necessary dependencies and configuration.

These changes lay the groundwork for more efficient Span transmission and provide flexibility for future performance tuning and feature enablement.