### PR TITLE
[#13871] Propagate serviceName through inspector stat collector pipeline

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/mapper/grpc/stat/GrpcAgentStatBatchMapper.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/mapper/grpc/stat/GrpcAgentStatBatchMapper.java
@@ -43,9 +43,10 @@ public class GrpcAgentStatBatchMapper {
         }
         final String applicationName = header.getApplicationName();
         final String agentId = header.getAgentId();
+        final String serviceName = header.getServiceName();
         final long startTimestamp = header.getAgentStartTime();
 
-        final AgentStatBo.Builder builder = AgentStatBo.newBuilder(applicationName, agentId, startTimestamp);
+        final AgentStatBo.Builder builder = AgentStatBo.newBuilder(serviceName, applicationName, agentId, startTimestamp);
         for (PAgentStat agentStat : agentStatBatch.getAgentStatList()) {
             this.mapper.map(agentStat, builder);
         }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/mapper/grpc/stat/GrpcAgentStatMapper.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/mapper/grpc/stat/GrpcAgentStatMapper.java
@@ -45,11 +45,10 @@ public class GrpcAgentStatMapper {
 
         final String applicationName = header.getApplicationName();
         final String agentId = header.getAgentId();
+        final String serviceName = header.getServiceName();
         final long startTimestamp = header.getAgentStartTime();
 
-
-
-        final AgentStatBo.Builder builder = AgentStatBo.newBuilder(applicationName, agentId, startTimestamp);
+        final AgentStatBo.Builder builder = AgentStatBo.newBuilder(serviceName, applicationName, agentId, startTimestamp);
 
         this.map(agentStat, builder);
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/stat/AgentStatBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/stat/AgentStatBo.java
@@ -34,6 +34,8 @@ public class AgentStatBo {
     private final String applicationName;
     @NonNull
     private final String agentId;
+    @NonNull
+    private final String serviceName;
     private final long startTimestamp;
 
     private final List<JvmGcBo> jvmGcBos;
@@ -53,6 +55,7 @@ public class AgentStatBo {
     private AgentStatBo(Builder builder) {
         this.applicationName = builder.applicationName;
         this.agentId = builder.agentId;
+        this.serviceName = builder.serviceName;
         this.startTimestamp = builder.startTimestamp;
         this.jvmGcBos = FilterUtils.filter(builder.statList, JvmGcBo.class);
         this.jvmGcDetailedBos = FilterUtils.filter(builder.statList, JvmGcDetailedBo.class);
@@ -79,6 +82,10 @@ public class AgentStatBo {
 
     public String getAgentId() {
         return agentId;
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 
     public List<JvmGcBo> getJvmGcBos() {
@@ -130,19 +137,21 @@ public class AgentStatBo {
         return loadedClassBos;
     }
 
-    public static Builder newBuilder(String applicationName, String agentId, long startTimestamp) {
-        return new Builder(applicationName, agentId, startTimestamp);
+    public static Builder newBuilder(String serviceName, String applicationName, String agentId, long startTimestamp) {
+        return new Builder(serviceName, applicationName, agentId, startTimestamp);
     }
 
     public static class Builder {
 
+        private final String serviceName;
         private final String applicationName;
         private final String agentId;
         private final long startTimestamp;
 
         private final List<StatDataPoint> statList = new ArrayList<>();
 
-        Builder(String applicationName, String agentId, long startTimestamp) {
+        Builder(String serviceName, String applicationName, String agentId, long startTimestamp) {
+            this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
             this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
             this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
             this.startTimestamp = NumberPrecondition.requirePositiveOrZero(startTimestamp, "startTimestamp");
@@ -156,7 +165,7 @@ public class AgentStatBo {
             private final DataPoint dataPoint;
 
             public StatBuilder(long timestamp) {
-                this.dataPoint = DataPoint.of(agentId, applicationName, startTimestamp, timestamp);
+                this.dataPoint = DataPoint.of(agentId, applicationName, serviceName, startTimestamp, timestamp);
             }
 
             public DataPoint getDataPoint() {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/stat/DataPoint.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/stat/DataPoint.java
@@ -25,11 +25,13 @@ public interface DataPoint {
 
     String getApplicationName();
 
+    String getServiceName();
+
     long getStartTimestamp();
 
     long getTimestamp();
 
-    static DataPoint of(String agentId, String applicationName, long startTimestamp, long timestamp) {
-        return new DefaultDataPoint(agentId, applicationName, startTimestamp, timestamp);
+    static DataPoint of(String agentId, String applicationName, String serviceName, long startTimestamp, long timestamp) {
+        return new DefaultDataPoint(agentId, applicationName, serviceName, startTimestamp, timestamp);
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/stat/DefaultDataPoint.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/stat/DefaultDataPoint.java
@@ -8,12 +8,14 @@ public class DefaultDataPoint implements DataPoint {
 
     private final String agentId;
     private final String applicationName;
+    private final String serviceName;
     private final long startTimestamp;
     private final long timestamp;
 
-    DefaultDataPoint(String agentId, String applicationName, long startTimestamp, long timestamp) {
+    DefaultDataPoint(String agentId, String applicationName, String serviceName, long startTimestamp, long timestamp) {
         this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
         this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
+        this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
         this.startTimestamp = startTimestamp;
         this.timestamp = timestamp;
     }
@@ -37,6 +39,11 @@ public class DefaultDataPoint implements DataPoint {
     @Override
     public String getApplicationName() {
         return applicationName;
+    }
+
+    @Override
+    public String getServiceName() {
+        return serviceName;
     }
 
     @Override

--- a/inspector-module/inspector-collector/src/main/java/com/navercorp/pinpoint/inspector/collector/model/kafka/AgentStat.java
+++ b/inspector-module/inspector-collector/src/main/java/com/navercorp/pinpoint/inspector/collector/model/kafka/AgentStat.java
@@ -33,6 +33,7 @@ public class AgentStat {
 
     private final String tenantId;
     private final long timestamp;
+    private final String serviceName;
     private final String applicationName;
     private final String agentId;
     private final String sortKey;
@@ -42,11 +43,12 @@ public class AgentStat {
     private final List<Tag> tags;
 
 
-    public AgentStat(String tenantId, long timestamp, String applicationName, String agentId,
-                     String sortKey,
+    public AgentStat(String tenantId, long timestamp, String serviceName,
+                     String applicationName, String agentId, String sortKey,
                      String metricName, String fieldName, double fieldValue, List<Tag> tags) {
         this.tenantId = tenantId;
         this.timestamp = timestamp;
+        this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
         this.sortKey = sortKey;
         this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
         this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
@@ -59,6 +61,10 @@ public class AgentStat {
     @Deprecated
     public String getTenantId() {
         return tenantId;
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 
     public String getApplicationName() {
@@ -99,6 +105,7 @@ public class AgentStat {
         return "AgentStat{" +
                 "tenantId='" + tenantId + '\'' +
                 ", timestamp=" + timestamp +
+                ", serviceName='" + serviceName + '\'' +
                 ", applicationName='" + applicationName + '\'' +
                 ", agentId='" + agentId + '\'' +
                 ", sortKey='" + sortKey + '\'' +

--- a/inspector-module/inspector-collector/src/main/java/com/navercorp/pinpoint/inspector/collector/model/kafka/AgentStatBuilder.java
+++ b/inspector-module/inspector-collector/src/main/java/com/navercorp/pinpoint/inspector/collector/model/kafka/AgentStatBuilder.java
@@ -28,6 +28,7 @@ public class AgentStatBuilder {
         String metricName = dataPoint.getAgentStatType().getChartType();
         return new AgentStat(tenantId,
                 point.getTimestamp(),
+                point.getServiceName(),
                 point.getApplicationName(), point.getAgentId(), sortKey,
                 metricName, fieldName.getFieldName(), fieldValue, tags);
     }


### PR DESCRIPTION
## Summary

- Extract `serviceName` from gRPC header in the collector inspector stat pipeline
- Add `serviceName` field to `DataPoint`, `AgentStatBo`, and `AgentStat` (Kafka model)
- Propagate from `GrpcAgentStatMapper` / `GrpcAgentStatBatchMapper` through to Pinot storage

## Context

The collector receives `serviceName` via gRPC header and the Pinot schema already has a `serviceName` column, but the Java code was not extracting the value — resulting in empty strings stored in Pinot.

## Test plan

- [x] commons-server compile pass
- [x] collector tests pass (99 tests)
- [x] inspector-collector tests pass (9 tests)