### PR TITLE
[#noissue] Fix IntelliJ Maven sync failure for os-maven-plugin extension

### DIFF
--- a/agent-module/agent-testweb/grpc-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/grpc-plugin-testweb/pom.xml
@@ -78,7 +78,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.5.0.Final</version>
+                <version>${plugin.os-maven.version}</version>
             </extension>
         </extensions>
 

--- a/agent-module/plugins-it/pom.xml
+++ b/agent-module/plugins-it/pom.xml
@@ -143,7 +143,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.5.0.Final</version>
+                <version>${plugin.os-maven.version}</version>
             </extension>
         </extensions>
 

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -179,7 +179,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.5.0.Final</version>
+                <version>${plugin.os-maven.version}</version>
             </extension>
         </extensions>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,20 @@
         -->
     </repositories>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <modules>
         <module>annotations</module>
         <module>agent-module</module>
@@ -269,6 +283,7 @@
         <plugin.build-helper.version>3.4.0</plugin.build-helper.version>
         <plugin.javadoc.version>3.6.3</plugin.javadoc.version>
         <plugin.protobuf.version>0.6.1</plugin.protobuf.version>
+        <plugin.os-maven.version>1.7.1</plugin.os-maven.version>
 
         <plugin.spotbugs.version>4.7.3.6</plugin.spotbugs.version>
         <plugin.pmd.version>3.21.2</plugin.pmd.version>


### PR DESCRIPTION
This pull request updates how the `os-maven-plugin` version is managed across the project and ensures that the Maven Central repository is explicitly defined for plugin resolution. The main improvements are in dependency management and build consistency.

Dependency and plugin management:

* Centralized the `os-maven-plugin` version by defining `${plugin.os-maven.version}` in the root `pom.xml` and updating all module `pom.xml` files to reference this property instead of hardcoding the version. This makes version upgrades easier and keeps all modules in sync. [[1]](diffhunk://#diff-0354f6bf4e74e013f12f18634bc16f10977bc7f856c1915e86972f3aa37aca1eL81-R81) [[2]](diffhunk://#diff-15f5dc257d882270b5329db129d90576d1eb5b4f60a6ccd9b0bd4ff7350e4760L146-R146) [[3]](diffhunk://#diff-45944c86e0452447902c811f67bc39b759eb37f3c675ef5c7fa291787124691dL182-R182) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R286)

Build configuration:

* Added an explicit `pluginRepositories` section to the root `pom.xml` to ensure Maven plugins are always resolved from Maven Central, improving build reliability and reducing the risk of missing plugins.