### PR TITLE
[#noissue] Make V4 gRPC apiKey optional and thread serviceUid through…

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/grpc/AgentHeaderFactoryProvider.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/grpc/AgentHeaderFactoryProvider.java
@@ -52,7 +52,9 @@ public class AgentHeaderFactoryProvider implements Provider<HeaderFactory> {
         String agentId = objectName.getAgentId();
         String agentName = objectName.getAgentName();
         String applicationName = objectName.getApplicationName();
-        return new ClientHeaderFactoryV1(agentId, agentName, applicationName, agentInformation.getServerType().getCode(), agentInformation.getStartTime());
+        short serviceType = agentInformation.getServerType().getCode();
+        long startTime = agentInformation.getStartTime();
+        return new ClientHeaderFactoryV1(agentId, agentName, applicationName, serviceType, startTime);
     }
 
     private HeaderFactory createV4() {
@@ -63,7 +65,10 @@ public class AgentHeaderFactoryProvider implements Provider<HeaderFactory> {
             String applicationName = objectName.getApplicationName();
             String serviceName = objectName.getServiceName();
             String apiKey = objectName.getApiKey();
-            return new ClientHeaderFactoryV4(agentId, agentName, applicationName, serviceName, agentInformation.getServerType().getCode(), agentInformation.getStartTime(), apiKey);
+
+            short serviceType = agentInformation.getServerType().getCode();
+            long startTime = agentInformation.getStartTime();
+            return new ClientHeaderFactoryV4(agentId, agentName, applicationName, serviceName, apiKey, serviceType, startTime);
         }
         throw new IllegalStateException("unsupported ObjectType:" + objectName);
     }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/name/v4/ObjectNameResolverV4.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/name/v4/ObjectNameResolverV4.java
@@ -82,8 +82,8 @@ public class ObjectNameResolverV4 implements ObjectNameResolver {
 
         final ObjectNameProperty apiKey = getApiKey(filter);
         if (!apiKey.hasLengthValue()) {
-            logger.warn("Failed to resolve ApiKey(-Dpinpoint.apikey)");
-            throw new ObjectNameValidationFailedException(AgentIdType.APIKEY, "ApiKey not provided");
+            logger.info("Failed to resolve ApiKey(-Dpinpoint.apikey)");
+//            throw new ObjectNameValidationFailedException(AgentIdType.APIKEY, "ApiKey not provided");
         } else {
             resolveLog(apiKey);
         }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/name/v4/ObjectNameV4.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/name/v4/ObjectNameV4.java
@@ -41,7 +41,7 @@ public class ObjectNameV4 implements ObjectName {
         this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
         this.serviceName = Objects.requireNonNull(serviceName, "serviceName");
 
-        this.apiKey = Objects.requireNonNull(apiKey, "apiKey");
+        this.apiKey = apiKey;
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.SpanId;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeCategory;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
@@ -75,7 +76,7 @@ public class HbaseApplicationMapService implements ApplicationMapService {
 
     private Vertex getSelfVertex(BasicSpan basicSpan) {
         final ServiceType applicationServiceType = getApplicationServiceType(basicSpan);
-        return Vertex.of(basicSpan.getApplicationName(), applicationServiceType);
+        return Vertex.of(ServiceUid.DEFAULT.getUid(), basicSpan.getApplicationName(), applicationServiceType);
     }
 
     private ServiceType getApplicationServiceType(BasicSpan basicSpan) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/DefaultServerRequestFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/DefaultServerRequestFactory.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.server.io.MessageType;
 import com.navercorp.pinpoint.common.server.io.ServerHeader;
 import com.navercorp.pinpoint.common.server.io.ServerRequest;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.grpc.Header;
 import com.navercorp.pinpoint.grpc.server.ServerContext;
 import com.navercorp.pinpoint.grpc.server.TransportMetadata;
@@ -64,6 +65,17 @@ public class DefaultServerRequestFactory implements ServerRequestFactory {
         ServerHeader serverHeader = headerFactory.serverHeader(header, new Supplier<ServiceUid>() {
             @Override
             public ServiceUid get() {
+                String serviceName = header.getServiceName();
+                if (StringUtils.isEmpty(serviceName)) {
+                    return ServiceUid.DEFAULT;
+                }
+                if (serviceName.equals(ServiceUid.DEFAULT_SERVICE_UID_NAME)) {
+                    return ServiceUid.DEFAULT;
+                }
+                // for Test
+                if (serviceName.equals(ServiceUid.TEST_SERVICE_UID_NAME)) {
+                    return ServiceUid.TEST_SERVICE;
+                }
 //                CompletableFuture<ServiceUid> future = uidFetcher.getServiceUid(ServiceUid.DEFAULT_SERVICE_UID_NAME);
                 return ServiceUid.DEFAULT;
             }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/Vertex.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/Vertex.java
@@ -31,13 +31,16 @@ public record Vertex(int serviceUid, String applicationName, ServiceType service
         this.serviceType = Objects.requireNonNull(serviceType, "serviceType");
     }
 
+    public static Vertex of(int serviceUid, String applicationName, ServiceType serviceType) {
+        return new Vertex(serviceUid, applicationName, serviceType);
+    }
 
     public static Vertex of(String applicationName, ServiceType serviceType) {
-        return new Vertex(DEFAULT.getUid(), applicationName, serviceType);
+        return of(DEFAULT.getUid(), applicationName, serviceType);
     }
 
     @Override
     public String toString() {
-        return applicationName + "/" + serviceType.getName() + ':' + serviceType.getCode();
+        return serviceUid + "/" + applicationName + "/" + serviceType.getName() + ':' + serviceType.getCode();
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceUid.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceUid.java
@@ -12,9 +12,11 @@ public class ServiceUid {
     public static final String DEFAULT_SERVICE_UID_NAME = "DEFAULT";
     public static final String UNKNOWN_SERVICE_UID_NAME = "UNKNOWN";
 
+    public static final String TEST_SERVICE_UID_NAME = "TEST_SERVICE";
+
     // serviceUid
     public static final ServiceUid DEFAULT = new ServiceUid(DEFAULT_SERVICE_UID_CODE);
-    public static final ServiceUid TEST = new ServiceUid(5);
+    public static final ServiceUid TEST_SERVICE = new ServiceUid(5);
 
     public static final ServiceUid ERROR = new ServiceUid(-1);
     public static final ServiceUid UNKNOWN = new ServiceUid(-2);

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/ClientHeaderFactoryV4.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/ClientHeaderFactoryV4.java
@@ -32,35 +32,38 @@ public class ClientHeaderFactoryV4 implements HeaderFactory {
     private final String agentName;
     private final String applicationName;
     private final String serviceName;
+    private final String apiKey;
+
     private final long agentStartTime;
     private final int serviceType;
 
-    private final String apiKey;
-
-    public ClientHeaderFactoryV4(String agentId, String agentName, String applicationName, String serviceName, int serviceType, long agentStartTime, String apiKey) {
+    public ClientHeaderFactoryV4(String agentId, String agentName, String applicationName, String serviceName, String apiKey, int serviceType, long agentStartTime) {
         this.protocolVersion = ProtocolVersion.V4;
         this.agentId = Objects.requireNonNull(agentId, "agentId");
         this.agentName = Objects.requireNonNull(agentName, "agentName");
         this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
         this.serviceName = Objects.requireNonNull(serviceName, "serviceName");
+        this.apiKey = apiKey;
+
         this.serviceType = serviceType;
         this.agentStartTime = agentStartTime;
-        this.apiKey = Objects.requireNonNull(apiKey, "apiKey");
     }
 
     public Metadata newHeader() {
         Metadata headers = new Metadata();
+        headers.put(Header.PROTOCOL_VERSION_NAME_KEY, Integer.toString(protocolVersion.version()));
+
         headers.put(Header.AGENT_ID_KEY, agentId);
         headers.put(Header.APPLICATION_NAME_KEY, applicationName);
         headers.put(Header.AGENT_NAME_KEY, agentName);
         headers.put(Header.SERVICE_NAME_KEY, serviceName);
-
-        headers.put(Header.PROTOCOL_VERSION_NAME_KEY, Integer.toString(protocolVersion.version()));
+        if (apiKey != null) {
+            headers.put(Header.API_KEY, apiKey);
+        }
 
         headers.put(Header.SERVICE_TYPE_KEY, Integer.toString(serviceType));
         headers.put(Header.AGENT_START_TIME_KEY, Long.toString(agentStartTime));
 
-        headers.put(Header.API_KEY, apiKey);
         return headers;
     }
 }

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/HeaderV4.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/HeaderV4.java
@@ -16,6 +16,8 @@
 
 package com.navercorp.pinpoint.grpc;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +35,7 @@ public class HeaderV4 implements Header {
     private final String applicationName;
     private final String serviceName;
 
+    @Nullable
     private final String apiKey;
 
     private final long agentStartTime;
@@ -45,6 +48,7 @@ public class HeaderV4 implements Header {
 
     public HeaderV4(String name,
                     String agentId, String agentName, String applicationName, String serviceName,
+                    @Nullable
                     String apiKey,
                     int serviceType,
                     long agentStartTime, long socketId,
@@ -56,7 +60,7 @@ public class HeaderV4 implements Header {
         this.agentName = Objects.requireNonNull(agentName, "agentName");
         this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
         this.serviceName = Objects.requireNonNull(serviceName, "serviceName");
-        this.apiKey = Objects.requireNonNull(apiKey, "apiKey");
+        this.apiKey = apiKey;
         this.serviceType = serviceType;
         this.agentStartTime = agentStartTime;
         this.socketId = socketId;
@@ -100,6 +104,7 @@ public class HeaderV4 implements Header {
         return serviceType;
     }
 
+    @Nullable
     public String getApiKey() {
         return apiKey;
     }

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/server/ServerHeaderReaderV4.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/server/ServerHeaderReaderV4.java
@@ -51,7 +51,7 @@ public class ServerHeaderReaderV4 implements HeaderReader<Header> {
         final String applicationName = headerExtractor.getName(headers, Header.APPLICATION_NAME_KEY);
         final String serviceName = headerExtractor.getName(headers, Header.SERVICE_NAME_KEY);
 
-        final String apikey = headerExtractor.getName(headers, Header.API_KEY);
+        final String apikey = headers.get(Header.API_KEY);
 
         final long startTime = headerExtractor.getTime(headers, Header.AGENT_START_TIME_KEY);
         final int serviceType = headerExtractor.getServiceType(headers);


### PR DESCRIPTION
… the application map

- V4 apiKey is now optional: ClientHeaderFactoryV4 omits the API_KEY header when null, HeaderV4/ObjectNameV4 drop requireNonNull and mark apiKey @Nullable, ServerHeaderReaderV4 reads it leniently, ObjectNameResolverV4 no longer fails when -Dpinpoint.apikey is absent
- ServiceUid: Vertex gains an of(serviceUid, applicationName, serviceType) overload and includes serviceUid in toString; HbaseApplicationMapService builds the self-vertex with ServiceUid.DEFAULT; rename ServiceUid.TEST -> TEST_SERVICE (+ TEST_SERVICE_UID_NAME); DefaultServerRequestFactory resolves the serviceUid from the header service name