### PR TITLE
[#13858] Disable basic login secure cookie by default

### DIFF
--- a/basic-login/README.md
+++ b/basic-login/README.md
@@ -2,10 +2,11 @@
 
 Use `-Dpinpoint.modules.web.login=basicLogin` to enable basic login.
 
-The `pinpointJwt` cookie is created with `HttpOnly` and `Secure` enabled by default.
+The `pinpointJwt` cookie is created with `HttpOnly` enabled by default.
+The `Secure` flag is disabled by default and can be enabled when Pinpoint Web is served over HTTPS.
 The cookie's `SameSite` attribute defaults to `Lax`.
 Use `web.security.auth.jwt.cookie.http-only`, `web.security.auth.jwt.cookie.secure`, and `web.security.auth.jwt.cookie.same-site` to change these flags.
 
 For Docker or Kubernetes environment variables, use `WEB_SECURITY_AUTH_JWT_COOKIE_HTTP_ONLY`,
 `WEB_SECURITY_AUTH_JWT_COOKIE_SECURE`, and `WEB_SECURITY_AUTH_JWT_COOKIE_SAME_SITE`.
-Set `WEB_SECURITY_AUTH_JWT_COOKIE_SECURE=false` only when Pinpoint Web is served over plain HTTP.
+Set `WEB_SECURITY_AUTH_JWT_COOKIE_SECURE=true` when Pinpoint Web is served over HTTPS.

--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/config/BasicLoginProperties.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/config/BasicLoginProperties.java
@@ -53,7 +53,7 @@ public class BasicLoginProperties implements InitializingBean {
     @Value("${web.security.auth.jwt.cookie.http-only:true}")
     private boolean jwtCookieHttpOnly;
 
-    @Value("${web.security.auth.jwt.cookie.secure:true}")
+    @Value("${web.security.auth.jwt.cookie.secure:false}")
     private boolean jwtCookieSecure;
 
     @Value("${web.security.auth.jwt.cookie.same-site:Lax}")

--- a/basic-login/src/test/java/com/navercorp/pinpoint/login/basic/service/BasicLoginServiceTest.java
+++ b/basic-login/src/test/java/com/navercorp/pinpoint/login/basic/service/BasicLoginServiceTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class BasicLoginServiceTest {
 
     @Test
-    void createNewCookieShouldUseSecureDefaults() {
+    void createNewCookieShouldUseDefaults() {
         try (AnnotationConfigApplicationContext context = newContext(Map.of(
                 "web.security.auth.user", "user:password"
         ))) {
@@ -42,7 +42,7 @@ class BasicLoginServiceTest {
             Cookie cookie = service.createNewCookie("user");
 
             assertThat(cookie.isHttpOnly()).isTrue();
-            assertThat(cookie.getSecure()).isTrue();
+            assertThat(cookie.getSecure()).isFalse();
             assertThat(cookie.getAttribute("SameSite")).isEqualTo("Lax");
         }
     }
@@ -52,7 +52,7 @@ class BasicLoginServiceTest {
         try (AnnotationConfigApplicationContext context = newContext(Map.of(
                 "web.security.auth.user", "user:password",
                 "web.security.auth.jwt.cookie.http-only", "false",
-                "web.security.auth.jwt.cookie.secure", "false",
+                "web.security.auth.jwt.cookie.secure", "true",
                 "web.security.auth.jwt.cookie.same-site", "Strict"
         ))) {
             BasicLoginService service = context.getBean(BasicLoginService.class);
@@ -60,7 +60,7 @@ class BasicLoginServiceTest {
             Cookie cookie = service.createNewCookie("user");
 
             assertThat(cookie.isHttpOnly()).isFalse();
-            assertThat(cookie.getSecure()).isFalse();
+            assertThat(cookie.getSecure()).isTrue();
             assertThat(cookie.getAttribute("SameSite")).isEqualTo("Strict");
         }
     }

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -83,7 +83,7 @@ web.installation.downloadUrl=
 #web.security.auth.admin=eve:baz
 #web.security.auth.jwt.secretkey=__PINPOINT_JWT_SECRET__
 #web.security.auth.jwt.cookie.http-only=true
-#web.security.auth.jwt.cookie.secure=true
+#web.security.auth.jwt.cookie.secure=false
 #web.security.auth.jwt.cookie.same-site=Lax
 
 # cache application list in seconds


### PR DESCRIPTION
## Summary

This PR updates the default `Secure` flag for the basic login JWT cookie.

- Changes `web.security.auth.jwt.cookie.secure` default from `true` to `false`
- Keeps the `Secure` flag configurable through properties/environment variables
- Updates tests and documentation for the HTTP-friendly default
- Documents how to enable `Secure=true` for HTTPS deployments

## Motivation

Basic login is mainly used for local or test deployments where Pinpoint Web is served over plain HTTP. If the JWT cookie is marked as `Secure` by default, browsers may refuse to store or send the cookie in those HTTP environments, which makes login testing unnecessarily difficult.

For production deployments served over HTTPS, the `Secure` flag should be enabled with:

```properties
web.security.auth.jwt.cookie.secure=true