### PR TITLE
[#noissue] Use backend apdexSlot for server map time-series Apdex

### DIFF
--- a/web-frontend/src/main/v3/packages/server-map/src/test/ui/template/node.test.ts
+++ b/web-frontend/src/main/v3/packages/server-map/src/test/ui/template/node.test.ts
@@ -152,6 +152,20 @@ describe('timeSeriesApdexInfo 처리', () => {
     expect(pathMatches?.length).toBe(6);
   });
 
+  it('슬롯이 1개면 풀 <circle>로 렌더링해야 함 (degenerate arc 회피)', () => {
+    const node: Node = {
+      id: 'n1',
+      label: 'Node 1',
+      timeSeriesApdexInfo: [0.95],
+    };
+
+    const result = getNodeSVGString(node);
+    const decoded = decodeURIComponent(result.split(',')[1] || '');
+    // 단일 슬롯은 arc(<path>)가 아니라 <circle>로 그려져야 함
+    expect(decoded).not.toMatch(/<path[^>]*A\s/);
+    expect(decoded).toMatch(/<circle[^>]*r="47"[^>]*stroke="#41c464"/);
+  });
+
   it('다양한 Apdex 등급을 올바르게 처리해야 함', () => {
     const node: Node = {
       id: 'n1',

--- a/web-frontend/src/main/v3/packages/server-map/src/ui/template/node.ts
+++ b/web-frontend/src/main/v3/packages/server-map/src/ui/template/node.ts
@@ -76,11 +76,25 @@ const getTimeSeriesApdexStatusSVGCircle = (timeSeriesApdexInfo: TimeSeriesApdexI
   }
 
   const segmentCount = timeSeriesApdexInfo.length;
-  const segmentAngle = 360 / segmentCount;
   const cx = 50;
   const cy = 50;
   const r = RADIUS;
   const strokeWidth = 8;
+
+  // 슬롯이 1개면 SVG arc는 시작점==끝점이 되어 그려지지 않으므로 풀 원을 직접 그린다.
+  if (segmentCount === 1) {
+    const grade = getApdexGrade(timeSeriesApdexInfo[0]);
+    const color = colorMap[grade] || '#cccccc';
+    return `
+      <circle cx="${cx}" cy="${cy}" r="${r}"
+        stroke="${color}"
+        stroke-width="${strokeWidth}"
+        fill="none"
+      />
+    `;
+  }
+
+  const segmentAngle = 360 / segmentCount;
   let svgString = '';
 
   // 12시 방향부터 반시계방향으로 slot을 채운다. (12~1시가 가장 최신 데이터)

--- a/web-frontend/src/main/v3/packages/ui/src/components/MergedServerSearchList/MergedServerSearchList.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/MergedServerSearchList/MergedServerSearchList.tsx
@@ -5,16 +5,11 @@ import { colorMap, getApdexGrade } from '@pinpoint-fe/server-map/src/ui/template
 import { RankColorClassNameMap, getRank } from '../ApdexScore/ApdexScoreFetcher';
 
 export interface MergedServerSearchListProps {
-  timestamp?: number[];
   list?: (GetServerMap.NodeData | FilteredMap.NodeData)[];
   onClickItem?: (nodeData: GetServerMap.NodeData | FilteredMap.NodeData) => void;
 }
 
-export const MergedServerSearchList = ({
-  timestamp,
-  list = [],
-  onClickItem,
-}: MergedServerSearchListProps) => {
+export const MergedServerSearchList = ({ list = [], onClickItem }: MergedServerSearchListProps) => {
   const handleClickItem: MergedServerSearchListProps['onClickItem'] = (nodeData) => {
     onClickItem?.(nodeData);
   };
@@ -37,7 +32,7 @@ export const MergedServerSearchList = ({
                 onClickItem={(item) => handleClickItem(item)}
                 itemChild={(item) => {
                   const MAX_CHART_WIDTH = 96;
-                  const timeSeriesApdexInfo = getTimeSeriesApdexInfo(item, timestamp);
+                  const timeSeriesApdexInfo = getTimeSeriesApdexInfo(item);
                   return (
                     <>
                       <div className="flex items-center justify-between text-xs">

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
@@ -222,7 +222,6 @@ export const ServerMapChartsBoardFetcher = ({
           <>
             {serverMapCurrentTarget?.nodes || serverMapCurrentTarget?.edges ? (
               <MergedServerSearchList
-                timestamp={timestamp}
                 list={getClickedMergedNodeList(serverMapCurrentTarget)}
                 onClickItem={handleClickMergedItem}
               />

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
@@ -165,7 +165,7 @@ export const ServerMapCore = ({
         transactionInfo: getTransactionInfo(node),
         timeSeriesApdexInfo: isFilteredMap
           ? undefined // filtered map에서는 시간 시리즈 Apdex 정보를 사용하지 않는다.
-          : getTimeSeriesApdexInfo(node, data?.applicationMapData?.timestamp),
+          : getTimeSeriesApdexInfo(node),
         shouldNotMerge: () => {
           // service group 노드(subNodes 보유)는 cytoscape의 자동 merge에 휘말리지 않도록 단독 표시한다.
           return (
@@ -266,9 +266,9 @@ export const ServerMapCore = ({
       setPopperContentType(SERVERMAP_MENU_CONTENT_TYPE.NODE);
       rightClickTargetRef.current = clickedData;
     } else if (eventType === 'left' && clickedData) {
-      const serviceGroup = (data?.applicationMapData?.nodeDataArray as
-        | GetServerMap.NodeData[]
-        | undefined)?.find(
+      const serviceGroup = (
+        data?.applicationMapData?.nodeDataArray as GetServerMap.NodeData[] | undefined
+      )?.find(
         (n) => n.key === clickedData.id && Array.isArray(n.subNodes) && n.subNodes.length > 0,
       );
       if (serviceGroup) {
@@ -534,7 +534,7 @@ export const ServerMapCore = ({
                             />
                           </div>
                         </div>
-                        <div className="max-h-72 overflow-y-auto">
+                        <div className="overflow-y-auto max-h-72">
                           {filteredSubNodes.length === 0 ? (
                             <div className="px-3 py-2 text-muted-foreground">
                               {t('COMMON.EMPTY_ON_SEARCH')}

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/GetServerMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/GetServerMap.ts
@@ -125,6 +125,7 @@ export namespace GetServerMap {
       apdexScore: number;
       apdexFormula: ApdexFormula;
     };
+    apdexSlot?: number[];
     timeSeriesHistogram: TimeSeriesHistogram[];
     instanceCount: number;
     instanceErrorCount: number;

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/TransactionTraceServerMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/TransactionTraceServerMap.ts
@@ -12,21 +12,8 @@ export namespace TransactionTraceServerMap {
   }
 
   export interface Response {
-    logLinkEnable: boolean;
-    logButtonName: string;
-    disableButtonMessage: string;
-    logPageUrl: string;
     transactionId: string;
     spanId: number;
-    completeState: string;
-    loggingTransactionInfo: boolean;
-    focusCallStackId?: number;
-    callStackStart: number;
-    callStackEnd: number;
     applicationMapData: GetServerMap.ApplicationMapData;
-    agentId: string;
-    applicationName: string;
-    agentName: string;
-    uri: string;
   }
 }

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.test.ts
@@ -1,4 +1,4 @@
-import { getBaseNodeId } from './serverMap';
+import { getBaseNodeId, getTimeSeriesApdexInfo } from './serverMap';
 import {
   ApplicationType,
   GetServerMap,
@@ -6,6 +6,57 @@ import {
 } from '@pinpoint-fe/ui/src/constants';
 
 describe('Test serverMap helper utils', () => {
+  describe('Test "getTimeSeriesApdexInfo"', () => {
+    const makeNode = (
+      overrides: Partial<GetServerMap.NodeData> = {},
+    ): GetServerMap.NodeData =>
+      ({
+        isAuthorized: true,
+        apdexSlot: [],
+        ...overrides,
+      }) as GetServerMap.NodeData;
+
+    test('Return empty array when node is not authorized', () => {
+      const node = makeNode({ isAuthorized: false, apdexSlot: [0.9, 0.8] });
+      expect(getTimeSeriesApdexInfo(node)).toEqual([]);
+    });
+
+    test('Return empty array when apdexSlot is undefined', () => {
+      const node = makeNode({ apdexSlot: undefined });
+      expect(getTimeSeriesApdexInfo(node)).toEqual([]);
+    });
+
+    test('Return empty array when apdexSlot is empty', () => {
+      const node = makeNode({ apdexSlot: [] });
+      expect(getTimeSeriesApdexInfo(node)).toEqual([]);
+    });
+
+    test('Return apdexSlot as-is when length is within 24', () => {
+      const slot = [0.95, 0.7, 0.5];
+      const node = makeNode({ apdexSlot: slot });
+      expect(getTimeSeriesApdexInfo(node)).toEqual(slot);
+    });
+
+    test('Return up to 24 entries when apdexSlot is longer (defensive)', () => {
+      const slot = Array.from({ length: 30 }, (_, i) => i / 30);
+      const node = makeNode({ apdexSlot: slot });
+      const result = getTimeSeriesApdexInfo(node);
+      expect(result).toHaveLength(24);
+      expect(result).toEqual(slot.slice(0, 24));
+    });
+
+    test('Return empty array for FilteredMap.NodeData (no apdexSlot field)', () => {
+      const node = { isAuthorized: true } as FilteredMap.NodeData;
+      expect(getTimeSeriesApdexInfo(node)).toEqual([]);
+    });
+
+    test('Treat -1 (UNCOLLECTED_VALUE) as 1 (Excellent)', () => {
+      const node = makeNode({ apdexSlot: [-1, 0.6, -1, 0.95] });
+      expect(getTimeSeriesApdexInfo(node)).toEqual([1, 0.6, 1, 0.95]);
+    });
+  });
+
+
   describe('Test "getBaseNodeId"', () => {
     test('Return base node ID when node list is empty', () => {
       const application: ApplicationType = {

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
@@ -53,71 +53,24 @@ export const getBaseNodeId = ({
   return '';
 };
 
+// apdexSlot은 백엔드가 미리 집계해 보내는 0~24개의 Apdex 점수 배열이다.
+// 배열 길이에 맞춰 칸을 나누어 timeSeriesApdexInfo로 렌더링한다.
+const APDEX_SLOT_MAX = 24;
+// 백엔드의 ApdexScoreSlotViewBuilder.UNCOLLECTED_VALUE. 데이터가 수집되지 않은 슬롯을 의미하며
+// 시각화에서는 Excellent(1)와 동일하게 다룬다.
+const APDEX_UNCOLLECTED = -1;
+
 export const getTimeSeriesApdexInfo = (
   node: GetServerMap.NodeData | FilteredMap.NodeData,
-  timestamp: number[] = [],
-) => {
-  const { isAuthorized, timeSeriesHistogram } = node;
+): number[] => {
+  const { isAuthorized } = node;
+  const apdexSlot = 'apdexSlot' in node ? node.apdexSlot : undefined;
 
-  if (!isAuthorized || !timeSeriesHistogram) {
+  if (!isAuthorized || !apdexSlot || apdexSlot.length === 0) {
     return [];
   }
 
-  const maxSlots = 24; // 전체 원을 최대 24개의 slot으로 나눈다.
-  const dataLength = timestamp?.length;
-
-  const oneSecond =
-    timeSeriesHistogram?.find((time) => time.key === '1s' || time.key === '100ms')?.values || [];
-  const threeSecond =
-    timeSeriesHistogram?.find((time) => time.key === '3s' || time.key === '300ms')?.values || [];
-  const total = timeSeriesHistogram?.find((time) => time.key === 'Tot')?.values || [];
-
-  if (
-    oneSecond.length !== dataLength ||
-    threeSecond.length !== dataLength ||
-    total.length !== dataLength
-  ) {
-    return [];
-  }
-
-  if (dataLength <= maxSlots) {
-    return timestamp?.map((time, index) => {
-      if (total?.[index] === 0) {
-        return 1;
-      }
-
-      return (oneSecond?.[index] * 1 + threeSecond?.[index] * 0.5) / total?.[index];
-    });
-  }
-
-  const groupSize = Math.floor(dataLength / maxSlots); // 각 slot에 최소 몇 개의 데이터씩 들어가는지
-  let remainder = dataLength % maxSlots; // 나머지는 앞쪽 slot에 하나씩 더 넣기
-
-  let i = 0;
-  const result = [];
-
-  while (i < dataLength) {
-    const currentSlotSize = groupSize + (remainder > 0 ? 1 : 0);
-    remainder = Math.max(0, remainder - 1); // 나머지 하나 줄이기
-
-    const mergedTotal = total?.slice(i, i + currentSlotSize)?.reduce((t, acc) => {
-      return acc + t;
-    }, 0);
-
-    if (mergedTotal === 0) {
-      result.push(1);
-    } else {
-      const mergedOneSecond = oneSecond?.slice(i, i + currentSlotSize)?.reduce((t, acc) => {
-        return acc + t;
-      }, 0);
-      const mergedThreeSecond = threeSecond?.slice(i, i + currentSlotSize)?.reduce((t, acc) => {
-        return acc + t;
-      }, 0);
-
-      result.push((mergedOneSecond * 1 + mergedThreeSecond * 0.5) / mergedTotal);
-    }
-    i += currentSlotSize;
-  }
-
-  return result;
+  return apdexSlot
+    .slice(0, APDEX_SLOT_MAX)
+    .map((score) => (score === APDEX_UNCOLLECTED ? 1 : score));
 };


### PR DESCRIPTION
Switch timeSeriesApdexInfo computation from client-side aggregation of timestamp + timeSeriesHistogram to the backend-provided apdexSlot (0~24 pre-aggregated scores) so the time-series Apdex ring stays in sync with what the server actually counts. Treat UNCOLLECTED_VALUE (-1) as Excellent (1) for display.

Also fix a rendering gap on the Transaction list page's trace server map: when apdexSlot has a single slot, the SVG arc collapsed because start and end points were identical. Draw a full <circle> in that case.