### PR TITLE
[#13858] Secure basic login JWT cookie

### DIFF
--- a/basic-login/README.md
+++ b/basic-login/README.md
@@ -1,3 +1,11 @@
 # pinpoint-basic-login
 
 Use `-Dpinpoint.modules.web.login=basicLogin` to enable basic login.
+
+The `pinpointJwt` cookie is created with `HttpOnly` and `Secure` enabled by default.
+The cookie's `SameSite` attribute defaults to `Lax`.
+Use `web.security.auth.jwt.cookie.http-only`, `web.security.auth.jwt.cookie.secure`, and `web.security.auth.jwt.cookie.same-site` to change these flags.
+
+For Docker or Kubernetes environment variables, use `WEB_SECURITY_AUTH_JWT_COOKIE_HTTP_ONLY`,
+`WEB_SECURITY_AUTH_JWT_COOKIE_SECURE`, and `WEB_SECURITY_AUTH_JWT_COOKIE_SAME_SITE`.
+Set `WEB_SECURITY_AUTH_JWT_COOKIE_SECURE=false` only when Pinpoint Web is served over plain HTTP.

--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/config/BasicLoginProperties.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/config/BasicLoginProperties.java
@@ -50,6 +50,15 @@ public class BasicLoginProperties implements InitializingBean {
     @Value("${web.security.auth.jwt.secretkey:#{null}}")
     private String jwtSecretKey = DEFAULT_JWT_SECRET_KEY;
 
+    @Value("${web.security.auth.jwt.cookie.http-only:true}")
+    private boolean jwtCookieHttpOnly;
+
+    @Value("${web.security.auth.jwt.cookie.secure:true}")
+    private boolean jwtCookieSecure;
+
+    @Value("${web.security.auth.jwt.cookie.same-site:Lax}")
+    private String jwtCookieSameSite;
+
     private List<UserDetails> userList;
 
     private List<UserDetails> adminList;
@@ -68,6 +77,18 @@ public class BasicLoginProperties implements InitializingBean {
 
     public long getExpirationTimeSeconds() {
         return DEFAULT_EXPIRATION_TIME_SECONDS;
+    }
+
+    public boolean isJwtCookieHttpOnly() {
+        return jwtCookieHttpOnly;
+    }
+
+    public boolean isJwtCookieSecure() {
+        return jwtCookieSecure;
+    }
+
+    public String getJwtCookieSameSite() {
+        return jwtCookieSameSite;
     }
 
     @Override

--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/BasicLoginService.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/BasicLoginService.java
@@ -40,10 +40,19 @@ public class BasicLoginService {
 
     private final JwtService jwtService;
 
+    private final boolean jwtCookieHttpOnly;
+
+    private final boolean jwtCookieSecure;
+
+    private final String jwtCookieSameSite;
+
     public BasicLoginService(BasicLoginProperties basicLoginProperties) {
         this.pinpointMemoryUserDetailsService = new PinpointMemoryUserDetailsService(basicLoginProperties);
 
         this.jwtService = new JwtService(basicLoginProperties);
+        this.jwtCookieHttpOnly = basicLoginProperties.isJwtCookieHttpOnly();
+        this.jwtCookieSecure = basicLoginProperties.isJwtCookieSecure();
+        this.jwtCookieSameSite = basicLoginProperties.getJwtCookieSameSite();
     }
 
     public UserDetails getUserDetails(Cookie[] cookies) {
@@ -87,6 +96,11 @@ public class BasicLoginService {
         String token = jwtService.createToken(userDetails);
         Cookie cookie = new Cookie(BasicLoginConstants.PINPOINT_JWT_COOKIE_NAME, token);
         cookie.setPath("/");
+        cookie.setHttpOnly(jwtCookieHttpOnly);
+        cookie.setSecure(jwtCookieSecure);
+        if (jwtCookieSameSite != null && !jwtCookieSameSite.isBlank()) {
+            cookie.setAttribute("SameSite", jwtCookieSameSite);
+        }
 
         long maxAge = TimeUnit.MILLISECONDS.toSeconds(jwtService.getExpirationTimeMillis());
         cookie.setMaxAge((int) maxAge);

--- a/basic-login/src/test/java/com/navercorp/pinpoint/login/basic/service/BasicLoginServiceTest.java
+++ b/basic-login/src/test/java/com/navercorp/pinpoint/login/basic/service/BasicLoginServiceTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.login.basic.service;
+
+import com.navercorp.pinpoint.login.basic.config.BasicLoginConfiguration;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BasicLoginServiceTest {
+
+    @Test
+    void createNewCookieShouldUseSecureDefaults() {
+        try (AnnotationConfigApplicationContext context = newContext(Map.of(
+                "web.security.auth.user", "user:password"
+        ))) {
+            BasicLoginService service = context.getBean(BasicLoginService.class);
+
+            Cookie cookie = service.createNewCookie("user");
+
+            assertThat(cookie.isHttpOnly()).isTrue();
+            assertThat(cookie.getSecure()).isTrue();
+            assertThat(cookie.getAttribute("SameSite")).isEqualTo("Lax");
+        }
+    }
+
+    @Test
+    void createNewCookieShouldUseConfiguredSecurityFlags() {
+        try (AnnotationConfigApplicationContext context = newContext(Map.of(
+                "web.security.auth.user", "user:password",
+                "web.security.auth.jwt.cookie.http-only", "false",
+                "web.security.auth.jwt.cookie.secure", "false",
+                "web.security.auth.jwt.cookie.same-site", "Strict"
+        ))) {
+            BasicLoginService service = context.getBean(BasicLoginService.class);
+
+            Cookie cookie = service.createNewCookie("user");
+
+            assertThat(cookie.isHttpOnly()).isFalse();
+            assertThat(cookie.getSecure()).isFalse();
+            assertThat(cookie.getAttribute("SameSite")).isEqualTo("Strict");
+        }
+    }
+
+    private AnnotationConfigApplicationContext newContext(Map<String, Object> properties) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.getEnvironment().getPropertySources().addFirst(new MapPropertySource("test", properties));
+        context.register(BasicLoginConfiguration.class);
+        context.refresh();
+        return context;
+    }
+}

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -82,6 +82,9 @@ web.installation.downloadUrl=
 #web.security.auth.user=alice:foo,bob:bar
 #web.security.auth.admin=eve:baz
 #web.security.auth.jwt.secretkey=__PINPOINT_JWT_SECRET__
+#web.security.auth.jwt.cookie.http-only=true
+#web.security.auth.jwt.cookie.secure=true
+#web.security.auth.jwt.cookie.same-site=Lax
 
 # cache application list in seconds
 web.applicationList.cacheTime=30


### PR DESCRIPTION
This pull request enhances the security and configurability of the JWT cookie used for basic login in Pinpoint Web. By default, the `pinpointJwt` cookie is now created with secure flags (`HttpOnly`, `Secure`, and `SameSite=Lax`), and these can be customized via configuration properties or environment variables. The changes also include tests to verify the new behavior.

**Security improvements and configurability:**

* Added new properties in `BasicLoginProperties` to control the JWT cookie's `HttpOnly`, `Secure`, and `SameSite` attributes, with secure defaults (`HttpOnly=true`, `Secure=true`, `SameSite=Lax`). These properties are now used when creating the JWT cookie in `BasicLoginService`. [[1]](diffhunk://#diff-c3e9d4950b74aa11b3636393f0f0021ccbb79570bd3e3115bb831e5893421464R53-R61) [[2]](diffhunk://#diff-c3e9d4950b74aa11b3636393f0f0021ccbb79570bd3e3115bb831e5893421464R82-R93) [[3]](diffhunk://#diff-6b60e18308c012050dff4c5bdd5e0cec2c0c4c0c308789a46eebf29883c33462R43-R55) [[4]](diffhunk://#diff-6b60e18308c012050dff4c5bdd5e0cec2c0c4c0c308789a46eebf29883c33462R99-R103)
* Updated the documentation in `README.md` to explain the new defaults and how to override them via properties or environment variables, including recommendations for Docker/Kubernetes deployments.
* Added commented-out example properties in `pinpoint-web-root.properties` for easy configuration of the new cookie flags.

**Testing:**

* Introduced a new test class `BasicLoginServiceTest` that verifies the JWT cookie is created with the correct security attributes both by default and when overridden via configuration.