### PR TITLE
[#13541] Move executor from RateLimitClientStreamServerInterceptor to SpanService/StatService

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/grpc/config/GrpcSpanReceiverConfiguration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/grpc/config/GrpcSpanReceiverConfiguration.java
@@ -71,13 +71,11 @@ public class GrpcSpanReceiverConfiguration {
         }
 
         @Bean
-        public ServerInterceptor spanStreamExecutorInterceptor(@Qualifier("grpcSpanWorkerExecutor")
-                                                               Executor executor,
-                                                               @Qualifier("spanBandwidth")
+        public ServerInterceptor spanStreamExecutorInterceptor(@Qualifier("spanBandwidth")
                                                                Bandwidth bandwidth,
                                                                @Qualifier("grpcSpanStreamProperties")
                                                                GrpcStreamProperties properties) {
-            return new RateLimitClientStreamServerInterceptor("SpanStream", executor, bandwidth, properties.getThrottledLoggerRatio());
+            return new RateLimitClientStreamServerInterceptor("SpanStream", bandwidth, properties.getThrottledLoggerRatio());
         }
     }
 
@@ -85,11 +83,13 @@ public class GrpcSpanReceiverConfiguration {
     public ServerServiceDefinition spanServerServiceDefinition(SimpleHandler<PSpan> spanHandler,
                                                                SimpleHandler<PSpanChunk> spanCheckHandler,
                                                                UidFetcherStreamService uidFetcherStreamService,
+                                                               @Qualifier("grpcSpanWorkerExecutor")
+                                                               Executor executor,
                                                                @Qualifier("spanStreamExecutorInterceptor")
                                                                ServerInterceptor serverInterceptor,
                                                                ServerRequestFactory serverRequestFactory,
                                                                StreamCloseOnError streamCloseOnError) {
-        BindableService spanService = new SpanService(spanHandler, spanCheckHandler, uidFetcherStreamService, serverRequestFactory, streamCloseOnError);
+        BindableService spanService = new SpanService(spanHandler, spanCheckHandler, uidFetcherStreamService, executor, serverRequestFactory, streamCloseOnError);
         return ServerInterceptors.intercept(spanService, serverInterceptor);
     }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/grpc/config/GrpcStatReceiverConfiguration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/grpc/config/GrpcStatReceiverConfiguration.java
@@ -69,8 +69,8 @@ public class GrpcStatReceiverConfiguration {
         }
 
         @Bean
-        public ServerInterceptor statStreamExecutorInterceptor(@Qualifier("grpcStatWorkerExecutor") Executor executor, @Qualifier("statBandwidth") Bandwidth bandwidth, @Qualifier("grpcStatStreamProperties") GrpcStreamProperties properties) {
-            return new RateLimitClientStreamServerInterceptor("StatStream", executor, bandwidth, properties.getThrottledLoggerRatio());
+        public ServerInterceptor statStreamExecutorInterceptor(@Qualifier("statBandwidth") Bandwidth bandwidth, @Qualifier("grpcStatStreamProperties") GrpcStreamProperties properties) {
+            return new RateLimitClientStreamServerInterceptor("StatStream", bandwidth, properties.getThrottledLoggerRatio());
         }
     }
 
@@ -79,12 +79,13 @@ public class GrpcStatReceiverConfiguration {
                                                                SimpleHandler<PAgentStat> statHandler,
                                                                SimpleHandler<PAgentUriStat> uriStatHandler,
                                                                UidFetcherStreamService uidFetcherStreamService,
+                                                               @Qualifier("grpcStatWorkerExecutor") Executor executor,
                                                                @Qualifier("statStreamExecutorInterceptor") ServerInterceptor serverInterceptor,
                                                                ServerRequestFactory serverRequestFactory,
                                                                StreamCloseOnError streamCloseOnError) {
 
-        BindableService spanService = new StatService(statBatchHandler, statHandler, uriStatHandler, uidFetcherStreamService, serverRequestFactory, streamCloseOnError);
-        return ServerInterceptors.intercept(spanService, serverInterceptor);
+        BindableService statService = new StatService(statBatchHandler, statHandler, uriStatHandler, uidFetcherStreamService, executor, serverRequestFactory, streamCloseOnError);
+        return ServerInterceptors.intercept(statService, serverInterceptor);
     }
 
     @Bean

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/flow/RateLimitClientStreamServerInterceptor.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/flow/RateLimitClientStreamServerInterceptor.java
@@ -23,7 +23,6 @@ import com.navercorp.pinpoint.grpc.server.flowcontrol.ServerCallWrapper;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.local.LocalBucketBuilder;
-import io.grpc.Context;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -34,33 +33,26 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Objects;
-import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * @author jaehong.kim
  */
 public class RateLimitClientStreamServerInterceptor implements ServerInterceptor {
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final ThrottledLogger rejectLogger;
     private final ThrottledLogger bandwidthLogger;
     private final String name;
-    private final Executor executor;
 
     private final Bandwidth bandwidth;
     private final LocalBucketBuilder bucketBuilder;
 
 
-    public RateLimitClientStreamServerInterceptor(String name, final Executor executor, Bandwidth bandwidth, final long throttledLoggerRatio) {
+    public RateLimitClientStreamServerInterceptor(String name, Bandwidth bandwidth, final long throttledLoggerRatio) {
         this.name = Objects.requireNonNull(name, "name");
-
-        Objects.requireNonNull(executor, "executor");
-        // Context wrapper
-        this.executor = Context.currentContextExecutor(executor);
 
         this.bandwidth = Objects.requireNonNull(bandwidth, "bandwidth");
         this.bucketBuilder = Bucket.builder().addLimit(bandwidth);
 
-        this.rejectLogger = ThrottledLogger.getLogger(logger, throttledLoggerRatio);
         this.bandwidthLogger = ThrottledLogger.getLogger(logger, throttledLoggerRatio);
     }
 
@@ -82,27 +74,17 @@ public class RateLimitClientStreamServerInterceptor implements ServerInterceptor
 
         return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(listener) {
             private final Bucket bucket = bucketBuilder.build();
+            private final AtomicLong dropCount = new AtomicLong();
 
             @Override
             public void onMessage(final ReqT message) {
                 if (bucket.tryConsume(1)) {
-                    try {
-                        executor.execute(new Runnable() {
-                            @Override
-                            public void run() {
-                                delegate().onMessage(message);
-                            }
-                        });
-                    } catch (Throwable th) {
-                        if (rejectLogger.isInfoEnabled()) {
-                            rejectLogger.info("Failed to request. ThreadPool is exhausted. {} {}/{} {} count={}",
-                                    name, serverCall.getApplicationName(), serverCall.getAgentId(), serverCall.getRemoteAddr(), rejectLogger.getCounter());
-                        }
-                    }
+                    delegate().onMessage(message);
                 } else {
+                    long count = dropCount.incrementAndGet();
                     if (bandwidthLogger.isInfoEnabled()) {
-                        bandwidthLogger.info("Too many requests. Bandwidth exceeded. {} {}/{} {}",
-                                name, serverCall.getApplicationName(), serverCall.getAgentId(), serverCall.getRemoteAddr());
+                        bandwidthLogger.info("Too many requests. Bandwidth exceeded. {} {}/{} {} drop={}",
+                                name, serverCall.getApplicationName(), serverCall.getAgentId(), serverCall.getRemoteAddr(), count);
                     }
                 }
             }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanService.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.collector.receiver.grpc.service;
 
 import com.google.protobuf.Empty;
 import com.navercorp.pinpoint.collector.handler.SimpleHandler;
+import com.navercorp.pinpoint.common.profiler.logging.ThrottledLogger;
 import com.navercorp.pinpoint.common.server.io.MessageTypes;
 import com.navercorp.pinpoint.common.server.io.ServerRequest;
 import com.navercorp.pinpoint.grpc.MessageFormatUtils;
@@ -35,6 +36,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -43,12 +46,14 @@ import java.util.concurrent.atomic.AtomicLong;
 public class SpanService extends SpanGrpc.SpanImplBase {
     private final Logger logger = LogManager.getLogger(this.getClass());
     private final boolean isDebug = logger.isDebugEnabled();
+    private final ThrottledLogger bandwidthLogger = ThrottledLogger.getLogger(logger, 100);
 
     private final AtomicLong serverStreamId = new AtomicLong();
 
     private final SimpleHandler<PSpan> spanHandler;
     private final SimpleHandler<PSpanChunk> spanCheckHandler;
 
+    private final Executor executor;
     private final ServerRequestFactory serverRequestFactory;
     private final StreamCloseOnError streamCloseOnError;
     private final UidFetcherStreamService uidFetcherStreamService;
@@ -56,12 +61,14 @@ public class SpanService extends SpanGrpc.SpanImplBase {
     public SpanService(SimpleHandler<PSpan> spanHandler,
                        SimpleHandler<PSpanChunk> spanCheckHandler,
                        UidFetcherStreamService uidFetcherStreamService,
+                       Executor executor,
                        ServerRequestFactory serverRequestFactory,
                        StreamCloseOnError streamCloseOnError) {
         this.spanHandler = Objects.requireNonNull(spanHandler, "spanHandler");
         this.spanCheckHandler = Objects.requireNonNull(spanCheckHandler, "spanCheckHandler");
 
         this.uidFetcherStreamService = Objects.requireNonNull(uidFetcherStreamService, "uidFetcherStreamService");
+        this.executor = Objects.requireNonNull(executor, "executor");
         this.serverRequestFactory = Objects.requireNonNull(serverRequestFactory, "serverRequestFactory");
         this.streamCloseOnError = Objects.requireNonNull(streamCloseOnError, "streamCloseOnError");
     }
@@ -81,23 +88,28 @@ public class SpanService extends SpanGrpc.SpanImplBase {
             logger.debug("Send PSpan={}", MessageFormatUtils.debugLog(spanMessage));
         }
 
+        final Context current = Context.current();
+        try {
+            executor.execute(current.wrap(() -> spanDispatch(current, spanMessage, call, responseObserver)));
+        } catch (RejectedExecutionException e) {
+            logger.warn("Failed to request. Executor rejected. header:{}", ServerContext.getAgentInfo(current));
+        }
+    }
+
+    private void spanDispatch(Context context, PSpanMessage spanMessage, ServerCallStream<PSpanMessage, Empty> call, ServerCallStream<PSpanMessage, Empty> responseObserver) {
         if (spanMessage.hasSpan()) {
             PSpan span = spanMessage.getSpan();
-
-            Context current = Context.current();
             UidFetcher fetcher = call.getUidFetcher();
-            ServerRequest<PSpan> request = serverRequestFactory.newServerRequest(current, fetcher, MessageTypes.SPAN, span);
+            ServerRequest<PSpan> request = serverRequestFactory.newServerRequest(context, fetcher, MessageTypes.SPAN, span);
             this.dispatch(this.spanHandler, request, responseObserver);
         } else if (spanMessage.hasSpanChunk()) {
             PSpanChunk spanChunk = spanMessage.getSpanChunk();
-
-            Context current = Context.current();
             UidFetcher fetcher = call.getUidFetcher();
-            ServerRequest<PSpanChunk> request = serverRequestFactory.newServerRequest(current, fetcher, MessageTypes.SPANCHUNK, spanChunk);
+            ServerRequest<PSpanChunk> request = serverRequestFactory.newServerRequest(context, fetcher, MessageTypes.SPANCHUNK, spanChunk);
             this.dispatch(this.spanCheckHandler, request, responseObserver);
         } else {
             if (logger.isInfoEnabled()) {
-                logger.info("Found empty span message, header:{}", ServerContext.getAgentInfo());
+                logger.info("Found empty span message, header:{}", ServerContext.getAgentInfo(context));
             }
         }
     }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/StatService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/StatService.java
@@ -37,6 +37,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -51,6 +53,7 @@ public class StatService extends StatGrpc.StatImplBase {
 
     private final UidFetcherStreamService uidFetcherStreamService;
 
+    private final Executor executor;
     private final ServerRequestFactory serverRequestFactory;
     private final StreamCloseOnError streamCloseOnError;
 
@@ -62,12 +65,14 @@ public class StatService extends StatGrpc.StatImplBase {
                        SimpleHandler<PAgentStat> statHandler,
                        SimpleHandler<PAgentUriStat> uriStatHandler,
                        UidFetcherStreamService uidFetcherStreamService,
+                       Executor executor,
                        ServerRequestFactory serverRequestFactory,
                        StreamCloseOnError streamCloseOnError) {
         this.statBatchHandler = Objects.requireNonNull(statBatchHandler, "statBatchHandler");
         this.statHandler = Objects.requireNonNull(statHandler, "statHandler");
         this.uriStatHandler = Objects.requireNonNull(uriStatHandler, "uriStatHandler");
         this.uidFetcherStreamService = Objects.requireNonNull(uidFetcherStreamService, "uidFetcherStreamService");
+        this.executor = Objects.requireNonNull(executor, "executor");
         this.serverRequestFactory = Objects.requireNonNull(serverRequestFactory, "serverRequestFactory");
         this.streamCloseOnError = Objects.requireNonNull(streamCloseOnError, "streamCloseOnError");
     }
@@ -85,18 +90,28 @@ public class StatService extends StatGrpc.StatImplBase {
         if (isTrace) {
             logger.trace("Send PAgentStat={}", MessageFormatUtils.debugLog(statMessage));
         }
+
+        final Context current = Context.current();
+        try {
+            executor.execute(current.wrap(() -> statDispatch(current, statMessage, call, response)));
+        } catch (RejectedExecutionException e) {
+            logger.warn("Failed to request. Executor rejected. header:{}", ServerContext.getAgentInfo(current));
+        }
+    }
+
+    private void statDispatch(Context context, PStatMessage statMessage, ServerCallStream<PStatMessage, Empty> call, ServerCallStream<PStatMessage, Empty> response) {
         if (statMessage.hasAgentStat()) {
             PAgentStat agentStat = statMessage.getAgentStat();
-            this.dispatch(agentStat, MessageTypes.AGENT_STAT, statHandler, call.getUidFetcher(), response);
+            this.dispatch(agentStat, MessageTypes.AGENT_STAT, statHandler, call.getUidFetcher(), context, response);
         } else if (statMessage.hasAgentStatBatch()) {
             PAgentStatBatch agentStatBatch = statMessage.getAgentStatBatch();
-            this.dispatch(agentStatBatch, MessageTypes.AGENT_STAT_BATCH, statBatchHandler, call.getUidFetcher(), response);
+            this.dispatch(agentStatBatch, MessageTypes.AGENT_STAT_BATCH, statBatchHandler, call.getUidFetcher(), context, response);
         } else if (statMessage.hasAgentUriStat()) {
             PAgentUriStat agentUriStat = statMessage.getAgentUriStat();
-            this.dispatch(agentUriStat, MessageTypes.AGENT_URI_STAT, uriStatHandler, call.getUidFetcher(), response);
+            this.dispatch(agentUriStat, MessageTypes.AGENT_URI_STAT, uriStatHandler, call.getUidFetcher(), context, response);
         } else {
             if (logger.isInfoEnabled()) {
-                logger.info("Found empty stat message header:{}", ServerContext.getAgentInfo());
+                logger.info("Found empty stat message header:{}", ServerContext.getAgentInfo(context));
             }
         }
     }
@@ -105,8 +120,8 @@ public class StatService extends StatGrpc.StatImplBase {
                               MessageType messageType,
                               SimpleHandler<T> handler,
                               UidFetcher fetcher,
+                              Context context,
                               ServerCallStream<PStatMessage, Empty> responseObserver) {
-        final Context context = Context.current();
         final ServerRequest<T> request = this.serverRequestFactory.newServerRequest(context, fetcher, messageType, data);
         try {
             handler.handleSimple(request);

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/SpanServerTestMain.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/SpanServerTestMain.java
@@ -105,7 +105,7 @@ public class SpanServerTestMain {
     private ServerServiceDefinition newSpanBindableService(Executor executor) {
 
         Bandwidth bandwidth = Bandwidth.builder().capacity(1000).refillGreedy(200, Duration.ofSeconds(1)).build();
-        RateLimitClientStreamServerInterceptor rateLimit = new RateLimitClientStreamServerInterceptor("test-span", executor, bandwidth, 1);
+        RateLimitClientStreamServerInterceptor rateLimit = new RateLimitClientStreamServerInterceptor("test-span", bandwidth, 1);
 
         SimpleHandler<PSpan> handler1 = new MockSimpleHandler<>();
         SimpleHandler<PSpanChunk> handler2 = new MockSimpleHandler<>();
@@ -115,7 +115,7 @@ public class SpanServerTestMain {
         UidFetcher uidFetcher = mock(UidFetcher.class);
         when(uidFetcherStreamService.newUidFetcher()).thenReturn(uidFetcher);
 
-        SpanService spanService = new SpanService(handler1, handler2, uidFetcherStreamService, serverRequestFactory, StreamCloseOnError.FALSE);
+        SpanService spanService = new SpanService(handler1, handler2, uidFetcherStreamService, executor, serverRequestFactory, StreamCloseOnError.FALSE);
         return ServerInterceptors.intercept(spanService, rateLimit);
     }
 

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/StatServerTestMain.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/StatServerTestMain.java
@@ -73,7 +73,7 @@ public class StatServerTestMain {
     private ServerServiceDefinition newStatBindableService(Executor executor) {
 
         Bandwidth bandwidth = Bandwidth.builder().capacity(1000).refillGreedy(200, Duration.ofSeconds(1)).build();
-        RateLimitClientStreamServerInterceptor rateLimit = new RateLimitClientStreamServerInterceptor("test-stat", executor, bandwidth, 1);
+        RateLimitClientStreamServerInterceptor rateLimit = new RateLimitClientStreamServerInterceptor("test-stat", bandwidth, 1);
         SimpleHandler<PAgentStatBatch> agentStatBatch = new MockDispatchHandler<>();
         SimpleHandler<PAgentStat> agentStat = new MockDispatchHandler<>();
         SimpleHandler<PAgentUriStat> agentUriStat = new MockDispatchHandler<>();
@@ -85,7 +85,7 @@ public class StatServerTestMain {
 
 
         StatService statService = new StatService(agentStatBatch, agentStat, agentUriStat,
-                uidFetcherStreamService, serverRequestFactory, StreamCloseOnError.FALSE);
+                uidFetcherStreamService, executor, serverRequestFactory, StreamCloseOnError.FALSE);
         return ServerInterceptors.intercept(statService, rateLimit);
     }
 

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/flow/StreamRateLimitServerInterceptorTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/receiver/grpc/flow/StreamRateLimitServerInterceptorTest.java
@@ -1,6 +1,5 @@
 package com.navercorp.pinpoint.collector.receiver.grpc.flow;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Empty;
 import com.navercorp.pinpoint.grpc.Header;
 import com.navercorp.pinpoint.grpc.trace.PSpanMessage;
@@ -19,11 +18,8 @@ import org.mockito.Mockito;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
-import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,9 +28,8 @@ class StreamRateLimitServerInterceptorTest {
     @Test
     void interceptCall() {
         Bandwidth bandwidth = bandwidth();
-        Executor executor = MoreExecutors.directExecutor();
 
-        RateLimitClientStreamServerInterceptor interceptor = new RateLimitClientStreamServerInterceptor("span-service", executor, bandwidth, 1);
+        RateLimitClientStreamServerInterceptor interceptor = new RateLimitClientStreamServerInterceptor("span-service", bandwidth, 1);
 
         ServiceDescriptor desc = SpanGrpc.getServiceDescriptor();
         MethodDescriptor<PSpanMessage, Empty> methodDescriptor = (MethodDescriptor<PSpanMessage, Empty>) desc.getMethods().iterator().next();
@@ -53,33 +48,6 @@ class StreamRateLimitServerInterceptorTest {
         verify(serverCallListener).onMessage(any());
     }
 
-
-
-    @Test
-    void interceptCall_reject() {
-        Bandwidth bandwidth = bandwidth();
-        Executor executor = command -> {
-            throw new RejectedExecutionException("error");
-        };
-        RateLimitClientStreamServerInterceptor interceptor = new RateLimitClientStreamServerInterceptor("span-service", executor, bandwidth, 1);
-
-        ServiceDescriptor desc = SpanGrpc.getServiceDescriptor();
-        MethodDescriptor<PSpanMessage, Empty> methodDescriptor = (MethodDescriptor<PSpanMessage, Empty>) desc.getMethods().iterator().next();
-
-        ServerCall<PSpanMessage, Empty> call = getServerCall(methodDescriptor);
-
-        Metadata headers = getMetadata();
-
-        ServerCallHandler<PSpanMessage, Empty> handler = Mockito.mock(ServerCallHandler.class);
-        ServerCall.Listener<PSpanMessage> serverCallListener = Mockito.mock(ServerCall.Listener.class);
-
-        when(handler.startCall(call, headers)).thenReturn(serverCallListener);
-
-        ServerCall.Listener<PSpanMessage> listener = interceptor.interceptCall(call, headers, handler);
-        listener.onMessage(PSpanMessage.newBuilder().build());
-
-        verify(serverCallListener, never()).onMessage(any());
-    }
 
 
     private Bandwidth bandwidth() {
@@ -116,8 +84,7 @@ class StreamRateLimitServerInterceptorTest {
                 .capacity(1)
                 .refillGreedy(1, Duration.ofMinutes(1))
                 .build();
-        Executor executor = MoreExecutors.directExecutor();
-        RateLimitClientStreamServerInterceptor interceptor = new RateLimitClientStreamServerInterceptor("span-service", executor, bandwidth, 1);
+        RateLimitClientStreamServerInterceptor interceptor = new RateLimitClientStreamServerInterceptor("span-service", bandwidth, 1);
 
         ServiceDescriptor desc = SpanGrpc.getServiceDescriptor();
         MethodDescriptor<PSpanMessage, Empty> methodDescriptor = (MethodDescriptor<PSpanMessage, Empty>) desc.getMethods().iterator().next();


### PR DESCRIPTION
## Summary
- Extract Bucket builder initialization to constructor field
- Add client stream type check to skip rate limiting for non-streaming RPCs
- Move executor from interceptor to SpanService/StatService for clearer separation of concerns
- Add RejectedExecutionException handling in service layer

## Test plan
- [ ] Verify `StreamRateLimitServerInterceptorTest` passes
- [ ] Verify SpanService/StatService correctly dispatch via executor
- [ ] Verify rate limiting still works for client streaming RPCs