### PR TITLE
[#noissue] Render service group nodes with centered name/count and 30% larger size

### DIFF
--- a/web-frontend/src/main/v3/packages/server-map/src/constants/style/theme-helper.ts
+++ b/web-frontend/src/main/v3/packages/server-map/src/constants/style/theme-helper.ts
@@ -23,11 +23,22 @@ export const getServerMapStyle = ({
       selector: 'node',
       style: {
         ...theme.node?.default,
-        width: GraphStyle.NODE_WIDTH,
-        height: GraphStyle.NODE_HEIGHT,
+        width: (el: cytoscape.NodeCollection) => {
+          const nodeData = cy.data(el.data()?.id)?.data;
+          return nodeData?.subNodesCount !== undefined
+            ? GraphStyle.NODE_WIDTH * 1.3
+            : GraphStyle.NODE_WIDTH;
+        },
+        height: (el: cytoscape.NodeCollection) => {
+          const nodeData = cy.data(el.data()?.id)?.data;
+          return nodeData?.subNodesCount !== undefined
+            ? GraphStyle.NODE_HEIGHT * 1.3
+            : GraphStyle.NODE_HEIGHT;
+        },
         label: (el: cytoscape.NodeCollection) => {
           const nodeData = cy.data(el.data()?.id)?.data;
-          return nodeLabelRenderer?.(nodeData) || nodeData?.label || '';
+          const customLabel = nodeLabelRenderer?.(nodeData);
+          return customLabel ?? nodeData?.label ?? '';
         },
         'background-image': (el: cytoscape.NodeCollection) => {
           const nodeData = cy.data(el.data()?.id)?.data;

--- a/web-frontend/src/main/v3/packages/server-map/src/core/merge.ts
+++ b/web-frontend/src/main/v3/packages/server-map/src/core/merge.ts
@@ -217,7 +217,9 @@ export const getMergedData = (data: { nodes: Node[]; edges: Edge[] }, renderNode
         return {
           data: {
             ...node,
-            imgArr: [node?.imgPath, getNodeSVGString(node, renderNode)],
+            imgArr: node?.imgPath
+              ? [node.imgPath, getNodeSVGString(node, renderNode)]
+              : [getNodeSVGString(node, renderNode)],
           },
         };
       }),

--- a/web-frontend/src/main/v3/packages/server-map/src/test/constants/style/theme-helper.test.ts
+++ b/web-frontend/src/main/v3/packages/server-map/src/test/constants/style/theme-helper.test.ts
@@ -70,8 +70,8 @@ describe('getServerMapStyle', () => {
 
     const nodeStyle = styles.find((s) => s.selector === 'node');
     expect(nodeStyle).toBeDefined();
-    expect(nodeStyle?.style?.width).toBe(100);
-    expect(nodeStyle?.style?.height).toBe(100);
+    expect(typeof nodeStyle?.style?.width).toBe('function');
+    expect(typeof nodeStyle?.style?.height).toBe('function');
   });
 
   it('엣지 스타일을 반환해야 함', () => {

--- a/web-frontend/src/main/v3/packages/server-map/src/types/index.ts
+++ b/web-frontend/src/main/v3/packages/server-map/src/types/index.ts
@@ -18,6 +18,7 @@ export interface Node {
     [key: string]: any;
   };
   timeSeriesApdexInfo?: number[];
+  subNodesCount?: number;
   shouldNotMerge?: () => boolean;
 }
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
@@ -38,6 +38,15 @@ import cytoscape from 'cytoscape';
 import { cn } from '../../lib';
 import { Input } from '../ui/input';
 
+const XML_ESCAPE_MAP: Record<string, string> = {
+  '<': '&lt;',
+  '>': '&gt;',
+  '&': '&amp;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+const escapeXmlText = (s: string) => s.replace(/[<>&"']/g, (c) => XML_ESCAPE_MAP[c] ?? c);
+
 export interface ServerMapCoreProps extends Omit<ServerMapComponentProps, 'data'> {
   data?: GetServerMap.Response | FilteredMap.Response;
   isLoading?: boolean;
@@ -144,13 +153,15 @@ export const ServerMapCore = ({
     allServiceTypes.current = Array.from(nodeTypes);
 
     const nodes: Node[] = nodeDataArray.map((node) => {
-      const hasSubNodes = Array.isArray((node as GetServerMap.NodeData).subNodes);
+      const subNodes = (node as GetServerMap.NodeData).subNodes;
+      const hasSubNodes = Array.isArray(subNodes);
       return {
         id: node.key,
         label: node.applicationName,
         type: node.serviceType,
         apdex: node.apdex,
-        imgPath: getServerImagePath(node),
+        imgPath: hasSubNodes ? '' : getServerImagePath(node),
+        subNodesCount: hasSubNodes ? subNodes!.length : undefined,
         transactionInfo: getTransactionInfo(node),
         timeSeriesApdexInfo: isFilteredMap
           ? undefined // filtered map에서는 시간 시리즈 Apdex 정보를 사용하지 않는다.
@@ -559,11 +570,19 @@ export const ServerMapCore = ({
                   baseNodeId={baseNodeId}
                   data={serverMapData}
                   renderNode={(node, transactionStatusSVGString) => {
+                    if (node?.subNodesCount !== undefined) {
+                      const serviceName = escapeXmlText(node.label ?? '');
+                      return `
+                  <text x="50" y="44" font-size="16" font-weight="bold" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif">${serviceName}</text>
+                  <line x1="35" y1="58" x2="65" y2="58" stroke="#999" stroke-width="1" />
+                  <text x="50" y="74" font-size="18" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif">${node.subNodesCount}</text>
+                `;
+                    }
                     return `
                   ${transactionStatusSVGString}
                   ${
                     node?.apdex?.apdexScore !== undefined &&
-                    `<text 
+                    `<text
                       x="50" y="80"
                       font-size="smaller"
                       dominant-baseline="middle"
@@ -572,6 +591,12 @@ export const ServerMapCore = ({
                     >${(Math.floor(node?.apdex?.apdexScore * 100) / 100).toFixed(2)}</text>`
                   }
                 `;
+                  }}
+                  renderNodeLabel={(node) => {
+                    if (node?.subNodesCount !== undefined) {
+                      return '';
+                    }
+                    return node?.label ?? '';
                   }}
                   renderEdgeLabel={(edge: MergedEdge) => {
                     if (edge?.transactionInfo?.totalCount) {


### PR DESCRIPTION
Service group 노드는 단일 애플리케이션이 아닌 묶음을 나타내므로
아이콘 대신 serviceName과 자식 노드 개수를 중앙에 표시하고,
일반 노드 대비 30% 크게 그려 시각적으로 구분한다.