### PR TITLE
[#noissue] Extract UTF-8 truncation into StringTruncator 

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/StringTruncator.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/StringTruncator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.util;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+
+public final class StringTruncator {
+
+    private StringTruncator() {
+    }
+
+    /**
+     * Truncates a string to at most {@code maxBytes} UTF-8 bytes without splitting a multi-byte
+     * character.
+     *
+     * @param str      the string to truncate; must not be {@code null}
+     * @param maxBytes the maximum length in UTF-8 bytes
+     * @return the truncated string, or {@code null} when no truncation is needed
+     * (value already within the limit)
+     */
+    public static @Nullable String truncateUtf8(String str, int maxBytes) {
+        Objects.requireNonNull(str, "str");
+        final int len = str.length();
+        // fast path: a UTF-8 char is at most 4 bytes, so when 4*len <= maxBytes
+        // the value cannot exceed the limit -> no truncation.
+        if ((long) len * 4 <= maxBytes) {
+            return null;
+        }
+        int byteCount = 0;
+        for (int i = 0; i < len; ) {
+            final int cp = str.codePointAt(i);
+            final int bytes;
+            if (cp <= 0x7F) {
+                bytes = 1;
+            } else if (cp <= 0x7FF) {
+                bytes = 2;
+            } else if (cp <= 0xFFFF) {
+                bytes = 3;
+            } else {
+                bytes = 4;
+            }
+            if (byteCount + bytes > maxBytes) {
+                return str.substring(0, i); // cut at the code-point boundary
+            }
+            byteCount += bytes;
+            i += Character.charCount(cp); // 1 or 2 (surrogate pair)
+        }
+        return null; // within limit
+    }
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/StringTruncatorTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/StringTruncatorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.util;
+
+import com.google.common.base.Utf8;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class StringTruncatorTest {
+
+    private static int utf8Len(String value) {
+        return Utf8.encodedLength(value); // Guava's Utf8 counts code points, not bytes
+    }
+
+    @Test
+    void truncateUtf8_withinLimit_returnsNull() {
+        assertThat(StringTruncator.truncateUtf8("short", 64)).isNull();
+    }
+
+    @Test
+    void truncateUtf8_exactlyAtLimit_returnsNull() {
+        // bytes.length == maxBytes => no truncation
+        String value = "abcde";
+        assertThat(StringTruncator.truncateUtf8(value, utf8Len(value))).isNull();
+    }
+
+    @Test
+    void truncateUtf8_emptyString_returnsNull() {
+        assertThat(StringTruncator.truncateUtf8("", 8)).isNull();
+    }
+
+    @Test
+    void truncateUtf8_fastPathBoundary_returnsNull() {
+        // 4 * len(3) == maxBytes(12) triggers the upper-bound fast path
+        assertThat(StringTruncator.truncateUtf8("abc", 12)).isNull();
+    }
+
+    @Test
+    void truncateUtf8_nullValue_throwsNpe() {
+        assertThatThrownBy(() -> StringTruncator.truncateUtf8(null, 8))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void truncateUtf8_asciiOverLimit_truncatedToMaxBytes() {
+        String result = StringTruncator.truncateUtf8("a".repeat(100), 10);
+
+        assertThat(result).isEqualTo("a".repeat(10));
+        assertThat(utf8Len(result)).isEqualTo(10);
+    }
+
+    @Test
+    void truncateUtf8_multiByteBoundary_doesNotSplitCharacter() {
+        // '가' is 3 UTF-8 bytes (0xEA 0xB0 0x80). "가가가" = 9 bytes.
+        // maxBytes=4 lands inside the 2nd char => must back off to the char boundary (3 bytes).
+        String result = StringTruncator.truncateUtf8("가가가", 4);
+
+        assertThat(result).isEqualTo("가");
+        assertThat(utf8Len(result)).isLessThanOrEqualTo(4);
+    }
+
+    @Test
+    void truncateUtf8_multiByteExactBoundary_keepsWholeCharacters() {
+        // maxBytes=6 == exactly two '가' chars; no back-off needed.
+        String result = StringTruncator.truncateUtf8("가가가", 6);
+
+        assertThat(result).isEqualTo("가가");
+        assertThat(utf8Len(result)).isEqualTo(6);
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
@@ -8,9 +8,9 @@ import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
 import com.navercorp.pinpoint.common.server.util.Base16Utils;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
+import com.navercorp.pinpoint.common.server.util.StringTruncator;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import io.opentelemetry.proto.trace.v1.Span;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -63,7 +63,7 @@ public class OtlpTraceLinkMapper {
             // since chained vendor entries can grow long.
             if (!link.getTraceState().isEmpty()) {
                 String traceState = link.getTraceState();
-                final String truncatedTraceState = OtlpTraceMapperUtils.truncateUtf8(traceState, valueMaxBytes);
+                final String truncatedTraceState = StringTruncator.truncateUtf8(traceState, valueMaxBytes);
                 if (truncatedTraceState != null) {
                     traceState = truncatedTraceState;
                     truncated++;

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.Base16Utils;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
+import com.navercorp.pinpoint.common.server.util.StringTruncator;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
@@ -32,7 +33,6 @@ import io.opentelemetry.proto.common.v1.ArrayValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import org.apache.commons.lang3.mutable.MutableInt;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -357,23 +357,6 @@ public class OtlpTraceMapperUtils {
     }
 
     /**
-     * Truncates a string to at most {@code maxBytes} UTF-8 bytes without splitting a multi-byte
-     * character. Returns {@code null} when no truncation is needed (value already within the limit).
-     */
-    public static String truncateUtf8(String value, int maxBytes) {
-        final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-        if (bytes.length <= maxBytes) {
-            return null;
-        }
-        int end = maxBytes;
-        // back off so a multi-byte UTF-8 sequence is not split (0b10xxxxxx == continuation byte)
-        while (end > 0 && (bytes[end] & 0xC0) == 0x80) {
-            end--;
-        }
-        return new String(bytes, 0, end, StandardCharsets.UTF_8);
-    }
-
-    /**
      * Truncates over-long string values (UTF-8 byte length) in an {@code Object} map produced by
      * {@link #getAttributeToMap}, recursing into nested maps/lists. Used for event/link attributes
      * that are serialized to JSON, keeping the JSON valid. Returns the number of values truncated.
@@ -384,7 +367,7 @@ public class OtlpTraceMapperUtils {
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             final Object value = entry.getValue();
             if (value instanceof String s) {
-                final String truncated = truncateUtf8(s, maxBytes);
+                final String truncated = StringTruncator.truncateUtf8(s, maxBytes);
                 if (truncated != null) {
                     entry.setValue(truncated);
                     count++;
@@ -404,7 +387,7 @@ public class OtlpTraceMapperUtils {
         for (int i = 0; i < list.size(); i++) {
             final Object value = list.get(i);
             if (value instanceof String s) {
-                final String truncated = truncateUtf8(s, maxBytes);
+                final String truncated = StringTruncator.truncateUtf8(s, maxBytes);
                 if (truncated != null) {
                     list.set(i, truncated);
                     count++;
@@ -422,7 +405,7 @@ public class OtlpTraceMapperUtils {
     private static AttributeValue truncateValue(AttributeValue value, int maxBytes, MutableInt counter) {
         switch (value.getType()) {
             case STRING: {
-                final String truncated = truncateUtf8((String) value.getValue(), maxBytes);
+                final String truncated = StringTruncator.truncateUtf8((String) value.getValue(), maxBytes);
                 if (truncated == null) {
                     return value;
                 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
+import com.navercorp.pinpoint.common.server.util.StringTruncator;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
@@ -96,7 +97,7 @@ public class OtlpTraceSpanEventMapper {
             if (isDatabaseExecuteQuery(attributes)) {
                 spanEventBo.setServiceType(dbSystemTypeResolver.resolveExecuteQueryCode(dbSystem));
                 String statement = getClientSpanDbStatement(attributes);
-                final String truncatedStatement = (statement == null) ? null : OtlpTraceMapperUtils.truncateUtf8(statement, sqlMaxBytes);
+                final String truncatedStatement = (statement == null) ? null : StringTruncator.truncateUtf8(statement, sqlMaxBytes);
                 if (truncatedStatement != null) {
                     statement = truncatedStatement;
                     truncatedSql = 1;

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -12,7 +12,6 @@ import io.opentelemetry.proto.common.v1.KeyValue;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -923,58 +922,6 @@ class OtlpTraceMapperUtilsTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getKey()).isEqualTo("keep");
         assertThat(result.get(0).getValue().getValue()).isEqualTo("ok");
-    }
-
-    // =======================================================================
-    // truncateUtf8(String, int)
-    // =======================================================================
-
-    private static int utf8Len(String value) {
-        return value.getBytes(StandardCharsets.UTF_8).length;
-    }
-
-    @Test
-    void truncateUtf8_withinLimit_returnsNull() {
-        assertThat(OtlpTraceMapperUtils.truncateUtf8("short", 64)).isNull();
-    }
-
-    @Test
-    void truncateUtf8_exactlyAtLimit_returnsNull() {
-        // bytes.length == maxBytes => no truncation
-        String value = "abcde";
-        assertThat(OtlpTraceMapperUtils.truncateUtf8(value, utf8Len(value))).isNull();
-    }
-
-    @Test
-    void truncateUtf8_emptyString_returnsNull() {
-        assertThat(OtlpTraceMapperUtils.truncateUtf8("", 8)).isNull();
-    }
-
-    @Test
-    void truncateUtf8_asciiOverLimit_truncatedToMaxBytes() {
-        String result = OtlpTraceMapperUtils.truncateUtf8("a".repeat(100), 10);
-
-        assertThat(result).isEqualTo("a".repeat(10));
-        assertThat(utf8Len(result)).isEqualTo(10);
-    }
-
-    @Test
-    void truncateUtf8_multiByteBoundary_doesNotSplitCharacter() {
-        // '가' is 3 UTF-8 bytes (0xEA 0xB0 0x80). "가가가" = 9 bytes.
-        // maxBytes=4 lands inside the 2nd char => must back off to the char boundary (3 bytes).
-        String result = OtlpTraceMapperUtils.truncateUtf8("가가가", 4);
-
-        assertThat(result).isEqualTo("가");
-        assertThat(utf8Len(result)).isLessThanOrEqualTo(4);
-    }
-
-    @Test
-    void truncateUtf8_multiByteExactBoundary_keepsWholeCharacters() {
-        // maxBytes=6 == exactly two '가' chars; no back-off needed.
-        String result = OtlpTraceMapperUtils.truncateUtf8("가가가", 6);
-
-        assertThat(result).isEqualTo("가가");
-        assertThat(utf8Len(result)).isEqualTo(6);
     }
 
     // =======================================================================


### PR DESCRIPTION
- Move truncateUtf8 from OtlpTraceMapperUtils to a dedicated commons-server StringTruncator (server-only usage; off the JDK 8 commons tier)
- Reimplement as a single pass over code points (no full byte[] allocation), with a 4*len <= maxBytes fast path and a requireNonNull guard
- Update OtlpTraceMapperUtils / SpanEventMapper / LinkMapper call sites
- Relocate the truncateUtf8 tests to StringTruncatorTest