### PR TITLE
[#13784] Fix SpaFallbackRewriter to fall back unregistered paths to index.html

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/servlet/SpaFallbackRewriter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/servlet/SpaFallbackRewriter.java
@@ -92,7 +92,7 @@ public class SpaFallbackRewriter {
                 return true;
             }
         }
-        return path.indexOf('.') != -1;
+        return false;
     }
 
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/servlet/SpaFallbackRewriterTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/servlet/SpaFallbackRewriterTest.java
@@ -65,8 +65,9 @@ class SpaFallbackRewriterTest {
 
     @Test
     public void dispatch_resource_jpg() {
+        // unregistered path: fall back to SPA index.html regardless of extension(dot)
         String rewrite = rewriter.rewrite("/test.jpg");
-        Assertions.assertNull(rewrite);
+        Assertions.assertEquals(main, rewrite);
     }
 
     @Test
@@ -81,4 +82,9 @@ class SpaFallbackRewriterTest {
         Assertions.assertEquals(main, rewrite);
     }
 
+    @Test
+    public void version_resource_comma() {
+        String rewrite = rewriter.rewrite("/transactionList/VOD.TEST");
+        Assertions.assertEquals(main, rewrite);
+    }
 }


### PR DESCRIPTION
…ndex.html

This pull request updates the SPA fallback logic to ensure that only explicitly registered static resource paths are treated as static, regardless of file extension. Unregistered paths, even those with a dot in the name (like `.jpg` or `.TEST`), now fall back to the SPA `index.html`. The test suite has been updated to reflect this new behavior.

**SPA fallback logic changes:**

* The `isStaticResource` method in `SpaFallbackRewriter.java` was changed to only return `true` for explicitly registered static resources, and not for any path containing a dot. Unregistered paths, even with extensions, now fall back to the SPA index.

**Test updates:**

* Updated `dispatch_resource_jpg` test to expect SPA fallback for unregistered `.jpg` paths, ensuring consistency with the new fallback logic.
* Added a new test `version_resource_comma` to verify that paths like `/transactionList/VOD.TEST` also fall back to the SPA index.