### PR TITLE
[#noissue] Keep error toasts interactive while a modal is open

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Toast/index.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Toast/index.tsx
@@ -10,6 +10,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import { toastCountAtom } from '@pinpoint-fe/ui/src/atoms';
 import { useAtom } from 'jotai';
 import { Button } from '../../components';
+import { cn } from '../../lib/utils';
 
 const defaultToastContainerProps: ToastContainerProps = {
   className: 'text-sm',
@@ -36,6 +37,9 @@ const ReactToastContainer = () => {
           top: 3,
           right: 275,
           zIndex: 9999,
+          // Radix modal(Sheet/Dialog)이 열리면 body에 pointer-events:none이 걸리므로,
+          // 그 위에서도 "Clear All" 버튼을 클릭할 수 있도록 명시적으로 auto로 복원한다.
+          pointerEvents: 'auto',
         }}
       >
         {show && (
@@ -68,6 +72,9 @@ function useReactToastifyToast() {
       toast[type](content, {
         ...defaultToastContainerProps,
         ...options,
+        // Radix modal(Sheet/Dialog) 오픈 시 body의 pointer-events:none 때문에 토스트가
+        // hover/클릭 불가가 되는 것을 막기 위해 토스트 자체는 항상 클릭 가능하게 둔다.
+        className: cn('pointer-events-auto', defaultToastContainerProps.className, options?.className),
         onOpen: (data) => {
           setToastCount((prev) => prev + 1);
           options?.onOpen?.(data);

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.tsx
@@ -1,6 +1,8 @@
 import { ErrorResponse } from '@pinpoint-fe/ui/src/constants';
 import { MutationCache, QueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
+import { getDefaultStore } from 'jotai';
+import { toastCountAtom } from '@pinpoint-fe/ui/src/atoms';
 import { ErrorToast } from '../../components/Error/ErrorToast';
 
 declare module '@tanstack/react-query' {
@@ -64,10 +66,15 @@ const mutationCache = new MutationCache({
   onError: (error, _variables, _context, mutation) => {
     if (mutation.meta?.ignoreGlobalError) return;
 
+    // 모듈 레벨이라 useReactToastifyToast 훅을 쓸 수 없으므로, 동일한 default store를
+    // 통해 toastCountAtom을 직접 갱신해 query 에러 토스트와 "Clear All" 동작을 일치시킨다.
+    const store = getDefaultStore();
     toast.error(<ErrorToast error={error as Error} />, {
       className: 'pointer-events-auto',
       bodyClassName: '!items-start',
       autoClose: false,
+      onOpen: () => store.set(toastCountAtom, (prev) => prev + 1),
+      onClose: () => store.set(toastCountAtom, (prev) => (prev === 0 ? prev : prev - 1)),
     });
   },
 });


### PR DESCRIPTION
## Summary
- Radix-based Sheet/Dialog sets `pointer-events: none` on `body` while open, so the toast stack and the "Clear All" button (rendered outside the modal portal) were visible but not hoverable/clickable. Restored `pointer-events: auto` on the "Clear All" button container and on hook-created toasts.
- Mutation-error toasts now increment/decrement `toastCountAtom` (via the shared Jotai default store), so the "Clear All" button appears for them too — matching query-error toasts.

## Test plan
- [ ] Trigger multiple error toasts (>1) and confirm the "Clear All" button appears on hover and clears them.
- [ ] Open a Sheet/drawer (e.g. Config users, Service add, OpenTelemetry metric definition), trigger an error toast, and confirm both the toast and "Clear All" remain clickable.
- [ ] Confirm a mutation error (failed create/edit/delete) shows a toast and that "Clear All" appears when more than one toast is open.
- [ ] `yarn build` and `yarn test` pass.
