### PR TITLE
[#noissue] Show selected service name under sidebar Service menu

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Layout/LayoutWithSideNavigation.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Layout/LayoutWithSideNavigation.tsx
@@ -107,7 +107,7 @@ export const LayoutWithSideNavigation = ({
         {item?.icon && (
           <span
             className={cn(
-              'flex relative justify-center items-center mr-1 text-lg transition-opacity w-[35px] h-[35px]',
+              'flex relative shrink-0 justify-center items-center mr-1 text-lg transition-opacity w-[35px] h-[35px]',
               isActive(item) ? 'opacity-100' : 'opacity-70',
             )}
           >
@@ -121,7 +121,7 @@ export const LayoutWithSideNavigation = ({
           <>
             <span
               className={cn(
-                'transition-opacity truncate',
+                'flex-1 min-w-0 transition-opacity truncate',
                 isActive(item) ? 'opacity-100' : 'opacity-70',
                 {
                   'pl-6 pr-2': !item?.icon,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Service/useServiceSideNavigation.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Service/useServiceSideNavigation.tsx
@@ -38,6 +38,12 @@ export const useServiceSideNavigation = (
           icon: <TbCategory />,
           name: SERVICE_CONFIG_MENU.title,
           path: APP_PATH.CONFIG_SERVICES,
+          children: (
+            <span className="flex flex-col min-w-0 leading-tight overflow-hidden">
+              <span className="truncate">{SERVICE_CONFIG_MENU.title}</span>
+              <span className="text-xs opacity-70 truncate">{selectedService}</span>
+            </span>
+          ),
           childItems: buildServiceSidebarItems(services, selectedService, setSelectedService),
           leftSectionTitle: 'Service Config',
           leftChildItems: serviceGroupItems,


### PR DESCRIPTION
## Summary
- Display the currently selected service name as a second line beneath the sidebar "Service" menu item, so users can see which service is active at a glance.
- Fix icon/text misalignment that occurred with long service names by letting the text area shrink (`min-w-0`/`flex-1`) and truncate, while keeping the icon fixed (`shrink-0`).

## Test plan
- [ ] With a short service selected, the name shows under "Service" without layout shift.
- [ ] With a long service name, the icon and "Service" label stay aligned and the name is truncated with an ellipsis.
- [ ] When the sidebar is collapsed, only the icon is shown (second line hidden).
- [ ] Other sidebar menu items (top/bottom/dropdown) render unchanged.
- [ ] yarn build / yarn test pass.