### PR TITLE
[#13651] Add hbase-testcluster module for integration tests

### DIFF
--- a/commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/test/HbaseDaoTest.java
+++ b/commons-hbase/src/test/java/com/navercorp/pinpoint/common/hbase/test/HbaseDaoTest.java
@@ -1,0 +1,62 @@
+package com.navercorp.pinpoint.common.hbase.test;
+
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+class HbaseDaoTest {
+
+    private static final HBaseTestingUtility UTIL = new HBaseTestingUtility();
+    private static final TableName TABLE = TableName.valueOf("my_test");
+    private static final byte[] CF = Bytes.toBytes("cf");
+
+    private static Connection connection;
+
+    @BeforeAll
+    static void startCluster() throws Exception {
+        UTIL.startMiniCluster();
+        connection = ConnectionFactory.createConnection(UTIL.getConfiguration());
+    }
+
+    @AfterAll
+    static void stopCluster() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
+        UTIL.shutdownMiniCluster();
+    }
+
+    @BeforeEach
+    void createTable() throws Exception {
+        if (UTIL.getAdmin().tableExists(TABLE)) {
+            UTIL.deleteTable(TABLE);
+        }
+        UTIL.createTable(TABLE, CF);
+    }
+
+    @Test
+    void putAndGet() throws Exception {
+        try (Table table = connection.getTable(TABLE)) {
+            Put put = new Put(Bytes.toBytes("row1"));
+            put.addColumn(CF, Bytes.toBytes("name"), Bytes.toBytes("alice"));
+            table.put(put);
+
+            Result result = table.get(new Get(Bytes.toBytes("row1")));
+            byte[] value = result.getValue(CF, Bytes.toBytes("name"));
+            assertEquals("alice", Bytes.toString(value));
+        }
+    }
+}

--- a/hbase-testcluster/README.md
+++ b/hbase-testcluster/README.md
@@ -1,0 +1,151 @@
+# pinpoint-hbase-testcluster
+
+A test-only module that boots an HBase MiniCluster (HBase + HDFS + ZooKeeper) for the lifetime of an integration test, so that components depending on HBase can be tested in-process without a real cluster.
+
+Internally it wraps `TestingHBaseCluster` from `org.apache.hbase:hbase-shaded-testing-util` and exposes it as Spring beans.
+
+## Dependency
+
+Add it to the consumer module's `pom.xml` with `test` scope. The version is managed by the parent BOM.
+
+```xml
+<dependency>
+    <groupId>com.navercorp.pinpoint</groupId>
+    <artifactId>pinpoint-hbase-testcluster</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+## Requirements
+
+- **JDK 17+** (the module itself is built with `jdk.version=17`).
+- The test JVM needs the following `--add-opens` for Hadoop 3 reflective access:
+  ```
+  --add-opens java.base/java.lang=ALL-UNNAMED
+  --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+  ```
+  Add them to the consumer module's `maven-surefire-plugin` `argLine`:
+
+  ```xml
+  <build>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>${plugin.surefire.version}</version>
+              <configuration>
+                  <argLine>
+                      @{argLine}
+                      --add-opens java.base/java.lang=ALL-UNNAMED
+                      --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                  </argLine>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+  ```
+
+## Quick start — Spring
+
+Importing `HbaseTestClusterConfiguration` into a Spring test context registers the following beans automatically.
+
+| Bean name | Type | Notes |
+|---|---|---|
+| `hbaseTestCluster` | `HbaseTestCluster` | Started in `@PostConstruct`, stopped via `destroyMethod="close"` |
+| `hbaseConfiguration` | `org.apache.hadoop.conf.Configuration` | Conf wired to the running cluster |
+| `hbaseConnection` | `org.apache.hadoop.hbase.client.Connection` | Synchronous client |
+| `hbaseAsyncConnection` | `org.apache.hadoop.hbase.client.AsyncConnection` | Asynchronous client |
+
+```java
+@SpringJUnitConfig(HbaseTestClusterConfiguration.class)
+class MyHbaseIT {
+
+    private static final TableName TABLE = TableName.valueOf("my_table");
+    private static final byte[] CF = Bytes.toBytes("cf");
+
+    @Autowired
+    private HbaseTestCluster cluster;
+
+    @Autowired
+    @Qualifier("hbaseConnection")
+    private Connection connection;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        cluster.createTable(TABLE, CF);
+    }
+
+    @Test
+    void putAndGet() throws Exception {
+        try (Table table = connection.getTable(TABLE)) {
+            Put put = new Put(Bytes.toBytes("row1"));
+            put.addColumn(CF, Bytes.toBytes("name"), Bytes.toBytes("alice"));
+            table.put(put);
+
+            Result result = table.get(new Get(Bytes.toBytes("row1")));
+            assertEquals("alice", Bytes.toString(result.getValue(CF, Bytes.toBytes("name"))));
+        }
+    }
+}
+```
+
+See `src/test/java/.../HbaseClusterIT.java` for a complete working example.
+
+## Standalone usage (without Spring)
+
+```java
+try (HbaseTestCluster cluster = new HbaseTestCluster()) {
+    cluster.start();
+
+    Configuration conf = cluster.getConfiguration();
+    try (Connection connection = ConnectionFactory.createConnection(conf)) {
+        cluster.createTable(TableName.valueOf("t"), Bytes.toBytes("cf"));
+        // ... use connection
+    }
+} // close() automatically calls cluster.stop()
+```
+
+`new HbaseTestCluster()` uses `defaultOption()` internally. To customize the topology, build the option yourself:
+
+```java
+TestingHBaseClusterOption option = TestingHBaseClusterOption.builder()
+        .numMasters(1)
+        .numRegionServers(2)
+        .numDataNodes(2)
+        .build();
+HbaseTestCluster cluster = new HbaseTestCluster(option);
+```
+
+## Logging
+
+The default logging configuration lives in `src/test/resources/log4j2-test.xml`. Hadoop and HBase are intentionally muted at `WARN` so the test output stays readable. Raise specific loggers to `DEBUG` only when diagnosing a problem.
+
+### Default log levels
+
+Drop the snippet below into your test's `log4j2-test.xml` to silence Hadoop/HBase noise while keeping the rest of the output readable.
+
+```xml
+<Loggers>
+    <!-- Hadoop core (HDFS, IPC) — extremely chatty at INFO -->
+    <Logger name="org.apache.hadoop" level="WARN"/>
+    <!-- HBase server-side -->
+    <Logger name="org.apache.hadoop.hbase" level="WARN"/>
+    <!-- Shaded third-party deps inside HBase (Netty, Guava, ...) -->
+    <Logger name="org.apache.hadoop.hbase.shaded" level="WARN"/>
+    <!-- Newer-package HBase classes -->
+    <Logger name="org.apache.hbase" level="WARN"/>
+    <!-- Shaded protobuf / netty under hbase.thirdparty -->
+    <Logger name="org.apache.hbase.thirdparty" level="WARN"/>
+    <!-- HDFS NameNode block-state log; one line per block transition -->
+    <Logger name="BlockStateChange" level="WARN"/>
+
+    <Root level="INFO">
+        <AppenderRef ref="console"/>
+    </Root>
+</Loggers>
+```
+
+## Notes
+
+- This is a **test-only** module. Do not import it from production code.
+- Cluster startup is expensive (seconds to tens of seconds). Prefer sharing a single cluster across tests within a class — Spring's test context caching does this by default.

--- a/hbase-testcluster/pom.xml
+++ b/hbase-testcluster/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2025 NAVER Corp.
+  ~ Copyright 2026 NAVER Corp.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@
         <version>3.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>pinpoint-commons-hbase</artifactId>
-    <name>pinpoint-commons-hbase</name>
+    <artifactId>pinpoint-hbase-testcluster</artifactId>
+    <name>pinpoint-hbase-minicluster</name>
     <packaging>jar</packaging>
 
     <properties>
@@ -35,85 +35,43 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.navercorp.pinpoint</groupId>
-            <artifactId>pinpoint-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.navercorp.pinpoint</groupId>
-            <artifactId>pinpoint-commons</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.navercorp.pinpoint</groupId>
-            <artifactId>pinpoint-commons-buffer</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.navercorp.pinpoint</groupId>
-            <artifactId>pinpoint-commons-config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.navercorp.pinpoint</groupId>
-            <artifactId>pinpoint-commons-profiler</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-shaded-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.navercorp.pinpoint</groupId>
-            <artifactId>pinpoint-hbase-testcluster</artifactId>
-            <scope>test</scope>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-shaded-testing-util</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-tx</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-        </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.1.0.Final</version>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
 
         <!-- Logging dependencies -->
         <dependency>
@@ -128,10 +86,7 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context-support</artifactId>
-        </dependency>
+
     </dependencies>
 
     <build>
@@ -141,11 +96,18 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${plugin.surefire.version}</version>
                 <configuration>
-                    <!-- Add  @{argLine} for jacoco -->
                     <argLine>
                         @{argLine}
                         --add-opens java.base/java.lang=ALL-UNNAMED
                         --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+<!--                        &#45;&#45;add-opens java.base/java.io=ALL-UNNAMED-->
+<!--                        &#45;&#45;add-opens java.base/java.net=ALL-UNNAMED-->
+<!--                        &#45;&#45;add-opens java.base/java.nio=ALL-UNNAMED-->
+<!--                        &#45;&#45;add-opens java.base/java.util=ALL-UNNAMED-->
+<!--                        &#45;&#45;add-opens java.base/java.util.concurrent=ALL-UNNAMED-->
+<!--                        &#45;&#45;add-opens java.base/sun.nio.ch=ALL-UNNAMED-->
+<!--                        &#45;&#45;add-opens java.base/sun.net.dns=ALL-UNNAMED-->
+<!--                        &#45;&#45;add-opens java.base/sun.security.action=ALL-UNNAMED-->
                     </argLine>
                 </configuration>
             </plugin>

--- a/hbase-testcluster/src/main/java/com/navercorp/pinpoint/common/hbase/it/HbaseTestCluster.java
+++ b/hbase-testcluster/src/main/java/com/navercorp/pinpoint/common/hbase/it/HbaseTestCluster.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase.it;
+
+import jakarta.annotation.PostConstruct;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.testing.TestingHBaseCluster;
+import org.apache.hadoop.hbase.testing.TestingHBaseClusterOption;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+
+public class HbaseTestCluster implements AutoCloseable {
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    private final TestingHBaseCluster cluster;
+
+    public HbaseTestCluster() {
+        this(defaultOption());
+    }
+
+    public HbaseTestCluster(TestingHBaseClusterOption option) {
+        Objects.requireNonNull(option, "option");
+        this.cluster = TestingHBaseCluster.create(option);
+    }
+
+    public static TestingHBaseClusterOption defaultOption() {
+//        Configuration conf = HBaseConfiguration.create();
+//        // AsyncFSWAL fails with NPE on JDK 17+ MiniDFSCluster; force synchronous FSHLog for tests.
+//        conf.set("hbase.wal.provider", "filesystem");
+//        conf.set("hbase.wal.meta_provider", "filesystem");
+//        conf.setBoolean("hbase.unsafe.stream.capability.enforce", false);
+//
+//        // MiniDFSCluster has a single DataNode. Prevent FSHLog sync failures
+//        // (DamagedWALException) that would otherwise abort the master.
+//        conf.setInt("dfs.replication", 1);
+//        conf.setInt("hbase.regionserver.hlog.replication", 1);
+//        conf.setInt("hbase.regionserver.hlog.tolerable.lowreplication", 1);
+//        conf.setBoolean("dfs.client.block.write.replace-datanode-on-failure.enable", false);
+
+//        return TestingHBaseClusterOption.builder()
+//                .conf(conf)
+//                .build();
+
+        TestingHBaseClusterOption.Builder builder = TestingHBaseClusterOption.builder();
+//        builder.numDataNodes(1);
+//        builder.numRegionServers(1);
+//        builder.numZkServers(1);
+        return builder
+                .build();
+    }
+
+    @PostConstruct
+    public void start() {
+        logger.info("TestingHBaseCluster start");
+        try {
+            cluster.start();
+        } catch (Exception e) {
+            throw new HbaseTestClusterException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        logger.info("TestingHBaseCluster close");
+        try {
+//            disableAndDeleteAllTables();
+            cluster.stop();
+        } catch (Exception e) {
+            throw new HbaseTestClusterException(e);
+        }
+    }
+
+    public boolean isHBaseClusterRunning() {
+        return cluster.isHBaseClusterRunning();
+    }
+
+    public Configuration getConfiguration() {
+        return cluster.getConf();
+    }
+
+    private void disableAndDeleteAllTables() {
+        try (Connection connection = ConnectionFactory.createConnection(cluster.getConf());
+             Admin admin = connection.getAdmin()) {
+            for (TableName tableName : admin.listTableNames()) {
+                if (admin.isTableEnabled(tableName)) {
+                    admin.disableTable(tableName);
+                }
+                admin.deleteTable(tableName);
+            }
+        } catch (Exception e) {
+            logger.info("disableAndDeleteAllTables failed", e);
+        }
+    }
+
+    public void createTable(TableName tableName, byte[] family) throws Exception {
+        try (Connection connection = ConnectionFactory.createConnection(cluster.getConf());
+             Admin admin = connection.getAdmin()) {
+            if (admin.tableExists(tableName)) {
+                if (admin.isTableEnabled(tableName)) {
+                    admin.disableTable(tableName);
+                }
+                admin.deleteTable(tableName);
+            }
+            TableDescriptorBuilder builder = TableDescriptorBuilder.newBuilder(tableName)
+                    .setColumnFamily(ColumnFamilyDescriptorBuilder.of(family));
+            admin.createTable(builder.build());
+        }
+    }
+}

--- a/hbase-testcluster/src/main/java/com/navercorp/pinpoint/common/hbase/it/HbaseTestClusterConfiguration.java
+++ b/hbase-testcluster/src/main/java/com/navercorp/pinpoint/common/hbase/it/HbaseTestClusterConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase.it;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.AsyncConnection;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+
+@org.springframework.context.annotation.Configuration
+public class HbaseTestClusterConfiguration {
+
+    @Bean(name = "hbaseTestCluster", destroyMethod = "close")
+    public HbaseTestCluster hbaseMiniCluster() {
+        return new HbaseTestCluster();
+    }
+
+    @Bean("hbaseConfiguration")
+    public Configuration hbaseConfiguration(HbaseTestCluster cluster) {
+        return cluster.getConfiguration();
+    }
+
+    @Bean(name = "hbaseConnection", destroyMethod = "close")
+    public Connection hbaseConnection(@Qualifier("hbaseConfiguration") Configuration configuration) throws Exception {
+        return ConnectionFactory.createConnection(configuration);
+    }
+
+    @Bean(name = "hbaseAsyncConnection", destroyMethod = "close")
+    public AsyncConnection hbaseAsyncConnection(@Qualifier("hbaseConfiguration") Configuration configuration) throws Exception {
+        return ConnectionFactory.createAsyncConnection(configuration).get();
+    }
+}

--- a/hbase-testcluster/src/main/java/com/navercorp/pinpoint/common/hbase/it/HbaseTestClusterException.java
+++ b/hbase-testcluster/src/main/java/com/navercorp/pinpoint/common/hbase/it/HbaseTestClusterException.java
@@ -1,0 +1,23 @@
+package com.navercorp.pinpoint.common.hbase.it;
+
+public class HbaseTestClusterException extends RuntimeException {
+    public HbaseTestClusterException() {
+    }
+
+    public HbaseTestClusterException(String message) {
+        super(message);
+    }
+
+    public HbaseTestClusterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public HbaseTestClusterException(Throwable cause) {
+        super(cause);
+    }
+
+    public HbaseTestClusterException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/hbase-testcluster/src/test/java/com/navercorp/pinpoint/common/hbase/it/HbaseClusterIT.java
+++ b/hbase-testcluster/src/test/java/com/navercorp/pinpoint/common/hbase/it/HbaseClusterIT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.hbase.it;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Disabled
+@SpringJUnitConfig(HbaseTestClusterConfiguration.class)
+class HbaseClusterIT {
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    private static final TableName TABLE = TableName.valueOf("mini_cluster_it");
+    private static final byte[] CF = Bytes.toBytes("cf");
+
+    @Autowired
+    private HbaseTestCluster cluster;
+
+    @Autowired
+    @Qualifier("hbaseConnection")
+    private Connection connection;
+
+    @BeforeEach
+    void createTable() throws Exception {
+        cluster.createTable(TABLE, CF);
+    }
+
+    @Test
+    void putAndGet() throws Exception {
+        logger.info("putAndGet start");
+        try (Table table = connection.getTable(TABLE)) {
+            Put put = new Put(Bytes.toBytes("row1"));
+            put.addColumn(CF, Bytes.toBytes("name"), Bytes.toBytes("alice"));
+            table.put(put);
+
+            Result result = table.get(new Get(Bytes.toBytes("row1")));
+            byte[] value = result.getValue(CF, Bytes.toBytes("name"));
+            assertEquals("alice", Bytes.toString(value));
+        }
+    }
+}

--- a/hbase-testcluster/src/test/resources/log4j2-test.xml
+++ b/hbase-testcluster/src/test/resources/log4j2-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration status="INFO">
+    <Properties>
+        <Property name="console_message_pattern">%d{MM-dd HH:mm:ss.SSS} [%15.15t] %clr{%-5level} %clr{%-40.40logger{1.}}{cyan}:%3L -- %msg%n</Property>
+        <Property name="file_message_pattern">%d{MM-dd HH:mm:ss.SSS} [%15.15t] %-5level %-40.40logger{1.}:%3L -- %msg%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="console" target="system_out">
+            <PatternLayout pattern="${file_message_pattern}"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+         <Logger name="com.navercorp.pinpoint" level="DEBUG" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+
+        <!-- hbase testcluster log start -->
+        <Logger name="org.apache.hadoop" level="WARN"/>
+        <Logger name="org.apache.hadoop.hbase" level="WARN"/>
+        <Logger name="org.apache.hadoop.hbase.shaded" level="WARN"/>
+        <Logger name="org.apache.hbase" level="WARN"/>
+        <Logger name="org.apache.hbase.thirdparty" level="WARN"/>
+        <Logger name="BlockStateChange" level="WARN"/>
+        <!-- hbase testcluster log end -->
+
+
+        <Root level="INFO">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
         <module>commons-config</module>
         <module>commons-profiler</module>
         <module>commons-hbase</module>
+        <module>hbase-testcluster</module>
         <module>commons-timeseries</module>
         <module>commons-server</module>
         <module>commons-mybatis</module>
@@ -392,6 +393,11 @@
             <dependency>
                 <groupId>com.navercorp.pinpoint</groupId>
                 <artifactId>pinpoint-commons-hbase</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.navercorp.pinpoint</groupId>
+                <artifactId>pinpoint-hbase-testcluster</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -1001,6 +1007,17 @@
             <dependency>
                 <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase-shaded-client</artifactId>
+                <version>${hbase.shaded.client.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hbase</groupId>
+                <artifactId>hbase-shaded-testing-util</artifactId>
                 <version>${hbase.shaded.client.version}</version>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
## Summary
- Introduce a new `hbase-testcluster` module that boots an in-process HBase MiniCluster (HBase + HDFS + ZooKeeper) for integration tests.
- Wraps `org.apache.hbase:hbase-shaded-testing-util` `TestingHBaseCluster` and exposes Spring beans (`hbaseTestCluster`, `hbaseConfiguration`, `hbaseConnection`, `hbaseAsyncConnection`) via `HbaseTestClusterConfiguration`.
- Adds `hbase-testcluster/README.md` covering usage, JDK 17 `--add-opens` requirements, and a log level guide.

Closes #13651

## Test plan
- [ ] `./mvnw -pl hbase-testcluster -am install -Dmaven.test.skip=true` builds the module
- [ ] `HbaseClusterIT` (currently `@Disabled`) runs locally with the configured `--add-opens` JVM args
- [ ] No regressions in `commons-hbase` after removing the embedded mini-cluster scaffolding