### PR TITLE
[#noissue] Simplify log4j2 agent config by replacing SystemPropertyArbiter with sys property lookup

### DIFF
--- a/agent-module/agent/src/main/resources/log4j2-agent.xml
+++ b/agent-module/agent/src/main/resources/log4j2-agent.xml
@@ -8,68 +8,12 @@
         <Property name="simple_message_pattern">%d{MM-dd HH:mm:ss.SSS} [%15.15t] %-5level %-40.40logger{1.} -- %msg%n</Property>
         <Property name="console_message_pattern">${simple_message_pattern}</Property>
         <Property name="file_message_pattern">${simple_message_pattern}</Property>
-        <Select>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.file.size" propertyValue="25m">
-                <Property name="backupsize">25m</Property>
-            </SystemPropertyArbiter>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.file.size" propertyValue="50m">
-                <Property name="backupsize">50m</Property>
-            </SystemPropertyArbiter>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.file.size" propertyValue="100m">
-                <Property name="backupsize">100m</Property>
-            </SystemPropertyArbiter>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.file.size" propertyValue="500m">
-                <Property name="backupsize">500m</Property>
-            </SystemPropertyArbiter>
-            <DefaultArbiter>
-                <Property name="backupsize">100m</Property>
-            </DefaultArbiter>
-        </Select>
-        <Select>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.file.lastmodified" propertyValue="3d">
-                <Property name="lastmodified">3d</Property>
-            </SystemPropertyArbiter>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.file.lastmodified" propertyValue="7d">
-                <Property name="lastmodified">7d</Property>
-            </SystemPropertyArbiter>
-            <DefaultArbiter>
-                <Property name="lastmodified">7d</Property>
-            </DefaultArbiter>
-        </Select>
-        <Select>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.file.rollover-strategy-max" propertyValue="1">
-                <Property name="default-rollover-strategy-max">1</Property>
-            </SystemPropertyArbiter>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.file.rollover-strategy-max" propertyValue="5">
-                <Property name="default-rollover-strategy-max">5</Property>
-            </SystemPropertyArbiter>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.file.rollover-strategy-max" propertyValue="10">
-                <Property name="default-rollover-strategy-max">10</Property>
-            </SystemPropertyArbiter>
-            <DefaultArbiter>
-                <Property name="default-rollover-strategy-max">5</Property>
-            </DefaultArbiter>
-        </Select>
-        <Select>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.level" propertyValue="DEBUG">
-                <Property name="logger.com.navercorp.pinpoint.level">DEBUG</Property>
-            </SystemPropertyArbiter>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.level" propertyValue="INFO">
-                <Property name="logger.com.navercorp.pinpoint.level">INFO</Property>
-            </SystemPropertyArbiter>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.level" propertyValue="WARN">
-                <Property name="logger.com.navercorp.pinpoint.level">WARN</Property>
-            </SystemPropertyArbiter>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.level" propertyValue="ERROR">
-                <Property name="logger.com.navercorp.pinpoint.level">ERROR</Property>
-            </SystemPropertyArbiter>
-            <SystemPropertyArbiter propertyName="pinpoint.logging.level" propertyValue="FATAL">
-                <Property name="logger.com.navercorp.pinpoint.level">FATAL</Property>
-            </SystemPropertyArbiter>
-            <DefaultArbiter>
-                <Property name="logger.com.navercorp.pinpoint.level">INFO</Property>
-            </DefaultArbiter>
-        </Select>
+
+        <Property name="backupsize">${sys:pinpoint.logging.file.size:-100m}</Property>
+        <Property name="lastmodified">${sys:pinpoint.logging.file.lastmodified:-7d}</Property>
+        <Property name="default-rollover-strategy-max">${sys:pinpoint.logging.file.rollover-strategy-max:-5}</Property>
+
+        <Property name="logger.com.navercorp.pinpoint.level">${sys:pinpoint.logging.level:-INFO}</Property>
     </Properties>
     <Appenders>
         <Console name="console" target="system_out">
@@ -128,7 +72,7 @@
             <AppenderRef ref="console"/>
             <AppenderRef ref="rollingFile"/>
         </Logger>
-        <Logger name="io.grpc" level="INFO" additivity="false">
+        <Logger name="io.grpc" level="${logger.com.navercorp.pinpoint.level}" additivity="false">
             <AppenderRef ref="console"/>
             <AppenderRef ref="rollingFile"/>
         </Logger>

--- a/agent-module/agent/src/main/resources/log4j2-agent.yaml
+++ b/agent-module/agent/src/main/resources/log4j2-agent.yaml
@@ -14,97 +14,14 @@ Configuration:
         value: "${simple_message_pattern}"
       - name: "file_message_pattern"
         value: "${simple_message_pattern}"
-    Select:
-      - SystemPropertyArbiter:
-          - propertyName: "pinpoint.logging.file.size"
-            propertyValue: "25m"
-            Property:
-              name: "backupsize"
-              value: "25m"
-          - propertyName: "pinpoint.logging.file.size"
-            propertyValue: "50m"
-            Property:
-              name: "backupsize"
-              value: "50m"
-          - propertyName: "pinpoint.logging.file.size"
-            propertyValue: "100m"
-            Property:
-              name: "backupsize"
-              value: "100m"
-          - propertyName: "pinpoint.logging.file.size"
-            propertyValue: "500m"
-            Property:
-              name: "backupsize"
-              value: "500m"
-        DefaultArbiter:
-          Property:
-            name: "backupsize"
-            value: "100m"
-      - SystemPropertyArbiter:
-          - propertyName: "pinpoint.logging.file.lastmodified"
-            propertyValue: "3d"
-            Property:
-              name: "lastmodified"
-              value: "3d"
-          - propertyName: "pinpoint.logging.file.lastmodified"
-            propertyValue: "7d"
-            Property:
-              name: "lastmodified"
-              value: "7d"
-        DefaultArbiter:
-          Property:
-            name: "lastmodified"
-            value: "7d"
-      - SystemPropertyArbiter:
-          - propertyName: "pinpoint.logging.file.rollover-strategy-max"
-            propertyValue: "1"
-            Property:
-              name: "default-rollover-strategy-max"
-              value: "1"
-          - propertyName: "pinpoint.logging.file.rollover-strategy-max"
-            propertyValue: "5"
-            Property:
-              name: "default-rollover-strategy-max"
-              value: "5"
-          - propertyName: "pinpoint.logging.file.rollover-strategy-max"
-            propertyValue: "10"
-            Property:
-              name: "default-rollover-strategy-max"
-              value: "10"
-        DefaultArbiter:
-          Property:
-            name: "default-rollover-strategy-max"
-            value: "5"
-      - SystemPropertyArbiter:
-          - propertyName: "pinpoint.logging.level"
-            propertyValue: "DEBUG"
-            Property:
-              name: "logger.com.navercorp.pinpoint.level"
-              value: "DEBUG"
-          - propertyName: "pinpoint.logging.level"
-            propertyValue: "INFO"
-            Property:
-              name: "logger.com.navercorp.pinpoint.level"
-              value: "INFO"
-          - propertyName: "pinpoint.logging.level"
-            propertyValue: "WARN"
-            Property:
-              name: "logger.com.navercorp.pinpoint.level"
-              value: "WARN"
-          - propertyName: "pinpoint.logging.level"
-            propertyValue: "ERROR"
-            Property:
-              name: "logger.com.navercorp.pinpoint.level"
-              value: "ERROR"
-          - propertyName: "pinpoint.logging.level"
-            propertyValue: "FATAL"
-            Property:
-              name: "logger.com.navercorp.pinpoint.level"
-              value: "FATAL"
-        DefaultArbiter:
-          Property:
-            name: "logger.com.navercorp.pinpoint.level"
-            value: "INFO"
+      - name: "backupsize"
+        value: "${sys:pinpoint.logging.file.size:-100m}"
+      - name: "lastmodified"
+        value: "${sys:pinpoint.logging.file.lastmodified:-7d}"
+      - name: "default-rollover-strategy-max"
+        value: "${sys:pinpoint.logging.file.rollover-strategy-max:-5}"
+      - name: "logger.com.navercorp.pinpoint.level"
+        value: "${sys:pinpoint.logging.level:-INFO}"
   Appenders:
     Console:
       name: console


### PR DESCRIPTION
…biter with sys property lookup

This pull request simplifies the logging configuration for the agent by replacing complex property selection logic with direct property references that use system properties and sensible defaults. This makes the configuration files easier to maintain and more flexible for runtime customization.

**Logging configuration simplification:**

* Replaced multiple `<Select>` and `<SystemPropertyArbiter>` blocks in `log4j2-agent.xml` with direct property references using system properties and default values for `backupsize`, `lastmodified`, `default-rollover-strategy-max`, and `logger.com.navercorp.pinpoint.level`.
* Updated the logger configuration for `io.grpc` in `log4j2-agent.xml` to use the centralized log level property (`${logger.com.navercorp.pinpoint.level}`) instead of a hardcoded value.

**YAML configuration alignment:**

* Simplified `log4j2-agent.yaml` by removing the nested `Select` and `SystemPropertyArbiter` structures, and replacing them with direct property assignments using system property references and default values.