### PR TITLE
[#13534] Apply service-level alarm permission check to AlarmController

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AlarmController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AlarmController.java
@@ -60,7 +60,7 @@ public class AlarmController {
         this.alarmService = Objects.requireNonNull(alarmService, "alarmService");
     }
 
-    @PreAuthorize("hasPermission(#rule.getApplicationName(), null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
+    @PreAuthorize("@naverPermissionEvaluator.hasAlarmPermission(#serviceName.getName(), #rule.getApplicationName(), T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
     @PostMapping
     public AlarmResponse insertRule(@ServiceParam ServiceName serviceName, @RequestBody Rule rule) {
         if (Rule.isRuleInvalidForPost(rule)) {
@@ -70,7 +70,7 @@ public class AlarmController {
         return new AlarmResponse(Result.SUCCESS, ruleId);
     }
 
-    @PreAuthorize("hasPermission(#rule.getApplicationName(), null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
+    @PreAuthorize("@naverPermissionEvaluator.hasAlarmPermission(#serviceName.getName(), #rule.getApplicationName(), T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
     @DeleteMapping
     public Response deleteRule(@ServiceParam ServiceName serviceName, @RequestBody Rule rule) {
         if (StringUtils.isEmpty(rule.getRuleId())) {
@@ -90,7 +90,7 @@ public class AlarmController {
         return alarmService.selectRuleByApplicationName(applicationName);
     }
 
-    @PreAuthorize("hasPermission(#rule.getApplicationName(), null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
+    @PreAuthorize("@naverPermissionEvaluator.hasAlarmPermission(#serviceName.getName(), #rule.getApplicationName(), T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
     @PutMapping
     public Response updateRule(@ServiceParam ServiceName serviceName, @RequestBody Rule rule) {
         if (Rule.isRuleInvalid(rule)) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/WebhookAlarmController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/WebhookAlarmController.java
@@ -52,7 +52,7 @@ public class WebhookAlarmController {
         this.webhookAlarmServiceFacade = Objects.requireNonNull(webhookAlarmServiceFacade, "webhookAlarmAdaptor");
     }
 
-    @PreAuthorize("hasPermission(#ruleWithWebhooks.getRule().getApplicationName(), null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
+    @PreAuthorize("@naverPermissionEvaluator.hasAlarmPermission(#serviceName.getName(), #ruleWithWebhooks.getRule().getApplicationName(), T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
     @PostMapping(value = "/includeWebhooks")
     public AlarmResponse insertRuleWithWebhooks(@ServiceParam ServiceName serviceName, @RequestBody RuleWithWebhooks ruleWithWebhooks) {
         Rule rule = ruleWithWebhooks.getRule();
@@ -64,7 +64,7 @@ public class WebhookAlarmController {
         return new AlarmResponse(Result.SUCCESS, ruleId);
     }
 
-    @PreAuthorize("hasPermission(#ruleWithWebhooks.getRule().getApplicationName(), null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
+    @PreAuthorize("@naverPermissionEvaluator.hasAlarmPermission(#serviceName.getName(), #ruleWithWebhooks.getRule().getApplicationName(), T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_ALARM_EDIT_ALARM_ONLY_MANAGER)")
     @PutMapping(value = "/includeWebhooks")
     public Response updateRuleWithWebhooks(@ServiceParam ServiceName serviceName, @RequestBody RuleWithWebhooks ruleWithWebhooks) {
         Rule rule = ruleWithWebhooks.getRule();


### PR DESCRIPTION
## Summary
- Change @PreAuthorize in AlarmController and WebhookAlarmController to use hasAlarmPermission with serviceName parameter
- When serviceName is DEFAULT, check application-level permission; when non-DEFAULT, check service-level permission
- Affects POST/DELETE/PUT endpoints for both alarm rules and webhook alarm rules

## Test plan
- [x] Unit test pass
- [x] Scenario test: admin (editAlarmForEverything=true) — all operations pass
- [x] Scenario test: authorized user (app/service manager) — all operations pass  
- [x] Scenario test: unauthorized user — all operations return 403