### PR TITLE
[#noissue] Refactor getParentVertex method to accept ParentApplication directly

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -145,8 +145,9 @@ public class HbaseApplicationMapService implements ApplicationMapService {
         }
     }
 
-    private Vertex getParentVertex(SpanBo span) {
-        ParentApplication parentApplication = Objects.requireNonNull(span.getParentApplication(), "parentApplication");
+    private Vertex getParentVertex(ParentApplication parentApplication) {
+        Objects.requireNonNull(parentApplication, "parentApplication");
+
         String parentApplicationName = parentApplication.applicationName();
         ServiceType parentApplicationType = registry.findServiceType(parentApplication.applicationServiceType());
         return Vertex.of(parentApplicationName, parentApplicationType);
@@ -189,7 +190,7 @@ public class HbaseApplicationMapService implements ApplicationMapService {
         // when drawing server map based on statistics info, you must know the application name of the previous node.
         if (span.getParentApplication() != null) {
 
-            Vertex parentVertex = getParentVertex(span);
+            Vertex parentVertex = getParentVertex(span.getParentApplication());
             logger.debug("Received parent application name. parentName:{} appName:{}", parentVertex, span.getApplicationName());
 
             // create virtual queue node if current' span's service type is a queue AND :


### PR DESCRIPTION
…n directly

This pull request refactors how the parent vertex is determined in the `HbaseApplicationMapService` class by changing the `getParentVertex` method to accept a `ParentApplication` object instead of a `SpanBo`. This simplifies the method's responsibility and clarifies its expected input.

Refactoring for clarity and simplicity:

* Changed the `getParentVertex` method to take a `ParentApplication` parameter instead of a `SpanBo`, and updated its usage in `insertSpanStat` to pass `span.getParentApplication()` directly. This makes the method more focused and reduces unnecessary coupling. [[1]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0L148-R150) [[2]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0L192-R193)