### PR TITLE
[#noissue] Replace parent application fields with ParentApplication

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.collector.applicationmap.dao.HostApplicationMapDao
 import com.navercorp.pinpoint.common.profiler.logging.ThrottledLogger;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.bo.BasicSpan;
+import com.navercorp.pinpoint.common.server.bo.ParentApplication;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
@@ -119,12 +120,13 @@ public class HbaseApplicationMapService implements ApplicationMapService {
             return;
         }
 
-        final String parentApplicationName = span.getParentApplicationName();
-        if (parentApplicationName == null) {
-            logger.debug("parentApplicationName is null agent: {}/{}", span.getApplicationName(), span.getAgentName());
+        final ParentApplication parentApplication = span.getParentApplication();
+        if (parentApplication == null) {
+            logger.debug("parentApplication is null agent: {}/{}", span.getApplicationName(), span.getAgentName());
             return;
         }
-        final int parentServiceType = span.getParentApplicationServiceType();
+        final String parentApplicationName = parentApplication.applicationName();
+        final int parentServiceType = parentApplication.applicationServiceType();
         final ServiceType spanServiceType = registry.findServiceType(span.getServiceType());
         if (spanServiceType.isQueue()) {
             final String host = span.getEndPoint();
@@ -139,8 +141,9 @@ public class HbaseApplicationMapService implements ApplicationMapService {
     }
 
     private Vertex getParentVertex(SpanBo span) {
-        String parentApplicationName = span.getParentApplicationName();
-        ServiceType parentApplicationType = registry.findServiceType(span.getParentApplicationServiceType());
+        ParentApplication parentApplication = Objects.requireNonNull(span.getParentApplication(), "parentApplication");
+        String parentApplicationName = parentApplication.applicationName();
+        ServiceType parentApplicationType = registry.findServiceType(parentApplication.applicationServiceType());
         return Vertex.of(parentApplicationName, parentApplicationType);
     }
 
@@ -179,7 +182,7 @@ public class HbaseApplicationMapService implements ApplicationMapService {
 
         // save statistics info only when parentApplicationContext exists
         // when drawing server map based on statistics info, you must know the application name of the previous node.
-        if (span.getParentApplicationName() != null) {
+        if (span.getParentApplication() != null) {
 
             Vertex parentVertex = getParentVertex(span);
             logger.debug("Received parent application name. parentName:{} appName:{}", parentVertex, span.getApplicationName());

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/ParentApplication.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/ParentApplication.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo;
+
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.util.StringPrecondition;
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+/**
+ * Parent application information of a {@link SpanBo}.
+ * Present only for non-root spans; {@code serviceName} is optional.
+ */
+public class ParentApplication {
+
+    private final String serviceName;
+    private final String applicationName;
+    private final int applicationServiceType;
+
+    public ParentApplication(String applicationName, int applicationServiceType) {
+        this(ServiceUid.DEFAULT_SERVICE_UID_NAME, applicationName, applicationServiceType);
+    }
+
+    public ParentApplication(String serviceName, String applicationName, int applicationServiceType) {
+        this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
+        this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
+        this.applicationServiceType = applicationServiceType;
+    }
+
+    /**
+     * Builds a {@link ParentApplication}, substituting {@link ServiceUid#DEFAULT_SERVICE_UID_NAME}
+     * when {@code serviceName} is absent (null or empty).
+     */
+    public static ParentApplication of(String serviceName, String applicationName, int applicationServiceType) {
+        if (StringUtils.isEmpty(serviceName)) {
+            return new ParentApplication(applicationName, applicationServiceType);
+        }
+        return new ParentApplication(serviceName, applicationName, applicationServiceType);
+    }
+
+    public String serviceName() {
+        return serviceName;
+    }
+
+    public String applicationName() {
+        return applicationName;
+    }
+
+    public int applicationServiceType() {
+        return applicationServiceType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ParentApplication that = (ParentApplication) o;
+        return applicationServiceType == that.applicationServiceType && serviceName.equals(that.serviceName) && applicationName.equals(that.applicationName);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = serviceName.hashCode();
+        result = 31 * result + applicationName.hashCode();
+        result = 31 * result + applicationServiceType;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return serviceName + '/' + applicationName + '/' + applicationServiceType;
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
@@ -61,8 +61,7 @@ public class SpanBo implements BasicSpan {
     private long spanId;
     private long parentSpanId;
 
-    private String parentApplicationName;
-    private short parentApplicationServiceType;
+    private ParentApplication parentApplication;
 
     private long startTime;
     private int elapsed;
@@ -91,8 +90,6 @@ public class SpanBo implements BasicSpan {
     private String remoteAddr; // optional
 
     private byte loggingTransactionInfo; //optional
-
-    private String parentServiceName;
 
     private List<AttributeBo> attributeBoList = new ArrayList<>();
 
@@ -405,20 +402,13 @@ public class SpanBo implements BasicSpan {
         }
     }
 
-    public String getParentApplicationName() {
-        return parentApplicationName;
+
+    public ParentApplication getParentApplication() {
+        return parentApplication;
     }
 
-    public void setParentApplicationName(String parentApplicationName) {
-        this.parentApplicationName = parentApplicationName;
-    }
-
-    public short getParentApplicationServiceType() {
-        return parentApplicationServiceType;
-    }
-
-    public void setParentApplicationServiceType(short parentApplicationServiceType) {
-        this.parentApplicationServiceType = parentApplicationServiceType;
+    public void setParentApplication(ParentApplication parentApplication) {
+        this.parentApplication = parentApplication;
     }
 
     /**
@@ -432,14 +422,6 @@ public class SpanBo implements BasicSpan {
 
     public void setLoggingTransactionInfo(byte loggingTransactionInfo) {
         this.loggingTransactionInfo = loggingTransactionInfo;
-    }
-
-    public String getParentServiceName() {
-        return parentServiceName;
-    }
-
-    public void setParentServiceName(String parentServiceName) {
-        this.parentServiceName = parentServiceName;
     }
 
     public List<AttributeBo> getAttributeBoList() {
@@ -477,8 +459,7 @@ public class SpanBo implements BasicSpan {
                 ", traceSourceType=" + traceSourceType +
                 ", spanId=" + spanId +
                 ", parentSpanId=" + parentSpanId +
-                ", parentApplicationName='" + parentApplicationName + '\'' +
-                ", parentApplicationServiceType=" + parentApplicationServiceType +
+                ", parentApplication=" + parentApplication +
                 ", startTime=" + startTime +
                 ", elapsed=" + elapsed +
                 ", rpc='" + rpc + '\'' +
@@ -497,7 +478,6 @@ public class SpanBo implements BasicSpan {
                 ", acceptorHost='" + acceptorHost + '\'' +
                 ", remoteAddr='" + remoteAddr + '\'' +
                 ", loggingTransactionInfo=" + loggingTransactionInfo +
-                ", parentServiceName='" + parentServiceName + '\'' +
                 ", attributeBoList=" + attributeBoList +
                 '}';
     }
@@ -524,8 +504,7 @@ public class SpanBo implements BasicSpan {
 
         private long parentSpanId;
 
-        private String parentApplicationName;
-        private short parentApplicationServiceType;
+        private ParentApplication parentApplication;
 
         private long startTime;
         private int elapsed;
@@ -553,8 +532,6 @@ public class SpanBo implements BasicSpan {
         private String remoteAddr; // optional
 
         private byte loggingTransactionInfo; //optional
-
-        private String parentServiceName;
 
         private List<AttributeBo> attributeBoList;
 
@@ -607,13 +584,8 @@ public class SpanBo implements BasicSpan {
             return this;
         }
 
-        public Builder setParentApplicationName(String parentApplicationName) {
-            this.parentApplicationName = parentApplicationName;
-            return this;
-        }
-
-        public Builder setParentApplicationServiceType(short parentApplicationServiceType) {
-            this.parentApplicationServiceType = parentApplicationServiceType;
+        public Builder setParentApplication(ParentApplication parentApplication) {
+            this.parentApplication = parentApplication;
             return this;
         }
 
@@ -707,11 +679,6 @@ public class SpanBo implements BasicSpan {
             return this;
         }
 
-        public Builder setParentServiceName(String parentServiceName) {
-            this.parentServiceName = parentServiceName;
-            return this;
-        }
-
         public Builder addAttributeBo(AttributeBo e) {
             if (this.attributeBoList == null) {
                 this.attributeBoList = new ArrayList<>();
@@ -746,9 +713,7 @@ public class SpanBo implements BasicSpan {
             result.setTransactionId(this.transactionId);
             result.setSpanId(this.spanId);
             result.setParentSpanId(this.parentSpanId);
-            result.setParentApplicationName(this.parentApplicationName);
-            result.setParentApplicationServiceType(this.parentApplicationServiceType);
-            result.setParentServiceName(this.parentServiceName);
+            result.setParentApplication(this.parentApplication);
             result.setStartTime(this.startTime);
             result.setElapsed(this.elapsed);
             result.setRpc(this.rpc);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/GrpcSpanBinder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/GrpcSpanBinder.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.server.bo.AnnotationFactory;
 import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.bo.ExceptionInfo;
 import com.navercorp.pinpoint.common.server.bo.LocalAsyncIdBo;
+import com.navercorp.pinpoint.common.server.bo.ParentApplication;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
@@ -155,12 +156,10 @@ public class GrpcSpanBinder {
                         throw new IllegalArgumentException("Invalid parentApplicationName " + parentApplicationName
                                 + " agent:" + serverHeader.getApplicationName() + "/" + serverHeader.getAgentId());
                     }
-                    spanBo.setParentApplicationName(parentApplicationName);
-                    spanBo.setParentApplicationServiceType((short) parentInfo.getParentApplicationType());
                     final String parentServiceName = parentInfo.getParentServiceName();
-                    if(StringUtils.hasLength(parentServiceName)) {
-                        spanBo.setParentServiceName(parentServiceName);
-                    }
+                    final int parentApplicationType = parentInfo.getParentApplicationType();
+                    ParentApplication parentApplication = ParentApplication.of(parentServiceName, parentApplicationName, parentApplicationType);
+                    spanBo.setParentApplication(parentApplication);
                 }
             }
         }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/SpanFactoryAssert.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/SpanFactoryAssert.java
@@ -55,10 +55,13 @@ public class SpanFactoryAssert {
             Assertions.assertEquals(acceptEvent.getEndPoint(), spanBo.getEndPoint());
             Assertions.assertEquals(acceptEvent.getRemoteAddr(), spanBo.getRemoteAddr());
 
-            PParentInfo parentInfo = acceptEvent.getParentInfo();
-            Assertions.assertEquals(parentInfo.getParentApplicationName(), spanBo.getParentApplicationName());
-            Assertions.assertEquals(parentInfo.getParentApplicationType(), spanBo.getParentApplicationServiceType());
-            Assertions.assertEquals(parentInfo.getAcceptorHost(), spanBo.getAcceptorHost());
+            if (acceptEvent.hasParentInfo()) {
+                PParentInfo parentInfo = acceptEvent.getParentInfo();
+                assertParentApplication(parentInfo, spanBo.getParentApplication());
+                Assertions.assertEquals(parentInfo.getAcceptorHost(), spanBo.getAcceptorHost());
+            } else {
+                Assertions.assertNull(spanBo.getParentApplication());
+            }
         }
         Assertions.assertEquals(pSpan.getServiceType(), spanBo.getServiceType());
 
@@ -92,6 +95,16 @@ public class SpanFactoryAssert {
         Assertions.assertEquals(pinpointServerTraceId.getAgentId(), pTransactionId.getAgentId());
         Assertions.assertEquals(pinpointServerTraceId.getAgentStartTime(), pTransactionId.getAgentStartTime());
         Assertions.assertEquals(pinpointServerTraceId.getTransactionSequence(), pTransactionId.getSequence());
+    }
+
+    private void assertParentApplication(PParentInfo parentInfo, ParentApplication parentApplication) {
+        Assertions.assertNotNull(parentApplication);
+
+        ParentApplication expectedParentApplication = ParentApplication.of(
+                parentInfo.getParentServiceName(),
+                parentInfo.getParentApplicationName(),
+                parentInfo.getParentApplicationType());
+        Assertions.assertEquals(expectedParentApplication, parentApplication);
     }
 
     public void assertAnnotation(List<PAnnotation> tAnnotationList, List<AnnotationBo> annotationBoList) {

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
@@ -205,12 +205,10 @@ public class SpanEncoderTest {
 
         SpanBo decode = (SpanBo) spanDecoder.decode(qualifier, column, decodingContext);
 
-        List<String> notSerializedField = Lists.newArrayList("parentApplicationName", "parentApplicationServiceType");
-        List<String> excludeField = List.of("annotationBoList", "spanEventBoList", "agentName");
-        notSerializedField.addAll(excludeField);
+        List<String> excludeField = List.of("parentApplication", "annotationBoList", "spanEventBoList", "agentName");
         Assertions.assertThat(decode)
                 .usingRecursiveComparison()
-                .ignoringFields(notSerializedField.toArray(new String[0]))
+                .ignoringFields(excludeField.toArray(new String[0]))
                 .isEqualTo(spanBo);
 
         logger.debug("{} {}", spanBo.getAnnotationBoList(), decode.getAnnotationBoList());

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/io/GrpcSpanBinderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/io/GrpcSpanBinderTest.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.common.server.io;
 
+import com.navercorp.pinpoint.common.server.bo.ParentApplication;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.grpc.trace.PAcceptEvent;
@@ -57,8 +58,7 @@ class GrpcSpanBinderTest {
         PSpan span = newSpan(event);
 
         SpanBo spanBo = grpcSpanBinder.newSpanBo(span, header, requestTime);
-        Assertions.assertEquals("validId", spanBo.getParentApplicationName());
-        Assertions.assertEquals(1000, spanBo.getParentApplicationServiceType());
+        Assertions.assertEquals(new ParentApplication("validId", 1000), spanBo.getParentApplication());
     }
 
     private PSpan newSpan(PAcceptEvent acceptEvent) {
@@ -84,7 +84,7 @@ class GrpcSpanBinderTest {
         PSpan span = newSpan(null);
 
         SpanBo spanBo = grpcSpanBinder.newSpanBo(span, header, requestTime);
-        Assertions.assertNull(spanBo.getParentApplicationName());
+        Assertions.assertNull(spanBo.getParentApplication());
 
     }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.bo.ExceptionInfo;
+import com.navercorp.pinpoint.common.server.bo.ParentApplication;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.OtelServerTraceId;
@@ -216,15 +217,13 @@ public class OtlpTraceSpanMapper {
                 || !IdValidateUtils.validateId(parentApplicationName, PinpointConstants.APPLICATION_NAME_MAX_LEN_V3)) {
             return;
         }
-        spanBo.setParentApplicationName(parentApplicationName);
         final Short parentApplicationType = header.parentApplicationType();
-        spanBo.setParentApplicationServiceType(parentApplicationType != null
+        final int parentServiceType = parentApplicationType != null
                 ? parentApplicationType
-                : ServiceType.OPENTELEMETRY_SERVER.getCode());
+                : ServiceType.OPENTELEMETRY_SERVER.getCode();
         final String parentServiceName = header.parentServiceName();
-        if (parentServiceName != null) {
-            spanBo.setParentServiceName(parentServiceName);
-        }
+        ParentApplication parentApplication = ParentApplication.of(parentServiceName, parentApplicationName, parentServiceType);
+        spanBo.setParentApplication(parentApplication);
     }
 
     /**

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -3,7 +3,9 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.server.bo.ParentApplication;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
@@ -662,10 +664,9 @@ class OtlpTraceSpanMapperTest {
                 .setTraceState("pp=svc:upstream-svc;app:upstream-app")
                 .build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationName()).isEqualTo("upstream-app");
-        assertThat(bo.getParentApplicationServiceType())
-                .isEqualTo((short) ServiceType.OPENTELEMETRY_SERVER.getCode());
-        assertThat(bo.getParentServiceName()).isEqualTo("upstream-svc");
+        assertThat(bo.getParentApplication())
+                .isEqualTo(new ParentApplication("upstream-svc", "upstream-app",
+                        (short) ServiceType.OPENTELEMETRY_SERVER.getCode()));
     }
 
     @Test
@@ -674,8 +675,9 @@ class OtlpTraceSpanMapperTest {
                 .setTraceState("dd=s:1;t.dm:-4,pp=svc:upstream-svc;app:upstream-app,nr=opaque")
                 .build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationName()).isEqualTo("upstream-app");
-        assertThat(bo.getParentServiceName()).isEqualTo("upstream-svc");
+        assertThat(bo.getParentApplication())
+                .isEqualTo(new ParentApplication("upstream-svc", "upstream-app",
+                        (short) ServiceType.OPENTELEMETRY_SERVER.getCode()));
     }
 
     @Test
@@ -687,20 +689,18 @@ class OtlpTraceSpanMapperTest {
                 .setTraceState("pp=svc:upstream-svc")
                 .build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationName()).isNull();
-        assertThat(bo.getParentServiceName()).isNull();
+        assertThat(bo.getParentApplication()).isNull();
     }
 
     @Test
-    void map_tracestate_appOnly_setsApplicationButLeavesServiceNull() {
+    void map_tracestate_appOnly_setsApplicationWithDefaultService() {
         Span span = serverSpanBuilder()
                 .setTraceState("pp=app:upstream-app")
                 .build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationName()).isEqualTo("upstream-app");
-        assertThat(bo.getParentApplicationServiceType())
-                .isEqualTo((short) ServiceType.OPENTELEMETRY_SERVER.getCode());
-        assertThat(bo.getParentServiceName()).isNull();
+        assertThat(bo.getParentApplication())
+                .isEqualTo(new ParentApplication(ServiceUid.DEFAULT_SERVICE_UID_NAME, "upstream-app",
+                        (short) ServiceType.OPENTELEMETRY_SERVER.getCode()));
     }
 
     @Test
@@ -711,16 +711,14 @@ class OtlpTraceSpanMapperTest {
                 .setTraceState("pp=svc:upstream-svc;app:한글앱")
                 .build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationName()).isNull();
-        assertThat(bo.getParentServiceName()).isNull();
+        assertThat(bo.getParentApplication()).isNull();
     }
 
     @Test
     void map_tracestate_emptyHeader_noParentFields() {
         Span span = serverSpanBuilder().build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationName()).isNull();
-        assertThat(bo.getParentServiceName()).isNull();
+        assertThat(bo.getParentApplication()).isNull();
     }
 
     @Test
@@ -735,8 +733,7 @@ class OtlpTraceSpanMapperTest {
                 .setTraceState("pp=svc:upstream-svc;app:upstream-app")
                 .build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationName()).isNull();
-        assertThat(bo.getParentServiceName()).isNull();
+        assertThat(bo.getParentApplication()).isNull();
     }
 
     @Test
@@ -753,8 +750,9 @@ class OtlpTraceSpanMapperTest {
                 .setTraceState("pp=svc:upstream-svc;app:upstream-app")
                 .build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationName()).isEqualTo("upstream-app");
-        assertThat(bo.getParentServiceName()).isEqualTo("upstream-svc");
+        assertThat(bo.getParentApplication())
+                .isEqualTo(new ParentApplication("upstream-svc", "upstream-app",
+                        (short) ServiceType.OPENTELEMETRY_SERVER.getCode()));
     }
 
     @Test
@@ -764,7 +762,7 @@ class OtlpTraceSpanMapperTest {
                 .setTraceState("pp=svc:upstream-svc;app:upstream-app;type:1010")
                 .build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationServiceType()).isEqualTo((short) 1010);
+        assertThat(bo.getParentApplication().applicationServiceType()).isEqualTo((short) 1010);
     }
 
     @Test
@@ -773,8 +771,8 @@ class OtlpTraceSpanMapperTest {
                 .setTraceState("pp=svc:upstream-svc;app:upstream-app")
                 .build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationServiceType())
-                .isEqualTo((short) ServiceType.OPENTELEMETRY_SERVER.getCode());
+        assertThat(bo.getParentApplication().applicationServiceType())
+                .isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getCode());
     }
 
     @Test
@@ -783,8 +781,8 @@ class OtlpTraceSpanMapperTest {
                 .setTraceState("pp=app:upstream-app;type:tomcat")
                 .build();
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getParentApplicationName()).isEqualTo("upstream-app");
-        assertThat(bo.getParentApplicationServiceType())
-                .isEqualTo((short) ServiceType.OPENTELEMETRY_SERVER.getCode());
+        assertThat(bo.getParentApplication())
+                .isEqualTo(new ParentApplication(ServiceUid.DEFAULT_SERVICE_UID_NAME, "upstream-app",
+                        ServiceType.OPENTELEMETRY_SERVER.getCode()));
     }
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
@@ -228,8 +228,6 @@ public class RecordFactoryTest {
                 .setAgentStartTime(1670293953108L)
                 .setTransactionId(new PinpointServerTraceId("express-node-sample-id", 1670293953108L, 30))
                 .setParentSpanId(-1)
-                .setParentApplicationName(null)
-                .setParentApplicationServiceType((short) 0)
                 .setStartTime(1670305848569L)
                 .setElapsed(14)
                 .setRpc("/")


### PR DESCRIPTION
This pull request refactors how parent application information is represented and handled in the tracing model. The main change is the introduction of a new `ParentApplication` class, which consolidates previously separate fields related to a span's parent application into a single object. This change improves code clarity and maintainability, and updates all relevant usages, including construction, setters/getters, and tests.

**Core Model Refactoring:**

* Introduced a new `ParentApplication` class to encapsulate parent application details (`serviceName`, `applicationName`, and `applicationServiceType`), replacing the previous individual fields in `SpanBo`.
* Updated `SpanBo` to use a `ParentApplication` object instead of the separate `parentApplicationName`, `parentApplicationServiceType`, and `parentServiceName` fields, including changes to its builder, accessors, and `toString` method. [[1]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL64-R64) [[2]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL95-L96) [[3]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL408-R411) [[4]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL437-L444) [[5]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL480-R462) [[6]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL500) [[7]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL527-R507) [[8]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL557-L558) [[9]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL610-R588) [[10]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL710-L714) [[11]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL749-R716)

**Binding and Mapping Updates:**

* Refactored `GrpcSpanBinder` and `OtlpTraceSpanMapper` to construct and set the new `ParentApplication` object when binding or mapping spans, replacing the previous logic that set individual parent fields. [[1]](diffhunk://#diff-86822cf528ce199ff3c6563d17f6b426237b40b84f38313d55cae2e450bcee49R27) [[2]](diffhunk://#diff-86822cf528ce199ff3c6563d17f6b426237b40b84f38313d55cae2e450bcee49L158-R162) [[3]](diffhunk://#diff-b905d913fa453efe31e279b2cc1f810314b54fe8dc3871146a9ef8505bf14edaR24) [[4]](diffhunk://#diff-b905d913fa453efe31e279b2cc1f810314b54fe8dc3871146a9ef8505bf14edaL219-R225)

**Test Adjustments:**

* Updated all relevant tests to use and assert against the new `ParentApplication` object, removing references to the old fields and ensuring correct equality checks. [[1]](diffhunk://#diff-3f9c59a6d82f28ac5980bd8d3cdd5c31afb7a6612d08f5505b30b19b3a7cfc52R58-R72) [[2]](diffhunk://#diff-c87ed6d0d98610e18522cb3f5adedcfc1f608b5f255f882b9691b9fd06be4965L208-R211) [[3]](diffhunk://#diff-1aff982165eb1d775c1c88e6de1650df4fe959d8b21569e1766f9a50d56f16e1R19) [[4]](diffhunk://#diff-1aff982165eb1d775c1c88e6de1650df4fe959d8b21569e1766f9a50d56f16e1L60-R61) [[5]](diffhunk://#diff-1aff982165eb1d775c1c88e6de1650df4fe959d8b21569e1766f9a50d56f16e1L87-R87) [[6]](diffhunk://#diff-10506490b032b32a6ee29b29e5bfa47b6cfcf4b8d4d00718333e7edf4ca7d769R6-R8) [[7]](diffhunk://#diff-10506490b032b32a6ee29b29e5bfa47b6cfcf4b8d4d00718333e7edf4ca7d769L665-R669)