### PR TITLE
[#noissue] Rename StringTruncator to Utf8 and extract truncateIndex

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/Utf8.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/Utf8.java
@@ -20,9 +20,9 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
-public final class StringTruncator {
+public final class Utf8 {
 
-    private StringTruncator() {
+    private Utf8() {
     }
 
     /**
@@ -34,16 +34,33 @@ public final class StringTruncator {
      * @return the truncated string, or {@code null} when no truncation is needed
      * (value already within the limit)
      */
-    public static @Nullable String truncateUtf8(String str, int maxBytes) {
-        Objects.requireNonNull(str, "str");
-        final int len = str.length();
-        // fast path: a UTF-8 char is at most 4 bytes, so when 4*len <= maxBytes
-        // the value cannot exceed the limit -> no truncation.
-        if ((long) len * 4 <= maxBytes) {
-            return null;
+    public static @Nullable String truncate(String str, int maxBytes) {
+        final int index = truncateIndex(str, maxBytes);
+        if (index == str.length()) {
+            return null; // within limit
         }
-        int byteCount = 0;
-        for (int i = 0; i < len; ) {
+        return str.substring(0, index);
+    }
+
+    /**
+     * Returns the char index marking the end of the longest prefix of {@code str} whose UTF-8 byte
+     * length is within {@code maxBytes}, never splitting a multi-byte character. Equals
+     * {@code str.length()} when the whole string already fits.
+     *
+     * @param str      the string to measure; must not be {@code null}
+     * @param maxBytes the maximum length in UTF-8 bytes
+     * @return the cut index in {@code [0, str.length()]}
+     */
+    public static int truncateIndex(String str, int maxBytes) {
+        Objects.requireNonNull(str, "str");
+        final int utf16Length = str.length();
+        // fast path: a UTF-8 char is at most 4 bytes, so when 4*utf16Length <= maxBytes
+        // the value cannot exceed the limit -> no truncation.
+        if ((long) utf16Length * 4 <= maxBytes) {
+            return utf16Length;
+        }
+        int utf8Length = 0;
+        for (int i = 0; i < utf16Length; ) {
             final int cp = str.codePointAt(i);
             final int bytes;
             if (cp <= 0x7F) {
@@ -55,12 +72,12 @@ public final class StringTruncator {
             } else {
                 bytes = 4;
             }
-            if (byteCount + bytes > maxBytes) {
-                return str.substring(0, i); // cut at the code-point boundary
+            if (utf8Length + bytes > maxBytes) {
+                return i; // cut at the code-point boundary
             }
-            byteCount += bytes;
+            utf8Length += bytes;
             i += Character.charCount(cp); // 1 or 2 (surrogate pair)
         }
-        return null; // within limit
+        return utf16Length; // within limit
     }
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/Utf8Test.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/util/Utf8Test.java
@@ -16,69 +16,68 @@
 
 package com.navercorp.pinpoint.common.server.util;
 
-import com.google.common.base.Utf8;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class StringTruncatorTest {
+class Utf8Test {
 
     private static int utf8Len(String value) {
-        return Utf8.encodedLength(value); // Guava's Utf8 counts code points, not bytes
+        return com.google.common.base.Utf8.encodedLength(value); // Guava's Utf8 counts code points, not bytes
     }
 
     @Test
-    void truncateUtf8_withinLimit_returnsNull() {
-        assertThat(StringTruncator.truncateUtf8("short", 64)).isNull();
+    void truncate_withinLimit_returnsNull() {
+        assertThat(Utf8.truncate("short", 64)).isNull();
     }
 
     @Test
-    void truncateUtf8_exactlyAtLimit_returnsNull() {
+    void truncate_exactlyAtLimit_returnsNull() {
         // bytes.length == maxBytes => no truncation
         String value = "abcde";
-        assertThat(StringTruncator.truncateUtf8(value, utf8Len(value))).isNull();
+        assertThat(Utf8.truncate(value, utf8Len(value))).isNull();
     }
 
     @Test
-    void truncateUtf8_emptyString_returnsNull() {
-        assertThat(StringTruncator.truncateUtf8("", 8)).isNull();
+    void truncate_emptyString_returnsNull() {
+        assertThat(Utf8.truncate("", 8)).isNull();
     }
 
     @Test
-    void truncateUtf8_fastPathBoundary_returnsNull() {
+    void truncate_fastPathBoundary_returnsNull() {
         // 4 * len(3) == maxBytes(12) triggers the upper-bound fast path
-        assertThat(StringTruncator.truncateUtf8("abc", 12)).isNull();
+        assertThat(Utf8.truncate("abc", 12)).isNull();
     }
 
     @Test
-    void truncateUtf8_nullValue_throwsNpe() {
-        assertThatThrownBy(() -> StringTruncator.truncateUtf8(null, 8))
+    void truncate_nullValue_throwsNpe() {
+        assertThatThrownBy(() -> Utf8.truncate(null, 8))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void truncateUtf8_asciiOverLimit_truncatedToMaxBytes() {
-        String result = StringTruncator.truncateUtf8("a".repeat(100), 10);
+    void truncate_asciiOverLimit_truncatedToMaxBytes() {
+        String result = Utf8.truncate("a".repeat(100), 10);
 
         assertThat(result).isEqualTo("a".repeat(10));
         assertThat(utf8Len(result)).isEqualTo(10);
     }
 
     @Test
-    void truncateUtf8_multiByteBoundary_doesNotSplitCharacter() {
+    void truncate_multiByteBoundary_doesNotSplitCharacter() {
         // '가' is 3 UTF-8 bytes (0xEA 0xB0 0x80). "가가가" = 9 bytes.
         // maxBytes=4 lands inside the 2nd char => must back off to the char boundary (3 bytes).
-        String result = StringTruncator.truncateUtf8("가가가", 4);
+        String result = Utf8.truncate("가가가", 4);
 
         assertThat(result).isEqualTo("가");
         assertThat(utf8Len(result)).isLessThanOrEqualTo(4);
     }
 
     @Test
-    void truncateUtf8_multiByteExactBoundary_keepsWholeCharacters() {
+    void truncate_multiByteExactBoundary_keepsWholeCharacters() {
         // maxBytes=6 == exactly two '가' chars; no back-off needed.
-        String result = StringTruncator.truncateUtf8("가가가", 6);
+        String result = Utf8.truncate("가가가", 6);
 
         assertThat(result).isEqualTo("가가");
         assertThat(utf8Len(result)).isEqualTo(6);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
-import com.navercorp.pinpoint.common.server.util.StringTruncator;
+import com.navercorp.pinpoint.common.server.util.Utf8;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import io.opentelemetry.proto.trace.v1.Span;
 import org.springframework.beans.factory.annotation.Value;
@@ -62,7 +62,7 @@ public class OtlpTraceLinkMapper {
             // since chained vendor entries can grow long.
             if (!link.getTraceState().isEmpty()) {
                 String traceState = link.getTraceState();
-                final String truncatedTraceState = StringTruncator.truncateUtf8(traceState, valueMaxBytes);
+                final String truncatedTraceState = Utf8.truncate(traceState, valueMaxBytes);
                 if (truncatedTraceState != null) {
                     traceState = truncatedTraceState;
                     truncated++;

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -23,7 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.Base16Utils;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
-import com.navercorp.pinpoint.common.server.util.StringTruncator;
+import com.navercorp.pinpoint.common.server.util.Utf8;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
@@ -301,7 +301,7 @@ public class OtlpTraceMapperUtils {
         if (context == null) {
             return value;
         }
-        final String truncated = StringTruncator.truncateUtf8(value, context.maxBytes());
+        final String truncated = Utf8.truncate(value, context.maxBytes());
         if (truncated != null) {
             context.truncated();
             return truncated;
@@ -393,7 +393,7 @@ public class OtlpTraceMapperUtils {
 
         switch (value.getType()) {
             case STRING: {
-                final String truncated = StringTruncator.truncateUtf8((String) value.getValue(), context.maxBytes());
+                final String truncated = Utf8.truncate((String) value.getValue(), context.maxBytes());
                 if (truncated == null) {
                     return value;
                 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
-import com.navercorp.pinpoint.common.server.util.StringTruncator;
+import com.navercorp.pinpoint.common.server.util.Utf8;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
@@ -97,7 +97,7 @@ public class OtlpTraceSpanEventMapper {
             if (isDatabaseExecuteQuery(attributes)) {
                 spanEventBo.setServiceType(dbSystemTypeResolver.resolveExecuteQueryCode(dbSystem));
                 String statement = getClientSpanDbStatement(attributes);
-                final String truncatedStatement = (statement == null) ? null : StringTruncator.truncateUtf8(statement, sqlMaxBytes);
+                final String truncatedStatement = (statement == null) ? null : Utf8.truncate(statement, sqlMaxBytes);
                 if (truncatedStatement != null) {
                     statement = truncatedStatement;
                     truncatedSql = 1;


### PR DESCRIPTION
- StringTruncator -> Utf8; truncateUtf8 -> truncate (the class name already says UTF-8)
- Extract Utf8.truncateIndex(str, maxBytes): the end index of the longest prefix within
  the byte limit (== length when it fits), so callers can cut without an extra scan;
  truncate() now delegates to it
- Update otlptrace mapper call sites
