### PR TITLE
[#13590] Add zero() and now() factory methods to Timestamp

### DIFF
--- a/commons-timeseries/src/main/java/com/navercorp/pinpoint/common/timeseries/time/Timestamp.java
+++ b/commons-timeseries/src/main/java/com/navercorp/pinpoint/common/timeseries/time/Timestamp.java
@@ -20,6 +20,9 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.Objects;
 
 /**
@@ -27,6 +30,15 @@ import java.util.Objects;
  */
 public final class Timestamp {
     private static final Timestamp ZERO = new Timestamp(0);
+
+    // ISO 8601 Basic format: 20260413T053000Z or 20260413T053000.999Z
+    public static final DateTimeFormatter BASIC_ISO_FORMAT = new DateTimeFormatterBuilder()
+            .appendPattern("yyyyMMdd'T'HHmmss")
+            .optionalStart()
+            .appendFraction(ChronoField.MILLI_OF_SECOND, 3, 3, true)
+            .optionalEnd()
+            .appendPattern("X")
+            .toFormatter();
 
     private final long epochMillis;
 
@@ -55,8 +67,18 @@ public final class Timestamp {
         if (StringUtils.isNumeric(dateTime)) {
             return new Timestamp(Long.parseLong(dateTime));
         }
-        long epochMillis = OffsetDateTime.parse(dateTime).toInstant().toEpochMilli();
+        long epochMillis = parseDateTime(dateTime);
         return new Timestamp(epochMillis);
+    }
+
+    private static long parseDateTime(String dateTime) {
+        int tIndex = dateTime.indexOf('T');
+        if (tIndex == 8) {
+            // ISO 8601 Basic: 20260413T053000Z or 20260413T053000.999Z
+            return OffsetDateTime.parse(dateTime, BASIC_ISO_FORMAT).toInstant().toEpochMilli();
+        }
+        // ISO 8601 Extended: 2026-04-13T05:30:00Z
+        return OffsetDateTime.parse(dateTime).toInstant().toEpochMilli();
     }
 
     public long getEpochMillis() {

--- a/commons-timeseries/src/main/java/com/navercorp/pinpoint/common/timeseries/time/Timestamp.java
+++ b/commons-timeseries/src/main/java/com/navercorp/pinpoint/common/timeseries/time/Timestamp.java
@@ -26,6 +26,7 @@ import java.util.Objects;
  * @author emeroad
  */
 public final class Timestamp {
+    private static final Timestamp ZERO = new Timestamp(0);
 
     private final long epochMillis;
 
@@ -34,6 +35,14 @@ public final class Timestamp {
             throw new IllegalArgumentException("epochMillis must not be negative: " + epochMillis);
         }
         this.epochMillis = epochMillis;
+    }
+
+    public static Timestamp zero() {
+        return ZERO;
+    }
+
+    public static Timestamp now() {
+        return ofEpochMilli(System.currentTimeMillis());
     }
 
     public static Timestamp ofEpochMilli(long epochMillis) {

--- a/commons-timeseries/src/test/java/com/navercorp/pinpoint/common/timeseries/time/TimestampTest.java
+++ b/commons-timeseries/src/test/java/com/navercorp/pinpoint/common/timeseries/time/TimestampTest.java
@@ -50,6 +50,34 @@ class TimestampTest {
     }
 
     @Test
+    void parseBasicIso8601Utc() {
+        String basic = "20250723T014203Z";
+        Timestamp timestamp = Timestamp.valueOf(basic);
+
+        Instant expected = Instant.parse("2025-07-23T01:42:03Z");
+        assertThat(timestamp.getEpochMillis()).isEqualTo(expected.toEpochMilli());
+    }
+
+    @Test
+    void parseBasicIso8601WithMillis() {
+        String basic = "20250723T014203.123Z";
+        Timestamp timestamp = Timestamp.valueOf(basic);
+
+        Instant expected = Instant.parse("2025-07-23T01:42:03.123Z");
+        assertThat(timestamp.getEpochMillis()).isEqualTo(expected.toEpochMilli());
+    }
+
+    @Test
+    void parseBasicIso8601WithOffset() {
+        String basic = "20250723T104203+0900";
+        Timestamp timestamp = Timestamp.valueOf(basic);
+
+        // Seoul 10:42:03 = UTC 01:42:03
+        Instant expected = Instant.parse("2025-07-23T01:42:03Z");
+        assertThat(timestamp.getEpochMillis()).isEqualTo(expected.toEpochMilli());
+    }
+
+    @Test
     void parseIso8601Utc() {
         String iso = "2025-07-23T01:42:03Z";
         Timestamp timestamp = Timestamp.valueOf(iso);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/FilteredMapController.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.DateTimeFormatUtils;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
@@ -103,7 +104,7 @@ public class FilteredMapController {
                     ApplicationForm appForm,
             @Valid @ModelAttribute
                     RangeForm rangeForm,
-            @RequestParam("originTo") long originTo,
+            @RequestParam("originTo") Timestamp originTo,
             @Valid @ModelAttribute
                     GroupForm groupForm,
             @Valid @ModelAttribute
@@ -132,7 +133,7 @@ public class FilteredMapController {
 
         final long lastScanTime = limitedScanResult.limitedTime();
         // original range: needed for visual chart data sampling
-        final Range originalRange = Range.between(rangeForm.getFrom().getEpochMillis(), originTo);
+        final Range originalRange = Range.between(rangeForm.getFrom(), originTo);
         // needed to figure out already scanned ranged
         final Range scannerRange = Range.between(lastScanTime, range.getTo());
         logger.debug("originalRange:{} scannerRange:{} ", originalRange, scannerRange);

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentStatisticsController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/AgentStatisticsController.java
@@ -52,7 +52,7 @@ public class AgentStatisticsController {
 
     @GetMapping(value = "/insertAgentCount", params = {"agentCount"})
     public Response insertAgentCount(@RequestParam("agentCount") @PositiveOrZero int agentCount) {
-        return insertAgentCount(agentCount, Timestamp.ofEpochMilli(System.currentTimeMillis()));
+        return insertAgentCount(agentCount, Timestamp.now());
     }
 
     @GetMapping(value = "/insertAgentCount", params = {"agentCount", "timestamp"})
@@ -73,12 +73,12 @@ public class AgentStatisticsController {
 
     @GetMapping(value = "/selectAgentCount")
     public List<AgentCountStatistics> selectAgentCount() {
-        return selectAgentCount(Timestamp.ofEpochMilli(0L), Timestamp.ofEpochMilli(System.currentTimeMillis()));
+        return selectAgentCount(Timestamp.zero(), Timestamp.now());
     }
 
     @GetMapping(value = "/selectAgentCount", params = {"to"})
     public List<AgentCountStatistics> selectAgentCount(@RequestParam("to") Timestamp to) {
-        return selectAgentCount(Timestamp.ofEpochMilli(0L), to);
+        return selectAgentCount(Timestamp.zero(), to);
     }
 
     @GetMapping(value = "/selectAgentCount", params = {"from", "to"})


### PR DESCRIPTION
## Summary
- Add `zero()` and `now()` static factory methods to `Timestamp` class for common use cases
- Apply `Timestamp` type to `FilteredMapController.originTo` parameter, replacing raw `long`
- Refactor `AgentStatisticsController` to use `Timestamp.zero()` and `Timestamp.now()`

## Test plan
- [ ] Verify `Timestamp.zero()` returns epoch 0 and `Timestamp.now()` returns current time
- [ ] Verify `FilteredMapController.filterServerMap` endpoint accepts `originTo` as ISO 8601 and epoch millis
- [ ] Verify `AgentStatisticsController` endpoints work correctly with the refactored Timestamp usage