### PR TITLE
[#13590] Apply Timestamp type to OTLP metric data request parameter

### DIFF
--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/MetricDataRequestParameter.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/MetricDataRequestParameter.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.otlp.web.view;
 
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
 
@@ -43,11 +44,9 @@ public class MetricDataRequestParameter {
 
     private List<String> fieldNameList;
 
-    @PositiveOrZero
-    private long from;
+    private Timestamp from;
 
-    @PositiveOrZero
-    private long to;
+    private Timestamp to;
 
     @NotBlank
     private String chartType;
@@ -115,19 +114,19 @@ public class MetricDataRequestParameter {
         this.fieldNameList = fieldNameList;
     }
 
-    public long getFrom() {
+    public Timestamp getFrom() {
         return from;
     }
 
-    public void setFrom(long from) {
+    public void setFrom(Timestamp from) {
         this.from = from;
     }
 
-    public long getTo() {
+    public Timestamp getTo() {
         return to;
     }
 
-    public void setTo(long to) {
+    public void setTo(Timestamp to) {
         this.to = to;
     }
 


### PR DESCRIPTION
This pull request refactors the `MetricDataRequestParameter` class to improve how time ranges are represented. Instead of using primitive `long` values for the `from` and `to` fields, it now uses the `Timestamp` type, which should provide better type safety and clarity when handling time-related data.

**Time handling improvements:**

* Replaced `long` types for `from` and `to` fields with the `Timestamp` type in `MetricDataRequestParameter`, and updated related getter and setter methods accordingly. [[1]](diffhunk://#diff-e4a788f6f163220a1a2dab58c580334d3ebd521f68dfe056da3f58eaae11dc54L46-R49) [[2]](diffhunk://#diff-e4a788f6f163220a1a2dab58c580334d3ebd521f68dfe056da3f58eaae11dc54L118-R129)
* Added an import for `Timestamp` to support the new field types.