### PR TITLE
[#noissue] Cap thrift IT version range at 0.22.0

### DIFF
--- a/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/ThriftVersion.java
+++ b/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/ThriftVersion.java
@@ -4,5 +4,6 @@ package com.navercorp.pinpoint.it.plugin.thrift.it;
  * <a href="https://issues.apache.org/jira/browse/THRIFT-5274"/>Thrift 0.13.0 does not work with JDK8</a>
  */
 public class ThriftVersion {
-    public static final String VERSION_14_16 = "org.apache.thrift:libthrift:[0.14.0,)";
+    // compatibility issue, ignore 0.23.0
+    public static final String VERSION_14_22 = "org.apache.thrift:libthrift:[0.14.0,0.22.0]";
 }

--- a/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/asynchronous/ThriftHalfSyncHalfAsyncServerAsyncIT_014.java
+++ b/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/asynchronous/ThriftHalfSyncHalfAsyncServerAsyncIT_014.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
  */
 @PluginTest
 @PinpointAgent(AgentPath.PATH)
-@Dependency({ ThriftVersion.VERSION_14_16,
+@Dependency({ ThriftVersion.VERSION_14_22,
         "org.slf4j:slf4j-simple:1.6.6", "org.slf4j:log4j-over-slf4j:1.6.6", "org.slf4j:slf4j-api:1.6.6" })
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-thrift-plugin"})
 public class ThriftHalfSyncHalfAsyncServerAsyncIT_014 extends EchoTestRunner<ThriftEchoTestServer<THsHaServer>> {

--- a/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/asynchronous/ThriftNonblockingServerAsyncIT014.java
+++ b/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/asynchronous/ThriftNonblockingServerAsyncIT014.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
  */
 @PluginTest
 @PinpointAgent(AgentPath.PATH)
-@Dependency({ ThriftVersion.VERSION_14_16,
+@Dependency({ ThriftVersion.VERSION_14_22,
         "org.slf4j:slf4j-simple:1.6.6", "org.slf4j:log4j-over-slf4j:1.6.6", "org.slf4j:slf4j-api:1.6.6" })
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-thrift-plugin"})
 public class ThriftNonblockingServerAsyncIT014 extends EchoTestRunner<ThriftEchoTestServer<TNonblockingServer>> {

--- a/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/asynchronous/ThriftThreadedSelectorServerAsyncIT014.java
+++ b/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/asynchronous/ThriftThreadedSelectorServerAsyncIT014.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
  */
 @PluginTest
 @PinpointAgent(AgentPath.PATH)
-@Dependency({ ThriftVersion.VERSION_14_16,
+@Dependency({ ThriftVersion.VERSION_14_22,
         "org.slf4j:slf4j-simple:1.6.6", "org.slf4j:log4j-over-slf4j:1.6.6", "org.slf4j:slf4j-api:1.6.6" })
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-thrift-plugin"})
 public class ThriftThreadedSelectorServerAsyncIT014 extends EchoTestRunner<ThriftEchoTestServer<TThreadedSelectorServer>> {

--- a/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/synchronous/ThriftHalfSyncHalfAsyncServerIT014.java
+++ b/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/synchronous/ThriftHalfSyncHalfAsyncServerIT014.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
  */
 @PluginTest
 @PinpointAgent(AgentPath.PATH)
-@Dependency({ ThriftVersion.VERSION_14_16,
+@Dependency({ ThriftVersion.VERSION_14_22,
         "org.slf4j:slf4j-simple:1.6.6", "org.slf4j:log4j-over-slf4j:1.6.6", "org.slf4j:slf4j-api:1.6.6" })
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-thrift-plugin"})
 public class ThriftHalfSyncHalfAsyncServerIT014 extends EchoTestRunner<ThriftEchoTestServer<THsHaServer>> {

--- a/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/synchronous/ThriftNonblockingServerIT014.java
+++ b/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/synchronous/ThriftNonblockingServerIT014.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
  */
 @PluginTest
 @PinpointAgent(AgentPath.PATH)
-@Dependency({ ThriftVersion.VERSION_14_16,
+@Dependency({ ThriftVersion.VERSION_14_22,
         "org.slf4j:slf4j-simple:1.6.6", "org.slf4j:log4j-over-slf4j:1.6.6", "org.slf4j:slf4j-api:1.6.6" })
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-thrift-plugin"})
 public class ThriftNonblockingServerIT014 extends EchoTestRunner<ThriftEchoTestServer<TNonblockingServer>> {

--- a/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/synchronous/ThriftThreadedSelectorServerIT014.java
+++ b/agent-module/plugins-it/thrift-it/thrift-0-14-it/src/test/java/com/navercorp/pinpoint/it/plugin/thrift/it/synchronous/ThriftThreadedSelectorServerIT014.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
  */
 @PluginTest
 @PinpointAgent(AgentPath.PATH)
-@Dependency({ ThriftVersion.VERSION_14_16,
+@Dependency({ ThriftVersion.VERSION_14_22,
         "org.slf4j:slf4j-simple:1.6.6", "org.slf4j:log4j-over-slf4j:1.6.6", "org.slf4j:slf4j-api:1.6.6" })
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-thrift-plugin"})
 public class ThriftThreadedSelectorServerIT014 extends EchoTestRunner<ThriftEchoTestServer<TThreadedSelectorServer>> {


### PR DESCRIPTION
Exclude libthrift 0.23.0 due to compatibility issues by renaming
VERSION_14_16 to VERSION_14_22 with range [0.14.0,0.22.0].
