### PR TITLE
[#noissue] Refactor ScatterData to use LongObjectMap for improved performance and memory efficiency

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/ScatterData.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/ScatterData.java
@@ -18,11 +18,11 @@ package com.navercorp.pinpoint.web.scatter;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Ordering;
 import com.navercorp.pinpoint.web.view.ScatterDataSerializer;
+import org.eclipse.collections.api.map.primitive.LongObjectMap;
 
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -35,7 +35,7 @@ public class ScatterData {
     private final long to;
 
     private final ScatterAgentMetadataRepository scatterAgentMetadataRepository;
-    private final Map<Long, DotGroups> scatterData;
+    private final LongObjectMap<DotGroups> scatterData;
 
     private final long oldestAcceptedTime;
     private final long latestAcceptedTime;
@@ -47,7 +47,7 @@ public class ScatterData {
                        long to,
                        long oldestAcceptedTime,
                        long latestAcceptedTime,
-                       Map<Long, DotGroups> scatterData,
+                       LongObjectMap<DotGroups> scatterData,
                        ScatterAgentMetadataRepository scatterAgentMetadataRepository) {
         if (from <= 0) {
             throw new IllegalArgumentException("from value must be higher than 0");
@@ -72,7 +72,7 @@ public class ScatterData {
         return new ScatterAgentMetaData(scatterAgentMetadataRepository.getDotAgentInfoSet());
     }
 
-    public Map<Long, DotGroups> getScatterDataMap() {
+    public LongObjectMap<DotGroups> getScatterDataMap() {
         return scatterData;
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/ScatterDataBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/ScatterDataBuilder.java
@@ -17,10 +17,10 @@ package com.navercorp.pinpoint.web.scatter;
 
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.scatter.vo.DotAgentInfo;
+import org.eclipse.collections.api.factory.primitive.LongObjectMaps;
+import org.eclipse.collections.api.map.primitive.MutableLongObjectMap;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Taejin Koo
@@ -33,7 +33,7 @@ public class ScatterDataBuilder {
     private final int yGroupUnitMillis;
 
     private ScatterAgentMetadataRepository scatterAgentMetadataRepository = new ScatterAgentMetadataRepository();
-    private Map<Long, DotGroups> scatterData = new HashMap<>();
+    private MutableLongObjectMap<DotGroups> scatterData;
 
     private long oldestAcceptedTime = Long.MAX_VALUE;
     private long latestAcceptedTime = Long.MIN_VALUE;
@@ -50,6 +50,8 @@ public class ScatterDataBuilder {
         this.to = to;
         this.xGroupUnitMillis = xGroupUnitMillis;
         this.yGroupUnitMillis = yGroupUnitMillis;
+
+        this.scatterData = LongObjectMaps.mutable.withInitialCapacity(16);
     }
 
     public void addDot(List<Dot> dotList) {
@@ -63,7 +65,8 @@ public class ScatterDataBuilder {
             return;
         }
 
-        long acceptedTimeDiff = dot.getAcceptedTime() - from;
+        final long acceptedTime = dot.getAcceptedTime();
+        long acceptedTimeDiff = acceptedTime - from;
         long x = acceptedTimeDiff - (acceptedTimeDiff  % xGroupUnitMillis);
         if (x < 0) {
             x = 0L;
@@ -73,13 +76,13 @@ public class ScatterDataBuilder {
         Coordinates coordinates = new Coordinates(x, y);
         addDot(coordinates, new Dot(dot.getTransactionId(), acceptedTimeDiff, dot.getElapsedTime(), dot.getExceptionCode(), dot.getAgentId()));
 
-        oldestAcceptedTime = Math.min(oldestAcceptedTime, dot.getAcceptedTime());
-        latestAcceptedTime = Math.max(latestAcceptedTime, dot.getAcceptedTime());
+        oldestAcceptedTime = Math.min(oldestAcceptedTime, acceptedTime);
+        latestAcceptedTime = Math.max(latestAcceptedTime, acceptedTime);
     }
 
     private void addDot(Coordinates coordinates, Dot dot) {
-        final Long x = coordinates.x();
-        DotGroups dotGroups = this.scatterData.computeIfAbsent(x, DotGroups::new);
+        final long x = coordinates.x();
+        DotGroups dotGroups = this.scatterData.getIfAbsentPut(x, () -> new DotGroups(x));
 
         dotGroups.addDot(coordinates, dot);
 
@@ -96,8 +99,8 @@ public class ScatterDataBuilder {
     }
 
     public ScatterData build() {
-        Map<Long, DotGroups> copyScatterData = this.scatterData;
-        this.scatterData = new HashMap<>();
+        MutableLongObjectMap<DotGroups> copyScatterData = this.scatterData;
+        this.scatterData = LongObjectMaps.mutable.of();
 
         ScatterAgentMetadataRepository copyRepo = new ScatterAgentMetadataRepository(this.scatterAgentMetadataRepository.getDotAgentInfoSet());
         this.scatterAgentMetadataRepository = new ScatterAgentMetadataRepository();


### PR DESCRIPTION
…formance and memory efficiency

This pull request refactors the scatter data collection to use Eclipse Collections' primitive maps for improved performance and memory efficiency, and increases the maximum limit constant in `LimitUtils`. The main changes are grouped as follows:

**Scatter Data Refactoring:**

* Replaced usages of `Map<Long, DotGroups>` and `HashMap` with `LongObjectMap<DotGroups>` and `MutableLongObjectMap<DotGroups>` in `ScatterData` and `ScatterDataBuilder`, switching to Eclipse Collections for better primitive handling. [[1]](diffhunk://#diff-36d9592db3f97ee1fb96dc979b3e67aa14972f385df8610b5a1a5b0919d76e53R21-L25) [[2]](diffhunk://#diff-36d9592db3f97ee1fb96dc979b3e67aa14972f385df8610b5a1a5b0919d76e53L38-R38) [[3]](diffhunk://#diff-36d9592db3f97ee1fb96dc979b3e67aa14972f385df8610b5a1a5b0919d76e53L50-R50) [[4]](diffhunk://#diff-36d9592db3f97ee1fb96dc979b3e67aa14972f385df8610b5a1a5b0919d76e53L75-R75) [[5]](diffhunk://#diff-393821f28e1c3531f6d4d71a4c41741be58b126272776382d9205cd6f3b46c05R20-L23) [[6]](diffhunk://#diff-393821f28e1c3531f6d4d71a4c41741be58b126272776382d9205cd6f3b46c05L36-R36) [[7]](diffhunk://#diff-393821f28e1c3531f6d4d71a4c41741be58b126272776382d9205cd6f3b46c05R53-R54)
* Updated logic in `addDot` and related methods to use the new map types and their idiomatic methods, such as `getIfAbsentPut` instead of `computeIfAbsent`. [[1]](diffhunk://#diff-393821f28e1c3531f6d4d71a4c41741be58b126272776382d9205cd6f3b46c05L66-R69) [[2]](diffhunk://#diff-393821f28e1c3531f6d4d71a4c41741be58b126272776382d9205cd6f3b46c05L76-R85)
* Adjusted the `build` method in `ScatterDataBuilder` to reset the map using `LongObjectMaps.mutable.of()` instead of a new `HashMap`.

**Configuration Change:**

* Increased the maximum value of `LimitUtils.MAX` from 10,000 to 100,000, allowing for larger data sets to be processed.