### PR TITLE
[#noissue] Fix Pinot compatibility table for v3.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Pinot compatibility table:
 |------------------|--------------|--------------|-------------|----------------------------------------------------------------------|-------------|
 | 2.5.x            | yes          | yes          | yes         | yes                                                                  | yes         |
 | 3.0.x            | no           | no           | yes         | yes                                                                  | yes         |
-| 3.1.x            | no           | no           | no          | yes                                                                  | yes         |
+| 3.1.x            | no           | no           | no          | no                                                                    | yes         |
 <!-- </compatibilityPinot.md> -->
 
 ## Community


### PR DESCRIPTION
## Summary
- Fix Pinot compatibility table: v3.1.x does not support Pinot 1.1.x (`yes` → `no`)