### PR TITLE
[#noissue] Guard against empty metricValueGroups in SystemMetricChartFetcher

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartFetcher.tsx
@@ -128,9 +128,11 @@ export const SystemMetricChartFetcher = ({
       columns: chartData
         ? [
             ['dates', ...chartData.timestamp],
-            ...chartData.metricValueGroups[0].metricValues.map(({ fieldName, values }) => {
-              return [fieldName, ...values.map((v: number) => (v < 0 ? null : v))];
-            }),
+            ...(chartData.metricValueGroups?.[0]?.metricValues ?? []).map(
+              ({ fieldName, values }) => {
+                return [fieldName, ...values.map((v: number) => (v < 0 ? null : v))];
+              },
+            ),
           ]
         : [],
       resizeAfter: true,


### PR DESCRIPTION
## Summary
- Guard the `metricValueGroups[0].metricValues` access in `SystemMetricChartFetcher` so an empty/null group array no longer throws a runtime `TypeError`.
- When `metricValueGroups` is empty, the chart now falls back to an empty column set and renders the "No Data" state instead of crashing.

## Test plan
- [ ] System metric chart renders normally with valid data (no regression).
- [ ] System metric chart with empty `metricValueGroups` shows "No Data" instead of a blank/error screen.
- [x] `yarn build` passes
- [x] `yarn test` passes (439/439)