### PR TITLE
[#13534] Add @ServiceParam to inspector controllers and unit tests

### DIFF
--- a/inspector-module/inspector-web/pom.xml
+++ b/inspector-module/inspector-web/pom.xml
@@ -37,6 +37,17 @@
         </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-service-module</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-web</artifactId>
             <exclusions>
                 <exclusion>

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
@@ -32,6 +32,8 @@ import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.vo.Service;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -67,9 +69,10 @@ public class AgentInspectorStatController {
     }
 
     // TODO : (minwoo) tenantId should be considered. The collector side should also be considered.
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/chart")
     public InspectorMetricView getAgentStatChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") String applicationName,
             @RequestParam("agentId") String agentId,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
@@ -86,9 +89,10 @@ public class AgentInspectorStatController {
         return new InspectorMetricView(inspectorMetricData);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/chart", params = "metricDefinitionId=apdex")
     public InspectorMetricView getApdexStatChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("agentId") String agentId,
@@ -102,9 +106,10 @@ public class AgentInspectorStatController {
         return new InspectorMetricView(inspectorMetricData);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/chartList")
     public InspectorMetricGroupDataView getAgentStatChartList(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") String applicationName,
             @RequestParam("agentId") String agentId,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
@@ -121,9 +126,10 @@ public class AgentInspectorStatController {
         return new InspectorMetricGroupDataView(inspectorMetricGroupData);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/chart", params = {"agentIds", "metricDefinitionId=apdex"})
     public InspectorMetricGroupDataView getApdexStatChartGroupedByAgentId(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("agentIds") @NotEmpty List<String> agentIds,
@@ -139,9 +145,10 @@ public class AgentInspectorStatController {
         return new InspectorMetricGroupDataView(inspectorMetricGroupData);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/chart", params = {"agentIds"})
     public InspectorMetricGroupDataView getAgentStatChartGroupedByAgentId(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") String applicationName,
             @RequestParam("agentIds") @NotEmpty List<String> agentIds,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
@@ -159,9 +166,10 @@ public class AgentInspectorStatController {
         return new InspectorMetricGroupDataView(inspectorMetricGroupData);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/chartList", params = {"agentIds"})
     public InspectorMetricGroupDataView getAgentStatChartListGroupedByAgentId(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") String applicationName,
             @RequestParam("agentIds") @NotEmpty List<String> agentIds,
             @RequestParam("metricDefinitionId") String metricDefinitionId,

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
@@ -16,6 +16,8 @@ import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.vo.Service;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -44,9 +46,10 @@ public class ApplicationInspectorStatController {
         this.rangeValidator = new ForwardRangeValidator(Duration.ofDays(inspectorWebProperties.getInspectorPeriodMax()));
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/chart")
     public InspectorMetricView getApplicationStatChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") String applicationName,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
             @RequestParam("from") Timestamp from,
@@ -62,9 +65,10 @@ public class ApplicationInspectorStatController {
         return new InspectorMetricView(inspectorMetricData);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/chart", params = "metricDefinitionId=apdex")
     public InspectorMetricView getApdexStatChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
@@ -77,9 +81,10 @@ public class ApplicationInspectorStatController {
         return new InspectorMetricView(inspectorMetricData);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/chartList")
     public InspectorMetricGroupDataView getApplicationStatChartList(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") String applicationName,
             @RequestParam("metricDefinitionId") String metricDefinitionId,
             @RequestParam("from") Timestamp from,

--- a/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatControllerTest.java
+++ b/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatControllerTest.java
@@ -1,0 +1,109 @@
+package com.navercorp.pinpoint.inspector.web.controller;
+
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
+import com.navercorp.pinpoint.inspector.web.config.InspectorWebProperties;
+import com.navercorp.pinpoint.inspector.web.model.InspectorMetricData;
+import com.navercorp.pinpoint.inspector.web.model.InspectorMetricGroupData;
+import com.navercorp.pinpoint.inspector.web.service.AgentStatService;
+import com.navercorp.pinpoint.inspector.web.service.ApdexStatService;
+import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
+import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
+import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentInspectorStatControllerTest {
+
+    @Mock
+    private AgentStatService agentStatService;
+    @Mock
+    private ApdexStatService apdexStatService;
+    @Mock
+    private TenantProvider tenantProvider;
+    @Mock
+    private InspectorWebProperties inspectorWebProperties;
+
+    private AgentInspectorStatController controller;
+
+    private static final Timestamp FROM = Timestamp.ofEpochMilli(0);
+    private static final Timestamp TO = Timestamp.ofEpochMilli(300000);
+
+    @BeforeEach
+    void setUp() {
+        when(inspectorWebProperties.getInspectorPeriodMax()).thenReturn(42);
+        controller = new AgentInspectorStatController(agentStatService, apdexStatService, tenantProvider, inspectorWebProperties);
+    }
+
+    @Test
+    void getAgentStatChart() {
+        when(tenantProvider.getTenantId()).thenReturn("pinpoint");
+        InspectorMetricData metricData = new InspectorMetricData("cpu", Collections.emptyList(), Collections.emptyList());
+        when(agentStatService.selectAgentStat(any(), any())).thenReturn(metricData);
+
+        InspectorMetricView result = controller.getAgentStatChart(new ServiceName("DEFAULT"), "testApp", "agent-01", "cpu", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("cpu");
+        verify(agentStatService).selectAgentStat(any(), any());
+    }
+
+    @Test
+    void getAgentStatChart_withNonDefaultService() {
+        when(tenantProvider.getTenantId()).thenReturn("pinpoint");
+        InspectorMetricData metricData = new InspectorMetricData("cpu", Collections.emptyList(), Collections.emptyList());
+        when(agentStatService.selectAgentStat(any(), any())).thenReturn(metricData);
+
+        InspectorMetricView result = controller.getAgentStatChart(new ServiceName("my-service"), "testApp", "agent-01", "cpu", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("cpu");
+    }
+
+    @Test
+    void getAgentStatChartList() {
+        when(tenantProvider.getTenantId()).thenReturn("pinpoint");
+        InspectorMetricGroupData groupData = new InspectorMetricGroupData("cpu", Collections.emptyList(), Collections.emptyMap());
+        when(agentStatService.selectAgentStatWithGrouping(any(), any())).thenReturn(groupData);
+
+        InspectorMetricGroupDataView result = controller.getAgentStatChartList(new ServiceName("DEFAULT"), "testApp", "agent-01", "cpu", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("cpu");
+        verify(agentStatService).selectAgentStatWithGrouping(any(), any());
+    }
+
+    @Test
+    void getAgentStatChartGroupedByAgentId() {
+        when(tenantProvider.getTenantId()).thenReturn("pinpoint");
+        InspectorMetricGroupData groupData = new InspectorMetricGroupData("cpu", Collections.emptyList(), Collections.emptyMap());
+        when(agentStatService.selectAgentStatGroupedByAgentId(any(), any(), any(), any(), any())).thenReturn(groupData);
+
+        InspectorMetricGroupDataView result = controller.getAgentStatChartGroupedByAgentId(
+                new ServiceName("DEFAULT"), "testApp", List.of("agent-01", "agent-02"), "cpu", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("cpu");
+        verify(agentStatService).selectAgentStatGroupedByAgentId(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void getAgentStatChartListGroupedByAgentId() {
+        when(tenantProvider.getTenantId()).thenReturn("pinpoint");
+        InspectorMetricGroupData groupData = new InspectorMetricGroupData("cpu", Collections.emptyList(), Collections.emptyMap());
+        when(agentStatService.selectAgentStatGroupedByAgentId(any(), any(), any(), any(), any())).thenReturn(groupData);
+
+        InspectorMetricGroupDataView result = controller.getAgentStatChartListGroupedByAgentId(
+                new ServiceName("DEFAULT"), "testApp", List.of("agent-01"), "cpu", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("cpu");
+    }
+}

--- a/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatControllerTest.java
+++ b/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatControllerTest.java
@@ -1,0 +1,83 @@
+package com.navercorp.pinpoint.inspector.web.controller;
+
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
+import com.navercorp.pinpoint.inspector.web.config.InspectorWebProperties;
+import com.navercorp.pinpoint.inspector.web.model.InspectorMetricData;
+import com.navercorp.pinpoint.inspector.web.model.InspectorMetricGroupData;
+import com.navercorp.pinpoint.inspector.web.service.ApdexStatService;
+import com.navercorp.pinpoint.inspector.web.service.ApplicationStatService;
+import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
+import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
+import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationInspectorStatControllerTest {
+
+    @Mock
+    private ApplicationStatService applicationStatService;
+    @Mock
+    private ApdexStatService apdexStatService;
+    @Mock
+    private TenantProvider tenantProvider;
+    @Mock
+    private InspectorWebProperties inspectorWebProperties;
+
+    private ApplicationInspectorStatController controller;
+
+    private static final Timestamp FROM = Timestamp.ofEpochMilli(0);
+    private static final Timestamp TO = Timestamp.ofEpochMilli(300000);
+
+    @BeforeEach
+    void setUp() {
+        when(inspectorWebProperties.getInspectorPeriodMax()).thenReturn(42);
+        controller = new ApplicationInspectorStatController(applicationStatService, tenantProvider, apdexStatService, inspectorWebProperties);
+    }
+
+    @Test
+    void getApplicationStatChart() {
+        when(tenantProvider.getTenantId()).thenReturn("pinpoint");
+        InspectorMetricData metricData = new InspectorMetricData("jvmCpu", Collections.emptyList(), Collections.emptyList());
+        when(applicationStatService.selectApplicationStat(any(), any())).thenReturn(metricData);
+
+        InspectorMetricView result = controller.getApplicationStatChart(new ServiceName("DEFAULT"), "testApp", "jvmCpu", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("jvmCpu");
+        verify(applicationStatService).selectApplicationStat(any(), any());
+    }
+
+    @Test
+    void getApplicationStatChart_withNonDefaultService() {
+        when(tenantProvider.getTenantId()).thenReturn("pinpoint");
+        InspectorMetricData metricData = new InspectorMetricData("jvmCpu", Collections.emptyList(), Collections.emptyList());
+        when(applicationStatService.selectApplicationStat(any(), any())).thenReturn(metricData);
+
+        InspectorMetricView result = controller.getApplicationStatChart(new ServiceName("my-service"), "testApp", "jvmCpu", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("jvmCpu");
+    }
+
+    @Test
+    void getApplicationStatChartList() {
+        when(tenantProvider.getTenantId()).thenReturn("pinpoint");
+        InspectorMetricGroupData groupData = new InspectorMetricGroupData("jvmCpu", Collections.emptyList(), Collections.emptyMap());
+        when(applicationStatService.selectApplicationStatWithGrouping(any(), any())).thenReturn(groupData);
+
+        InspectorMetricGroupDataView result = controller.getApplicationStatChartList(new ServiceName("DEFAULT"), "testApp", "jvmCpu", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("jvmCpu");
+        verify(applicationStatService).selectApplicationStatWithGrouping(any(), any());
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentNamesController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentNamesController.java
@@ -37,6 +37,8 @@ import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilters;
 import com.navercorp.pinpoint.web.vo.agent.AgentNameGroupView;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatusAndLink;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -85,9 +87,10 @@ public class AgentNamesController {
         this.rangeValidator = new ForwardRangeValidator(Duration.ofDays(configProperties.getInspectorPeriodMax()));
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/overview", params = {"application"})
     public List<AgentNameGroupView> getAgentsListGroupedByName(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
@@ -103,9 +106,10 @@ public class AgentNamesController {
         return AgentsFactory.groupByAgentName(agents);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/overview", params = {"application", "from", "to"})
     public List<AgentNameGroupView> getAgentsListGroupedByName(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
@@ -124,9 +128,10 @@ public class AgentNamesController {
     }
 
     //use only for server map list
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/overview", params = {"application", "from", "to", "applicationPairs"})
     public List<AgentNameGroupView> getAgentsListGroupedByNameWithVirtualNodes(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
@@ -138,7 +143,7 @@ public class AgentNamesController {
         if (serviceType.isWas()) {
             final ApplicationAgentListQueryRule serverMapAgentListQueryRule = ApplicationAgentListQueryRule.getByValue(query, ApplicationAgentListQueryRule.ACTIVE_STATISTICS);
             return getAgentsListGroupedByName(
-                    applicationName, serviceTypeCode, serviceTypeName, from, to, String.valueOf(serverMapAgentListQueryRule)
+                    serviceName, applicationName, serviceTypeCode, serviceTypeName, from, to, String.valueOf(serverMapAgentListQueryRule)
             );
         }
         Range range = Range.between(from, to);

--- a/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentsController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentsController.java
@@ -36,6 +36,8 @@ import com.navercorp.pinpoint.web.vo.ApplicationPairs;
 import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilters;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatusAndLink;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -88,9 +90,10 @@ public class AgentsController {
     }
 
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/overview", params = {"application"})
     public List<AgentStatusAndLink> getAgentsList(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
@@ -109,9 +112,10 @@ public class AgentsController {
         );
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/overview", params = {"application", "from", "to"})
     public List<AgentStatusAndLink> getAgentsList(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
@@ -134,9 +138,10 @@ public class AgentsController {
 
 
     //use only for server map list
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/overview", params = {"application", "from", "to", "applicationPairs"})
     public List<AgentStatusAndLink> getAgentsListWithVirtualNodes(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
@@ -149,7 +154,7 @@ public class AgentsController {
         if (serviceType.isWas()) {
             final ApplicationAgentListQueryRule serverMapAgentListQueryRule = ApplicationAgentListQueryRule.getByValue(query, ApplicationAgentListQueryRule.ACTIVE_STATISTICS);
             return getAgentsList(
-                    applicationName, serviceTypeCode, serviceTypeName, from, to, String.valueOf(serverMapAgentListQueryRule)
+                    serviceName, applicationName, serviceTypeCode, serviceTypeName, from, to, String.valueOf(serverMapAgentListQueryRule)
             );
         }
         Range range = Range.between(from, to);

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ActiveThreadDumpController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ActiveThreadDumpController.java
@@ -25,6 +25,8 @@ import com.navercorp.pinpoint.web.service.AgentService;
 import com.navercorp.pinpoint.web.vo.activethread.AgentActiveThreadDumpFactory;
 import com.navercorp.pinpoint.web.vo.activethread.AgentActiveThreadDumpList;
 import com.navercorp.pinpoint.web.vo.activethread.ThreadDumpResult;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -59,9 +61,10 @@ public class ActiveThreadDumpController implements AccessDeniedExceptionHandler 
         this.activeThreadDumpService = Objects.requireNonNull(activeThreadDumpService, "activeThreadDumpService");
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/activeThreadDump")
     public CodeResult<ThreadDumpResult> getActiveThreadDump(
+            @ServiceParam ServiceName serviceName,
             @RequestParam(value = "applicationName") @NotBlank String applicationName,
             @RequestParam(value = "agentId") @NotBlank String agentId,
             @RequestParam(value = "limit", required = false, defaultValue = "-1") int limit,
@@ -84,9 +87,10 @@ public class ActiveThreadDumpController implements AccessDeniedExceptionHandler 
         ));
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/activeThreadLightDump")
     public CodeResult<ThreadDumpResult> getActiveThreadLightDump(
+            @ServiceParam ServiceName serviceName,
             @RequestParam(value = "applicationName") @NotBlank String applicationName,
             @RequestParam(value = "agentId") @NotBlank String agentId,
             @RequestParam(value = "limit", required = false, defaultValue = "-1") int limit,

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentInfoController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentInfoController.java
@@ -33,6 +33,8 @@ import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatus;
 import com.navercorp.pinpoint.web.vo.agent.DetailedAgentAndStatus;
 import com.navercorp.pinpoint.web.vo.timeline.inspector.InspectorTimeline;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -69,9 +71,10 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
         this.rangeValidator = new ForwardRangeValidator(Duration.ofDays(configProperties.getInspectorPeriodMax()));
     }
 
-    @PreAuthorize("hasPermission(new com.navercorp.pinpoint.web.vo.AgentParam(#agentId, #timestamp), 'agentParam', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), new com.navercorp.pinpoint.web.vo.AgentParam(#agentId, #timestamp))")
     @GetMapping(value = "/getAgentInfo")
     public AgentAndStatus getAgentInfo(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("agentId") @NotBlank String agentId,
             @RequestParam("timestamp") Timestamp timestamp) {
         AgentAndStatus result = this.agentInfoService.findAgentInfoAndStatus(agentId, timestamp.getEpochMillis());
@@ -83,6 +86,7 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
 
     @GetMapping(value = "/getDetailedAgentInfo")
     public DetailedAgentAndStatus getDetailedAgentInfo(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("agentId") @NotBlank String agentId,
             @RequestParam("timestamp") Timestamp timestamp) {
         DetailedAgentAndStatus result = this.agentInfoService.findDetailedAgentInfoAndStatus(agentId, timestamp.getEpochMillis());
@@ -94,6 +98,7 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
 
     @GetMapping(value = "/getAgentStatus")
     public AgentStatus getAgentStatus(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("agentId") @NotBlank String agentId,
             @RequestParam("timestamp") Timestamp timestamp) {
         AgentStatus result = this.agentInfoService.findAgentStatus(agentId, timestamp.getEpochMillis());
@@ -105,6 +110,7 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
 
     @GetMapping(value = "/getAgentEvent")
     public AgentEvent getAgentEvent(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("agentId") @NotBlank String agentId,
             @RequestParam("eventTimestamp") Timestamp eventTimestamp,
             @RequestParam("eventTypeCode") int eventTypeCode
@@ -121,9 +127,10 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
         return result;
     }
 
-    @PreAuthorize("hasPermission(new com.navercorp.pinpoint.web.vo.AgentParam(#agentId, #to), 'agentParam', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), new com.navercorp.pinpoint.web.vo.AgentParam(#agentId, #to))")
     @GetMapping(value = "/getAgentEvents")
     public List<AgentEvent> getAgentEvents(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("agentId") @NotBlank String agentId,
             @RequestParam("from") Timestamp from,
             @RequestParam("to") Timestamp to,
@@ -145,9 +152,10 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
         return excludeEventTypes;
     }
 
-    @PreAuthorize("hasPermission(new com.navercorp.pinpoint.web.vo.AgentParam(#agentId, #to), 'agentParam', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), new com.navercorp.pinpoint.web.vo.AgentParam(#agentId, #to))")
     @GetMapping(value = "/getAgentStatusTimeline")
     public InspectorTimeline getAgentStatusTimeline(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("agentId") @NotBlank String agentId,
             @RequestParam("from") Timestamp from,
@@ -156,9 +164,10 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
         return agentInfoService.getAgentStatusTimeline(applicationName, agentId, range);
     }
 
-    @PreAuthorize("hasPermission(new com.navercorp.pinpoint.web.vo.AgentParam(#agentId, #to), 'agentParam', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), new com.navercorp.pinpoint.web.vo.AgentParam(#agentId, #to))")
     @GetMapping(value = "/getAgentStatusTimeline", params = {"exclude"})
     public InspectorTimeline getAgentStatusTimeline(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("agentId") @NotBlank String agentId,
             @RequestParam("from") Timestamp from,
@@ -170,7 +179,7 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
     }
 
     @RequestMapping(value = "/isAvailableAgentId")
-    public CodeResult<String> isAvailableAgentId(@RequestParam("agentId") @NotBlank String agentId) {
+    public CodeResult<String> isAvailableAgentId(@ServiceParam ServiceName serviceName, @RequestParam("agentId") @NotBlank String agentId) {
         final IdValidateUtils.CheckResult result = IdValidateUtils.checkId(agentId, PinpointConstants.AGENT_ID_MAX_LEN);
         if (result == IdValidateUtils.CheckResult.FAIL_LENGTH) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "length range is 1 ~ 24");

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentV2Controller.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentV2Controller.java
@@ -37,6 +37,8 @@ import com.navercorp.pinpoint.web.vo.agent.AgentStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatusAndLink;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,7 +84,7 @@ public class AgentV2Controller {
     }
 
     @GetMapping("/agents")
-    public void forwardAgentsRequest(ServletRequest req, HttpServletResponse res) throws Exception {
+    public void forwardAgentsRequest(@ServiceParam ServiceName serviceName, ServletRequest req, HttpServletResponse res) throws Exception {
         if (agentReadV2) {
             req.getRequestDispatcher("/api/v2/agents").forward(req, res);
             return;
@@ -90,16 +92,16 @@ public class AgentV2Controller {
         req.getRequestDispatcher("/api/v1/agents").forward(req, res);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/v2/agents", params = {"applicationName", "from", "to"})
     public List<AgentIdView> getAgentsV2(
-            @RequestParam(value = "serviceName", required = false) String serviceName,
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
             @RequestParam("from") Timestamp from,
             @RequestParam("to") Timestamp to) {
-        ServiceUid serviceUid = handleServiceUid(serviceName);
+        ServiceUid serviceUid = handleServiceUid(serviceName.getName());
         final ServiceType serviceType = findServiceType(serviceTypeCode, serviceTypeName);
         Range range = Range.between(from, to);
         rangeValidator.validate(range);
@@ -112,16 +114,16 @@ public class AgentV2Controller {
                 .toList();
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/v1/agents", params = {"applicationName", "from", "to"})
     public List<AgentIdView> getAgentsV1(
-            @RequestParam(value = "serviceName", required = false) String serviceName,
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
             @RequestParam("from") Timestamp from,
             @RequestParam("to") Timestamp to) {
-        ServiceUid serviceUid = handleServiceUid(serviceName);
+        ServiceUid serviceUid = handleServiceUid(serviceName.getName());
         final ServiceType serviceType = findServiceType(serviceTypeCode, serviceTypeName);
         Range range = Range.between(from, to);
         rangeValidator.validate(range);

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatMapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatMapController.java
@@ -29,6 +29,8 @@ import com.navercorp.pinpoint.web.validation.NullOrNotBlank;
 import com.navercorp.pinpoint.web.view.transactionlist.DotMetaDataView;
 import com.navercorp.pinpoint.web.view.transactionlist.TransactionDotMetaDataViewModel;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 import jakarta.validation.constraints.NotBlank;
@@ -64,9 +66,10 @@ public class HeatMapController {
         this.defaultTraceIndexReadV2 = defaultTraceIndexReadV2;
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/drag")
     public ResultView dragScatterArea(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Integer serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatmapChartController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatmapChartController.java
@@ -24,6 +24,8 @@ import com.navercorp.pinpoint.web.heatmap.service.EmptyHeatmapService;
 import com.navercorp.pinpoint.web.heatmap.service.HeatmapChartService;
 import com.navercorp.pinpoint.web.heatmap.view.HeatMapDataView;
 import com.navercorp.pinpoint.web.heatmap.vo.HeatMapData;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
@@ -57,9 +59,10 @@ public class HeatmapChartController {
         //TODO : (minwoo) need to set rangeValidator
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/applicationData")
-    public HeatMapDataView getHeatmapAppData(@RequestParam("applicationName") @NotBlank String applicationName,
+    public HeatMapDataView getHeatmapAppData(@ServiceParam ServiceName serviceName,
+                                  @RequestParam("applicationName") @NotBlank String applicationName,
                                   @RequestParam("from") Timestamp from,
                                   @RequestParam("to") Timestamp to,
                                   @RequestParam("minElapsedTime") @PositiveOrZero int minElapsedTime,

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ResponseTimeController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ResponseTimeController.java
@@ -40,6 +40,8 @@ import com.navercorp.pinpoint.web.vo.ApplicationPair;
 import com.navercorp.pinpoint.web.vo.ApplicationPairs;
 import com.navercorp.pinpoint.web.vo.ResponseTimeStatics;
 import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
 import org.apache.logging.log4j.LogManager;
@@ -82,9 +84,10 @@ public class ResponseTimeController {
         this.hyperLinkFactory = Objects.requireNonNull(hyperLinkFactory, "hyperLinkFactory");
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/getWas/serverHistogramData")
     public ServerHistogramView getWasServerHistogramData(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
@@ -104,9 +107,10 @@ public class ResponseTimeController {
         return ServerHistogramView.view(nodeHistogramSummary, hyperLinkFactory);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/getWas/histogram")
     public Histogram getWasHistogram(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
@@ -126,22 +130,24 @@ public class ResponseTimeController {
         return nodeHistogramSummary.getHistogram();
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/getWas/responseStatistics")
     public ResponseTimeStatics getWasResponseTimeStatistics(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
             @RequestParam("from") Timestamp from,
             @RequestParam("to") Timestamp to
     ) {
-        Histogram histogram = getWasHistogram(applicationName, serviceTypeCode, serviceTypeName, from, to);
+        Histogram histogram = getWasHistogram(serviceName, applicationName, serviceTypeCode, serviceTypeName, from, to);
         return ResponseTimeStatics.fromHistogram(histogram);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/getWas/{type}/chart")
     public TimeHistogramChart getWasTimeHistogramChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
@@ -167,6 +173,7 @@ public class ResponseTimeController {
 
     @GetMapping(value = "/getWas/histogramData")
     public HistogramView getWasHistogramData(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
@@ -193,9 +200,10 @@ public class ResponseTimeController {
         return new ResponseTimeHistogramServiceOption.Builder(application, timeWindow, Collections.emptyList(), Collections.emptyList());
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @PostMapping(value = "/getNode/serverHistogramData")
     public ServerHistogramView postNodeServerHistogramData(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
@@ -216,9 +224,10 @@ public class ResponseTimeController {
         return ServerHistogramView.view(nodeHistogramSummary, hyperLinkFactory);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @PostMapping(value = "/getNode/histogramData")
     public HistogramView postNodeHistogramData(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
@@ -240,9 +249,10 @@ public class ResponseTimeController {
         return HistogramView.view(nodeHistogramSummary);
     }
 
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @PostMapping(value = "/getNode/{type}/chart")
     public TimeHistogramChart postNodeTimeHistogramChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Short serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) @NotBlank String serviceTypeName,
@@ -273,9 +283,10 @@ public class ResponseTimeController {
                 .build(timeHistogramType);
     }
 
-    @PreAuthorize("hasPermission(#fromApplicationName, 'application', 'inspector') or hasPermission(#toApplicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #fromApplicationName) or @naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #toApplicationName)")
     @GetMapping(value = "/getLink/histogramData")
     public HistogramView getLinkHistogramData(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("fromApplicationName") @NotBlank String fromApplicationName,
             @RequestParam(value = "fromServiceTypeCode", required = false) Short fromServiceTypeCode,
             @RequestParam(value = "fromServiceTypeName", required = false) @NotBlank String fromServiceTypeName,
@@ -305,9 +316,10 @@ public class ResponseTimeController {
         return new HistogramView(linkName, histogram, appHistogram);
     }
 
-    @PreAuthorize("hasPermission(#fromApplicationName, 'application', 'inspector') or hasPermission(#toApplicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #fromApplicationName) or @naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #toApplicationName)")
     @GetMapping(value = "/getLink/{type}/chart")
     public TimeHistogramChart getLinkTimeHistogramChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("fromApplicationName") @NotBlank String fromApplicationName,
             @RequestParam(value = "fromServiceTypeCode", required = false) Short fromServiceTypeCode,
             @RequestParam(value = "fromServiceTypeName", required = false) @NotBlank String fromServiceTypeName,

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ScatterChartController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ScatterChartController.java
@@ -30,6 +30,8 @@ import com.navercorp.pinpoint.web.util.LimitUtils;
 import com.navercorp.pinpoint.web.view.transactionlist.TransactionMetaDataViewModel;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.GetTraceInfoParser;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
@@ -83,7 +85,7 @@ public class ScatterChartController implements AccessDeniedExceptionHandler {
      * @return TransactionMetaDataViewModel
      */
     @PostMapping(value = "/transactionmetadata")
-    public TransactionMetaDataViewModel postTransactionMetadata(@RequestParam Map<String, String> requestParam) {
+    public TransactionMetaDataViewModel postTransactionMetadata(@ServiceParam ServiceName serviceName, @RequestParam Map<String, String> requestParam) {
         final List<GetTraceInfo> selectTraceInfoList = this.getTraceInfoParser.parse(requestParam);
 
         if (CollectionUtils.isEmpty(selectTraceInfoList)) {
@@ -102,9 +104,10 @@ public class ScatterChartController implements AccessDeniedExceptionHandler {
      *                        additional calls to fetch the rest of the data
      * @return ScatterView.ResultView
      */
-    @PreAuthorize("hasPermission(#applicationName, 'application', 'inspector')")
+    @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
     @GetMapping(value = "/getScatterData")
     public ScatterView.ResultView getScatterData(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("application") @NotBlank String applicationName,
             @RequestParam(value = "serviceTypeCode", required = false) Integer serviceTypeCode,
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,


### PR DESCRIPTION
## Summary
- Add `@ServiceParam` annotation to `@PreAuthorize` expressions in inspector controllers (`AgentInspectorStatController`, `ApplicationInspectorStatController`) for service-level permission checks
- Apply the same pattern to additional web controllers (`AgentNamesController`, `AgentsController`, `ActiveThreadDumpController`, `AgentInfoController`, `AgentV2Controller`, `HeatMapController`, `HeatmapChartController`, `ResponseTimeController`, `ScatterChartController`)
- Add unit tests for `AgentInspectorStatController` (5 tests) and `ApplicationInspectorStatController` (3 tests)
- Add test dependencies (`mockito-core`, `assertj-core`) to inspector-web module

## Test plan
- [x] Unit tests pass for AgentInspectorStatController (5 cases)
- [x] Unit tests pass for ApplicationInspectorStatController (3 cases)
- [x] Scenario tests for inspector service permission (18/18 ALL PASS)