### PR TITLE
[#noissue] Truncate OTLP attribute values in a single pass via TransformContext

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/Base16Utils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/Base16Utils.java
@@ -15,4 +15,12 @@ public final class Base16Utils {
     public static byte[] decodeToBytes(String pArray) {
         return BASE16.decode(pArray);
     }
+
+    /**
+     * Returns the full Base16 (hex) length for {@code byteCount} bytes — 2 chars per byte, returned
+     * as a {@code long} so {@code byteCount * 2} never overflows for any non-negative int byteCount.
+     */
+    public static long encodedLength(int byteCount) {
+        return (long) byteCount * 2;
+    }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ByteStringUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/ByteStringUtils.java
@@ -3,9 +3,15 @@ package com.navercorp.pinpoint.common.server.util;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 public final class ByteStringUtils {
+    private static final byte[] HEX = {
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+    };
+
+
     private ByteStringUtils() {
     }
 
@@ -51,5 +57,44 @@ public final class ByteStringUtils {
 
     public static void checkBounds(ByteString bytes, int offset, int length) {
         Objects.checkFromIndexSize(offset, length, bytes.size());
+    }
+
+    /**
+     * Encodes the full {@code bytes} to lower-case Base16 (hex). See
+     * {@link #encodeBase16(ByteString, int)} for the length-capped form.
+     */
+    public static String encodeBase16(ByteString bytes) {
+        return encodeBase16(bytes, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Encodes {@code bytes} to lower-case Base16 (hex), capped at {@code maxLength} characters. Each
+     * byte yields 2 hex chars, so when the full encoding would exceed the limit only the first
+     * {@code ceil(maxLength / 2)} bytes are encoded and the result is cut to exactly {@code maxLength}
+     * (hex is pure ASCII, so a char cut is a byte cut — no multi-byte boundary concern). Returns an
+     * empty string for empty input or non-positive {@code maxLength}; throws {@link ArithmeticException}
+     * when {@code bytes.size() * 2} overflows int (> ~1GB).
+     */
+    public static String encodeBase16(ByteString bytes, int maxLength) {
+        if (bytes.isEmpty() || maxLength <= 0) {
+            return "";
+        }
+        // encodedLength is a long so size*2 can't overflow; min caps it back within int maxLength.
+        // Non-empty + positive maxLength guarantees hexLength >= 1 here.
+        final int hexLength = (int) Math.min(Base16Utils.encodedLength(bytes.size()), maxLength);
+        // Encode directly from the ByteString into a byte[] of exactly hexLength (no source-bytes
+        // copy, no over-encoding past the cap). Each byte yields 2 lower-case hex chars; an odd
+        // hexLength keeps the high nibble of the last byte (matching a char-level cut of full hex).
+        final byte[] out = new byte[hexLength];
+        int oi = 0;
+        for (int i = 0; oi < hexLength; i++) {
+            final int b = bytes.byteAt(i) & 0xFF;
+            out[oi++] = HEX[b >>> 4];
+            if (oi < hexLength) {
+                out[oi++] = HEX[b & 0x0F];
+            }
+        }
+        // hex is pure ASCII; ISO-8859-1 maps each byte straight to its char (fast, no validation)
+        return new String(out, StandardCharsets.ISO_8859_1);
     }
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/util/ByteStringUtilsTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/util/ByteStringUtilsTest.java
@@ -54,4 +54,34 @@ class ByteStringUtilsTest {
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> ByteStringUtils.parseInt(byteString, 1));
     }
 
+    @Test
+    void encodeBase16_empty_returnsEmptyString() {
+        Assertions.assertEquals("", ByteStringUtils.encodeBase16(ByteString.EMPTY, 8));
+    }
+
+    @Test
+    void encodeBase16_withinLimit_fullHex() {
+        ByteString buf = ByteString.copyFrom(new byte[]{0x0a, (byte) 0xbc});
+
+        Assertions.assertEquals("0abc", ByteStringUtils.encodeBase16(buf, 64));
+    }
+
+    @Test
+    void encodeBase16_overLimit_cutToMaxLength() {
+        ByteString buf = ByteString.copyFrom(new byte[16]); // 16 bytes -> 32 hex chars
+
+        String result = ByteStringUtils.encodeBase16(buf, 10);
+
+        Assertions.assertEquals(10, result.length());
+        Assertions.assertEquals("0000000000", result);
+    }
+
+    @Test
+    void encodeBase16_oddLimit_cutToExactLength() {
+        ByteString buf = ByteString.copyFrom(new byte[16]);
+
+        // odd maxLength: ceil(5/2)=3 bytes -> 6 hex chars, then cut to 5
+        Assertions.assertEquals("00000", ByteStringUtils.encodeBase16(buf, 5));
+    }
+
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapper.java
@@ -51,10 +51,12 @@ public class OtlpTraceEventMapper {
             Map<String, Object> inner = new HashMap<>(2);
             inner.put(FIELD_TIME, event.getTimeUnixNano());
             if (event.getAttributesCount() > 0) {
-                final Map<String, Object> eventAttributes = getAttributeToMap(event.getAttributesList());
                 // Cap over-long string values (notably exception.stacktrace, which is also kept in
                 // full in exception metadata) so a single event cannot bloat the span row.
-                truncated = OtlpTraceMapperUtils.truncateStringValues(eventAttributes, valueMaxBytes);
+                final TransformContext context = new TransformContext(valueMaxBytes);
+                final Map<String, Object> eventAttributes =
+                        getAttributeToMap(event.getAttributesList(), context);
+                truncated = context.truncatedCount();
                 inner.put(FIELD_ATTRIBUTES, eventAttributes);
             }
             Map<String, Object> map = Map.of(event.getName(), inner);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
-import com.navercorp.pinpoint.common.server.util.Base16Utils;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
 import com.navercorp.pinpoint.common.server.util.StringTruncator;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
@@ -50,7 +49,7 @@ public class OtlpTraceLinkMapper {
         try {
             Map<String, Object> map = new HashMap<>();
             if (!link.getTraceId().isEmpty()) {
-                map.put("traceId", Base16Utils.encodeToString(link.getTraceId().toByteArray()));
+                map.put("traceId", ByteStringUtils.encodeBase16(link.getTraceId()));
             }
             if (!link.getSpanId().isEmpty()) {
                 // Stored as decimal String to avoid JS Number precision loss for any consumer that
@@ -71,8 +70,9 @@ public class OtlpTraceLinkMapper {
                 map.put("traceState", traceState);
             }
             if (link.getAttributesCount() > 0) {
-                final Map<String, Object> linkAttributes = getAttributeToMap(link.getAttributesList());
-                truncated += OtlpTraceMapperUtils.truncateStringValues(linkAttributes, valueMaxBytes);
+                final TransformContext context = new TransformContext(valueMaxBytes);
+                final Map<String, Object> linkAttributes = getAttributeToMap(link.getAttributesList(), context);
+                truncated += context.truncatedCount();
                 map.put("attributes", linkAttributes);
             }
             // SDK-side data-loss counter for link attributes. Same convention as Span/SpanEvent

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -31,14 +31,15 @@ import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.ArrayValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
-import org.apache.commons.lang3.mutable.MutableInt;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -223,13 +224,24 @@ public class OtlpTraceMapperUtils {
     }
 
     public static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList) {
+        // no context: plain conversion without truncation ((TransformContext) cast disambiguates the null)
+        return getAttributeToMap(keyValueList, (TransformContext) null);
+    }
+
+    /**
+     * Converts OTel attributes to a JSON-serializable map, recursing into nested arrays/maps. When
+     * {@code context} is non-null, over-long string / byte leaf values are truncated (bytes on their
+     * hex form) in the same pass and the count accumulates in the context; a {@code null} context
+     * renders without truncation.
+     */
+    public static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList, @Nullable TransformContext context) {
         final int size = keyValueList.size();
         if (size == 0) {
             return Map.of();
         }
         Map<String, Object> map = new HashMap<>(size);
         for (KeyValue kv : keyValueList) {
-            map.put(kv.getKey(), getAttributeValueToValue(kv.getValue()));
+            map.put(kv.getKey(), getAttributeValueToValue(kv.getValue(), context));
         }
         return map;
     }
@@ -251,6 +263,10 @@ public class OtlpTraceMapperUtils {
     }
 
     public static List<Object> getArrayValueToList(ArrayValue arrayValue) {
+        return getArrayValueToList(arrayValue, null);
+    }
+
+    public static List<Object> getArrayValueToList(ArrayValue arrayValue, @Nullable TransformContext context) {
         final int size = arrayValue.getValuesCount();
         if (size == 0) {
             return List.of();
@@ -259,32 +275,49 @@ public class OtlpTraceMapperUtils {
         final List<AnyValue> valuesList = arrayValue.getValuesList();
         List<Object> list = new ArrayList<>(valuesList.size());
         for (AnyValue anyValue : valuesList) {
-            list.add(getAttributeValueToValue(anyValue));
+            list.add(getAttributeValueToValue(anyValue, context));
         }
         return list;
     }
 
     public static Object getAttributeValueToValue(AnyValue anyValue) {
-        switch (anyValue.getValueCase()) {
-            case INT_VALUE:
-                return anyValue.getIntValue();
-            case DOUBLE_VALUE:
-                return anyValue.getDoubleValue();
-            case BOOL_VALUE:
-                return anyValue.getBoolValue();
-            case STRING_VALUE:
-                return anyValue.getStringValue();
-            case ARRAY_VALUE:
-                return getArrayValueToList(anyValue.getArrayValue());
-            case BYTES_VALUE:
-                // Base16 of an empty byte array is "" — emit it as such (symmetric with the empty
-                // STRING case) instead of null.
-                return Base16Utils.encodeToString(anyValue.getBytesValue().toByteArray());
-            case KVLIST_VALUE:
-                return getAttributeToMap(anyValue.getKvlistValue().getValuesList());
-            default:
-                return null;
+        return getAttributeValueToValue(anyValue, null);
+    }
+
+    public static Object getAttributeValueToValue(AnyValue anyValue, @Nullable TransformContext context) {
+        return switch (anyValue.getValueCase()) {
+            case INT_VALUE -> anyValue.getIntValue();
+            case DOUBLE_VALUE -> anyValue.getDoubleValue();
+            case BOOL_VALUE -> anyValue.getBoolValue();
+            case STRING_VALUE -> transformString(anyValue.getStringValue(), context);
+            case BYTES_VALUE -> transformBytes(anyValue.getBytesValue(), context);
+            case ARRAY_VALUE -> getArrayValueToList(anyValue.getArrayValue(), context);
+            case KVLIST_VALUE -> getAttributeToMap(anyValue.getKvlistValue().getValuesList(), context);
+            default -> null;
+        };
+    }
+
+    private static String transformString(String value, @Nullable TransformContext context) {
+        if (context == null) {
+            return value;
         }
+        final String truncated = StringTruncator.truncateUtf8(value, context.maxBytes());
+        if (truncated != null) {
+            context.truncated();
+            return truncated;
+        }
+        return value;
+    }
+
+    private static Object transformBytes(ByteString bytes, @Nullable TransformContext context) {
+        // empty bytes -> "" (Base16 of an empty array), symmetric with the empty STRING case
+        if (context == null) {
+            return ByteStringUtils.encodeBase16(bytes);
+        }
+        if (Base16Utils.encodedLength(bytes.size()) > context.maxBytes()) {
+            context.truncated();
+        }
+        return ByteStringUtils.encodeBase16(bytes, context.maxBytes());
     }
 
     public static AttributeValue toAttributeValue(AnyValue anyValue) {
@@ -320,6 +353,19 @@ public class OtlpTraceMapperUtils {
     }
 
     public static List<AttributeBo> toAttributeBoList(Map<String, AttributeValue> attributes, Predicate<String> excludeFilter) {
+        // no context: plain conversion without truncation
+        return toAttributeBoList(attributes, excludeFilter, null);
+    }
+
+    /**
+     * Converts attributes to an {@link AttributeBo} list, applying {@code excludeFilter} and — when
+     * {@code context} is non-null — truncating over-long string (UTF-8 byte length) and byte (raw
+     * byte length) values in the same pass, recursing into ARRAY / KVLIST. Numeric and boolean
+     * values are left untouched, matching the OTel spec (only string and byte values are
+     * length-limited). The truncated leaf count accumulates in {@code context} so the caller can
+     * emit a single per-span {@code OPENTELEMETRY_TRUNCATED} summary.
+     */
+    public static List<AttributeBo> toAttributeBoList(Map<String, AttributeValue> attributes, Predicate<String> excludeFilter, @Nullable TransformContext context) {
         if (attributes.isEmpty()) {
             return List.of();
         }
@@ -328,102 +374,46 @@ public class OtlpTraceMapperUtils {
             if (excludeFilter.test(entry.getKey())) {
                 continue;
             }
-            result.add(new AttributeBo(entry.getKey(), entry.getValue()));
+            final AttributeValue value = transformValue(entry.getValue(), context);
+            result.add(new AttributeBo(entry.getKey(), value));
         }
         return result;
     }
 
-    /**
-     * Truncates over-long string / byte attribute values in place (UTF-8 byte length), recursing
-     * into ARRAY / KVLIST. Numeric and boolean values are left untouched, matching the OTel spec
-     * (only string and byte values are length-limited). Returns the number of leaf values truncated
-     * so the caller can emit a single per-span {@code OPENTELEMETRY_TRUNCATED} summary.
-     */
-    public static int truncateAttributeValues(List<AttributeBo> attributeBoList, int maxValueBytes) {
-        int truncated = 0;
-        final ListIterator<AttributeBo> iterator = attributeBoList.listIterator();
-        while (iterator.hasNext()) {
-            final AttributeBo bo = iterator.next();
-            final MutableInt counter = new MutableInt();
-            final AttributeValue value = truncateValue(bo.getValue(), maxValueBytes, counter);
-            if (counter.intValue() > 0) {
-                iterator.set(new AttributeBo(bo.getKey(), value));
-                truncated += counter.intValue();
-            }
+    private static AttributeValue transformValue(AttributeValue value, @Nullable TransformContext context) {
+        if (context == null) {
+            return value;
         }
-        return truncated;
-    }
-
-    /**
-     * Truncates over-long string values (UTF-8 byte length) in an {@code Object} map produced by
-     * {@link #getAttributeToMap}, recursing into nested maps/lists. Used for event/link attributes
-     * that are serialized to JSON, keeping the JSON valid. Returns the number of values truncated.
-     */
-    @SuppressWarnings("unchecked")
-    public static int truncateStringValues(Map<String, Object> map, int maxBytes) {
-        int count = 0;
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
-            final Object value = entry.getValue();
-            if (value instanceof String s) {
-                final String truncated = StringTruncator.truncateUtf8(s, maxBytes);
-                if (truncated != null) {
-                    entry.setValue(truncated);
-                    count++;
-                }
-            } else if (value instanceof Map) {
-                count += truncateStringValues((Map<String, Object>) value, maxBytes);
-            } else if (value instanceof List) {
-                count += truncateStringValues((List<Object>) value, maxBytes);
-            }
-        }
-        return count;
+        return truncateValue(value, context);
     }
 
     @SuppressWarnings("unchecked")
-    public static int truncateStringValues(List<Object> list, int maxBytes) {
-        int count = 0;
-        for (int i = 0; i < list.size(); i++) {
-            final Object value = list.get(i);
-            if (value instanceof String s) {
-                final String truncated = StringTruncator.truncateUtf8(s, maxBytes);
-                if (truncated != null) {
-                    list.set(i, truncated);
-                    count++;
-                }
-            } else if (value instanceof Map) {
-                count += truncateStringValues((Map<String, Object>) value, maxBytes);
-            } else if (value instanceof List) {
-                count += truncateStringValues((List<Object>) value, maxBytes);
-            }
-        }
-        return count;
-    }
+    private static AttributeValue truncateValue(AttributeValue value, @NonNull TransformContext context) {
+        Objects.requireNonNull(context, "context");
 
-    @SuppressWarnings("unchecked")
-    private static AttributeValue truncateValue(AttributeValue value, int maxBytes, MutableInt counter) {
         switch (value.getType()) {
             case STRING: {
-                final String truncated = StringTruncator.truncateUtf8((String) value.getValue(), maxBytes);
+                final String truncated = StringTruncator.truncateUtf8((String) value.getValue(), context.maxBytes());
                 if (truncated == null) {
                     return value;
                 }
-                counter.increment();
+                context.truncated();
                 return AttributeValue.of(truncated);
             }
             case BYTES: {
                 final byte[] bytes = (byte[]) value.getValue();
-                if (bytes.length <= maxBytes) {
+                if (bytes.length <= context.maxBytes()) {
                     return value;
                 }
-                counter.increment();
-                return AttributeValue.of(Arrays.copyOf(bytes, maxBytes));
+                context.truncated();
+                return AttributeValue.of(Arrays.copyOf(bytes, context.maxBytes()));
             }
             case ARRAY: {
                 final List<AttributeValue> array = (List<AttributeValue>) value.getValue();
                 boolean changed = false;
                 final List<AttributeValue> result = new ArrayList<>(array.size());
                 for (AttributeValue item : array) {
-                    final AttributeValue newItem = truncateValue(item, maxBytes, counter);
+                    final AttributeValue newItem = truncateValue(item, context);
                     result.add(newItem);
                     changed |= (newItem != item);
                 }
@@ -435,7 +425,7 @@ public class OtlpTraceMapperUtils {
                 final AttributeKeyValue[] result = new AttributeKeyValue[kvList.size()];
                 for (int i = 0; i < kvList.size(); i++) {
                     final AttributeKeyValue entry = kvList.get(i);
-                    final AttributeValue newValue = truncateValue(entry.getValue(), maxBytes, counter);
+                    final AttributeValue newValue = truncateValue(entry.getValue(), context);
                     final boolean entryChanged = newValue != entry.getValue();
                     result[i] = entryChanged ? AttributeKeyValue.of(entry.getKey(), newValue) : entry;
                     changed |= entryChanged;

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -139,9 +139,10 @@ public class OtlpTraceSpanEventMapper {
         spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_PARENT_SPAN_ID.getCode(), OtlpTraceMapperUtils.getParentSpanId(span.getParentSpanId())));
         // attributes
         if (!attributes.isEmpty()) {
+            final TransformContext context = new TransformContext(attributeValueMaxBytes);
             List<AttributeBo> attributeBoList = OtlpTraceMapperUtils.toAttributeBoList(
-                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY);
-            truncatedAttributes = OtlpTraceMapperUtils.truncateAttributeValues(attributeBoList, attributeValueMaxBytes);
+                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, context);
+            truncatedAttributes = context.truncatedCount();
             spanEventBo.setAttributeBoList(attributeBoList);
         }
         // event

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -117,9 +117,10 @@ public class OtlpTraceSpanMapper {
         // attributes
         int truncatedAttributes = 0;
         if (!attributes.isEmpty()) {
+            final TransformContext context = new TransformContext(attributeValueMaxBytes);
             List<AttributeBo> attributeBoList = OtlpTraceMapperUtils.toAttributeBoList(
-                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY);
-            truncatedAttributes = OtlpTraceMapperUtils.truncateAttributeValues(attributeBoList, attributeValueMaxBytes);
+                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, context);
+            truncatedAttributes = context.truncatedCount();
             spanBo.setAttributeBoList(attributeBoList);
         }
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/TransformContext.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/TransformContext.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+/**
+ * Carries the byte limit and accumulates the number of leaf values truncated across a single
+ * attribute-tree transform pass (including nested ARRAY / KVLIST values). Create one instance per
+ * pass; not thread-safe.
+ */
+public final class TransformContext {
+    private final int maxBytes;
+    private int truncatedCount;
+
+    public TransformContext(int maxBytes) {
+        if (maxBytes < 0) {
+            throw new IllegalArgumentException("maxBytes must be >= 0: " + maxBytes);
+        }
+        this.maxBytes = maxBytes;
+    }
+
+    public int maxBytes() {
+        return maxBytes;
+    }
+
+    public void truncated() {
+        truncatedCount++;
+    }
+
+    public int truncatedCount() {
+        return truncatedCount;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -12,8 +12,8 @@ import io.opentelemetry.proto.common.v1.KeyValue;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class OtlpTraceMapperUtilsTest {
 
     // =======================================================================
-    // getAttributeToMap(List<KeyValue>, Predicate)
+    // getAttributeToMapExcluding(List<KeyValue>, Predicate)
     // =======================================================================
 
     @Test
@@ -957,35 +957,42 @@ class OtlpTraceMapperUtilsTest {
     }
 
     // =======================================================================
-    // truncateAttributeValues(List<AttributeBo>, int)
+    // toAttributeBoList(Map, Predicate, TransformContext) — single-pass truncation
     // =======================================================================
 
-    private static List<AttributeBo> mutableBoList(AttributeBo... bos) {
-        return new ArrayList<>(List.of(bos));
+    private static List<AttributeBo> truncate(TransformContext context, AttributeValue value) {
+        final Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+        attrs.put("k", value);
+        return OtlpTraceMapperUtils.toAttributeBoList(attrs, key -> false, context);
     }
 
     @Test
-    void truncateAttributeValues_emptyList_returnsZero() {
-        assertThat(OtlpTraceMapperUtils.truncateAttributeValues(new ArrayList<>(), 8)).isZero();
+    void truncateAttributeValues_emptyMap_returnsZero() {
+        TransformContext context = new TransformContext(8);
+
+        List<AttributeBo> result = OtlpTraceMapperUtils.toAttributeBoList(Map.of(), key -> false, context);
+
+        assertThat(result).isEmpty();
+        assertThat(context.truncatedCount()).isZero();
     }
 
     @Test
     void truncateAttributeValues_shortString_unchanged() {
-        List<AttributeBo> list = mutableBoList(new AttributeBo("k", AttributeValue.of("ok")));
+        TransformContext context = new TransformContext(64);
 
-        int truncated = OtlpTraceMapperUtils.truncateAttributeValues(list, 64);
+        List<AttributeBo> list = truncate(context, AttributeValue.of("ok"));
 
-        assertThat(truncated).isZero();
+        assertThat(context.truncatedCount()).isZero();
         assertThat(list.get(0).getValue().getValue()).isEqualTo("ok");
     }
 
     @Test
     void truncateAttributeValues_overLongString_truncatedAndCounted() {
-        List<AttributeBo> list = mutableBoList(new AttributeBo("k", AttributeValue.of("a".repeat(100))));
+        TransformContext context = new TransformContext(10);
 
-        int truncated = OtlpTraceMapperUtils.truncateAttributeValues(list, 10);
+        List<AttributeBo> list = truncate(context, AttributeValue.of("a".repeat(100)));
 
-        assertThat(truncated).isEqualTo(1);
+        assertThat(context.truncatedCount()).isEqualTo(1);
         AttributeValue value = list.get(0).getValue();
         assertThat(value.getType()).isEqualTo(AttributeValueType.STRING);
         assertThat((String) value.getValue()).isEqualTo("a".repeat(10));
@@ -993,16 +1000,16 @@ class OtlpTraceMapperUtilsTest {
 
     @Test
     void truncateAttributeValues_numericAndBoolean_neverTruncated() {
-        List<AttributeBo> list = mutableBoList(
-                new AttributeBo("i", AttributeValue.of(1234567890L)),
-                new AttributeBo("d", AttributeValue.of(3.14159d)),
-                new AttributeBo("b", AttributeValue.of(true))
-        );
+        TransformContext context = new TransformContext(1);
+        Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+        attrs.put("i", AttributeValue.of(1234567890L));
+        attrs.put("d", AttributeValue.of(3.14159d));
+        attrs.put("b", AttributeValue.of(true));
 
         // maxBytes=1: would truncate any string, but numbers/booleans are exempt per OTel spec
-        int truncated = OtlpTraceMapperUtils.truncateAttributeValues(list, 1);
+        List<AttributeBo> list = OtlpTraceMapperUtils.toAttributeBoList(attrs, key -> false, context);
 
-        assertThat(truncated).isZero();
+        assertThat(context.truncatedCount()).isZero();
         assertThat(list.get(0).getValue().getValue()).isEqualTo(1234567890L);
         assertThat(list.get(1).getValue().getValue()).isEqualTo(3.14159d);
         assertThat(list.get(2).getValue().getValue()).isEqualTo(true);
@@ -1014,11 +1021,11 @@ class OtlpTraceMapperUtilsTest {
         for (int i = 0; i < payload.length; i++) {
             payload[i] = (byte) i;
         }
-        List<AttributeBo> list = mutableBoList(new AttributeBo("k", AttributeValue.of(payload)));
+        TransformContext context = new TransformContext(16);
 
-        int truncated = OtlpTraceMapperUtils.truncateAttributeValues(list, 16);
+        List<AttributeBo> list = truncate(context, AttributeValue.of(payload));
 
-        assertThat(truncated).isEqualTo(1);
+        assertThat(context.truncatedCount()).isEqualTo(1);
         AttributeValue value = list.get(0).getValue();
         assertThat(value.getType()).isEqualTo(AttributeValueType.BYTES);
         assertThat((byte[]) value.getValue()).hasSize(16)
@@ -1028,11 +1035,11 @@ class OtlpTraceMapperUtilsTest {
     @Test
     void truncateAttributeValues_bytesWithinLimit_unchanged() {
         byte[] payload = new byte[]{1, 2, 3};
-        List<AttributeBo> list = mutableBoList(new AttributeBo("k", AttributeValue.of(payload)));
+        TransformContext context = new TransformContext(16);
 
-        int truncated = OtlpTraceMapperUtils.truncateAttributeValues(list, 16);
+        List<AttributeBo> list = truncate(context, AttributeValue.of(payload));
 
-        assertThat(truncated).isZero();
+        assertThat(context.truncatedCount()).isZero();
         assertThat((byte[]) list.get(0).getValue().getValue()).containsExactly(1, 2, 3);
     }
 
@@ -1043,12 +1050,12 @@ class OtlpTraceMapperUtilsTest {
                 AttributeValue.of("short"),
                 AttributeValue.of("b".repeat(100))
         );
-        List<AttributeBo> list = mutableBoList(new AttributeBo("k", array));
+        TransformContext context = new TransformContext(10);
 
-        int truncated = OtlpTraceMapperUtils.truncateAttributeValues(list, 10);
+        List<AttributeBo> list = truncate(context, array);
 
         // two over-long leaves truncated, the "short" one untouched
-        assertThat(truncated).isEqualTo(2);
+        assertThat(context.truncatedCount()).isEqualTo(2);
         @SuppressWarnings("unchecked")
         List<AttributeValue> result = (List<AttributeValue>) list.get(0).getValue().getValue();
         assertThat(result).extracting(AttributeValue::getValue)
@@ -1058,11 +1065,11 @@ class OtlpTraceMapperUtilsTest {
     @Test
     void truncateAttributeValues_array_noOverLongLeaf_unchanged() {
         AttributeValue array = AttributeValue.of(AttributeValue.of("x"), AttributeValue.of("y"));
-        List<AttributeBo> list = mutableBoList(new AttributeBo("k", array));
+        TransformContext context = new TransformContext(10);
 
-        int truncated = OtlpTraceMapperUtils.truncateAttributeValues(list, 10);
+        List<AttributeBo> list = truncate(context, array);
 
-        assertThat(truncated).isZero();
+        assertThat(context.truncatedCount()).isZero();
         @SuppressWarnings("unchecked")
         List<AttributeValue> result = (List<AttributeValue>) list.get(0).getValue().getValue();
         assertThat(result).extracting(AttributeValue::getValue).containsExactly("x", "y");
@@ -1074,11 +1081,11 @@ class OtlpTraceMapperUtilsTest {
                 AttributeKeyValue.of("big", AttributeValue.of("a".repeat(100))),
                 AttributeKeyValue.of("small", AttributeValue.of("ok"))
         );
-        List<AttributeBo> list = mutableBoList(new AttributeBo("k", kvList));
+        TransformContext context = new TransformContext(10);
 
-        int truncated = OtlpTraceMapperUtils.truncateAttributeValues(list, 10);
+        List<AttributeBo> list = truncate(context, kvList);
 
-        assertThat(truncated).isEqualTo(1);
+        assertThat(context.truncatedCount()).isEqualTo(1);
         @SuppressWarnings("unchecked")
         List<AttributeKeyValue> result = (List<AttributeKeyValue>) list.get(0).getValue().getValue();
         assertThat(result.get(0).getKey()).isEqualTo("big");
@@ -1093,11 +1100,11 @@ class OtlpTraceMapperUtilsTest {
                         AttributeValue.of("a".repeat(100)),
                         AttributeValue.of("b".repeat(100))))
         );
-        List<AttributeBo> list = mutableBoList(new AttributeBo("k", kvList));
+        TransformContext context = new TransformContext(10);
 
-        int truncated = OtlpTraceMapperUtils.truncateAttributeValues(list, 10);
+        List<AttributeBo> list = truncate(context, kvList);
 
-        assertThat(truncated).isEqualTo(2);
+        assertThat(context.truncatedCount()).isEqualTo(2);
         @SuppressWarnings("unchecked")
         List<AttributeKeyValue> outer = (List<AttributeKeyValue>) list.get(0).getValue().getValue();
         @SuppressWarnings("unchecked")
@@ -1108,98 +1115,118 @@ class OtlpTraceMapperUtilsTest {
 
     @Test
     void truncateAttributeValues_multipleBos_sumsTruncations() {
-        List<AttributeBo> list = mutableBoList(
-                new AttributeBo("a", AttributeValue.of("a".repeat(100))),
-                new AttributeBo("b", AttributeValue.of("ok")),
-                new AttributeBo("c", AttributeValue.of("c".repeat(100)))
-        );
+        TransformContext context = new TransformContext(10);
+        Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+        attrs.put("a", AttributeValue.of("a".repeat(100)));
+        attrs.put("b", AttributeValue.of("ok"));
+        attrs.put("c", AttributeValue.of("c".repeat(100)));
 
-        int truncated = OtlpTraceMapperUtils.truncateAttributeValues(list, 10);
+        List<AttributeBo> list = OtlpTraceMapperUtils.toAttributeBoList(attrs, key -> false, context);
 
-        assertThat(truncated).isEqualTo(2);
+        assertThat(context.truncatedCount()).isEqualTo(2);
         assertThat(list.get(0).getValue().getValue()).isEqualTo("a".repeat(10));
         assertThat(list.get(1).getValue().getValue()).isEqualTo("ok");
         assertThat(list.get(2).getValue().getValue()).isEqualTo("c".repeat(10));
     }
 
     // =======================================================================
-    // truncateStringValues(Map<String, Object>, int) / (List<Object>, int)
+    // getAttributeToMap(List<KeyValue>, TransformContext) — single-pass truncation
     // =======================================================================
 
+    @SuppressWarnings("unchecked")
     @Test
-    void truncateStringValues_map_overLongString_truncatedAndCounted() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("big", "a".repeat(100));
-        map.put("small", "ok");
+    void truncatingTransform_overLongString_truncatedAndCounted() {
+        TransformContext context = new TransformContext(10);
 
-        int count = OtlpTraceMapperUtils.truncateStringValues(map, 10);
+        Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
+                kv("big", strVal("a".repeat(100))),
+                kv("small", strVal("ok"))
+        ), context);
 
-        assertThat(count).isEqualTo(1);
+        assertThat(context.truncatedCount()).isEqualTo(1);
         assertThat(map).containsEntry("big", "a".repeat(10));
         assertThat(map).containsEntry("small", "ok");
     }
 
     @Test
-    void truncateStringValues_map_nonStringValues_untouched() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("i", 1234567890L);
-        map.put("b", true);
-        map.put("d", 3.14d);
+    void truncatingTransform_nonStringValues_untouched() {
+        TransformContext context = new TransformContext(1);
 
-        int count = OtlpTraceMapperUtils.truncateStringValues(map, 1);
+        Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
+                kv("i", intVal(1234567890L)),
+                kv("b", boolVal(true)),
+                kv("d", doubleVal(3.14d))
+        ), context);
 
-        assertThat(count).isZero();
+        assertThat(context.truncatedCount()).isZero();
         assertThat(map).containsEntry("i", 1234567890L);
         assertThat(map).containsEntry("b", true);
         assertThat(map).containsEntry("d", 3.14d);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    void truncateStringValues_map_nestedMapAndList_recurses() {
-        Map<String, Object> nestedMap = new HashMap<>();
-        nestedMap.put("inner", "a".repeat(100));
-        List<Object> nestedList = new ArrayList<>(List.of("b".repeat(100), "ok"));
-        Map<String, Object> map = new HashMap<>();
-        map.put("map", nestedMap);
-        map.put("list", nestedList);
+    void truncatingTransform_nestedMapAndList_recurses() {
+        TransformContext context = new TransformContext(10);
 
-        int count = OtlpTraceMapperUtils.truncateStringValues(map, 10);
+        Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
+                kv("map", kvlistVal(kv("inner", strVal("a".repeat(100))))),
+                kv("list", arrayVal(strVal("b".repeat(100)), strVal("ok")))
+        ), context);
 
-        assertThat(count).isEqualTo(2);
-        assertThat(nestedMap).containsEntry("inner", "a".repeat(10));
-        assertThat(nestedList).containsExactly("b".repeat(10), "ok");
+        assertThat(context.truncatedCount()).isEqualTo(2);
+        assertThat((Map<String, Object>) map.get("map")).containsEntry("inner", "a".repeat(10));
+        assertThat((List<Object>) map.get("list")).containsExactly("b".repeat(10), "ok");
     }
 
     @Test
-    void truncateStringValues_map_withinLimit_returnsZero() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("k", "short");
+    void truncatingTransform_withinLimit_countsZero() {
+        TransformContext context = new TransformContext(64);
 
-        assertThat(OtlpTraceMapperUtils.truncateStringValues(map, 64)).isZero();
+        Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
+                kv("k", strVal("short"))
+        ), context);
+
+        assertThat(context.truncatedCount()).isZero();
+        assertThat(map).containsEntry("k", "short");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void truncatingTransform_arrayOverLongStrings_truncatedInPlace() {
+        TransformContext context = new TransformContext(10);
+
+        Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
+                kv("list", arrayVal(strVal("a".repeat(100)), strVal("ok"), strVal("b".repeat(100))))
+        ), context);
+
+        assertThat(context.truncatedCount()).isEqualTo(2);
+        assertThat((List<Object>) map.get("list")).containsExactly("a".repeat(10), "ok", "b".repeat(10));
     }
 
     @Test
-    void truncateStringValues_list_overLongString_truncatedInPlace() {
-        List<Object> list = new ArrayList<>(List.of("a".repeat(100), "ok", "b".repeat(100)));
+    void truncatingTransform_bytesWithinLimit_notTruncated() {
+        TransformContext context = new TransformContext(64);
 
-        int count = OtlpTraceMapperUtils.truncateStringValues(list, 10);
+        Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
+                kv("bin", bytesVal(new byte[]{0x0a, (byte) 0xbc})) // 2 bytes -> 4 hex chars
+        ), context);
 
-        assertThat(count).isEqualTo(2);
-        assertThat(list).containsExactly("a".repeat(10), "ok", "b".repeat(10));
+        assertThat(context.truncatedCount()).isZero();
+        assertThat((String) map.get("bin")).hasSize(4);
     }
 
     @Test
-    void truncateStringValues_list_nestedMapAndList_recurses() {
-        Map<String, Object> nestedMap = new HashMap<>();
-        nestedMap.put("inner", "a".repeat(100));
-        List<Object> nestedList = new ArrayList<>(List.of("b".repeat(100)));
-        List<Object> list = new ArrayList<>(List.of(nestedMap, nestedList, "ok"));
+    void truncatingTransform_bytesHexString_truncated() {
+        // BYTES values are rendered as a hex string and subject to the same cap.
+        TransformContext context = new TransformContext(10);
 
-        int count = OtlpTraceMapperUtils.truncateStringValues(list, 10);
+        Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
+                kv("bin", bytesVal(new byte[16])) // 16 bytes -> 32 hex chars, exceeds 10
+        ), context);
 
-        assertThat(count).isEqualTo(2);
-        assertThat(nestedMap).containsEntry("inner", "a".repeat(10));
-        assertThat(nestedList).containsExactly("b".repeat(10));
+        assertThat(context.truncatedCount()).isEqualTo(1);
+        assertThat((String) map.get("bin")).hasSize(10);
     }
 
 }


### PR DESCRIPTION
Cap over-long string / byte attribute values while converting OTel attributes, instead
of a separate post-build pass, on both attribute paths:

- AnyValue -> Map: getAttributeToMap(list, TransformContext) truncates string/byte leaves
  (bytes on their hex form) in place; a null context renders without truncation
- AttributeValue -> AttributeBo: toAttributeBoList(map, excludeFilter, TransformContext)
  truncates via the recursive truncateValue in the same pass
- TransformContext (top-level) carries the byte limit and accumulates the truncated count;
  Span/SpanEvent/Event/Link mappers read context.truncatedCount(). @Nullable/@NonNull mark
  the contract, with a requireNonNull guard on the non-null path
- ByteStringUtils.encodeBase16(ByteString[, maxLength]) renders hex directly from the
  ByteString into a byte[] (ISO-8859-1), capped at maxLength, rejecting size*2 overflow via
  multiplyExact; empty bytes render as ""
- Remove the old truncateStringValues / truncateAttributeValues passes and MutableInt counter
