### PR TITLE
[ #13838] Introduce bitmask-based ErrorCategorySet

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolver.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolver.java
@@ -16,30 +16,21 @@
 
 package com.navercorp.pinpoint.common.trace;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Set;
-
 public class ErrorCategoryResolver {
 
-    private static final ErrorCategory[] DISPLAY_CANDIDATE = displayCandidate();
+    private static final int DISPLAY_MASK = displayMask();
 
-    private static ErrorCategory[] displayCandidate() {
-        ErrorCategory[] values = ErrorCategory.values();
-        List<ErrorCategory> list = new ArrayList<>(Arrays.asList(values));
-        list.remove(ErrorCategory.UNKNOWN);
-        return list.toArray(new ErrorCategory[0]);
-    }
-
-    public Set<ErrorCategory> resolve(int errorCode) {
-        Set<ErrorCategory> flagged = EnumSet.noneOf(ErrorCategory.class);
-        for (ErrorCategory category : DISPLAY_CANDIDATE) {
-            if ((errorCode & category.getBitMask()) != 0) {
-                flagged.add(category);
+    private static int displayMask() {
+        int mask = 0;
+        for (ErrorCategory category : ErrorCategory.values()) {
+            if (category != ErrorCategory.UNKNOWN) {
+                mask |= category.getBitMask();
             }
         }
-        return flagged;
+        return mask;
+    }
+
+    public ErrorCategorySet resolve(int errorCode) {
+        return ErrorCategorySet.of(errorCode & DISPLAY_MASK);
     }
 }

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/ErrorCategorySet.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/ErrorCategorySet.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.trace;
+
+import java.util.StringJoiner;
+
+public final class ErrorCategorySet {
+
+    private static final String SEPARATOR = ", ";
+
+    private static final ErrorCategory[] CATEGORIES = ErrorCategory.values();
+
+    private static final ErrorCategorySet EMPTY = new ErrorCategorySet(0);
+
+    public static ErrorCategorySet empty() {
+        return EMPTY;
+    }
+
+    private final int bitMask;
+
+    public static ErrorCategorySet of(int bitMask) {
+        if (bitMask == 0) {
+            return EMPTY;
+        }
+        return new ErrorCategorySet(bitMask);
+    }
+
+    private ErrorCategorySet(int bitMask) {
+        this.bitMask = bitMask;
+    }
+
+    public boolean isEmpty() {
+        return bitMask == 0;
+    }
+
+    public boolean contains(ErrorCategory category) {
+        return (bitMask & category.getBitMask()) != 0;
+    }
+
+    public String format() {
+        if (bitMask == 0) {
+            return "";
+        }
+        StringJoiner joiner = new StringJoiner(SEPARATOR);
+        for (ErrorCategory category : CATEGORIES) {
+            if ((bitMask & category.getBitMask()) != 0) {
+                joiner.add(category.name());
+            }
+        }
+        return joiner.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ErrorCategorySet)) {
+            return false;
+        }
+        ErrorCategorySet that = (ErrorCategorySet) o;
+        return bitMask == that.bitMask;
+    }
+
+    @Override
+    public int hashCode() {
+        return bitMask;
+    }
+
+    @Override
+    public String toString() {
+        return format();
+    }
+}

--- a/commons/src/test/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolverTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolverTest.java
@@ -42,5 +42,30 @@ class ErrorCategoryResolverTest {
         Assertions.assertTrue(result.isEmpty());
     }
 
+    @Test
+    public void containsShouldReturnTrueForResolvedCategories() {
+        int errorCode = ErrorCategory.EXCEPTION.getBitMask() | ErrorCategory.SQL.getBitMask();
+        ErrorCategorySet result = new ErrorCategoryResolver().resolve(errorCode);
+        Assertions.assertTrue(result.contains(ErrorCategory.EXCEPTION));
+        Assertions.assertTrue(result.contains(ErrorCategory.SQL));
+        Assertions.assertFalse(result.contains(ErrorCategory.HTTP_STATUS));
+    }
+
+    @Test
+    public void containsShouldReturnFalseForEmptySet() {
+        ErrorCategorySet result = new ErrorCategoryResolver().resolve(0);
+        Assertions.assertFalse(result.contains(ErrorCategory.EXCEPTION));
+        Assertions.assertFalse(result.contains(ErrorCategory.HTTP_STATUS));
+        Assertions.assertFalse(result.contains(ErrorCategory.SQL));
+    }
+
+    @Test
+    public void containsShouldReturnFalseForUnknownCategory() {
+        int errorCode = ErrorCategory.UNKNOWN.getBitMask() | ErrorCategory.EXCEPTION.getBitMask();
+        ErrorCategorySet result = new ErrorCategoryResolver().resolve(errorCode);
+        Assertions.assertFalse(result.contains(ErrorCategory.UNKNOWN));
+        Assertions.assertTrue(result.contains(ErrorCategory.EXCEPTION));
+    }
+
 
 }

--- a/commons/src/test/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolverTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/trace/ErrorCategoryResolverTest.java
@@ -19,29 +19,26 @@ package com.navercorp.pinpoint.common.trace;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.EnumSet;
-import java.util.Set;
-
 class ErrorCategoryResolverTest {
 
     @Test
     public void resolveShouldReturnEmptySetForUnknownErrorCode() {
         int unknownErrorCode = ErrorCategory.UNKNOWN.getBitMask();
-        Set<ErrorCategory> result = new ErrorCategoryResolver().resolve(unknownErrorCode);
+        ErrorCategorySet result = new ErrorCategoryResolver().resolve(unknownErrorCode);
         Assertions.assertTrue(result.isEmpty());
     }
 
     @Test
     public void resolveShouldReturnSingleCategoryForMatchingErrorCode() {
         int networkErrorCode = ErrorCategory.EXCEPTION.getBitMask();
-        Set<ErrorCategory> result = new ErrorCategoryResolver().resolve(networkErrorCode);
-        Assertions.assertEquals(EnumSet.of(ErrorCategory.EXCEPTION), result);
+        ErrorCategorySet result = new ErrorCategoryResolver().resolve(networkErrorCode);
+        Assertions.assertEquals(ErrorCategorySet.of(ErrorCategory.EXCEPTION.getBitMask()), result);
     }
 
     @Test
     public void resolveShouldReturnEmptySetForZeroErrorCode() {
         int zeroErrorCode = 0;
-        Set<ErrorCategory> result = new ErrorCategoryResolver().resolve(zeroErrorCode);
+        ErrorCategorySet result = new ErrorCategoryResolver().resolve(zeroErrorCode);
         Assertions.assertTrue(result.isEmpty());
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java
@@ -28,7 +28,7 @@ import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.util.AnnotationUtils;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.AnnotationKeyMatcher;
-import com.navercorp.pinpoint.common.trace.ErrorCategory;
+import com.navercorp.pinpoint.common.trace.ErrorCategorySet;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValueList;
@@ -47,8 +47,6 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 
 /**
@@ -289,8 +287,8 @@ public class RecordFactory {
         return new ParameterRecord(depth, getNextId(), parentId, method, argument);
     }
 
-    public Record getErrorCategory(final int depth, final int parentId, final Set<ErrorCategory> categories) {
-        String argument = categories.stream().map(Enum::name).collect(Collectors.joining(", "));
+    public Record getErrorCategory(final int depth, final int parentId, final ErrorCategorySet categories) {
+        String argument = categories.format();
         return ParameterRecord.errorRecord(depth, getNextId(), parentId, argument);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/service/TransactionInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/service/TransactionInfoServiceImpl.java
@@ -19,8 +19,8 @@ package com.navercorp.pinpoint.web.trace.service;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.trace.AnnotationKeyMatcher;
-import com.navercorp.pinpoint.common.trace.ErrorCategory;
 import com.navercorp.pinpoint.common.trace.ErrorCategoryResolver;
+import com.navercorp.pinpoint.common.trace.ErrorCategorySet;
 import com.navercorp.pinpoint.common.trace.LoggingInfo;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
@@ -324,7 +324,7 @@ public class TransactionInfoServiceImpl implements TransactionInfoService {
                 if (align.isSpan()) {
                     final SpanBo spanBo = align.getSpanBo();
                     if (spanBo.hasError()) {
-                        Set<ErrorCategory> flagged = errorCategoryResolver.resolve(spanBo.getErrCode());
+                        ErrorCategorySet flagged = errorCategoryResolver.resolve(spanBo.getErrCode());
                         if (!flagged.isEmpty()) {
                             final Record errorCategoryRecord = factory.getErrorCategory(record.getTab() + 1, record.getId(), flagged);
                             recordList.add(errorCategoryRecord);


### PR DESCRIPTION
- Add ErrorCategorySet first-class collection backed by an int bitmask
  with cached EMPTY instance and empty fast-path in format()
- ErrorCategoryResolver.resolve() returns ErrorCategorySet via single mask operation
- RecordFactory/TransactionInfoServiceImpl consume the domain type directly
