### PR TITLE
[#noissue] Refactor AttributeValue to non-generic interface with typed value accessors

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/SpanMessageMapper.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/SpanMessageMapper.java
@@ -16,11 +16,31 @@
 package com.navercorp.pinpoint.profiler.context.grpc.mapper;
 
 
-import com.navercorp.pinpoint.grpc.trace.*;
-import com.navercorp.pinpoint.io.SpanVersion;
-import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
-import com.navercorp.pinpoint.common.trace.attribute.AttributeValueType;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValueList;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueArray;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueBoolean;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueBytes;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueDouble;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueLong;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueString;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueType;
+import com.navercorp.pinpoint.grpc.trace.PAcceptEvent;
+import com.navercorp.pinpoint.grpc.trace.PAnnotation;
+import com.navercorp.pinpoint.grpc.trace.PAnnotationValue;
+import com.navercorp.pinpoint.grpc.trace.PAttribute;
+import com.navercorp.pinpoint.grpc.trace.PAttributeArrayValue;
+import com.navercorp.pinpoint.grpc.trace.PAttributeKeyValueList;
+import com.navercorp.pinpoint.grpc.trace.PAttributeValue;
+import com.navercorp.pinpoint.grpc.trace.PLocalAsyncId;
+import com.navercorp.pinpoint.grpc.trace.PMessageEvent;
+import com.navercorp.pinpoint.grpc.trace.PNextEvent;
+import com.navercorp.pinpoint.grpc.trace.PParentInfo;
+import com.navercorp.pinpoint.grpc.trace.PSpan;
+import com.navercorp.pinpoint.grpc.trace.PSpanChunk;
+import com.navercorp.pinpoint.grpc.trace.PSpanEvent;
+import com.navercorp.pinpoint.io.SpanVersion;
 import com.navercorp.pinpoint.profiler.context.Annotation;
 import com.navercorp.pinpoint.profiler.context.AsyncSpanChunk;
 import com.navercorp.pinpoint.profiler.context.LocalAsyncId;
@@ -150,29 +170,28 @@ public interface SpanMessageMapper {
         return builder.build();
     }
 
-    @SuppressWarnings("unchecked")
     default PAttributeValue mapAttributeValue(AttributeValue attributeValue) {
         PAttributeValue.Builder valueBuilder = PAttributeValue.newBuilder();
         AttributeValueType type = attributeValue.getType();
         switch (type) {
             case STRING:
-                valueBuilder.setStringValue((String) attributeValue.getValue());
+                valueBuilder.setStringValue(((AttributeValueString) attributeValue).getStringValue());
                 break;
             case BOOLEAN:
-                valueBuilder.setBoolValue((Boolean) attributeValue.getValue());
+                valueBuilder.setBoolValue(((AttributeValueBoolean) attributeValue).getBooleanValue());
                 break;
             case LONG:
-                valueBuilder.setLongValue((Long) attributeValue.getValue());
+                valueBuilder.setLongValue(((AttributeValueLong) attributeValue).getLongValue());
                 break;
             case DOUBLE:
-                valueBuilder.setDoubleValue((Double) attributeValue.getValue());
+                valueBuilder.setDoubleValue(((AttributeValueDouble) attributeValue).getDoubleValue());
                 break;
             case BYTES:
-                valueBuilder.setBinaryValue(com.google.protobuf.ByteString.copyFrom((byte[]) attributeValue.getValue()));
+                valueBuilder.setBinaryValue(com.google.protobuf.ByteString.copyFrom(((AttributeValueBytes) attributeValue).getBytesValue()));
                 break;
             case ARRAY:
                 PAttributeArrayValue.Builder arrayBuilder = PAttributeArrayValue.newBuilder();
-                for (AttributeValue item : (java.util.List<AttributeValue>) attributeValue.getValue()) {
+                for (AttributeValue item : ((AttributeValueArray) attributeValue).getArrayValue()) {
                     if (item != null) {
                         arrayBuilder.addValues(mapAttributeValue(item));
                     }
@@ -181,11 +200,12 @@ public interface SpanMessageMapper {
                 break;
             case KEY_VALUE_LIST:
                 PAttributeKeyValueList.Builder kvBuilder = PAttributeKeyValueList.newBuilder();
-                for (AttributeKeyValue kv : (java.util.List<AttributeKeyValue>) attributeValue.getValue()) {
+                for (AttributeKeyValue kv : ((AttributeKeyValueList) attributeValue).getKeyValueListValue()) {
                     PAttribute.Builder attrBuilder = PAttribute.newBuilder();
                     attrBuilder.setKey(kv.getKey());
-                    if (kv.getValue() != null) {
-                        attrBuilder.setValue(mapAttributeValue(kv.getValue()));
+                    final AttributeValue value = kv.getValue();
+                    if (value != null) {
+                        attrBuilder.setValue(mapAttributeValue(value));
                     }
                     kvBuilder.addValues(attrBuilder.build());
                 }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/AbstractRecorder.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/AbstractRecorder.java
@@ -16,15 +16,15 @@
 package com.navercorp.pinpoint.profiler.context.recorder;
 
 import com.navercorp.pinpoint.bootstrap.context.AttributeRecorder;
-import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.bootstrap.context.ErrorRecorder;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ErrorCategory;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.common.util.AnnotationKeyUtils;
 import com.navercorp.pinpoint.common.util.DataType;
 import com.navercorp.pinpoint.common.util.StringUtils;
-import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
 import com.navercorp.pinpoint.profiler.context.Annotation;
 import com.navercorp.pinpoint.profiler.context.annotation.Annotations;
 import com.navercorp.pinpoint.profiler.context.errorhandler.IgnoreErrorHandler;

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/AttributeTranscoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/AttributeTranscoder.java
@@ -18,7 +18,14 @@ package com.navercorp.pinpoint.common.server.bo;
 
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValueList;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueArray;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueBoolean;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueBytes;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueDouble;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueLong;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueString;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -46,31 +53,30 @@ public class AttributeTranscoder {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void writeValue(Buffer buffer, AttributeValue attributeValue) {
         switch (attributeValue.getType()) {
             case STRING:
                 buffer.putByte(TYPE_STRING);
-                buffer.putPrefixedBytes(((String) attributeValue.getValue()).getBytes(StandardCharsets.UTF_8));
+                buffer.putPrefixedBytes(((AttributeValueString) attributeValue).getStringValue().getBytes(StandardCharsets.UTF_8));
                 break;
             case BOOLEAN:
-                buffer.putByte((Boolean) attributeValue.getValue() ? TYPE_BOOL_TRUE : TYPE_BOOL_FALSE);
+                buffer.putByte(((AttributeValueBoolean) attributeValue).getBooleanValue() ? TYPE_BOOL_TRUE : TYPE_BOOL_FALSE);
                 break;
             case LONG:
                 buffer.putByte(TYPE_LONG);
-                buffer.putSVLong((Long) attributeValue.getValue());
+                buffer.putSVLong(((AttributeValueLong) attributeValue).getLongValue());
                 break;
             case DOUBLE:
                 buffer.putByte(TYPE_DOUBLE);
-                buffer.putLong(Double.doubleToRawLongBits((Double) attributeValue.getValue()));
+                buffer.putLong(Double.doubleToRawLongBits(((AttributeValueDouble) attributeValue).getDoubleValue()));
                 break;
             case BYTES:
                 buffer.putByte(TYPE_BYTES);
-                buffer.putPrefixedBytes((byte[]) attributeValue.getValue());
+                buffer.putPrefixedBytes(((AttributeValueBytes) attributeValue).getBytesValue());
                 break;
             case ARRAY:
                 buffer.putByte(TYPE_ARRAY);
-                List<AttributeValue> array = (List<AttributeValue>) attributeValue.getValue();
+                List<AttributeValue> array = ((AttributeValueArray) attributeValue).getArrayValue();
                 buffer.putVInt(array.size());
                 for (AttributeValue item : array) {
                     writeValue(buffer, item);
@@ -78,7 +84,7 @@ public class AttributeTranscoder {
                 break;
             case KEY_VALUE_LIST:
                 buffer.putByte(TYPE_KVLIST);
-                List<AttributeKeyValue> kvList = (List<AttributeKeyValue>) attributeValue.getValue();
+                List<AttributeKeyValue> kvList = ((AttributeKeyValueList) attributeValue).getKeyValueListValue();
                 buffer.putVInt(kvList.size());
                 for (AttributeKeyValue kv : kvList) {
                     buffer.putNullTerminatedString(kv.getKey());

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeKeyValueList.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeKeyValueList.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * @author jaehong.kim
  */
-final class AttributeKeyValueList implements AttributeValue {
+public final class AttributeKeyValueList implements AttributeValue {
     private final List<AttributeKeyValue> value;
 
     AttributeKeyValueList(AttributeKeyValue... values) {
@@ -49,7 +49,11 @@ final class AttributeKeyValueList implements AttributeValue {
     }
 
     @Override
-    public List<AttributeKeyValue> getValue() {
+    public Object getValue() {
+        return value;
+    }
+
+    public List<AttributeKeyValue> getKeyValueListValue() {
         return value;
     }
 

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValue.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValue.java
@@ -22,6 +22,10 @@ import java.util.Map;
 /**
  * Typed attribute value for Span/SpanEvent attributes.
  * Inspired by OpenTelemetry's {@code io.opentelemetry.api.common.Value<T>}.
+ * <p>
+ * {@link #getValue()} returns the wrapped value as {@link Object} (boxing primitives).
+ * On hot paths, prefer the per-type accessors on the concrete classes
+ * (e.g. {@link AttributeValueLong#getLongValue()}) to avoid boxing.
  *
  * @author jaehong.kim
  */
@@ -31,39 +35,39 @@ public interface AttributeValue {
 
     Object getValue();
 
-    static AttributeValue of(String value) {
+    static AttributeValueString of(String value) {
         return new AttributeValueString(value);
     }
 
-    static AttributeValue of(boolean value) {
-        return new AttributeValueBoolean(value);
+    static AttributeValueBoolean of(boolean value) {
+        return AttributeValueBoolean.of(value);
     }
 
-    static AttributeValue of(long value) {
+    static AttributeValueLong of(long value) {
         return new AttributeValueLong(value);
     }
 
-    static AttributeValue of(double value) {
+    static AttributeValueDouble of(double value) {
         return new AttributeValueDouble(value);
     }
 
-    static AttributeValue of(byte[] value) {
+    static AttributeValueBytes of(byte[] value) {
         return new AttributeValueBytes(value);
     }
 
-    static AttributeValue of(AttributeValue... values) {
+    static AttributeValueArray of(AttributeValue... values) {
         return new AttributeValueArray(values);
     }
 
-    static AttributeValue of(List<AttributeValue> values) {
+    static AttributeValueArray of(List<AttributeValue> values) {
         return new AttributeValueArray(values);
     }
 
-    static AttributeValue ofAttributeKeyValueList(AttributeKeyValue... values) {
+    static AttributeKeyValueList ofAttributeKeyValueList(AttributeKeyValue... values) {
         return new AttributeKeyValueList(values);
     }
 
-    static AttributeValue ofAttributeKeyValueList(Map<String, AttributeValue> values) {
+    static AttributeKeyValueList ofAttributeKeyValueList(Map<String, AttributeValue> values) {
         return new AttributeKeyValueList(values);
     }
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueArray.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueArray.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 /**
  * @author jaehong.kim
  */
-final class AttributeValueArray implements AttributeValue {
+public final class AttributeValueArray implements AttributeValue {
     private final List<AttributeValue> value;
 
     AttributeValueArray(AttributeValue... values) {
@@ -44,7 +44,11 @@ final class AttributeValueArray implements AttributeValue {
     }
 
     @Override
-    public List<AttributeValue> getValue() {
+    public Object getValue() {
+        return value;
+    }
+
+    public List<AttributeValue> getArrayValue() {
         return value;
     }
 

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueBoolean.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueBoolean.java
@@ -19,10 +19,17 @@ package com.navercorp.pinpoint.common.trace.attribute;
 /**
  * @author jaehong.kim
  */
-final class AttributeValueBoolean implements AttributeValue {
+public final class AttributeValueBoolean implements AttributeValue {
+    private static final AttributeValueBoolean TRUE = new AttributeValueBoolean(true);
+    private static final AttributeValueBoolean FALSE = new AttributeValueBoolean(false);
+
     private final boolean value;
 
-    AttributeValueBoolean(boolean value) {
+    static AttributeValueBoolean of(boolean value) {
+        return value ? TRUE : FALSE;
+    }
+
+    private AttributeValueBoolean(boolean value) {
         this.value = value;
     }
 
@@ -32,12 +39,16 @@ final class AttributeValueBoolean implements AttributeValue {
     }
 
     @Override
-    public Boolean getValue() {
+    public Object getValue() {
+        return value;
+    }
+
+    public boolean getBooleanValue() {
         return value;
     }
 
     @Override
     public String toString() {
-        return String.valueOf(value);
+        return Boolean.toString(value);
     }
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueBytes.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueBytes.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 /**
  * @author jaehong.kim
  */
-final class AttributeValueBytes implements AttributeValue {
+public final class AttributeValueBytes implements AttributeValue {
     private final byte[] value;
 
     AttributeValueBytes(byte[] value) {
@@ -36,7 +36,11 @@ final class AttributeValueBytes implements AttributeValue {
     }
 
     @Override
-    public byte[] getValue() {
+    public Object getValue() {
+        return Arrays.copyOf(value, value.length);
+    }
+
+    public byte[] getBytesValue() {
         return Arrays.copyOf(value, value.length);
     }
 

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueDouble.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueDouble.java
@@ -19,7 +19,7 @@ package com.navercorp.pinpoint.common.trace.attribute;
 /**
  * @author jaehong.kim
  */
-final class AttributeValueDouble implements AttributeValue {
+public final class AttributeValueDouble implements AttributeValue {
     private final double value;
 
     AttributeValueDouble(double value) {
@@ -32,12 +32,16 @@ final class AttributeValueDouble implements AttributeValue {
     }
 
     @Override
-    public Double getValue() {
+    public Object getValue() {
+        return value;
+    }
+
+    public double getDoubleValue() {
         return value;
     }
 
     @Override
     public String toString() {
-        return String.valueOf(value);
+        return Double.toString(value);
     }
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueLong.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueLong.java
@@ -19,7 +19,7 @@ package com.navercorp.pinpoint.common.trace.attribute;
 /**
  * @author jaehong.kim
  */
-final class AttributeValueLong implements AttributeValue {
+public final class AttributeValueLong implements AttributeValue {
     private final long value;
 
     AttributeValueLong(long value) {
@@ -32,12 +32,16 @@ final class AttributeValueLong implements AttributeValue {
     }
 
     @Override
-    public Long getValue() {
+    public Object getValue() {
+        return value;
+    }
+
+    public long getLongValue() {
         return value;
     }
 
     @Override
     public String toString() {
-        return String.valueOf(value);
+        return Long.toString(value);
     }
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueString.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueString.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 /**
  * @author jaehong.kim
  */
-final class AttributeValueString implements AttributeValue {
+public final class AttributeValueString implements AttributeValue {
     private final String value;
 
     AttributeValueString(String value) {
@@ -34,7 +34,11 @@ final class AttributeValueString implements AttributeValue {
     }
 
     @Override
-    public String getValue() {
+    public Object getValue() {
+        return value;
+    }
+
+    public String getStringValue() {
         return value;
     }
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/util/AttributeUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/util/AttributeUtils.java
@@ -1,7 +1,8 @@
 package com.navercorp.pinpoint.otlp.trace.collector.util;
 
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
-import com.navercorp.pinpoint.common.trace.attribute.AttributeValueType;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueLong;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueString;
 
 import java.util.Map;
 
@@ -11,7 +12,7 @@ public final class AttributeUtils {
 
     public static long getIntValue(Map<String, Object> attributes, String key, long defaultValue) {
         final Object value = attributes.get(key);
-        if (value != null && value instanceof Number) {
+        if (value instanceof Number) {
             return (long) value;
         }
         return defaultValue;
@@ -19,7 +20,7 @@ public final class AttributeUtils {
 
     public static String getStringValue(Map<String, Object> attributes, String key, String defaultValue) {
         final Object value = attributes.get(key);
-        if (value != null && value instanceof String) {
+        if (value instanceof String) {
             return (String) value;
         }
         return defaultValue;
@@ -27,16 +28,16 @@ public final class AttributeUtils {
 
     public static long getAttributeIntValue(Map<String, AttributeValue> attributes, String key, long defaultValue) {
         final AttributeValue value = attributes.get(key);
-        if (value != null && value.getType() == AttributeValueType.LONG) {
-            return (Long) value.getValue();
+        if (value instanceof AttributeValueLong longValue) {
+            return longValue.getLongValue();
         }
         return defaultValue;
     }
 
     public static String getAttributeStringValue(Map<String, AttributeValue> attributes, String key, String defaultValue) {
         final AttributeValue value = attributes.get(key);
-        if (value != null && value.getType() == AttributeValueType.STRING) {
-            return (String) value.getValue();
+        if (value instanceof AttributeValueString stringValue) {
+            return stringValue.getStringValue();
         }
         return defaultValue;
     }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -1,12 +1,11 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.google.protobuf.ByteString;
-
 import com.navercorp.pinpoint.common.server.bo.AttributeBo;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValueType;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.ArrayValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
@@ -780,7 +779,15 @@ class OtlpTraceMapperUtilsTest {
         assertThat(outer.get(0).getType()).isEqualTo(AttributeValueType.ARRAY);
         @SuppressWarnings("unchecked")
         List<AttributeValue> inner = (List<AttributeValue>) outer.get(0).getValue();
-        assertThat(inner).extracting(AttributeValue::getValue).containsExactly("x", "y");
+        assertThat(inner).extracting(this::getStringValue).containsExactly("x", "y");
+    }
+
+    private String getStringValue(AttributeValue s) {
+        return (String) s.getValue();
+    }
+
+    private Object getObjectValue(AttributeValue s) {
+        return s.getValue();
     }
 
     @Test
@@ -811,7 +818,7 @@ class OtlpTraceMapperUtilsTest {
         assertThat(nested.getType()).isEqualTo(AttributeValueType.ARRAY);
         @SuppressWarnings("unchecked")
         List<AttributeValue> innerList = (List<AttributeValue>) nested.getValue();
-        assertThat(innerList).extracting(AttributeValue::getValue).containsExactly("t1", "t2");
+        assertThat(innerList).extracting(this::getObjectValue).containsExactly("t1", "t2");
     }
 
     @Test
@@ -830,7 +837,7 @@ class OtlpTraceMapperUtilsTest {
         @SuppressWarnings("unchecked")
         List<AttributeValue> list = (List<AttributeValue>) result.getValue();
         assertThat(list).hasSize(2);
-        assertThat(list).extracting(AttributeValue::getValue).containsExactly("keep", 1L);
+        assertThat(list).extracting(this::getObjectValue).containsExactly("keep", 1L);
     }
 
     @Test

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java
@@ -31,7 +31,10 @@ import com.navercorp.pinpoint.common.trace.AnnotationKeyMatcher;
 import com.navercorp.pinpoint.common.trace.ErrorCategory;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValueList;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueArray;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueBytes;
 import com.navercorp.pinpoint.loader.service.AnnotationKeyRegistryService;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.component.AnnotationKeyMatcherService;
@@ -253,20 +256,22 @@ public class RecordFactory {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static Object toPlainObject(AttributeValue value) {
         if (value == null) {
             return null;
         }
         return switch (value.getType()) {
             case STRING, BOOLEAN, LONG, DOUBLE -> value.getValue();
-            case BYTES -> Base64.getEncoder().encodeToString((byte[]) value.getValue());
+            case BYTES -> {
+                byte[] bytesValue = ((AttributeValueBytes) value).getBytesValue();
+                yield Base64.getEncoder().encodeToString(bytesValue);
+            }
             case ARRAY -> {
-                List<AttributeValue> list = (List<AttributeValue>) value.getValue();
+                List<AttributeValue> list = ((AttributeValueArray) value).getArrayValue();
                 yield list.stream().map(RecordFactory::toPlainObject).toList();
             }
             case KEY_VALUE_LIST -> {
-                List<AttributeKeyValue> kvList = (List<AttributeKeyValue>) value.getValue();
+                List<AttributeKeyValue> kvList = ((AttributeKeyValueList) value).getKeyValueListValue();
                 LinkedHashMap<String, Object> kvMap = new LinkedHashMap<>();
                 for (AttributeKeyValue kv : kvList) {
                     kvMap.put(kv.getKey(), toPlainObject(kv.getValue()));


### PR DESCRIPTION
- Remove generic type parameter; getValue() returns Object
- Make concrete AttributeValue types public (keep factory-only construction)
- Add per-type value accessors (getStringValue, getLongValue, ...) to avoid boxing on hot paths
- Factory methods return concrete implementation types
- Cache TRUE/FALSE singletons in AttributeValueBoolean
- Migrate getValue() casts to per-type accessors (instanceof pattern / switch)
- Replace AttributeValue<?> wildcard usages across modules
