### PR TITLE
[#13839] Fix heatmap Kafka topic name in Pinot realtime table config

### DIFF
--- a/collector/src/main/pinot/pinot-heatmap-stat-application-realtime-table.json
+++ b/collector/src/main/pinot/pinot-heatmap-stat-application-realtime-table.json
@@ -22,7 +22,7 @@
     "streamConfigs": {
       "streamType": "kafka",
       "stream.kafka.consumer.type": "lowlevel",
-      "stream.kafka.topic.name": "heatmap-stat-00",
+      "stream.kafka.topic.name": "heatmap-stat-app-00",
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
       "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
       "stream.kafka.broker.list": "localhost:19092",


### PR DESCRIPTION
## Summary
- Fix incorrect Kafka topic name in heatmap Pinot realtime table config (`heatmap-stat-00` → `heatmap-stat-app-00`)

## Test plan
- Verify heatmap data ingestion works with corrected topic name