### PR TITLE
[#13590] Apply Timestamp type to OTLP metric data request parameter

### DIFF
--- a/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/MetricDataRequestParameter.java
+++ b/otlpmetric/otlpmetric-web/src/main/java/com/navercorp/pinpoint/otlp/web/view/MetricDataRequestParameter.java
@@ -16,7 +16,9 @@
 
 package com.navercorp.pinpoint.otlp.web.view;
 
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
 import java.util.List;
@@ -43,11 +45,11 @@ public class MetricDataRequestParameter {
 
     private List<String> fieldNameList;
 
-    @PositiveOrZero
-    private long from;
+    @NotNull
+    private Timestamp from;
 
-    @PositiveOrZero
-    private long to;
+    @NotNull
+    private Timestamp to;
 
     @NotBlank
     private String chartType;
@@ -115,19 +117,19 @@ public class MetricDataRequestParameter {
         this.fieldNameList = fieldNameList;
     }
 
-    public long getFrom() {
+    public Timestamp getFrom() {
         return from;
     }
 
-    public void setFrom(long from) {
+    public void setFrom(Timestamp from) {
         this.from = from;
     }
 
-    public long getTo() {
+    public Timestamp getTo() {
         return to;
     }
 
-    public void setTo(long to) {
+    public void setTo(Timestamp to) {
         this.to = to;
     }
 


### PR DESCRIPTION
This pull request updates the `MetricDataRequestParameter` class to improve type safety and validation for time range parameters. The main change is replacing primitive `long` fields for `from` and `to` with the more robust `Timestamp` type, and adding validation annotations to ensure these values are always present.

**Type safety and validation improvements:**

* Changed the types of the `from` and `to` fields from `long` to `Timestamp`, and updated their getter and setter methods accordingly in `MetricDataRequestParameter.java` [[1]](diffhunk://#diff-e4a788f6f163220a1a2dab58c580334d3ebd521f68dfe056da3f58eaae11dc54L46-R52) [[2]](diffhunk://#diff-e4a788f6f163220a1a2dab58c580334d3ebd521f68dfe056da3f58eaae11dc54L118-R132)
* Added `@NotNull` validation annotations to the `from` and `to` fields to ensure they are always provided, replacing the previous `@PositiveOrZero` annotations
* Imported the `Timestamp` class and `@NotNull` annotation to support these changes