### PR TITLE
[#13845] Decouple ui package from configurationAtom in service-name interceptor

### DIFF
--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
@@ -25,7 +25,7 @@ export const InitialFetchOutlet = () => {
   const setSearchParameters = useSetAtom(searchParametersAtom);
 
   useExperimentals(data);
-  useServicesFetch();
+  useServicesFetch(configuration);
 
   // selectedService가 바뀌면 fetch 인터셉터가 주입하는 pServiceName 헤더 값이 달라진다.
   // 하지만 queryKey에는 service가 포함되지 않아, 캐시된 쿼리는 새 헤더로 재요청되지 않는다.

--- a/web-frontend/src/main/v3/apps/web/src/main.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/main.tsx
@@ -6,6 +6,7 @@ import { IconContext } from 'react-icons';
 // import { ReactToastContainer, queryClient } from '@pinpoint-fe/ui';
 import { ReactToastContainer } from '@pinpoint-fe/ui/src/components';
 import { queryClient, installServiceNameFetchInterceptor } from '@pinpoint-fe/ui/src/hooks';
+import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
 import router from './routes';
 import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n';
@@ -17,7 +18,9 @@ const jotaiStore = getDefaultStore();
 
 // configuration의 experimental.enableServiceMap이 켜져 있을 때, 모든 /api 요청 헤더에
 // 현재 선택된 service를 주입한다. 렌더링/최초 fetch 이전에 한 번 설치해야 한다.
-installServiceNameFetchInterceptor();
+// configuration은 부트스트랩 이후 비동기로 로드되므로, 매 요청 시 store에서 최신값을
+// 읽도록 getter를 주입한다.
+installServiceNameFetchInterceptor(() => jotaiStore.get(configurationAtom));
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.Fragment>

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
@@ -22,8 +22,9 @@ const headerOfLastCall = (): string | null => {
 describe('serviceNameFetchInterceptor', () => {
   beforeAll(() => {
     // 패치 대상이 될 원본 fetch를 먼저 심어두고, 인터셉터를 한 번 설치한다.
+    // 인터셉터는 매 요청 시 getter로 최신 configuration을 읽으므로, store에서 읽도록 주입한다.
     window.fetch = originalFetch as typeof window.fetch;
-    installServiceNameFetchInterceptor();
+    installServiceNameFetchInterceptor(() => store.get(configurationAtom));
   });
 
   beforeEach(() => {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
@@ -1,5 +1,6 @@
 import { getDefaultStore } from 'jotai';
-import { configurationAtom, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration } from '@pinpoint-fe/ui/src/constants';
 
 /**
  * 백엔드(service-module)의 `ServiceConstants.KEY`와 동일한 헤더 이름.
@@ -35,11 +36,18 @@ let installed = false;
  * `experimental.enableServiceMap.value`가 true일 때 백엔드로 가는 모든
  * `/api` 요청 헤더에 현재 선택된 service(`selectedServiceAtom`)를 주입한다.
  *
- * Jotai 기본 store(`getDefaultStore`)를 사용하므로 컴포넌트의
+ * configuration은 부트스트랩 이후 비동기로 로드/갱신되므로, 값이 아니라
+ * 매 요청 시 최신 configuration을 반환하는 getter(`getConfiguration`)를 받는다.
+ * 이를 통해 ui 패키지가 `configurationAtom`에 직접 의존하지 않고,
+ * web 앱이 configuration의 출처를 주입한다.
+ *
+ * service는 Jotai 기본 store(`getDefaultStore`)에서 읽으므로 컴포넌트의
  * `useAtomValue`/`useSetAtom`과 동일한 상태를 참조한다.
  * 앱 부트스트랩(main.tsx)에서 렌더링 전에 한 번 호출한다.
  */
-export const installServiceNameFetchInterceptor = () => {
+export const installServiceNameFetchInterceptor = (
+  getConfiguration: () => Configuration | undefined,
+) => {
   if (installed) return;
   if (typeof window === 'undefined' || typeof window.fetch !== 'function') return;
   installed = true;
@@ -49,7 +57,7 @@ export const installServiceNameFetchInterceptor = () => {
 
   window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
     try {
-      const configuration = store.get(configurationAtom);
+      const configuration = getConfiguration();
       const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
 
       if (enableServiceMap && isApiRequest(input)) {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.ts
@@ -1,14 +1,15 @@
 import React from 'react';
-import { useAtomValue, useSetAtom } from 'jotai';
-import { configurationAtom, servicesAtom } from '@pinpoint-fe/ui/src/atoms';
+import { useSetAtom } from 'jotai';
+import { servicesAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import { useGetServices } from '@pinpoint-fe/ui/src/hooks';
 
-export const useServicesFetch = () => {
-  // configurationAtom(전역 store)을 기준으로 enable한다. fetch 인터셉터가 동일한
-  // atom으로 enableServiceMap을 판단하므로, atom이 채워진 뒤에 /api/v2/services가
+export const useServicesFetch = (configuration: Configuration | undefined) => {
+  // configurationAtom(전역 store)에서 읽은 값을 그대로 받아 enable한다. fetch 인터셉터가
+  // 동일한 atom으로 enableServiceMap을 판단하므로, atom이 채워진 뒤에 /api/v2/services가
   // 발생해야 pServiceName 헤더가 누락되지 않는다. (raw config로 enable하면 atom이
-  // useEffect로 채워지기 전에 요청이 나가 헤더가 빠진다.)
-  const configuration = useAtomValue(configurationAtom);
+  // useEffect로 채워지기 전에 요청이 나가 헤더가 빠지므로, 호출자는 raw config가 아니라
+  // configurationAtom 값을 넘겨야 한다.)
   const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
   const { data: services } = useGetServices({ enabled: enableServiceMap });
   const setServices = useSetAtom(servicesAtom);


### PR DESCRIPTION
## Summary
- Follow-up refactor to #13845. The service-name fetch interceptor and `useServicesFetch` read `configurationAtom` directly, coupling the `@pinpoint-fe/ui` package to a configuration source it should not own.
- `installServiceNameFetchInterceptor` now takes a `getConfiguration: () => Configuration | undefined` getter, reading the latest configuration per request; `useServicesFetch` now receives the `configuration` value from its caller.
- The web app supplies the source via `jotaiStore.get(configurationAtom)` (main.tsx) and `InitialFetchOutlet` passes the atom value into `useServicesFetch`, preserving the async-bootstrap timing guarantee while removing the direct atom dependency from `ui`.

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (444 tests, interceptor tests updated for the new getter signature)
- [ ] With service map enabled, verify `/api/*` requests (incl. `/api/v2/services`) still carry the `pServiceName` header in the Network tab
- [ ] With service map disabled, verify no `pServiceName` header is added