### PR TITLE
[#noissue] Avoid empty span chunk application map updates

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -66,13 +66,16 @@ public class HbaseApplicationMapService implements ApplicationMapService {
 
     @Override
     public void insertSpanChunk(final SpanChunkBo spanChunkBo) {
-        Vertex selfVertex = getSelfVertex(spanChunkBo);
         final List<SpanEventBo> spanEventList = spanChunkBo.getSpanEventBoList();
-        if (spanEventList != null) {
-            // TODO need to batch update later.
-            insertSpanEventList(spanEventList, selfVertex, spanChunkBo.getAgentId(), spanChunkBo.getEndPoint(), spanChunkBo.getCollectorAcceptTime());
+        if (CollectionUtils.isEmpty(spanEventList)) {
+            return;
         }
-
+        if (logger.isDebugEnabled()) {
+            logger.debug("handle insertSpanChunk {}/{} size:{}", spanChunkBo.getApplicationName(), spanChunkBo.getAgentId(), spanEventList.size());
+        }
+        Vertex selfVertex = getSelfVertex(spanChunkBo);
+        // TODO need to batch update later.
+        insertSpanEventList(spanEventList, selfVertex, spanChunkBo.getAgentId(), spanChunkBo.getEndPoint(), spanChunkBo.getCollectorAcceptTime());
     }
 
     private Vertex getSelfVertex(BasicSpan basicSpan) {
@@ -248,7 +251,7 @@ public class HbaseApplicationMapService implements ApplicationMapService {
             return;
         }
         if (logger.isDebugEnabled()) {
-            logger.debug("handle spanEvent {}/{} size:{}", span.getApplicationName(), span.getAgentId(), spanEventList.size());
+            logger.debug("handle insertSpanEventStat {}/{} size:{}", span.getApplicationName(), span.getAgentId(), spanEventList.size());
         }
 
         // TODO need to batch update later.


### PR DESCRIPTION
This pull request makes improvements to logging and input validation in the `HbaseApplicationMapService` class, primarily affecting how span chunks and span events are handled. The changes help ensure that empty span event lists are ignored early and that debug log messages are more descriptive and consistent.

**Logging and Input Validation Improvements:**

* Updated `insertSpanChunk` to check for empty `spanEventList` using `CollectionUtils.isEmpty`, returning early if the list is empty, which prevents unnecessary processing. Also, added a debug log statement that provides more context about the span chunk being inserted.
* Improved the debug log message in `insertSpanEventStat` to clarify that it logs the insertion of span event stats, making the log output more consistent and descriptive.