### PR TITLE
[#noissue] Refine VIEW SERVERS button visibility and empty states

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerList/ServerList.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerList/ServerList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { GoDotFill } from 'react-icons/go';
 import { FaChartLine } from 'react-icons/fa';
 import { GetHistogramStatistics, AgentOverview } from '@pinpoint-fe/ui/src/constants';
@@ -24,6 +25,18 @@ export const ServerList = ({
   onClickInspectorLink,
   itemRenderer,
 }: ServerListProps) => {
+  const { t } = useTranslation();
+
+  if (!data?.length) {
+    return (
+      <div className={cn('h-full', className)}>
+        <div className="flex items-center justify-center p-3 opacity-50 h-[calc(100%-45px)]">
+          {t('COMMON.NO_DATA')}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={cn('h-full', className)}>
       <div className="p-3 flex gap-2 flex-col h-[calc(100%-45px)] overflow-y-auto">

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
@@ -183,6 +183,14 @@ export const ServerMapChartsBoardFetcher = ({
     return;
   }, [isLoading, data, currentServer?.agentId]);
 
+  // serviceType의 진실의 원천: 클릭 즉시 세팅되는 serverMapCurrentTarget을 우선 사용하고,
+  // 그 다음으로 조회된 currentTargetData, 마지막으로 기본 application으로 폴백한다.
+  // currentTargetData만 보면 전환 중에 undefined가 되어 USER/UNKNOWN 체크를 통과시킬 수 있다.
+  const targetServiceType =
+    serverMapCurrentTarget?.serviceType ??
+    (currentTargetData as GetServerMap.NodeData)?.serviceType ??
+    application?.serviceType;
+
   // service group 노드/링크가 선택된 경우(subNodes/subLinks 보유) ChartsBoard를 그리지 않는다.
   // 팝업에서 자식 노드/링크를 선택하면 currentTarget이 자식 key로 바뀌어 다시 렌더된다.
   if (
@@ -231,8 +239,8 @@ export const ServerMapChartsBoardFetcher = ({
             ) : (
               <>
                 {(serverMapCurrentTarget?.type === 'node' || !serverMapCurrentTarget) &&
-                (currentTargetData as GetServerMap.NodeData)?.serviceType !== 'USER' &&
-                (currentTargetData as GetServerMap.NodeData)?.serviceType !== 'UNKNOWN' ? (
+                targetServiceType !== 'USER' &&
+                targetServiceType !== 'UNKNOWN' ? (
                   <div className="flex items-center h-12 py-2.5 px-4 gap-2">
                     <Button
                       className="px-2 py-1 text-xs"

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
@@ -231,7 +231,8 @@ export const ServerMapChartsBoardFetcher = ({
             ) : (
               <>
                 {(serverMapCurrentTarget?.type === 'node' || !serverMapCurrentTarget) &&
-                (currentTargetData as GetServerMap.NodeData)?.instanceCount ? (
+                (currentTargetData as GetServerMap.NodeData)?.serviceType !== 'USER' &&
+                (currentTargetData as GetServerMap.NodeData)?.serviceType !== 'UNKNOWN' ? (
                   <div className="flex items-center h-12 py-2.5 px-4 gap-2">
                     <Button
                       className="px-2 py-1 text-xs"
@@ -350,6 +351,11 @@ export const ServerMapChartsBoardFetcher = ({
                 </div>
                 <Separator />
               </>
+            )}
+            {!isLoading && data && Object.keys(data.agentHistogram || {}).length === 0 && (
+              <div className="flex items-center justify-center h-full opacity-50">
+                {t('COMMON.NO_DATA')}
+              </div>
             )}
           </ChartsBoard>
         </div>


### PR DESCRIPTION
- Show VIEW SERVERS button only when serviceType is not USER/UNKNOWN
- Display "No Data" in ServerList and agent ChartsBoard when empty