### PR TITLE
[#noissue] Use empty timeseries histogram view for server/service map

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkRender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/LinkRender.java
@@ -27,14 +27,14 @@ public interface LinkRender {
 
     static LinkRender forServerMap(MapProperties mapProperties) {
         return new DefaultLinkRender(
-                ApplicationTimeSeriesHistogramLinkView.detailedView(TimeHistogramView.TimeseriesHistogram),
+                ApplicationTimeSeriesHistogramLinkView.emptyView(),
                 AgentLinkView.emptyView(),
                 mapProperties.isEnableServiceMap());
     }
 
     static LinkRender forServiceMap() {
         return new DefaultLinkRender(
-                ApplicationTimeSeriesHistogramLinkView.detailedView(TimeHistogramView.TimeseriesHistogram),
+                ApplicationTimeSeriesHistogramLinkView.emptyView(),
                 AgentLinkView.emptyView(),
                 true);
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeRender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/view/NodeRender.java
@@ -25,6 +25,13 @@ import java.util.Objects;
 public interface NodeRender {
     NodeView render(Node node);
 
+    /**
+     * Creates a detailed node render with the given time histogram view, hyper link factory, and map properties.
+     * @param timeHistogramView the time histogram view
+     * @param hyperLinkFactory the hyper link factory
+     * @param mapProperties the map properties
+     * @return a detailed node render
+     */
     static NodeRender detailedRender(TimeHistogramView timeHistogramView, HyperLinkFactory hyperLinkFactory, MapProperties mapProperties) {
         return new DefaultNodeRender(
                 ApplicationTimeSeriesHistogramNodeView.detailedView(timeHistogramView),
@@ -37,7 +44,7 @@ public interface NodeRender {
 
     static NodeRender forServerMap(MapProperties mapProperties) {
         return new DefaultNodeRender(
-                ApplicationTimeSeriesHistogramNodeView.detailedView(TimeHistogramView.TimeseriesHistogram),
+                ApplicationTimeSeriesHistogramNodeView.emptyView(),
                 ApplicationApdexScoreSlotView.detailedView(),
                 ServerListNodeView.emptyView(),
                 AgentHistogramNodeView.emptyView(),
@@ -47,7 +54,7 @@ public interface NodeRender {
 
     static NodeRender forServiceMap() {
         return new DefaultNodeRender(
-                ApplicationTimeSeriesHistogramNodeView.detailedView(TimeHistogramView.TimeseriesHistogram),
+                ApplicationTimeSeriesHistogramNodeView.emptyView(),
                 ApplicationApdexScoreSlotView.detailedView(),
                 ServerListNodeView.emptyView(),
                 AgentHistogramNodeView.emptyView(),


### PR DESCRIPTION
This pull request updates how node and link views are rendered in the server map and service map by switching from detailed time series histogram views to empty views. It also adds documentation for the `detailedRender` method in the `NodeRender` interface. These changes likely simplify the default visualization or prepare for new rendering logic elsewhere.

Rendering logic changes:

* Updated `NodeRender.forServerMap` and `NodeRender.forServiceMap` to use `ApplicationTimeSeriesHistogramNodeView.emptyView()` instead of the detailed time series histogram view. [[1]](diffhunk://#diff-3fb87307ff2b45b9f0245ef22eebc10517451669c70df498a6716750a8c8dbbfL40-R47) [[2]](diffhunk://#diff-3fb87307ff2b45b9f0245ef22eebc10517451669c70df498a6716750a8c8dbbfL50-R57)
* Updated `LinkRender.forServerMap` and `LinkRender.forServiceMap` to use `ApplicationTimeSeriesHistogramLinkView.emptyView()` instead of the detailed time series histogram view.

Documentation improvements:

* Added a Javadoc comment to the `NodeRender.detailedRender` static method to clarify its parameters and return value.