### PR TITLE
[#13875] Propagate serviceName through inspector web query pipeline

### DIFF
--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
@@ -83,7 +83,7 @@ public class AgentInspectorStatController {
 
         String tenantId = tenantProvider.getTenantId();
         TimeWindow timeWindow = getTimeWindow(range);
-        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, applicationName, agentId, metricDefinitionId, timeWindow);
+        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, serviceName.getName(), applicationName, agentId, metricDefinitionId, timeWindow);
 
         InspectorMetricData inspectorMetricData = agentStatService.selectAgentStat(inspectorDataSearchKey, timeWindow);
         return new InspectorMetricView(inspectorMetricData);
@@ -120,7 +120,7 @@ public class AgentInspectorStatController {
 
         String tenantId = tenantProvider.getTenantId();
         TimeWindow timeWindow = getTimeWindow(range);
-        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, applicationName, agentId, metricDefinitionId, timeWindow);
+        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, serviceName.getName(), applicationName, agentId, metricDefinitionId, timeWindow);
 
         InspectorMetricGroupData inspectorMetricGroupData = agentStatService.selectAgentStatWithGrouping(inspectorDataSearchKey, timeWindow);
         return new InspectorMetricGroupDataView(inspectorMetricGroupData);
@@ -161,7 +161,7 @@ public class AgentInspectorStatController {
         TimeWindow timeWindow = getTimeWindow(range);
 
         InspectorMetricGroupData inspectorMetricGroupData = agentStatService.selectAgentStatGroupedByAgentId(
-                tenantId, applicationName, agentIds, metricDefinitionId, timeWindow
+                tenantId, serviceName.getName(), applicationName, agentIds, metricDefinitionId, timeWindow
         );
         return new InspectorMetricGroupDataView(inspectorMetricGroupData);
     }
@@ -182,7 +182,7 @@ public class AgentInspectorStatController {
         TimeWindow timeWindow = getTimeWindow(range);
 
         InspectorMetricGroupData inspectorMetricGroupData = agentStatService.selectAgentStatGroupedByAgentId(
-                tenantId, applicationName, agentIds, metricDefinitionId, timeWindow
+                tenantId, serviceName.getName(), applicationName, agentIds, metricDefinitionId, timeWindow
         );
         return new InspectorMetricGroupDataView(inspectorMetricGroupData);
     }

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
@@ -59,7 +59,7 @@ public class ApplicationInspectorStatController {
 
         String tenantId = tenantProvider.getTenantId();
         TimeWindow timeWindow = getTimeWindow(range);
-        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, applicationName, InspectorDataSearchKey.UNKNOWN_NAME, metricDefinitionId, timeWindow);
+        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, serviceName.getName(), applicationName, InspectorDataSearchKey.UNKNOWN_NAME, metricDefinitionId, timeWindow);
 
         InspectorMetricData inspectorMetricData = applicationStatService.selectApplicationStat(inspectorDataSearchKey, timeWindow);
         return new InspectorMetricView(inspectorMetricData);
@@ -94,7 +94,7 @@ public class ApplicationInspectorStatController {
 
         String tenantId = tenantProvider.getTenantId();
         TimeWindow timeWindow = getTimeWindow(range);
-        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, applicationName, InspectorDataSearchKey.UNKNOWN_NAME, metricDefinitionId, timeWindow);
+        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, serviceName.getName(), applicationName, InspectorDataSearchKey.UNKNOWN_NAME, metricDefinitionId, timeWindow);
 
         InspectorMetricGroupData inspectorMetricGroupData = applicationStatService.selectApplicationStatWithGrouping(inspectorDataSearchKey, timeWindow);
         return new InspectorMetricGroupDataView(inspectorMetricGroupData);

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/dao/AgentStatDao.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/dao/AgentStatDao.java
@@ -40,11 +40,11 @@ public interface AgentStatDao {
 
     CompletableFuture<List<DataPoint<Double>>> selectAgentStatSum(InspectorDataSearchKey inspectorDataSearchKey, String metricName, Field field);
 
-    CompletableFuture<List<AgentStatPoint>> selectAgentStatAvgByAgentIds(String tenantId, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow);
+    CompletableFuture<List<AgentStatPoint>> selectAgentStatAvgByAgentIds(String tenantId, String serviceName, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow);
 
-    CompletableFuture<List<AgentStatPoint>> selectAgentStatMaxByAgentIds(String tenantId, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow);
+    CompletableFuture<List<AgentStatPoint>> selectAgentStatMaxByAgentIds(String tenantId, String serviceName, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow);
 
-    CompletableFuture<List<AgentStatPoint>> selectAgentStatSumByAgentIds(String tenantId, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow);
+    CompletableFuture<List<AgentStatPoint>> selectAgentStatSumByAgentIds(String tenantId, String serviceName, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow);
 
     List<Tag> getTagInfo(InspectorDataSearchKey inspectorDataSearchKey, String metricName, Field field);
 

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/dao/model/InspectorQueryGroupParameter.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/dao/model/InspectorQueryGroupParameter.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 public class InspectorQueryGroupParameter {
 
     private final String tenantId;
+    private final String serviceName;
     private final String tableName;
     private final List<String> sortKeys;
     private final String metricName;
@@ -41,10 +42,11 @@ public class InspectorQueryGroupParameter {
     private final TimePrecision timePrecision;
     private final long limit;
 
-    public InspectorQueryGroupParameter(String tenantId, String tableName, List<String> sortKeys,
+    public InspectorQueryGroupParameter(String tenantId, String serviceName, String tableName, List<String> sortKeys,
                                         String metricName, String fieldName, List<Tag> tagList,
                                         Range range, TimePrecision timePrecision, long perAgentLimit) {
         this.tenantId = Objects.requireNonNull(tenantId, "tenantId");
+        this.serviceName = Objects.requireNonNull(serviceName, "serviceName");
         this.tableName = Objects.requireNonNull(tableName, "tableName");
         this.sortKeys = Objects.requireNonNull(sortKeys, "sortKeys");
         this.metricName = Objects.requireNonNull(metricName, "metricName");
@@ -57,6 +59,10 @@ public class InspectorQueryGroupParameter {
 
     public String getTenantId() {
         return tenantId;
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 
     public String getTableName() {

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/dao/model/InspectorQueryParameter.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/dao/model/InspectorQueryParameter.java
@@ -34,6 +34,7 @@ public class InspectorQueryParameter {
 
     private final static String DEFAULT_TABLE_NAME = "tableName";
     private final String tenantId;
+    private final String serviceName;
     private final String tableName;
     private final String applicationName;
     private final String sortKey;
@@ -62,6 +63,7 @@ public class InspectorQueryParameter {
         Objects.requireNonNull(inspectorDataSearchKey, "inspectorDataSearchKey");
 
         this.tenantId = inspectorDataSearchKey.getTenantId();
+        this.serviceName = inspectorDataSearchKey.getServiceName();
         this.tableName = StringPrecondition.requireHasLength(tableName, "tableName");
         this.sortKey = StringPrecondition.requireHasLength(sortKey, "sortKey");
         this.applicationName = inspectorDataSearchKey.getApplicationName();
@@ -76,6 +78,10 @@ public class InspectorQueryParameter {
 
     public String getTenantId() {
         return tenantId;
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 
     public String getTableName() {
@@ -123,18 +129,19 @@ public class InspectorQueryParameter {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         InspectorQueryParameter that = (InspectorQueryParameter) o;
-        return limit == that.limit && Objects.equals(tenantId, that.tenantId) && Objects.equals(tableName, that.tableName) && Objects.equals(applicationName, that.applicationName) && Objects.equals(sortKey, that.sortKey) && Objects.equals(agentId, that.agentId) && Objects.equals(metricName, that.metricName) && Objects.equals(fieldName, that.fieldName) && Objects.equals(tagList, that.tagList) && Objects.equals(range, that.range) && Objects.equals(timePrecision, that.timePrecision);
+        return limit == that.limit && Objects.equals(tenantId, that.tenantId) && Objects.equals(serviceName, that.serviceName) && Objects.equals(tableName, that.tableName) && Objects.equals(applicationName, that.applicationName) && Objects.equals(sortKey, that.sortKey) && Objects.equals(agentId, that.agentId) && Objects.equals(metricName, that.metricName) && Objects.equals(fieldName, that.fieldName) && Objects.equals(tagList, that.tagList) && Objects.equals(range, that.range) && Objects.equals(timePrecision, that.timePrecision);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tenantId, tableName, applicationName, sortKey, agentId, metricName, fieldName, tagList, range, timePrecision, limit);
+        return Objects.hash(tenantId, serviceName, tableName, applicationName, sortKey, agentId, metricName, fieldName, tagList, range, timePrecision, limit);
     }
 
     @Override
     public String toString() {
         return "InspectorQueryParameterV2{" +
                 "tenantId='" + tenantId + '\'' +
+                ", serviceName='" + serviceName + '\'' +
                 ", tableName='" + tableName + '\'' +
                 ", applicationName='" + applicationName + '\'' +
                 ", sortKey='" + sortKey + '\'' +

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/dao/pinot/PinotAgentStatDao.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/dao/pinot/PinotAgentStatDao.java
@@ -85,24 +85,24 @@ public class PinotAgentStatDao implements AgentStatDao {
     }
 
     @Override
-    public CompletableFuture<List<AgentStatPoint>> selectAgentStatAvgByAgentIds(String tenantId, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow) {
-        InspectorQueryGroupParameter param = buildGroupParameter(tenantId, applicationName, agentIds, metricName, field, timeWindow);
+    public CompletableFuture<List<AgentStatPoint>> selectAgentStatAvgByAgentIds(String tenantId, String serviceName, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow) {
+        InspectorQueryGroupParameter param = buildGroupParameter(tenantId, serviceName, applicationName, agentIds, metricName, field, timeWindow);
         return asyncTemplate.selectList(NAMESPACE + "selectInspectorAvgDataByAgentIds", param);
     }
 
     @Override
-    public CompletableFuture<List<AgentStatPoint>> selectAgentStatMaxByAgentIds(String tenantId, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow) {
-        InspectorQueryGroupParameter param = buildGroupParameter(tenantId, applicationName, agentIds, metricName, field, timeWindow);
+    public CompletableFuture<List<AgentStatPoint>> selectAgentStatMaxByAgentIds(String tenantId, String serviceName, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow) {
+        InspectorQueryGroupParameter param = buildGroupParameter(tenantId, serviceName, applicationName, agentIds, metricName, field, timeWindow);
         return asyncTemplate.selectList(NAMESPACE + "selectInspectorMaxDataByAgentIds", param);
     }
 
     @Override
-    public CompletableFuture<List<AgentStatPoint>> selectAgentStatSumByAgentIds(String tenantId, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow) {
-        InspectorQueryGroupParameter param = buildGroupParameter(tenantId, applicationName, agentIds, metricName, field, timeWindow);
+    public CompletableFuture<List<AgentStatPoint>> selectAgentStatSumByAgentIds(String tenantId, String serviceName, String applicationName, List<String> agentIds, String metricName, Field field, TimeWindow timeWindow) {
+        InspectorQueryGroupParameter param = buildGroupParameter(tenantId, serviceName, applicationName, agentIds, metricName, field, timeWindow);
         return asyncTemplate.selectList(NAMESPACE + "selectInspectorSumDataByAgentIds", param);
     }
 
-    private InspectorQueryGroupParameter buildGroupParameter(String tenantId, String applicationName, List<String> agentIds,
+    private InspectorQueryGroupParameter buildGroupParameter(String tenantId, String serviceName, String applicationName, List<String> agentIds,
                                                              String metricName, Field field, TimeWindow timeWindow) {
         String tableName = tableNameManager.getTableName(applicationName);
         List<String> sortKeys = agentIds.stream()
@@ -111,7 +111,7 @@ public class PinotAgentStatDao implements AgentStatDao {
         Range range = timeWindow.getWindowRange();
         TimePrecision timePrecision = TimePrecision.newTimePrecision(TimeUnit.MILLISECONDS, timeWindow.getWindowSlotSize());
         long perAgentLimit = timeWindow.getWindowRangeCount();
-        return new InspectorQueryGroupParameter(tenantId, tableName, sortKeys, metricName, field.getFieldName(), field.getTags(), range, timePrecision, perAgentLimit);
+        return new InspectorQueryGroupParameter(tenantId, serviceName, tableName, sortKeys, metricName, field.getFieldName(), field.getTags(), range, timePrecision, perAgentLimit);
     }
 
     @Override

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/model/InspectorDataSearchKey.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/model/InspectorDataSearchKey.java
@@ -36,6 +36,8 @@ public class InspectorDataSearchKey {
 
     private final String tenantId;
 
+    private final String serviceName;
+
     private final String applicationName;
 
     private final String agentId;
@@ -46,8 +48,9 @@ public class InspectorDataSearchKey {
     private final TimePrecision timePrecision;
     private final long limit;
 
-    public InspectorDataSearchKey(String tenantId, String applicationName, String agentId, String metricDefinitionId, TimeWindow timeWindow) {
+    public InspectorDataSearchKey(String tenantId, String serviceName, String applicationName, String agentId, String metricDefinitionId, TimeWindow timeWindow) {
         this.tenantId = StringPrecondition.requireHasLength(tenantId, "tenantId");
+        this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
         this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
         this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
         this.metricDefinitionId = StringPrecondition.requireHasLength(metricDefinitionId, "metricDefinitionId");
@@ -64,6 +67,10 @@ public class InspectorDataSearchKey {
 
     public String getTenantId() {
         return tenantId;
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 
     public String getAgentId() {

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/AgentStatService.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/AgentStatService.java
@@ -34,5 +34,5 @@ public interface AgentStatService {
 
     InspectorMetricGroupData selectAgentStatWithGrouping(InspectorDataSearchKey inspectorDataSearchKey, TimeWindow timeWindow);
 
-    InspectorMetricGroupData selectAgentStatGroupedByAgentId(String tenantId, String applicationName, List<String> agentIds, String metricDefinitionId, TimeWindow timeWindow);
+    InspectorMetricGroupData selectAgentStatGroupedByAgentId(String tenantId, String serviceName, String applicationName, List<String> agentIds, String metricDefinitionId, TimeWindow timeWindow);
 }

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/AgentWarningStatServiceImpl.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/AgentWarningStatServiceImpl.java
@@ -23,7 +23,6 @@ import com.navercorp.pinpoint.common.timeseries.window.TimeWindowSampler;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowSlotCentricSampler;
 import com.navercorp.pinpoint.inspector.web.model.InspectorDataSearchKey;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
-import com.navercorp.pinpoint.service.web.vo.ServiceConstants;
 import com.navercorp.pinpoint.web.service.stat.AgentWarningStatService;
 import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentState;
 import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentStatusTimelineSegment;
@@ -55,10 +54,10 @@ public class AgentWarningStatServiceImpl implements AgentWarningStatService {
     }
 
     @Override
-    public List<AgentStatusTimelineSegment> select(String applicationName, String agentId, Range range) {
+    public List<AgentStatusTimelineSegment> select(String serviceName, String applicationName, String agentId, Range range) {
         String tenantId = tenantProvider.getTenantId();
         TimeWindow timeWindow = new TimeWindow(range, DEFAULT_TIME_WINDOW_SAMPLER);
-        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, ServiceConstants.DEFAULT, applicationName, agentId, DEADLOCK_DEFINITION_ID, timeWindow);
+        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, serviceName, applicationName, agentId, DEADLOCK_DEFINITION_ID, timeWindow);
         List<DataPoint<Double>> dataPoints = agentStatService.selectAgentStatUnconvertedTime(inspectorDataSearchKey, timeWindow);
         return createTimelineSegment(dataPoints);
     }

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/AgentWarningStatServiceImpl.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/AgentWarningStatServiceImpl.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.timeseries.window.TimeWindowSampler;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowSlotCentricSampler;
 import com.navercorp.pinpoint.inspector.web.model.InspectorDataSearchKey;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.service.web.vo.ServiceConstants;
 import com.navercorp.pinpoint.web.service.stat.AgentWarningStatService;
 import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentState;
 import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentStatusTimelineSegment;
@@ -57,7 +58,7 @@ public class AgentWarningStatServiceImpl implements AgentWarningStatService {
     public List<AgentStatusTimelineSegment> select(String applicationName, String agentId, Range range) {
         String tenantId = tenantProvider.getTenantId();
         TimeWindow timeWindow = new TimeWindow(range, DEFAULT_TIME_WINDOW_SAMPLER);
-        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, applicationName, agentId, DEADLOCK_DEFINITION_ID, timeWindow);
+        InspectorDataSearchKey inspectorDataSearchKey = new InspectorDataSearchKey(tenantId, ServiceConstants.DEFAULT, applicationName, agentId, DEADLOCK_DEFINITION_ID, timeWindow);
         List<DataPoint<Double>> dataPoints = agentStatService.selectAgentStatUnconvertedTime(inspectorDataSearchKey, timeWindow);
         return createTimelineSegment(dataPoints);
     }

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultAgentStatService.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultAgentStatService.java
@@ -215,7 +215,7 @@ public class DefaultAgentStatService implements AgentStatService {
 
     @Override
     public InspectorMetricGroupData selectAgentStatGroupedByAgentId(
-            String tenantId, String applicationName, List<String> agentIds,
+            String tenantId, String serviceName, String applicationName, List<String> agentIds,
             String metricDefinitionId, TimeWindow timeWindow) {
 
         if (agentIds.size() > MAX_AGENT_IDS) {
@@ -225,7 +225,7 @@ public class DefaultAgentStatService implements AgentStatService {
         MetricDefinition metricDefinition = ymlInspectorManager.findElementOfBasicGroup(metricDefinitionId);
 
         // One query per field (M queries) instead of N×M queries
-        List<BatchQueryResult> batchResults = selectAllByAgentIds(tenantId, applicationName, agentIds, metricDefinition, timeWindow);
+        List<BatchQueryResult> batchResults = selectAllByAgentIds(tenantId, serviceName, applicationName, agentIds, metricDefinition, timeWindow);
 
         CompletableFuture<?>[] allFutures = batchResults.stream()
                 .map(BatchQueryResult::future)
@@ -261,17 +261,17 @@ public class DefaultAgentStatService implements AgentStatService {
         return new InspectorMetricGroupData(metricDefinition.getTitle(), timeStampList, metricValueGroups);
     }
 
-    private List<BatchQueryResult> selectAllByAgentIds(String tenantId, String applicationName, List<String> agentIds,
+    private List<BatchQueryResult> selectAllByAgentIds(String tenantId, String serviceName, String applicationName, List<String> agentIds,
                                                        MetricDefinition metricDefinition, TimeWindow timeWindow) {
         List<BatchQueryResult> results = new ArrayList<>();
         for (Field field : metricDefinition.getFields()) {
             CompletableFuture<List<AgentStatPoint>> future;
             if (AggregationFunction.AVG.equals(field.getAggregationFunction())) {
-                future = agentStatDao.selectAgentStatAvgByAgentIds(tenantId, applicationName, agentIds, metricDefinition.getMetricName(), field, timeWindow);
+                future = agentStatDao.selectAgentStatAvgByAgentIds(tenantId, serviceName, applicationName, agentIds, metricDefinition.getMetricName(), field, timeWindow);
             } else if (AggregationFunction.MAX.equals(field.getAggregationFunction())) {
-                future = agentStatDao.selectAgentStatMaxByAgentIds(tenantId, applicationName, agentIds, metricDefinition.getMetricName(), field, timeWindow);
+                future = agentStatDao.selectAgentStatMaxByAgentIds(tenantId, serviceName, applicationName, agentIds, metricDefinition.getMetricName(), field, timeWindow);
             } else if (AggregationFunction.SUM.equals(field.getAggregationFunction())) {
-                future = agentStatDao.selectAgentStatSumByAgentIds(tenantId, applicationName, agentIds, metricDefinition.getMetricName(), field, timeWindow);
+                future = agentStatDao.selectAgentStatSumByAgentIds(tenantId, serviceName, applicationName, agentIds, metricDefinition.getMetricName(), field, timeWindow);
             } else {
                 throw new IllegalArgumentException("Unknown aggregation function : " + field.getAggregationFunction());
             }

--- a/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatControllerTest.java
+++ b/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatControllerTest.java
@@ -86,20 +86,20 @@ class AgentInspectorStatControllerTest {
     void getAgentStatChartGroupedByAgentId() {
         when(tenantProvider.getTenantId()).thenReturn("pinpoint");
         InspectorMetricGroupData groupData = new InspectorMetricGroupData("cpu", Collections.emptyList(), Collections.emptyMap());
-        when(agentStatService.selectAgentStatGroupedByAgentId(any(), any(), any(), any(), any())).thenReturn(groupData);
+        when(agentStatService.selectAgentStatGroupedByAgentId(any(), any(), any(), any(), any(), any())).thenReturn(groupData);
 
         InspectorMetricGroupDataView result = controller.getAgentStatChartGroupedByAgentId(
                 new ServiceName("DEFAULT"), "testApp", List.of("agent-01", "agent-02"), "cpu", FROM, TO);
 
         assertThat(result.getTitle()).isEqualTo("cpu");
-        verify(agentStatService).selectAgentStatGroupedByAgentId(any(), any(), any(), any(), any());
+        verify(agentStatService).selectAgentStatGroupedByAgentId(any(), any(), any(), any(), any(), any());
     }
 
     @Test
     void getAgentStatChartListGroupedByAgentId() {
         when(tenantProvider.getTenantId()).thenReturn("pinpoint");
         InspectorMetricGroupData groupData = new InspectorMetricGroupData("cpu", Collections.emptyList(), Collections.emptyMap());
-        when(agentStatService.selectAgentStatGroupedByAgentId(any(), any(), any(), any(), any())).thenReturn(groupData);
+        when(agentStatService.selectAgentStatGroupedByAgentId(any(), any(), any(), any(), any(), any())).thenReturn(groupData);
 
         InspectorMetricGroupDataView result = controller.getAgentStatChartListGroupedByAgentId(
                 new ServiceName("DEFAULT"), "testApp", List.of("agent-01"), "cpu", FROM, TO);

--- a/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/service/AgentWarningStatServiceImplTest.java
+++ b/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/service/AgentWarningStatServiceImplTest.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.inspector.web.model.InspectorDataSearchKey;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.service.web.vo.ServiceConstants;
 import com.navercorp.pinpoint.web.service.stat.AgentWarningStatService;
 import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentState;
 import com.navercorp.pinpoint.web.vo.timeline.inspector.AgentStatusTimelineSegment;
@@ -92,7 +93,7 @@ class AgentWarningStatServiceImplTest {
         when(agentStatService.selectAgentStatUnconvertedTime(any(InspectorDataSearchKey.class), any(TimeWindow.class))).thenReturn(mockDataList);
         when(tenantProvider.getTenantId()).thenReturn("pinpoint");
 
-        List<AgentStatusTimelineSegment> timelineSegmentList = agentWarningStatService.select("applicationName", "pinpoint", range);
+        List<AgentStatusTimelineSegment> timelineSegmentList = agentWarningStatService.select(ServiceConstants.DEFAULT, "applicationName", "pinpoint", range);
         assertThat(timelineSegmentList).hasSize(3);
 
         validateAgentStatusTimelineSegment(timelineSegmentList.get(0), AgentState.UNSTABLE_RUNNING, firstStartTimestamp, firstEndTimestamp);
@@ -123,7 +124,7 @@ class AgentWarningStatServiceImplTest {
         when(agentStatService.selectAgentStatUnconvertedTime(any(InspectorDataSearchKey.class), any(TimeWindow.class))).thenReturn(mockDataList);
         when(tenantProvider.getTenantId()).thenReturn("pinpoint");
 
-        List<AgentStatusTimelineSegment> timelineSegmentList = agentWarningStatService.select("applicationName", "pinpoint", range);
+        List<AgentStatusTimelineSegment> timelineSegmentList = agentWarningStatService.select(ServiceConstants.DEFAULT, "applicationName", "pinpoint", range);
 
         assertThat(timelineSegmentList).hasSize(1);
         validateAgentStatusTimelineSegment(timelineSegmentList.get(0), AgentState.UNSTABLE_RUNNING, from, from + 25000);

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentInfoController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentInfoController.java
@@ -161,7 +161,7 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
             @RequestParam("from") Timestamp from,
             @RequestParam("to") Timestamp to) {
         final Range range = Range.between(from, to);
-        return agentInfoService.getAgentStatusTimeline(applicationName, agentId, range);
+        return agentInfoService.getAgentStatusTimeline(serviceName.getName(), applicationName, agentId, range);
     }
 
     @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), new com.navercorp.pinpoint.common.server.bo.AgentParam(#agentId, #to))")
@@ -175,7 +175,7 @@ public class AgentInfoController implements AccessDeniedExceptionHandler {
             @RequestParam(value = "exclude", defaultValue = "") int[] excludeEventTypeCodes) {
         final Range range = Range.between(from, to);
         rangeValidator.validate(range);
-        return agentInfoService.getAgentStatusTimeline(applicationName, agentId, range, excludeEventTypeCodes);
+        return agentInfoService.getAgentStatusTimeline(serviceName.getName(), applicationName, agentId, range, excludeEventTypeCodes);
     }
 
     @RequestMapping(value = "/isAvailableAgentId")

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
@@ -55,6 +55,6 @@ public interface AgentInfoService {
 
     List<Optional<AgentStatus>> getAgentStatus(AgentStatusQuery query);
 
-    InspectorTimeline getAgentStatusTimeline(String applicationName, String agentId, Range range, int... excludeAgentEventTypeCodes);
+    InspectorTimeline getAgentStatusTimeline(String serviceName, String applicationName, String agentId, Range range, int... excludeAgentEventTypeCodes);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
@@ -229,14 +229,14 @@ public class AgentInfoServiceImpl implements AgentInfoService {
 
 
     @Override
-    public InspectorTimeline getAgentStatusTimeline(String applicationName, String agentId, Range range, int... excludeAgentEventTypeCodes) {
+    public InspectorTimeline getAgentStatusTimeline(String serviceName, String applicationName, String agentId, Range range, int... excludeAgentEventTypeCodes) {
         Objects.requireNonNull(agentId, "agentId");
         Objects.requireNonNull(range, "range");
 
         AgentStatus initialStatus = findAgentStatus(agentId, range.getFrom());
         List<AgentEvent> agentEvents = agentEventService.getAgentEvents(agentId, range);
 
-        List<AgentStatusTimelineSegment> warningStatusTimelineSegmentList = agentWarningStatService.select(applicationName, agentId, range);
+        List<AgentStatusTimelineSegment> warningStatusTimelineSegmentList = agentWarningStatService.select(serviceName, applicationName, agentId, range);
 
         AgentStatusTimelineBuilder agentStatusTimelinebuilder = new AgentStatusTimelineBuilder(range, initialStatus, agentEvents, warningStatusTimelineSegmentList);
         AgentStatusTimeline agentStatusTimeline = agentStatusTimelinebuilder.build();

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/stat/AgentWarningStatService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/stat/AgentWarningStatService.java
@@ -26,6 +26,6 @@ import java.util.List;
  */
 public interface AgentWarningStatService {
 
-    List<AgentStatusTimelineSegment> select(String applicationName, String agentId, Range range);
+    List<AgentStatusTimelineSegment> select(String serviceName, String applicationName, String agentId, Range range);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/stat/EmptyAgentWarningStatService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/stat/EmptyAgentWarningStatService.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class EmptyAgentWarningStatService implements AgentWarningStatService {
 
     @Override
-    public List<AgentStatusTimelineSegment> select(String applicationName, String agentId, Range range) {
+    public List<AgentStatusTimelineSegment> select(String serviceName, String applicationName, String agentId, Range range) {
         return Collections.emptyList();
     }
 


### PR DESCRIPTION
## Summary
- Propagate serviceName from controller through service/DAO layers in inspector web module
- Add serviceName parameter to InspectorDataSearchKey, InspectorQueryParameter, InspectorQueryGroupParameter
- Propagate serviceName through AgentWarningStatService call chain (AgentInfoController → AgentInfoService → AgentWarningStatService)

## Test plan
- [x] inspector-web module tests pass (11/11)
- [ ] Verify inspector stat chart API returns data correctly with serviceName parameter