### PR TITLE
[#noissue] Add client stream check to RateLimitClientStreamServerInterceptor

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/flow/RateLimitClientStreamServerInterceptor.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/flow/RateLimitClientStreamServerInterceptor.java
@@ -26,6 +26,7 @@ import io.github.bucket4j.local.LocalBucketBuilder;
 import io.grpc.Context;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
@@ -65,10 +66,17 @@ public class RateLimitClientStreamServerInterceptor implements ServerInterceptor
 
     @Override
     public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(final ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        final MethodDescriptor<ReqT, RespT> methodDescriptor = call.getMethodDescriptor();
+
+        final MethodDescriptor.MethodType methodType = methodDescriptor.getType();
+        if (!isClientStream(methodType)) {
+            return next.startCall(call, headers);
+        }
+
         final ServerCallWrapper serverCall = newServerCallWrapper(call, headers);
         if (logger.isInfoEnabled()) {
             logger.info("Initialize {} interceptor. {}, headers={}, remoteAddr={} Bandwidth(capacity={}, refillTokens={})",
-                    this.name, call.getMethodDescriptor().getFullMethodName(), headers, serverCall.getRemoteAddr(), bandwidth.getCapacity(), bandwidth.getRefillTokens());
+                    this.name, methodDescriptor.getFullMethodName(), headers, serverCall.getRemoteAddr(), bandwidth.getCapacity(), bandwidth.getRefillTokens());
         }
         final ServerCall.Listener<ReqT> listener = next.startCall(call, headers);
 
@@ -99,6 +107,10 @@ public class RateLimitClientStreamServerInterceptor implements ServerInterceptor
                 }
             }
         };
+    }
+
+    private boolean isClientStream(MethodDescriptor.MethodType methodType) {
+        return methodType == MethodDescriptor.MethodType.CLIENT_STREAMING;
     }
 
     private <ReqT, RespT> ServerCallWrapper newServerCallWrapper(ServerCall<ReqT, RespT> call, Metadata headers) {


### PR DESCRIPTION
…rceptor

This pull request updates the `RateLimitClientStreamServerInterceptor` to only apply rate limiting to gRPC client streaming methods. The interceptor now checks the method type before applying its logic, improving efficiency and correctness by avoiding unnecessary processing for non-client-streaming calls.

**Interceptor logic improvements:**

* The `interceptCall` method now checks the gRPC method type using `MethodDescriptor` and only applies rate limiting if the method is of type `CLIENT_STREAMING`. Non-client-streaming calls bypass the rate limiting logic. [[1]](diffhunk://#diff-cf76af1286844209f9036eadee617780d97ac09e55c19a9c6b5f1ba979fe185fR69-R79) [[2]](diffhunk://#diff-cf76af1286844209f9036eadee617780d97ac09e55c19a9c6b5f1ba979fe185fR112-R115)
* Imports and logging have been updated to use the extracted `MethodDescriptor`. [[1]](diffhunk://#diff-cf76af1286844209f9036eadee617780d97ac09e55c19a9c6b5f1ba979fe185fR29) [[2]](diffhunk://#diff-cf76af1286844209f9036eadee617780d97ac09e55c19a9c6b5f1ba979fe185fR69-R79)