### PR TITLE
[#13534] Add @ServiceParam to AlarmController and WebhookAlarmController

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AlarmController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AlarmController.java
@@ -20,6 +20,8 @@ import com.navercorp.pinpoint.common.server.response.Response;
 import com.navercorp.pinpoint.common.server.response.Result;
 import com.navercorp.pinpoint.common.server.response.SimpleResponse;
 import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.alarm.CheckerCategory;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
 import com.navercorp.pinpoint.web.response.AlarmResponse;
@@ -60,7 +62,7 @@ public class AlarmController {
 
     @PreAuthorize("hasPermission(#rule.getApplicationName(), null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
     @PostMapping
-    public AlarmResponse insertRule(@RequestBody Rule rule) {
+    public AlarmResponse insertRule(@ServiceParam ServiceName serviceName, @RequestBody Rule rule) {
         if (Rule.isRuleInvalidForPost(rule)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "there is not applicationId/checkerName/userGroupId/threashold to insert alarm rule");
         }
@@ -70,7 +72,7 @@ public class AlarmController {
 
     @PreAuthorize("hasPermission(#rule.getApplicationName(), null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
     @DeleteMapping
-    public Response deleteRule(@RequestBody Rule rule) {
+    public Response deleteRule(@ServiceParam ServiceName serviceName, @RequestBody Rule rule) {
         if (StringUtils.isEmpty(rule.getRuleId())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "there is not ruleId to delete alarm rule");
         }
@@ -79,18 +81,18 @@ public class AlarmController {
     }
 
     @GetMapping(params = USER_GROUP_ID_PARAMS)
-    public List<Rule> getRulesByUserGroup(@RequestParam(value = USER_GROUP_ID_PARAMS) @NotBlank String userGroupId) {
+    public List<Rule> getRulesByUserGroup(@ServiceParam ServiceName serviceName, @RequestParam(value = USER_GROUP_ID_PARAMS) @NotBlank String userGroupId) {
         return alarmService.selectRuleByUserGroupId(userGroupId);
     }
 
     @GetMapping(params = APPLICATION_ID_PARAMS)
-    public List<Rule> getRulesByApplication(@RequestParam(value = APPLICATION_ID_PARAMS) @NotBlank String applicationName) {
+    public List<Rule> getRulesByApplication(@ServiceParam ServiceName serviceName, @RequestParam(value = APPLICATION_ID_PARAMS) @NotBlank String applicationName) {
         return alarmService.selectRuleByApplicationName(applicationName);
     }
 
     @PreAuthorize("hasPermission(#rule.getApplicationName(), null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
     @PutMapping
-    public Response updateRule(@RequestBody Rule rule) {
+    public Response updateRule(@ServiceParam ServiceName serviceName, @RequestBody Rule rule) {
         if (Rule.isRuleInvalid(rule)) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
@@ -102,7 +104,7 @@ public class AlarmController {
     }
 
     @GetMapping(value = "/checker")
-    public List<String> getCheckerName() {
+    public List<String> getCheckerName(@ServiceParam ServiceName serviceName) {
         return CheckerCategory.getNames();
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/WebhookAlarmController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/WebhookAlarmController.java
@@ -20,6 +20,8 @@ package com.navercorp.pinpoint.web.authorization.controller;
 import com.navercorp.pinpoint.common.server.response.Response;
 import com.navercorp.pinpoint.common.server.response.Result;
 import com.navercorp.pinpoint.common.server.response.SimpleResponse;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.alarm.vo.Rule;
 import com.navercorp.pinpoint.web.response.AlarmResponse;
 import com.navercorp.pinpoint.web.webhook.WebhookModule;
@@ -52,7 +54,7 @@ public class WebhookAlarmController {
 
     @PreAuthorize("hasPermission(#ruleWithWebhooks.getRule().getApplicationName(), null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
     @PostMapping(value = "/includeWebhooks")
-    public AlarmResponse insertRuleWithWebhooks(@RequestBody RuleWithWebhooks ruleWithWebhooks) {
+    public AlarmResponse insertRuleWithWebhooks(@ServiceParam ServiceName serviceName, @RequestBody RuleWithWebhooks ruleWithWebhooks) {
         Rule rule = ruleWithWebhooks.getRule();
         if (Rule.isRuleInvalidForPost(rule)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "there is not applicationId/checkerName/userGroupId/threashold to insert alarm rule");
@@ -64,7 +66,7 @@ public class WebhookAlarmController {
 
     @PreAuthorize("hasPermission(#ruleWithWebhooks.getRule().getApplicationName(), null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
     @PutMapping(value = "/includeWebhooks")
-    public Response updateRuleWithWebhooks(@RequestBody RuleWithWebhooks ruleWithWebhooks) {
+    public Response updateRuleWithWebhooks(@ServiceParam ServiceName serviceName, @RequestBody RuleWithWebhooks ruleWithWebhooks) {
         Rule rule = ruleWithWebhooks.getRule();
         if (Rule.isRuleInvalid(rule)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "there is not ruleId/userGroupId/applicationid/checkerName to update alarm rule");


### PR DESCRIPTION
## Summary
- Add `@ServiceParam ServiceName serviceName` parameter to all methods in AlarmController and WebhookAlarmController
- Preparation for service-level permission checks on alarm APIs

## Changes
- **AlarmController**: 6 methods (insertRule, deleteRule, updateRule, getRulesByUserGroup, getRulesByApplication, getCheckerName)
- **WebhookAlarmController**: 2 methods (insertRuleWithWebhooks, updateRuleWithWebhooks)
- No behavioral change — `@PreAuthorize` logic is unchanged in this PR