### PR TITLE
[#noissue] Extract Bucket builder initialization to constructor in RateLimitClientStreamServerInterceptor

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/flow/RateLimitClientStreamServerInterceptor.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/flow/RateLimitClientStreamServerInterceptor.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.grpc.server.flowcontrol.DefaultServerCallWrapper;
 import com.navercorp.pinpoint.grpc.server.flowcontrol.ServerCallWrapper;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
+import io.github.bucket4j.local.LocalBucketBuilder;
 import io.grpc.Context;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
@@ -45,6 +46,7 @@ public class RateLimitClientStreamServerInterceptor implements ServerInterceptor
     private final Executor executor;
 
     private final Bandwidth bandwidth;
+    private final LocalBucketBuilder bucketBuilder;
 
 
     public RateLimitClientStreamServerInterceptor(String name, final Executor executor, Bandwidth bandwidth, final long throttledLoggerRatio) {
@@ -55,6 +57,7 @@ public class RateLimitClientStreamServerInterceptor implements ServerInterceptor
         this.executor = Context.currentContextExecutor(executor);
 
         this.bandwidth = Objects.requireNonNull(bandwidth, "bandwidth");
+        this.bucketBuilder = Bucket.builder().addLimit(bandwidth);
 
         this.rejectLogger = ThrottledLogger.getLogger(logger, throttledLoggerRatio);
         this.bandwidthLogger = ThrottledLogger.getLogger(logger, throttledLoggerRatio);
@@ -70,7 +73,7 @@ public class RateLimitClientStreamServerInterceptor implements ServerInterceptor
         final ServerCall.Listener<ReqT> listener = next.startCall(call, headers);
 
         return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(listener) {
-            private final Bucket bucket = Bucket.builder().addLimit(bandwidth).build();
+            private final Bucket bucket = bucketBuilder.build();
 
             @Override
             public void onMessage(final ReqT message) {


### PR DESCRIPTION
…teLimitClientStreamServerInterceptor

This pull request refactors the `RateLimitClientStreamServerInterceptor` to improve the construction and reuse of the `Bucket` used for rate limiting. The main change is the introduction of a `LocalBucketBuilder` instance, which is initialized once and then used to build new `Bucket` instances, rather than creating a new builder each time. This makes the code cleaner and potentially more efficient.

**Refactoring and code simplification:**

* Added a `LocalBucketBuilder` field (`bucketBuilder`) to the `RateLimitClientStreamServerInterceptor` class, initialized with the provided `bandwidth`, allowing for reuse when constructing new `Bucket` instances. [[1]](diffhunk://#diff-cf76af1286844209f9036eadee617780d97ac09e55c19a9c6b5f1ba979fe185fR49) [[2]](diffhunk://#diff-cf76af1286844209f9036eadee617780d97ac09e55c19a9c6b5f1ba979fe185fR60)
* Updated the `interceptCall` method to use the shared `bucketBuilder` to build `Bucket` instances, rather than creating a new builder each time.

**Dependency update:**

* Imported `LocalBucketBuilder` from the `bucket4j` library to support the new builder pattern.