### PR TITLE
[#13590] Introduce human-readable Timestamp type for controller parameters

### DIFF
--- a/commons-timeseries/pom.xml
+++ b/commons-timeseries/pom.xml
@@ -30,6 +30,11 @@
 
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>

--- a/commons-timeseries/src/main/java/com/navercorp/pinpoint/common/timeseries/time/Range.java
+++ b/commons-timeseries/src/main/java/com/navercorp/pinpoint/common/timeseries/time/Range.java
@@ -51,12 +51,24 @@ public final class Range {
         return between(from.toEpochMilli(), to.toEpochMilli());
     }
 
+    public static Range between(Timestamp from, Timestamp to) {
+        Objects.requireNonNull(from, "from");
+        Objects.requireNonNull(to, "to");
+        return between(from.getEpochMillis(), to.getEpochMillis());
+    }
+
     public static Range unchecked(long from, long to) {
         return unchecked(ofEpochMilli(from), ofEpochMilli(to));
     }
 
     public static Range unchecked(Instant from, Instant to) {
         return new Range(from.toEpochMilli(), to.toEpochMilli());
+    }
+
+    public static Range unchecked(Timestamp from, Timestamp to) {
+        Objects.requireNonNull(from, "from");
+        Objects.requireNonNull(to, "to");
+        return new Range(from.getEpochMillis(), to.getEpochMillis());
     }
 
     public long getFrom() {

--- a/commons-timeseries/src/main/java/com/navercorp/pinpoint/common/timeseries/time/Timestamp.java
+++ b/commons-timeseries/src/main/java/com/navercorp/pinpoint/common/timeseries/time/Timestamp.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.timeseries.time;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+/**
+ * @author emeroad
+ */
+public final class Timestamp {
+
+    private final long epochMillis;
+
+    private Timestamp(long epochMillis) {
+        if (epochMillis < 0) {
+            throw new IllegalArgumentException("epochMillis must not be negative: " + epochMillis);
+        }
+        this.epochMillis = epochMillis;
+    }
+
+    public static Timestamp ofEpochMilli(long epochMillis) {
+        return new Timestamp(epochMillis);
+    }
+
+    public static Timestamp valueOf(String dateTime) {
+        Objects.requireNonNull(dateTime, "dateTime");
+
+        if (StringUtils.isNumeric(dateTime)) {
+            return new Timestamp(Long.parseLong(dateTime));
+        }
+        long epochMillis = OffsetDateTime.parse(dateTime).toInstant().toEpochMilli();
+        return new Timestamp(epochMillis);
+    }
+
+    public long getEpochMillis() {
+        return epochMillis;
+    }
+
+    public Instant toInstant() {
+        return Instant.ofEpochMilli(epochMillis);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Timestamp timestamp = (Timestamp) o;
+        return epochMillis == timestamp.epochMillis;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(epochMillis);
+    }
+
+    @Override
+    public String toString() {
+        return "Timestamp{" +
+                Instant.ofEpochMilli(epochMillis) +
+                ", epochMillis=" + epochMillis +
+                '}';
+    }
+}

--- a/commons-timeseries/src/test/java/com/navercorp/pinpoint/common/timeseries/time/TimestampTest.java
+++ b/commons-timeseries/src/test/java/com/navercorp/pinpoint/common/timeseries/time/TimestampTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.timeseries.time;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TimestampTest {
+
+    @Test
+    void of() {
+        Timestamp timestamp = Timestamp.ofEpochMilli(1000L);
+        assertThat(timestamp.getEpochMillis()).isEqualTo(1000L);
+    }
+
+    @Test
+    void parseEpochMillis() {
+        Timestamp timestamp = Timestamp.valueOf("1690000000000");
+        assertThat(timestamp.getEpochMillis()).isEqualTo(1690000000000L);
+    }
+
+    @Test
+    void parseIso8601WithOffset() {
+        String iso = "2025-07-23T10:42:03.688390+09:00";
+        Timestamp timestamp = Timestamp.valueOf(iso);
+
+        OffsetDateTime expected = OffsetDateTime.of(2025, 7, 23, 10, 42, 3, 688390000, ZoneOffset.ofHours(9));
+        assertThat(timestamp.getEpochMillis()).isEqualTo(expected.toInstant().toEpochMilli());
+    }
+
+    @Test
+    void parseIso8601Utc() {
+        String iso = "2025-07-23T01:42:03Z";
+        Timestamp timestamp = Timestamp.valueOf(iso);
+
+        Instant expected = Instant.parse("2025-07-23T01:42:03Z");
+        assertThat(timestamp.getEpochMillis()).isEqualTo(expected.toEpochMilli());
+    }
+
+    @Test
+    void parseIso8601SeoulTimezone() {
+        String iso = "2025-07-23T10:42:03+09:00";
+        Timestamp timestamp = Timestamp.valueOf(iso);
+
+        // 서울 시간 10:42:03 = UTC 01:42:03
+        Instant expected = Instant.parse("2025-07-23T01:42:03Z");
+        assertThat(timestamp.getEpochMillis()).isEqualTo(expected.toEpochMilli());
+    }
+
+    @Test
+    void parseIso8601SeoulTimezoneWithMillis() {
+        String iso = "2025-07-23T10:42:03.123+09:00";
+        Timestamp timestamp = Timestamp.valueOf(iso);
+
+        Instant expected = Instant.parse("2025-07-23T01:42:03.123Z");
+        assertThat(timestamp.getEpochMillis()).isEqualTo(expected.toEpochMilli());
+    }
+
+    @Test
+    void toInstant() {
+        long millis = 1690000000000L;
+        Timestamp timestamp = Timestamp.ofEpochMilli(millis);
+        assertThat(timestamp.toInstant()).isEqualTo(Instant.ofEpochMilli(millis));
+    }
+
+    @Test
+    void parseNull() {
+        assertThatThrownBy(() -> Timestamp.valueOf(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void parseInvalidString() {
+        assertThatThrownBy(() -> Timestamp.valueOf("invalid"))
+                .isInstanceOf(DateTimeParseException.class);
+    }
+
+    @Test
+    void ofNegative() {
+        assertThatThrownBy(() -> Timestamp.ofEpochMilli(-1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void ofZero() {
+        Timestamp timestamp = Timestamp.ofEpochMilli(0L);
+        assertThat(timestamp.getEpochMillis()).isEqualTo(0L);
+    }
+
+    @Test
+    void equals() {
+        Timestamp a = Timestamp.ofEpochMilli(1000L);
+        Timestamp b = Timestamp.ofEpochMilli(1000L);
+        Timestamp c = Timestamp.ofEpochMilli(2000L);
+
+        assertThat(a).isEqualTo(b);
+        assertThat(a).isNotEqualTo(c);
+    }
+}

--- a/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/controller/ExceptionTraceController.java
+++ b/exceptiontrace/exceptiontrace-web/src/main/java/com/navercorp/pinpoint/exceptiontrace/web/controller/ExceptionTraceController.java
@@ -36,8 +36,8 @@ import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionChartView;
 import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionDetailView;
 import com.navercorp.pinpoint.exceptiontrace.web.view.ExceptionGroupSummaryView;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
@@ -119,8 +119,8 @@ public class ExceptionTraceController {
     public List<ExceptionDetailView> getListOfExceptionMetaDataByGivenRange(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "agentId", required = false) String agentId,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
 
             @RequestParam(value = "filters", required = false) List<String> filters,
             @RequestParam("orderBy") String orderBy,
@@ -150,8 +150,8 @@ public class ExceptionTraceController {
     public List<ExceptionGroupSummaryView> getListOfExceptionMetaDataWithDynamicGroupBy(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "agentId", required = false) String agentId,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
 
             @RequestParam("groupBy") List<String> groupByList
     ) {
@@ -178,8 +178,8 @@ public class ExceptionTraceController {
     public ExceptionChartView getCollectedExceptionMetaDataByGivenRange(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "agentId", required = false) String agentId,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
 
             @RequestParam(value = "groupBy", required = false) List<String> groupByList
     ) {

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
@@ -30,6 +30,7 @@ import com.navercorp.pinpoint.inspector.web.service.AgentStatService;
 import com.navercorp.pinpoint.inspector.web.service.ApdexStatService;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.web.vo.Service;
 import jakarta.validation.constraints.NotBlank;
@@ -72,8 +73,8 @@ public class AgentInspectorStatController {
             @RequestParam("applicationName") String applicationName,
             @RequestParam("agentId") String agentId,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 
@@ -92,12 +93,12 @@ public class AgentInspectorStatController {
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("agentId") String agentId,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 
-        InspectorMetricData inspectorMetricData = apdexStatService.selectAgentStat(Service.DEFAULT, applicationName, serviceTypeName, metricDefinitionId, agentId, from, to);
+        InspectorMetricData inspectorMetricData = apdexStatService.selectAgentStat(Service.DEFAULT, applicationName, serviceTypeName, metricDefinitionId, agentId, from.getEpochMillis(), to.getEpochMillis());
         return new InspectorMetricView(inspectorMetricData);
     }
 
@@ -107,8 +108,8 @@ public class AgentInspectorStatController {
             @RequestParam("applicationName") String applicationName,
             @RequestParam("agentId") String agentId,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 
@@ -127,13 +128,13 @@ public class AgentInspectorStatController {
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("agentIds") @NotEmpty List<String> agentIds,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 
         InspectorMetricGroupData inspectorMetricGroupData = apdexStatService.selectAgentStatGroupedByAgentId(
-                Service.DEFAULT, applicationName, serviceTypeName, metricDefinitionId, agentIds, from, to
+                Service.DEFAULT, applicationName, serviceTypeName, metricDefinitionId, agentIds, from.getEpochMillis(), to.getEpochMillis()
         );
         return new InspectorMetricGroupDataView(inspectorMetricGroupData);
     }
@@ -144,8 +145,8 @@ public class AgentInspectorStatController {
             @RequestParam("applicationName") String applicationName,
             @RequestParam("agentIds") @NotEmpty List<String> agentIds,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 
@@ -164,8 +165,8 @@ public class AgentInspectorStatController {
             @RequestParam("applicationName") String applicationName,
             @RequestParam("agentIds") @NotEmpty List<String> agentIds,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
@@ -14,6 +14,7 @@ import com.navercorp.pinpoint.inspector.web.service.ApdexStatService;
 import com.navercorp.pinpoint.inspector.web.service.ApplicationStatService;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.web.vo.Service;
 import jakarta.validation.constraints.NotBlank;
@@ -48,8 +49,8 @@ public class ApplicationInspectorStatController {
     public InspectorMetricView getApplicationStatChart(
             @RequestParam("applicationName") String applicationName,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 
@@ -67,12 +68,12 @@ public class ApplicationInspectorStatController {
             @RequestParam("applicationName") String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 
-        InspectorMetricData inspectorMetricData = apdexStatService.selectApplicationStat(Service.DEFAULT, applicationName, serviceTypeName, metricDefinitionId, from, to);
+        InspectorMetricData inspectorMetricData = apdexStatService.selectApplicationStat(Service.DEFAULT, applicationName, serviceTypeName, metricDefinitionId, from.getEpochMillis(), to.getEpochMillis());
         return new InspectorMetricView(inspectorMetricData);
     }
 
@@ -81,8 +82,8 @@ public class ApplicationInspectorStatController {
     public InspectorMetricGroupDataView getApplicationStatChartList(
             @RequestParam("applicationName") String applicationName,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 

--- a/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/controller/SystemMetricController.java
+++ b/metric-module/metric/src/main/java/com/navercorp/pinpoint/metric/web/controller/SystemMetricController.java
@@ -32,6 +32,7 @@ import com.navercorp.pinpoint.metric.web.service.SystemMetricDataService;
 import com.navercorp.pinpoint.metric.web.service.SystemMetricHostInfoService;
 import com.navercorp.pinpoint.metric.web.service.YMLSystemMetricBasicGroupManager;
 import com.navercorp.pinpoint.metric.web.view.SystemMetricView;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -98,8 +99,8 @@ public class SystemMetricController {
     public SystemMetricView getCollectedMetricData(@RequestParam("hostGroupName") String hostGroupName,
                                                    @RequestParam("hostName") String hostName,
                                                    @RequestParam("metricDefinitionId") String metricDefinitionId,
-                                                   @RequestParam("from") long from,
-                                                   @RequestParam("to") long to,
+                                                   @RequestParam("from") Timestamp from,
+                                                   @RequestParam("to") Timestamp to,
                                                    @RequestParam(value = "tags", required = false) String tags) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());

--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/controller/OpenTelemetryMetricController.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/controller/OpenTelemetryMetricController.java
@@ -32,9 +32,9 @@ import com.navercorp.pinpoint.otlp.common.web.vo.view.MetricDataView;
 import com.navercorp.pinpoint.otlp.web.view.legacy.OtlpChartView;
 import com.navercorp.pinpoint.otlp.common.web.vo.MetricData;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -95,9 +95,9 @@ public class OpenTelemetryMetricController {
                                        @RequestParam("metricGroupName") @NotBlank String metricGroupName,
                                        @RequestParam("metricName") @NotBlank String metricName,
                                        @RequestParam("tag") String tag,
-                                       @RequestParam("from") @PositiveOrZero long from,
-                                       @RequestParam("to") @PositiveOrZero long to) {
-        return otlpMetricWebService.getMetricChartData(tenantId, DEFAULT_SERVICE_NAME, applicationName, agentId, metricGroupName, metricName, tag, from, to);
+                                       @RequestParam("from") Timestamp from,
+                                       @RequestParam("to") Timestamp to) {
+        return otlpMetricWebService.getMetricChartData(tenantId, DEFAULT_SERVICE_NAME, applicationName, agentId, metricGroupName, metricName, tag, from.getEpochMillis(), to.getEpochMillis());
     }
 
     @PostMapping("/metricData")

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/controller/UriStatController.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/controller/UriStatController.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.timeseries.window.TimePrecision;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowSampler;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowSlotCentricSampler;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.uristat.web.chart.UriStatChartType;
 import com.navercorp.pinpoint.uristat.web.chart.UriStatChartTypeFactory;
@@ -76,7 +77,7 @@ public class UriStatController {
         this.rangeValidator = new ForwardRangeValidator(Duration.ofDays(uriStatProperties.getUriStatPeriodMax()));
     }
 
-    private Range checkTimeRange(long from, long to) {
+    private Range checkTimeRange(Timestamp from, Timestamp to) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
         return range;
@@ -86,8 +87,8 @@ public class UriStatController {
     public List<UriStatSummaryView> getUriStatPagedSummary(
             @RequestParam("applicationName") String applicationName,
             @RequestParam(value = "agentId", required = false) String agentId,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestParam("orderby") String column,
             @RequestParam("isDesc") boolean isDesc,
             @RequestParam("count") int count,
@@ -123,8 +124,8 @@ public class UriStatController {
             @RequestParam("applicationName") String applicationName,
             @RequestParam(value = "agentId", required = false) String agentId,
             @RequestParam("uri") String uri,
-            @RequestParam("from") long from,
-            @RequestParam("to") long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestParam(value = "type", required = false) String type
     ) {
         Range range = checkTimeRange(from, to);

--- a/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentNamesController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentNamesController.java
@@ -37,8 +37,8 @@ import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilters;
 import com.navercorp.pinpoint.web.vo.agent.AgentNameGroupView;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatusAndLink;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -109,8 +109,8 @@ public class AgentNamesController {
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestParam(value = "query", required = false) String query) {
         final ApplicationAgentListQueryRule rule = ApplicationAgentListQueryRule
                 .getByValue(query, ApplicationAgentListQueryRule.ACTIVE_STATUS);
@@ -130,8 +130,8 @@ public class AgentNamesController {
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestParam(value = "query", required = false) String query,
             @RequestParam(value = "applicationPairs", required = false) ApplicationPairs applicationPairs) {
         ServiceType serviceType = registry.findServiceType(serviceTypeCode);

--- a/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentsController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentsController.java
@@ -36,8 +36,8 @@ import com.navercorp.pinpoint.web.vo.ApplicationPairs;
 import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilters;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatusAndLink;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -115,8 +115,8 @@ public class AgentsController {
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestParam(value = "query", required = false) String query) {
         final ApplicationAgentListQueryRule applicationAgentListQueryRule = ApplicationAgentListQueryRule.getByValue(query, ApplicationAgentListQueryRule.ACTIVE_STATUS);
         final Application application = createApplication(Service.DEFAULT, applicationName, serviceTypeCode, serviceTypeName);
@@ -140,8 +140,8 @@ public class AgentsController {
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestParam(value = "query", required = false) String query,
             @RequestParam(value = "applicationPairs", required = false) ApplicationPairs applicationPairs
     ) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
@@ -132,7 +132,7 @@ public class FilteredMapController {
 
         final long lastScanTime = limitedScanResult.limitedTime();
         // original range: needed for visual chart data sampling
-        final Range originalRange = Range.between(rangeForm.getFrom(), originTo);
+        final Range originalRange = Range.between(rangeForm.getFrom().getEpochMillis(), originTo);
         // needed to figure out already scanned ranged
         final Range scannerRange = Range.between(lastScanTime, range.getTo());
         logger.debug("originalRange:{} scannerRange:{} ", originalRange, scannerRange);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/form/RangeForm.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/form/RangeForm.java
@@ -1,27 +1,22 @@
 package com.navercorp.pinpoint.web.applicationmap.controller.form;
 
-import jakarta.validation.constraints.PositiveOrZero;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 
 public class RangeForm {
 
-    @PositiveOrZero
-    private long from;
-    @PositiveOrZero
-    private long to;
+    private final Timestamp from;
+    private final Timestamp to;
 
-    public long getFrom() {
+    public RangeForm(Timestamp from, Timestamp to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    public Timestamp getFrom() {
         return from;
     }
 
-    public void setFrom(long from) {
-        this.from = from;
-    }
-
-    public long getTo() {
+    public Timestamp getTo() {
         return to;
-    }
-
-    public void setTo(long to) {
-        this.to = to;
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentInfoController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentInfoController.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.server.util.AgentEventType;
 import com.navercorp.pinpoint.common.timeseries.time.ForwardRangeValidator;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.time.RangeValidator;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
 import com.navercorp.pinpoint.web.config.ConfigProperties;
 import com.navercorp.pinpoint.web.response.CodeResult;
@@ -33,7 +34,6 @@ import com.navercorp.pinpoint.web.vo.agent.AgentStatus;
 import com.navercorp.pinpoint.web.vo.agent.DetailedAgentAndStatus;
 import com.navercorp.pinpoint.web.vo.timeline.inspector.InspectorTimeline;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -73,8 +73,8 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
     @GetMapping(value = "/getAgentInfo")
     public AgentAndStatus getAgentInfo(
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("timestamp") @PositiveOrZero long timestamp) {
-        AgentAndStatus result = this.agentInfoService.findAgentInfoAndStatus(agentId, timestamp);
+            @RequestParam("timestamp") Timestamp timestamp) {
+        AgentAndStatus result = this.agentInfoService.findAgentInfoAndStatus(agentId, timestamp.getEpochMillis());
         if (result == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "agent info not found");
         }
@@ -84,8 +84,8 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
     @GetMapping(value = "/getDetailedAgentInfo")
     public DetailedAgentAndStatus getDetailedAgentInfo(
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("timestamp") @PositiveOrZero long timestamp) {
-        DetailedAgentAndStatus result = this.agentInfoService.findDetailedAgentInfoAndStatus(agentId, timestamp);
+            @RequestParam("timestamp") Timestamp timestamp) {
+        DetailedAgentAndStatus result = this.agentInfoService.findDetailedAgentInfoAndStatus(agentId, timestamp.getEpochMillis());
         if (result == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "detailed agent info not found");
         }
@@ -95,8 +95,8 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
     @GetMapping(value = "/getAgentStatus")
     public AgentStatus getAgentStatus(
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("timestamp") @PositiveOrZero long timestamp) {
-        AgentStatus result = this.agentInfoService.findAgentStatus(agentId, timestamp);
+            @RequestParam("timestamp") Timestamp timestamp) {
+        AgentStatus result = this.agentInfoService.findAgentStatus(agentId, timestamp.getEpochMillis());
         if (result == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "agent status not found");
         }
@@ -106,7 +106,7 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
     @GetMapping(value = "/getAgentEvent")
     public AgentEvent getAgentEvent(
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("eventTimestamp") @PositiveOrZero long eventTimestamp,
+            @RequestParam("eventTimestamp") Timestamp eventTimestamp,
             @RequestParam("eventTypeCode") int eventTypeCode
     ) {
         final AgentEventType eventType = AgentEventType.getTypeByCode(eventTypeCode);
@@ -114,7 +114,7 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
             throw new IllegalArgumentException("invalid eventTypeCode [" + eventTypeCode + "]");
         }
 
-        AgentEvent result = this.agentEventService.getAgentEvent(agentId, eventTimestamp, eventType);
+        AgentEvent result = this.agentEventService.getAgentEvent(agentId, eventTimestamp.getEpochMillis(), eventType);
         if (result == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "agent event not found");
         }
@@ -125,8 +125,8 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
     @GetMapping(value = "/getAgentEvents")
     public List<AgentEvent> getAgentEvents(
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestParam(value = "exclude", defaultValue = "") int[] excludeEventTypeCodes) {
         final Range range = Range.between(from, to);
         final Set<AgentEventType> excludeEventTypes = getAgentEventTypes(excludeEventTypeCodes);
@@ -150,8 +150,8 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
     public InspectorTimeline getAgentStatusTimeline(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         final Range range = Range.between(from, to);
         return agentInfoService.getAgentStatusTimeline(applicationName, agentId, range);
     }
@@ -161,8 +161,8 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
     public InspectorTimeline getAgentStatusTimeline(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestParam(value = "exclude", defaultValue = "") int[] excludeEventTypeCodes) {
         final Range range = Range.between(from, to);
         rangeValidator.validate(range);

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentListController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentListController.java
@@ -6,7 +6,7 @@ import com.navercorp.pinpoint.common.timeseries.time.RangeValidator;
 import com.navercorp.pinpoint.web.config.ConfigProperties;
 import com.navercorp.pinpoint.web.service.AgentInfoService;
 import com.navercorp.pinpoint.web.vo.agent.DetailedAgentAndStatus;
-import jakarta.validation.constraints.PositiveOrZero;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -48,8 +48,8 @@ public class AgentListController implements AccessDeniedExceptionHandler {
     @PreAuthorize("hasPermission(null, null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ADMINISTRATION_CALL_API_FOR_APP_AGENT_MANAGEMENT)")
     @GetMapping(value = "/statistics", params = {"from", "to"})
     public List<DetailedAgentAndStatus> getAllAgentStatistics(
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to
     ) {
         Range range = Range.between(from, to);
         rangeValidator.validate(range);

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentV2Controller.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentV2Controller.java
@@ -37,8 +37,8 @@ import com.navercorp.pinpoint.web.vo.agent.AgentStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatusAndLink;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -97,8 +97,8 @@ public class AgentV2Controller {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         ServiceUid serviceUid = handleServiceUid(serviceName);
         final ServiceType serviceType = findServiceType(serviceTypeCode, serviceTypeName);
         Range range = Range.between(from, to);
@@ -119,8 +119,8 @@ public class AgentV2Controller {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         ServiceUid serviceUid = handleServiceUid(serviceName);
         final ServiceType serviceType = findServiceType(serviceTypeCode, serviceTypeName);
         Range range = Range.between(from, to);

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatmapChartController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatmapChartController.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.web.heatmap.service.EmptyHeatmapService;
 import com.navercorp.pinpoint.web.heatmap.service.HeatmapChartService;
 import com.navercorp.pinpoint.web.heatmap.view.HeatMapDataView;
 import com.navercorp.pinpoint.web.heatmap.vo.HeatMapData;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -59,8 +60,8 @@ public class HeatmapChartController {
     @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
     @GetMapping(value = "/applicationData")
     public HeatMapDataView getHeatmapAppData(@RequestParam("applicationName") @NotBlank String applicationName,
-                                  @RequestParam("from") @PositiveOrZero long from,
-                                  @RequestParam("to") @PositiveOrZero long to,
+                                  @RequestParam("from") Timestamp from,
+                                  @RequestParam("to") Timestamp to,
                                   @RequestParam("minElapsedTime") @PositiveOrZero int minElapsedTime,
                                   @RequestParam("maxElapsedTime") @Positive int maxElapsedTime) {
         Range range = Range.between(from, to);

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ResponseTimeController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ResponseTimeController.java
@@ -40,8 +40,8 @@ import com.navercorp.pinpoint.web.vo.ApplicationPair;
 import com.navercorp.pinpoint.web.vo.ApplicationPairs;
 import com.navercorp.pinpoint.web.vo.ResponseTimeStatics;
 import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -88,8 +88,8 @@ public class ResponseTimeController {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
@@ -110,8 +110,8 @@ public class ResponseTimeController {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
@@ -132,8 +132,8 @@ public class ResponseTimeController {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to
     ) {
         Histogram histogram = getWasHistogram(applicationName, serviceTypeCode, serviceTypeName, from, to);
         return ResponseTimeStatics.fromHistogram(histogram);
@@ -145,8 +145,8 @@ public class ResponseTimeController {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @PathVariable("type") String type
     ) {
         final Range range = Range.between(from, to);
@@ -170,8 +170,8 @@ public class ResponseTimeController {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
@@ -199,8 +199,8 @@ public class ResponseTimeController {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestBody ApplicationPairs applicationPairs
     ) {
         final Range range = Range.between(from, to);
@@ -222,8 +222,8 @@ public class ResponseTimeController {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestBody ApplicationPairs applicationPairs
     ) {
         final Range range = Range.between(from, to);
@@ -246,8 +246,8 @@ public class ResponseTimeController {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @PathVariable("type") String type,
             @RequestBody ApplicationPairs applicationPairs
     ) {
@@ -282,8 +282,8 @@ public class ResponseTimeController {
             @RequestParam("toApplicationName") String toApplicationName,
             @RequestParam(value = "toServiceTypeCode", required = false) Short toServiceTypeCode,
             @RequestParam(value = "toServiceTypeName", required = false) @NotBlank String toServiceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to
     ) {
         final Range range = Range.between(from, to);
         this.rangeValidator.validate(range);
@@ -314,8 +314,8 @@ public class ResponseTimeController {
             @RequestParam("toApplicationName") String toApplicationName,
             @RequestParam(value = "toServiceTypeCode", required = false) Short toServiceTypeCode,
             @RequestParam(value = "toServiceTypeName", required = false) @NotBlank String toServiceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @PathVariable("type") String type
     ) {
         final Range range = Range.between(from, to);

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ScatterChartController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ScatterChartController.java
@@ -30,9 +30,9 @@ import com.navercorp.pinpoint.web.util.LimitUtils;
 import com.navercorp.pinpoint.web.view.transactionlist.TransactionMetaDataViewModel;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.GetTraceInfoParser;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
@@ -108,8 +108,8 @@ public class ScatterChartController implements AccessDeniedExceptionHandler {
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Integer serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to,
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to,
             @RequestParam("xGroupUnit") @Positive int xGroupUnit,
             @RequestParam("yGroupUnit") @Positive int yGroupUnit,
             @RequestParam("limit") int limitParam,

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentStatisticsController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentStatisticsController.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.web.controller;
 import com.navercorp.pinpoint.common.server.response.Response;
 import com.navercorp.pinpoint.common.server.response.SimpleResponse;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.web.service.AgentStatisticsService;
 import com.navercorp.pinpoint.web.util.DateTimeUtils;
 import com.navercorp.pinpoint.web.vo.AgentCountStatistics;
@@ -32,7 +33,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -52,16 +52,16 @@ public class AgentStatisticsController {
 
     @GetMapping(value = "/insertAgentCount", params = {"agentCount"})
     public Response insertAgentCount(@RequestParam("agentCount") @PositiveOrZero int agentCount) {
-        return insertAgentCount(agentCount, new Date().getTime());
+        return insertAgentCount(agentCount, Timestamp.ofEpochMilli(System.currentTimeMillis()));
     }
 
     @GetMapping(value = "/insertAgentCount", params = {"agentCount", "timestamp"})
     public Response insertAgentCount(
             @RequestParam("agentCount") @PositiveOrZero int agentCount,
-            @RequestParam("timestamp") @PositiveOrZero long timestamp
+            @RequestParam("timestamp") Timestamp timestamp
     ) {
         AgentCountStatistics agentCountStatistics =
-                new AgentCountStatistics(agentCount, DateTimeUtils.timestampToStartOfDay(timestamp));
+                new AgentCountStatistics(agentCount, DateTimeUtils.timestampToStartOfDay(timestamp.getEpochMillis()));
         boolean success = agentStatisticsService.insertAgentCount(agentCountStatistics);
 
         if (success) {
@@ -73,20 +73,20 @@ public class AgentStatisticsController {
 
     @GetMapping(value = "/selectAgentCount")
     public List<AgentCountStatistics> selectAgentCount() {
-        return selectAgentCount(0L, System.currentTimeMillis());
+        return selectAgentCount(Timestamp.ofEpochMilli(0L), Timestamp.ofEpochMilli(System.currentTimeMillis()));
     }
 
     @GetMapping(value = "/selectAgentCount", params = {"to"})
-    public List<AgentCountStatistics> selectAgentCount(@RequestParam("to") @PositiveOrZero long to) {
-        return selectAgentCount(0L, to);
+    public List<AgentCountStatistics> selectAgentCount(@RequestParam("to") Timestamp to) {
+        return selectAgentCount(Timestamp.ofEpochMilli(0L), to);
     }
 
     @GetMapping(value = "/selectAgentCount", params = {"from", "to"})
     public List<AgentCountStatistics> selectAgentCount(
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to")  @PositiveOrZero long to
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to
     ) {
-        Range range = Range.between(DateTimeUtils.timestampToStartOfDay(from), DateTimeUtils.timestampToStartOfDay(to));
+        Range range = Range.between(DateTimeUtils.timestampToStartOfDay(from.getEpochMillis()), DateTimeUtils.timestampToStartOfDay(to.getEpochMillis()));
         List<AgentCountStatistics> agentCountStatisticsList = agentStatisticsService.selectAgentCount(range);
 
         agentCountStatisticsList.sort(Comparator.comparingLong(AgentCountStatistics::getTimestamp).reversed());

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/ApdexScoreController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/ApdexScoreController.java
@@ -10,8 +10,8 @@ import com.navercorp.pinpoint.web.service.ApdexScoreService;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.stat.chart.StatChart;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,8 +38,8 @@ public class ApdexScoreController {
     public ApdexScore getApdexScore(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range);
 
@@ -52,8 +52,8 @@ public class ApdexScoreController {
     public ApdexScore getApdexScore(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range);
 
@@ -67,8 +67,8 @@ public class ApdexScoreController {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range);
 
@@ -82,8 +82,8 @@ public class ApdexScoreController {
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range);
 
@@ -96,8 +96,8 @@ public class ApdexScoreController {
     public StatChart<?> getApplicationApdexScoreChart(
             @RequestParam("applicationId") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range, APDEX_SCORE_TIME_WINDOW_SAMPLER);
 
@@ -110,8 +110,8 @@ public class ApdexScoreController {
     public StatChart<?> getApplicationApdexScoreChart(
             @RequestParam("applicationId") @NotBlank String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range, APDEX_SCORE_TIME_WINDOW_SAMPLER);
 
@@ -125,8 +125,8 @@ public class ApdexScoreController {
             @RequestParam("applicationId") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range, APDEX_SCORE_TIME_WINDOW_SAMPLER);
 
@@ -140,8 +140,8 @@ public class ApdexScoreController {
             @RequestParam("applicationId") @NotBlank String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("from") @PositiveOrZero long from,
-            @RequestParam("to") @PositiveOrZero long to) {
+            @RequestParam("from") Timestamp from,
+            @RequestParam("to") Timestamp to) {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range, APDEX_SCORE_TIME_WINDOW_SAMPLER);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/realtime/EchoController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/realtime/EchoController.java
@@ -17,10 +17,10 @@
 package com.navercorp.pinpoint.web.realtime;
 
 import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.web.service.AgentService;
 import com.navercorp.pinpoint.web.service.EchoService;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -48,15 +48,15 @@ public class EchoController {
     public String echo(
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("agentId") @NotBlank String agentId,
-            @RequestParam("startTimeStamp") @PositiveOrZero long startTimeStamp,
+            @RequestParam("startTimeStamp") Timestamp startTimeStamp,
             @RequestParam("message") @NotBlank String message
     ) {
-        final ClusterKey clusterKey = agentService.getClusterKey(applicationName, agentId, startTimeStamp, true);
+        final ClusterKey clusterKey = agentService.getClusterKey(applicationName, agentId, startTimeStamp.getEpochMillis(), true);
         if (clusterKey == null) {
             throw new ResponseStatusException(
                     HttpStatus.NOT_FOUND,
                     String.format("Can't find suitable PinpointServer(%s/%s/%d).",
-                            applicationName, agentId, startTimeStamp)
+                            applicationName, agentId, startTimeStamp.getEpochMillis())
             );
         }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/AgentParam.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/AgentParam.java
@@ -1,6 +1,7 @@
 package com.navercorp.pinpoint.web.vo;
 
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 
 import java.io.Serializable;
 
@@ -12,6 +13,10 @@ public class AgentParam implements Serializable {
     public AgentParam(String agentId, long timeStamp) {
         this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
         this.timeStamp = timeStamp;
+    }
+
+    public AgentParam(String agentId, Timestamp timestamp) {
+        this(agentId, timestamp.getEpochMillis());
     }
 
     public String getAgentId() {


### PR DESCRIPTION
## Summary
- Add `Timestamp` value type (`commons-timeseries`) that accepts both epoch milliseconds and ISO 8601 strings (e.g., `2025-07-23T10:42:03.68839+09:00`)
- Add Spring `TimestampConverter` and register it in `WebMvcConfig` for automatic `@RequestParam` binding
- Migrate `long from/to` parameters to `Timestamp from/to` across 18 controllers and `RangeForm`

Closes #13590

## Changes
### Commit 1: Add Timestamp type with ISO 8601 and epoch milliseconds support
- `Timestamp` value type with `parse(String)` supporting numeric and ISO 8601 formats
- `Range.between(Timestamp, Timestamp)` and `Range.unchecked(Timestamp, Timestamp)` overloads
- `TimestampConverter` for Spring MVC parameter binding
- 10 unit tests covering parsing, equality, and edge cases

### Commit 2: Apply Timestamp type to controller parameters
- Replace `@RequestParam("from") @PositiveOrZero long from` → `@RequestParam("from") Timestamp from` in all controllers
- Update `RangeForm` fields from `long` to `Timestamp`
- Handle special cases: `Range.unchecked()`, `DateTimeUtils.timestampToStartOfDay()`, service methods expecting raw `long`

## Test plan
- [x] `TimestampTest` — 10 test cases for parsing and conversion
- [x] Verify compilation: `./mvnw compile -pl commons-timeseries,web -am -Dmaven.test.skip=true`
- [x] Verify existing API contracts remain backward-compatible (epoch ms still works)