### PR TITLE
[#noissue] Fix negative timestamp when opening errorAnalysis from CallTree

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
@@ -318,15 +318,11 @@ const MethodCell = (props: {
     Icon = <FaFire className="fill-status-fail" />;
 
     if (rowData.exceptionChainId) {
-      let parentIndex = Number(rowData.id);
-      while (!metaData.callStack[parentIndex]?.[metaData.callStackIndex.id]) {
-        parentIndex--;
-      }
-
-      const parentData = metaData.callStack[parentIndex];
-      const startTime = parentData[metaData.callStackIndex.begin];
-      const endTime = parentData[metaData.callStackIndex.end];
-      const baseTime = (startTime + endTime) / 2;
+      // The call stack's begin/end can be empty (0) for many nodes, which would
+      // produce a window around epoch 0 and a negative `from` that the backend
+      // (Timestamp) rejects. Center the window on the transaction's focus
+      // timestamp, the same absolute time passed as `timestamp` below.
+      const baseTime = transactionInfo.focusTimestamp;
       const from = formatInTimeZone(baseTime - 150000, timezone, SEARCH_PARAMETER_DATE_FORMAT);
       const to = formatInTimeZone(baseTime + 150000, timezone, SEARCH_PARAMETER_DATE_FORMAT);
       const href = `${BASE_PATH}${getErrorAnalysisPath(application)}?${convertParamsToQueryString({

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
@@ -321,8 +321,10 @@ const MethodCell = (props: {
       // The call stack's begin/end can be empty (0) for many nodes, which would
       // produce a window around epoch 0 and a negative `from` that the backend
       // (Timestamp) rejects. Center the window on the transaction's focus
-      // timestamp, the same absolute time passed as `timestamp` below.
-      const baseTime = transactionInfo.focusTimestamp;
+      // timestamp, the same absolute time passed as `timestamp` below. Fall back
+      // to the transaction's start time when focusTimestamp is missing (0), e.g.
+      // when reached via an OTel link that carries no focus timestamp.
+      const baseTime = transactionInfo.focusTimestamp || metaData.callStackStart;
       const from = formatInTimeZone(baseTime - 150000, timezone, SEARCH_PARAMETER_DATE_FORMAT);
       const to = formatInTimeZone(baseTime + 150000, timezone, SEARCH_PARAMETER_DATE_FORMAT);
       const href = `${BASE_PATH}${getErrorAnalysisPath(application)}?${convertParamsToQueryString({

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/charts/TransactionCharts.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/charts/TransactionCharts.tsx
@@ -26,8 +26,6 @@ export const TransactionCharts = () => {
   const { transactionInfo } = useTransactionSearchParameters();
   const transactionInfoData = useAtomValue(transactionInfoDatasAtom);
   const focusTimestamp = transactionInfo.focusTimestamp || transactionInfoData?.callStackEnd;
-  const fromDate = subMinutes(focusTimestamp, 10);
-  const toDate = addMinutes(focusTimestamp, 10);
 
   React.useEffect(() => {
     const resizeObserver = new ResizeObserver(() => {
@@ -43,9 +41,15 @@ export const TransactionCharts = () => {
     };
   }, []);
 
+  // focusTimestamp can be 0 (epoch) when missing; subtracting an offset from 0
+  // would produce a negative `from` that the backend (Timestamp) rejects.
+  // Bail out before computing the window so a negative timestamp is never sent.
   if (!focusTimestamp) {
     return null;
   }
+
+  const fromDate = subMinutes(focusTimestamp, 10);
+  const toDate = addMinutes(focusTimestamp, 10);
 
   return (
     <div ref={containerRef} className="h-full p-3">


### PR DESCRIPTION


The error-category link in CallTree derived its from/to window from the parent node's begin/end times. These are often unset (0) in the call stack, so the window collapsed around epoch 0 and produced a negative 'from' (e.g. 19691231T235730Z) that the backend Timestamp rejects (epochMillis < 0), failing all errorAnalysis requests with 400.

Center the window on transactionInfo.focusTimestamp instead, the same absolute time already passed as the 'timestamp' field in the navigation payload.