### PR TITLE
[#noissue] Cleanup StdoutRecorder

### DIFF
--- a/agent-module/plugins-test-module/plugins-it-utils/src/main/java/com/navercorp/pinpoint/it/plugin/utils/StdoutRecorder.java
+++ b/agent-module/plugins-test-module/plugins-it-utils/src/main/java/com/navercorp/pinpoint/it/plugin/utils/StdoutRecorder.java
@@ -21,10 +21,12 @@ import com.navercorp.pinpoint.common.util.IOUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 public class StdoutRecorder {
+    private static final Charset UTF8 = StandardCharsets.UTF_8;
 
     public String record(Runnable runnable) {
         try {
@@ -40,25 +42,18 @@ public class StdoutRecorder {
 
         final PrintStream originalOut = System.out;
 
-        final StringOutputStream stream = new StringOutputStream();
-        final PrintStream printStream = new PrintStream(stream, false, StandardCharsets.UTF_8.name());
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        final PrintStream printStream = new PrintStream(stream, false, UTF8.name());
 
         System.setOut(printStream);
 
         try {
             runnable.run();
-            return stream.toString();
+            return stream.toString(UTF8.name());
         } finally {
             System.setOut(originalOut);
             IOUtils.closeQuietly(printStream);
             IOUtils.closeQuietly(stream);
-        }
-    }
-
-    private static class StringOutputStream extends ByteArrayOutputStream {
-        @Override
-        public synchronized String toString() {
-            return new String(this.buf, 0, this.count, StandardCharsets.UTF_8);
         }
     }
 


### PR DESCRIPTION
This pull request refactors the `StdoutRecorder` utility to simplify its implementation and improve charset handling. The main change is replacing a custom `StringOutputStream` class with the standard `ByteArrayOutputStream` and consistently using a UTF-8 charset constant.

Refactoring and simplification:

* Replaced the custom `StringOutputStream` inner class with the standard `ByteArrayOutputStream`, removing unnecessary code and using the built-in method for string conversion.
* Introduced a private static final `UTF8` charset constant for consistent UTF-8 handling throughout the class.
* Updated the `PrintStream` and string conversion logic in `record0` to use the `UTF8` constant and standard methods, ensuring proper encoding and cleaner code.