### PR TITLE
[#13875] Propagate serviceName through inspector stat pipeline

### DIFF
--- a/inspector-module/inspector-collector/src/main/java/com/navercorp/pinpoint/inspector/collector/model/kafka/ApplicationStat.java
+++ b/inspector-module/inspector-collector/src/main/java/com/navercorp/pinpoint/inspector/collector/model/kafka/ApplicationStat.java
@@ -27,6 +27,7 @@ public class ApplicationStat {
     private static final String NULL_STRING = "null";
 
     private final String tenantId;
+    private final String serviceName;
 
     private final long timestamp;
 
@@ -37,14 +38,15 @@ public class ApplicationStat {
     private final double fieldValue;
     private final String primaryTag;
 
-    public static ApplicationStat ofEmptyTag(String tenantId, long timestamp, String applicationName, String metricName, String fieldName, double fieldValue) {
-        return new ApplicationStat(tenantId, timestamp, applicationName, metricName, fieldName, NULL_STRING, fieldValue);
+    public static ApplicationStat ofEmptyTag(String tenantId, String serviceName, long timestamp, String applicationName, String metricName, String fieldName, double fieldValue) {
+        return new ApplicationStat(tenantId, serviceName, timestamp, applicationName, metricName, fieldName, NULL_STRING, fieldValue);
     }
 
-    public ApplicationStat(String tenantId, long timestamp,
+    public ApplicationStat(String tenantId, String serviceName, long timestamp,
                            String applicationName, String metricName,
                            String fieldName, String primaryTag, double fieldValue) {
         this.tenantId = tenantId;
+        this.serviceName = serviceName;
         this.timestamp = timestamp;
         this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
         this.metricName = metricName;
@@ -57,6 +59,10 @@ public class ApplicationStat {
     @Deprecated
     public String getTenantId() {
         return tenantId;
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 
     public long getEventTime() {

--- a/inspector-module/inspector-collector/src/main/java/com/navercorp/pinpoint/inspector/collector/model/kafka/ApplicationStatModelConverter.java
+++ b/inspector-module/inspector-collector/src/main/java/com/navercorp/pinpoint/inspector/collector/model/kafka/ApplicationStatModelConverter.java
@@ -35,10 +35,11 @@ public class ApplicationStatModelConverter {
 
         for (AgentStat agentStat : agentStatList) {
             applicationStatList.add(ApplicationStat.ofEmptyTag(agentStat.getTenantId(),
+                    agentStat.getServiceName(),
                     agentStat.getEventTime(), agentStat.getApplicationName(),
-                                                        agentStat.getMetricName(),
-                                                        agentStat.getFieldName(),
-                                                        agentStat.getFieldValue()
+                    agentStat.getMetricName(),
+                    agentStat.getFieldName(),
+                    agentStat.getFieldValue()
             ));
         }
 
@@ -63,11 +64,12 @@ public class ApplicationStatModelConverter {
             }
 
             applicationStatList.add(new ApplicationStat(agentStat.getTenantId(),
+                    agentStat.getServiceName(),
                     agentStat.getEventTime(), agentStat.getApplicationName(),
-                                                        agentStat.getMetricName(),
-                                                        agentStat.getFieldName(),
-                                                        jdbcUrlTag.toString(),
-                                                        agentStat.getFieldValue()
+                    agentStat.getMetricName(),
+                    agentStat.getFieldName(),
+                    jdbcUrlTag.toString(),
+                    agentStat.getFieldValue()
             ));
         }
 


### PR DESCRIPTION
## Summary
- Propagate serviceName through inspector web query pipeline (controller → service → DAO)
- Propagate serviceName through AgentWarningStatService call chain
- Add serviceName field to ApplicationStat for inspector-stat-app Kafka topic