### PR TITLE
[#13726] Bump maven-surefire-plugin from 3.5.2 to 3.5.5

### DIFF
--- a/agent-module/agent-testweb/vertx-3-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/vertx-3-plugin-testweb/pom.xml
@@ -33,7 +33,6 @@
         <vertx.version>3.9.8</vertx.version>
 
         <spring-boot-build-skip>true</spring-boot-build-skip>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <main.verticle>com.pinpoint.test.plugin.Vertx3PluginTestStarter</main.verticle>
         <launcher.class>io.vertx.core.Launcher</launcher.class>
 

--- a/agent-module/agent-testweb/vertx-4-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/vertx-4-plugin-testweb/pom.xml
@@ -34,7 +34,6 @@
         <vertx.version>4.5.0</vertx.version>
 
         <spring-boot-build-skip>true</spring-boot-build-skip>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <main.verticle>com.pinpoint.test.plugin.Vertx4PluginTestStarter</main.verticle>
         <launcher.class>io.vertx.core.Launcher</launcher.class>
 
@@ -86,8 +85,8 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -115,7 +115,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${plugin.surefire.version}</version>
                 <configuration>
                     <enableAssertions>false</enableAssertions>
                 </configuration>

--- a/commons-server/pom.xml
+++ b/commons-server/pom.xml
@@ -216,7 +216,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${plugin.surefire.version}</version>
                 <configuration>
                     <!-- Add  @{argLine} for jacoco -->
                     <argLine>@{argLine} --add-opens java.base/java.nio=ALL-UNNAMED</argLine>

--- a/hbase-testcluster/pom.xml
+++ b/hbase-testcluster/pom.xml
@@ -94,7 +94,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${plugin.surefire.version}</version>
                 <configuration>
                     <argLine>
                         @{argLine}

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
         <plugin.compiler.version>3.15.0</plugin.compiler.version>
         <plugin.source.version>3.3.1</plugin.source.version>
         <plugin.resources.version>3.3.1</plugin.resources.version>
-        <plugin.surefire.version>3.5.2</plugin.surefire.version>
+        <plugin.surefire.version>3.5.5</plugin.surefire.version>
         <plugin.failsafe.version>3.5.2</plugin.failsafe.version>
         <plugin.shade.version>3.4.1</plugin.shade.version>
         <plugin.assembly.version>3.6.0</plugin.assembly.version>
@@ -1875,6 +1875,12 @@
                     <version>${plugin.compiler.version}</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${plugin.surefire.version}</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>templating-maven-plugin</artifactId>
                     <version>3.1.0</version>
@@ -2067,7 +2073,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${plugin.surefire.version}</version>
                 <configuration>
                     <excludes>
                         <exclude>**/Mock*</exclude>


### PR DESCRIPTION
Move maven-surefire-plugin version to pluginManagement and remove
redundant version declarations from sub-modules.
