### PR TITLE
[#noissue] Avoid defensive byte[] copies when serializing attribute bytes

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/AnnotationValueMapper.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/AnnotationValueMapper.java
@@ -17,6 +17,7 @@ package com.navercorp.pinpoint.profiler.context.grpc.mapper;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.StringValue;
+import com.google.protobuf.UnsafeByteOperations;
 import com.navercorp.pinpoint.common.util.BytesStringStringValue;
 import com.navercorp.pinpoint.common.util.DataType;
 import com.navercorp.pinpoint.common.util.IntBooleanIntBooleanValue;
@@ -185,12 +186,12 @@ public interface AnnotationValueMapper {
     PAnnotationValue map(ByteAnnotation annotation);
 
     @InheritConfiguration(name = "dummyForIgnoreMapping")
-    @Mapping(source = "value", target = "binaryValue", qualifiedByName = "copyFrom")
+    @Mapping(source = "value", target = "binaryValue", qualifiedByName = "toByteString")
     PAnnotationValue map(BytesAnnotation annotation);
 
-    @Named("copyFrom")
-    default ByteString copyFrom(byte[] v) {
-        return ByteString.copyFrom(v);
+    @Named("toByteString")
+    default ByteString toByteString(byte[] v) {
+        return UnsafeByteOperations.unsafeWrap(v);
     }
 
     @InheritConfiguration(name = "dummyForIgnoreMapping")
@@ -292,7 +293,7 @@ public interface AnnotationValueMapper {
     PIntBooleanIntBooleanValue map(IntBooleanIntBooleanValue v);
 
     @InheritConfiguration(name = "dummyForIgnoreMapping")
-    @Mapping(source = "bytesValue", target = "bytesValue", qualifiedByName = "copyFrom")
+    @Mapping(source = "bytesValue", target = "bytesValue", qualifiedByName = "toByteString")
     PBytesStringStringValue map(BytesStringStringValue v);
 
 

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/MetaDataMapper.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/MetaDataMapper.java
@@ -17,6 +17,7 @@ package com.navercorp.pinpoint.profiler.context.grpc.mapper;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.UnsafeByteOperations;
 import com.navercorp.pinpoint.grpc.trace.PApiMetaData;
 import com.navercorp.pinpoint.grpc.trace.PSqlMetaData;
 import com.navercorp.pinpoint.grpc.trace.PSqlUidMetaData;
@@ -68,6 +69,6 @@ public interface MetaDataMapper {
     PStringMetaData map(StringMetaData stringMetaData);
 
     default ByteString map(byte[] bytes) {
-        return ByteString.copyFrom(bytes);
+        return UnsafeByteOperations.unsafeWrap(bytes);
     }
 }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/SpanMessageMapper.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/SpanMessageMapper.java
@@ -16,6 +16,8 @@
 package com.navercorp.pinpoint.profiler.context.grpc.mapper;
 
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValueList;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
@@ -187,7 +189,8 @@ public interface SpanMessageMapper {
                 valueBuilder.setDoubleValue(((AttributeValueDouble) attributeValue).getDoubleValue());
                 break;
             case BYTES:
-                valueBuilder.setBinaryValue(com.google.protobuf.ByteString.copyFrom(((AttributeValueBytes) attributeValue).getBytesValue()));
+                ByteString byteString = UnsafeByteOperations.unsafeWrap(((AttributeValueBytes) attributeValue).getRawBytesValue());
+                valueBuilder.setBinaryValue(byteString);
                 break;
             case ARRAY:
                 PAttributeArrayValue.Builder arrayBuilder = PAttributeArrayValue.newBuilder();

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/AttributeTranscoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/AttributeTranscoder.java
@@ -72,7 +72,7 @@ public class AttributeTranscoder {
                 break;
             case BYTES:
                 buffer.putByte(TYPE_BYTES);
-                buffer.putPrefixedBytes(((AttributeValueBytes) attributeValue).getBytesValue());
+                buffer.putPrefixedBytes(((AttributeValueBytes) attributeValue).getRawBytesValue());
                 break;
             case ARRAY:
                 buffer.putByte(TYPE_ARRAY);

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueBytes.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/attribute/AttributeValueBytes.java
@@ -36,11 +36,15 @@ public final class AttributeValueBytes implements AttributeValue {
 
     @Override
     public Object getValue() {
-        return Arrays.copyOf(value, value.length);
+        return getBytesValue();
     }
 
     public byte[] getBytesValue() {
         return Arrays.copyOf(value, value.length);
+    }
+
+    public byte[] getRawBytesValue() {
+        return value;
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java
@@ -263,7 +263,7 @@ public class RecordFactory {
         return switch (value.getType()) {
             case STRING, BOOLEAN, LONG, DOUBLE -> value.getValue();
             case BYTES -> {
-                byte[] bytesValue = ((AttributeValueBytes) value).getBytesValue();
+                byte[] bytesValue = ((AttributeValueBytes) value).getRawBytesValue();
                 yield Base64.getEncoder().encodeToString(bytesValue);
             }
             case ARRAY -> {


### PR DESCRIPTION
- AttributeValueBytes.getRawBytesValue() exposes the backing array without a defensive
  copy; getBytesValue() still copies for external callers, getValue() delegates to it
- Read-only consumers use the raw view: SpanMessageMapper and the meta/annotation mappers
  wrap it via UnsafeByteOperations.unsafeWrap into protobuf (no copy), AttributeTranscoder
  writes it to the buffer, RecordFactory Base64-encodes it
