### PR TITLE
[#noissue] Fix "No Data" text not clearing after data is loaded in ECharts

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Chart/Load/LoadChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Chart/Load/LoadChart.tsx
@@ -195,21 +195,19 @@ export const LoadChart = ({
         },
       },
       series,
-      graphic: !hasData
-        ? [
-            {
-              type: 'text',
-              left: 'center',
-              top: '30%',
-              style: {
-                text: emptyMessage,
-                fontSize: 14,
-                fill: '#999',
-                textAlign: 'center',
-              },
-            },
-          ]
-        : [],
+      graphic: [
+        {
+          type: 'text',
+          left: 'center',
+          top: '30%',
+          style: {
+            text: hasData ? '' : emptyMessage,
+            fontSize: 14,
+            fill: '#999',
+            textAlign: 'center',
+          },
+        },
+      ],
     });
   }, [chartData, chartColors, timezone, emptyMessage]);
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseAvgMax/ResponseAvgMaxChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseAvgMax/ResponseAvgMaxChart.tsx
@@ -113,22 +113,19 @@ export const ResponseAvgMaxChart = ({
           },
         },
       ],
-      graphic:
-        chartData.length === 0
-          ? [
-              {
-                type: 'text',
-                left: 'center',
-                top: 'middle',
-                style: {
-                  text: emptyMessage,
-                  fontSize: 14,
-                  fill: '#999',
-                  textAlign: 'center',
-                },
-              },
-            ]
-          : [],
+      graphic: [
+        {
+          type: 'text',
+          left: 'center',
+          top: 'middle',
+          style: {
+            text: chartData.length === 0 ? emptyMessage : '',
+            fontSize: 14,
+            fill: '#999',
+            textAlign: 'center',
+          },
+        },
+      ],
     });
   }, [chartData, categories, colors, emptyMessage]);
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseSummary/ResponseSummaryChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseSummary/ResponseSummaryChart.tsx
@@ -185,22 +185,19 @@ export const ResponseSummaryChart = ({
           },
         },
       ],
-      graphic:
-        chartData.length === 0
-          ? [
-              {
-                type: 'text',
-                left: 'center',
-                top: 'middle',
-                style: {
-                  text: emptyMessage,
-                  fontSize: 14,
-                  fill: '#999',
-                  textAlign: 'center',
-                },
-              },
-            ]
-          : [],
+      graphic: [
+        {
+          type: 'text',
+          left: 'center',
+          top: 'middle',
+          style: {
+            text: chartData.length === 0 ? emptyMessage : '',
+            fontSize: 14,
+            fill: '#999',
+            textAlign: 'center',
+          },
+        },
+      ],
     });
   }, [categories, chartData, colors, breakConfig, emptyMessage]);
 


### PR DESCRIPTION
ECharts setOption merges by default, so setting graphic: [] does not remove a previously rendered graphic element. Fixed by always keeping the graphic element and toggling its text content instead.