### PR TITLE
Fix missing pServiceName header on service-map API requests

### DIFF
--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { useExperimentals, useGetConfiguration, useServicesFetch } from '@pinpoint-fe/ui/src/hooks';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { configurationAtom, searchParametersAtom } from '@pinpoint-fe/ui/src/atoms';
+import {
+  configurationAtom,
+  searchParametersAtom,
+  selectedServiceAtom,
+} from '@pinpoint-fe/ui/src/atoms';
 import { APP_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
 
@@ -11,6 +16,9 @@ export const InitialFetchOutlet = () => {
   const { data, error } = useGetConfiguration<Configuration>();
   const setConfiguration = useSetAtom(configurationAtom);
   const configuration = useAtomValue(configurationAtom);
+  const selectedService = useAtomValue(selectedServiceAtom);
+  const queryClient = useQueryClient();
+  const prevSelectedServiceRef = React.useRef(selectedService);
   const { pathname, search } = useLocation();
   const application = getApplicationTypeAndName(pathname);
   const searchParameters = Object.fromEntries(new URLSearchParams(search));
@@ -18,6 +26,19 @@ export const InitialFetchOutlet = () => {
 
   useExperimentals(data);
   useServicesFetch();
+
+  // selectedService가 바뀌면 fetch 인터셉터가 주입하는 pServiceName 헤더 값이 달라진다.
+  // 하지만 queryKey에는 service가 포함되지 않아, 캐시된 쿼리는 새 헤더로 재요청되지 않는다.
+  // service 변경 시 캐시를 무효화하여 활성 쿼리가 새 service로 다시 요청되도록 한다.
+  // enableServiceMap이 꺼진 환경에서는 인터셉터가 헤더를 주입하지 않으므로 무효화도 불필요하다.
+  const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
+
+  React.useEffect(() => {
+    if (prevSelectedServiceRef.current === selectedService) return;
+    prevSelectedServiceRef.current = selectedService;
+    if (!enableServiceMap) return;
+    queryClient.invalidateQueries();
+  }, [selectedService, enableServiceMap, queryClient]);
 
   React.useEffect(() => {
     if (application && searchParameters) {

--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
@@ -17,7 +17,7 @@ export const InitialFetchOutlet = () => {
   const setSearchParameters = useSetAtom(searchParametersAtom);
 
   useExperimentals(data);
-  useServicesFetch(data);
+  useServicesFetch();
 
   React.useEffect(() => {
     if (application && searchParameters) {

--- a/web-frontend/src/main/v3/apps/web/src/main.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/main.tsx
@@ -1,21 +1,29 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
-import { Provider as JotaiProvider } from 'jotai';
+import { Provider as JotaiProvider, getDefaultStore } from 'jotai';
 import { IconContext } from 'react-icons';
 // import { ReactToastContainer, queryClient } from '@pinpoint-fe/ui';
 import { ReactToastContainer } from '@pinpoint-fe/ui/src/components';
-import { queryClient } from '@pinpoint-fe/ui/src/hooks';
+import { queryClient, installServiceNameFetchInterceptor } from '@pinpoint-fe/ui/src/hooks';
 import router from './routes';
 import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n';
 import { QueryClientProvider } from '@tanstack/react-query';
 
+// 인터셉터(getDefaultStore)와 React 트리(JotaiProvider)가 동일한 store를 공유해야
+// configurationAtom/selectedServiceAtom 값을 인터셉터가 읽을 수 있다.
+const jotaiStore = getDefaultStore();
+
+// configuration의 experimental.enableServiceMap이 켜져 있을 때, 모든 /api 요청 헤더에
+// 현재 선택된 service를 주입한다. 렌더링/최초 fetch 이전에 한 번 설치해야 한다.
+installServiceNameFetchInterceptor();
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.Fragment>
     <I18nextProvider i18n={i18n}>
       <QueryClientProvider client={queryClient}>
-        <JotaiProvider>
+        <JotaiProvider store={jotaiStore}>
           <IconContext.Provider value={{ style: { verticalAlign: 'middle' } }}>
             <React.Suspense fallback={null}>
               <RouterProvider router={router} />

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.ts
@@ -7,4 +7,9 @@ export const RESERVED_SERVICE_NAMES = ['DEFAULT', 'TEST', 'ERROR', 'UNKNOWN', 'N
 export const isReservedServiceName = (name: string) =>
   RESERVED_SERVICE_NAMES.includes(name.toUpperCase());
 
-export const selectedServiceAtom = atomWithStorage<string>('selectedService', DEFAULT_SERVICE);
+// getOnInit: true → 첫 렌더부터 localStorage 값을 동기로 읽는다.
+// 이로써 fetch 인터셉터의 최초 요청도 저장된 service를 반영하고,
+// 새로고침 시 hydration으로 인한 불필요한 캐시 무효화를 방지한다.
+export const selectedServiceAtom = atomWithStorage<string>('selectedService', DEFAULT_SERVICE, undefined, {
+  getOnInit: true,
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/index.ts
@@ -1,4 +1,5 @@
 export * from './reactQueryHelper';
+export * from './serviceNameFetchInterceptor';
 export * from './useAdmin';
 export * from './useAlarmRuleMutation';
 export * from './useAlarmRuleQuery';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
@@ -1,0 +1,87 @@
+import { getDefaultStore } from 'jotai';
+import { configurationAtom, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration } from '@pinpoint-fe/ui/src/constants';
+import {
+  installServiceNameFetchInterceptor,
+  SERVICE_NAME_HEADER,
+} from './serviceNameFetchInterceptor';
+
+const store = getDefaultStore();
+const originalFetch = jest.fn(() => Promise.resolve(undefined as unknown as Response));
+
+const configWithServiceMap = (enable: boolean) =>
+  ({ 'experimental.enableServiceMap.value': enable }) as unknown as Configuration;
+
+const lastCall = () => originalFetch.mock.calls[originalFetch.mock.calls.length - 1];
+
+const headerOfLastCall = (): string | null => {
+  const [, init] = lastCall() as [RequestInfo | URL, RequestInit | undefined];
+  return new Headers(init?.headers).get(SERVICE_NAME_HEADER);
+};
+
+describe('serviceNameFetchInterceptor', () => {
+  beforeAll(() => {
+    // 패치 대상이 될 원본 fetch를 먼저 심어두고, 인터셉터를 한 번 설치한다.
+    window.fetch = originalFetch as typeof window.fetch;
+    installServiceNameFetchInterceptor();
+  });
+
+  beforeEach(() => {
+    originalFetch.mockClear();
+    store.set(configurationAtom, undefined);
+    store.set(selectedServiceAtom, 'DEFAULT');
+  });
+
+  test('does not add the service header when enableServiceMap is off', async () => {
+    store.set(configurationAtom, configWithServiceMap(false));
+    store.set(selectedServiceAtom, 'my-service');
+
+    await window.fetch('/api/serverMap');
+
+    expect(originalFetch).toHaveBeenCalledTimes(1);
+    expect(headerOfLastCall()).toBeNull();
+  });
+
+  test('adds the selected service header on /api requests when enableServiceMap is on', async () => {
+    store.set(configurationAtom, configWithServiceMap(true));
+    store.set(selectedServiceAtom, 'my-service');
+
+    await window.fetch('/api/serverMap');
+
+    expect(headerOfLastCall()).toBe('my-service');
+  });
+
+  test('sends DEFAULT when the selected service is the default value', async () => {
+    store.set(configurationAtom, configWithServiceMap(true));
+
+    await window.fetch('/api/configuration');
+
+    expect(headerOfLastCall()).toBe('DEFAULT');
+  });
+
+  test('does not add the header to non-/api requests', async () => {
+    store.set(configurationAtom, configWithServiceMap(true));
+    store.set(selectedServiceAtom, 'my-service');
+
+    await window.fetch('/static/logo.png');
+
+    expect(headerOfLastCall()).toBeNull();
+  });
+
+  test('preserves existing request headers while adding the service header', async () => {
+    store.set(configurationAtom, configWithServiceMap(true));
+    store.set(selectedServiceAtom, 'my-service');
+
+    await window.fetch('/api/userGroup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const [, init] = lastCall() as [RequestInfo | URL, RequestInit | undefined];
+    const headers = new Headers(init?.headers);
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(headers.get(SERVICE_NAME_HEADER)).toBe('my-service');
+    expect(init?.method).toBe('POST');
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
@@ -1,0 +1,72 @@
+import { getDefaultStore } from 'jotai';
+import { configurationAtom, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+
+/**
+ * 백엔드(service-module)의 `ServiceConstants.KEY`와 동일한 헤더 이름.
+ * `HeaderServiceNameExtractor`가 이 헤더로 현재 선택된 service를 읽는다.
+ */
+export const SERVICE_NAME_HEADER = 'pServiceName';
+
+const API_PATH_PREFIX = '/api';
+
+const isRequestObject = (input: RequestInfo | URL): input is Request =>
+  typeof Request !== 'undefined' && input instanceof Request;
+
+const getRequestUrl = (input: RequestInfo | URL): string => {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  if (isRequestObject(input)) return input.url;
+  return String(input);
+};
+
+const isApiRequest = (input: RequestInfo | URL): boolean => {
+  try {
+    const { pathname } = new URL(getRequestUrl(input), window.location.origin);
+    return pathname.startsWith(API_PATH_PREFIX);
+  } catch {
+    return false;
+  }
+};
+
+let installed = false;
+
+/**
+ * 전역 `fetch`를 한 번 래핑하여, configuration의
+ * `experimental.enableServiceMap.value`가 true일 때 백엔드로 가는 모든
+ * `/api` 요청 헤더에 현재 선택된 service(`selectedServiceAtom`)를 주입한다.
+ *
+ * Jotai 기본 store(`getDefaultStore`)를 사용하므로 컴포넌트의
+ * `useAtomValue`/`useSetAtom`과 동일한 상태를 참조한다.
+ * 앱 부트스트랩(main.tsx)에서 렌더링 전에 한 번 호출한다.
+ */
+export const installServiceNameFetchInterceptor = () => {
+  if (installed) return;
+  if (typeof window === 'undefined' || typeof window.fetch !== 'function') return;
+  installed = true;
+
+  const store = getDefaultStore();
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    try {
+      const configuration = store.get(configurationAtom);
+      const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
+
+      if (enableServiceMap && isApiRequest(input)) {
+        const selectedService = store.get(selectedServiceAtom);
+
+        if (selectedService) {
+          const headers = new Headers(
+            init?.headers ?? (isRequestObject(input) ? input.headers : undefined),
+          );
+          headers.set(SERVICE_NAME_HEADER, selectedService);
+          return originalFetch(input, { ...init, headers });
+        }
+      }
+    } catch {
+      // 인터셉터 내부 오류가 요청 자체를 막지 않도록 원본 fetch로 폴백한다.
+    }
+
+    return originalFetch(input, init);
+  };
+};

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.ts
@@ -1,10 +1,14 @@
 import React from 'react';
-import { useSetAtom } from 'jotai';
-import { servicesAtom } from '@pinpoint-fe/ui/src/atoms';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { configurationAtom, servicesAtom } from '@pinpoint-fe/ui/src/atoms';
 import { useGetServices } from '@pinpoint-fe/ui/src/hooks';
-import type { Configuration } from '@pinpoint-fe/ui/src/constants';
 
-export const useServicesFetch = (configuration: Configuration | undefined) => {
+export const useServicesFetch = () => {
+  // configurationAtom(전역 store)을 기준으로 enable한다. fetch 인터셉터가 동일한
+  // atom으로 enableServiceMap을 판단하므로, atom이 채워진 뒤에 /api/v2/services가
+  // 발생해야 pServiceName 헤더가 누락되지 않는다. (raw config로 enable하면 atom이
+  // useEffect로 채워지기 전에 요청이 나가 헤더가 빠진다.)
+  const configuration = useAtomValue(configurationAtom);
   const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
   const { data: services } = useGetServices({ enabled: enableServiceMap });
   const setServices = useSetAtom(servicesAtom);


### PR DESCRIPTION
## Summary
- When `experimental.enableServiceMap` is on, the fetch interceptor injects the selected service as a `pServiceName` header on `/api` requests, but the header was never sent (notably on `/api/v2/services`).
- Root cause 1: the interceptor reads atoms via `getDefaultStore()`, but `JotaiProvider` was mounted without a `store` prop, so the React tree wrote `configurationAtom`/`selectedServiceAtom` to a separate isolated store. Now `getDefaultStore()` is passed to `JotaiProvider` so both share the same store.
- Root cause 2: `useServicesFetch` enabled the `/api/v2/services` query from the raw configuration `data`, which fires before `setConfiguration` writes the atom. It now gates on `configurationAtom`, so the request fires only after the atom is populated and the interceptor can inject the header.

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (444 tests, incl. 5 new interceptor tests)
- [ ] With service map enabled, verify `/api/*` requests (incl. `/api/v2/services`) carry the `pServiceName` header in the Network tab
- [ ] With service map disabled, verify no `pServiceName` header is added