### PR TITLE
[#13534] Add service-level permission check to UriStatController

### DIFF
--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/controller/UriStatController.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/controller/UriStatController.java
@@ -40,6 +40,7 @@ import com.navercorp.pinpoint.uristat.web.view.UriStatSummaryView;
 import com.navercorp.pinpoint.uristat.web.view.UriStatView;
 import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -85,6 +86,7 @@ public class UriStatController {
         return range;
     }
 
+    @PreAuthorize("@naverPermissionEvaluator.hasUrlStatPermission(#serviceName.getName(), #applicationName)")
     @GetMapping("/summary")
     public List<UriStatSummaryView> getUriStatPagedSummary(
             @ServiceParam ServiceName serviceName,
@@ -122,6 +124,7 @@ public class UriStatController {
         }
     }
 
+    @PreAuthorize("@naverPermissionEvaluator.hasUrlStatPermission(#serviceName.getName(), #applicationName)")
     @GetMapping("/chart")
     public UriStatView getCollectedUriStat(
             @ServiceParam ServiceName serviceName,


### PR DESCRIPTION
## Summary
- Add `@PreAuthorize` annotations to UriStatController's `getUriStatPagedSummary` and `getCollectedUriStat` endpoints
- Uses `hasUrlStatPermission(serviceName, applicationName)` for service-level access control

## Test plan
- [x] Unit tests for hasUrlStatPermission (6 cases: admin, DEFAULT authorized/denied, non-DEFAULT authorized/denied, null auth)
- [x] Scenario tests: admin bypass (3/3), user authorized (4/4), user denied (4/4) — total 11/11 passed