### PR TITLE
[#13715] Backport : Change default NameVersion to v3

### DIFF
--- a/agent-module/agent/src/main/resources/pinpoint-root.config
+++ b/agent-module/agent/src/main/resources/pinpoint-root.config
@@ -26,6 +26,9 @@ pinpoint.disable=false
 ## experimental feature : WARNING Do not enable v4
 #pinpoint.v4.enable=false
 
+# v3: ApplicationName: 254-Character Support
+pinpoint.modules.uid.version=v3
+
 # GRPC or THRIFT
 profiler.transport.module=GRPC
 ###########################################################

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/ObjectNameBuilder.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/ObjectNameBuilder.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
 public class ObjectNameBuilder {
 
     public ObjectName build(AgentOption agentOption, ProfilerConfig profilerConfig) {
-        String version = profilerConfig.readString(NameVersion.KEY, "v1");
+        String version = profilerConfig.readString(NameVersion.KEY, NameVersion.v3.name());
 
         NameVersion nameVersion = NameVersion.getVersion(version);
 

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/name/NameVersion.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/name/NameVersion.java
@@ -24,14 +24,12 @@ public enum NameVersion {
     public static final String KEY = "pinpoint.modules.uid.version";
 
     public static NameVersion getVersion(String version) {
-        if ("v1".equalsIgnoreCase(version)) {
-            return v1;
-        } else if ("v3".equalsIgnoreCase(version)) {
-            return v3;
-        } else if ("v4".equalsIgnoreCase(version)) {
-            return v4;
+        for (NameVersion value : NameVersion.values()) {
+            if (value.name().equalsIgnoreCase(version)) {
+                return value;
+            }
         }
-        return v1;
+        return v3;
     }
 
 }

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/name/NameVersionTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/name/NameVersionTest.java
@@ -1,0 +1,20 @@
+package com.navercorp.pinpoint.profiler.name;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NameVersionTest {
+
+    @Test
+    void getVersion() {
+        Assertions.assertEquals(NameVersion.v1, NameVersion.getVersion(NameVersion.v1.name()));
+        Assertions.assertEquals(NameVersion.v3, NameVersion.getVersion(NameVersion.v3.name()));
+    }
+
+    @Test
+    void getVersion_default() {
+        Assertions.assertEquals(NameVersion.v3, NameVersion.getVersion("unknown"));
+    }
+}


### PR DESCRIPTION
Enable 254-character ApplicationName support by setting v3 as the
default name version. Refactor getVersion lookup to iterate enum
values and add tests.
