### PR TITLE
[#13858] Fix basic login authentication recursion

### DIFF
--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/PinpointBasicLoginConfig.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/PinpointBasicLoginConfig.java
@@ -26,11 +26,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -54,20 +54,16 @@ public class PinpointBasicLoginConfig {
         this.basicLoginService = Objects.requireNonNull(basicLoginService, "basicLoginService");
     }
 
-
     @Bean
-    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
-        AuthenticationManagerBuilder auth = http.getSharedObject(AuthenticationManagerBuilder.class);
-
-        auth.eraseCredentials(false);
-        auth.userDetailsService(basicLoginService.getUserDetailsService());
-        return auth.build();
+    public UserDetailsService userDetailsService() {
+        return basicLoginService.getUserDetailsService();
     }
 
     @Bean
-    public SecurityFilterChain configure(HttpSecurity http) throws Exception {
+    public SecurityFilterChain configure(HttpSecurity http, UserDetailsService userDetailsService) throws Exception {
         // for common
         http
+                .userDetailsService(userDetailsService)
                 .csrf(customizer -> {
                     customizer.disable();
                 })
@@ -77,8 +73,7 @@ public class PinpointBasicLoginConfig {
                 .formLogin(customizer -> {
                     customizer.successHandler(new SaveJwtTokenAuthenticationSuccessHandler(basicLoginService));
                 })
-                .httpBasic(customizer -> {
-                })
+                .httpBasic(AbstractHttpConfigurer::disable)
                 .logout(customizer -> {
                     customizer.deleteCookies(BasicLoginConstants.PINPOINT_JWT_COOKIE_NAME);
                 });

--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/BasicLoginService.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/BasicLoginService.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
@@ -71,15 +72,14 @@ public class BasicLoginService {
                     if (expirationDate.getTime() > System.currentTimeMillis()) {
                         String userId = jwtService.getUserId(pinpointJwtToken);
 
-                        UserDetails userDetails = pinpointMemoryUserDetailsService.loadUserByUsername(String.valueOf(userId));
-                        if (userDetails != null) {
-                            return userDetails;
-                        }
+                        return pinpointMemoryUserDetailsService.loadUserByUsername(String.valueOf(userId));
                     } else {
                         logger.warn("This token already expired.");
                     }
                 } catch (ExpiredJwtException e) {
                     logger.warn("This token already expired. message:{}", e.getMessage(), e);
+                } catch (UsernameNotFoundException e) {
+                    logger.warn("Could not find user for JWT token. message:{}", e.getMessage());
                 }
             }
         }

--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/PinpointMemoryUserDetailsService.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/PinpointMemoryUserDetailsService.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.login.basic.service;
 import com.navercorp.pinpoint.login.basic.config.BasicLoginProperties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -69,7 +70,20 @@ public class PinpointMemoryUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return userDetailsMap.get(username);
+        UserDetails userDetails = userDetailsMap.get(username);
+        if (userDetails == null) {
+            throw new UsernameNotFoundException("User not found: " + username);
+        }
+
+        return new User(
+                userDetails.getUsername(),
+                userDetails.getPassword(),
+                userDetails.isEnabled(),
+                userDetails.isAccountNonExpired(),
+                userDetails.isCredentialsNonExpired(),
+                userDetails.isAccountNonLocked(),
+                userDetails.getAuthorities()
+        );
     }
 
 }

--- a/basic-login/src/test/java/com/navercorp/pinpoint/login/basic/service/BasicLoginServiceTest.java
+++ b/basic-login/src/test/java/com/navercorp/pinpoint/login/basic/service/BasicLoginServiceTest.java
@@ -21,10 +21,14 @@ import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.env.MapPropertySource;
+import org.springframework.security.core.CredentialsContainer;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class BasicLoginServiceTest {
 
@@ -58,6 +62,51 @@ class BasicLoginServiceTest {
             assertThat(cookie.isHttpOnly()).isFalse();
             assertThat(cookie.getSecure()).isFalse();
             assertThat(cookie.getAttribute("SameSite")).isEqualTo("Strict");
+        }
+    }
+
+    @Test
+    void userDetailsServiceShouldReturnCredentialCopy() {
+        try (AnnotationConfigApplicationContext context = newContext(Map.of(
+                "web.security.auth.user", "user:password"
+        ))) {
+            BasicLoginService service = context.getBean(BasicLoginService.class);
+
+            UserDetails userDetails = service.getUserDetailsService().loadUserByUsername("user");
+            ((CredentialsContainer) userDetails).eraseCredentials();
+
+            UserDetails reloaded = service.getUserDetailsService().loadUserByUsername("user");
+            assertThat(reloaded.getPassword()).isNotBlank();
+        }
+    }
+
+    @Test
+    void userDetailsServiceShouldThrowWhenUserIsUnknown() {
+        try (AnnotationConfigApplicationContext context = newContext(Map.of(
+                "web.security.auth.user", "user:password"
+        ))) {
+            BasicLoginService service = context.getBean(BasicLoginService.class);
+
+            assertThatThrownBy(() -> service.getUserDetailsService().loadUserByUsername("unknown"))
+                    .isInstanceOf(UsernameNotFoundException.class)
+                    .hasMessage("User not found: unknown");
+        }
+    }
+
+    @Test
+    void getUserDetailsShouldIgnoreJwtForUnknownUser() {
+        Cookie cookie;
+        try (AnnotationConfigApplicationContext context = newContext(Map.of(
+                "web.security.auth.user", "user:password"
+        ))) {
+            BasicLoginService service = context.getBean(BasicLoginService.class);
+            cookie = service.createNewCookie("user");
+        }
+
+        try (AnnotationConfigApplicationContext context = newContext(Map.of())) {
+            BasicLoginService service = context.getBean(BasicLoginService.class);
+
+            assertThat(service.getUserDetails(new Cookie[]{cookie})).isNull();
         }
     }
 


### PR DESCRIPTION
This pull request improves the security and robustness of the basic login module by updating how user details are managed and enhancing error handling. The changes ensure that user details are returned as new credential copies and proper exceptions are thrown for unknown users. Additionally, the security configuration is modernized to align with current Spring Security best practices.

**Authentication and User Details Handling:**
* The `PinpointMemoryUserDetailsService` now throws a `UsernameNotFoundException` when a user is not found and always returns a new `User` instance based on the stored details, ensuring credentials are not shared between requests.
* The service's tests are updated to verify that credentials are properly isolated and that unknown users result in exceptions.

**Spring Security Configuration Updates:**
* The security configuration in `PinpointBasicLoginConfig` is refactored to define a `UserDetailsService` bean instead of an `AuthenticationManager`, and the `SecurityFilterChain` is updated to use this service directly.
* The `.httpBasic()` configuration is changed to explicitly disable HTTP Basic authentication, improving security by preventing fallback to basic auth.
* Imports are updated to remove unused authentication manager classes and include only necessary dependencies. [[1]](diffhunk://#diff-ae55cd9d3cef001dee04c28b5f9b387b85a0137869212969376dc201852aee40L29-R33) [[2]](diffhunk://#diff-6dfd3c9859bccf98372605ef2622a0147c3e4c2316911b8e3038357f112f177bR22)