### PR TITLE
Fix server map centering for unauthorized node and transaction skeleton

### DIFF
--- a/web-frontend/src/main/v3/.claude/rules/git-workflow.md
+++ b/web-frontend/src/main/v3/.claude/rules/git-workflow.md
@@ -44,6 +44,7 @@ git push -u origin <branch-name>
 빌드나 테스트가 실패하면 커밋하지 마세요. 먼저 문제를 해결하세요.
 
 ## 커밋 메시지
+- **언어: 항상 영어로 작성** — 제목과 본문 모두 예외 없이 영어. (한글 금지)
 - 형식: `[#issue_number] Description` (예: `[#9520] Preserve timestamp during server map loading`)
 - **같은 플랫폼**: 이슈와 저장소가 같은 플랫폼에 있는 경우(예: 둘 다 github.com이거나 둘 다 oss.navercorp.com), 이슈 번호 사용: `[#issue_number]`
 - **다른 플랫폼**: 이슈와 저장소가 다른 플랫폼에 있는 경우(예: 이슈는 oss.navercorp.com에, 저장소는 github.com에 있는 경우), `[#noissue]` 사용
@@ -59,6 +60,7 @@ git push -u origin <branch-name>
 - 리모트 설정: `origin` = 포크 (jihea-park/pinpoint), `upstream` = pinpoint-apm/pinpoint
 
 ## Pull Request 생성
+- **언어: PR 제목과 본문은 항상 영어로 작성** — 예외 없음. (한글 금지)
 - PR은 `upstream` (pinpoint-apm/pinpoint) master 브랜치를 대상으로 합니다.
 - **항상** 사용자(jihea-park)를 PR에 어사인하세요.
 - **GitHub 저장소에서**, REST API로 Copilot 코드 리뷰를 요청하세요:

--- a/web-frontend/src/main/v3/packages/server-map/src/ui/ServerMap.tsx
+++ b/web-frontend/src/main/v3/packages/server-map/src/ui/ServerMap.tsx
@@ -270,7 +270,11 @@ export const ServerMap = ({
         const baseNode = cy.getElementById(baseNodeId);
         highlightNode(baseNode);
         cy.resize();
-        cy.center(baseNode);
+        // baseNodeId가 실제 노드 id와 어긋나면 baseNode가 빈 컬렉션이고,
+        // cy.center(empty)는 아무 동작도 하지 않아 노드가 화면 밖/구석에 남는다.
+        // 이 경우 전체 노드 기준으로 센터링해 항상 화면 안에 보이도록 한다.
+        // (엣지를 제외한 cy.nodes()를 사용해 노드 클러스터 중심에 더 가깝게 맞춘다.)
+        cy.center(baseNode.nonempty() ? baseNode : cy.nodes());
       })
         .on('mouseover', ({ target, renderedPosition }) => {
           cy.container()!.style.cursor = target === cy ? 'default' : 'pointer';

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/traceServerMap/traceServerMap.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/traceServerMap/traceServerMap.tsx
@@ -11,7 +11,7 @@ export interface TraceServerMapProps extends TraceServerMapFetcherProps {}
 export const TraceServerMap = (props: TraceServerMapProps) => {
   return (
     <ErrorBoundary>
-      <React.Suspense fallback={<ServerMapSkeleton />}>
+      <React.Suspense fallback={<ServerMapSkeleton className="w-full h-full" />}>
         <TraceServerMapFetcher {...props} />
       </React.Suspense>
     </ErrorBoundary>

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.test.ts
@@ -173,7 +173,94 @@ describe('Test serverMap helper utils', () => {
       expect(result).toBe('test-app^TOMCAT');
     });
 
-    test('Handle case-insensitive matching for UNAUTHORIZED replacement', () => {
+    test('Return actual 3-part node key for unauthorized serviceMap node', () => {
+      // serviceMap 응답: key는 3-part(serviceName^app^serviceType), nodeKey는 2-part.
+      // 권한 없는 노드는 serviceType이 UNAUTHORIZED로 치환되어 내려온다.
+      const application: ApplicationType = {
+        applicationName: 'test-app',
+        serviceType: 'TOMCAT',
+      };
+      const applicationMapData: GetServerMap.ApplicationMapData = {
+        range: {
+          from: 0,
+          to: 0,
+          fromDateTime: '',
+          toDateTime: '',
+        },
+        timestamp: [],
+        nodeDataArray: [
+          {
+            key: 'my-service^test-app^UNAUTHORIZED',
+            nodeKey: 'test-app^UNAUTHORIZED',
+          } as GetServerMap.NodeData,
+        ],
+        linkDataArray: [],
+      };
+
+      const result = getBaseNodeId({ application, applicationMapData });
+      // 합성한 2-part('test-app^UNAUTHORIZED')가 아니라 실제 노드 key(3-part)를 반환해야
+      // cytoscape id와 일치하여 센터링이 동작한다.
+      expect(result).toBe('my-service^test-app^UNAUTHORIZED');
+    });
+
+    test('Return node key when 2-part unauthorized node exists in serverMap response', () => {
+      // 레거시 serverMap 응답: key가 2-part(app^serviceType)이고 nodeKey가 없다.
+      // 권한 없는 노드(app^UNAUTHORIZED)가 목록에 존재하면 합성한 키와 동일한
+      // 실제 node.key를 반환하여 기존 동작과 호환됨을 보장한다.
+      const application: ApplicationType = {
+        applicationName: 'test-app',
+        serviceType: 'TOMCAT',
+      };
+      const applicationMapData: GetServerMap.ApplicationMapData = {
+        range: {
+          from: 0,
+          to: 0,
+          fromDateTime: '',
+          toDateTime: '',
+        },
+        timestamp: [],
+        nodeDataArray: [{ key: 'test-app^UNAUTHORIZED' } as GetServerMap.NodeData],
+        linkDataArray: [],
+      };
+
+      const result = getBaseNodeId({ application, applicationMapData });
+      expect(result).toBe('test-app^UNAUTHORIZED');
+    });
+
+    test('Return group node key when unauthorized node is a child of a service group', () => {
+      // 권한 없는 노드가 service group의 자식인 경우: 그래프에는 그룹 노드만 그려지므로
+      // subNodes 안의 UNAUTHORIZED 키를 찾아 그룹 노드의 key를 base로 반환해야 한다.
+      const application: ApplicationType = {
+        applicationName: 'test-app',
+        serviceType: 'TOMCAT',
+      };
+      const applicationMapData: GetServerMap.ApplicationMapData = {
+        range: {
+          from: 0,
+          to: 0,
+          fromDateTime: '',
+          toDateTime: '',
+        },
+        timestamp: [],
+        nodeDataArray: [
+          {
+            key: 'my-service-group^UNAUTHORIZED',
+            subNodes: [
+              {
+                key: 'my-service^test-app^UNAUTHORIZED',
+                nodeKey: 'test-app^UNAUTHORIZED',
+              } as GetServerMap.NodeData,
+            ],
+          } as GetServerMap.NodeData,
+        ],
+        linkDataArray: [],
+      };
+
+      const result = getBaseNodeId({ application, applicationMapData });
+      expect(result).toBe('my-service-group^UNAUTHORIZED');
+    });
+
+    test('Return UNAUTHORIZED key when serviceType case does not match (matching is case-sensitive)', () => {
       const application: ApplicationType = {
         applicationName: 'test-app',
         serviceType: 'tomcat', // lowercase

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
@@ -48,7 +48,26 @@ export const getBaseNodeId = ({
         n.subNodes.some((inner) => inner.key === baseNodeId || inner.nodeKey === baseNodeId),
     );
     if (groupContaining) return groupContaining.key;
-    return baseNodeId.replace(/\^[^^]*$/, '^UNAUTHORIZED');
+    // 권한이 없는 노드는 백엔드가 serviceType을 UNAUTHORIZED로 치환해 내려준다.
+    // serviceMap 응답에서는 key가 3-part(serviceName^app^UNAUTHORIZED)이고 nodeKey가
+    // 2-part(app^UNAUTHORIZED)이므로, 합성한 2-part id 대신 실제 노드의 key를 반환해
+    // cytoscape id(=node.key)와 일치시켜야 센터링/하이라이트가 동작한다.
+    const unauthorizedKey = baseNodeId.replace(/\^[^^]*$/, '^UNAUTHORIZED');
+    const unauthorizedNode = (nodeList as GetServerMap.NodeData[]).find(
+      (n) => n.key === unauthorizedKey || n.nodeKey === unauthorizedKey,
+    );
+    if (unauthorizedNode) return unauthorizedNode.key;
+    // 권한 없는 노드가 service group의 자식인 경우, 그래프에 그려지는 것은 그룹 노드이므로
+    // subNodes까지 탐색해 그룹 노드의 key를 base로 사용한다. (위 groupContaining과 동일한 처리)
+    const groupContainingUnauthorized = (nodeList as GetServerMap.NodeData[]).find(
+      (n) =>
+        Array.isArray(n.subNodes) &&
+        n.subNodes.some(
+          (inner) => inner.key === unauthorizedKey || inner.nodeKey === unauthorizedKey,
+        ),
+    );
+    if (groupContainingUnauthorized) return groupContainingUnauthorized.key;
+    return unauthorizedKey;
   }
   return '';
 };


### PR DESCRIPTION
## Summary
- Fix serviceMap unauthorized node centering by matching the real node key when centering the graph
- Center the server map loading skeleton in the transaction Server Map tab — the Suspense fallback rendered `ServerMapSkeleton` without the `w-full h-full` className used by every other usage, leaving the fixed 975×625 SVG anchored to the top-left of the wider tab container

## Test plan
- [ ] Open an unauthorized node in the service map and confirm it is centered correctly
- [ ] Open a transaction in Transaction list → Server Map tab and confirm the loading skeleton is centered (not left-aligned)
- [ ] `yarn build` passes
- [ ] `yarn test` passes (51 suites / 439 tests)
