### PR TITLE
[#noissue] Rename WasOnlyProcessor to ApplicationNodeFilter

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/ApplicationNodeFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/ApplicationNodeFilter.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.Logger;
  *
  * @author HyunGil Jeong
  */
-public class WasOnlyProcessor implements LinkDataMapProcessor {
+public class ApplicationNodeFilter implements LinkDataMapProcessor {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/LinkDataMapProcessor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/processor/LinkDataMapProcessor.java
@@ -34,4 +34,8 @@ public interface LinkDataMapProcessor {
             return linkDataMap;
         }
     };
+
+    static LinkDataMapProcessor applicationNodeFilter(boolean enabled) {
+        return enabled ? new ApplicationNodeFilter() : NO_OP;
+    }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/HistogramServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/HistogramServiceImpl.java
@@ -29,7 +29,6 @@ import com.navercorp.pinpoint.web.applicationmap.map.LinkSelectorType;
 import com.navercorp.pinpoint.web.applicationmap.map.processor.DestinationApplicationFilter;
 import com.navercorp.pinpoint.web.applicationmap.map.processor.LinkDataMapProcessor;
 import com.navercorp.pinpoint.web.applicationmap.map.processor.SourceApplicationFilter;
-import com.navercorp.pinpoint.web.applicationmap.map.processor.WasOnlyProcessor;
 import com.navercorp.pinpoint.web.applicationmap.nodes.Node;
 import com.navercorp.pinpoint.web.applicationmap.nodes.NodeList;
 import com.navercorp.pinpoint.web.applicationmap.nodes.NodeListFactory;
@@ -76,10 +75,7 @@ public class HistogramServiceImpl implements HistogramService {
         int outSearchDepth = searchOption.getOutSearchDepth();
         int inSearchDepth = searchOption.getInSearchDepth();
 
-        LinkDataMapProcessor outLinkProcessor = LinkDataMapProcessor.NO_OP;
-        if (searchOption.isWasOnly()) {
-            outLinkProcessor = new WasOnlyProcessor();
-        }
+        LinkDataMapProcessor outLinkProcessor = LinkDataMapProcessor.applicationNodeFilter(searchOption.isWasOnly());
         LinkDataMapProcessor inLinkProcessor = LinkDataMapProcessor.NO_OP;
         LinkSelector linkSelector = linkSelectorFactory.createLinkSelector(linkSelectorType, outLinkProcessor, inLinkProcessor);
 
@@ -91,7 +87,6 @@ public class HistogramServiceImpl implements HistogramService {
                 watch.getTotalTimeMillis(), option.getSourceApplication(), outSearchDepth, inSearchDepth, linkDataDuplexMap.size());
         return linkDataDuplexMap;
     }
-
 
     @Override
     public LinkHistogramSummary selectLinkHistogramData(Application fromApplication, Application toApplication, TimeWindow timeWindow) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/service/MapServiceImpl.java
@@ -26,7 +26,6 @@ import com.navercorp.pinpoint.web.applicationmap.map.LinkSelector;
 import com.navercorp.pinpoint.web.applicationmap.map.LinkSelectorFactory;
 import com.navercorp.pinpoint.web.applicationmap.map.LinkSelectorType;
 import com.navercorp.pinpoint.web.applicationmap.map.processor.LinkDataMapProcessor;
-import com.navercorp.pinpoint.web.applicationmap.map.processor.WasOnlyProcessor;
 import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataDuplexMap;
 import com.navercorp.pinpoint.web.security.ServerMapDataFilter;
 import com.navercorp.pinpoint.web.service.ServerInstanceDatasourceService;
@@ -95,10 +94,7 @@ public class MapServiceImpl implements MapService {
         int outSearchDepth = searchOption.getOutSearchDepth();
         int inSearchDepth = searchOption.getInSearchDepth();
 
-        LinkDataMapProcessor outLinkProcessor = LinkDataMapProcessor.NO_OP;
-        if (searchOption.isWasOnly()) {
-            outLinkProcessor = new WasOnlyProcessor();
-        }
+        LinkDataMapProcessor outLinkProcessor = LinkDataMapProcessor.applicationNodeFilter(searchOption.isWasOnly());
         LinkDataMapProcessor inLinkProcessor = LinkDataMapProcessor.NO_OP;
         LinkSelector linkSelector = linkSelectorFactory.createLinkSelector(linkSelectorType, outLinkProcessor, inLinkProcessor);
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/processor/ApplicationNodeFilterTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/processor/ApplicationNodeFilterTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author HyunGil Jeong
  */
-public class WasOnlyProcessorTest {
+public class ApplicationNodeFilterTest {
 
     private final Range testRange = Range.between(System.currentTimeMillis(), System.currentTimeMillis());
     private final TimeWindow timeWindow = new TimeWindow(testRange);
@@ -49,8 +49,8 @@ public class WasOnlyProcessorTest {
         linkDataMap.addLinkData(wasToTerminalLinkData);
 
         // When
-        WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
-        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
+        ApplicationNodeFilter filter = new ApplicationNodeFilter();
+        LinkDataMap filteredLinkDataMap = filter.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         assertThat(filteredLinkDataMap.getLinkDataList()).isEmpty();
@@ -66,8 +66,8 @@ public class WasOnlyProcessorTest {
         linkDataMap.addLinkData(wasToUnknownLinkData);
 
         // When
-        WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
-        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
+        ApplicationNodeFilter filter = new ApplicationNodeFilter();
+        LinkDataMap filteredLinkDataMap = filter.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         assertThat(filteredLinkDataMap.getLinkDataList()).isEmpty();
@@ -83,8 +83,8 @@ public class WasOnlyProcessorTest {
         linkDataMap.addLinkData(wasToWasLinkData);
 
         // When
-        WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
-        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
+        ApplicationNodeFilter filter = new ApplicationNodeFilter();
+        LinkDataMap filteredLinkDataMap = filter.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         assertThat(filteredLinkDataMap.getLinkDataList()).isNotEmpty();
@@ -100,8 +100,8 @@ public class WasOnlyProcessorTest {
         linkDataMap.addLinkData(wasToQueueLinkData);
 
         // When
-        WasOnlyProcessor wasOnlyProcessor = new WasOnlyProcessor();
-        LinkDataMap filteredLinkDataMap = wasOnlyProcessor.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
+        ApplicationNodeFilter filter = new ApplicationNodeFilter();
+        LinkDataMap filteredLinkDataMap = filter.processLinkDataMap(LinkDirection.IN_LINK, linkDataMap, timeWindow);
 
         // Then
         assertThat(filteredLinkDataMap.getLinkDataList()).isNotEmpty();


### PR DESCRIPTION
This pull request refactors the filtering logic for application nodes in the application map by renaming and generalizing the `WasOnlyProcessor` to `ApplicationNodeFilter`. It also introduces a factory method for cleaner instantiation and updates usages and tests accordingly. The most important changes are grouped below:

### Refactoring and Renaming

* Renamed the `WasOnlyProcessor` class and its test to `ApplicationNodeFilter` and `ApplicationNodeFilterTest`, respectively, to better reflect its purpose and generalize its filtering logic. [[1]](diffhunk://#diff-5fc2d12024f774a50df523c9ab9cb11f436f86b06bbef06fb0e81ba138390f2cL33-R33) [[2]](diffhunk://#diff-b2b14a375ebc2ae8e560090a882b4ef1e212cf8a18e45e4976086dde7757540dL36-R36)

### API Improvements

* Added a static factory method `applicationNodeFilter(boolean enabled)` to the `LinkDataMapProcessor` interface for cleaner and more flexible instantiation based on a flag.

### Usage Updates

* Replaced direct instantiation of `WasOnlyProcessor` with the new `applicationNodeFilter` factory method in both `HistogramServiceImpl` and `MapServiceImpl`, simplifying the logic for selecting the appropriate processor. [[1]](diffhunk://#diff-e26614f156f710b8c8c1ff2067b20647b8c9103d5b0d999b74fb510bd1ee6737L79-R78) [[2]](diffhunk://#diff-f6878cdbb008253fdc0a31505d859cdbc14afa7b13d567a2a6e07a5202e77991L98-R97)

### Test Updates

* Updated all test cases to use `ApplicationNodeFilter` instead of `WasOnlyProcessor`, ensuring the tests continue to verify the correct filtering behavior. [[1]](diffhunk://#diff-b2b14a375ebc2ae8e560090a882b4ef1e212cf8a18e45e4976086dde7757540dL52-R53) [[2]](diffhunk://#diff-b2b14a375ebc2ae8e560090a882b4ef1e212cf8a18e45e4976086dde7757540dL69-R70) [[3]](diffhunk://#diff-b2b14a375ebc2ae8e560090a882b4ef1e212cf8a18e45e4976086dde7757540dL86-R87) [[4]](diffhunk://#diff-b2b14a375ebc2ae8e560090a882b4ef1e212cf8a18e45e4976086dde7757540dL103-R104)

### Cleanup

* Removed unnecessary imports and adjusted references to the renamed class in all affected files. [[1]](diffhunk://#diff-e26614f156f710b8c8c1ff2067b20647b8c9103d5b0d999b74fb510bd1ee6737L32) [[2]](diffhunk://#diff-f6878cdbb008253fdc0a31505d859cdbc14afa7b13d567a2a6e07a5202e77991L29)