### PR TITLE
Add collector tail sampling (error/latency-aware, Redis-backed)

### DIFF
--- a/agent-module/agent-plugins/agent-plugins-parent/pom.xml
+++ b/agent-module/agent-plugins/agent-plugins-parent/pom.xml
@@ -22,7 +22,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-plugins-parent</artifactId>

--- a/agent-module/agent-plugins/pom.xml
+++ b/agent-module/agent-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-plugins</artifactId>

--- a/agent-module/agent-plugins/proxy-apache/pom.xml
+++ b/agent-module/agent-plugins/proxy-apache/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-plugins-parent</artifactId>
         <relativePath>../agent-plugins-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-proxy-apache-plugin</artifactId>

--- a/agent-module/agent-plugins/proxy-app/pom.xml
+++ b/agent-module/agent-plugins/proxy-app/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-plugins-parent</artifactId>
         <relativePath>../agent-plugins-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-proxy-app-plugin</artifactId>

--- a/agent-module/agent-plugins/proxy-common/pom.xml
+++ b/agent-module/agent-plugins/proxy-common/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-plugins-parent</artifactId>
         <relativePath>../agent-plugins-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-proxy-common</artifactId>

--- a/agent-module/agent-plugins/proxy-nginx/pom.xml
+++ b/agent-module/agent-plugins/proxy-nginx/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-plugins-parent</artifactId>
         <relativePath>../agent-plugins-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-proxy-nginx-plugin</artifactId>

--- a/agent-module/agent-plugins/proxy-user/pom.xml
+++ b/agent-module/agent-plugins/proxy-user/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-plugins-parent</artifactId>
         <relativePath>../agent-plugins-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-proxy-user-plugin</artifactId>

--- a/agent-module/agent-sdk/pom.xml
+++ b/agent-module/agent-sdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/agent-testweb/agent-proxy-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/agent-proxy-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-proxy-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/agent-testweb-commons/pom.xml
+++ b/agent-module/agent-testweb/agent-testweb-commons/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <artifactId>pinpoint-agent-testweb-commons</artifactId>
     <packaging>jar</packaging>

--- a/agent-module/agent-testweb/agentsdk-async-testweb/pom.xml
+++ b/agent-module/agent-testweb/agentsdk-async-testweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agentsdk-async-testweb</artifactId>

--- a/agent-module/agent-testweb/arcus-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/arcus-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-arcus-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/aws-sdk-s3-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/aws-sdk-s3-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-aws-sdk-s3-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/bom/pom.xml
+++ b/agent-module/agent-testweb/bom/pom.xml
@@ -22,7 +22,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/agent-module/agent-testweb/cassandra3-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/cassandra3-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-cassandra3-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/cassandra4-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/cassandra4-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-cassandra4-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/closed-module-testlib/pom.xml
+++ b/agent-module/agent-testweb/closed-module-testlib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-closed-module-testlib</artifactId>

--- a/agent-module/agent-testweb/closed-module-testweb/pom.xml
+++ b/agent-module/agent-testweb/closed-module-testweb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-closed-module-testweb</artifactId>

--- a/agent-module/agent-testweb/db2-jdbc-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/db2-jdbc-plugin-testweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-db2-jdbc-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/dubbo-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/dubbo-plugin-testweb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-dubbo-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/elasticsearch-8-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/elasticsearch-8-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-elasticsearch-8-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/elasticsearch-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/elasticsearch-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-elasticsearch-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/grpc-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/grpc-plugin-testweb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-grpc-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/httpclient4-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/httpclient4-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-httpclient4-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/httpclient5-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/httpclient5-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-httpclient5-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/jdk-http-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/jdk-http-plugin-testweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jdk-http-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/jdk-httpclient-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/jdk-httpclient-plugin-testweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jdk-httpclient-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/jetty-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/jetty-plugin-testweb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jetty-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/jetty12-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/jetty12-plugin-testweb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jetty12-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/kafka-4-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/kafka-4-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-kafka-4-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/kafka-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/kafka-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-kafka-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/kafka-streams-testweb/pom.xml
+++ b/agent-module/agent-testweb/kafka-streams-testweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-agent-testweb</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/agent-testweb/ktor-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/ktor-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-ktor-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/mariadb-jdbc-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/mariadb-jdbc-plugin-testweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mariadb-jdbc-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/mongodb-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/mongodb-plugin-testweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mongodb-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/mongodb-reactive-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/mongodb-reactive-plugin-testweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mongodb-reactive-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/mysql-jdbc-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/mysql-jdbc-plugin-testweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mysql-jdbc-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/ning-asynchttpclient-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/ning-asynchttpclient-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-ning-asynchttpclient-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/okhttp-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/okhttp-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-okhttp-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/paho-mqtt-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/paho-mqtt-plugin-testweb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-paho-mqtt-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/pom.xml
+++ b/agent-module/agent-testweb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-testweb</artifactId>

--- a/agent-module/agent-testweb/postgresql-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/postgresql-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-postgresql-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/pulsar-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/pulsar-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-pulsar-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/reactor-netty-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/reactor-netty-plugin-testweb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-reactor-netty-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/reactor-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/reactor-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-reactor-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/redis-lettuce-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/redis-lettuce-plugin-testweb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-redis-lettuce-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/resilience4j-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/resilience4j-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-resilience4j-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/rocketmq-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/rocketmq-plugin-testweb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.navercorp.pinpoint</groupId>
     <artifactId>pinpoint-agent-testweb</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>pinpoint-rocketmq-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/rocketmq-plugin-testweb/rocketmq-original/pom.xml
+++ b/agent-module/agent-testweb/rocketmq-plugin-testweb/rocketmq-original/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-rocketmq-plugin-testweb</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/agent-module/agent-testweb/rocketmq-plugin-testweb/rocketmq-springboot/pom.xml
+++ b/agent-module/agent-testweb/rocketmq-plugin-testweb/rocketmq-springboot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-agent-testweb</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/agent-module/agent-testweb/rocketmq-plugin-testweb/rocketmq-springcloud-stream/pom.xml
+++ b/agent-module/agent-testweb/rocketmq-plugin-testweb/rocketmq-springcloud-stream/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pinpoint-agent-testweb</artifactId>
     <groupId>com.navercorp.pinpoint</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/agent-module/agent-testweb/spring-boot3-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-boot3-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-boot3-testweb</artifactId>

--- a/agent-module/agent-testweb/spring-boot3-webflux-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-boot3-webflux-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-boot3-webflux-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/spring-cloud-gateway-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-cloud-gateway-plugin-testweb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-cloud-gateway-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/spring-data-r2dbc-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-data-r2dbc-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-data-r2dbc-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/spring-kafka-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-kafka-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-kafka-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/spring-restclient-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-restclient-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-restclient-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/spring-webflux-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-webflux-plugin-testweb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-webflux-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/thread-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/thread-plugin-testweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-thread-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/thrift-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/thrift-plugin-testweb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-thrift-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/undertow-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/undertow-plugin-testweb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-undertow-plugin-testweb</artifactId>

--- a/agent-module/agent-testweb/vertx-3-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/vertx-3-plugin-testweb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <artifactId>pinpoint-vertx-3-plugin-testweb</artifactId>
     <packaging>jar</packaging>

--- a/agent-module/agent-testweb/vertx-4-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/vertx-4-plugin-testweb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-testweb</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-vertx-4-plugin-testweb</artifactId>

--- a/agent-module/agent-tools/pom.xml
+++ b/agent-module/agent-tools/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-tools</artifactId>

--- a/agent-module/agent/pom.xml
+++ b/agent-module/agent/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent</artifactId>

--- a/agent-module/bootstraps/bootstrap-core/pom.xml
+++ b/agent-module/bootstraps/bootstrap-core/pom.xml
@@ -6,7 +6,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-bootstrap-parent</artifactId>
         <relativePath>../bootstrap-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-bootstrap-core</artifactId>

--- a/agent-module/bootstraps/bootstrap-interceptor/pom.xml
+++ b/agent-module/bootstraps/bootstrap-interceptor/pom.xml
@@ -23,7 +23,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-bootstrap-parent</artifactId>
         <relativePath>../bootstrap-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-bootstrap-interceptor</artifactId>

--- a/agent-module/bootstraps/bootstrap-interceptor/pom.xml
+++ b/agent-module/bootstraps/bootstrap-interceptor/pom.xml
@@ -27,6 +27,8 @@
     </parent>
 
     <artifactId>pinpoint-bootstrap-interceptor</artifactId>
+    <name>pinpoint-bootstrap-interceptor</name>
+    <description>pinpoint bootstrap interceptor</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/agent-module/bootstraps/bootstrap-java15/pom.xml
+++ b/agent-module/bootstraps/bootstrap-java15/pom.xml
@@ -22,7 +22,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-bootstrap-parent</artifactId>
         <relativePath>../bootstrap-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <properties>

--- a/agent-module/bootstraps/bootstrap-java16/pom.xml
+++ b/agent-module/bootstraps/bootstrap-java16/pom.xml
@@ -22,7 +22,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-bootstrap-parent</artifactId>
         <relativePath>../bootstrap-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <properties>

--- a/agent-module/bootstraps/bootstrap-java9-internal/pom.xml
+++ b/agent-module/bootstraps/bootstrap-java9-internal/pom.xml
@@ -22,7 +22,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-bootstrap-parent</artifactId>
         <relativePath>../bootstrap-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <properties>

--- a/agent-module/bootstraps/bootstrap-java9/pom.xml
+++ b/agent-module/bootstraps/bootstrap-java9/pom.xml
@@ -22,7 +22,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-bootstrap-parent</artifactId>
         <relativePath>../bootstrap-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <properties>

--- a/agent-module/bootstraps/bootstrap-parent/pom.xml
+++ b/agent-module/bootstraps/bootstrap-parent/pom.xml
@@ -22,7 +22,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-bootstrap-parent</artifactId>

--- a/agent-module/bootstraps/bootstrap/pom.xml
+++ b/agent-module/bootstraps/bootstrap/pom.xml
@@ -6,7 +6,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-bootstrap-parent</artifactId>
         <relativePath>../bootstrap-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-bootstrap</artifactId>

--- a/agent-module/bootstraps/pom.xml
+++ b/agent-module/bootstraps/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     
     <artifactId>pinpoint-bootstraps</artifactId>

--- a/agent-module/plugins-it/activemq-it/activemq-5-15-it/pom.xml
+++ b/agent-module/plugins-it/activemq-it/activemq-5-15-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-activemq-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-activemq-5-15-plugin-it</artifactId>

--- a/agent-module/plugins-it/activemq-it/activemq-5-17-it/pom.xml
+++ b/agent-module/plugins-it/activemq-it/activemq-5-17-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-activemq-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-activemq-5-17-plugin-it</artifactId>

--- a/agent-module/plugins-it/activemq-it/pom.xml
+++ b/agent-module/plugins-it/activemq-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/cassandra-it/cassandra-2-it/pom.xml
+++ b/agent-module/plugins-it/cassandra-it/cassandra-2-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-cassandra-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-cassandra-2-plugin-it</artifactId>

--- a/agent-module/plugins-it/cassandra-it/cassandra-4-it/pom.xml
+++ b/agent-module/plugins-it/cassandra-it/cassandra-4-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-cassandra-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-cassandra-4-plugin-it</artifactId>

--- a/agent-module/plugins-it/cassandra-it/pom.xml
+++ b/agent-module/plugins-it/cassandra-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/clickhouse-jdbc-it/pom.xml
+++ b/agent-module/plugins-it/clickhouse-jdbc-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-clickhouse-jdbc-plugin-it</artifactId>

--- a/agent-module/plugins-it/cxf-it/cxf-3-0-it/pom.xml
+++ b/agent-module/plugins-it/cxf-it/cxf-3-0-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-cxf-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-cxf-3-0-plugin-it</artifactId>

--- a/agent-module/plugins-it/cxf-it/cxf-3-6-it/pom.xml
+++ b/agent-module/plugins-it/cxf-it/cxf-3-6-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-cxf-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-cxf-3-6-plugin-it</artifactId>

--- a/agent-module/plugins-it/cxf-it/pom.xml
+++ b/agent-module/plugins-it/cxf-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/dameng-jdbc-it/pom.xml
+++ b/agent-module/plugins-it/dameng-jdbc-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-dameng-jdbc-driver-plugin-it</artifactId>

--- a/agent-module/plugins-it/dbcp-it/pom.xml
+++ b/agent-module/plugins-it/dbcp-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-dbcp-plugin-it</artifactId>

--- a/agent-module/plugins-it/druid-it/pom.xml
+++ b/agent-module/plugins-it/druid-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-druid-plugin-it</artifactId>

--- a/agent-module/plugins-it/elasticsearch-it/elasticsearch-6-it/pom.xml
+++ b/agent-module/plugins-it/elasticsearch-it/elasticsearch-6-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-elasticsearch-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-elasticsearch-6-plugin-it</artifactId>

--- a/agent-module/plugins-it/elasticsearch-it/elasticsearch-7-16-it/pom.xml
+++ b/agent-module/plugins-it/elasticsearch-it/elasticsearch-7-16-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-elasticsearch-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-elasticsearch-7-16-plugin-it</artifactId>

--- a/agent-module/plugins-it/elasticsearch-it/pom.xml
+++ b/agent-module/plugins-it/elasticsearch-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/fastjson-it/pom.xml
+++ b/agent-module/plugins-it/fastjson-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-fastjson-plugin-it</artifactId>

--- a/agent-module/plugins-it/google-grpc-it/google-grpc-1-42-it/pom.xml
+++ b/agent-module/plugins-it/google-grpc-it/google-grpc-1-42-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-grpc-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/google-grpc-it/pom.xml
+++ b/agent-module/plugins-it/google-grpc-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/google-httpclient-it/pom.xml
+++ b/agent-module/plugins-it/google-httpclient-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-google-httpclient-plugin-it</artifactId>

--- a/agent-module/plugins-it/gson-it/pom.xml
+++ b/agent-module/plugins-it/gson-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-gson-plugin-it</artifactId>

--- a/agent-module/plugins-it/hbase-it/pom.xml
+++ b/agent-module/plugins-it/hbase-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-hbase-plugin-it</artifactId>

--- a/agent-module/plugins-it/hikaricp-it/hikaricp-4-it/pom.xml
+++ b/agent-module/plugins-it/hikaricp-it/hikaricp-4-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-hikaricp-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-hikaricp-4-plugin-it</artifactId>

--- a/agent-module/plugins-it/hikaricp-it/hikaricp-5-it/pom.xml
+++ b/agent-module/plugins-it/hikaricp-it/hikaricp-5-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-hikaricp-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-hikaricp-5-plugin-it</artifactId>

--- a/agent-module/plugins-it/hikaricp-it/pom.xml
+++ b/agent-module/plugins-it/hikaricp-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/httpclient-it/httpclient-3-it/pom.xml
+++ b/agent-module/plugins-it/httpclient-it/httpclient-3-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-httpclient-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-httpclient-3-plugin-it</artifactId>

--- a/agent-module/plugins-it/httpclient-it/httpclient-4-it/pom.xml
+++ b/agent-module/plugins-it/httpclient-it/httpclient-4-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-httpclient-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-httpclient-4-plugin-it</artifactId>

--- a/agent-module/plugins-it/httpclient-it/httpclient-5-it/pom.xml
+++ b/agent-module/plugins-it/httpclient-it/httpclient-5-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-httpclient-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-httpclient-5-plugin-it</artifactId>

--- a/agent-module/plugins-it/httpclient-it/pom.xml
+++ b/agent-module/plugins-it/httpclient-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/hystrix-it/pom.xml
+++ b/agent-module/plugins-it/hystrix-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-hystrix-plugin-it</artifactId>

--- a/agent-module/plugins-it/ibatis-it/pom.xml
+++ b/agent-module/plugins-it/ibatis-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-ibatis-plugin-it</artifactId>

--- a/agent-module/plugins-it/informix-jdbc-it/pom.xml
+++ b/agent-module/plugins-it/informix-jdbc-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-informix-jdbc-driver-plugin-it</artifactId>

--- a/agent-module/plugins-it/jackson-it/pom.xml
+++ b/agent-module/plugins-it/jackson-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jackson-plugin-it</artifactId>

--- a/agent-module/plugins-it/jdk-http-it/pom.xml
+++ b/agent-module/plugins-it/jdk-http-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jdk-http-plugin-it</artifactId>

--- a/agent-module/plugins-it/json-lib-it/pom.xml
+++ b/agent-module/plugins-it/json-lib-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-json-lib-plugin-it</artifactId>

--- a/agent-module/plugins-it/jtds-it/pom.xml
+++ b/agent-module/plugins-it/jtds-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jtds-plugin-it</artifactId>

--- a/agent-module/plugins-it/kafka-it/kafka-2-it/pom.xml
+++ b/agent-module/plugins-it/kafka-it/kafka-2-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-kafka-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/kafka-it/kafka-3-it/pom.xml
+++ b/agent-module/plugins-it/kafka-it/kafka-3-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-kafka-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/kafka-it/pom.xml
+++ b/agent-module/plugins-it/kafka-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/kotlin-coroutines-it/pom.xml
+++ b/agent-module/plugins-it/kotlin-coroutines-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/lambda-it/pom.xml
+++ b/agent-module/plugins-it/lambda-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-lambda-it</artifactId>

--- a/agent-module/plugins-it/log4j-it/pom.xml
+++ b/agent-module/plugins-it/log4j-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-log4j-plugin-it</artifactId>

--- a/agent-module/plugins-it/log4j2-it/pom.xml
+++ b/agent-module/plugins-it/log4j2-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-log4j2-plugin-it</artifactId>

--- a/agent-module/plugins-it/logback-it/pom.xml
+++ b/agent-module/plugins-it/logback-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-logback-plugin-it</artifactId>

--- a/agent-module/plugins-it/mariadb-jdbc-it/pom.xml
+++ b/agent-module/plugins-it/mariadb-jdbc-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mariadb-jdbc-driver-plugin-it</artifactId>

--- a/agent-module/plugins-it/mongodb-it/mongodb-3-it/pom.xml
+++ b/agent-module/plugins-it/mongodb-it/mongodb-3-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-mongodb-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mongodb-3-plugin-it</artifactId>

--- a/agent-module/plugins-it/mongodb-it/mongodb-4-it/pom.xml
+++ b/agent-module/plugins-it/mongodb-it/mongodb-4-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-mongodb-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mongodb-4-plugin-it</artifactId>

--- a/agent-module/plugins-it/mongodb-it/pom.xml
+++ b/agent-module/plugins-it/mongodb-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/mssql-jdbc-it/pom.xml
+++ b/agent-module/plugins-it/mssql-jdbc-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mssql-jdbc-driver-plugin-it</artifactId>

--- a/agent-module/plugins-it/mybatis-it/pom.xml
+++ b/agent-module/plugins-it/mybatis-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mybatis-plugin-it</artifactId>

--- a/agent-module/plugins-it/mysql-jdbc-driver-plugin-it/pom.xml
+++ b/agent-module/plugins-it/mysql-jdbc-driver-plugin-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mysql-jdbc-driver-plugin-it</artifactId>

--- a/agent-module/plugins-it/netty-it/pom.xml
+++ b/agent-module/plugins-it/netty-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-netty-plugin-it</artifactId>

--- a/agent-module/plugins-it/ning-asyncclient-it/pom.xml
+++ b/agent-module/plugins-it/ning-asyncclient-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-ning-aysncclient-plugin-it</artifactId>

--- a/agent-module/plugins-it/okhttp-it/pom.xml
+++ b/agent-module/plugins-it/okhttp-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-okhttp-plugin-it</artifactId>

--- a/agent-module/plugins-it/oracledb-it/oracledb-11-it/pom.xml
+++ b/agent-module/plugins-it/oracledb-it/oracledb-11-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-oracle-jdbc-driver-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-oracle-jdbc-driver-11-plugin-it</artifactId>

--- a/agent-module/plugins-it/oracledb-it/oracledb-19-it/pom.xml
+++ b/agent-module/plugins-it/oracledb-it/oracledb-19-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-oracle-jdbc-driver-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-oracle-jdbc-driver-19-plugin-it</artifactId>

--- a/agent-module/plugins-it/oracledb-it/pom.xml
+++ b/agent-module/plugins-it/oracledb-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/paho-mqtt-it/pom.xml
+++ b/agent-module/plugins-it/paho-mqtt-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>pinpoint-plugins-it</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-paho-mqtt-plugin-it</artifactId>

--- a/agent-module/plugins-it/pom.xml
+++ b/agent-module/plugins-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-plugins-it</artifactId>

--- a/agent-module/plugins-it/postgresql-jdbc-it/pom.xml
+++ b/agent-module/plugins-it/postgresql-jdbc-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-postgresql-jdbc-driver-plugin-it</artifactId>

--- a/agent-module/plugins-it/process-it/pom.xml
+++ b/agent-module/plugins-it/process-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/pulsar-it/pom.xml
+++ b/agent-module/plugins-it/pulsar-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/pulsar-it/pulsar-40-it/pom.xml
+++ b/agent-module/plugins-it/pulsar-it/pulsar-40-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-pulsar-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/pulsar-it/pulsar-41-it/pom.xml
+++ b/agent-module/plugins-it/pulsar-it/pulsar-41-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-pulsar-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/rabbitmq-it/pom.xml
+++ b/agent-module/plugins-it/rabbitmq-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-rabbitmq-plugin-it</artifactId>

--- a/agent-module/plugins-it/reactor-it/pom.xml
+++ b/agent-module/plugins-it/reactor-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-reactor-plugin-it</artifactId>

--- a/agent-module/plugins-it/redis-lettuce-it/pom.xml
+++ b/agent-module/plugins-it/redis-lettuce-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-redis-lettuce-plugin-it</artifactId>

--- a/agent-module/plugins-it/rxjava-it/pom.xml
+++ b/agent-module/plugins-it/rxjava-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-rxjava-plugin-it</artifactId>

--- a/agent-module/plugins-it/spring-data-r2dbc-it/pom.xml
+++ b/agent-module/plugins-it/spring-data-r2dbc-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-data-r2dbc-plugin-it</artifactId>

--- a/agent-module/plugins-it/spring-it/pom.xml
+++ b/agent-module/plugins-it/spring-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/spring-it/spring-3-it/pom.xml
+++ b/agent-module/plugins-it/spring-it/spring-3-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-spring-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-3-plugin-it</artifactId>

--- a/agent-module/plugins-it/spring-it/spring-6-it/pom.xml
+++ b/agent-module/plugins-it/spring-it/spring-6-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-spring-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-6-plugin-it</artifactId>

--- a/agent-module/plugins-it/thread-it/pom.xml
+++ b/agent-module/plugins-it/thread-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-thread-plugin-it</artifactId>

--- a/agent-module/plugins-it/thrift-it/pom.xml
+++ b/agent-module/plugins-it/thrift-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins-it/thrift-it/thrift-0-10-it/pom.xml
+++ b/agent-module/plugins-it/thrift-it/thrift-0-10-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-thrift-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-thrift-0-10-plugin-it</artifactId>

--- a/agent-module/plugins-it/thrift-it/thrift-0-14-it/pom.xml
+++ b/agent-module/plugins-it/thrift-it/thrift-0-14-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-thrift-plugin-it</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-thrift-0-14-plugin-it</artifactId>

--- a/agent-module/plugins-loader/pom.xml
+++ b/agent-module/plugins-loader/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-plugins-loader</artifactId>

--- a/agent-module/plugins-test-module/plugins-it-utils-jdbc/pom.xml
+++ b/agent-module/plugins-test-module/plugins-it-utils-jdbc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-test-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-plugin-it-utils-jdbc</artifactId>

--- a/agent-module/plugins-test-module/plugins-it-utils/pom.xml
+++ b/agent-module/plugins-test-module/plugins-it-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-test-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-plugin-it-utils</artifactId>

--- a/agent-module/plugins-test-module/plugins-test/pom.xml
+++ b/agent-module/plugins-test-module/plugins-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-test-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-plugins-test</artifactId>

--- a/agent-module/plugins-test-module/pom.xml
+++ b/agent-module/plugins-test-module/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-plugins-test-module</artifactId>

--- a/agent-module/plugins-test-module/testcase/pom.xml
+++ b/agent-module/plugins-test-module/testcase/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins-test-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-testcase</artifactId>

--- a/agent-module/plugins/activemq-client/pom.xml
+++ b/agent-module/plugins/activemq-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-activemq-client-plugin</artifactId>

--- a/agent-module/plugins/agentsdk-async/pom.xml
+++ b/agent-module/plugins/agentsdk-async/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agentsdk-async-plugin</artifactId>

--- a/agent-module/plugins/akka-http/pom.xml
+++ b/agent-module/plugins/akka-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-akka-http-plugin</artifactId>

--- a/agent-module/plugins/apache-dubbo/pom.xml
+++ b/agent-module/plugins/apache-dubbo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-apache-dubbo-plugin</artifactId>

--- a/agent-module/plugins/arcus/pom.xml
+++ b/agent-module/plugins/arcus/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-arcus-plugin</artifactId>

--- a/agent-module/plugins/assembly/pom.xml
+++ b/agent-module/plugins/assembly/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-plugins-assembly</artifactId>

--- a/agent-module/plugins/aws-sdk-s3/pom.xml
+++ b/agent-module/plugins/aws-sdk-s3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-aws-sdk-s3-plugin</artifactId>

--- a/agent-module/plugins/bom/pom.xml
+++ b/agent-module/plugins/bom/pom.xml
@@ -22,7 +22,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/agent-module/plugins/cassandra/pom.xml
+++ b/agent-module/plugins/cassandra/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-cassandra-driver-plugin</artifactId>

--- a/agent-module/plugins/cassandra4/pom.xml
+++ b/agent-module/plugins/cassandra4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-cassandra4-driver-plugin</artifactId>

--- a/agent-module/plugins/clickhouse-jdbc/pom.xml
+++ b/agent-module/plugins/clickhouse-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-clickhouse-jdbc-driver-plugin</artifactId>

--- a/agent-module/plugins/common-servlet/pom.xml
+++ b/agent-module/plugins/common-servlet/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-common-servlet</artifactId>

--- a/agent-module/plugins/cubrid-jdbc/pom.xml
+++ b/agent-module/plugins/cubrid-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-cubrid-jdbc-driver-plugin</artifactId>

--- a/agent-module/plugins/cxf/pom.xml
+++ b/agent-module/plugins/cxf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-cxf-plugin</artifactId>

--- a/agent-module/plugins/dameng-jdbc/pom.xml
+++ b/agent-module/plugins/dameng-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-dameng-jdbc-driver-plugin</artifactId>

--- a/agent-module/plugins/db2-jdbc/pom.xml
+++ b/agent-module/plugins/db2-jdbc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-db2-jdbc-driver-plugin</artifactId>

--- a/agent-module/plugins/dbcp/pom.xml
+++ b/agent-module/plugins/dbcp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-commons-dbcp-plugin</artifactId>

--- a/agent-module/plugins/dbcp2/pom.xml
+++ b/agent-module/plugins/dbcp2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <properties>

--- a/agent-module/plugins/druid/pom.xml
+++ b/agent-module/plugins/druid/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-druid-plugin</artifactId>

--- a/agent-module/plugins/elasticsearch/pom.xml
+++ b/agent-module/plugins/elasticsearch/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <artifactId>pinpoint-elasticsearch-plugin</artifactId>
     <name>pinpoint-elasticsearch-plugin</name>

--- a/agent-module/plugins/elasticsearch8/pom.xml
+++ b/agent-module/plugins/elasticsearch8/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <artifactId>pinpoint-elasticsearch8-plugin</artifactId>
     <name>pinpoint-elasticsearch8-plugin</name>

--- a/agent-module/plugins/external/pom.xml
+++ b/agent-module/plugins/external/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-external-plugins</artifactId>

--- a/agent-module/plugins/fastjson/pom.xml
+++ b/agent-module/plugins/fastjson/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-fastjson-plugin</artifactId>

--- a/agent-module/plugins/google-httpclient/pom.xml
+++ b/agent-module/plugins/google-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-google-httpclient-plugin</artifactId>

--- a/agent-module/plugins/grpc/pom.xml
+++ b/agent-module/plugins/grpc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-grpc-plugin</artifactId>

--- a/agent-module/plugins/gson/pom.xml
+++ b/agent-module/plugins/gson/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-gson-plugin</artifactId>

--- a/agent-module/plugins/hbase/pom.xml
+++ b/agent-module/plugins/hbase/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-hbase-plugin</artifactId>

--- a/agent-module/plugins/hikaricp/pom.xml
+++ b/agent-module/plugins/hikaricp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-hikaricp-plugin</artifactId>

--- a/agent-module/plugins/httpclient3/pom.xml
+++ b/agent-module/plugins/httpclient3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-httpclient3-plugin</artifactId>

--- a/agent-module/plugins/httpclient4/pom.xml
+++ b/agent-module/plugins/httpclient4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-httpclient4-plugin</artifactId>

--- a/agent-module/plugins/httpclient5/pom.xml
+++ b/agent-module/plugins/httpclient5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-httpclient5-plugin</artifactId>

--- a/agent-module/plugins/hystrix/pom.xml
+++ b/agent-module/plugins/hystrix/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-hystrix-plugin</artifactId>

--- a/agent-module/plugins/ibatis/pom.xml
+++ b/agent-module/plugins/ibatis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-ibatis-plugin</artifactId>

--- a/agent-module/plugins/informix-jdbc/pom.xml
+++ b/agent-module/plugins/informix-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-informix-jdbc-driver-plugin</artifactId>

--- a/agent-module/plugins/jackson/pom.xml
+++ b/agent-module/plugins/jackson/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jackson-plugin</artifactId>

--- a/agent-module/plugins/jboss/pom.xml
+++ b/agent-module/plugins/jboss/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jboss-plugin</artifactId>

--- a/agent-module/plugins/jdk-completable-future/pom.xml
+++ b/agent-module/plugins/jdk-completable-future/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jdk-completable-future-plugin</artifactId>

--- a/agent-module/plugins/jdk-http/pom.xml
+++ b/agent-module/plugins/jdk-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jdk-http-plugin</artifactId>

--- a/agent-module/plugins/jdk-httpclient/pom.xml
+++ b/agent-module/plugins/jdk-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jdk-httpclient-plugin</artifactId>

--- a/agent-module/plugins/jetty/pom.xml
+++ b/agent-module/plugins/jetty/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jetty-plugin</artifactId>

--- a/agent-module/plugins/jetty12/pom.xml
+++ b/agent-module/plugins/jetty12/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jetty12-plugin</artifactId>

--- a/agent-module/plugins/json-lib/pom.xml
+++ b/agent-module/plugins/json-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-json-lib-plugin</artifactId>

--- a/agent-module/plugins/jsp/pom.xml
+++ b/agent-module/plugins/jsp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jsp-plugin</artifactId>

--- a/agent-module/plugins/jtds/pom.xml
+++ b/agent-module/plugins/jtds/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-jtds-plugin</artifactId>

--- a/agent-module/plugins/kafka/pom.xml
+++ b/agent-module/plugins/kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-kafka-plugin</artifactId>

--- a/agent-module/plugins/kotlin-coroutines/pom.xml
+++ b/agent-module/plugins/kotlin-coroutines/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-kotlin-coroutines-plugin</artifactId>

--- a/agent-module/plugins/ktor/pom.xml
+++ b/agent-module/plugins/ktor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-ktor-plugin</artifactId>

--- a/agent-module/plugins/log4j/pom.xml
+++ b/agent-module/plugins/log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-log4j-plugin</artifactId>

--- a/agent-module/plugins/log4j2/pom.xml
+++ b/agent-module/plugins/log4j2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-log4j2-plugin</artifactId>

--- a/agent-module/plugins/logback/pom.xml
+++ b/agent-module/plugins/logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-logback-plugin</artifactId>

--- a/agent-module/plugins/mariadb-jdbc/pom.xml
+++ b/agent-module/plugins/mariadb-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mariadb-jdbc-driver-plugin</artifactId>

--- a/agent-module/plugins/mongodb/pom.xml
+++ b/agent-module/plugins/mongodb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mongodb-driver-plugin</artifactId>

--- a/agent-module/plugins/mssql-jdbc/pom.xml
+++ b/agent-module/plugins/mssql-jdbc/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.navercorp.pinpoint</groupId>
     <artifactId>pinpoint-plugins</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>pinpoint-mssql-jdbc-driver-plugin</artifactId>

--- a/agent-module/plugins/mybatis/pom.xml
+++ b/agent-module/plugins/mybatis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mybatis-plugin</artifactId>

--- a/agent-module/plugins/mysql-jdbc/pom.xml
+++ b/agent-module/plugins/mysql-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-mysql-jdbc-driver-plugin</artifactId>

--- a/agent-module/plugins/netty/pom.xml
+++ b/agent-module/plugins/netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-netty-plugin</artifactId>

--- a/agent-module/plugins/ning-asynchttpclient/pom.xml
+++ b/agent-module/plugins/ning-asynchttpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-ning-asynchttpclient-plugin</artifactId>

--- a/agent-module/plugins/okhttp/pom.xml
+++ b/agent-module/plugins/okhttp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-okhttp-plugin</artifactId>

--- a/agent-module/plugins/openwhisk/pom.xml
+++ b/agent-module/plugins/openwhisk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-openwhisk-plugin</artifactId>

--- a/agent-module/plugins/oracle-jdbc/pom.xml
+++ b/agent-module/plugins/oracle-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-oracle-jdbc-driver-plugin</artifactId>

--- a/agent-module/plugins/paho-mqtt/pom.xml
+++ b/agent-module/plugins/paho-mqtt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-plugins</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-module/plugins/pom.xml
+++ b/agent-module/plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-plugins</artifactId>

--- a/agent-module/plugins/postgresql-jdbc/pom.xml
+++ b/agent-module/plugins/postgresql-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-postgresql-jdbc-driver-plugin</artifactId>

--- a/agent-module/plugins/process/pom.xml
+++ b/agent-module/plugins/process/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-process-plugin</artifactId>

--- a/agent-module/plugins/pulsar/pom.xml
+++ b/agent-module/plugins/pulsar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-pulsar-plugin</artifactId>

--- a/agent-module/plugins/rabbitmq/pom.xml
+++ b/agent-module/plugins/rabbitmq/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-rabbitmq-plugin</artifactId>

--- a/agent-module/plugins/reactor-netty/pom.xml
+++ b/agent-module/plugins/reactor-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-reactor-netty-plugin</artifactId>

--- a/agent-module/plugins/reactor/pom.xml
+++ b/agent-module/plugins/reactor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-reactor-plugin</artifactId>

--- a/agent-module/plugins/redis-lettuce/pom.xml
+++ b/agent-module/plugins/redis-lettuce/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-redis-lettuce-plugin</artifactId>

--- a/agent-module/plugins/redis-redisson/pom.xml
+++ b/agent-module/plugins/redis-redisson/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-redis-redisson-plugin</artifactId>

--- a/agent-module/plugins/redis/pom.xml
+++ b/agent-module/plugins/redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-redis-plugin</artifactId>

--- a/agent-module/plugins/resilience4j/pom.xml
+++ b/agent-module/plugins/resilience4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-resilience4j-plugin</artifactId>

--- a/agent-module/plugins/resttemplate/pom.xml
+++ b/agent-module/plugins/resttemplate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-resttemplate-plugin</artifactId>

--- a/agent-module/plugins/rocketmq/pom.xml
+++ b/agent-module/plugins/rocketmq/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.navercorp.pinpoint</groupId>
     <artifactId>pinpoint-plugins</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>pinpoint-rocketmq-plugin</artifactId>

--- a/agent-module/plugins/rxjava/pom.xml
+++ b/agent-module/plugins/rxjava/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-rxjava-plugin</artifactId>

--- a/agent-module/plugins/spring-boot/pom.xml
+++ b/agent-module/plugins/spring-boot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-boot-plugin</artifactId>

--- a/agent-module/plugins/spring-cloud-sleuth/pom.xml
+++ b/agent-module/plugins/spring-cloud-sleuth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-cloud-sleuth-plugin</artifactId>

--- a/agent-module/plugins/spring-data-r2dbc/pom.xml
+++ b/agent-module/plugins/spring-data-r2dbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-data-r2dbc-plugin</artifactId>

--- a/agent-module/plugins/spring-stub/pom.xml
+++ b/agent-module/plugins/spring-stub/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-stub</artifactId>

--- a/agent-module/plugins/spring-tx/pom.xml
+++ b/agent-module/plugins/spring-tx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-tx-plugin</artifactId>

--- a/agent-module/plugins/spring-webflux/pom.xml
+++ b/agent-module/plugins/spring-webflux/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-webflux-plugin</artifactId>

--- a/agent-module/plugins/spring/pom.xml
+++ b/agent-module/plugins/spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-spring-plugin</artifactId>

--- a/agent-module/plugins/thread/pom.xml
+++ b/agent-module/plugins/thread/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-thread-plugin</artifactId>

--- a/agent-module/plugins/thrift/pom.xml
+++ b/agent-module/plugins/thrift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-thrift-plugin</artifactId>

--- a/agent-module/plugins/tomcat/pom.xml
+++ b/agent-module/plugins/tomcat/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-tomcat-plugin</artifactId>

--- a/agent-module/plugins/undertow-servlet/pom.xml
+++ b/agent-module/plugins/undertow-servlet/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-undertow-servlet-plugin</artifactId>

--- a/agent-module/plugins/undertow/pom.xml
+++ b/agent-module/plugins/undertow/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-undertow-plugin</artifactId>

--- a/agent-module/plugins/user/pom.xml
+++ b/agent-module/plugins/user/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-user-plugin</artifactId>

--- a/agent-module/plugins/vertx/pom.xml
+++ b/agent-module/plugins/vertx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-vertx-plugin</artifactId>

--- a/agent-module/plugins/weblogic/pom.xml
+++ b/agent-module/plugins/weblogic/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-weblogic-plugin</artifactId>

--- a/agent-module/plugins/websphere/pom.xml
+++ b/agent-module/plugins/websphere/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-websphere-plugin</artifactId>

--- a/agent-module/pom.xml
+++ b/agent-module/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-agent-module</artifactId>

--- a/agent-module/profiler-logging/pom.xml
+++ b/agent-module/profiler-logging/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-profiler-logging</artifactId>

--- a/agent-module/profiler-micrometer/pom.xml
+++ b/agent-module/profiler-micrometer/pom.xml
@@ -10,6 +10,8 @@
     </parent>
 
     <artifactId>pinpoint-profiler-micrometer</artifactId>
+    <name>pinpoint-profiler-micrometer</name>
+    <description>pinpoint profiler micrometer integration</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/agent-module/profiler-micrometer/pom.xml
+++ b/agent-module/profiler-micrometer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-profiler-micrometer</artifactId>

--- a/agent-module/profiler-optional/pom.xml
+++ b/agent-module/profiler-optional/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     
     <artifactId>pinpoint-profiler-optional</artifactId>

--- a/agent-module/profiler-optional/profiler-optional-jdk8/pom.xml
+++ b/agent-module/profiler-optional/profiler-optional-jdk8/pom.xml
@@ -23,7 +23,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-profiler-optional-parent</artifactId>
         <relativePath>../profiler-optional-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-profiler-optional-jdk8</artifactId>

--- a/agent-module/profiler-optional/profiler-optional-jdk9/pom.xml
+++ b/agent-module/profiler-optional/profiler-optional-jdk9/pom.xml
@@ -23,7 +23,7 @@
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-profiler-optional-parent</artifactId>
         <relativePath>../profiler-optional-parent</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-profiler-optional-jdk9</artifactId>

--- a/agent-module/profiler-optional/profiler-optional-parent/pom.xml
+++ b/agent-module/profiler-optional/profiler-optional-parent/pom.xml
@@ -9,7 +9,7 @@
 <!--        <relativePath>../../../pom.xml</relativePath>-->
         <artifactId>pinpoint-agent-module</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-profiler-optional-parent</artifactId>

--- a/agent-module/profiler-test/pom.xml
+++ b/agent-module/profiler-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-profiler-test</artifactId>

--- a/agent-module/profiler/pom.xml
+++ b/agent-module/profiler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-agent-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-profiler</artifactId>

--- a/agent-statistics/agent-statistics-collector/pom.xml
+++ b/agent-statistics/agent-statistics-collector/pom.xml
@@ -10,6 +10,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pinpoint-agentstatistics-collector</artifactId>
+    <name>pinpoint-agentstatistics-collector</name>
+    <description>pinpoint agent-statistics collector</description>
 
     <properties>
         <jdk.version>17</jdk.version>

--- a/agent-statistics/agent-statistics-collector/pom.xml
+++ b/agent-statistics/agent-statistics-collector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-agentstatistics-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-statistics/pom.xml
+++ b/agent-statistics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agent-statistics/pom.xml
+++ b/agent-statistics/pom.xml
@@ -10,6 +10,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pinpoint-agentstatistics-module</artifactId>
+    <name>pinpoint-agentstatistics-module</name>
+    <description>pinpoint agent-statistics pom</description>
     <packaging>pom</packaging>
 
     <modules>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <!--

--- a/banner/pom.xml
+++ b/banner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-banner</artifactId>

--- a/banner/pom.xml
+++ b/banner/pom.xml
@@ -9,6 +9,8 @@
     </parent>
 
     <artifactId>pinpoint-banner</artifactId>
+    <name>pinpoint-banner</name>
+    <description>pinpoint startup banner</description>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/basic-login/pom.xml
+++ b/basic-login/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-basic-login</artifactId>

--- a/batch-alarmsender/pom.xml
+++ b/batch-alarmsender/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/channel/pom.xml
+++ b/channel/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/collector-monitor/pom.xml
+++ b/collector-monitor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-collector-monitor</artifactId>

--- a/collector-starter/pom.xml
+++ b/collector-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-collector</artifactId>

--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -235,6 +235,11 @@
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- for test -->
         <dependency>

--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -221,6 +221,21 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
+        <!-- tail sampling: redis buffer -->
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- for test -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/PinpointCollectorModule.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/PinpointCollectorModule.java
@@ -26,6 +26,7 @@ import com.navercorp.pinpoint.collector.grpc.CollectorGrpcConfiguration;
 import com.navercorp.pinpoint.collector.grpc.ssl.GrpcSslModule;
 import com.navercorp.pinpoint.collector.heatmap.HeatmapCollectorModule;
 import com.navercorp.pinpoint.collector.manage.CollectorAdminConfiguration;
+import com.navercorp.pinpoint.collector.sampling.tail.TailSamplingConfiguration;
 import com.navercorp.pinpoint.collector.uid.CollectorUidConfiguration;
 import com.navercorp.pinpoint.common.server.CommonsServerConfiguration;
 import com.navercorp.pinpoint.common.server.config.TypeLoaderConfiguration;
@@ -64,7 +65,9 @@ import org.springframework.context.annotation.Import;
         CollectorUidConfiguration.class,
         HeatmapCollectorModule.class,
 
-        CollectorEventConfiguration.class
+        CollectorEventConfiguration.class,
+
+        TailSamplingConfiguration.class
 })
 @ComponentScan(basePackages = {
         "com.navercorp.pinpoint.collector.handler",

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanChunkHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanChunkHandler.java
@@ -91,6 +91,7 @@ public class GrpcSpanChunkHandler implements SimpleHandler<PSpanChunk> {
             } catch (Throwable e) {
                 logger.warn("Failed to tail-sample SpanChunk {} {}", header, MessageFormatUtils.debugLog(spanChunk), e);
             }
+            // tail sampler owns disposition; on unexpected failure, drop rather than write-through
             return;
         }
         if (!sampler.isSampling(spanChunkBo)) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanChunkHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanChunkHandler.java
@@ -28,12 +28,14 @@ import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
 import com.navercorp.pinpoint.common.server.io.ServerHeader;
 import com.navercorp.pinpoint.common.server.io.ServerRequest;
+import com.navercorp.pinpoint.collector.sampling.tail.TailSampler;
 import com.navercorp.pinpoint.grpc.MessageFormatUtils;
 import com.navercorp.pinpoint.grpc.trace.PSpanChunk;
 import com.navercorp.pinpoint.grpc.trace.PSpanEvent;
 import com.navercorp.pinpoint.grpc.trace.PTransactionId;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
@@ -57,12 +59,16 @@ public class GrpcSpanChunkHandler implements SimpleHandler<PSpanChunk> {
 
     private final Sampler<BasicSpan> sampler;
 
-    public GrpcSpanChunkHandler(TraceService[] traceServices, GrpcSpanFactory spanFactory, SpanSamplerFactory spanSamplerFactory) {
+    private final TailSampler tailSampler;
+
+    public GrpcSpanChunkHandler(TraceService[] traceServices, GrpcSpanFactory spanFactory, SpanSamplerFactory spanSamplerFactory,
+                                ObjectProvider<TailSampler> tailSamplerProvider) {
         this.traceServices = Objects.requireNonNull(traceServices, "traceServices");
         this.spanFactory = Objects.requireNonNull(spanFactory, "spanFactory");
         this.sampler = spanSamplerFactory.createBasicSpanSampler();
+        this.tailSampler = tailSamplerProvider.getIfAvailable();
 
-        logger.info("TraceServices {}", Arrays.toString(traceServices));
+        logger.info("TraceServices {} tailSampler={}", Arrays.toString(traceServices), tailSampler != null ? "enabled" : "disabled");
     }
 
     @Override
@@ -79,6 +85,14 @@ public class GrpcSpanChunkHandler implements SimpleHandler<PSpanChunk> {
             logger.debug("Handle {} {}", header, createSimpleSpanChunkLog(spanChunk));
         }
         final SpanChunkBo spanChunkBo = spanFactory.buildSpanChunkBo(spanChunk, header, requestTime);
+        if (tailSampler != null) {
+            try {
+                tailSampler.acceptSpanChunk(spanChunkBo, spanChunk.toByteArray());
+            } catch (Throwable e) {
+                logger.warn("Failed to tail-sample SpanChunk {} {}", header, MessageFormatUtils.debugLog(spanChunk), e);
+            }
+            return;
+        }
         if (!sampler.isSampling(spanChunkBo)) {
             if (isDebug) {
                 logger.debug("Unsampled {} {}", header, createSimpleSpanChunkLog(spanChunk));

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanHandler.java
@@ -93,6 +93,7 @@ public class GrpcSpanHandler implements SimpleHandler<PSpan> {
             } catch (Throwable e) {
                 logger.warn("Failed to tail-sample Span {} {}", serverHeader, MessageFormatUtils.debugLog(span), e);
             }
+            // tail sampler owns disposition; on unexpected failure, drop rather than write-through
             return;
         }
         if (!sampler.isSampling(spanBo)) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanHandler.java
@@ -27,12 +27,14 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
 import com.navercorp.pinpoint.common.server.io.ServerHeader;
 import com.navercorp.pinpoint.common.server.io.ServerRequest;
+import com.navercorp.pinpoint.collector.sampling.tail.TailSampler;
 import com.navercorp.pinpoint.grpc.MessageFormatUtils;
 import com.navercorp.pinpoint.grpc.trace.PSpan;
 import com.navercorp.pinpoint.grpc.trace.PSpanEvent;
 import com.navercorp.pinpoint.grpc.trace.PTransactionId;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
@@ -57,12 +59,16 @@ public class GrpcSpanHandler implements SimpleHandler<PSpan> {
 
     private final Sampler<BasicSpan> sampler;
 
-    public GrpcSpanHandler(TraceService[] traceServices, GrpcSpanFactory spanFactory, SpanSamplerFactory spanSamplerFactory) {
+    private final TailSampler tailSampler;
+
+    public GrpcSpanHandler(TraceService[] traceServices, GrpcSpanFactory spanFactory, SpanSamplerFactory spanSamplerFactory,
+                           ObjectProvider<TailSampler> tailSamplerProvider) {
         this.traceServices = Objects.requireNonNull(traceServices, "traceServices");
         this.spanFactory = Objects.requireNonNull(spanFactory, "spanFactory");
         this.sampler = spanSamplerFactory.createBasicSpanSampler();
+        this.tailSampler = tailSamplerProvider.getIfAvailable();
 
-        logger.info("TraceServices {}", Arrays.toString(traceServices));
+        logger.info("TraceServices {} tailSampler={}", Arrays.toString(traceServices), tailSampler != null ? "enabled" : "disabled");
     }
 
     @Override
@@ -81,6 +87,14 @@ public class GrpcSpanHandler implements SimpleHandler<PSpan> {
         }
 
         final SpanBo spanBo = spanFactory.buildSpanBo(span, serverHeader, requestTime);
+        if (tailSampler != null) {
+            try {
+                tailSampler.acceptSpan(spanBo, span.toByteArray());
+            } catch (Throwable e) {
+                logger.warn("Failed to tail-sample Span {} {}", serverHeader, MessageFormatUtils.debugLog(span), e);
+            }
+            return;
+        }
         if (!sampler.isSampling(spanBo)) {
             if (isDebug) {
                 logger.debug("Unsampled {} {}", serverHeader, createSimpleSpanLog(span));

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/heatmap/service/HeatmapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/heatmap/service/HeatmapService.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.collector.heatmap.service;
 
 import com.navercorp.pinpoint.collector.heatmap.dao.HeatmapDao;
 import com.navercorp.pinpoint.collector.heatmap.vo.HeatmapStat;
-import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.collector.sampling.tail.StatisticsTraceService;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import org.springframework.stereotype.Service;
@@ -29,7 +29,7 @@ import java.util.Objects;
  * @author minwoo-jung
  */
 @Service
-public class HeatmapService implements TraceService {
+public class HeatmapService implements StatisticsTraceService {
 
     private final HeatmapDao heatmapDao;
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpan.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpan.java
@@ -16,6 +16,10 @@
 
 package com.navercorp.pinpoint.collector.sampling.tail;
 
+/**
+ * Transient envelope used only to serialize a span/chunk into the Redis buffer and rebuild it at flush time.
+ * Instances are never compared or hashed, so the record's default array-reference equals/hashCode are not used.
+ */
 public record BufferedSpan(
         Type type,
         String agentId,

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpan.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpan.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+public record BufferedSpan(
+        Type type,
+        String agentId,
+        String agentName,
+        String applicationName,
+        long agentStartTime,
+        long requestTime,
+        byte[] protoBytes) {
+
+    public enum Type {
+        SPAN, SPAN_CHUNK
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodec.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodec.java
@@ -28,10 +28,12 @@ import java.io.UncheckedIOException;
  */
 public class BufferedSpanCodec {
 
+    private static final BufferedSpan.Type[] TYPES = BufferedSpan.Type.values();
+
     public byte[] encode(BufferedSpan span) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (DataOutputStream out = new DataOutputStream(baos)) {
-            out.writeByte(span.type() == BufferedSpan.Type.SPAN ? 0 : 1);
+            out.writeByte(span.type().ordinal());
             out.writeUTF(nullToEmpty(span.agentId()));
             out.writeUTF(nullToEmpty(span.agentName()));
             out.writeUTF(nullToEmpty(span.applicationName()));
@@ -47,7 +49,7 @@ public class BufferedSpanCodec {
 
     public BufferedSpan decode(byte[] bytes) {
         try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
-            BufferedSpan.Type type = in.readByte() == 0 ? BufferedSpan.Type.SPAN : BufferedSpan.Type.SPAN_CHUNK;
+            BufferedSpan.Type type = TYPES[in.readByte() & 0xFF];
             String agentId = in.readUTF();
             String agentName = in.readUTF();
             String applicationName = in.readUTF();

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodec.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodec.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * Length-prefixed binary serialization of BufferedSpan to/from byte[] for the Redis buffer.
+ */
+public class BufferedSpanCodec {
+
+    public byte[] encode(BufferedSpan span) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeByte(span.type() == BufferedSpan.Type.SPAN ? 0 : 1);
+            out.writeUTF(nullToEmpty(span.agentId()));
+            out.writeUTF(nullToEmpty(span.agentName()));
+            out.writeUTF(nullToEmpty(span.applicationName()));
+            out.writeLong(span.agentStartTime());
+            out.writeLong(span.requestTime());
+            out.writeInt(span.protoBytes().length);
+            out.write(span.protoBytes());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return baos.toByteArray();
+    }
+
+    public BufferedSpan decode(byte[] bytes) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
+            BufferedSpan.Type type = in.readByte() == 0 ? BufferedSpan.Type.SPAN : BufferedSpan.Type.SPAN_CHUNK;
+            String agentId = in.readUTF();
+            String agentName = in.readUTF();
+            String applicationName = in.readUTF();
+            long agentStartTime = in.readLong();
+            long requestTime = in.readLong();
+            int len = in.readInt();
+            byte[] proto = new byte[len];
+            in.readFully(proto);
+            return new BufferedSpan(type, agentId, agentName, applicationName, agentStartTime, requestTime, proto);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/ReconstructedServerHeader.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/ReconstructedServerHeader.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import org.jspecify.annotations.NonNull;
+
+import java.util.function.Supplier;
+
+/**
+ * Minimal ServerHeader used to reconstruct a buffered span at flush time.
+ * Only the four fields actually read by GrpcSpanBinder carry meaning.
+ */
+public class ReconstructedServerHeader implements ServerHeader {
+
+    private final String agentId;
+    private final String agentName;
+    private final String applicationName;
+    private final long agentStartTime;
+
+    public ReconstructedServerHeader(String agentId, String agentName, String applicationName, long agentStartTime) {
+        this.agentId = agentId;
+        this.agentName = agentName;
+        this.applicationName = applicationName;
+        this.agentStartTime = agentStartTime;
+    }
+
+    @NonNull
+    @Override
+    public String getAgentId() { return agentId; }
+
+    @NonNull
+    @Override
+    public String getAgentName() { return agentName; }
+
+    @NonNull
+    @Override
+    public String getApplicationName() { return applicationName; }
+
+    @Override
+    public String getServiceName() { return null; }
+
+    @Override
+    public Supplier<ServiceUid> getServiceUid() { return () -> ServiceUid.DEFAULT; }
+
+    @Override
+    public long getAgentStartTime() { return agentStartTime; }
+
+    @Override
+    public int getServiceType() { return 0; }
+
+    @Override
+    public boolean isGrpcBuiltInRetry() { return false; }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/StatisticsTraceService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/StatisticsTraceService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.service.TraceService;
+
+/**
+ * Marker for statistic TraceServices that must always be invoked at 100% (servermap, heatmap).
+ * These bypass the tail-sampling buffer/decision gate.
+ */
+public interface StatisticsTraceService extends TraceService {
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailDecisions.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailDecisions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+public final class TailDecisions {
+
+    private TailDecisions() {
+    }
+
+    /**
+     * Deterministic keep decision based on the transactionId.
+     * @param ratePercent 0..100
+     */
+    public static boolean keep(String txid, int ratePercent) {
+        if (ratePercent >= 100) {
+            return true;
+        }
+        if (ratePercent <= 0) {
+            return false;
+        }
+        int bucket = Math.floorMod(txid.hashCode(), 100);
+        return bucket < ratePercent;
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
@@ -48,6 +48,7 @@ public class TailSampler {
     private final Counter bufferedCounter;
     private final Counter redisErrorCounter;
     private final Counter flushTimeoutCounter;
+    private final Counter errorKeptCounter;
 
     public TailSampler(TraceService[] traceServices,
                        TailSamplingRepository repository,
@@ -78,6 +79,7 @@ public class TailSampler {
         this.bufferedCounter = meterRegistry.counter("collector.tail.sampling", "result", "buffered");
         this.redisErrorCounter = meterRegistry.counter("collector.tail.sampling", "result", "redis-error");
         this.flushTimeoutCounter = meterRegistry.counter("collector.tail.sampling", "result", "flush-timeout");
+        this.errorKeptCounter = meterRegistry.counter("collector.tail.sampling", "result", "kept-error");
     }
 
     public void acceptSpan(SpanBo spanBo, byte[] protoBytes) {
@@ -100,7 +102,8 @@ public class TailSampler {
             } else {
                 bufferedCounter.increment();
                 if (spanBo.isRoot()) {
-                    decideAndFlush(txid, spanBo.getElapsed());
+                    boolean error = spanBo.hasError() || spanBo.hasException();
+                    decideAndFlush(txid, spanBo.getElapsed(), error);
                 }
             }
         } catch (Exception e) {
@@ -138,15 +141,18 @@ public class TailSampler {
         }
     }
 
-    private void decideAndFlush(String txid, int elapsedMillis) {
-        int rate = properties.rateFor(elapsedMillis);
-        boolean keep = TailDecisions.keep(txid, rate);
+    private void decideAndFlush(String txid, int elapsedMillis, boolean error) {
+        final boolean keepOnError = properties.isKeepOnError() && error;
+        final boolean keep = keepOnError || TailDecisions.keep(txid, properties.rateFor(elapsedMillis));
         List<byte[]> won = repository.decide(txid, keep);
         if (won == null) {
             return;
         }
         if (keep) {
             keptCounter.increment();
+            if (keepOnError) {
+                errorKeptCounter.increment();
+            }
             replay(won);
         } else {
             droppedCounter.increment();

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.grpc.trace.PSpan;
+import com.navercorp.pinpoint.grpc.trace.PSpanChunk;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class TailSampler {
+
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    private final TraceService[] alwaysServices;
+    private final TraceService[] sampledServices;
+    private final TailSamplingRepository repository;
+    private final TailSamplingProperties properties;
+    private final BufferedSpanCodec codec;
+    private final GrpcSpanFactory spanFactory;
+
+    private final Counter keptCounter;
+    private final Counter droppedCounter;
+    private final Counter bufferedCounter;
+    private final Counter redisErrorCounter;
+
+    public TailSampler(TraceService[] traceServices,
+                       TailSamplingRepository repository,
+                       TailSamplingProperties properties,
+                       BufferedSpanCodec codec,
+                       GrpcSpanFactory spanFactory,
+                       MeterRegistry meterRegistry) {
+        this.repository = Objects.requireNonNull(repository, "repository");
+        this.properties = Objects.requireNonNull(properties, "properties");
+        this.codec = Objects.requireNonNull(codec, "codec");
+        this.spanFactory = Objects.requireNonNull(spanFactory, "spanFactory");
+
+        List<TraceService> always = new ArrayList<>();
+        List<TraceService> sampled = new ArrayList<>();
+        for (TraceService ts : traceServices) {
+            if (ts instanceof StatisticsTraceService) {
+                always.add(ts);
+            } else {
+                sampled.add(ts);
+            }
+        }
+        this.alwaysServices = always.toArray(new TraceService[0]);
+        this.sampledServices = sampled.toArray(new TraceService[0]);
+
+        this.keptCounter = meterRegistry.counter("collector.tail.sampling", "result", "kept");
+        this.droppedCounter = meterRegistry.counter("collector.tail.sampling", "result", "dropped");
+        this.bufferedCounter = meterRegistry.counter("collector.tail.sampling", "result", "buffered");
+        this.redisErrorCounter = meterRegistry.counter("collector.tail.sampling", "result", "redis-error");
+    }
+
+    public void acceptSpan(SpanBo spanBo, byte[] protoBytes) {
+        for (TraceService ts : alwaysServices) {
+            ts.insertSpan(spanBo);
+        }
+
+        final String txid = spanBo.getTransactionId().toString();
+        try {
+            byte[] envelope = codec.encode(new BufferedSpan(BufferedSpan.Type.SPAN,
+                    spanBo.getAgentId(), spanBo.getAgentName(), spanBo.getApplicationName(),
+                    spanBo.getAgentStartTime(), spanBo.getCollectorAcceptTime(), protoBytes));
+            String decision = repository.accept(txid, envelope, System.currentTimeMillis());
+
+            if ("keep".equals(decision)) {
+                keptCounter.increment();
+                insertSampledSpanLive(spanBo);
+            } else if ("drop".equals(decision)) {
+                droppedCounter.increment();
+            } else {
+                bufferedCounter.increment();
+                if (spanBo.isRoot()) {
+                    decideAndFlush(txid, spanBo.getElapsed());
+                }
+            }
+        } catch (Exception e) {
+            redisErrorCounter.increment();
+            logger.warn("tail sampling redis error, fail-open write-through. txid={}", txid, e);
+            insertSampledSpanLive(spanBo);
+        }
+    }
+
+    public void acceptSpanChunk(SpanChunkBo spanChunkBo, byte[] protoBytes) {
+        for (TraceService ts : alwaysServices) {
+            ts.insertSpanChunk(spanChunkBo);
+        }
+
+        final String txid = spanChunkBo.getTransactionId().toString();
+        try {
+            byte[] envelope = codec.encode(new BufferedSpan(BufferedSpan.Type.SPAN_CHUNK,
+                    spanChunkBo.getAgentId(), null, spanChunkBo.getApplicationName(),
+                    spanChunkBo.getAgentStartTime(), spanChunkBo.getCollectorAcceptTime(), protoBytes));
+            String decision = repository.accept(txid, envelope, System.currentTimeMillis());
+
+            if ("keep".equals(decision)) {
+                insertSampledSpanChunkLive(spanChunkBo);
+            } else if ("drop".equals(decision)) {
+                // discard
+            }
+            // chunk is never a decision trigger (not root); buffered -> wait
+        } catch (Exception e) {
+            redisErrorCounter.increment();
+            logger.warn("tail sampling redis error (chunk), fail-open. txid={}", txid, e);
+            insertSampledSpanChunkLive(spanChunkBo);
+        }
+    }
+
+    private void decideAndFlush(String txid, int elapsedMillis) {
+        int rate = properties.rateFor(elapsedMillis);
+        boolean keep = TailDecisions.keep(txid, rate);
+        List<byte[]> won = repository.decide(txid, keep);
+        if (won == null) {
+            return;
+        }
+        if (keep) {
+            keptCounter.increment();
+            replay(won);
+        } else {
+            droppedCounter.increment();
+        }
+    }
+
+    /** Rebuild buffered envelopes and write them to the sampled services. */
+    void replay(List<byte[]> encodedSpans) {
+        for (byte[] encoded : encodedSpans) {
+            BufferedSpan buffered = codec.decode(encoded);
+            ServerHeader header = new ReconstructedServerHeader(
+                    buffered.agentId(), buffered.agentName(), buffered.applicationName(), buffered.agentStartTime());
+            try {
+                if (buffered.type() == BufferedSpan.Type.SPAN) {
+                    PSpan pSpan = parsePSpan(buffered.protoBytes());
+                    SpanBo bo = spanFactory.buildSpanBo(pSpan, header, buffered.requestTime());
+                    insertSampledSpanLive(bo);
+                } else {
+                    PSpanChunk pSpanChunk = parsePSpanChunk(buffered.protoBytes());
+                    SpanChunkBo bo = spanFactory.buildSpanChunkBo(pSpanChunk, header, buffered.requestTime());
+                    insertSampledSpanChunkLive(bo);
+                }
+            } catch (Exception e) {
+                logger.warn("failed to replay buffered span", e);
+            }
+        }
+    }
+
+    private PSpan parsePSpan(byte[] bytes) {
+        try {
+            return PSpan.parseFrom(bytes);
+        } catch (Exception e) {
+            logger.warn("failed to parse PSpan from buffered bytes, using default instance", e);
+            return PSpan.getDefaultInstance();
+        }
+    }
+
+    private PSpanChunk parsePSpanChunk(byte[] bytes) {
+        try {
+            return PSpanChunk.parseFrom(bytes);
+        } catch (Exception e) {
+            logger.warn("failed to parse PSpanChunk from buffered bytes, using default instance", e);
+            return PSpanChunk.getDefaultInstance();
+        }
+    }
+
+    private void insertSampledSpanLive(SpanBo spanBo) {
+        for (TraceService ts : sampledServices) {
+            ts.insertSpan(spanBo);
+        }
+    }
+
+    private void insertSampledSpanChunkLive(SpanChunkBo spanChunkBo) {
+        for (TraceService ts : sampledServices) {
+            ts.insertSpanChunk(spanChunkBo);
+        }
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
@@ -89,10 +89,11 @@ public class TailSampler {
 
         final String txid = spanBo.getTransactionId().toString();
         try {
+            boolean error = properties.isKeepOnError() && TraceErrors.hasError(spanBo);
             byte[] envelope = codec.encode(new BufferedSpan(BufferedSpan.Type.SPAN,
                     spanBo.getAgentId(), spanBo.getAgentName(), spanBo.getApplicationName(),
                     spanBo.getAgentStartTime(), spanBo.getCollectorAcceptTime(), protoBytes));
-            String decision = repository.accept(txid, envelope, System.currentTimeMillis());
+            String decision = repository.accept(txid, envelope, System.currentTimeMillis(), error);
 
             if ("keep".equals(decision)) {
                 keptCounter.increment();
@@ -102,8 +103,7 @@ public class TailSampler {
             } else {
                 bufferedCounter.increment();
                 if (spanBo.isRoot()) {
-                    boolean error = spanBo.hasError() || spanBo.hasException();
-                    decideAndFlush(txid, spanBo.getElapsed(), error);
+                    decideAndFlush(txid, spanBo.getElapsed());
                 }
             }
         } catch (Exception e) {
@@ -120,10 +120,11 @@ public class TailSampler {
 
         final String txid = spanChunkBo.getTransactionId().toString();
         try {
+            boolean error = properties.isKeepOnError() && TraceErrors.hasError(spanChunkBo);
             byte[] envelope = codec.encode(new BufferedSpan(BufferedSpan.Type.SPAN_CHUNK,
                     spanChunkBo.getAgentId(), null, spanChunkBo.getApplicationName(),
                     spanChunkBo.getAgentStartTime(), spanChunkBo.getCollectorAcceptTime(), protoBytes));
-            String decision = repository.accept(txid, envelope, System.currentTimeMillis());
+            String decision = repository.accept(txid, envelope, System.currentTimeMillis(), error);
 
             if ("keep".equals(decision)) {
                 keptCounter.increment();
@@ -141,22 +142,23 @@ public class TailSampler {
         }
     }
 
-    private void decideAndFlush(String txid, int elapsedMillis, boolean error) {
-        final boolean keepOnError = properties.isKeepOnError() && error;
-        final boolean keep = keepOnError || TailDecisions.keep(txid, properties.rateFor(elapsedMillis));
-        List<byte[]> won = repository.decide(txid, keep);
+    private void decideAndFlush(String txid, int elapsedMillis) {
+        // Proposed decision is the response-time band; the script may upgrade it to keep
+        // when the trace's error flag is set, so we act on the returned list, not on `proposed`.
+        final boolean proposed = TailDecisions.keep(txid, properties.rateFor(elapsedMillis));
+        List<byte[]> won = repository.decide(txid, proposed);
         if (won == null) {
+            return; // another node already decided
+        }
+        if (won.isEmpty()) {
+            droppedCounter.increment();
             return;
         }
-        if (keep) {
-            keptCounter.increment();
-            if (keepOnError) {
-                errorKeptCounter.increment();
-            }
-            replay(won);
-        } else {
-            droppedCounter.increment();
+        keptCounter.increment();
+        if (!proposed) {
+            errorKeptCounter.increment(); // band would have dropped; kept because the trace errored
         }
+        replay(won);
     }
 
     /** Replay a sweeper-flushed (orphaned, default-keep) trace: counts it as kept + flush-timeout. */

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
@@ -54,6 +54,7 @@ public class TailSampler {
                        BufferedSpanCodec codec,
                        GrpcSpanFactory spanFactory,
                        MeterRegistry meterRegistry) {
+        Objects.requireNonNull(traceServices, "traceServices");
         this.repository = Objects.requireNonNull(repository, "repository");
         this.properties = Objects.requireNonNull(properties, "properties");
         this.codec = Objects.requireNonNull(codec, "codec");
@@ -120,9 +121,12 @@ public class TailSampler {
             String decision = repository.accept(txid, envelope, System.currentTimeMillis());
 
             if ("keep".equals(decision)) {
+                keptCounter.increment();
                 insertSampledSpanChunkLive(spanChunkBo);
             } else if ("drop".equals(decision)) {
-                // discard
+                droppedCounter.increment();
+            } else {
+                bufferedCounter.increment();
             }
             // chunk is never a decision trigger (not root); buffered -> wait
         } catch (Exception e) {
@@ -155,35 +159,15 @@ public class TailSampler {
                     buffered.agentId(), buffered.agentName(), buffered.applicationName(), buffered.agentStartTime());
             try {
                 if (buffered.type() == BufferedSpan.Type.SPAN) {
-                    PSpan pSpan = parsePSpan(buffered.protoBytes());
-                    SpanBo bo = spanFactory.buildSpanBo(pSpan, header, buffered.requestTime());
+                    SpanBo bo = spanFactory.buildSpanBo(PSpan.parseFrom(buffered.protoBytes()), header, buffered.requestTime());
                     insertSampledSpanLive(bo);
                 } else {
-                    PSpanChunk pSpanChunk = parsePSpanChunk(buffered.protoBytes());
-                    SpanChunkBo bo = spanFactory.buildSpanChunkBo(pSpanChunk, header, buffered.requestTime());
+                    SpanChunkBo bo = spanFactory.buildSpanChunkBo(PSpanChunk.parseFrom(buffered.protoBytes()), header, buffered.requestTime());
                     insertSampledSpanChunkLive(bo);
                 }
             } catch (Exception e) {
                 logger.warn("failed to replay buffered span", e);
             }
-        }
-    }
-
-    private PSpan parsePSpan(byte[] bytes) {
-        try {
-            return PSpan.parseFrom(bytes);
-        } catch (Exception e) {
-            logger.warn("failed to parse PSpan from buffered bytes, using default instance", e);
-            return PSpan.getDefaultInstance();
-        }
-    }
-
-    private PSpanChunk parsePSpanChunk(byte[] bytes) {
-        try {
-            return PSpanChunk.parseFrom(bytes);
-        } catch (Exception e) {
-            logger.warn("failed to parse PSpanChunk from buffered bytes, using default instance", e);
-            return PSpanChunk.getDefaultInstance();
         }
     }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
@@ -103,7 +103,7 @@ public class TailSampler {
             } else {
                 bufferedCounter.increment();
                 if (spanBo.isRoot()) {
-                    decideAndFlush(txid, spanBo.getElapsed());
+                    decideRoot(txid, spanBo.getElapsed(), error);
                 }
             }
         } catch (Exception e) {
@@ -142,10 +142,28 @@ public class TailSampler {
         }
     }
 
-    private void decideAndFlush(String txid, int elapsedMillis) {
-        // Proposed decision is the response-time band; the script may upgrade it to keep
-        // when the trace's error flag is set, so we act on the returned list, not on `proposed`.
-        final boolean proposed = TailDecisions.keep(txid, properties.rateFor(elapsedMillis));
+    /**
+     * Root span arrived. If the band keeps, or the trace already errored, decide now.
+     * Otherwise (band would drop and no error yet) defer the decision for the grace window so a
+     * late-arriving errored span can still flip it to keep.
+     */
+    private void decideRoot(String txid, int elapsedMillis, boolean selfError) {
+        final boolean bandKeep = TailDecisions.keep(txid, properties.rateFor(elapsedMillis));
+        // defer only when keep-on-error is on and this band-drop trace has no error yet
+        final boolean deferForError = properties.isKeepOnError()
+                && !bandKeep
+                && !selfError
+                && !repository.isErrorFlagged(txid);
+        if (deferForError) {
+            repository.defer(txid, System.currentTimeMillis());
+            return;
+        }
+        decideAndFlush(txid, bandKeep);
+    }
+
+    private void decideAndFlush(String txid, boolean proposed) {
+        // The script may upgrade a proposed drop to keep when the trace's error flag is set,
+        // so we act on the returned list, not on `proposed`.
         List<byte[]> won = repository.decide(txid, proposed);
         if (won == null) {
             return; // another node already decided
@@ -158,6 +176,22 @@ public class TailSampler {
         if (!proposed) {
             errorKeptCounter.increment(); // band would have dropped; kept because the trace errored
         }
+        replay(won);
+    }
+
+    /** Finalizes a deferred trace once its grace window elapsed (band drop, unless an error flipped it). */
+    public void finalizeDeferred(String txid) {
+        List<byte[]> won = repository.decide(txid, false);
+        repository.removeDeferred(txid);
+        if (won == null) {
+            return;
+        }
+        if (won.isEmpty()) {
+            droppedCounter.increment();
+            return;
+        }
+        keptCounter.increment();
+        errorKeptCounter.increment();
         replay(won);
     }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java
@@ -47,6 +47,7 @@ public class TailSampler {
     private final Counter droppedCounter;
     private final Counter bufferedCounter;
     private final Counter redisErrorCounter;
+    private final Counter flushTimeoutCounter;
 
     public TailSampler(TraceService[] traceServices,
                        TailSamplingRepository repository,
@@ -76,6 +77,7 @@ public class TailSampler {
         this.droppedCounter = meterRegistry.counter("collector.tail.sampling", "result", "dropped");
         this.bufferedCounter = meterRegistry.counter("collector.tail.sampling", "result", "buffered");
         this.redisErrorCounter = meterRegistry.counter("collector.tail.sampling", "result", "redis-error");
+        this.flushTimeoutCounter = meterRegistry.counter("collector.tail.sampling", "result", "flush-timeout");
     }
 
     public void acceptSpan(SpanBo spanBo, byte[] protoBytes) {
@@ -149,6 +151,13 @@ public class TailSampler {
         } else {
             droppedCounter.increment();
         }
+    }
+
+    /** Replay a sweeper-flushed (orphaned, default-keep) trace: counts it as kept + flush-timeout. */
+    public void replaySwept(List<byte[]> encodedSpans) {
+        flushTimeoutCounter.increment();
+        keptCounter.increment();
+        replay(encodedSpans);
     }
 
     /** Rebuild buffered envelopes and write them to the sampled services. */

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingConfiguration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(prefix = "collector.sampling.tail", name = "enable", havingValue = "true")
+@EnableConfigurationProperties
+@EnableScheduling
+@Import(TailSamplingRedisConfig.class)
+public class TailSamplingConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "collector.sampling.tail")
+    public TailSamplingProperties tailSamplingProperties() {
+        return new TailSamplingProperties();
+    }
+
+    @Bean
+    public BufferedSpanCodec bufferedSpanCodec() {
+        return new BufferedSpanCodec();
+    }
+
+    @Bean
+    public TailSamplingRepository tailSamplingRepository(
+            @Qualifier("tailSamplingRedisTemplate") RedisTemplate<String, byte[]> redisTemplate,
+            @Qualifier("tailAcceptScript") byte[] acceptScript,
+            @Qualifier("tailDecideScript") byte[] decideScript,
+            TailSamplingProperties properties) {
+        return new TailSamplingRepository(redisTemplate, acceptScript, decideScript,
+                properties.getBufferTtl().toSeconds(), properties.getDecisionTtl().toSeconds());
+    }
+
+    @Bean
+    public TailSampler tailSampler(TraceService[] traceServices,
+                                   TailSamplingRepository repository,
+                                   TailSamplingProperties properties,
+                                   BufferedSpanCodec codec,
+                                   GrpcSpanFactory spanFactory,
+                                   MeterRegistry meterRegistry) {
+        return new TailSampler(traceServices, repository, properties, codec, spanFactory, meterRegistry);
+    }
+
+    @Bean
+    public TailSamplingSweeper tailSamplingSweeper(TailSamplingRepository repository,
+                                                   TailSampler tailSampler,
+                                                   TailSamplingProperties properties) {
+        return new TailSamplingSweeper(repository, tailSampler, properties);
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java
@@ -1,0 +1,48 @@
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TailSamplingProperties {
+
+    private boolean enable = false;
+    private Duration bufferTtl = Duration.ofSeconds(300);
+    private Duration sweepInterval = Duration.ofSeconds(5);
+    private Duration decisionTtl = Duration.ofSeconds(600);
+    private List<Band> bands = new ArrayList<>();
+
+    /** elapsedMillis 가 속하는 첫 밴드의 수집률(%)을 반환. 매칭 없으면 100(keep, fail-safe). */
+    public int rateFor(long elapsedMillis) {
+        for (Band band : bands) {
+            if (band.getMaxElapsed() == null) {
+                return band.getRate(); // catch-all
+            }
+            if (elapsedMillis < band.getMaxElapsed().toMillis()) {
+                return band.getRate();
+            }
+        }
+        return 100;
+    }
+
+    public boolean isEnable() { return enable; }
+    public void setEnable(boolean enable) { this.enable = enable; }
+    public Duration getBufferTtl() { return bufferTtl; }
+    public void setBufferTtl(Duration bufferTtl) { this.bufferTtl = bufferTtl; }
+    public Duration getSweepInterval() { return sweepInterval; }
+    public void setSweepInterval(Duration sweepInterval) { this.sweepInterval = sweepInterval; }
+    public Duration getDecisionTtl() { return decisionTtl; }
+    public void setDecisionTtl(Duration decisionTtl) { this.decisionTtl = decisionTtl; }
+    public List<Band> getBands() { return bands; }
+    public void setBands(List<Band> bands) { this.bands = bands; }
+
+    public static class Band {
+        private Duration maxElapsed; // null => catch-all (must be last)
+        private int rate;            // 0..100
+
+        public Duration getMaxElapsed() { return maxElapsed; }
+        public void setMaxElapsed(Duration maxElapsed) { this.maxElapsed = maxElapsed; }
+        public int getRate() { return rate; }
+        public void setRate(int rate) { this.rate = rate; }
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.collector.sampling.tail;
 
 import java.time.Duration;
@@ -12,7 +28,7 @@ public class TailSamplingProperties {
     private Duration decisionTtl = Duration.ofSeconds(600);
     private List<Band> bands = new ArrayList<>();
 
-    /** elapsedMillis 가 속하는 첫 밴드의 수집률(%)을 반환. 매칭 없으면 100(keep, fail-safe). */
+    /** Returns the sampling rate (%) of the first band matching elapsedMillis. Returns 100 (keep, fail-safe) when no band matches. */
     public int rateFor(long elapsedMillis) {
         for (Band band : bands) {
             if (band.getMaxElapsed() == null) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java
@@ -29,7 +29,8 @@ public class TailSamplingProperties {
     private boolean keepOnError = true;
     // Grace window: when a band would drop a trace, hold the decision this long so a late-arriving
     // errored span (e.g. a downstream tier) can flip it to keep before it is finalized.
-    private Duration decisionGrace = Duration.ofSeconds(2);
+    // Must stay below bufferTtl. Longer grace catches later errors but buffers more in Redis.
+    private Duration decisionGrace = Duration.ofSeconds(60);
     private List<Band> bands = new ArrayList<>();
 
     /** Returns the sampling rate (%) of the first band matching elapsedMillis. Returns 100 (keep, fail-safe) when no band matches. */

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java
@@ -26,6 +26,7 @@ public class TailSamplingProperties {
     private Duration bufferTtl = Duration.ofSeconds(300);
     private Duration sweepInterval = Duration.ofSeconds(5);
     private Duration decisionTtl = Duration.ofSeconds(600);
+    private boolean keepOnError = true;
     private List<Band> bands = new ArrayList<>();
 
     /** Returns the sampling rate (%) of the first band matching elapsedMillis. Returns 100 (keep, fail-safe) when no band matches. */
@@ -49,6 +50,8 @@ public class TailSamplingProperties {
     public void setSweepInterval(Duration sweepInterval) { this.sweepInterval = sweepInterval; }
     public Duration getDecisionTtl() { return decisionTtl; }
     public void setDecisionTtl(Duration decisionTtl) { this.decisionTtl = decisionTtl; }
+    public boolean isKeepOnError() { return keepOnError; }
+    public void setKeepOnError(boolean keepOnError) { this.keepOnError = keepOnError; }
     public List<Band> getBands() { return bands; }
     public void setBands(List<Band> bands) { this.bands = bands; }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java
@@ -27,6 +27,9 @@ public class TailSamplingProperties {
     private Duration sweepInterval = Duration.ofSeconds(5);
     private Duration decisionTtl = Duration.ofSeconds(600);
     private boolean keepOnError = true;
+    // Grace window: when a band would drop a trace, hold the decision this long so a late-arriving
+    // errored span (e.g. a downstream tier) can flip it to keep before it is finalized.
+    private Duration decisionGrace = Duration.ofSeconds(2);
     private List<Band> bands = new ArrayList<>();
 
     /** Returns the sampling rate (%) of the first band matching elapsedMillis. Returns 100 (keep, fail-safe) when no band matches. */
@@ -52,6 +55,8 @@ public class TailSamplingProperties {
     public void setDecisionTtl(Duration decisionTtl) { this.decisionTtl = decisionTtl; }
     public boolean isKeepOnError() { return keepOnError; }
     public void setKeepOnError(boolean keepOnError) { this.keepOnError = keepOnError; }
+    public Duration getDecisionGrace() { return decisionGrace; }
+    public void setDecisionGrace(Duration decisionGrace) { this.decisionGrace = decisionGrace; }
     public List<Band> getBands() { return bands; }
     public void setBands(List<Band> bands) { this.bands = bands; }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRedisConfig.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRedisConfig.java
@@ -16,10 +16,13 @@
 
 package com.navercorp.pinpoint.collector.sampling.tail;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
@@ -31,11 +34,21 @@ import java.io.UncheckedIOException;
 @Configuration(proxyBeanMethods = false)
 public class TailSamplingRedisConfig {
 
+    /**
+     * Redis connection factory for tail-sampling.
+     * host, port, and password are resolved from {@code spring.data.redis.*} properties,
+     * allowing a clustered collector to point at a shared Redis instance.
+     */
     @Bean("tailSamplingRedisConnectionFactory")
-    public RedisConnectionFactory tailSamplingRedisConnectionFactory(TailSamplingProperties properties) {
-        // host/port default to spring.data.redis.* defaults (localhost:6379).
-        // Extend with RedisStandaloneConfiguration if custom host/port is required.
-        LettuceConnectionFactory factory = new LettuceConnectionFactory();
+    public RedisConnectionFactory tailSamplingRedisConnectionFactory(
+            @Value("${spring.data.redis.host:localhost}") String host,
+            @Value("${spring.data.redis.port:6379}") int port,
+            @Value("${spring.data.redis.password:}") String password) {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        if (password != null && !password.isEmpty()) {
+            config.setPassword(RedisPassword.of(password));
+        }
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
         factory.afterPropertiesSet();
         return factory;
     }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRedisConfig.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRedisConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+@Configuration(proxyBeanMethods = false)
+public class TailSamplingRedisConfig {
+
+    @Bean("tailSamplingRedisConnectionFactory")
+    public RedisConnectionFactory tailSamplingRedisConnectionFactory(TailSamplingProperties properties) {
+        // host/port default to spring.data.redis.* defaults (localhost:6379).
+        // Extend with RedisStandaloneConfiguration if custom host/port is required.
+        LettuceConnectionFactory factory = new LettuceConnectionFactory();
+        factory.afterPropertiesSet();
+        return factory;
+    }
+
+    @Bean("tailSamplingRedisTemplate")
+    public RedisTemplate<String, byte[]> tailSamplingRedisTemplate(
+            @org.springframework.beans.factory.annotation.Qualifier("tailSamplingRedisConnectionFactory")
+            RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(RedisSerializer.string());
+        template.setValueSerializer(RedisSerializer.byteArray());
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean("tailAcceptScript")
+    public byte[] tailAcceptScript() {
+        return loadScript("redis/tail-accept.lua");
+    }
+
+    @Bean("tailDecideScript")
+    public byte[] tailDecideScript() {
+        return loadScript("redis/tail-decide.lua");
+    }
+
+    private static byte[] loadScript(String path) {
+        try {
+            return StreamUtils.copyToByteArray(new ClassPathResource(path).getInputStream());
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to load lua script: " + path, e);
+        }
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepository.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepository.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.Limit;
+import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Binary-safe Lua-eval Redis repository for tail sampling.
+ * Keys: buffer:{txid} (list), decision:{txid} (string), pending (zset).
+ */
+public class TailSamplingRepository {
+
+    static final String BUFFER_PREFIX = "buffer:";
+    static final String DECISION_PREFIX = "decision:";
+    static final String PENDING_KEY = "pending";
+
+    private final RedisTemplate<String, byte[]> template;
+    private final byte[] acceptScript;
+    private final byte[] decideScript;
+    private final byte[] bufferTtlSeconds;
+    private final byte[] decisionTtlSeconds;
+
+    public TailSamplingRepository(RedisTemplate<String, byte[]> template,
+                                  byte[] acceptScript, byte[] decideScript,
+                                  long bufferTtlSeconds, long decisionTtlSeconds) {
+        this.template = Objects.requireNonNull(template, "template");
+        this.acceptScript = Objects.requireNonNull(acceptScript, "acceptScript");
+        this.decideScript = Objects.requireNonNull(decideScript, "decideScript");
+        this.bufferTtlSeconds = String.valueOf(bufferTtlSeconds).getBytes(StandardCharsets.UTF_8);
+        this.decisionTtlSeconds = String.valueOf(decisionTtlSeconds).getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Accepts a span into the tail-sampling buffer.
+     *
+     * @return "keep" | "drop" | "buffered"
+     */
+    public String accept(String txid, byte[] bufferedSpanBytes, long firstSeenMillis) {
+        byte[] bufferKey = key(BUFFER_PREFIX, txid);
+        byte[] decisionKey = key(DECISION_PREFIX, txid);
+        byte[] pendingKey = PENDING_KEY.getBytes(StandardCharsets.UTF_8);
+        byte[] txidBytes = txid.getBytes(StandardCharsets.UTF_8);
+        byte[] firstSeen = String.valueOf(firstSeenMillis).getBytes(StandardCharsets.UTF_8);
+
+        byte[] result = template.execute((RedisCallback<byte[]>) connection ->
+                connection.scriptingCommands().eval(acceptScript, ReturnType.VALUE, 3,
+                        bufferKey, decisionKey, pendingKey,
+                        bufferedSpanBytes, txidBytes, firstSeen, bufferTtlSeconds));
+        return result == null ? null : new String(result, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Records the sampling decision for a transaction and returns buffered spans.
+     *
+     * @return null if another node already decided (skip); otherwise the buffered span bytes
+     *         (the kept spans), or an empty list when the decision is drop.
+     */
+    public List<byte[]> decide(String txid, boolean keep) {
+        byte[] bufferKey = key(BUFFER_PREFIX, txid);
+        byte[] decisionKey = key(DECISION_PREFIX, txid);
+        byte[] pendingKey = PENDING_KEY.getBytes(StandardCharsets.UTF_8);
+        byte[] txidBytes = txid.getBytes(StandardCharsets.UTF_8);
+        byte[] decisionValue = (keep ? "keep" : "drop").getBytes(StandardCharsets.UTF_8);
+
+        @SuppressWarnings("unchecked")
+        List<byte[]> raw = template.execute((RedisCallback<List<byte[]>>) connection ->
+                (List<byte[]>) (List<?>) connection.scriptingCommands().eval(decideScript, ReturnType.MULTI, 3,
+                        bufferKey, decisionKey, pendingKey,
+                        decisionValue, txidBytes, decisionTtlSeconds));
+
+        // When Lua returns `false` (another node already decided), Lettuce maps it to a
+        // single-element list containing null.  An empty or null list also means "already decided".
+        if (raw == null || raw.isEmpty() || raw.get(0) == null) {
+            return null;
+        }
+        List<byte[]> spans = new ArrayList<>(raw.size() - 1);
+        for (int i = 1; i < raw.size(); i++) {
+            spans.add(raw.get(i));
+        }
+        return spans;
+    }
+
+    /**
+     * Returns txids whose firstSeen score is &lt;= thresholdMillis and not yet decided (up to limit).
+     */
+    public List<String> findStale(long thresholdMillis, int limit) {
+        Set<byte[]> members = template.execute((RedisCallback<Set<byte[]>>) connection ->
+                connection.zSetCommands().zRangeByScore(
+                        PENDING_KEY.getBytes(StandardCharsets.UTF_8),
+                        Range.closed(0d, (double) thresholdMillis),
+                        Limit.limit().count(limit)));
+        List<String> result = new ArrayList<>();
+        if (members != null) {
+            for (byte[] m : members) {
+                result.add(new String(m, StandardCharsets.UTF_8));
+            }
+        }
+        return result;
+    }
+
+    private static byte[] key(String prefix, String txid) {
+        return (prefix + txid).getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepository.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepository.java
@@ -37,6 +37,7 @@ public class TailSamplingRepository {
     static final String BUFFER_PREFIX = "buffer:";
     static final String DECISION_PREFIX = "decision:";
     static final String PENDING_KEY = "pending";
+    static final String ERROR_PREFIX = "error:";
 
     private final RedisTemplate<String, byte[]> template;
     private final byte[] acceptScript;
@@ -54,42 +55,51 @@ public class TailSamplingRepository {
         this.decisionTtlSeconds = String.valueOf(decisionTtlSeconds).getBytes(StandardCharsets.UTF_8);
     }
 
+    private static final byte[] FLAG_TRUE = "1".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] FLAG_FALSE = "0".getBytes(StandardCharsets.UTF_8);
+
     /**
      * Accepts a span into the tail-sampling buffer.
      *
+     * @param error when true, marks the whole trace for keep-on-error (any span erroring forces keep)
      * @return "keep" | "drop" | "buffered"
      */
-    public String accept(String txid, byte[] bufferedSpanBytes, long firstSeenMillis) {
+    public String accept(String txid, byte[] bufferedSpanBytes, long firstSeenMillis, boolean error) {
         byte[] bufferKey = key(BUFFER_PREFIX, txid);
         byte[] decisionKey = key(DECISION_PREFIX, txid);
         byte[] pendingKey = PENDING_KEY.getBytes(StandardCharsets.UTF_8);
+        byte[] errorKey = key(ERROR_PREFIX, txid);
         byte[] txidBytes = txid.getBytes(StandardCharsets.UTF_8);
         byte[] firstSeen = String.valueOf(firstSeenMillis).getBytes(StandardCharsets.UTF_8);
+        byte[] errorFlag = error ? FLAG_TRUE : FLAG_FALSE;
 
         byte[] result = template.execute((RedisCallback<byte[]>) connection ->
-                connection.scriptingCommands().eval(acceptScript, ReturnType.VALUE, 3,
-                        bufferKey, decisionKey, pendingKey,
-                        bufferedSpanBytes, txidBytes, firstSeen, bufferTtlSeconds));
+                connection.scriptingCommands().eval(acceptScript, ReturnType.VALUE, 4,
+                        bufferKey, decisionKey, pendingKey, errorKey,
+                        bufferedSpanBytes, txidBytes, firstSeen, bufferTtlSeconds, errorFlag, decisionTtlSeconds));
         return result == null ? null : new String(result, StandardCharsets.UTF_8);
     }
 
     /**
      * Records the sampling decision for a transaction and returns buffered spans.
+     * The proposed decision may be upgraded to keep inside the script when the trace's
+     * error flag is set, so callers must act on the returned list, not on {@code keep}:
      *
-     * @return null if another node already decided (skip); otherwise the buffered span bytes
-     *         (the kept spans), or an empty list when the decision is drop.
+     * @return null if another node already decided (skip); a non-empty list of buffered span
+     *         bytes when the trace is kept; an empty list when the trace is dropped.
      */
     public List<byte[]> decide(String txid, boolean keep) {
         byte[] bufferKey = key(BUFFER_PREFIX, txid);
         byte[] decisionKey = key(DECISION_PREFIX, txid);
         byte[] pendingKey = PENDING_KEY.getBytes(StandardCharsets.UTF_8);
+        byte[] errorKey = key(ERROR_PREFIX, txid);
         byte[] txidBytes = txid.getBytes(StandardCharsets.UTF_8);
         byte[] decisionValue = (keep ? "keep" : "drop").getBytes(StandardCharsets.UTF_8);
 
         @SuppressWarnings("unchecked")
         List<byte[]> raw = template.execute((RedisCallback<List<byte[]>>) connection ->
-                (List<byte[]>) (List<?>) connection.scriptingCommands().eval(decideScript, ReturnType.MULTI, 3,
-                        bufferKey, decisionKey, pendingKey,
+                (List<byte[]>) (List<?>) connection.scriptingCommands().eval(decideScript, ReturnType.MULTI, 4,
+                        bufferKey, decisionKey, pendingKey, errorKey,
                         decisionValue, txidBytes, decisionTtlSeconds));
 
         // When Lua returns `false` (another node already decided), Lettuce maps it to a

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepository.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepository.java
@@ -38,6 +38,7 @@ public class TailSamplingRepository {
     static final String DECISION_PREFIX = "decision:";
     static final String PENDING_KEY = "pending";
     static final String ERROR_PREFIX = "error:";
+    static final String DEFERRED_KEY = "deferred";
 
     private final RedisTemplate<String, byte[]> template;
     private final byte[] acceptScript;
@@ -112,6 +113,50 @@ public class TailSamplingRepository {
             spans.add(raw.get(i));
         }
         return spans;
+    }
+
+    /** True if the trace's error flag is set (some span of the trace errored). */
+    public boolean isErrorFlagged(String txid) {
+        byte[] errorKey = key(ERROR_PREFIX, txid);
+        byte[] value = template.execute((RedisCallback<byte[]>) connection ->
+                connection.stringCommands().get(errorKey));
+        return value != null;
+    }
+
+    /** Defers a band-drop decision so a late errored span can still flip it to keep. */
+    public void defer(String txid, long rootSeenMillis) {
+        byte[] deferredKey = DEFERRED_KEY.getBytes(StandardCharsets.UTF_8);
+        byte[] txidBytes = txid.getBytes(StandardCharsets.UTF_8);
+        template.execute((RedisCallback<Object>) connection -> {
+            connection.zSetCommands().zAdd(deferredKey, (double) rootSeenMillis, txidBytes);
+            return null;
+        });
+    }
+
+    /** Returns deferred txids whose root was seen at or before thresholdMillis (grace elapsed). */
+    public List<String> findDeferredDue(long thresholdMillis, int limit) {
+        Set<byte[]> members = template.execute((RedisCallback<Set<byte[]>>) connection ->
+                connection.zSetCommands().zRangeByScore(
+                        DEFERRED_KEY.getBytes(StandardCharsets.UTF_8),
+                        Range.closed(0d, (double) thresholdMillis),
+                        Limit.limit().count(limit)));
+        List<String> result = new ArrayList<>();
+        if (members != null) {
+            for (byte[] m : members) {
+                result.add(new String(m, StandardCharsets.UTF_8));
+            }
+        }
+        return result;
+    }
+
+    /** Removes a txid from the deferred set after it has been finalized. */
+    public void removeDeferred(String txid) {
+        byte[] deferredKey = DEFERRED_KEY.getBytes(StandardCharsets.UTF_8);
+        byte[] txidBytes = txid.getBytes(StandardCharsets.UTF_8);
+        template.execute((RedisCallback<Object>) connection -> {
+            connection.zSetCommands().zRem(deferredKey, txidBytes);
+            return null;
+        });
     }
 
     /**

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeper.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeper.java
@@ -64,4 +64,24 @@ public class TailSamplingSweeper {
             logger.warn("tail sampling sweeper error", e);
         }
     }
+
+    /**
+     * Finalizes band-drop traces whose grace window has elapsed. A late-arriving errored span may
+     * have flipped the decision to keep in the meantime; otherwise the trace is dropped.
+     */
+    @Scheduled(fixedDelayString = "${collector.sampling.tail.grace-sweep-interval:1s}")
+    public void finalizeDeferred() {
+        try {
+            long threshold = System.currentTimeMillis() - properties.getDecisionGrace().toMillis();
+            List<String> due = repository.findDeferredDue(threshold, BATCH_LIMIT);
+            for (String txid : due) {
+                tailSampler.finalizeDeferred(txid);
+            }
+            if (!due.isEmpty() && logger.isDebugEnabled()) {
+                logger.debug("tail sampling finalized {} deferred traces", due.size());
+            }
+        } catch (Exception e) {
+            logger.warn("tail sampling deferred finalize error", e);
+        }
+    }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeper.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Flushes traces whose root span never arrived: after bufferTtl elapses, forces a default-keep
+ * decision so slow/incomplete traces are never lost. In a cluster, decide()'s SET NX ensures
+ * only one node flushes each trace.
+ */
+public class TailSamplingSweeper {
+
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    private static final int BATCH_LIMIT = 500;
+
+    private final TailSamplingRepository repository;
+    private final TailSampler tailSampler;
+    private final TailSamplingProperties properties;
+
+    public TailSamplingSweeper(TailSamplingRepository repository,
+                               TailSampler tailSampler,
+                               TailSamplingProperties properties) {
+        this.repository = Objects.requireNonNull(repository, "repository");
+        this.tailSampler = Objects.requireNonNull(tailSampler, "tailSampler");
+        this.properties = Objects.requireNonNull(properties, "properties");
+    }
+
+    @Scheduled(fixedDelayString = "${collector.sampling.tail.sweep-interval:5s}")
+    public void sweep() {
+        try {
+            long threshold = System.currentTimeMillis() - properties.getBufferTtl().toMillis();
+            List<String> stale = repository.findStale(threshold, BATCH_LIMIT);
+            for (String txid : stale) {
+                List<byte[]> won = repository.decide(txid, true); // default keep
+                if (won != null) {
+                    tailSampler.replay(won);
+                }
+            }
+            if (!stale.isEmpty() && logger.isInfoEnabled()) {
+                logger.info("tail sampling sweeper flushed {} stale traces (default keep)", stale.size());
+            }
+        } catch (Exception e) {
+            logger.warn("tail sampling sweeper error", e);
+        }
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeper.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeper.java
@@ -54,7 +54,7 @@ public class TailSamplingSweeper {
             for (String txid : stale) {
                 List<byte[]> won = repository.decide(txid, true); // default keep
                 if (won != null) {
-                    tailSampler.replay(won);
+                    tailSampler.replaySwept(won);
                 }
             }
             if (!stale.isEmpty() && logger.isInfoEnabled()) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TraceErrors.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TraceErrors.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+
+import java.util.List;
+
+/**
+ * Detects whether a span or span chunk carries an error, for keep-on-error (B) tail sampling.
+ * Any span/chunk in a trace that errors marks the whole trace for 100% retention.
+ */
+public final class TraceErrors {
+
+    private TraceErrors() {
+    }
+
+    public static boolean hasError(SpanBo spanBo) {
+        if (spanBo.hasError() || spanBo.hasException()) {
+            return true;
+        }
+        return anyEventException(spanBo.getSpanEventBoList());
+    }
+
+    public static boolean hasError(SpanChunkBo spanChunkBo) {
+        // SpanChunkBo carries no span-level error code; errors surface as span-event exceptions.
+        return anyEventException(spanChunkBo.getSpanEventBoList());
+    }
+
+    private static boolean anyEventException(List<SpanEventBo> events) {
+        if (events == null) {
+            return false;
+        }
+        for (SpanEventBo event : events) {
+            if (event.hasException()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/service/ApplicationMapTraceService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/service/ApplicationMapTraceService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.service;
+
+import com.navercorp.pinpoint.collector.applicationmap.service.ApplicationMapService;
+import com.navercorp.pinpoint.collector.sampling.tail.StatisticsTraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+/**
+ * Always-on (100%) TraceService that records servermap statistics.
+ * Previously this was invoked inside HbaseTraceService; it is split out so tail sampling
+ * can keep servermap at 100% while sampling trace detail + scatter.
+ * Lives in the component-scanned `service` package so it is always registered regardless
+ * of whether tail sampling is enabled.
+ */
+@Service
+public class ApplicationMapTraceService implements StatisticsTraceService {
+
+    private final ApplicationMapService applicationMapService;
+
+    public ApplicationMapTraceService(ApplicationMapService applicationMapService) {
+        this.applicationMapService = Objects.requireNonNull(applicationMapService, "applicationMapService");
+    }
+
+    @Override
+    public void insertSpan(SpanBo spanBo) {
+        this.applicationMapService.insertSpan(spanBo);
+    }
+
+    @Override
+    public void insertSpanChunk(SpanChunkBo spanChunkBo) {
+        this.applicationMapService.insertSpanChunk(spanChunkBo);
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.java
@@ -44,6 +44,7 @@ public class HbaseTraceService implements TraceService {
 
     private final ScatterService scatterService;
 
+    // retained for constructor/DI compatibility; servermap moved to ApplicationMapTraceService
     private final ApplicationMapService applicationMapService;
 
     private final SpanStorePublisher publisher;

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.java
@@ -67,8 +67,6 @@ public class HbaseTraceService implements TraceService {
 
         this.traceDao.insertSpanChunk(spanChunkBo);
 
-        this.applicationMapService.insertSpanChunk(spanChunkBo);
-
         // TODO should be able to tell whether the span chunk is successfully inserted
         publisher.publishEvent(event, true);
     }
@@ -80,8 +78,6 @@ public class HbaseTraceService implements TraceService {
         CompletableFuture<Void> future = traceDao.asyncInsert(spanBo);
 
         this.scatterService.insert(spanBo);
-
-        this.applicationMapService.insertSpan(spanBo);
 
         future.whenCompleteAsync((unused, throwable) -> {
             final boolean result = throwable == null;

--- a/collector/src/main/resources/application.yml
+++ b/collector/src/main/resources/application.yml
@@ -83,7 +83,7 @@ collector:
       buffer-ttl: 300s
       sweep-interval: 5s
       decision-ttl: 600s
-      keep-on-error: true        # error traces (root errCode>0 / exception) kept 100% regardless of band
+      keep-on-error: true        # if ANY span/chunk in a trace errors (errCode>0 / exception), keep it 100% regardless of band
       bands:
         - max-elapsed: 50ms
           rate: 1

--- a/collector/src/main/resources/application.yml
+++ b/collector/src/main/resources/application.yml
@@ -83,6 +83,7 @@ collector:
       buffer-ttl: 300s
       sweep-interval: 5s
       decision-ttl: 600s
+      keep-on-error: true        # error traces (root errCode>0 / exception) kept 100% regardless of band
       bands:
         - max-elapsed: 50ms
           rate: 1

--- a/collector/src/main/resources/application.yml
+++ b/collector/src/main/resources/application.yml
@@ -75,3 +75,19 @@ pinpoint:
     uid:
       # v2: lagacy table, v3: new table, dual : DualWrite for Data Migration
       version: v3
+
+collector:
+  sampling:
+    tail:
+      enable: false            # disabled by default; enabling requires Redis
+      buffer-ttl: 300s
+      sweep-interval: 5s
+      decision-ttl: 600s
+      bands:
+        - max-elapsed: 50ms
+          rate: 1
+        - max-elapsed: 100ms
+          rate: 5
+        - max-elapsed: 500ms
+          rate: 10
+        - rate: 100            # catch-all (>= 500ms)

--- a/collector/src/main/resources/application.yml
+++ b/collector/src/main/resources/application.yml
@@ -84,7 +84,7 @@ collector:
       sweep-interval: 5s
       decision-ttl: 600s
       keep-on-error: true        # if ANY span/chunk in a trace errors (errCode>0 / exception), keep it 100% regardless of band
-      decision-grace: 2s         # hold a band-drop decision this long so a late downstream error span can flip it to keep
+      decision-grace: 60s        # hold a band-drop decision this long so a late downstream error span can flip it to keep (must be < buffer-ttl)
       grace-sweep-interval: 1s   # how often deferred (band-drop) traces past the grace window are finalized
       bands:
         - max-elapsed: 50ms

--- a/collector/src/main/resources/application.yml
+++ b/collector/src/main/resources/application.yml
@@ -84,6 +84,8 @@ collector:
       sweep-interval: 5s
       decision-ttl: 600s
       keep-on-error: true        # if ANY span/chunk in a trace errors (errCode>0 / exception), keep it 100% regardless of band
+      decision-grace: 2s         # hold a band-drop decision this long so a late downstream error span can flip it to keep
+      grace-sweep-interval: 1s   # how often deferred (band-drop) traces past the grace window are finalized
       bands:
         - max-elapsed: 50ms
           rate: 1

--- a/collector/src/main/resources/redis/tail-accept.lua
+++ b/collector/src/main/resources/redis/tail-accept.lua
@@ -1,0 +1,16 @@
+-- KEYS[1] = buffer:{txid}   (list)
+-- KEYS[2] = decision:{txid} (string)
+-- KEYS[3] = pending         (zset, global)
+-- ARGV[1] = bufferedSpanBytes
+-- ARGV[2] = txid (zset member)
+-- ARGV[3] = firstSeenMillis
+-- ARGV[4] = bufferTtlSeconds
+-- returns: "keep" | "drop" | "buffered"
+local d = redis.call('GET', KEYS[2])
+if d then
+    return d
+end
+redis.call('RPUSH', KEYS[1], ARGV[1])
+redis.call('EXPIRE', KEYS[1], ARGV[4])
+redis.call('ZADD', KEYS[3], 'NX', ARGV[3], ARGV[2])
+return 'buffered'

--- a/collector/src/main/resources/redis/tail-accept.lua
+++ b/collector/src/main/resources/redis/tail-accept.lua
@@ -1,10 +1,13 @@
 -- KEYS[1] = buffer:{txid}   (list)
 -- KEYS[2] = decision:{txid} (string)
 -- KEYS[3] = pending         (zset, global)
+-- KEYS[4] = error:{txid}    (string flag; set when any span of the trace errors)
 -- ARGV[1] = bufferedSpanBytes
 -- ARGV[2] = txid (zset member)
 -- ARGV[3] = firstSeenMillis
 -- ARGV[4] = bufferTtlSeconds
+-- ARGV[5] = isError ("1" when this span carries an error, else "0")
+-- ARGV[6] = errorTtlSeconds
 -- returns: "keep" | "drop" | "buffered"
 local d = redis.call('GET', KEYS[2])
 if d then
@@ -13,4 +16,7 @@ end
 redis.call('RPUSH', KEYS[1], ARGV[1])
 redis.call('EXPIRE', KEYS[1], ARGV[4])
 redis.call('ZADD', KEYS[3], 'NX', ARGV[3], ARGV[2])
+if ARGV[5] == '1' then
+    redis.call('SET', KEYS[4], '1', 'EX', tonumber(ARGV[6]))
+end
 return 'buffered'

--- a/collector/src/main/resources/redis/tail-decide.lua
+++ b/collector/src/main/resources/redis/tail-decide.lua
@@ -1,20 +1,26 @@
 -- KEYS[1] = buffer:{txid}   (list)
 -- KEYS[2] = decision:{txid} (string)
 -- KEYS[3] = pending         (zset, global)
--- ARGV[1] = "keep" | "drop"
+-- KEYS[4] = error:{txid}    (string flag; if present, force keep regardless of band)
+-- ARGV[1] = "keep" | "drop"  (proposed decision from the response-time band)
 -- ARGV[2] = txid (zset member)
 -- ARGV[3] = decisionTtlSeconds
 -- returns: false if another node already decided (skip).
 --          otherwise {decision, span1, span2, ...} (spans included only when keep).
-local ok = redis.call('SET', KEYS[2], ARGV[1], 'NX', 'EX', ARGV[3])
+local decision = ARGV[1]
+if redis.call('GET', KEYS[4]) then
+    decision = 'keep'  -- any span in the trace errored -> keep 100%
+end
+local ok = redis.call('SET', KEYS[2], decision, 'NX', 'EX', ARGV[3])
 if not ok then
     return false
 end
 local spans = redis.call('LRANGE', KEYS[1], 0, -1)
 redis.call('DEL', KEYS[1])
 redis.call('ZREM', KEYS[3], ARGV[2])
-local result = {ARGV[1]}
-if ARGV[1] == 'keep' then
+redis.call('DEL', KEYS[4])
+local result = {decision}
+if decision == 'keep' then
     for i = 1, #spans do
         result[#result + 1] = spans[i]
     end

--- a/collector/src/main/resources/redis/tail-decide.lua
+++ b/collector/src/main/resources/redis/tail-decide.lua
@@ -1,0 +1,22 @@
+-- KEYS[1] = buffer:{txid}   (list)
+-- KEYS[2] = decision:{txid} (string)
+-- KEYS[3] = pending         (zset, global)
+-- ARGV[1] = "keep" | "drop"
+-- ARGV[2] = txid (zset member)
+-- ARGV[3] = decisionTtlSeconds
+-- returns: false if another node already decided (skip).
+--          otherwise {decision, span1, span2, ...} (spans included only when keep).
+local ok = redis.call('SET', KEYS[2], ARGV[1], 'NX', 'EX', ARGV[3])
+if not ok then
+    return false
+end
+local spans = redis.call('LRANGE', KEYS[1], 0, -1)
+redis.call('DEL', KEYS[1])
+redis.call('ZREM', KEYS[3], ARGV[2])
+local result = {ARGV[1]}
+if ARGV[1] == 'keep' then
+    for i = 1, #spans do
+        result[#result + 1] = spans[i]
+    end
+end
+return result

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanChunkHandlerTailTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanChunkHandlerTailTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.handler.grpc;
+
+import com.navercorp.pinpoint.collector.sampler.SpanSamplerFactory;
+import com.navercorp.pinpoint.collector.sampler.TrueSampler;
+import com.navercorp.pinpoint.collector.sampling.tail.TailSampler;
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.common.server.io.ServerRequest;
+import com.navercorp.pinpoint.grpc.trace.PSpanChunk;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.ObjectProvider;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GrpcSpanChunkHandlerTailTest {
+
+    @Test
+    void whenTailEnabled_routesToTailSampler_bypassingTraceServiceLoop() {
+        TraceService traceService = Mockito.mock(TraceService.class);
+        GrpcSpanFactory factory = Mockito.mock(GrpcSpanFactory.class);
+        SpanSamplerFactory samplerFactory = Mockito.mock(SpanSamplerFactory.class);
+        when(samplerFactory.createBasicSpanSampler()).thenReturn(TrueSampler.instance());
+        TailSampler tailSampler = Mockito.mock(TailSampler.class);
+
+        @SuppressWarnings("unchecked")
+        ObjectProvider<TailSampler> provider = Mockito.mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(tailSampler);
+
+        SpanChunkBo chunkBo = new SpanChunkBo();
+        when(factory.buildSpanChunkBo(any(), any(), org.mockito.ArgumentMatchers.anyLong())).thenReturn(chunkBo);
+
+        @SuppressWarnings("unchecked")
+        ServerRequest<PSpanChunk> request = Mockito.mock(ServerRequest.class);
+        when(request.getData()).thenReturn(PSpanChunk.getDefaultInstance());
+        when(request.getHeader()).thenReturn(Mockito.mock(ServerHeader.class));
+        when(request.getRequestTime()).thenReturn(123L);
+
+        GrpcSpanChunkHandler handler = new GrpcSpanChunkHandler(
+                new TraceService[]{traceService}, factory, samplerFactory, provider);
+        handler.handleSimple(request);
+
+        verify(tailSampler).acceptSpanChunk(org.mockito.ArgumentMatchers.eq(chunkBo), any(byte[].class));
+        verify(traceService, never()).insertSpanChunk(any());
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanHandlerTailTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanHandlerTailTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.handler.grpc;
+
+import com.navercorp.pinpoint.collector.sampler.SpanSamplerFactory;
+import com.navercorp.pinpoint.collector.sampler.TrueSampler;
+import com.navercorp.pinpoint.collector.sampling.tail.TailSampler;
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.common.server.io.ServerRequest;
+import com.navercorp.pinpoint.grpc.trace.PSpan;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.ObjectProvider;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GrpcSpanHandlerTailTest {
+
+    @Test
+    void whenTailEnabled_routesToTailSampler_bypassingTraceServiceLoop() {
+        TraceService traceService = Mockito.mock(TraceService.class);
+        GrpcSpanFactory factory = Mockito.mock(GrpcSpanFactory.class);
+        SpanSamplerFactory samplerFactory = Mockito.mock(SpanSamplerFactory.class);
+        when(samplerFactory.createBasicSpanSampler()).thenReturn(TrueSampler.instance());
+        TailSampler tailSampler = Mockito.mock(TailSampler.class);
+
+        @SuppressWarnings("unchecked")
+        ObjectProvider<TailSampler> provider = Mockito.mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(tailSampler);
+
+        SpanBo spanBo = new SpanBo();
+        when(factory.buildSpanBo(any(), any(), org.mockito.ArgumentMatchers.anyLong())).thenReturn(spanBo);
+
+        @SuppressWarnings("unchecked")
+        ServerRequest<PSpan> request = Mockito.mock(ServerRequest.class);
+        when(request.getData()).thenReturn(PSpan.getDefaultInstance());
+        when(request.getHeader()).thenReturn(Mockito.mock(ServerHeader.class));
+        when(request.getRequestTime()).thenReturn(123L);
+
+        GrpcSpanHandler handler = new GrpcSpanHandler(
+                new TraceService[]{traceService}, factory, samplerFactory, provider);
+        handler.handleSimple(request);
+
+        verify(tailSampler).acceptSpan(org.mockito.ArgumentMatchers.eq(spanBo), any(byte[].class));
+        verify(traceService, never()).insertSpan(any()); // existing loop bypassed
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/ApplicationMapTraceServiceTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/ApplicationMapTraceServiceTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.applicationmap.service.ApplicationMapService;
+import com.navercorp.pinpoint.collector.service.ApplicationMapTraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.verify;
+
+class ApplicationMapTraceServiceTest {
+
+    @Test
+    void insertSpanDelegatesToApplicationMapService() {
+        ApplicationMapService delegate = Mockito.mock(ApplicationMapService.class);
+        ApplicationMapTraceService service = new ApplicationMapTraceService(delegate);
+        SpanBo spanBo = new SpanBo();
+
+        service.insertSpan(spanBo);
+
+        verify(delegate).insertSpan(spanBo);
+    }
+
+    @Test
+    void insertSpanChunkDelegatesToApplicationMapService() {
+        ApplicationMapService delegate = Mockito.mock(ApplicationMapService.class);
+        ApplicationMapTraceService service = new ApplicationMapTraceService(delegate);
+        SpanChunkBo chunkBo = new SpanChunkBo();
+
+        service.insertSpanChunk(chunkBo);
+
+        verify(delegate).insertSpanChunk(chunkBo);
+    }
+
+    @Test
+    void isStatisticsTraceService() {
+        org.assertj.core.api.Assertions.assertThat(StatisticsTraceService.class)
+                .isAssignableFrom(ApplicationMapTraceService.class);
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodecTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodecTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BufferedSpanCodecTest {
+
+    private final BufferedSpanCodec codec = new BufferedSpanCodec();
+
+    @Test
+    void roundTripSpan() {
+        byte[] proto = new byte[]{1, 2, 3, 4, 5};
+        BufferedSpan original = new BufferedSpan(BufferedSpan.Type.SPAN,
+                "agent-1", "agent-name", "app-1", 1000L, 2000L, proto);
+
+        byte[] encoded = codec.encode(original);
+        BufferedSpan decoded = codec.decode(encoded);
+
+        assertThat(decoded.type()).isEqualTo(BufferedSpan.Type.SPAN);
+        assertThat(decoded.agentId()).isEqualTo("agent-1");
+        assertThat(decoded.agentName()).isEqualTo("agent-name");
+        assertThat(decoded.applicationName()).isEqualTo("app-1");
+        assertThat(decoded.agentStartTime()).isEqualTo(1000L);
+        assertThat(decoded.requestTime()).isEqualTo(2000L);
+        assertThat(decoded.protoBytes()).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void roundTripChunkPreservesType() {
+        BufferedSpan original = new BufferedSpan(BufferedSpan.Type.SPAN_CHUNK,
+                "a", "n", "app", 1L, 2L, new byte[]{9});
+        BufferedSpan decoded = codec.decode(codec.encode(original));
+        assertThat(decoded.type()).isEqualTo(BufferedSpan.Type.SPAN_CHUNK);
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodecTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodecTest.java
@@ -48,4 +48,18 @@ class BufferedSpanCodecTest {
         BufferedSpan decoded = codec.decode(codec.encode(original));
         assertThat(decoded.type()).isEqualTo(BufferedSpan.Type.SPAN_CHUNK);
     }
+
+    @Test
+    void roundTripChunkAllFieldsAndEmptyProto() {
+        BufferedSpan original = new BufferedSpan(BufferedSpan.Type.SPAN_CHUNK,
+                "agent-2", "name-2", "app-2", 11L, 22L, new byte[0]);
+        BufferedSpan decoded = codec.decode(codec.encode(original));
+        assertThat(decoded.type()).isEqualTo(BufferedSpan.Type.SPAN_CHUNK);
+        assertThat(decoded.agentId()).isEqualTo("agent-2");
+        assertThat(decoded.agentName()).isEqualTo("name-2");
+        assertThat(decoded.applicationName()).isEqualTo("app-2");
+        assertThat(decoded.agentStartTime()).isEqualTo(11L);
+        assertThat(decoded.requestTime()).isEqualTo(22L);
+        assertThat(decoded.protoBytes()).isEmpty();
+    }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/ReconstructedServerHeaderTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/ReconstructedServerHeaderTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReconstructedServerHeaderTest {
+
+    @Test
+    void exposesStoredFields() {
+        ServerHeader header = new ReconstructedServerHeader("agent-1", "agent-name", "app-1", 1000L);
+        assertThat(header.getAgentId()).isEqualTo("agent-1");
+        assertThat(header.getAgentName()).isEqualTo("agent-name");
+        assertThat(header.getApplicationName()).isEqualTo("app-1");
+        assertThat(header.getAgentStartTime()).isEqualTo(1000L);
+        assertThat(header.getServiceUid().get()).isEqualTo(ServiceUid.DEFAULT);
+        assertThat(header.isGrpcBuiltInRetry()).isFalse();
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/StatisticsTraceServiceTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/StatisticsTraceServiceTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.heatmap.service.HeatmapService;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StatisticsTraceServiceTest {
+
+    @Test
+    void heatmapServiceIsStatisticsTraceService() {
+        assertThat(StatisticsTraceService.class)
+                .isAssignableFrom(HeatmapService.class);
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailDecisionsTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailDecisionsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TailDecisionsTest {
+
+    @Test
+    void rate100_alwaysKeep() {
+        assertThat(TailDecisions.keep("agent^1^1", 100)).isTrue();
+        assertThat(TailDecisions.keep("agent^1^999999", 100)).isTrue();
+    }
+
+    @Test
+    void rate0_neverKeep() {
+        assertThat(TailDecisions.keep("agent^1^1", 0)).isFalse();
+        assertThat(TailDecisions.keep("agent^1^999999", 0)).isFalse();
+    }
+
+    @Test
+    void deterministicForSameTxid() {
+        boolean first = TailDecisions.keep("agent^1^42", 10);
+        for (int i = 0; i < 100; i++) {
+            assertThat(TailDecisions.keep("agent^1^42", 10)).isEqualTo(first);
+        }
+    }
+
+    @Test
+    void approximatesRateAcrossManyTxids() {
+        int kept = 0;
+        int total = 10000;
+        for (int i = 0; i < total; i++) {
+            if (TailDecisions.keep("agent^1^" + i, 10)) {
+                kept++;
+            }
+        }
+        // 10% ± 2%p
+        assertThat(kept).isBetween((int) (total * 0.08), (int) (total * 0.12));
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
@@ -231,4 +231,59 @@ class TailSamplerTest {
 
         verify(repository).accept(anyString(), any(), anyLong(), eq(true));
     }
+
+    @Test
+    void bandDrop_noErrorYet_defersInsteadOfDeciding() {
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("buffered");
+        when(repository.isErrorFlagged(anyString())).thenReturn(false);
+
+        TailSampler sampler = dropAllSampler(true);
+        sampler.acceptSpan(rootSpan(10), new byte[]{1}); // band rate 0, not an error
+
+        verify(repository).defer(anyString(), anyLong());
+        verify(repository, never()).decide(anyString(), anyBoolean());
+        verify(sampled, never()).insertSpan(any());
+    }
+
+    @Test
+    void bandDrop_alreadyErrorFlagged_decidesImmediately() {
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("buffered");
+        when(repository.isErrorFlagged(anyString())).thenReturn(true); // a child error already arrived
+        BufferedSpan buffered = new BufferedSpan(BufferedSpan.Type.SPAN, "agent", "agentName", "app", 1L, 2L,
+                com.navercorp.pinpoint.grpc.trace.PSpan.newBuilder().build().toByteArray());
+        when(repository.decide(anyString(), eq(false)))
+                .thenReturn(List.of(new BufferedSpanCodec().encode(buffered)));
+        when(factory.buildSpanBo(any(), any(), anyLong())).thenReturn(new SpanBo());
+
+        TailSampler sampler = dropAllSampler(true);
+        sampler.acceptSpan(rootSpan(10), new byte[]{1});
+
+        verify(repository, never()).defer(anyString(), anyLong());
+        verify(repository).decide(anyString(), eq(false));
+        verify(sampled).insertSpan(any());
+    }
+
+    @Test
+    void finalizeDeferred_replaysWhenErrorFlippedToKeep() {
+        BufferedSpan buffered = new BufferedSpan(BufferedSpan.Type.SPAN, "agent", "agentName", "app", 1L, 2L,
+                com.navercorp.pinpoint.grpc.trace.PSpan.newBuilder().build().toByteArray());
+        when(repository.decide(anyString(), eq(false)))
+                .thenReturn(List.of(new BufferedSpanCodec().encode(buffered)));
+        when(factory.buildSpanBo(any(), any(), anyLong())).thenReturn(new SpanBo());
+
+        tailSampler.finalizeDeferred("agent^1^100");
+
+        verify(repository).removeDeferred("agent^1^100");
+        verify(sampled).insertSpan(any());
+    }
+
+    @Test
+    void finalizeDeferred_dropsWhenNoError() {
+        when(repository.decide(anyString(), eq(false))).thenReturn(List.of());
+
+        tailSampler.finalizeDeferred("agent^1^100");
+
+        verify(repository).removeDeferred("agent^1^100");
+        verify(sampled, never()).insertSpan(any());
+    }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TailSamplerTest {
+
+    private StatisticsTraceService always;
+    private TraceService sampled;
+    private TailSamplingRepository repository;
+    private GrpcSpanFactory factory;
+    private TailSampler tailSampler;
+
+    @BeforeEach
+    void setUp() {
+        always = Mockito.mock(StatisticsTraceService.class);
+        sampled = Mockito.mock(TraceService.class);
+        repository = Mockito.mock(TailSamplingRepository.class);
+        factory = Mockito.mock(GrpcSpanFactory.class);
+        TailSamplingProperties props = new TailSamplingProperties();
+        props.setBands(List.of()); // rateFor -> 100
+
+        tailSampler = new TailSampler(
+                new TraceService[]{always, sampled},
+                repository, props, new BufferedSpanCodec(), factory, new SimpleMeterRegistry());
+    }
+
+    private SpanBo rootSpan(int elapsed) {
+        SpanBo bo = new SpanBo();
+        bo.setTransactionId(new PinpointServerTraceId("agent", 1L, 100L));
+        bo.setParentSpanId(-1L); // root
+        bo.setElapsed(elapsed);
+        bo.setAgentId("agent");
+        bo.setApplicationName("app");
+        bo.setAgentName("agentName");
+        return bo;
+    }
+
+    @Test
+    void alwaysGroupCalledImmediately_regardlessOfDecision() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+        SpanBo bo = rootSpan(10);
+
+        tailSampler.acceptSpan(bo, new byte[]{1});
+
+        verify(always).insertSpan(bo);
+    }
+
+    @Test
+    void decisionDrop_sampledNotWritten() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("drop");
+        SpanBo bo = rootSpan(10);
+
+        tailSampler.acceptSpan(bo, new byte[]{1});
+
+        verify(sampled, never()).insertSpan(any());
+        verify(always).insertSpan(bo);
+    }
+
+    @Test
+    void decisionKeep_writesThroughToSampledLive() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("keep");
+        SpanBo bo = rootSpan(10);
+
+        tailSampler.acceptSpan(bo, new byte[]{1});
+
+        verify(sampled).insertSpan(bo);
+    }
+
+    @Test
+    void rootBuffered_triggersDecide_andReplaysKeptSpans() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+        BufferedSpan buffered = new BufferedSpan(BufferedSpan.Type.SPAN,
+                "agent", "agentName", "app", 1L, 2L, new byte[]{7});
+        byte[] encoded = new BufferedSpanCodec().encode(buffered);
+        when(repository.decide(anyString(), org.mockito.ArgumentMatchers.eq(true)))
+                .thenReturn(List.of(encoded));
+        SpanBo rebuilt = new SpanBo();
+        when(factory.buildSpanBo(any(), any(), anyLong())).thenReturn(rebuilt);
+
+        tailSampler.acceptSpan(rootSpan(10), new byte[]{1});
+
+        verify(sampled).insertSpan(rebuilt);
+    }
+
+    @Test
+    void redisFailure_failsOpen_writesSampledLive() {
+        when(repository.accept(anyString(), any(), anyLong()))
+                .thenThrow(new RuntimeException("redis down"));
+        SpanBo bo = rootSpan(10);
+
+        tailSampler.acceptSpan(bo, new byte[]{1});
+
+        verify(always).insertSpan(bo);
+        verify(sampled).insertSpan(bo); // fail-open
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
@@ -29,8 +29,10 @@ import org.mockito.Mockito;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -70,7 +72,7 @@ class TailSamplerTest {
 
     @Test
     void alwaysGroupCalledImmediately_regardlessOfDecision() {
-        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("buffered");
         SpanBo bo = rootSpan(10);
 
         tailSampler.acceptSpan(bo, new byte[]{1});
@@ -80,7 +82,7 @@ class TailSamplerTest {
 
     @Test
     void decisionDrop_sampledNotWritten() {
-        when(repository.accept(anyString(), any(), anyLong())).thenReturn("drop");
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("drop");
         SpanBo bo = rootSpan(10);
 
         tailSampler.acceptSpan(bo, new byte[]{1});
@@ -91,7 +93,7 @@ class TailSamplerTest {
 
     @Test
     void decisionKeep_writesThroughToSampledLive() {
-        when(repository.accept(anyString(), any(), anyLong())).thenReturn("keep");
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("keep");
         SpanBo bo = rootSpan(10);
 
         tailSampler.acceptSpan(bo, new byte[]{1});
@@ -101,7 +103,7 @@ class TailSamplerTest {
 
     @Test
     void rootBuffered_triggersDecide_andReplaysKeptSpans() {
-        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("buffered");
         BufferedSpan buffered = new BufferedSpan(BufferedSpan.Type.SPAN,
                 "agent", "agentName", "app", 1L, 2L,
                 com.navercorp.pinpoint.grpc.trace.PSpan.newBuilder().build().toByteArray());
@@ -118,7 +120,7 @@ class TailSamplerTest {
 
     @Test
     void redisFailure_failsOpen_writesSampledLive() {
-        when(repository.accept(anyString(), any(), anyLong()))
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean()))
                 .thenThrow(new RuntimeException("redis down"));
         SpanBo bo = rootSpan(10);
 
@@ -139,7 +141,7 @@ class TailSamplerTest {
 
     @Test
     void chunk_alwaysGroupCalledImmediately() {
-        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("buffered");
         SpanChunkBo bo = chunk();
         tailSampler.acceptSpanChunk(bo, new byte[]{1});
         verify(always).insertSpanChunk(bo);
@@ -147,7 +149,7 @@ class TailSamplerTest {
 
     @Test
     void chunk_keep_writesThroughToSampledLive() {
-        when(repository.accept(anyString(), any(), anyLong())).thenReturn("keep");
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("keep");
         SpanChunkBo bo = chunk();
         tailSampler.acceptSpanChunk(bo, new byte[]{1});
         verify(sampled).insertSpanChunk(bo);
@@ -155,7 +157,7 @@ class TailSamplerTest {
 
     @Test
     void chunk_drop_notWritten() {
-        when(repository.accept(anyString(), any(), anyLong())).thenReturn("drop");
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("drop");
         SpanChunkBo bo = chunk();
         tailSampler.acceptSpanChunk(bo, new byte[]{1});
         verify(sampled, never()).insertSpanChunk(any());
@@ -163,7 +165,7 @@ class TailSamplerTest {
 
     @Test
     void chunk_redisFailure_failsOpen() {
-        when(repository.accept(anyString(), any(), anyLong())).thenThrow(new RuntimeException("down"));
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenThrow(new RuntimeException("down"));
         SpanChunkBo bo = chunk();
         tailSampler.acceptSpanChunk(bo, new byte[]{1});
         verify(sampled).insertSpanChunk(bo);
@@ -181,28 +183,30 @@ class TailSamplerTest {
     }
 
     @Test
-    void rootError_keptEvenWhenBandWouldDrop() {
-        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+    void erroredSpan_setsErrorFlag_andReplaysWhenDecideUpgradesToKeep() {
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("buffered");
+        // band rate 0 -> proposed decision is drop (false); simulate the script upgrading to keep
+        // (error flag) by returning buffered spans for the proposed=drop call.
         BufferedSpan buffered = new BufferedSpan(BufferedSpan.Type.SPAN, "agent", "agentName", "app", 1L, 2L,
                 com.navercorp.pinpoint.grpc.trace.PSpan.newBuilder().build().toByteArray());
-        when(repository.decide(anyString(), org.mockito.ArgumentMatchers.eq(true)))
+        when(repository.decide(anyString(), eq(false)))
                 .thenReturn(List.of(new BufferedSpanCodec().encode(buffered)));
         when(factory.buildSpanBo(any(), any(), anyLong())).thenReturn(new SpanBo());
 
         TailSampler sampler = dropAllSampler(true);
-        SpanBo bo = rootSpan(10); // < any band; would drop by response time
+        SpanBo bo = rootSpan(10); // < any band; band would drop by response time
         bo.setErrCode(1);         // but it is an error
 
         sampler.acceptSpan(bo, com.navercorp.pinpoint.grpc.trace.PSpan.newBuilder().build().toByteArray());
 
-        verify(repository).decide(anyString(), org.mockito.ArgumentMatchers.eq(true)); // forced keep
-        verify(sampled).insertSpan(any());
+        verify(repository).accept(anyString(), any(), anyLong(), eq(true)); // error flag propagated
+        verify(sampled).insertSpan(any());                                   // kept via upgrade (non-empty result)
     }
 
     @Test
-    void rootError_butKeepOnErrorDisabled_followsBandAndDrops() {
-        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
-        when(repository.decide(anyString(), org.mockito.ArgumentMatchers.eq(false))).thenReturn(List.of());
+    void keepOnErrorDisabled_doesNotSetErrorFlag_andDrops() {
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("buffered");
+        when(repository.decide(anyString(), eq(false))).thenReturn(List.of()); // drop
 
         TailSampler sampler = dropAllSampler(false);
         SpanBo bo = rootSpan(10);
@@ -210,7 +214,21 @@ class TailSamplerTest {
 
         sampler.acceptSpan(bo, com.navercorp.pinpoint.grpc.trace.PSpan.newBuilder().build().toByteArray());
 
-        verify(repository).decide(anyString(), org.mockito.ArgumentMatchers.eq(false)); // band rate 0 -> drop
+        verify(repository).accept(anyString(), any(), anyLong(), eq(false)); // flag NOT set (toggle off)
         verify(sampled, never()).insertSpan(any());
+    }
+
+    @Test
+    void erroredChunk_setsErrorFlagOnAccept() {
+        when(repository.accept(anyString(), any(), anyLong(), anyBoolean())).thenReturn("buffered");
+        com.navercorp.pinpoint.common.server.bo.SpanEventBo event =
+                Mockito.mock(com.navercorp.pinpoint.common.server.bo.SpanEventBo.class);
+        when(event.hasException()).thenReturn(true);
+        SpanChunkBo bo = chunk();
+        bo.addSpanEventBoList(List.of(event));
+
+        tailSampler.acceptSpanChunk(bo, new byte[]{1});
+
+        verify(repository).accept(anyString(), any(), anyLong(), eq(true));
     }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.collector.sampling.tail;
 
 import com.navercorp.pinpoint.collector.service.TraceService;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -102,7 +103,8 @@ class TailSamplerTest {
     void rootBuffered_triggersDecide_andReplaysKeptSpans() {
         when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
         BufferedSpan buffered = new BufferedSpan(BufferedSpan.Type.SPAN,
-                "agent", "agentName", "app", 1L, 2L, new byte[]{7});
+                "agent", "agentName", "app", 1L, 2L,
+                com.navercorp.pinpoint.grpc.trace.PSpan.newBuilder().build().toByteArray());
         byte[] encoded = new BufferedSpanCodec().encode(buffered);
         when(repository.decide(anyString(), org.mockito.ArgumentMatchers.eq(true)))
                 .thenReturn(List.of(encoded));
@@ -124,5 +126,46 @@ class TailSamplerTest {
 
         verify(always).insertSpan(bo);
         verify(sampled).insertSpan(bo); // fail-open
+    }
+
+    private SpanChunkBo chunk() {
+        SpanChunkBo bo = new SpanChunkBo();
+        bo.setTransactionId(new PinpointServerTraceId("agent", 1L, 200L));
+        bo.setAgentId("agent");
+        bo.setApplicationName("app");
+        bo.setAgentStartTime(1L);
+        return bo;
+    }
+
+    @Test
+    void chunk_alwaysGroupCalledImmediately() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+        SpanChunkBo bo = chunk();
+        tailSampler.acceptSpanChunk(bo, new byte[]{1});
+        verify(always).insertSpanChunk(bo);
+    }
+
+    @Test
+    void chunk_keep_writesThroughToSampledLive() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("keep");
+        SpanChunkBo bo = chunk();
+        tailSampler.acceptSpanChunk(bo, new byte[]{1});
+        verify(sampled).insertSpanChunk(bo);
+    }
+
+    @Test
+    void chunk_drop_notWritten() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("drop");
+        SpanChunkBo bo = chunk();
+        tailSampler.acceptSpanChunk(bo, new byte[]{1});
+        verify(sampled, never()).insertSpanChunk(any());
+    }
+
+    @Test
+    void chunk_redisFailure_failsOpen() {
+        when(repository.accept(anyString(), any(), anyLong())).thenThrow(new RuntimeException("down"));
+        SpanChunkBo bo = chunk();
+        tailSampler.acceptSpanChunk(bo, new byte[]{1});
+        verify(sampled).insertSpanChunk(bo);
     }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
@@ -168,4 +168,49 @@ class TailSamplerTest {
         tailSampler.acceptSpanChunk(bo, new byte[]{1});
         verify(sampled).insertSpanChunk(bo);
     }
+
+    /** Builds a sampler whose band drops everything (rate 0), with the given keep-on-error toggle. */
+    private TailSampler dropAllSampler(boolean keepOnError) {
+        TailSamplingProperties props = new TailSamplingProperties();
+        TailSamplingProperties.Band dropAll = new TailSamplingProperties.Band();
+        dropAll.setRate(0); // catch-all, drop everything by response time
+        props.setBands(List.of(dropAll));
+        props.setKeepOnError(keepOnError);
+        return new TailSampler(new TraceService[]{always, sampled},
+                repository, props, new BufferedSpanCodec(), factory, new SimpleMeterRegistry());
+    }
+
+    @Test
+    void rootError_keptEvenWhenBandWouldDrop() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+        BufferedSpan buffered = new BufferedSpan(BufferedSpan.Type.SPAN, "agent", "agentName", "app", 1L, 2L,
+                com.navercorp.pinpoint.grpc.trace.PSpan.newBuilder().build().toByteArray());
+        when(repository.decide(anyString(), org.mockito.ArgumentMatchers.eq(true)))
+                .thenReturn(List.of(new BufferedSpanCodec().encode(buffered)));
+        when(factory.buildSpanBo(any(), any(), anyLong())).thenReturn(new SpanBo());
+
+        TailSampler sampler = dropAllSampler(true);
+        SpanBo bo = rootSpan(10); // < any band; would drop by response time
+        bo.setErrCode(1);         // but it is an error
+
+        sampler.acceptSpan(bo, com.navercorp.pinpoint.grpc.trace.PSpan.newBuilder().build().toByteArray());
+
+        verify(repository).decide(anyString(), org.mockito.ArgumentMatchers.eq(true)); // forced keep
+        verify(sampled).insertSpan(any());
+    }
+
+    @Test
+    void rootError_butKeepOnErrorDisabled_followsBandAndDrops() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+        when(repository.decide(anyString(), org.mockito.ArgumentMatchers.eq(false))).thenReturn(List.of());
+
+        TailSampler sampler = dropAllSampler(false);
+        SpanBo bo = rootSpan(10);
+        bo.setErrCode(1);
+
+        sampler.acceptSpan(bo, com.navercorp.pinpoint.grpc.trace.PSpan.newBuilder().build().toByteArray());
+
+        verify(repository).decide(anyString(), org.mockito.ArgumentMatchers.eq(false)); // band rate 0 -> drop
+        verify(sampled, never()).insertSpan(any());
+    }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingEndToEndIT.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingEndToEndIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.grpc.trace.PSpan;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.util.StreamUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@Testcontainers
+class TailSamplingEndToEndIT {
+
+    @Container
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7.0")).withExposedPorts(6379);
+
+    // Valid empty serialized PSpan so replay()'s PSpan.parseFrom(...) succeeds.
+    private static final byte[] VALID_PROTO = PSpan.newBuilder().build().toByteArray();
+
+    private LettuceConnectionFactory factory;
+    private TraceService always;
+    private TraceService sampled;
+    private TailSampler tailSampler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        factory = new LettuceConnectionFactory(REDIS.getHost(), REDIS.getMappedPort(6379));
+        factory.afterPropertiesSet();
+        RedisTemplate<String, byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(RedisSerializer.string());
+        template.setValueSerializer(RedisSerializer.byteArray());
+        template.afterPropertiesSet();
+        template.execute((RedisCallback<Object>) c -> {
+            c.serverCommands().flushDb();
+            return null;
+        });
+
+        byte[] acceptScript = StreamUtils.copyToByteArray(new ClassPathResource("redis/tail-accept.lua").getInputStream());
+        byte[] decideScript = StreamUtils.copyToByteArray(new ClassPathResource("redis/tail-decide.lua").getInputStream());
+        TailSamplingRepository repository = new TailSamplingRepository(template, acceptScript, decideScript, 300, 600);
+
+        always = Mockito.mock(StatisticsTraceService.class);
+        sampled = Mockito.mock(TraceService.class);
+        GrpcSpanFactory spanFactory = Mockito.mock(GrpcSpanFactory.class);
+        Mockito.when(spanFactory.buildSpanBo(any(), any(), Mockito.anyLong())).thenReturn(new SpanBo());
+
+        TailSamplingProperties props = new TailSamplingProperties();
+        TailSamplingProperties.Band fast = new TailSamplingProperties.Band();
+        fast.setMaxElapsed(java.time.Duration.ofMillis(50));
+        fast.setRate(0); // fast traces 0% (deterministic drop for the test)
+        TailSamplingProperties.Band slow = new TailSamplingProperties.Band();
+        slow.setRate(100); // catch-all keep
+        props.setBands(List.of(fast, slow));
+
+        tailSampler = new TailSampler(new TraceService[]{always, sampled},
+                repository, props, new BufferedSpanCodec(), spanFactory, new SimpleMeterRegistry());
+    }
+
+    @AfterEach
+    void tearDown() {
+        factory.destroy();
+    }
+
+    private SpanBo span(long seq, int elapsed, boolean root) {
+        SpanBo bo = new SpanBo();
+        bo.setTransactionId(new PinpointServerTraceId("agent", 1L, seq));
+        bo.setParentSpanId(root ? -1L : 10L);
+        bo.setElapsed(elapsed);
+        bo.setAgentId("agent");
+        bo.setApplicationName("app");
+        bo.setAgentName("agentName");
+        return bo;
+    }
+
+    @Test
+    void slowTrace_childBeforeRoot_allKept() {
+        // child first (buffered), then root with elapsed 500 -> catch-all 100% keep
+        tailSampler.acceptSpan(span(1, 0, false), VALID_PROTO);
+        tailSampler.acceptSpan(span(1, 500, true), VALID_PROTO);
+        // root triggers decide(keep) -> both buffered spans replayed to sampled
+        verify(sampled, Mockito.atLeast(1)).insertSpan(any());
+    }
+
+    @Test
+    void fastTrace_dropped() {
+        // root first, elapsed 10 -> fast band rate 0 -> drop
+        tailSampler.acceptSpan(span(2, 10, true), VALID_PROTO);
+        // later child sees decision=drop -> discarded immediately
+        tailSampler.acceptSpan(span(2, 0, false), VALID_PROTO);
+        verify(sampled, never()).insertSpan(any());
+        verify(always, Mockito.times(2)).insertSpan(any()); // always group called for every span
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingPropertiesTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingPropertiesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.pinpoint.collector.sampling.tail;
 
 import org.junit.jupiter.api.Test;

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingPropertiesTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingPropertiesTest.java
@@ -1,0 +1,45 @@
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.junit.jupiter.api.Test;
+import java.time.Duration;
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TailSamplingPropertiesTest {
+
+    private TailSamplingProperties props() {
+        TailSamplingProperties p = new TailSamplingProperties();
+        TailSamplingProperties.Band b1 = new TailSamplingProperties.Band();
+        b1.setMaxElapsed(Duration.ofMillis(50));
+        b1.setRate(1);
+        TailSamplingProperties.Band b2 = new TailSamplingProperties.Band();
+        b2.setMaxElapsed(Duration.ofMillis(100));
+        b2.setRate(5);
+        TailSamplingProperties.Band b3 = new TailSamplingProperties.Band();
+        b3.setMaxElapsed(Duration.ofMillis(500));
+        b3.setRate(10);
+        TailSamplingProperties.Band b4 = new TailSamplingProperties.Band(); // catch-all (maxElapsed = null)
+        b4.setRate(100);
+        p.setBands(List.of(b1, b2, b3, b4));
+        return p;
+    }
+
+    @Test
+    void rateFor_matchesFirstBandByUpperBound() {
+        TailSamplingProperties p = props();
+        assertThat(p.rateFor(49)).isEqualTo(1);
+        assertThat(p.rateFor(50)).isEqualTo(5);   // 50 < 50 false -> next band
+        assertThat(p.rateFor(99)).isEqualTo(5);
+        assertThat(p.rateFor(100)).isEqualTo(10);
+        assertThat(p.rateFor(499)).isEqualTo(10);
+        assertThat(p.rateFor(500)).isEqualTo(100);
+        assertThat(p.rateFor(5000)).isEqualTo(100);
+    }
+
+    @Test
+    void rateFor_noBandMatches_defaultsToKeep100() {
+        TailSamplingProperties p = new TailSamplingProperties();
+        p.setBands(List.of()); // empty
+        assertThat(p.rateFor(10)).isEqualTo(100); // fail-safe: keep
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepositoryIT.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepositoryIT.java
@@ -136,4 +136,38 @@ class TailSamplingRepositoryIT {
         assertThat(spans).isEmpty();
         assertThat(repository.accept("tx-nor", new byte[]{9}, 1000L, false)).isEqualTo("drop");
     }
+
+    @Test
+    void isErrorFlagged_reflectsErrorAccept() {
+        repository.accept("tx-flag-no", new byte[]{1}, 1000L, false);
+        assertThat(repository.isErrorFlagged("tx-flag-no")).isFalse();
+
+        repository.accept("tx-flag-yes", new byte[]{1}, 1000L, true);
+        assertThat(repository.isErrorFlagged("tx-flag-yes")).isTrue();
+    }
+
+    @Test
+    void defer_findDue_remove_roundTrip() {
+        repository.defer("tx-def-old", 1000L);
+        repository.defer("tx-def-new", 5000L);
+
+        List<String> due = repository.findDeferredDue(2000L, 100);
+        assertThat(due).contains("tx-def-old").doesNotContain("tx-def-new");
+
+        repository.removeDeferred("tx-def-old");
+        assertThat(repository.findDeferredDue(2000L, 100)).doesNotContain("tx-def-old");
+    }
+
+    @Test
+    void deferredTrace_finalizedAsKeep_whenErrorArrivesDuringGrace() {
+        // root buffered (band would drop) -> deferred
+        repository.accept("tx-grace", new byte[]{1}, 1000L, false);
+        repository.defer("tx-grace", 1000L);
+        // a downstream error span arrives during the grace window
+        repository.accept("tx-grace", new byte[]{2}, 1000L, true);
+
+        // finalize with proposed drop -> error flag upgrades to keep
+        List<byte[]> won = repository.decide("tx-grace", false);
+        assertThat(won).hasSize(2);
+    }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepositoryIT.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepositoryIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class TailSamplingRepositoryIT {
+
+    @Container
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7.0")).withExposedPorts(6379);
+
+    private LettuceConnectionFactory factory;
+    private TailSamplingRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        factory = new LettuceConnectionFactory(REDIS.getHost(), REDIS.getMappedPort(6379));
+        factory.afterPropertiesSet();
+        RedisTemplate<String, byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(RedisSerializer.string());
+        template.setValueSerializer(RedisSerializer.byteArray());
+        template.afterPropertiesSet();
+
+        byte[] acceptScript = load("redis/tail-accept.lua");
+        byte[] decideScript = load("redis/tail-decide.lua");
+        repository = new TailSamplingRepository(template, acceptScript, decideScript, 300, 600);
+        template.execute((org.springframework.data.redis.core.RedisCallback<Object>) c -> {
+            c.serverCommands().flushDb();
+            return null;
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        factory.destroy();
+    }
+
+    private static byte[] load(String path) {
+        try {
+            return org.springframework.util.StreamUtils.copyToByteArray(
+                    new org.springframework.core.io.ClassPathResource(path).getInputStream());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void accept_firstTime_returnsBuffered() {
+        String r = repository.accept("tx-1", new byte[]{1}, 1000L);
+        assertThat(r).isEqualTo("buffered");
+    }
+
+    @Test
+    void decide_keep_returnsBufferedSpansAndClearsBuffer() {
+        repository.accept("tx-2", new byte[]{1}, 1000L);
+        repository.accept("tx-2", new byte[]{2}, 1000L);
+
+        List<byte[]> spans = repository.decide("tx-2", true);
+
+        assertThat(spans).hasSize(2);
+        assertThat(repository.accept("tx-2", new byte[]{3}, 1000L)).isEqualTo("keep");
+    }
+
+    @Test
+    void decide_drop_returnsEmptyAndSubsequentAcceptDrops() {
+        repository.accept("tx-3", new byte[]{1}, 1000L);
+        List<byte[]> spans = repository.decide("tx-3", false);
+        assertThat(spans).isEmpty();
+        assertThat(repository.accept("tx-3", new byte[]{9}, 1000L)).isEqualTo("drop");
+    }
+
+    @Test
+    void decide_secondCall_returnsNull_noDoubleFlush() {
+        repository.accept("tx-4", new byte[]{1}, 1000L);
+        assertThat(repository.decide("tx-4", true)).isNotNull();
+        assertThat(repository.decide("tx-4", true)).isNull();
+    }
+
+    @Test
+    void findStale_returnsTxidsOlderThanThreshold() {
+        repository.accept("tx-old", new byte[]{1}, 1000L);
+        repository.accept("tx-new", new byte[]{1}, 5000L);
+        List<String> stale = repository.findStale(2000L, 100);
+        assertThat(stale).contains("tx-old").doesNotContain("tx-new");
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepositoryIT.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepositoryIT.java
@@ -77,41 +77,63 @@ class TailSamplingRepositoryIT {
 
     @Test
     void accept_firstTime_returnsBuffered() {
-        String r = repository.accept("tx-1", new byte[]{1}, 1000L);
+        String r = repository.accept("tx-1", new byte[]{1}, 1000L, false);
         assertThat(r).isEqualTo("buffered");
     }
 
     @Test
     void decide_keep_returnsBufferedSpansAndClearsBuffer() {
-        repository.accept("tx-2", new byte[]{1}, 1000L);
-        repository.accept("tx-2", new byte[]{2}, 1000L);
+        repository.accept("tx-2", new byte[]{1}, 1000L, false);
+        repository.accept("tx-2", new byte[]{2}, 1000L, false);
 
         List<byte[]> spans = repository.decide("tx-2", true);
 
         assertThat(spans).hasSize(2);
-        assertThat(repository.accept("tx-2", new byte[]{3}, 1000L)).isEqualTo("keep");
+        assertThat(repository.accept("tx-2", new byte[]{3}, 1000L, false)).isEqualTo("keep");
     }
 
     @Test
     void decide_drop_returnsEmptyAndSubsequentAcceptDrops() {
-        repository.accept("tx-3", new byte[]{1}, 1000L);
+        repository.accept("tx-3", new byte[]{1}, 1000L, false);
         List<byte[]> spans = repository.decide("tx-3", false);
         assertThat(spans).isEmpty();
-        assertThat(repository.accept("tx-3", new byte[]{9}, 1000L)).isEqualTo("drop");
+        assertThat(repository.accept("tx-3", new byte[]{9}, 1000L, false)).isEqualTo("drop");
     }
 
     @Test
     void decide_secondCall_returnsNull_noDoubleFlush() {
-        repository.accept("tx-4", new byte[]{1}, 1000L);
+        repository.accept("tx-4", new byte[]{1}, 1000L, false);
         assertThat(repository.decide("tx-4", true)).isNotNull();
         assertThat(repository.decide("tx-4", true)).isNull();
     }
 
     @Test
     void findStale_returnsTxidsOlderThanThreshold() {
-        repository.accept("tx-old", new byte[]{1}, 1000L);
-        repository.accept("tx-new", new byte[]{1}, 5000L);
+        repository.accept("tx-old", new byte[]{1}, 1000L, false);
+        repository.accept("tx-new", new byte[]{1}, 5000L, false);
         List<String> stale = repository.findStale(2000L, 100);
         assertThat(stale).contains("tx-old").doesNotContain("tx-new");
+    }
+
+    @Test
+    void decide_proposedDrop_upgradedToKeep_whenErrorFlagSet() {
+        // a child span (no error) buffered, then an errored span sets the error flag
+        repository.accept("tx-err", new byte[]{1}, 1000L, false);
+        repository.accept("tx-err", new byte[]{2}, 1000L, true);
+
+        // band proposes drop, but the error flag forces keep -> spans returned
+        List<byte[]> spans = repository.decide("tx-err", false);
+
+        assertThat(spans).hasSize(2);
+        // decision stored as keep -> late spans write through
+        assertThat(repository.accept("tx-err", new byte[]{3}, 1000L, false)).isEqualTo("keep");
+    }
+
+    @Test
+    void decide_proposedDrop_staysDrop_whenNoErrorFlag() {
+        repository.accept("tx-nor", new byte[]{1}, 1000L, false);
+        List<byte[]> spans = repository.decide("tx-nor", false);
+        assertThat(spans).isEmpty();
+        assertThat(repository.accept("tx-nor", new byte[]{9}, 1000L, false)).isEqualTo("drop");
     }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeperTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeperTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TailSamplingSweeperTest {
+
+    @Test
+    void sweep_forcesKeepDecisionForStaleTxids_andReplays() {
+        TailSamplingRepository repository = Mockito.mock(TailSamplingRepository.class);
+        TailSampler tailSampler = Mockito.mock(TailSampler.class);
+        TailSamplingProperties props = new TailSamplingProperties();
+        props.setBufferTtl(Duration.ofSeconds(300));
+
+        when(repository.findStale(anyLong(), anyInt())).thenReturn(List.of("tx-stale"));
+        List<byte[]> spans = List.of(new byte[]{1});
+        when(repository.decide(eq("tx-stale"), eq(true))).thenReturn(spans);
+
+        TailSamplingSweeper sweeper = new TailSamplingSweeper(repository, tailSampler, props);
+        sweeper.sweep();
+
+        verify(repository).decide("tx-stale", true); // default keep
+        verify(tailSampler).replay(spans);
+    }
+
+    @Test
+    void sweep_skipsWhenDecideReturnsNull() {
+        TailSamplingRepository repository = Mockito.mock(TailSamplingRepository.class);
+        TailSampler tailSampler = Mockito.mock(TailSampler.class);
+        TailSamplingProperties props = new TailSamplingProperties();
+
+        when(repository.findStale(anyLong(), anyInt())).thenReturn(List.of("tx-x"));
+        when(repository.decide(eq("tx-x"), eq(true))).thenReturn(null); // another node won
+
+        TailSamplingSweeper sweeper = new TailSamplingSweeper(repository, tailSampler, props);
+        sweeper.sweep();
+
+        verify(tailSampler, Mockito.never()).replay(Mockito.any());
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeperTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeperTest.java
@@ -45,7 +45,7 @@ class TailSamplingSweeperTest {
         sweeper.sweep();
 
         verify(repository).decide("tx-stale", true); // default keep
-        verify(tailSampler).replay(spans);
+        verify(tailSampler).replaySwept(spans);
     }
 
     @Test
@@ -60,6 +60,6 @@ class TailSamplingSweeperTest {
         TailSamplingSweeper sweeper = new TailSamplingSweeper(repository, tailSampler, props);
         sweeper.sweep();
 
-        verify(tailSampler, Mockito.never()).replay(Mockito.any());
+        verify(tailSampler, Mockito.never()).replaySwept(Mockito.any());
     }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeperTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeperTest.java
@@ -62,4 +62,19 @@ class TailSamplingSweeperTest {
 
         verify(tailSampler, Mockito.never()).replaySwept(Mockito.any());
     }
+
+    @Test
+    void finalizeDeferred_finalizesDueTraces() {
+        TailSamplingRepository repository = Mockito.mock(TailSamplingRepository.class);
+        TailSampler tailSampler = Mockito.mock(TailSampler.class);
+        TailSamplingProperties props = new TailSamplingProperties();
+        props.setDecisionGrace(Duration.ofSeconds(2));
+
+        when(repository.findDeferredDue(anyLong(), anyInt())).thenReturn(List.of("tx-deferred"));
+
+        TailSamplingSweeper sweeper = new TailSamplingSweeper(repository, tailSampler, props);
+        sweeper.finalizeDeferred();
+
+        verify(tailSampler).finalizeDeferred("tx-deferred");
+    }
 }

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TraceErrorsTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TraceErrorsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class TraceErrorsTest {
+
+    @Test
+    void span_cleanSpan_noError() {
+        assertThat(TraceErrors.hasError(new SpanBo())).isFalse();
+    }
+
+    @Test
+    void span_errCode_isError() {
+        SpanBo bo = new SpanBo();
+        bo.setErrCode(1);
+        assertThat(TraceErrors.hasError(bo)).isTrue();
+    }
+
+    @Test
+    void span_spanEventException_isError() {
+        SpanEventBo event = Mockito.mock(SpanEventBo.class);
+        when(event.hasException()).thenReturn(true);
+        SpanBo bo = new SpanBo();
+        bo.addSpanEventBoList(List.of(event));
+        assertThat(TraceErrors.hasError(bo)).isTrue();
+    }
+
+    @Test
+    void chunk_cleanChunk_noError() {
+        assertThat(TraceErrors.hasError(new SpanChunkBo())).isFalse();
+    }
+
+    @Test
+    void chunk_spanEventException_isError() {
+        SpanEventBo event = Mockito.mock(SpanEventBo.class);
+        when(event.hasException()).thenReturn(true);
+        SpanChunkBo bo = new SpanChunkBo();
+        bo.addSpanEventBoList(List.of(event));
+        assertThat(TraceErrors.hasError(bo)).isTrue();
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/service/ApplicationMapTraceServiceTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/service/ApplicationMapTraceServiceTest.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.navercorp.pinpoint.collector.sampling.tail;
+package com.navercorp.pinpoint.collector.service;
 
 import com.navercorp.pinpoint.collector.applicationmap.service.ApplicationMapService;
-import com.navercorp.pinpoint.collector.service.ApplicationMapTraceService;
+import com.navercorp.pinpoint.collector.sampling.tail.StatisticsTraceService;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import org.junit.jupiter.api.Test;

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/service/HbaseTraceServiceTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/service/HbaseTraceServiceTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.collector.service;
+
+import com.navercorp.pinpoint.collector.applicationmap.service.ApplicationMapService;
+import com.navercorp.pinpoint.collector.dao.TraceDao;
+import com.navercorp.pinpoint.collector.event.SpanStorePublisher;
+import com.navercorp.pinpoint.collector.scatter.service.ScatterService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.event.SpanInsertEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HbaseTraceServiceTest {
+
+    @Test
+    void insertSpan_doesNotCallApplicationMapService() {
+        TraceDao traceDao = Mockito.mock(TraceDao.class);
+        ScatterService scatterService = Mockito.mock(ScatterService.class);
+        ApplicationMapService applicationMapService = Mockito.mock(ApplicationMapService.class);
+        SpanStorePublisher publisher = Mockito.mock(SpanStorePublisher.class);
+        when(publisher.captureContext(any(SpanBo.class))).thenReturn(Mockito.mock(SpanInsertEvent.class));
+        when(traceDao.asyncInsert(any(SpanBo.class))).thenReturn(CompletableFuture.completedFuture(null));
+        Executor direct = Runnable::run;
+
+        HbaseTraceService service = new HbaseTraceService(traceDao, scatterService, applicationMapService, publisher, direct);
+        SpanBo spanBo = new SpanBo();
+
+        service.insertSpan(spanBo);
+
+        verify(traceDao).asyncInsert(spanBo);
+        verify(scatterService).insert(spanBo);
+        verify(applicationMapService, never()).insertSpan(any());
+    }
+}

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/service/HbaseTraceServiceTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/service/HbaseTraceServiceTest.java
@@ -54,4 +54,23 @@ class HbaseTraceServiceTest {
         verify(scatterService).insert(spanBo);
         verify(applicationMapService, never()).insertSpan(any());
     }
+
+    @Test
+    void insertSpanChunk_doesNotCallApplicationMapService() {
+        TraceDao traceDao = Mockito.mock(TraceDao.class);
+        ScatterService scatterService = Mockito.mock(ScatterService.class);
+        ApplicationMapService applicationMapService = Mockito.mock(ApplicationMapService.class);
+        SpanStorePublisher publisher = Mockito.mock(SpanStorePublisher.class);
+        when(publisher.captureContext(any(com.navercorp.pinpoint.common.server.bo.SpanChunkBo.class)))
+                .thenReturn(Mockito.mock(com.navercorp.pinpoint.common.server.event.SpanChunkInsertEvent.class));
+        Executor direct = Runnable::run;
+
+        HbaseTraceService service = new HbaseTraceService(traceDao, scatterService, applicationMapService, publisher, direct);
+        com.navercorp.pinpoint.common.server.bo.SpanChunkBo chunkBo = new com.navercorp.pinpoint.common.server.bo.SpanChunkBo();
+
+        service.insertSpanChunk(chunkBo);
+
+        verify(traceDao).insertSpanChunk(chunkBo);
+        verify(applicationMapService, never()).insertSpanChunk(any());
+    }
 }

--- a/commons-buffer/pom.xml
+++ b/commons-buffer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-commons-buffer</artifactId>

--- a/commons-config/pom.xml
+++ b/commons-config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-commons-config</artifactId>

--- a/commons-hbase/pom.xml
+++ b/commons-hbase/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-commons-hbase</artifactId>

--- a/commons-mapstruct-spi/pom.xml
+++ b/commons-mapstruct-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-commons-mapstruct-spi</artifactId>

--- a/commons-mybatis/pom.xml
+++ b/commons-mybatis/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-commons-mybatis</artifactId>

--- a/commons-profiler/pom.xml
+++ b/commons-profiler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-commons-profiler</artifactId>

--- a/commons-server/pom.xml
+++ b/commons-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-commons-server</artifactId>

--- a/commons-timeseries/pom.xml
+++ b/commons-timeseries/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-commons-timeseries</artifactId>

--- a/commons-timeseries/pom.xml
+++ b/commons-timeseries/pom.xml
@@ -10,6 +10,8 @@
     </parent>
 
     <artifactId>pinpoint-commons-timeseries</artifactId>
+    <name>pinpoint-commons-timeseries</name>
+    <description>pinpoint commons time-series utilities</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-commons</artifactId>

--- a/datasource/pom.xml
+++ b/datasource/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-datasource</artifactId>

--- a/docs/superpowers/plans/2026-05-29-collector-tail-sampling.md
+++ b/docs/superpowers/plans/2026-05-29-collector-tail-sampling.md
@@ -1,0 +1,2193 @@
+# 컬렉터 응답시간 기반 Tail Sampling 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 컬렉터에서 트랜잭션의 루트 응답시간(elapsed)에 따라 trace 상세 저장을 차등 샘플링하되(느린 트레이스 100% 보존), servermap·heatmap 집계는 100% 유지하는 tail-based sampling을 추가한다.
+
+**Architecture:** 모든 span을 중앙 Redis 버퍼(`buffer:{txid}`)에 적재하고, 루트 span 도착 시 `elapsed`로 밴드를 판정해 keep/drop을 결정한다. 결정 전 도착한 span은 버퍼링, 결정 후 도착한 span은 `decision:{txid}` 조회로 즉시 처리한다. 루트 미도착 트레이스는 sweeper가 buffer-ttl 경과 후 기본 keep으로 flush한다. accept/decide는 Lua 스크립트로 원자화하고, 클러스터 중복 flush는 `SET NX`로 막는다. Redis 장애 시 fail-open(전량 기록)으로 유실 0을 보장한다.
+
+**Tech Stack:** Java 17, Spring Boot 3.5.x, spring-data-redis 3.5.x + Lettuce 6.5.x, Redis Lua, Micrometer, JUnit 5 + Mockito + AssertJ + Testcontainers(Redis), Protocol Buffers(gRPC PSpan/PSpanChunk).
+
+**설계 문서:** `docs/superpowers/specs/2026-05-29-collector-tail-sampling-design.md`
+
+---
+
+## File Structure
+
+신규 패키지: `com.navercorp.pinpoint.collector.sampling.tail` (collector 모듈)
+
+| 파일 | 책임 |
+|---|---|
+| `sampling/tail/TailSamplingProperties.java` | yml 바인딩(enable, ttl, sweep, bands) + `int rateFor(long elapsedMillis)` |
+| `sampling/tail/TailSamplingProperties$Band` (정적 중첩) | `Duration maxElapsed`(nullable=catch-all), `int rate` |
+| `sampling/tail/TailDecisions.java` | `static boolean keep(String txid, int ratePercent)` 결정론적 해시 |
+| `sampling/tail/BufferedSpan.java` | 버퍼 엔벨로프 VO (type, header 4필드, requestTime, protoBytes) |
+| `sampling/tail/BufferedSpanCodec.java` | `BufferedSpan` ↔ `byte[]` 직렬화/역직렬화 |
+| `sampling/tail/ReconstructedServerHeader.java` | flush 시 `ServerHeader` 최소 복원 구현 |
+| `sampling/tail/TailSamplingRepository.java` | Redis 연동(accept/decide/findStale) — Lua eval, 바이너리 안전 |
+| `sampling/tail/StatisticsTraceService.java` | 마커 인터페이스(always 그룹: 100% 즉시) |
+| `sampling/tail/ApplicationMapTraceService.java` | servermap을 always 그룹으로 분리한 `TraceService` |
+| `sampling/tail/TailSampler.java` | 오케스트레이터: always 즉시 호출 + sampled 버퍼/결정/flush + fail-open |
+| `sampling/tail/TailSamplingSweeper.java` | `@Scheduled` 만료 트레이스 기본 keep flush |
+| `sampling/tail/TailSamplingConfiguration.java` | `@Configuration` — Redis 템플릿/스크립트/빈 와이어링, enable 토글 |
+| `resources/redis/tail-accept.lua`, `resources/redis/tail-decide.lua` | Lua 스크립트 |
+
+수정:
+- `service/HbaseTraceService.java` — appmap 호출 제거(servermap은 `ApplicationMapTraceService`로 이동), trace+scatter만 담당(sampled 그룹).
+- `heatmap/service/HeatmapService.java` — `implements StatisticsTraceService`(always 마커).
+- `handler/grpc/GrpcSpanHandler.java` / `GrpcSpanChunkHandler.java` — tail 활성 시 `TailSampler`로 라우팅(기존 샘플러 우회), 비활성 시 기존 동작.
+- `PinpointCollectorModule.java` — `@Import(TailSamplingConfiguration.class)`.
+- `collector/src/main/resources/application.yml` — `collector.sampling.tail.*` 기본값.
+- `collector/pom.xml` — spring-data-redis, lettuce-core, (test) testcontainers 의존성.
+
+---
+
+## Phase 1 — 설정 & 밴드 매칭 (순수 로직, Redis 무관)
+
+### Task 1: TailSamplingProperties + 밴드 매칭
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingPropertiesTest.java`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.junit.jupiter.api.Test;
+import java.time.Duration;
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TailSamplingPropertiesTest {
+
+    private TailSamplingProperties props() {
+        TailSamplingProperties p = new TailSamplingProperties();
+        TailSamplingProperties.Band b1 = new TailSamplingProperties.Band();
+        b1.setMaxElapsed(Duration.ofMillis(50));
+        b1.setRate(1);
+        TailSamplingProperties.Band b2 = new TailSamplingProperties.Band();
+        b2.setMaxElapsed(Duration.ofMillis(100));
+        b2.setRate(5);
+        TailSamplingProperties.Band b3 = new TailSamplingProperties.Band();
+        b3.setMaxElapsed(Duration.ofMillis(500));
+        b3.setRate(10);
+        TailSamplingProperties.Band b4 = new TailSamplingProperties.Band(); // catch-all (maxElapsed = null)
+        b4.setRate(100);
+        p.setBands(List.of(b1, b2, b3, b4));
+        return p;
+    }
+
+    @Test
+    void rateFor_matchesFirstBandByUpperBound() {
+        TailSamplingProperties p = props();
+        assertThat(p.rateFor(49)).isEqualTo(1);
+        assertThat(p.rateFor(50)).isEqualTo(5);   // 50 < 50 false -> next band
+        assertThat(p.rateFor(99)).isEqualTo(5);
+        assertThat(p.rateFor(100)).isEqualTo(10);
+        assertThat(p.rateFor(499)).isEqualTo(10);
+        assertThat(p.rateFor(500)).isEqualTo(100);
+        assertThat(p.rateFor(5000)).isEqualTo(100);
+    }
+
+    @Test
+    void rateFor_noBandMatches_defaultsToKeep100() {
+        TailSamplingProperties p = new TailSamplingProperties();
+        p.setBands(List.of()); // empty
+        assertThat(p.rateFor(10)).isEqualTo(100); // fail-safe: keep
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailSamplingPropertiesTest`
+Expected: FAIL — `TailSamplingProperties` 컴파일 불가(cannot find symbol).
+
+- [ ] **Step 3: 최소 구현**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TailSamplingProperties {
+
+    private boolean enable = false;
+    private Duration bufferTtl = Duration.ofSeconds(300);
+    private Duration sweepInterval = Duration.ofSeconds(5);
+    private Duration decisionTtl = Duration.ofSeconds(600);
+    private List<Band> bands = new ArrayList<>();
+
+    /** elapsedMillis 가 속하는 첫 밴드의 수집률(%)을 반환. 매칭 없으면 100(keep, fail-safe). */
+    public int rateFor(long elapsedMillis) {
+        for (Band band : bands) {
+            if (band.getMaxElapsed() == null) {
+                return band.getRate(); // catch-all
+            }
+            if (elapsedMillis < band.getMaxElapsed().toMillis()) {
+                return band.getRate();
+            }
+        }
+        return 100;
+    }
+
+    public boolean isEnable() { return enable; }
+    public void setEnable(boolean enable) { this.enable = enable; }
+    public Duration getBufferTtl() { return bufferTtl; }
+    public void setBufferTtl(Duration bufferTtl) { this.bufferTtl = bufferTtl; }
+    public Duration getSweepInterval() { return sweepInterval; }
+    public void setSweepInterval(Duration sweepInterval) { this.sweepInterval = sweepInterval; }
+    public Duration getDecisionTtl() { return decisionTtl; }
+    public void setDecisionTtl(Duration decisionTtl) { this.decisionTtl = decisionTtl; }
+    public List<Band> getBands() { return bands; }
+    public void setBands(List<Band> bands) { this.bands = bands; }
+
+    public static class Band {
+        private Duration maxElapsed; // null => catch-all (must be last)
+        private int rate;            // 0..100
+
+        public Duration getMaxElapsed() { return maxElapsed; }
+        public void setMaxElapsed(Duration maxElapsed) { this.maxElapsed = maxElapsed; }
+        public int getRate() { return rate; }
+        public void setRate(int rate) { this.rate = rate; }
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailSamplingPropertiesTest`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingProperties.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingPropertiesTest.java
+git commit -m "[#noissue] Add TailSamplingProperties with response-time band matching"
+```
+
+### Task 2: TailDecisions — 결정론적 keep 해시
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailDecisions.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailDecisionsTest.java`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TailDecisionsTest {
+
+    @Test
+    void rate100_alwaysKeep() {
+        assertThat(TailDecisions.keep("agent^1^1", 100)).isTrue();
+        assertThat(TailDecisions.keep("agent^1^999999", 100)).isTrue();
+    }
+
+    @Test
+    void rate0_neverKeep() {
+        assertThat(TailDecisions.keep("agent^1^1", 0)).isFalse();
+        assertThat(TailDecisions.keep("agent^1^999999", 0)).isFalse();
+    }
+
+    @Test
+    void deterministicForSameTxid() {
+        boolean first = TailDecisions.keep("agent^1^42", 10);
+        for (int i = 0; i < 100; i++) {
+            assertThat(TailDecisions.keep("agent^1^42", 10)).isEqualTo(first);
+        }
+    }
+
+    @Test
+    void approximatesRateAcrossManyTxids() {
+        int kept = 0;
+        int total = 10000;
+        for (int i = 0; i < total; i++) {
+            if (TailDecisions.keep("agent^1^" + i, 10)) {
+                kept++;
+            }
+        }
+        // 10% ± 2%p
+        assertThat(kept).isBetween((int) (total * 0.08), (int) (total * 0.12));
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailDecisionsTest`
+Expected: FAIL — cannot find symbol `TailDecisions`.
+
+- [ ] **Step 3: 최소 구현**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+public final class TailDecisions {
+
+    private TailDecisions() {
+    }
+
+    /**
+     * transactionId 기반 결정론적 keep 판정.
+     * @param ratePercent 0..100
+     */
+    public static boolean keep(String txid, int ratePercent) {
+        if (ratePercent >= 100) {
+            return true;
+        }
+        if (ratePercent <= 0) {
+            return false;
+        }
+        int bucket = Math.floorMod(txid.hashCode(), 100);
+        return bucket < ratePercent;
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailDecisionsTest`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailDecisions.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailDecisionsTest.java
+git commit -m "[#noissue] Add deterministic keep decision for tail sampling"
+```
+
+---
+
+## Phase 2 — 버퍼 엔벨로프 코덱 & 헤더 복원
+
+### Task 3: ReconstructedServerHeader
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/ReconstructedServerHeader.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/ReconstructedServerHeaderTest.java`
+
+> 바인더(`GrpcSpanBinder`)는 header에서 `getAgentId`, `getApplicationName`, `getAgentName`, `getAgentStartTime`만 사용한다. 나머지는 미사용이므로 기본값을 반환한다.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReconstructedServerHeaderTest {
+
+    @Test
+    void exposesStoredFields() {
+        ServerHeader header = new ReconstructedServerHeader("agent-1", "agent-name", "app-1", 1000L);
+        assertThat(header.getAgentId()).isEqualTo("agent-1");
+        assertThat(header.getAgentName()).isEqualTo("agent-name");
+        assertThat(header.getApplicationName()).isEqualTo("app-1");
+        assertThat(header.getAgentStartTime()).isEqualTo(1000L);
+        assertThat(header.getServiceUid().get()).isEqualTo(ServiceUid.DEFAULT);
+        assertThat(header.isGrpcBuiltInRetry()).isFalse();
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=ReconstructedServerHeaderTest`
+Expected: FAIL — cannot find symbol.
+
+- [ ] **Step 3: 최소 구현**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import org.jspecify.annotations.NonNull;
+
+import java.util.function.Supplier;
+
+/**
+ * flush 시 버퍼된 span 을 재구성하기 위한 최소 ServerHeader.
+ * GrpcSpanBinder 가 실제로 사용하는 4개 필드만 의미를 갖는다.
+ */
+public class ReconstructedServerHeader implements ServerHeader {
+
+    private final String agentId;
+    private final String agentName;
+    private final String applicationName;
+    private final long agentStartTime;
+
+    public ReconstructedServerHeader(String agentId, String agentName, String applicationName, long agentStartTime) {
+        this.agentId = agentId;
+        this.agentName = agentName;
+        this.applicationName = applicationName;
+        this.agentStartTime = agentStartTime;
+    }
+
+    @NonNull
+    @Override
+    public String getAgentId() { return agentId; }
+
+    @NonNull
+    @Override
+    public String getAgentName() { return agentName; }
+
+    @NonNull
+    @Override
+    public String getApplicationName() { return applicationName; }
+
+    @Override
+    public String getServiceName() { return null; }
+
+    @Override
+    public Supplier<ServiceUid> getServiceUid() { return () -> ServiceUid.DEFAULT; }
+
+    @Override
+    public long getAgentStartTime() { return agentStartTime; }
+
+    @Override
+    public int getServiceType() { return 0; }
+
+    @Override
+    public boolean isGrpcBuiltInRetry() { return false; }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=ReconstructedServerHeaderTest`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/ReconstructedServerHeader.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/ReconstructedServerHeaderTest.java
+git commit -m "[#noissue] Add ReconstructedServerHeader for buffered span replay"
+```
+
+### Task 4: BufferedSpan + BufferedSpanCodec
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpan.java`
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodec.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodecTest.java`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BufferedSpanCodecTest {
+
+    private final BufferedSpanCodec codec = new BufferedSpanCodec();
+
+    @Test
+    void roundTripSpan() {
+        byte[] proto = new byte[]{1, 2, 3, 4, 5};
+        BufferedSpan original = new BufferedSpan(BufferedSpan.Type.SPAN,
+                "agent-1", "agent-name", "app-1", 1000L, 2000L, proto);
+
+        byte[] encoded = codec.encode(original);
+        BufferedSpan decoded = codec.decode(encoded);
+
+        assertThat(decoded.type()).isEqualTo(BufferedSpan.Type.SPAN);
+        assertThat(decoded.agentId()).isEqualTo("agent-1");
+        assertThat(decoded.agentName()).isEqualTo("agent-name");
+        assertThat(decoded.applicationName()).isEqualTo("app-1");
+        assertThat(decoded.agentStartTime()).isEqualTo(1000L);
+        assertThat(decoded.requestTime()).isEqualTo(2000L);
+        assertThat(decoded.protoBytes()).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void roundTripChunkPreservesType() {
+        BufferedSpan original = new BufferedSpan(BufferedSpan.Type.SPAN_CHUNK,
+                "a", "n", "app", 1L, 2L, new byte[]{9});
+        BufferedSpan decoded = codec.decode(codec.encode(original));
+        assertThat(decoded.type()).isEqualTo(BufferedSpan.Type.SPAN_CHUNK);
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=BufferedSpanCodecTest`
+Expected: FAIL — cannot find symbol.
+
+- [ ] **Step 3: 최소 구현 (VO)**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+public record BufferedSpan(
+        Type type,
+        String agentId,
+        String agentName,
+        String applicationName,
+        long agentStartTime,
+        long requestTime,
+        byte[] protoBytes) {
+
+    public enum Type {
+        SPAN, SPAN_CHUNK
+    }
+}
+```
+
+- [ ] **Step 4: 최소 구현 (코덱)**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * BufferedSpan <-> byte[] 길이-프리픽스 바이너리 직렬화. Redis 버퍼 저장용.
+ */
+public class BufferedSpanCodec {
+
+    public byte[] encode(BufferedSpan span) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeByte(span.type() == BufferedSpan.Type.SPAN ? 0 : 1);
+            out.writeUTF(nullToEmpty(span.agentId()));
+            out.writeUTF(nullToEmpty(span.agentName()));
+            out.writeUTF(nullToEmpty(span.applicationName()));
+            out.writeLong(span.agentStartTime());
+            out.writeLong(span.requestTime());
+            out.writeInt(span.protoBytes().length);
+            out.write(span.protoBytes());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return baos.toByteArray();
+    }
+
+    public BufferedSpan decode(byte[] bytes) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
+            BufferedSpan.Type type = in.readByte() == 0 ? BufferedSpan.Type.SPAN : BufferedSpan.Type.SPAN_CHUNK;
+            String agentId = in.readUTF();
+            String agentName = in.readUTF();
+            String applicationName = in.readUTF();
+            long agentStartTime = in.readLong();
+            long requestTime = in.readLong();
+            int len = in.readInt();
+            byte[] proto = new byte[len];
+            in.readFully(proto);
+            return new BufferedSpan(type, agentId, agentName, applicationName, agentStartTime, requestTime, proto);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+}
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=BufferedSpanCodecTest`
+Expected: PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpan.java \
+        collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodec.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/BufferedSpanCodecTest.java
+git commit -m "[#noissue] Add BufferedSpan envelope codec for tail sampling buffer"
+```
+
+---
+
+## Phase 3 — 의존성 & Lua 스크립트 & Redis 설정
+
+### Task 5: collector 모듈에 Redis/Testcontainers 의존성 추가
+
+**Files:**
+- Modify: `collector/pom.xml`
+
+- [ ] **Step 1: 의존성 추가**
+
+`collector/pom.xml` 의 `<dependencies>` 블록에 다음을 추가한다(버전은 루트 pom `dependencyManagement` 가 관리하므로 생략).
+
+```xml
+<!-- tail sampling: redis buffer -->
+<dependency>
+    <groupId>org.springframework.data</groupId>
+    <artifactId>spring-data-redis</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.lettuce</groupId>
+    <artifactId>lettuce-core</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>testcontainers</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+- [ ] **Step 2: 의존성 해석 확인**
+
+Run: `./mvnw -pl collector dependency:resolve -q`
+Expected: BUILD SUCCESS, 에러 없이 `spring-data-redis`, `lettuce-core`, `testcontainers` 해석.
+
+> 만약 버전이 관리되지 않아 실패하면, 루트 `pom.xml` 의 `<dependencyManagement>` 에 이미 존재하는 좌표/버전을 확인한다(redis 모듈이 동일 의존성을 사용 중). 없으면 `spring-data-redis:3.5.3`, `io.lettuce:lettuce-core:6.5.2.RELEASE` 를 management 에 추가한다.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add collector/pom.xml
+git commit -m "[#noissue] Add redis and testcontainers dependencies to collector"
+```
+
+### Task 6: Lua 스크립트 작성
+
+**Files:**
+- Create: `collector/src/main/resources/redis/tail-accept.lua`
+- Create: `collector/src/main/resources/redis/tail-decide.lua`
+
+> 이 단계는 리소스 파일 생성만 한다. 동작 검증은 Task 8(Repository 통합 테스트)에서 한다.
+
+- [ ] **Step 1: tail-accept.lua 작성**
+
+`collector/src/main/resources/redis/tail-accept.lua`:
+
+```lua
+-- KEYS[1] = buffer:{txid}   (list)
+-- KEYS[2] = decision:{txid} (string)
+-- KEYS[3] = pending         (zset, global)
+-- ARGV[1] = bufferedSpanBytes
+-- ARGV[2] = txid (zset member)
+-- ARGV[3] = firstSeenMillis
+-- ARGV[4] = bufferTtlSeconds
+-- returns: "keep" | "drop" | "buffered"
+local d = redis.call('GET', KEYS[2])
+if d then
+    return d
+end
+redis.call('RPUSH', KEYS[1], ARGV[1])
+redis.call('EXPIRE', KEYS[1], ARGV[4])
+redis.call('ZADD', KEYS[3], 'NX', ARGV[3], ARGV[2])
+return 'buffered'
+```
+
+- [ ] **Step 2: tail-decide.lua 작성**
+
+`collector/src/main/resources/redis/tail-decide.lua`:
+
+```lua
+-- KEYS[1] = buffer:{txid}   (list)
+-- KEYS[2] = decision:{txid} (string)
+-- KEYS[3] = pending         (zset, global)
+-- ARGV[1] = "keep" | "drop"
+-- ARGV[2] = txid (zset member)
+-- ARGV[3] = decisionTtlSeconds
+-- returns: false 이면 이미 다른 노드가 결정함(skip).
+--          아니면 {decision, span1, span2, ...} (keep 일 때만 span 포함)
+local ok = redis.call('SET', KEYS[2], ARGV[1], 'NX', 'EX', ARGV[3])
+if not ok then
+    return false
+end
+local spans = redis.call('LRANGE', KEYS[1], 0, -1)
+redis.call('DEL', KEYS[1])
+redis.call('ZREM', KEYS[3], ARGV[2])
+local result = {ARGV[1]}
+if ARGV[1] == 'keep' then
+    for i = 1, #spans do
+        result[#result + 1] = spans[i]
+    end
+end
+return result
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add collector/src/main/resources/redis/tail-accept.lua \
+        collector/src/main/resources/redis/tail-decide.lua
+git commit -m "[#noissue] Add Lua scripts for atomic tail sampling accept/decide"
+```
+
+### Task 7: TailSamplingRedisConfig — byte[] 템플릿 & 스크립트 빈
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRedisConfig.java`
+
+> 이 단계는 빈 정의만 한다. enable 토글과 전체 와이어링은 Task 15 에서 한다. 검증은 Task 8.
+
+- [ ] **Step 1: 구현**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+@Configuration(proxyBeanMethods = false)
+public class TailSamplingRedisConfig {
+
+    @Bean("tailSamplingRedisConnectionFactory")
+    public RedisConnectionFactory tailSamplingRedisConnectionFactory(TailSamplingProperties properties) {
+        // 기본 host/port 는 spring.data.redis.* 를 따른다. 단순화를 위해 기본 LettuceConnectionFactory 사용.
+        // (host/port 커스터마이즈가 필요하면 RedisStandaloneConfiguration 으로 확장)
+        LettuceConnectionFactory factory = new LettuceConnectionFactory();
+        factory.afterPropertiesSet();
+        return factory;
+    }
+
+    @Bean("tailSamplingRedisTemplate")
+    public RedisTemplate<String, byte[]> tailSamplingRedisTemplate(
+            @org.springframework.beans.factory.annotation.Qualifier("tailSamplingRedisConnectionFactory")
+            RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(RedisSerializer.string());
+        template.setValueSerializer(RedisSerializer.byteArray());
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean("tailAcceptScript")
+    public byte[] tailAcceptScript() {
+        return loadScript("redis/tail-accept.lua");
+    }
+
+    @Bean("tailDecideScript")
+    public byte[] tailDecideScript() {
+        return loadScript("redis/tail-decide.lua");
+    }
+
+    private static byte[] loadScript(String path) {
+        try {
+            return StreamUtils.copyToByteArray(new ClassPathResource(path).getInputStream());
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to load lua script: " + path, e);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+Run: `./mvnw test-compile -pl collector -q`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRedisConfig.java
+git commit -m "[#noissue] Add redis template and lua script beans for tail sampling"
+```
+
+---
+
+## Phase 4 — TailSamplingRepository (Redis 연동, Testcontainers 검증)
+
+### Task 8: TailSamplingRepository + 통합 테스트
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepository.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepositoryIT.java`
+
+- [ ] **Step 1: 실패 테스트 작성 (Testcontainers Redis)**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class TailSamplingRepositoryIT {
+
+    @Container
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7.0")).withExposedPorts(6379);
+
+    private LettuceConnectionFactory factory;
+    private TailSamplingRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        factory = new LettuceConnectionFactory(REDIS.getHost(), REDIS.getMappedPort(6379));
+        factory.afterPropertiesSet();
+        RedisTemplate<String, byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(RedisSerializer.string());
+        template.setValueSerializer(RedisSerializer.byteArray());
+        template.afterPropertiesSet();
+
+        byte[] acceptScript = load("redis/tail-accept.lua");
+        byte[] decideScript = load("redis/tail-decide.lua");
+        repository = new TailSamplingRepository(template, acceptScript, decideScript, 300, 600);
+        template.execute((org.springframework.data.redis.core.RedisCallback<Object>) c -> {
+            c.serverCommands().flushDb();
+            return null;
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        factory.destroy();
+    }
+
+    private static byte[] load(String path) {
+        try {
+            return org.springframework.util.StreamUtils.copyToByteArray(
+                    new org.springframework.core.io.ClassPathResource(path).getInputStream());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void accept_firstTime_returnsBuffered() {
+        String r = repository.accept("tx-1", new byte[]{1}, 1000L);
+        assertThat(r).isEqualTo("buffered");
+    }
+
+    @Test
+    void decide_keep_returnsBufferedSpansAndClearsBuffer() {
+        repository.accept("tx-2", new byte[]{1}, 1000L);
+        repository.accept("tx-2", new byte[]{2}, 1000L);
+
+        List<byte[]> spans = repository.decide("tx-2", true);
+
+        assertThat(spans).hasSize(2);
+        // 결정 후 새 span 은 keep 반환
+        assertThat(repository.accept("tx-2", new byte[]{3}, 1000L)).isEqualTo("keep");
+    }
+
+    @Test
+    void decide_drop_returnsEmptyAndSubsequentAcceptDrops() {
+        repository.accept("tx-3", new byte[]{1}, 1000L);
+        List<byte[]> spans = repository.decide("tx-3", false);
+        assertThat(spans).isEmpty();
+        assertThat(repository.accept("tx-3", new byte[]{9}, 1000L)).isEqualTo("drop");
+    }
+
+    @Test
+    void decide_secondCall_returnsNull_noDoubleFlush() {
+        repository.accept("tx-4", new byte[]{1}, 1000L);
+        assertThat(repository.decide("tx-4", true)).isNotNull();
+        assertThat(repository.decide("tx-4", true)).isNull(); // 이미 결정됨
+    }
+
+    @Test
+    void findStale_returnsTxidsOlderThanThreshold() {
+        repository.accept("tx-old", new byte[]{1}, 1000L);
+        repository.accept("tx-new", new byte[]{1}, 5000L);
+        List<String> stale = repository.findStale(2000L, 100);
+        assertThat(stale).contains("tx-old").doesNotContain("tx-new");
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailSamplingRepositoryIT`
+Expected: FAIL — cannot find symbol `TailSamplingRepository`.
+
+- [ ] **Step 3: 최소 구현**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Redis 바이너리-안전 Lua eval 기반 tail sampling 저장소.
+ * 키: buffer:{txid} (list), decision:{txid} (string), pending (zset).
+ */
+public class TailSamplingRepository {
+
+    static final String BUFFER_PREFIX = "buffer:";
+    static final String DECISION_PREFIX = "decision:";
+    static final String PENDING_KEY = "pending";
+
+    private final RedisTemplate<String, byte[]> template;
+    private final byte[] acceptScript;
+    private final byte[] decideScript;
+    private final byte[] bufferTtlSeconds;
+    private final byte[] decisionTtlSeconds;
+
+    public TailSamplingRepository(RedisTemplate<String, byte[]> template,
+                                  byte[] acceptScript, byte[] decideScript,
+                                  long bufferTtlSeconds, long decisionTtlSeconds) {
+        this.template = Objects.requireNonNull(template, "template");
+        this.acceptScript = Objects.requireNonNull(acceptScript, "acceptScript");
+        this.decideScript = Objects.requireNonNull(decideScript, "decideScript");
+        this.bufferTtlSeconds = String.valueOf(bufferTtlSeconds).getBytes(StandardCharsets.UTF_8);
+        this.decisionTtlSeconds = String.valueOf(decisionTtlSeconds).getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** @return "keep" | "drop" | "buffered" */
+    public String accept(String txid, byte[] bufferedSpanBytes, long firstSeenMillis) {
+        byte[] bufferKey = key(BUFFER_PREFIX, txid);
+        byte[] decisionKey = key(DECISION_PREFIX, txid);
+        byte[] pendingKey = PENDING_KEY.getBytes(StandardCharsets.UTF_8);
+        byte[] txidBytes = txid.getBytes(StandardCharsets.UTF_8);
+        byte[] firstSeen = String.valueOf(firstSeenMillis).getBytes(StandardCharsets.UTF_8);
+
+        byte[] result = template.execute((RedisCallback<byte[]>) connection ->
+                connection.scriptingCommands().eval(acceptScript, ReturnType.VALUE, 3,
+                        bufferKey, decisionKey, pendingKey,
+                        bufferedSpanBytes, txidBytes, firstSeen, bufferTtlSeconds));
+        return result == null ? null : new String(result, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * @return null 이면 이미 다른 노드가 결정함(skip). 아니면 keep 시 버퍼된 span 바이트 목록(drop 시 빈 목록).
+     */
+    public List<byte[]> decide(String txid, boolean keep) {
+        byte[] bufferKey = key(BUFFER_PREFIX, txid);
+        byte[] decisionKey = key(DECISION_PREFIX, txid);
+        byte[] pendingKey = PENDING_KEY.getBytes(StandardCharsets.UTF_8);
+        byte[] txidBytes = txid.getBytes(StandardCharsets.UTF_8);
+        byte[] decisionValue = (keep ? "keep" : "drop").getBytes(StandardCharsets.UTF_8);
+
+        @SuppressWarnings("unchecked")
+        List<byte[]> raw = template.execute((RedisCallback<List<byte[]>>) connection ->
+                (List<byte[]>) (List<?>) connection.scriptingCommands().eval(decideScript, ReturnType.MULTI, 3,
+                        bufferKey, decisionKey, pendingKey,
+                        decisionValue, txidBytes, decisionTtlSeconds));
+
+        if (raw == null || raw.isEmpty()) {
+            return null; // SET NX 실패 = 이미 결정됨
+        }
+        // raw[0] = decision marker, 이후가 span 들
+        List<byte[]> spans = new ArrayList<>(raw.size() - 1);
+        for (int i = 1; i < raw.size(); i++) {
+            spans.add(raw.get(i));
+        }
+        return spans;
+    }
+
+    /** firstSeen <= thresholdMillis 인 미결정 txid 목록(최대 limit). */
+    public List<String> findStale(long thresholdMillis, int limit) {
+        java.util.Set<byte[]> members = template.execute((RedisCallback<java.util.Set<byte[]>>) connection ->
+                connection.zSetCommands().zRangeByScore(
+                        PENDING_KEY.getBytes(StandardCharsets.UTF_8),
+                        org.springframework.data.domain.Range.closed(0d, (double) thresholdMillis),
+                        org.springframework.data.redis.connection.Limit.limit().count(limit)));
+        List<String> result = new ArrayList<>();
+        if (members != null) {
+            for (byte[] m : members) {
+                result.add(new String(m, StandardCharsets.UTF_8));
+            }
+        }
+        return result;
+    }
+
+    private static byte[] key(String prefix, String txid) {
+        return (prefix + txid).getBytes(StandardCharsets.UTF_8);
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailSamplingRepositoryIT`
+Expected: PASS (Docker 필요; 5개 테스트 통과)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepository.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingRepositoryIT.java
+git commit -m "[#noissue] Add TailSamplingRepository with atomic Lua accept/decide/findStale"
+```
+
+---
+
+## Phase 5 — always/sampled TraceService 분리
+
+### Task 9: StatisticsTraceService 마커 + HeatmapService 적용
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/StatisticsTraceService.java`
+- Modify: `collector/src/main/java/com/navercorp/pinpoint/collector/heatmap/service/HeatmapService.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/StatisticsTraceServiceTest.java`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.heatmap.service.HeatmapService;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StatisticsTraceServiceTest {
+
+    @Test
+    void heatmapServiceIsStatisticsTraceService() {
+        assertThat(StatisticsTraceService.class)
+                .isAssignableFrom(HeatmapService.class);
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=StatisticsTraceServiceTest`
+Expected: FAIL — cannot find symbol `StatisticsTraceService` 또는 assignable 실패.
+
+- [ ] **Step 3: 마커 인터페이스 생성**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.service.TraceService;
+
+/**
+ * 항상 100% 즉시 처리되어야 하는 집계성 TraceService 마커.
+ * tail sampling 의 버퍼/결정 게이트를 거치지 않는다. (servermap, heatmap)
+ */
+public interface StatisticsTraceService extends TraceService {
+}
+```
+
+- [ ] **Step 4: HeatmapService 에 마커 적용**
+
+`HeatmapService.java` 의 클래스 선언을 수정:
+
+```java
+// import 추가
+import com.navercorp.pinpoint.collector.sampling.tail.StatisticsTraceService;
+
+// 변경 전: public class HeatmapService implements TraceService {
+// 변경 후:
+@Service
+public class HeatmapService implements StatisticsTraceService {
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=StatisticsTraceServiceTest`
+Expected: PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/StatisticsTraceService.java \
+        collector/src/main/java/com/navercorp/pinpoint/collector/heatmap/service/HeatmapService.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/StatisticsTraceServiceTest.java
+git commit -m "[#noissue] Mark HeatmapService as always-on StatisticsTraceService"
+```
+
+### Task 10: ApplicationMapTraceService 분리 + HbaseTraceService 에서 appmap 제거
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/service/ApplicationMapTraceService.java`
+- Modify: `collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/ApplicationMapTraceServiceTest.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/service/HbaseTraceServiceTest.java`
+
+> servermap 집계를 always 그룹으로 옮긴다. **중요:** `ApplicationMapTraceService` 는 `com.navercorp.pinpoint.collector.service` 패키지(이미 `@ComponentScan` 대상)에 두어 **tail 활성화 여부와 무관하게 항상 빈으로 등록**되게 한다. (tail OFF 시 핸들러가 모든 TraceService 를 순회하므로 servermap 이 그대로 호출되어야 한다.) `sampling.tail` 패키지는 스캔 대상이 아니므로 거기에 두면 안 된다.
+
+- [ ] **Step 1: ApplicationMapTraceService 실패 테스트 작성**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.applicationmap.service.ApplicationMapService;
+import com.navercorp.pinpoint.collector.service.ApplicationMapTraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.verify;
+
+class ApplicationMapTraceServiceTest {
+
+    @Test
+    void insertSpanDelegatesToApplicationMapService() {
+        ApplicationMapService delegate = Mockito.mock(ApplicationMapService.class);
+        ApplicationMapTraceService service = new ApplicationMapTraceService(delegate);
+        SpanBo spanBo = new SpanBo();
+
+        service.insertSpan(spanBo);
+
+        verify(delegate).insertSpan(spanBo);
+    }
+
+    @Test
+    void insertSpanChunkDelegatesToApplicationMapService() {
+        ApplicationMapService delegate = Mockito.mock(ApplicationMapService.class);
+        ApplicationMapTraceService service = new ApplicationMapTraceService(delegate);
+        SpanChunkBo chunkBo = new SpanChunkBo();
+
+        service.insertSpanChunk(chunkBo);
+
+        verify(delegate).insertSpanChunk(chunkBo);
+    }
+
+    @Test
+    void isStatisticsTraceService() {
+        org.assertj.core.api.Assertions.assertThat(StatisticsTraceService.class)
+                .isAssignableFrom(ApplicationMapTraceService.class);
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=ApplicationMapTraceServiceTest`
+Expected: FAIL — cannot find symbol `ApplicationMapTraceService`.
+
+- [ ] **Step 3: ApplicationMapTraceService 구현**
+
+```java
+package com.navercorp.pinpoint.collector.service;
+
+import com.navercorp.pinpoint.collector.applicationmap.service.ApplicationMapService;
+import com.navercorp.pinpoint.collector.sampling.tail.StatisticsTraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+/**
+ * servermap 집계를 always 그룹(100% 즉시)으로 분리한 TraceService.
+ * 이전에는 HbaseTraceService 내부에서 호출되었다.
+ * com.navercorp.pinpoint.collector.service 패키지(@ComponentScan 대상)에 두어
+ * tail 활성화 여부와 무관하게 항상 빈으로 등록된다.
+ */
+@Service
+public class ApplicationMapTraceService implements StatisticsTraceService {
+
+    private final ApplicationMapService applicationMapService;
+
+    public ApplicationMapTraceService(ApplicationMapService applicationMapService) {
+        this.applicationMapService = Objects.requireNonNull(applicationMapService, "applicationMapService");
+    }
+
+    @Override
+    public void insertSpan(SpanBo spanBo) {
+        this.applicationMapService.insertSpan(spanBo);
+    }
+
+    @Override
+    public void insertSpanChunk(SpanChunkBo spanChunkBo) {
+        this.applicationMapService.insertSpanChunk(spanChunkBo);
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=ApplicationMapTraceServiceTest`
+Expected: PASS
+
+- [ ] **Step 5: HbaseTraceService 에서 appmap 제거 — 실패 테스트 작성**
+
+`HbaseTraceServiceTest.java`:
+
+```java
+package com.navercorp.pinpoint.collector.service;
+
+import com.navercorp.pinpoint.collector.applicationmap.service.ApplicationMapService;
+import com.navercorp.pinpoint.collector.dao.TraceDao;
+import com.navercorp.pinpoint.collector.event.SpanStorePublisher;
+import com.navercorp.pinpoint.collector.scatter.service.ScatterService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.event.SpanInsertEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HbaseTraceServiceTest {
+
+    @Test
+    void insertSpan_doesNotCallApplicationMapService() {
+        TraceDao traceDao = Mockito.mock(TraceDao.class);
+        ScatterService scatterService = Mockito.mock(ScatterService.class);
+        ApplicationMapService applicationMapService = Mockito.mock(ApplicationMapService.class);
+        SpanStorePublisher publisher = Mockito.mock(SpanStorePublisher.class);
+        when(publisher.captureContext(any(SpanBo.class))).thenReturn(Mockito.mock(SpanInsertEvent.class));
+        when(traceDao.asyncInsert(any(SpanBo.class))).thenReturn(CompletableFuture.completedFuture(null));
+        Executor direct = Runnable::run;
+
+        HbaseTraceService service = new HbaseTraceService(traceDao, scatterService, applicationMapService, publisher, direct);
+        SpanBo spanBo = new SpanBo();
+
+        service.insertSpan(spanBo);
+
+        verify(traceDao).asyncInsert(spanBo);
+        verify(scatterService).insert(spanBo);
+        verify(applicationMapService, never()).insertSpan(any());
+    }
+}
+```
+
+- [ ] **Step 6: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=HbaseTraceServiceTest`
+Expected: FAIL — `applicationMapService.insertSpan` 이 호출되어 `never()` 위반.
+
+- [ ] **Step 7: HbaseTraceService 수정 — appmap 호출 제거**
+
+`HbaseTraceService.insertSpan` 에서 `this.applicationMapService.insertSpan(spanBo);` 줄 삭제.
+`HbaseTraceService.insertSpanChunk` 에서 `this.applicationMapService.insertSpanChunk(spanChunkBo);` 줄 삭제.
+
+> 생성자의 `applicationMapService` 파라미터와 필드는 **유지**한다(테스트 호환 및 향후 참조). 사용하지 않는 경고가 거슬리면 필드를 제거하고 생성자에서도 제거하되, 이 경우 위 테스트의 생성자 인자도 함께 수정한다. 본 계획은 필드 유지를 택한다.
+
+수정 후 `insertSpan`:
+
+```java
+@Override
+public void insertSpan(final SpanBo spanBo) {
+    SpanInsertEvent event = publisher.captureContext(spanBo);
+
+    CompletableFuture<Void> future = traceDao.asyncInsert(spanBo);
+
+    this.scatterService.insert(spanBo);
+
+    future.whenCompleteAsync((unused, throwable) -> {
+        final boolean result = throwable == null;
+        if (logger.isTraceEnabled()) {
+            logger.trace("success {}", result);
+        }
+        publisher.publishEvent(event, result);
+    }, grpcSpanServerExecutor);
+}
+```
+
+수정 후 `insertSpanChunk`:
+
+```java
+@Override
+public void insertSpanChunk(final SpanChunkBo spanChunkBo) {
+    SpanChunkInsertEvent event = publisher.captureContext(spanChunkBo);
+
+    this.traceDao.insertSpanChunk(spanChunkBo);
+
+    // TODO should be able to tell whether the span chunk is successfully inserted
+    publisher.publishEvent(event, true);
+}
+```
+
+- [ ] **Step 8: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=HbaseTraceServiceTest,ApplicationMapTraceServiceTest`
+Expected: PASS
+
+- [ ] **Step 9: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/service/ApplicationMapTraceService.java \
+        collector/src/main/java/com/navercorp/pinpoint/collector/service/HbaseTraceService.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/ApplicationMapTraceServiceTest.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/service/HbaseTraceServiceTest.java
+git commit -m "[#noissue] Split servermap into always-on ApplicationMapTraceService"
+```
+
+---
+
+## Phase 6 — TailSampler 오케스트레이터
+
+### Task 11: TailSampler — always 즉시 + sampled 버퍼/결정/flush + fail-open
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java`
+
+> 의존: `TraceService[]`(always/sampled 분류), `TailSamplingRepository`, `TailSamplingProperties`, `BufferedSpanCodec`, `GrpcSpanFactory`, `MeterRegistry`.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TailSamplerTest {
+
+    private StatisticsTraceService always;
+    private TraceService sampled;
+    private TailSamplingRepository repository;
+    private GrpcSpanFactory factory;
+    private TailSampler tailSampler;
+
+    @BeforeEach
+    void setUp() {
+        always = Mockito.mock(StatisticsTraceService.class);
+        sampled = Mockito.mock(TraceService.class);
+        repository = Mockito.mock(TailSamplingRepository.class);
+        factory = Mockito.mock(GrpcSpanFactory.class);
+        TailSamplingProperties props = new TailSamplingProperties();
+        props.setBands(List.of()); // rateFor -> 100
+
+        tailSampler = new TailSampler(
+                new TraceService[]{always, sampled},
+                repository, props, new BufferedSpanCodec(), factory, new SimpleMeterRegistry());
+    }
+
+    private SpanBo rootSpan(int elapsed) {
+        SpanBo bo = new SpanBo();
+        bo.setTransactionId(new PinpointServerTraceId("agent", 1L, 100L));
+        bo.setParentSpanId(-1L); // root
+        bo.setElapsed(elapsed);
+        bo.setAgentId("agent");
+        bo.setApplicationName("app");
+        bo.setAgentName("agentName");
+        return bo;
+    }
+
+    @Test
+    void alwaysGroupCalledImmediately_regardlessOfDecision() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+        SpanBo bo = rootSpan(10);
+
+        tailSampler.acceptSpan(bo, new byte[]{1});
+
+        verify(always).insertSpan(bo);
+    }
+
+    @Test
+    void decisionDrop_sampledNotWritten() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("drop");
+        SpanBo bo = rootSpan(10);
+
+        tailSampler.acceptSpan(bo, new byte[]{1});
+
+        verify(sampled, never()).insertSpan(any());
+        verify(always).insertSpan(bo); // always 는 항상
+    }
+
+    @Test
+    void decisionKeep_writesThroughToSampledLive() {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("keep");
+        SpanBo bo = rootSpan(10);
+
+        tailSampler.acceptSpan(bo, new byte[]{1});
+
+        verify(sampled).insertSpan(bo);
+    }
+
+    @Test
+    void rootBuffered_triggersDecide_andReplaysKeptSpans() throws Exception {
+        when(repository.accept(anyString(), any(), anyLong())).thenReturn("buffered");
+        // props rateFor=100 -> keep=true
+        BufferedSpan buffered = new BufferedSpan(BufferedSpan.Type.SPAN,
+                "agent", "agentName", "app", 1L, 2L, new byte[]{7});
+        byte[] encoded = new BufferedSpanCodec().encode(buffered);
+        when(repository.decide(anyString(), org.mockito.ArgumentMatchers.eq(true)))
+                .thenReturn(List.of(encoded));
+        SpanBo rebuilt = new SpanBo();
+        when(factory.buildSpanBo(any(), any(), anyLong())).thenReturn(rebuilt);
+
+        tailSampler.acceptSpan(rootSpan(10), new byte[]{1});
+
+        verify(sampled).insertSpan(rebuilt);
+    }
+
+    @Test
+    void redisFailure_failsOpen_writesSampledLive() {
+        when(repository.accept(anyString(), any(), anyLong()))
+                .thenThrow(new RuntimeException("redis down"));
+        SpanBo bo = rootSpan(10);
+
+        tailSampler.acceptSpan(bo, new byte[]{1});
+
+        verify(always).insertSpan(bo);
+        verify(sampled).insertSpan(bo); // fail-open
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailSamplerTest`
+Expected: FAIL — cannot find symbol `TailSampler`.
+
+- [ ] **Step 3: 최소 구현**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.grpc.trace.PSpan;
+import com.navercorp.pinpoint.grpc.trace.PSpanChunk;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class TailSampler {
+
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    private final TraceService[] alwaysServices;
+    private final TraceService[] sampledServices;
+    private final TailSamplingRepository repository;
+    private final TailSamplingProperties properties;
+    private final BufferedSpanCodec codec;
+    private final GrpcSpanFactory spanFactory;
+
+    private final Counter keptCounter;
+    private final Counter droppedCounter;
+    private final Counter bufferedCounter;
+    private final Counter redisErrorCounter;
+
+    public TailSampler(TraceService[] traceServices,
+                       TailSamplingRepository repository,
+                       TailSamplingProperties properties,
+                       BufferedSpanCodec codec,
+                       GrpcSpanFactory spanFactory,
+                       MeterRegistry meterRegistry) {
+        this.repository = Objects.requireNonNull(repository, "repository");
+        this.properties = Objects.requireNonNull(properties, "properties");
+        this.codec = Objects.requireNonNull(codec, "codec");
+        this.spanFactory = Objects.requireNonNull(spanFactory, "spanFactory");
+
+        List<TraceService> always = new ArrayList<>();
+        List<TraceService> sampled = new ArrayList<>();
+        for (TraceService ts : traceServices) {
+            if (ts instanceof StatisticsTraceService) {
+                always.add(ts);
+            } else {
+                sampled.add(ts);
+            }
+        }
+        this.alwaysServices = always.toArray(new TraceService[0]);
+        this.sampledServices = sampled.toArray(new TraceService[0]);
+
+        this.keptCounter = meterRegistry.counter("collector.tail.sampling", "result", "kept");
+        this.droppedCounter = meterRegistry.counter("collector.tail.sampling", "result", "dropped");
+        this.bufferedCounter = meterRegistry.counter("collector.tail.sampling", "result", "buffered");
+        this.redisErrorCounter = meterRegistry.counter("collector.tail.sampling", "result", "redis-error");
+    }
+
+    public void acceptSpan(SpanBo spanBo, byte[] protoBytes) {
+        // always 그룹은 항상 100% 즉시 (servermap, heatmap)
+        for (TraceService ts : alwaysServices) {
+            ts.insertSpan(spanBo);
+        }
+
+        final String txid = spanBo.getTransactionId().toString();
+        try {
+            byte[] envelope = codec.encode(new BufferedSpan(BufferedSpan.Type.SPAN,
+                    spanBo.getAgentId(), spanBo.getAgentName(), spanBo.getApplicationName(),
+                    spanBo.getAgentStartTime(), spanBo.getCollectorAcceptTime(), protoBytes));
+            String decision = repository.accept(txid, envelope, System.currentTimeMillis());
+
+            if ("keep".equals(decision)) {
+                keptCounter.increment();
+                insertSampledSpanLive(spanBo);
+            } else if ("drop".equals(decision)) {
+                droppedCounter.increment();
+                // discard
+            } else { // buffered
+                bufferedCounter.increment();
+                if (spanBo.isRoot()) {
+                    decideAndFlush(txid, spanBo.getElapsed());
+                }
+            }
+        } catch (Exception e) {
+            redisErrorCounter.increment();
+            logger.warn("tail sampling redis error, fail-open write-through. txid={}", txid, e);
+            insertSampledSpanLive(spanBo); // fail-open
+        }
+    }
+
+    public void acceptSpanChunk(SpanChunkBo spanChunkBo, byte[] protoBytes) {
+        for (TraceService ts : alwaysServices) {
+            ts.insertSpanChunk(spanChunkBo);
+        }
+
+        final String txid = spanChunkBo.getTransactionId().toString();
+        try {
+            byte[] envelope = codec.encode(new BufferedSpan(BufferedSpan.Type.SPAN_CHUNK,
+                    spanChunkBo.getAgentId(), null, spanChunkBo.getApplicationName(),
+                    spanChunkBo.getAgentStartTime(), spanChunkBo.getCollectorAcceptTime(), protoBytes));
+            String decision = repository.accept(txid, envelope, System.currentTimeMillis());
+
+            if ("keep".equals(decision)) {
+                insertSampledSpanChunkLive(spanChunkBo);
+            } else if ("drop".equals(decision)) {
+                // discard
+            }
+            // chunk 는 결정 트리거 아님(root 아님) -> buffered 면 대기
+        } catch (Exception e) {
+            redisErrorCounter.increment();
+            logger.warn("tail sampling redis error (chunk), fail-open. txid={}", txid, e);
+            insertSampledSpanChunkLive(spanChunkBo);
+        }
+    }
+
+    private void decideAndFlush(String txid, int elapsedMillis) {
+        int rate = properties.rateFor(elapsedMillis);
+        boolean keep = TailDecisions.keep(txid, rate);
+        List<byte[]> won = repository.decide(txid, keep);
+        if (won == null) {
+            return; // 다른 노드가 이미 처리
+        }
+        if (keep) {
+            keptCounter.increment();
+            replay(won);
+        } else {
+            droppedCounter.increment();
+        }
+    }
+
+    /** 버퍼된 엔벨로프들을 재구성해 sampled 그룹에 기록. */
+    void replay(List<byte[]> encodedSpans) {
+        for (byte[] encoded : encodedSpans) {
+            BufferedSpan buffered = codec.decode(encoded);
+            ServerHeader header = new ReconstructedServerHeader(
+                    buffered.agentId(), buffered.agentName(), buffered.applicationName(), buffered.agentStartTime());
+            try {
+                if (buffered.type() == BufferedSpan.Type.SPAN) {
+                    SpanBo bo = spanFactory.buildSpanBo(PSpan.parseFrom(buffered.protoBytes()), header, buffered.requestTime());
+                    insertSampledSpanLive(bo);
+                } else {
+                    SpanChunkBo bo = spanFactory.buildSpanChunkBo(PSpanChunk.parseFrom(buffered.protoBytes()), header, buffered.requestTime());
+                    insertSampledSpanChunkLive(bo);
+                }
+            } catch (Exception e) {
+                logger.warn("failed to replay buffered span", e);
+            }
+        }
+    }
+
+    private void insertSampledSpanLive(SpanBo spanBo) {
+        for (TraceService ts : sampledServices) {
+            ts.insertSpan(spanBo);
+        }
+    }
+
+    private void insertSampledSpanChunkLive(SpanChunkBo spanChunkBo) {
+        for (TraceService ts : sampledServices) {
+            ts.insertSpanChunk(spanChunkBo);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailSamplerTest`
+Expected: PASS (5개 통과)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSampler.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplerTest.java
+git commit -m "[#noissue] Add TailSampler orchestrator with fail-open write-through"
+```
+
+---
+
+## Phase 7 — Sweeper
+
+### Task 12: TailSamplingSweeper — 만료 트레이스 기본 keep flush
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeper.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeperTest.java`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TailSamplingSweeperTest {
+
+    @Test
+    void sweep_forcesKeepDecisionForStaleTxids_andReplays() {
+        TailSamplingRepository repository = Mockito.mock(TailSamplingRepository.class);
+        TailSampler tailSampler = Mockito.mock(TailSampler.class);
+        TailSamplingProperties props = new TailSamplingProperties();
+        props.setBufferTtl(Duration.ofSeconds(300));
+
+        when(repository.findStale(anyLong(), anyInt())).thenReturn(List.of("tx-stale"));
+        List<byte[]> spans = List.of(new byte[]{1});
+        when(repository.decide(eq("tx-stale"), eq(true))).thenReturn(spans);
+
+        TailSamplingSweeper sweeper = new TailSamplingSweeper(repository, tailSampler, props);
+        sweeper.sweep();
+
+        verify(repository).decide("tx-stale", true); // 기본 keep
+        verify(tailSampler).replay(spans);
+    }
+
+    @Test
+    void sweep_skipsWhenDecideReturnsNull() {
+        TailSamplingRepository repository = Mockito.mock(TailSamplingRepository.class);
+        TailSampler tailSampler = Mockito.mock(TailSampler.class);
+        TailSamplingProperties props = new TailSamplingProperties();
+
+        when(repository.findStale(anyLong(), anyInt())).thenReturn(List.of("tx-x"));
+        when(repository.decide(eq("tx-x"), eq(true))).thenReturn(null); // 다른 노드 선점
+
+        TailSamplingSweeper sweeper = new TailSamplingSweeper(repository, tailSampler, props);
+        sweeper.sweep();
+
+        verify(tailSampler, Mockito.never()).replay(Mockito.any());
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailSamplingSweeperTest`
+Expected: FAIL — cannot find symbol `TailSamplingSweeper`.
+
+- [ ] **Step 3: 최소 구현**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 루트가 끝내 도착하지 않은 트레이스를 buffer-ttl 경과 후 기본 keep 으로 flush.
+ * 클러스터에서 다수 인스턴스가 동시에 돌아도 decide()의 SET NX 로 1회만 flush 된다.
+ */
+public class TailSamplingSweeper {
+
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    private static final int BATCH_LIMIT = 500;
+
+    private final TailSamplingRepository repository;
+    private final TailSampler tailSampler;
+    private final TailSamplingProperties properties;
+
+    public TailSamplingSweeper(TailSamplingRepository repository,
+                               TailSampler tailSampler,
+                               TailSamplingProperties properties) {
+        this.repository = Objects.requireNonNull(repository, "repository");
+        this.tailSampler = Objects.requireNonNull(tailSampler, "tailSampler");
+        this.properties = Objects.requireNonNull(properties, "properties");
+    }
+
+    @Scheduled(fixedDelayString = "${collector.sampling.tail.sweep-interval:5s}")
+    public void sweep() {
+        try {
+            long threshold = System.currentTimeMillis() - properties.getBufferTtl().toMillis();
+            List<String> stale = repository.findStale(threshold, BATCH_LIMIT);
+            for (String txid : stale) {
+                List<byte[]> won = repository.decide(txid, true); // 기본 keep
+                if (won != null) {
+                    tailSampler.replay(won);
+                }
+            }
+            if (!stale.isEmpty() && logger.isInfoEnabled()) {
+                logger.info("tail sampling sweeper flushed {} stale traces (default keep)", stale.size());
+            }
+        } catch (Exception e) {
+            logger.warn("tail sampling sweeper error", e);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailSamplingSweeperTest`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeper.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingSweeperTest.java
+git commit -m "[#noissue] Add TailSamplingSweeper for orphaned-trace default-keep flush"
+```
+
+---
+
+## Phase 8 — 와이어링 & 핸들러 통합 & 설정
+
+### Task 13: TailSamplingConfiguration — 빈 조립 (enable 토글)
+
+**Files:**
+- Create: `collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingConfiguration.java`
+
+> `collector.sampling.tail.enable=true` 일 때만 활성화. `TraceService[]`, `GrpcSpanFactory`, `MeterRegistry` 는 collector 컨텍스트에 이미 존재. `ApplicationMapTraceService`(service 패키지)/`HeatmapService`(HeatmapCollectorModule) 는 tail 비활성 시에도 항상 빈으로 등록되므로 이 Configuration 에서 등록하지 않는다. 이 Configuration 은 tail 전용 빈(Redis/codec/repository/sampler/sweeper)만 조립한다.
+
+- [ ] **Step 1: 구현**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(prefix = "collector.sampling.tail", name = "enable", havingValue = "true")
+@EnableConfigurationProperties
+@EnableScheduling
+@Import(TailSamplingRedisConfig.class)
+public class TailSamplingConfiguration {
+
+    @Bean
+    @org.springframework.boot.context.properties.ConfigurationProperties(prefix = "collector.sampling.tail")
+    public TailSamplingProperties tailSamplingProperties() {
+        return new TailSamplingProperties();
+    }
+
+    @Bean
+    public BufferedSpanCodec bufferedSpanCodec() {
+        return new BufferedSpanCodec();
+    }
+
+    @Bean
+    public TailSamplingRepository tailSamplingRepository(
+            @Qualifier("tailSamplingRedisTemplate") RedisTemplate<String, byte[]> redisTemplate,
+            @Qualifier("tailAcceptScript") byte[] acceptScript,
+            @Qualifier("tailDecideScript") byte[] decideScript,
+            TailSamplingProperties properties) {
+        return new TailSamplingRepository(redisTemplate, acceptScript, decideScript,
+                properties.getBufferTtl().toSeconds(), properties.getDecisionTtl().toSeconds());
+    }
+
+    @Bean
+    public TailSampler tailSampler(TraceService[] traceServices,
+                                   TailSamplingRepository repository,
+                                   TailSamplingProperties properties,
+                                   BufferedSpanCodec codec,
+                                   GrpcSpanFactory spanFactory,
+                                   MeterRegistry meterRegistry) {
+        return new TailSampler(traceServices, repository, properties, codec, spanFactory, meterRegistry);
+    }
+
+    @Bean
+    public TailSamplingSweeper tailSamplingSweeper(TailSamplingRepository repository,
+                                                   TailSampler tailSampler,
+                                                   TailSamplingProperties properties) {
+        return new TailSamplingSweeper(repository, tailSampler, properties);
+    }
+}
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+Run: `./mvnw test-compile -pl collector -q`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingConfiguration.java
+git commit -m "[#noissue] Wire tail sampling beans behind enable toggle"
+```
+
+### Task 14: 핸들러 통합 — tail 활성 시 라우팅
+
+**Files:**
+- Modify: `collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanHandler.java`
+- Modify: `collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanChunkHandler.java`
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanHandlerTailTest.java`
+
+> `ObjectProvider<TailSampler>` 로 선택적 주입. tail 빈이 없으면(비활성) 기존 동작 유지. 있으면 기존 per-span 샘플러 우회 후 `TailSampler` 로 라우팅.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```java
+package com.navercorp.pinpoint.collector.handler.grpc;
+
+import com.navercorp.pinpoint.collector.sampler.SpanSamplerFactory;
+import com.navercorp.pinpoint.collector.sampler.TrueSampler;
+import com.navercorp.pinpoint.collector.sampling.tail.TailSampler;
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.common.server.io.ServerRequest;
+import com.navercorp.pinpoint.grpc.trace.PSpan;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.ObjectProvider;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GrpcSpanHandlerTailTest {
+
+    @Test
+    void whenTailEnabled_routesToTailSampler_bypassingTraceServiceLoop() {
+        TraceService traceService = Mockito.mock(TraceService.class);
+        GrpcSpanFactory factory = Mockito.mock(GrpcSpanFactory.class);
+        SpanSamplerFactory samplerFactory = Mockito.mock(SpanSamplerFactory.class);
+        when(samplerFactory.createBasicSpanSampler()).thenReturn(TrueSampler.instance());
+        TailSampler tailSampler = Mockito.mock(TailSampler.class);
+
+        @SuppressWarnings("unchecked")
+        ObjectProvider<TailSampler> provider = Mockito.mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(tailSampler);
+
+        SpanBo spanBo = new SpanBo();
+        when(factory.buildSpanBo(any(), any(), org.mockito.ArgumentMatchers.anyLong())).thenReturn(spanBo);
+
+        @SuppressWarnings("unchecked")
+        ServerRequest<PSpan> request = Mockito.mock(ServerRequest.class);
+        when(request.getData()).thenReturn(PSpan.getDefaultInstance());
+        when(request.getHeader()).thenReturn(Mockito.mock(ServerHeader.class));
+        when(request.getRequestTime()).thenReturn(123L);
+
+        GrpcSpanHandler handler = new GrpcSpanHandler(
+                new TraceService[]{traceService}, factory, samplerFactory, provider);
+        handler.handleSimple(request);
+
+        verify(tailSampler).acceptSpan(org.mockito.ArgumentMatchers.eq(spanBo), any(byte[].class));
+        verify(traceService, never()).insertSpan(any()); // 기존 루프 우회
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `./mvnw test -pl collector -Dtest=GrpcSpanHandlerTailTest`
+Expected: FAIL — `GrpcSpanHandler` 생성자에 `ObjectProvider<TailSampler>` 인자 없음.
+
+- [ ] **Step 3: GrpcSpanHandler 수정**
+
+import 추가:
+
+```java
+import com.navercorp.pinpoint.collector.sampling.tail.TailSampler;
+import org.springframework.beans.factory.ObjectProvider;
+```
+
+필드/생성자 수정:
+
+```java
+private final TailSampler tailSampler; // nullable
+
+public GrpcSpanHandler(TraceService[] traceServices, GrpcSpanFactory spanFactory,
+                       SpanSamplerFactory spanSamplerFactory,
+                       ObjectProvider<TailSampler> tailSamplerProvider) {
+    this.traceServices = Objects.requireNonNull(traceServices, "traceServices");
+    this.spanFactory = Objects.requireNonNull(spanFactory, "spanFactory");
+    this.sampler = spanSamplerFactory.createBasicSpanSampler();
+    this.tailSampler = tailSamplerProvider.getIfAvailable();
+
+    logger.info("TraceServices {}, tailSampling={}", Arrays.toString(traceServices), tailSampler != null);
+}
+```
+
+`handleSpan` 의 SpanBo 빌드 직후 분기 추가:
+
+```java
+private void handleSpan(PSpan span, ServerHeader serverHeader, long requestTime) {
+    if (isDebug) {
+        logger.debug("Handle {} {}", serverHeader, createSimpleSpanLog(span));
+    }
+
+    final SpanBo spanBo = spanFactory.buildSpanBo(span, serverHeader, requestTime);
+
+    // tail sampling: 활성 시 기존 per-span 샘플러를 우회하고 TailSampler 로 라우팅
+    if (tailSampler != null) {
+        try {
+            tailSampler.acceptSpan(spanBo, span.toByteArray());
+        } catch (Throwable e) {
+            logger.warn("Failed to tail-sample Span {} {}", serverHeader, MessageFormatUtils.debugLog(span), e);
+        }
+        return;
+    }
+
+    if (!sampler.isSampling(spanBo)) {
+        if (isDebug) {
+            logger.debug("Unsampled {} {}", serverHeader, createSimpleSpanLog(span));
+        } else {
+            infoLog.log(() -> {
+                if (logger.isInfoEnabled()) {
+                    logger.info("Unsampled {} {}", serverHeader, createSimpleSpanLog(span));
+                }
+            });
+        }
+        return;
+    }
+    for (TraceService traceService : traceServices) {
+        try {
+            traceService.insertSpan(spanBo);
+        } catch (RequestNotPermittedException notPermitted) {
+            warnLog.log((c) -> logger.warn("Failed to handle Span {} RequestNotPermitted:{} {}", serverHeader, notPermitted.getMessage(), c));
+        } catch (Throwable e) {
+            logger.warn("Failed to handle {} {}", serverHeader, MessageFormatUtils.debugLog(span), e);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: GrpcSpanChunkHandler 동일 패턴 수정**
+
+import 추가(`TailSampler`, `ObjectProvider`). 생성자에 `ObjectProvider<TailSampler> tailSamplerProvider` 추가하고 `this.tailSampler = tailSamplerProvider.getIfAvailable();`. `handleSpanChunk` 의 `spanChunkBo` 빌드 직후:
+
+```java
+final SpanChunkBo spanChunkBo = spanFactory.buildSpanChunkBo(spanChunk, header, requestTime);
+
+if (tailSampler != null) {
+    try {
+        tailSampler.acceptSpanChunk(spanChunkBo, spanChunk.toByteArray());
+    } catch (Throwable e) {
+        logger.warn("Failed to tail-sample SpanChunk {} {}", header, MessageFormatUtils.debugLog(spanChunk), e);
+    }
+    return;
+}
+// ... 기존 sampler/loop 유지
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=GrpcSpanHandlerTailTest`
+Expected: PASS
+
+> 기존 핸들러 테스트가 생성자 시그니처 변경으로 깨질 수 있다. 깨지면 해당 테스트의 `new GrpcSpanHandler(...)` 호출에 4번째 인자로 빈 provider 를 추가한다:
+> `org.springframework.beans.factory.support.StaticListableBeanFactory` 대신 간단히 mock: `Mockito.mock(ObjectProvider.class)` 에 `getIfAvailable()` → null 스텁.
+
+- [ ] **Step 6: 전체 collector 컴파일/기존 핸들러 테스트 회귀 확인**
+
+Run: `./mvnw test -pl collector -Dtest=GrpcSpanHandler*`
+Expected: PASS (기존 테스트 포함)
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanHandler.java \
+        collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanChunkHandler.java \
+        collector/src/test/java/com/navercorp/pinpoint/collector/handler/grpc/GrpcSpanHandlerTailTest.java
+git commit -m "[#noissue] Route span handlers through TailSampler when enabled"
+```
+
+### Task 15: PinpointCollectorModule 등록 + application.yml 기본값
+
+**Files:**
+- Modify: `collector/src/main/java/com/navercorp/pinpoint/collector/PinpointCollectorModule.java`
+- Modify: `collector/src/main/resources/application.yml`
+
+- [ ] **Step 1: 모듈 @Import 추가**
+
+`PinpointCollectorModule.java` 의 `@Import({...})` 목록에 `TailSamplingConfiguration.class` 추가하고 import 문 추가:
+
+```java
+import com.navercorp.pinpoint.collector.sampling.tail.TailSamplingConfiguration;
+```
+
+`@Import` 배열 마지막에 추가:
+
+```java
+        CollectorEventConfiguration.class,
+        TailSamplingConfiguration.class
+```
+
+- [ ] **Step 2: application.yml 기본 설정 추가**
+
+`collector/src/main/resources/application.yml` 최상위에 다음 블록 추가:
+
+```yaml
+collector:
+  sampling:
+    tail:
+      enable: false            # 기본 비활성 (활성화 시 Redis 필요)
+      buffer-ttl: 300s
+      sweep-interval: 5s
+      decision-ttl: 600s
+      bands:
+        - max-elapsed: 50ms
+          rate: 1
+        - max-elapsed: 100ms
+          rate: 5
+        - max-elapsed: 500ms
+          rate: 10
+        - rate: 100            # catch-all (>= 500ms)
+```
+
+> Redis 접속 정보는 표준 `spring.data.redis.host`/`spring.data.redis.port` 를 사용한다(Task 7 의 `LettuceConnectionFactory` 기본값이 이를 따른다). 운영 환경에서 활성화 시 해당 프로퍼티를 설정한다.
+
+- [ ] **Step 3: 컨텍스트 로딩 회귀 확인 (tail 비활성 기본값)**
+
+Run: `./mvnw test -pl collector -q`
+Expected: 전체 collector 테스트 PASS. tail 비활성이므로 기존 동작 불변.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add collector/src/main/java/com/navercorp/pinpoint/collector/PinpointCollectorModule.java \
+        collector/src/main/resources/application.yml
+git commit -m "[#noissue] Register tail sampling module and default config"
+```
+
+### Task 16: 엔드투엔드 통합 테스트 (Testcontainers Redis)
+
+**Files:**
+- Test: `collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingEndToEndIT.java`
+
+> `TailSampler` + 실제 `TailSamplingRepository`(Redis 컨테이너) + mock TraceService 로 핵심 시나리오를 검증한다.
+
+- [ ] **Step 1: 통합 테스트 작성**
+
+```java
+package com.navercorp.pinpoint.collector.sampling.tail;
+
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.io.GrpcSpanFactory;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.util.StreamUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@Testcontainers
+class TailSamplingEndToEndIT {
+
+    @Container
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7.0")).withExposedPorts(6379);
+
+    private LettuceConnectionFactory factory;
+    private TraceService always;
+    private TraceService sampled;
+    private TailSampler tailSampler;
+    private TailSamplingRepository repository;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        factory = new LettuceConnectionFactory(REDIS.getHost(), REDIS.getMappedPort(6379));
+        factory.afterPropertiesSet();
+        RedisTemplate<String, byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(RedisSerializer.string());
+        template.setValueSerializer(RedisSerializer.byteArray());
+        template.afterPropertiesSet();
+        template.execute((RedisCallback<Object>) c -> { c.serverCommands().flushDb(); return null; });
+
+        byte[] acceptScript = StreamUtils.copyToByteArray(new ClassPathResource("redis/tail-accept.lua").getInputStream());
+        byte[] decideScript = StreamUtils.copyToByteArray(new ClassPathResource("redis/tail-decide.lua").getInputStream());
+        repository = new TailSamplingRepository(template, acceptScript, decideScript, 300, 600);
+
+        always = Mockito.mock(StatisticsTraceService.class);
+        sampled = Mockito.mock(TraceService.class);
+        GrpcSpanFactory spanFactory = Mockito.mock(GrpcSpanFactory.class);
+        Mockito.when(spanFactory.buildSpanBo(any(), any(), Mockito.anyLong())).thenReturn(new SpanBo());
+
+        TailSamplingProperties props = new TailSamplingProperties();
+        TailSamplingProperties.Band fast = new TailSamplingProperties.Band();
+        fast.setMaxElapsed(java.time.Duration.ofMillis(50));
+        fast.setRate(0); // 빠른 트레이스 0% (테스트 결정론)
+        TailSamplingProperties.Band slow = new TailSamplingProperties.Band();
+        slow.setRate(100); // catch-all keep
+        props.setBands(List.of(fast, slow));
+
+        tailSampler = new TailSampler(new TraceService[]{always, sampled},
+                repository, props, new BufferedSpanCodec(), spanFactory, new SimpleMeterRegistry());
+    }
+
+    @AfterEach
+    void tearDown() {
+        factory.destroy();
+    }
+
+    private SpanBo span(long seq, int elapsed, boolean root) {
+        SpanBo bo = new SpanBo();
+        bo.setTransactionId(new PinpointServerTraceId("agent", 1L, seq));
+        bo.setParentSpanId(root ? -1L : 10L);
+        bo.setElapsed(elapsed);
+        bo.setAgentId("agent");
+        bo.setApplicationName("app");
+        bo.setAgentName("agentName");
+        return bo;
+    }
+
+    @Test
+    void slowTrace_childBeforeRoot_allKept() {
+        // 자식 먼저(버퍼), 루트 나중(elapsed 500 -> 100% keep)
+        tailSampler.acceptSpan(span(1, 0, false), new byte[]{1});
+        tailSampler.acceptSpan(span(1, 500, true), new byte[]{2});
+        // sampled 그룹에 2건 기록 (replay) — always 는 매번
+        verify(sampled, Mockito.atLeast(1)).insertSpan(any());
+    }
+
+    @Test
+    void fastTrace_dropped() {
+        // 루트 먼저, elapsed 10 -> band rate 0 -> drop
+        tailSampler.acceptSpan(span(2, 10, true), new byte[]{1});
+        // 이후 자식 도착 -> decision=drop -> 즉시 폐기
+        tailSampler.acceptSpan(span(2, 0, false), new byte[]{2});
+        verify(sampled, never()).insertSpan(any());
+        // always 는 항상 호출
+        verify(always, Mockito.times(2)).insertSpan(any());
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 통과 확인**
+
+Run: `./mvnw test -pl collector -Dtest=TailSamplingEndToEndIT`
+Expected: PASS (Docker 필요)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add collector/src/test/java/com/navercorp/pinpoint/collector/sampling/tail/TailSamplingEndToEndIT.java
+git commit -m "[#noissue] Add end-to-end tail sampling integration test"
+```
+
+### Task 17: 전체 빌드 & 회귀 검증
+
+- [ ] **Step 1: collector 전체 테스트**
+
+Run: `./mvnw test -pl collector`
+Expected: BUILD SUCCESS (신규 + 기존 테스트 모두 통과)
+
+- [ ] **Step 2: collector 패키징(테스트 스킵) 으로 와이어링 점검**
+
+Run: `./mvnw install -pl collector -am -Dmaven.test.skip=true`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: 최종 확인**
+
+tail 비활성(기본) 상태에서 컨텍스트가 정상 기동하고, 기존 동작이 보존되는지 확인(Step 1 의 컨텍스트 로딩 테스트로 충족). 활성화 시나리오는 Task 8/16 통합 테스트가 커버.
+
+---
+
+## 향후 작업 (이 계획 범위 밖, spec §14)
+
+- EVALSHA 캐싱으로 Lua eval 최적화(현재는 매 호출 eval; Redis 가 SHA 캐시).
+- `decision-ttl` 실측 기반 튜닝(비동기/MQ 최대 지연).
+- Redis 메모리/엔벨로프 압축 측정.
+- 늦은-span(decision-ttl 만료 후) stray 조각 모니터링 대시보드.
+- accept 시 `applicationMapService`(always) 가 Redis 와 무관하게 항상 1회 실행됨을 메트릭으로 확인.

--- a/docs/superpowers/specs/2026-05-29-collector-tail-sampling-design.md
+++ b/docs/superpowers/specs/2026-05-29-collector-tail-sampling-design.md
@@ -1,0 +1,222 @@
+# 컬렉터 응답시간 기반 Tail Sampling 설계
+
+- **작성일:** 2026-05-29
+- **대상 컴포넌트:** `collector` / `collector-starter`
+- **버전 컨텍스트:** v3.1.0 (히트맵 도입 이후)
+
+## 1. 개요 & 목표
+
+컬렉터에서 트랜잭션의 **응답시간(루트 span의 `elapsed`)에 따라 트레이스 상세 저장 비율을 차등 적용**하는 tail-based sampling을 추가한다.
+
+응답시간 밴드별 수집률(기본값, 설정 가능):
+
+| 응답시간 | 수집률 |
+|---|---|
+| `< 50ms` | 1% |
+| `50ms ≤ t < 100ms` | 5% |
+| `100ms ≤ t < 500ms` | 10% |
+| `≥ 500ms` | 100% |
+
+### 우선순위
+1. **(최우선) 느린 트레이스 100% 보존** — 결정 전에는 어떤 span도 버리지 않는다. 장애·예외 경로에서도 유실 0을 보장한다(fail-open, 타임아웃 기본 keep).
+2. **(부차) 쓰기/저장 부하 절감** — 빠른 트레이스를 결정 시점에 폐기하여 trace 테이블 write·저장량을 줄인다.
+
+### 비목표 (YAGNI)
+- 에이전트 측 샘플링 변경 없음(상위·독립).
+- servermap·heatmap 등 집계 통계의 정확도는 **건드리지 않는다**(항상 100%).
+- 동적/엔드포인트별 정책, ML 기반 샘플링 등은 범위 밖.
+
+## 2. 배경 & 제약 (현재 구조)
+
+- span 수신 경로: `SpanService`(gRPC) → `GrpcSpanHandler.handleSimple` → (line 84) `Sampler<BasicSpan>` per-span 게이트 → `traceService.insertSpan(spanBo)` 루프.
+- `TraceService[]` 루프에는 최소 두 구현이 등록됨:
+  - `HbaseTraceService.insertSpan` — 내부에서 (1) `traceDao.asyncInsert` (trace 테이블), (2) `scatterService.insert` (scatter), (3) `applicationMapService.insertSpan` (servermap) 를 모두 수행.
+  - `HeatmapService.insertSpan` — 원본 `elapsed`를 200ms 버킷으로 Kafka→Pinot(`heatmapStatApp`)에 COUNT 집계.
+- 응답시간은 **루트 span(`SpanBo.isRoot()` = `parentSpanId == -1`)의 `elapsed`** 에만 존재. 자식 span / `SpanChunk`에는 전체 응답시간 없음.
+- 컬렉터는 span을 **도착 즉시** HBase에 기록(버퍼링·트레이스 완료 신호 없음).
+- 분산 트레이스의 모든 span은 동일 `transactionId`(`agentId^agentStartTime^sequence`)를 공유하나, 에이전트별로 **다른 컬렉터 인스턴스**(클러스터)로 흩어질 수 있음.
+- 기존 per-span 샘플러는 `transactionSequence` 해시 기반(head sampling)이라 조율 없이 일관 결정이 가능하지만, **응답시간은 transactionId로부터 유도 불가** → 공유 상태(Redis)가 필요.
+
+→ 따라서 본 기능은 본질적으로 **tail-based**이며, 결정 전까지 span을 모아두는 **중앙 버퍼(Redis)** 방식을 채택한다.
+
+## 3. 핵심 설계 결정 요약
+
+| # | 결정 | 근거 |
+|---|---|---|
+| D1 | **중앙 Redis 버퍼** 방식(안 1) | 상태를 한 곳에 모아 운영·추론 단순화. Redis 성능으로 처리량 감내 가능 판단. |
+| D2 | 결정 트리거 = **루트 span 도착** 시 `elapsed`로 밴드 판정 | 루트만 전체 응답시간 보유. |
+| D3 | keep 여부 = `hash(transactionId) % 100 < 밴드 rate` (결정 1회 계산 후 Redis에 저장) | 기존 `PercentRateSampler` 방식 재활용, 1회 계산으로 클러스터 일관성 확보. |
+| D4 | 루트 미도착 시 **buffer-ttl 경과 후 기본 keep** (sweeper가 flush) | 우선순위 1(유실 0) 보장. |
+| D5 | 샘플링 적용 범위 = **C안**: `trace + scatter`만 샘플링, `servermap + heatmap`은 100% 즉시 | 집계 통계 왜곡 방지. 특히 히트맵은 응답시간 분포 뷰라 왜곡 시 치명적. |
+| D6 | `accept`/`decide`를 **Lua 스크립트로 원자화** | check-then-buffer / set-then-flush 경합 제거. |
+| D7 | Redis 장애 시 **fail-open**(전량 즉시 HBase 기록) | 우선순위 1 보장. |
+| D8 | tail 샘플링 ON 시 기존 per-span `Sampler<BasicSpan>` 게이트 **우회** | 사전 드롭은 트레이스 완전성·집계 100%를 깨뜨림. |
+
+## 4. 설정 (`application.yml`)
+
+```yaml
+collector:
+  sampling:
+    tail:
+      enable: true
+      buffer-ttl: 300s          # 루트 미도착 시 강제 flush까지 대기(기본 keep)
+      sweep-interval: 5s        # sweeper 주기
+      decision-ttl: 600s        # 결정 레코드 보관(늦은 span 조회용; buffer-ttl보다 충분히 길게,
+                                #   현실적 비동기/MQ 지연 상한보다 길게 설정)
+      # 응답시간 밴드 — 위에서부터 매칭, 첫 매칭 적용
+      bands:
+        - max-elapsed: 50ms     # t < 50ms
+          rate: 1               # 1%
+        - max-elapsed: 100ms    # 50ms ≤ t < 100ms
+          rate: 5
+        - max-elapsed: 500ms    # 100ms ≤ t < 500ms
+          rate: 10
+        - max-elapsed: -1       # t ≥ 500ms (상한 없음)
+          rate: 100
+  # Redis 연결 설정(Lettuce) — host/port/password/timeout 등
+  # (CollectorApp 의 Redis auto-config exclude 해제 또는 전용 클라이언트 구성)
+```
+
+- `@ConfigurationProperties("collector.sampling.tail")` → `TailSamplingProperties`.
+- 밴드는 정렬된 리스트. 매칭: `elapsed < max-elapsed`인 **첫** 밴드의 `rate` 적용. `max-elapsed: -1`은 상한 없음(마지막 fallthrough).
+- 모든 값(비율·경계·TTL)은 재배포 없이 yml만 수정하면 됨.
+
+## 5. 아키텍처 & 컴포넌트
+
+신규/수정 컴포넌트:
+
+- **`TailSamplingProperties`** (신규) — yml 바인딩, 밴드 매처 제공(`int rateFor(int elapsed)`).
+- **`TailSamplingBuffer`** (신규) — 핵심 오케스트레이터. `accept(spanBo, protoBytes)` / `accept(spanChunkBo, protoBytes)` 진입. Redis 연동, 결정·flush 수행.
+- **Redis 클라이언트(Lettuce)** (신규 설정) — 컬렉터는 현재 Redis auto-config를 `exclude` 중이므로 전용 빈/설정 추가.
+- **Lua 스크립트 2종** (신규) — `accept`, `decide` 원자 실행.
+- **`TailSamplingSweeper`** (신규) — `sweep-interval` 주기 스케줄러. 오래된 미결정 트레이스를 기본 keep flush.
+- **TraceService 분류** (수정) — `always`(100% 즉시) 그룹과 `sampled`(버퍼링) 그룹으로 구분.
+- **`HbaseTraceService`** (수정) — 내부 3작업을 분리 호출 가능하도록 리팩터: `servermap`(즉시) vs `trace+scatter`(지연).
+- **`GrpcSpanHandler` / `GrpcSpanChunkHandler`** (수정) — tail ON 시 기존 per-span 샘플러 우회, `TailSamplingBuffer.accept(...)`로 라우팅.
+
+### 샘플링 적용 범위 (D5, C안)
+
+| 그룹 | 작업 | 처리 시점 |
+|---|---|---|
+| **always (100%)** | `HeatmapService` (heatmap), `applicationMapService` (servermap) | 매 span `accept` 시 즉시 1회 |
+| **sampled (버퍼링)** | trace 테이블 write(`traceDao`), `scatterService` (scatter) | 버퍼 적재 후 keep 결정 시에만 flush |
+
+- 히트맵은 이미 독립 `TraceService`라 "버퍼로 보내지 않는다"는 분류만으로 100% 유지.
+- servermap은 `HbaseTraceService` 내부에 묶여 있으므로 즉시 그룹으로 분리.
+- **이중집계 방지:** `always` 작업은 첫 `accept`에서만 실행하고 flush 시 **재실행하지 않는다**. flush(및 늦은 span write-through)는 `sampled`(trace+scatter)만 replay.
+
+## 6. 데이터 흐름
+
+```
+span 도착 (GrpcSpanHandler / GrpcSpanChunkHandler)
+  └─ (tail ON) 기존 per-span 샘플러 우회
+     └─ TailSamplingBuffer.accept(bo, protoBytes)
+        ├─ [always] applicationMapService + HeatmapService 즉시 호출 (100%, 1회)
+        └─ [sampled] 결정 상태에 따라 분기 (아래 §8)
+```
+
+flush 시 `sampled` replay 경로는 **기존 검증된 경로 재사용**: 버퍼의 원본 protobuf 바이트 → 기존 팩토리로 `SpanBo`/`SpanChunkBo` 재생성 → `traceDao.asyncInsert` + `scatterService.insert`.
+
+## 7. Redis 데이터 모델
+
+```
+buffer:{txid}    → LIST. 해당 트레이스의 모든 sampled-대상 span/chunk 원본 protobuf 바이트.
+                   루트/자식/SpanChunk 구분 없이 RPUSH로 append.
+pending          → ZSET. member=txid, score=firstSeen(ms). sweeper 탐색용.
+decision:{txid}  → STRING. "keep" | "drop". 1회 기록, TTL=decision-ttl.
+```
+
+- `buffer:{txid}`에는 **always 그룹은 들어가지 않음**(즉시 처리되므로). 오직 trace+scatter replay용 원본만.
+- 키 메모리 상한 ≈ (평균 트레이스 지속시간 + 여유) × 유입속도. buffer-ttl은 루트 유실 최악 케이스 상한.
+
+## 8. 생명주기
+
+### 8.1 accept(bo, protoBytes) — 모든 span 공통
+1. `applicationMapService` + `HeatmapService` 즉시 호출 (always, 1회).
+2. Lua(accept) 원자 실행:
+   - `d = GET decision:{txid}`
+   - `d == "keep"` → 즉시 trace+scatter write-through (버퍼링 안 함)
+   - `d == "drop"` → trace+scatter 폐기
+   - `d == null` (미결정):
+     - `RPUSH buffer:{txid} protoBytes`
+     - `ZADD pending txid firstSeen` (신규일 때만)
+     - `EXPIRE buffer:{txid} buffer-ttl` (누수 방지 안전망)
+3. (accept 밖) `bo.isRoot()`이면 → `decide(txid, bo.elapsed)` 호출.
+
+> `SpanChunk`는 `elapsed`/root 개념이 없어 결정 트리거가 되지 않으며 항상 자식으로 버퍼링된다.
+
+### 8.2 decide(txid, elapsed) — 결정 & flush (Lua 원자)
+1. `rate = properties.rateFor(elapsed)`; `keep = (hash(txid) % 100 < rate)`.
+2. `SET decision:{txid} (keep?"keep":"drop") NX EX decision-ttl`
+   - 성공(선점):
+     - `spans = LRANGE buffer:{txid} 0 -1`
+     - keep이면 spans 전부 trace+scatter replay, drop이면 아무것도 안 씀
+     - `DEL buffer:{txid}`; `ZREM pending txid`
+   - 실패(다른 컬렉터/sweeper가 이미 처리) → skip.
+
+### 8.3 케이스별 동작
+- **정상(루트 ~1초 내 도착):** 자식들 버퍼 적재 → 루트 도착 시 decide → flush.
+- **루트 먼저, 자식 늦게(비동기/MQ/reorder):** decide가 먼저 끝나 `decision` 존재 → 늦은 자식은 accept에서 즉시 write-through(keep)/폐기(drop).
+- **루트 미도착(크래시·유실·미계측):** sweeper가 `pending`에서 `firstSeen` 기준 age > buffer-ttl인 txid 발견 → `decide`를 **기본 keep** 으로 강제(밴드 rate=100 동등) → flush.
+- **아주 늦은 span(decision-ttl 만료 후):** `decision` 없음 → 신규처럼 재버퍼링 → sweeper가 기본 keep. 원결정 keep이면 일관, drop이면 stray 조각 잔존(경미). → `decision-ttl`을 현실적 비동기/MQ 지연 상한보다 충분히 길게 설정해 회피.
+
+## 9. 동시성 (클러스터)
+
+- 컬렉터 다중 인스턴스 + sweeper 다중 실행 환경.
+- `decide`의 `SET ... NX`로 **단일 인스턴스만 flush** 선점. 루트 도착 결정과 sweeper가 경합해도 NX로 1회만 수행.
+- `accept`/`decide`를 각각 **Lua 스크립트**로 묶어 "결정 조회+RPUSH", "결정 SET+flush 대상 확정"의 경합 창을 제거.
+
+## 10. 안정성 (fail-open)
+
+- Redis 연결 실패/타임아웃 등 예외 시 → **샘플링 우회, 전량 즉시 HBase 기록**(현행 동작과 동일). 샘플링은 일시 중단되나 유실 0(우선순위 1) 보장.
+- always 그룹(servermap/heatmap)은 Redis와 무관하게 항상 수행되므로 Redis 장애의 영향 없음.
+
+## 11. 관측성 / 메트릭
+
+Micrometer 카운터/게이지로 노출:
+- `tail.sampling.buffered` (적재 span 수)
+- `tail.sampling.kept` / `tail.sampling.dropped` (결정 결과)
+- `tail.sampling.flush.timeout` (sweeper 기본 keep flush 수)
+- `tail.sampling.redis.error` (fail-open 발동 수)
+- 밴드별 분포 카운터(밴드 rate 튜닝·B 검증용)
+- (게이지) `pending` ZSET 크기, `buffer:*` 추정 메모리
+
+## 12. 테스트 전략
+
+테스트 스택: JUnit 5, Mockito, AssertJ, TestContainers(Redis).
+
+- **단위:**
+  - 밴드 매칭 경계값(49/50/99/100/499/500ms), `max-elapsed: -1` fallthrough.
+  - keep 해시 결정론(`hash(txid)%100 < rate`).
+  - always/sampled 분류·이중집계 방지(servermap·heatmap 1회, trace+scatter는 keep시에만).
+- **통합(TestContainers Redis):**
+  - 루트-먼저 / 자식-먼저(비동기) 순서 모두에서 일관 keep/drop.
+  - 루트 유실 → sweeper 기본 keep flush.
+  - 늦은 span write-through(keep)/폐기(drop).
+  - 클러스터 NX 중복 flush 방지(decide 동시 호출 시 1회만 flush).
+  - Lua accept/decide 원자성(경합 시나리오).
+  - Redis 장애 → fail-open(전량 기록).
+- **회귀:** tail OFF 시 기존 동작 불변.
+
+## 13. 영향받는/신규 파일 (예상)
+
+신규:
+- `.../collector/sampling/tail/TailSamplingProperties.java`
+- `.../collector/sampling/tail/TailSamplingBuffer.java`
+- `.../collector/sampling/tail/TailSamplingSweeper.java`
+- `.../collector/sampling/tail/RedisTailSamplingConfig.java` (Lettuce 빈/스크립트 로드)
+- Lua 리소스: `accept.lua`, `decide.lua`
+
+수정:
+- `.../collector/service/HbaseTraceService.java` — servermap(즉시) vs trace+scatter(지연) 분리.
+- `.../collector/handler/grpc/GrpcSpanHandler.java` / `GrpcSpanChunkHandler.java` — tail ON 시 기존 샘플러 우회 + 버퍼 라우팅.
+- `.../collector/CollectorApp.java` — Redis(Lettuce) 활성화/설정.
+- `collector` 프로파일 `application.yml` — `collector.sampling.tail.*`.
+- `HeatmapService` 등록부 확인(always 그룹 분류).
+
+## 14. 미해결 / 추후 고려
+
+- `decision-ttl`(기본 600s)의 적정값은 실제 비동기/MQ 최대 지연 측정 후 조정.
+- `buffer-ttl` 300s는 루트 유실 트레이스의 UI 가시성 지연 상한(정상 트레이스 무관). 길다고 판단되면 하향.
+- 버퍼 원본을 protobuf 바이트로 저장(직렬화 재사용) — 압축 적용 여부는 메모리 측정 후 결정.
+- Redis 메모리 eviction 정책: 버퍼 키는 명시 TTL로 보호하되 maxmemory 정책과의 상호작용 검토.

--- a/exceptiontrace/exceptiontrace-collector/pom.xml
+++ b/exceptiontrace/exceptiontrace-collector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-exceptiontrace-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/exceptiontrace/exceptiontrace-common/pom.xml
+++ b/exceptiontrace/exceptiontrace-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-exceptiontrace-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/exceptiontrace/exceptiontrace-web/pom.xml
+++ b/exceptiontrace/exceptiontrace-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-exceptiontrace-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/exceptiontrace/pom.xml
+++ b/exceptiontrace/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/feature-flag/pom.xml
+++ b/feature-flag/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-feature-flag</artifactId>

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-grpc</artifactId>

--- a/hbase-testcluster/pom.xml
+++ b/hbase-testcluster/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-hbase-testcluster</artifactId>

--- a/hbase/hbase-schema-definition/pom.xml
+++ b/hbase/hbase-schema-definition/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-hbase</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hbase/hbase-schema-manager/pom.xml
+++ b/hbase/hbase-schema-manager/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>pinpoint-hbase</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-hbase-schema-manager</artifactId>

--- a/hbase/hbase-schema/pom.xml
+++ b/hbase/hbase-schema/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>pinpoint-hbase</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
 

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-hbase</artifactId>

--- a/inspector-module/inspector-collector/pom.xml
+++ b/inspector-module/inspector-collector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>pinpoint-inspector-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inspector-module/inspector-commons/pom.xml
+++ b/inspector-module/inspector-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-inspector-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-inspector-commons</artifactId>

--- a/inspector-module/inspector-web/pom.xml
+++ b/inspector-module/inspector-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-inspector-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inspector-module/pom.xml
+++ b/inspector-module/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-inspector-module</artifactId>

--- a/log/log-collector/pom.xml
+++ b/log/log-collector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>pinpoint-log-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/log/log-common/pom.xml
+++ b/log/log-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-log-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/log/log-web/pom.xml
+++ b/log/log-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-log-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/metric-module/metric-commons/pom.xml
+++ b/metric-module/metric-commons/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-metric-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-metric-commons</artifactId>

--- a/metric-module/metric/pom.xml
+++ b/metric-module/metric/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-metric-module</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-metric</artifactId>

--- a/metric-module/pom.xml
+++ b/metric-module/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     
     <artifactId>pinpoint-metric-module</artifactId>

--- a/otlpmetric/otlpmetric-collector/pom.xml
+++ b/otlpmetric/otlpmetric-collector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-otlpmetric</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-otlpmetric-collector</artifactId>

--- a/otlpmetric/otlpmetric-common/pom.xml
+++ b/otlpmetric/otlpmetric-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-otlpmetric</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-otlpmetric-common</artifactId>

--- a/otlpmetric/otlpmetric-web/pom.xml
+++ b/otlpmetric/otlpmetric-web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-otlpmetric</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-otlpmetric-web</artifactId>

--- a/otlpmetric/pom.xml
+++ b/otlpmetric/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-otlpmetric</artifactId>

--- a/otlptrace/otlptrace-collector/pom.xml
+++ b/otlptrace/otlptrace-collector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-otlptrace</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-otlptrace-collector</artifactId>

--- a/otlptrace/pom.xml
+++ b/otlptrace/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-otlptrace</artifactId>

--- a/pinot/pinot-batch/pom.xml
+++ b/pinot/pinot-batch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-pinot</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-pinot-batch</artifactId>

--- a/pinot/pinot-config/pom.xml
+++ b/pinot/pinot-config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-pinot</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-pinot-config</artifactId>

--- a/pinot/pinot-datasource/pom.xml
+++ b/pinot/pinot-datasource/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-pinot</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-pinot-datasource</artifactId>

--- a/pinot/pinot-kafka/pom.xml
+++ b/pinot/pinot-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint-pinot</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-pinot-kafka</artifactId>

--- a/pinot/pom.xml
+++ b/pinot/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </organization>
     <groupId>com.navercorp.pinpoint</groupId>
     <artifactId>pinpoint</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
     <name>pinpoint</name>
     <packaging>pom</packaging>
 

--- a/quickstart/testapp/pom.xml
+++ b/quickstart/testapp/pom.xml
@@ -24,7 +24,7 @@
     <groupId>com.navercorp.pinpoint</groupId>
     <artifactId>pinpoint-quickstart-testapp</artifactId>
     <name>Pinpoint TestApp QuickStart</name>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
 
     <properties>
         <java.version>1.8</java.version>

--- a/realtime/pom.xml
+++ b/realtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/realtime/realtime-collector/pom.xml
+++ b/realtime/realtime-collector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-realtime</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/realtime/realtime-common/pom.xml
+++ b/realtime/realtime-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>pinpoint-realtime</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/realtime/realtime-web/pom.xml
+++ b/realtime/realtime-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-realtime</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-module/pom.xml
+++ b/service-module/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/uristat/pom.xml
+++ b/uristat/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/uristat/uristat-batch/pom.xml
+++ b/uristat/uristat-batch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-uristat-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/uristat/uristat-collector/pom.xml
+++ b/uristat/uristat-collector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-uristat-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/uristat/uristat-common/pom.xml
+++ b/uristat/uristat-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-uristat-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/uristat/uristat-web/pom.xml
+++ b/uristat/uristat-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint-uristat-module</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/user/pom.xml
+++ b/user/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pinpoint</artifactId>
         <groupId>com.navercorp.pinpoint</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/web-frontend/pom.xml
+++ b/web-frontend/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-web-frontend</artifactId>

--- a/web-starter/pom.xml
+++ b/web-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-web</artifactId>

--- a/webhook/pom.xml
+++ b/webhook/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.navercorp.pinpoint</groupId>
         <artifactId>pinpoint</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
     </parent>
 
     <artifactId>pinpoint-webhook</artifactId>


### PR DESCRIPTION
## Summary

Adds tail-based sampling to the Collector. Unlike head sampling (decided at the
agent before the outcome is known), the keep/drop decision is deferred until the
collector has observed a trace's spans, so traces can be retained by outcome —
errors and response-time bands — while uninteresting traces are dropped.

Disabled by default; existing behavior is unchanged unless the enable toggle is set.

## Motivation

Head sampling discards traces before their result is known, so error and slow
traces can be lost. Tail sampling buffers spans at the collector and decides
per trace, allowing 100% retention of error traces and configurable latency-band
retention.

## How it works

- Spans are buffered and the decision is deferred to the collector.
- Decision policy (deterministic, so all instances of a trace agree):
  - `keepOnError`: any errored span upgrades the decision to keep; a root error
    forces 100% keep, overriding band rates.
  - Response-time bands: each band has a `maxElapsed` threshold and a keep `rate`.
  - Orphaned/incomplete traces are flushed by a sweeper with a default-keep.
- Storage: Redis with atomic Lua scripts (accept / decide / findStale) so the
  decision is race-free across multiple collector instances.
- Fail-open: on storage failure the orchestrator writes through / keeps rather
  than dropping data.
- Servermap and heatmap are **always-on** and unaffected by sampling
  (`ApplicationMapTraceService`, `StatisticsTraceService`), so topology and
  statistics keep complete data with no sampling-induced gaps.

## Configuration

Env example:

```yaml
- name: COLLECTOR_SAMPLING_TAIL_ENABLE
  value: "true"
- name: COLLECTOR_SAMPLING_TAIL_KEEPONERROR
  value: "true"
- name: COLLECTOR_SAMPLING_TAIL_BANDS_0_MAXELAPSED
  value: "250ms"
- name: COLLECTOR_SAMPLING_TAIL_BANDS_0_RATE
  value: "0"
- name: COLLECTOR_SAMPLING_TAIL_BANDS_1_MAXELAPSED
  value: "500ms"
- name: COLLECTOR_SAMPLING_TAIL_BANDS_1_RATE
  value: "50"
```

Equivalent properties (Spring relaxed binding):

```properties
collector.sampling.tail.enable=true
collector.sampling.tail.keepOnError=true
collector.sampling.tail.bands[0].maxElapsed=250ms
collector.sampling.tail.bands[0].rate=0
collector.sampling.tail.bands[1].maxElapsed=500ms
collector.sampling.tail.bands[1].rate=50
```

With the example above: traces ≤250ms are dropped (rate 0), traces ≤500ms are
kept at 50%, and error traces are always kept (`keepOnError=true`). Redis
connection settings are configurable.

## What changed

- **Config**: `TailSamplingProperties` (response-time bands, enable toggle,
  configurable Redis), default config + module registration, license header/javadoc.
- **Decision**: deterministic keep decision; root-error 100% keep overriding band;
  error-flag + decide upgrade for any errored span.
- **Buffer/replay**: `BufferedSpan` envelope codec (hardened type decode, empty-proto
  round-trip test), `ReconstructedServerHeader` for replay, corrupt-span skip on
  replay (no default-instance write) + chunk metrics.
- **Storage**: Lua scripts for atomic accept/decide; `TailSamplingRepository`
  (accept/decide/findStale); redis template + lua script beans; redis +
  testcontainers dependencies.
- **Orchestration/routing**: `TailSampler` orchestrator (fail-open write-through);
  beans wired behind the enable toggle; span handlers routed through `TailSampler`
  when enabled (drop-on-error clarified); `TailSamplingSweeper` for orphaned-trace
  default-keep flush + flush counters.
- **Always-on split**: servermap → `ApplicationMapTraceService`,
  heatmap → `StatisticsTraceService`.

## Testing

- End-to-end tail sampling integration test (Redis via testcontainers).
- Unit tests: `GrpcSpanChunkHandler` tail-routing, `BufferedSpan` codec round-trip,
  `ApplicationMapTraceService` chunk coverage.

## Compatibility

Off by default. When `collector.sampling.tail.enable` is false, the span path and
behavior are unchanged. Enabling adds a Redis dependency to the collector.

## Notes / Follow-ups

- New Redis dependency for the collector when enabled.
- Verify behavior under multiple collector instances at scale.