### PR TITLE
[#noissue] Add ServiceMap page with redirect from ServerMap

### DIFF
--- a/web-frontend/src/main/v3/apps/web/src/pages/ServerMap/index.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/ServerMap/index.tsx
@@ -1,11 +1,20 @@
 import { useAtomValue } from 'jotai';
 import { ServerMapPage } from '@pinpoint-fe/ui';
 import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
+import { APP_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { Navigate, useLocation, useParams } from 'react-router-dom';
 
 export default function ServerMap() {
   const configuration = useAtomValue(configurationAtom) as
     | (Configuration & Record<string, string>)
     | undefined;
+  const { application } = useParams<{ application?: string }>();
+  const { search } = useLocation();
+
+  if (configuration?.['experimental.enableServiceMap.value']) {
+    const applicationPath = application ? `/${application}` : '';
+    return <Navigate to={`${APP_PATH.SERVICE_MAP}${applicationPath}${search}`} replace />;
+  }
+
   return <ServerMapPage configuration={configuration} />;
 }

--- a/web-frontend/src/main/v3/apps/web/src/pages/ServiceMap/index.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/ServiceMap/index.tsx
@@ -1,0 +1,11 @@
+import { useAtomValue } from 'jotai';
+import { ServiceMapPage } from '@pinpoint-fe/ui';
+import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration } from '@pinpoint-fe/ui/src/constants';
+
+export default function ServiceMap() {
+  const configuration = useAtomValue(configurationAtom) as
+    | (Configuration & Record<string, string>)
+    | undefined;
+  return <ServiceMapPage configuration={configuration} />;
+}

--- a/web-frontend/src/main/v3/apps/web/src/routes/index.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/routes/index.tsx
@@ -22,6 +22,7 @@ import { ConfigurationOutlet } from '@pinpoint-fe/web/src/components/Layout/Conf
 import { RouteErrorFallback } from '@pinpoint-fe/ui/src/components/Error';
 
 import ServerMap from '@pinpoint-fe/web/src/pages/ServerMap';
+const ServiceMap = lazy(() => import('@pinpoint-fe/web/src/pages/ServiceMap'));
 const Realtime = lazy(() => import('@pinpoint-fe/web/src/pages/ServerMap/Realtime'));
 const ScatterOrHeatmapFullScreen = lazy(
   () => import('@pinpoint-fe/web/src/pages/ScatterOrHeatmapFullScreen'),
@@ -88,6 +89,11 @@ const router = createBrowserRouter(
                 {
                   path: `${APP_PATH.SERVER_MAP}/:application?`,
                   element: <ServerMap />,
+                  loader: serverMapRouteLoader,
+                },
+                {
+                  path: `${APP_PATH.SERVICE_MAP}/:application?`,
+                  element: <ServiceMap />,
                   loader: serverMapRouteLoader,
                 },
                 {

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServiceMapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServiceMapFetcher.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { useSetAtom } from 'jotai';
+import { MergedEdge, MergedNode } from '@pinpoint-fe/server-map';
+import {
+  serverMapDataAtom,
+  currentServerAtom,
+  serverMapCurrentTargetAtom,
+} from '@pinpoint-fe/ui/src/atoms';
+import {
+  useExperimentals,
+  useGetServiceMapData,
+  useServerMapSearchParameters,
+} from '@pinpoint-fe/ui/src/hooks';
+import { GetServerMap, GetServiceMap } from '@pinpoint-fe/ui/src/constants';
+import { useTranslation } from 'react-i18next';
+import { getServiceMapBaseNodeId, getServerImagePath } from '@pinpoint-fe/ui/src/utils';
+import { ServerMapCore, ServerMapCoreProps } from './ServerMapCore';
+
+export type ServiceMapFetcherProps = Pick<
+  ServerMapCoreProps,
+  'onClickMenuItem' | 'onApplyChangedOption' | 'queryOption'
+>;
+
+export const ServiceMapFetcher = ({ ...props }: ServiceMapFetcherProps) => {
+  const setDataAtom = useSetAtom(serverMapDataAtom);
+  const setCurrentServer = useSetAtom(currentServerAtom);
+  const setServerMapCurrentTarget = useSetAtom(serverMapCurrentTargetAtom);
+  const { application, dateRange, queryOption } = useServerMapSearchParameters();
+  const experimentalOption = useExperimentals();
+  const useStatisticsAgentState = experimentalOption.statisticsAgentState.value || true;
+
+  const { data, isLoading, error } = useGetServiceMapData({
+    applicationName: application?.applicationName,
+    serviceTypeName: application?.serviceType,
+    from: dateRange.from.getTime(),
+    to: dateRange.to.getTime(),
+    calleeRange: queryOption.inbound,
+    callerRange: queryOption.outbound,
+    wasOnly: !!queryOption.wasOnly,
+    bidirectional: !!queryOption.bidirectional,
+    useStatisticsAgentState,
+  });
+  const { t } = useTranslation();
+
+  // GetServiceMap.Response shares the same runtime shape for server-map rendering
+  React.useEffect(() => {
+    setDataAtom(data as unknown as GetServerMap.Response);
+  }, [data]);
+
+  const applicationMapData = data?.applicationMapData;
+  const baseNodeId = getServiceMapBaseNodeId({ application, applicationMapData });
+
+  const handleClickNode: ServerMapCoreProps['onClickNode'] = ({ data, eventType }) => {
+    const { label, type, imgPath, id, nodes } = data as MergedNode;
+    if (eventType === 'left' || eventType === 'programmatic') {
+      setServerMapCurrentTarget({
+        id,
+        applicationName: label,
+        serviceType: type,
+        imgPath: imgPath!,
+        nodes,
+        type: 'node',
+      });
+      setCurrentServer(undefined);
+    }
+  };
+
+  const handleClickEdge: ServerMapCoreProps['onClickEdge'] = ({ data, eventType }) => {
+    const { id, source, target, edges } = data as MergedEdge;
+    if (eventType === 'left') {
+      setServerMapCurrentTarget({
+        id,
+        source,
+        target,
+        edges,
+        type: 'edge',
+      });
+      setCurrentServer(undefined);
+    }
+  };
+
+  const handleMergeStateChange = () => {
+    if (data && baseNodeId) {
+      const baseNode = applicationMapData?.nodeDataArray.find(
+        (node): node is GetServiceMap.NodeData =>
+          !GetServiceMap.isServiceGroupNode(node) && node.key === baseNodeId,
+      );
+      if (baseNode) {
+        setServerMapCurrentTarget({
+          id: baseNode.key,
+          applicationName: baseNode.applicationName,
+          serviceType: baseNode.serviceType,
+          imgPath: getServerImagePath(baseNode),
+          type: 'node',
+        });
+      }
+    }
+  };
+
+  return (
+    <ServerMapCore
+      data={(data as unknown as GetServerMap.Response) || {}}
+      isLoading={isLoading}
+      error={error}
+      forceLayoutUpdate={true}
+      onClickNode={handleClickNode}
+      onClickEdge={handleClickEdge}
+      onMergeStateChange={handleMergeStateChange}
+      baseNodeId={baseNodeId}
+      inputPlaceHolder={t('COMMON.SEARCH_INPUT')}
+      {...props}
+    />
+  );
+};

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/index.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/index.tsx
@@ -4,3 +4,4 @@ export * from './ServerMapCore';
 export * from './ServerMapSkeleton';
 export * from './ServerMapMenu';
 export * from './ServerMapFetcher';
+export * from './ServiceMapFetcher';

--- a/web-frontend/src/main/v3/packages/ui/src/constants/EndPoints.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/EndPoints.ts
@@ -7,6 +7,7 @@ export const SERVER_TIME = `${LOCAL_API_PATH}/serverTime`;
 export const APPLICATION_LIST = `${LOCAL_API_PATH}/applications`;
 // export const = '/getServerMapData';
 export const SERVER_MAP_DATA_V2 = `${LOCAL_API_PATH}/servermap/serverMap`;
+export const SERVICE_MAP_DATA = `${LOCAL_API_PATH}/servermap/serviceMap`;
 // export const RESPONSE_TIME_HISTOGRAM_DATA_V2 = `${LOCAL_API_PATH}/servermap/getResponseTimeHistogramDataV2`;
 export const HISTOGRAM_STATISTICS = `${LOCAL_API_PATH}/histogram/statistics`;
 export const HISTOGRAM_STATISTICS_LINKS = `${LOCAL_API_PATH}/histogram/statistics/links`;

--- a/web-frontend/src/main/v3/packages/ui/src/constants/path.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/path.ts
@@ -23,6 +23,7 @@ export const APP_PATH = {
   HEATMAP_FULL_SCREEN: '/heatmapFullScreenMode',
   SERVER_MAP_REALTIME: '/serverMap/realtime',
   SERVER_MAP: '/serverMap',
+  SERVICE_MAP: '/serviceMap',
   SYSTEM_METRIC: '/systemMetric',
   THREAD_DUMP: '/threadDump',
   TRANSACTION_DETAIL: '/transactionDetail',

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/Configuration.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/Configuration.ts
@@ -18,6 +18,8 @@ export interface Configuration {
   'experimental.enableHeatmap.value': boolean;
   'experimental.enableHeatmap.description': string;
   'experimental.enableServerMapRealTime.value': boolean;
+  'experimental.enableServiceMap.value': boolean;
+  'experimental.enableServiceMap.description': string;
   'experimental.enableServerSideScanForScatter.description': string;
   'experimental.useStatisticsAgentState.value': boolean;
   'experimental.sampleScatter.description': string;

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/GetServiceMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/GetServiceMap.ts
@@ -1,0 +1,38 @@
+import { GetServerMap } from './GetServerMap';
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace GetServiceMap {
+  export interface Parameters extends GetServerMap.Parameters {
+    keepServiceNames?: string[];
+  }
+
+  export interface Response {
+    applicationMapData: ApplicationMapData;
+  }
+
+  export interface ApplicationMapData {
+    range: GetServerMap.Range;
+    timestamp: number[];
+    linkDataArray: GetServerMap.LinkData[];
+    nodeDataArray: NodeViewEntry[];
+  }
+
+  /** Individual app node in serviceMap — key format: "serviceName^applicationName^serviceType" */
+  export interface NodeData extends GetServerMap.NodeData {
+    serviceName: string;
+  }
+
+  /** Collapsed service group node — key format: "serviceName" */
+  export interface ServiceGroupNodeData {
+    key: string;
+    type: 'service';
+    serviceName: string;
+    nodes: NodeData[];
+  }
+
+  export type NodeViewEntry = NodeData | ServiceGroupNodeData;
+
+  export function isServiceGroupNode(node: NodeViewEntry): node is ServiceGroupNodeData {
+    return (node as ServiceGroupNodeData).type === 'service';
+  }
+}

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/index.ts
@@ -24,6 +24,7 @@ export * from './GetApdexScore';
 export * from './GetHeatmapAppData';
 export * from './GetScatter';
 export * from './GetServerMap';
+export * from './GetServiceMap';
 export * from './GetHistogramStatistics';
 export * from './HeatmapDrag';
 export * from './InspectorAgentChart';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/index.ts
@@ -37,6 +37,7 @@ export * from './useGetOtlpMetricDefUserDefined';
 export * from './useGetScatterData';
 export * from './useGetScatterRealtimeData';
 export * from './useGetServerMapDataV2';
+export * from './useGetServiceMapData';
 export * from './useGetSeverTime';
 export * from './useGetSystemMetricChartData';
 export * from './useGetSystemMetricHostData';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetServiceMapData.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetServiceMapData.ts
@@ -1,0 +1,29 @@
+import { GetServiceMap, END_POINTS } from '@pinpoint-fe/ui/src/constants';
+import { convertParamsToQueryString } from '@pinpoint-fe/ui/src/utils';
+import { useQuery } from '@tanstack/react-query';
+import { queryFn } from './reactQueryHelper';
+
+const getQueryString = (queryParams: Partial<GetServiceMap.Parameters>) => {
+  if (
+    queryParams.useStatisticsAgentState !== null &&
+    queryParams.useStatisticsAgentState !== undefined &&
+    queryParams.applicationName &&
+    queryParams.serviceTypeName &&
+    queryParams.from &&
+    queryParams.to
+  ) {
+    return '?' + convertParamsToQueryString(queryParams);
+  }
+  return '';
+};
+
+export const useGetServiceMapData = (params: Partial<GetServiceMap.Parameters>) => {
+  const queryString = getQueryString(params);
+
+  return useQuery<GetServiceMap.Response>({
+    queryKey: [END_POINTS.SERVICE_MAP_DATA, queryString],
+    queryFn: queryFn(`${END_POINTS.SERVICE_MAP_DATA}${queryString}`),
+    enabled: !!queryString,
+    gcTime: 30000,
+  });
+};

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapOnClickMenuItem.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapOnClickMenuItem.ts
@@ -31,6 +31,36 @@ export function useServerMapOnClickMenuItem<
 }) {
   const serverMapData = useAtomValue(serverMapDataAtom);
 
+  // Extracts correct applicationName/serviceType from atom data, overriding
+  // values parsed from node/edge IDs. This is necessary because serviceMap uses
+  // "serviceName^applicationName^serviceType" key format which getDefaultFilters
+  // cannot parse correctly.
+  const getAtomApplicationInfo = (data: Node | Edge): Partial<FilteredMap.FilterState> => {
+    if ('source' in data) {
+      const edgeData = data as Edge;
+      const link = (serverMapData?.applicationMapData?.linkDataArray as R[])?.find(
+        (l) => l?.key === edgeData.id,
+      );
+      if (link?.sourceInfo && link?.targetInfo) {
+        return {
+          fromApplication: link.sourceInfo.applicationName,
+          fromServiceType: link.sourceInfo.serviceType,
+          toApplication: link.targetInfo.applicationName,
+          toServiceType: link.targetInfo.serviceType,
+        };
+      }
+    } else if ('type' in data) {
+      const nodeData = data as Node;
+      const node = (serverMapData?.applicationMapData?.nodeDataArray as T[])?.find(
+        (n) => n?.key === nodeData.id,
+      );
+      if (node) {
+        return { applicationName: node.applicationName, serviceType: node.serviceType };
+      }
+    }
+    return {};
+  };
+
   return (type: SERVERMAP_MENU_FUNCTION_TYPE, data: Node | Edge) => {
     if (type === SERVERMAP_MENU_FUNCTION_TYPE.FILTER_WIZARD) {
       let serverInfos: Parameters<typeof getDefaultFilters>[1];
@@ -53,11 +83,17 @@ export function useServerMapOnClickMenuItem<
         };
       }
 
-      setFilter?.(getDefaultFilters(data, serverInfos));
+      setFilter?.({
+        ...getDefaultFilters(data, serverInfos),
+        ...getAtomApplicationInfo(data),
+      } as FilteredMap.FilterState);
       setShowFilter?.(true);
       setShowFilterConfig?.(true);
     } else if (type === SERVERMAP_MENU_FUNCTION_TYPE.FILTER_TRANSACTION) {
-      const defaultFilterState = getDefaultFilters(data);
+      const defaultFilterState = {
+        ...getDefaultFilters(data),
+        ...getAtomApplicationInfo(data),
+      } as FilteredMap.FilterState;
       const link = (serverMapData?.applicationMapData?.linkDataArray as R[])?.find(
         (l) => l?.key === data?.id,
       );

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ServiceMap.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ServiceMap.tsx
@@ -1,0 +1,256 @@
+import React from 'react';
+import { useAtom, useAtomValue } from 'jotai';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+  getServiceMapPath,
+  getRealtimePath,
+  convertParamsToQueryString,
+  getServerImagePath,
+  getFormattedDateRange,
+} from '@pinpoint-fe/ui/src/utils';
+import { useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import {
+  serverMapDataAtom,
+  serverMapCurrentTargetAtom,
+  CurrentTarget,
+} from '@pinpoint-fe/ui/src/atoms';
+import {
+  FilteredMapType as FilteredMap,
+  GetServerMap,
+  GetServiceMap,
+  Configuration,
+} from '@pinpoint-fe/ui/src/constants';
+import { IoMdClose } from 'react-icons/io';
+import {
+  DatetimePicker,
+  DatetimePickerChangeHandler,
+  FilterWizard,
+  MainHeader,
+  LayoutWithHorizontalResizable,
+  ApplicationCombinedList,
+  HelpPopover,
+  ApplicationCombinedListProps,
+  ErrorBoundary,
+} from '@pinpoint-fe/ui';
+import { PiTreeStructureDuotone } from 'react-icons/pi';
+import {
+  useFilterWizardOnClickApply,
+  useServerMapOnClickMenuItem,
+} from '@pinpoint-fe/ui/src/hooks/serverMap';
+import { ServerMapChartsBoard } from '@pinpoint-fe/ui/src/components/ServerMap/ServerMapChartBoard';
+import { ServerMapSkeleton } from '@pinpoint-fe/ui/src/components/ServerMap/ServerMapSkeleton';
+import { ServiceMapFetcher } from '@pinpoint-fe/ui/src/components/ServerMap/ServiceMapFetcher';
+
+export interface ServiceMapPageProps {
+  authorizationGuideUrl?: string;
+  configuration?: Configuration & Record<string, string>;
+  ApplicationList?: (props: ApplicationCombinedListProps) => React.ReactElement;
+}
+
+const SERVICEMAP_CONTAINER_ID = 'service-map-main-container';
+
+export const ServiceMapPage = ({
+  authorizationGuideUrl,
+  configuration,
+  ApplicationList = ApplicationCombinedList,
+}: ServiceMapPageProps) => {
+  const periodMax = configuration?.[`periodMax.serverMap`];
+  const periodInterval = configuration?.[`periodInterval.serverMap`];
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+  const { dateRange, application, searchParameters, queryOption, pathname } =
+    useServerMapSearchParameters();
+  const [serverMapCurrentTarget, setServerMapCurrentTarget] = useAtom(serverMapCurrentTargetAtom);
+  const serverMapData = useAtomValue(serverMapDataAtom);
+  const [showFilter, setShowFilter] = React.useState(false);
+  const [filter, setFilter] = React.useState<FilteredMap.FilterState>();
+  const { t } = useTranslation();
+
+  React.useEffect(() => {
+    initPage();
+  }, [pathname]);
+
+  React.useEffect(() => {
+    setShowFilter(false);
+
+    if (
+      serverMapData &&
+      serverMapData?.applicationMapData?.nodeDataArray &&
+      serverMapData?.applicationMapData?.nodeDataArray.length
+    ) {
+      let currentTarget: CurrentTarget;
+      const nodeDataArray = serverMapData.applicationMapData.nodeDataArray as (
+        | GetServiceMap.NodeData
+        | GetServiceMap.ServiceGroupNodeData
+      )[];
+      const linkDataArray = serverMapData.applicationMapData.linkDataArray as GetServerMap.LinkData[];
+
+      const isTargetIncluded =
+        serverMapCurrentTarget &&
+        (nodeDataArray.some(({ key }) => key === serverMapCurrentTarget.id) ||
+          linkDataArray.some(({ key }) => key === serverMapCurrentTarget.id));
+
+      if (isTargetIncluded || serverMapCurrentTarget?.nodes || serverMapCurrentTarget?.edges) {
+        currentTarget = serverMapCurrentTarget;
+        setServerMapCurrentTarget(currentTarget);
+      } else {
+        // ServiceMap node keys use "serviceName^applicationName^serviceType" format,
+        // so find the base node by matching applicationName and serviceType fields.
+        const applicationInfo = nodeDataArray.find(
+          (node): node is GetServiceMap.NodeData =>
+            !GetServiceMap.isServiceGroupNode(node) &&
+            (node.applicationName === application?.applicationName &&
+              (node.serviceType === application?.serviceType ||
+                node.serviceType === 'UNAUTHORIZED')),
+        );
+
+        if (applicationInfo) {
+          const { key, applicationName, serviceType } = applicationInfo;
+          currentTarget = {
+            id: key,
+            applicationName,
+            serviceType,
+            imgPath: getServerImagePath({ applicationName, serviceType }),
+            type: 'node',
+          };
+          setServerMapCurrentTarget(currentTarget);
+        }
+      }
+    } else {
+      setServerMapCurrentTarget(undefined);
+    }
+  }, [serverMapData]);
+
+  const handleChangeDateRangePicker = React.useCallback(
+    (({ formattedDates: formattedDate, isRealtime }) => {
+      if (isRealtime) {
+        navigate(`${getRealtimePath(application!)}`);
+      } else {
+        navigate(
+          `${getServiceMapPath(application!)}?${convertParamsToQueryString({
+            ...formattedDate,
+            ...queryOption,
+          })}`,
+        );
+      }
+    }) as DatetimePickerChangeHandler,
+    [application?.applicationName, queryOption],
+  );
+
+  const initPage = () => {
+    setServerMapCurrentTarget(undefined);
+    setShowFilter(false);
+  };
+
+  const handleClickApply = useFilterWizardOnClickApply<GetServerMap.LinkData>({
+    from: searchParameters.from,
+    to: searchParameters.to,
+  });
+
+  const handleClickMenuItem = useServerMapOnClickMenuItem<
+    GetServerMap.NodeData,
+    GetServerMap.LinkData
+  >({
+    from: searchParameters.from,
+    to: searchParameters.to,
+    setFilter,
+    setShowFilter,
+  });
+
+  return (
+    <div className="flex flex-col flex-1 h-full">
+      <MainHeader
+        title={
+          <div className="flex items-center gap-2">
+            <PiTreeStructureDuotone />
+            <div className="flex items-center gap-1">
+              Servicemap
+              <HelpPopover helpKey="HELP_VIEWER.SERVER_MAP" />
+            </div>
+          </div>
+        }
+      >
+        <ApplicationList
+          open={!application}
+          selectedApplication={application}
+          onClickApplication={(application) => navigate(getServiceMapPath(application))}
+        />
+        {application && (
+          <div className="flex gap-1 ml-auto">
+            <DatetimePicker
+              enableRealtimeButton
+              from={searchParameters.from}
+              to={searchParameters.to}
+              onChange={handleChangeDateRangePicker}
+              maxDateRangeDays={periodMax}
+              outOfDateRangeMessage={t('DATE_RANGE_PICKER.MAX_SEARCH_PERIOD', {
+                maxSearchPeriod: periodMax,
+              })}
+              timeUnits={periodInterval}
+            />
+            <HelpPopover helpKey="HELP_VIEWER.NAVBAR" />
+          </div>
+        )}
+      </MainHeader>
+      {application && (
+        <div
+          id={SERVICEMAP_CONTAINER_ID}
+          className="relative flex-1 h-full overflow-x-hidden"
+          ref={containerRef}
+        >
+          <LayoutWithHorizontalResizable disabled={!serverMapCurrentTarget}>
+            <div className="relative w-full h-full">
+              {application && (
+                <>
+                  {showFilter && (
+                    <div className="absolute top-3 left-3 z-[1] bg-background rounded-lg shadow-lg border">
+                      <button
+                        className="absolute text-xl top-3 right-3 text-muted-foreground"
+                        onClick={() => setShowFilter(false)}
+                      >
+                        <IoMdClose />
+                      </button>
+                      <FilterWizard
+                        hideStatus={true}
+                        tempFilter={filter}
+                        openConfigures={true}
+                        onClickApply={handleClickApply}
+                      />
+                    </div>
+                  )}
+                  <ErrorBoundary>
+                    <React.Suspense fallback={<ServerMapSkeleton className="w-full h-full" />}>
+                      <ServiceMapFetcher
+                        queryOption={queryOption}
+                        onApplyChangedOption={(option) => {
+                          navigate(
+                            `${getServiceMapPath(application)}?${convertParamsToQueryString({
+                              ...getFormattedDateRange(dateRange),
+                              ...option,
+                            })}`,
+                          );
+                        }}
+                        onClickMenuItem={handleClickMenuItem}
+                      />
+                    </React.Suspense>
+                  </ErrorBoundary>
+                </>
+              )}
+            </div>
+            {({ currentPanelWidth, SERVER_LIST_WIDTH, resizeHandleWidth }) => (
+              <ServerMapChartsBoard
+                authorizationGuideUrl={authorizationGuideUrl}
+                currentPanelWidth={currentPanelWidth}
+                SERVER_LIST_WIDTH={SERVER_LIST_WIDTH}
+                resizeHandleWidth={resizeHandleWidth}
+                SERVERMAP_CONTAINER_ID={SERVICEMAP_CONTAINER_ID}
+                configuration={configuration}
+              />
+            )}
+          </LayoutWithHorizontalResizable>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web-frontend/src/main/v3/packages/ui/src/pages/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/index.ts
@@ -7,6 +7,7 @@ export * from './OpenTelemetry';
 export * from './Realtime';
 export * from './ScatterOrHeatmapFullScreen';
 export * from './ServerMap';
+export * from './ServiceMap';
 export * from './SystemMetric';
 export * from './TransactionList';
 export * from './TransactionDetail';

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.ts
@@ -65,6 +65,8 @@ export const getHostGroupPath =
 
 /** /serverMap */
 export const getServerMapPath = getApplicationPath(APP_PATH.SERVER_MAP);
+/** /serviceMap */
+export const getServiceMapPath = getApplicationPath(APP_PATH.SERVICE_MAP);
 /** /realtime */
 export const getRealtimePath = getApplicationPath(APP_PATH.SERVER_MAP_REALTIME);
 /** /scatterFullScreenMode */

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
@@ -2,6 +2,7 @@ import {
   ApplicationType,
   FilteredMapType as FilteredMap,
   GetServerMap,
+  GetServiceMap,
 } from '@pinpoint-fe/ui/src/constants';
 import { Edge as ServerMapEdge, Node as ServerMapNode } from '@pinpoint-fe/server-map';
 
@@ -22,6 +23,40 @@ export const getBaseNodeId = ({
     return nodeList.length === 0 || nodeList.some(({ key }: { key: string }) => key === baseNodeId)
       ? baseNodeId
       : baseNodeId.replace(/(.*)\^(.*)/i, '$1^UNAUTHORIZED');
+  }
+  return '';
+};
+
+/**
+ * Returns the base node key for a serviceMap response.
+ * ServiceMap node keys use the format "serviceName^applicationName^serviceType",
+ * so we find the node by matching applicationName and serviceType fields.
+ */
+export const getServiceMapBaseNodeId = ({
+  application,
+  applicationMapData,
+}: {
+  application: ApplicationType | null;
+  applicationMapData?: GetServiceMap.ApplicationMapData;
+}): string => {
+  if (application && applicationMapData) {
+    const nodeList = applicationMapData.nodeDataArray;
+
+    const matchingNode = nodeList.find(
+      (node): node is GetServiceMap.NodeData =>
+        !GetServiceMap.isServiceGroupNode(node) &&
+        node.applicationName === application.applicationName &&
+        node.serviceType === application.serviceType,
+    );
+    if (matchingNode) return matchingNode.key;
+
+    const unauthorizedNode = nodeList.find(
+      (node): node is GetServiceMap.NodeData =>
+        !GetServiceMap.isServiceGroupNode(node) &&
+        node.applicationName === application.applicationName &&
+        node.serviceType === 'UNAUTHORIZED',
+    );
+    if (unauthorizedNode) return unauthorizedNode.key;
   }
   return '';
 };


### PR DESCRIPTION


- Redirect /serverMap to /serviceMap when experimental.enableServiceMap.value is true
- Add /serviceMap route backed by /api/servermap/serviceMap endpoint
- Handle serviceMap's "serviceName^applicationName^serviceType" node key format by adding getServiceMapBaseNodeId utility
- Add GetServiceMap.NodeData type with serviceName field