### PR TITLE
[#13846] Fix empty tags in system metric chart group selector

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartFetcher.tsx
@@ -40,9 +40,14 @@ export const SystemMetricChartFetcher = ({
   const { data: tagData } = useGetSystemMetricTagsData({
     metricDefinitionId: tagGroup ? metricDefinitionId : '',
   });
-  const [tags, selectedTags] = React.useState<string>(tagData?.[0] || '');
+  // 사용자가 직접 고른 tag만 상태로 보관하고, 선택 전에는 tagData의 첫 tag를 파생값으로 사용한다.
+  // (useEffect로 뒤늦게 동기화하면 tagData 변경 시 ''로 리셋되는 문제가 있어 렌더 중 파생값으로 처리)
+  const [selectedTag, setSelectedTag] = React.useState<string>();
+  // 사용자가 고른 tag가 현재 tagData에 없으면(host/metric 전환 등) 첫 tag로 폴백한다.
+  const tags = selectedTag && tagData?.includes(selectedTag) ? selectedTag : (tagData?.[0] ?? '');
   const { data: chartData } = useGetSystemMetricChartData({
     metricDefinitionId,
+    tagGroup,
     tags,
   });
 
@@ -118,10 +123,6 @@ export const SystemMetricChartFetcher = ({
   };
 
   React.useEffect(() => {
-    selectedTags(tagData?.[0] || '');
-  }, [tagData]);
-
-  React.useEffect(() => {
     const chart = chartComponent.current?.instance;
 
     chart?.load({
@@ -146,7 +147,7 @@ export const SystemMetricChartFetcher = ({
         {tagGroup && (
           <CardDescription className="flex items-center gap-2.5 !mt-3">
             <Label className="text-xs">Group</Label>
-            <Select value={tags} onValueChange={(value) => selectedTags(value)}>
+            <Select value={tags} onValueChange={(value) => setSelectedTag(value)}>
               <SelectTrigger className="w-[calc(100%-3.125rem)] text-xs">
                 <span className="flex-1 text-left truncate">
                   <SelectValue>{tags}</SelectValue>

--- a/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartListFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartListFetcher.tsx
@@ -11,14 +11,14 @@ export const SystemMetricChartListFetcher = ({
   const { data } = useGetSystemMetricMetricInfoData();
 
   return (
-    <div className="grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+    <div className="grid gap-4 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3">
       {data &&
         data.map((chartInfo, i) => (
           <SystemMetricChart
             key={i}
             chartInfo={chartInfo}
             emptyMessage={emptyMessage}
-            className="aspect-video min-h-0"
+            className="min-h-0 aspect-video"
           />
         ))}
     </div>

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetSystemMetricChartData.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetSystemMetricChartData.ts
@@ -4,13 +4,15 @@ import { useSystemMetricSearchParameters } from '../searchParameters';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { queryFn } from './reactQueryHelper';
 
-const getQueryString = (queryParams: Partial<SystemMetricChart.Parameters>) => {
+const getQueryString = (queryParams: Partial<SystemMetricChart.Parameters>, tagGroup?: boolean) => {
   if (
     queryParams.hostGroupName &&
     queryParams.hostName &&
     queryParams.metricDefinitionId &&
     queryParams.from &&
-    queryParams.to
+    queryParams.to &&
+    // tagGroup이 있는 metric은 tags가 정해지기 전에는 요청하지 않는다 (빈 tags= 요청 방지)
+    (!tagGroup || queryParams.tags)
   ) {
     return '?' + convertParamsToQueryString(queryParams);
   }
@@ -19,9 +21,11 @@ const getQueryString = (queryParams: Partial<SystemMetricChart.Parameters>) => {
 
 export const useGetSystemMetricChartData = ({
   metricDefinitionId,
+  tagGroup,
   tags,
 }: {
   metricDefinitionId: string;
+  tagGroup?: boolean;
   tags?: string;
 }) => {
   const { hostGroupName, hostName, dateRange } = useSystemMetricSearchParameters();
@@ -36,7 +40,7 @@ export const useGetSystemMetricChartData = ({
     tags,
   };
 
-  const queryString = getQueryString(queryParams);
+  const queryString = getQueryString(queryParams, tagGroup);
 
   const { data, isLoading, isFetching } = useSuspenseQuery<SystemMetricChart.Response | null>({
     queryKey: [END_POINTS.SYSTEM_METRIC_CHART, queryString],


### PR DESCRIPTION
## Summary
- The system metric Group selector could render empty, and `collectedMetricData` could be requested with an empty `tags=` value even though the tags API returned data.
- Root cause: the selected tag was stored in `useState` (initialized once) and synced via a lagging `useEffect`, so when `tagData` arrived/changed the tag was reset to `''` and the chart query fired before a tag was resolved.
- Fix: derive the selected tag during render (`selectedTag ?? tagData[0]`) and remove the `useEffect` sync; additionally guard the chart query so `tagGroup` metrics are not requested until a tag is resolved.

## Test plan
- [ ] `yarn build` passes
- [ ] `yarn test` passes (444 tests)
- [ ] Group selector shows the first tag on load (not empty) for metrics with a tag group
- [ ] No `collectedMetricData?...&tags=` (empty) request is sent for tagGroup metrics
- [ ] Metrics without a tag group (e.g. cpu) still load normally without tags