### PR TITLE
Add tests for service-map logic and extract testable helpers/hooks

### DIFF
--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
-import { useExperimentals, useGetConfiguration, useServicesFetch } from '@pinpoint-fe/ui/src/hooks';
-import { useAtomValue, useSetAtom } from 'jotai';
 import {
-  configurationAtom,
-  searchParametersAtom,
-  selectedServiceAtom,
-} from '@pinpoint-fe/ui/src/atoms';
+  useExperimentals,
+  useGetConfiguration,
+  useInvalidateQueriesOnServiceChange,
+  useServicesFetch,
+} from '@pinpoint-fe/ui/src/hooks';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { configurationAtom, searchParametersAtom } from '@pinpoint-fe/ui/src/atoms';
 import { APP_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
 
@@ -16,29 +16,16 @@ export const InitialFetchOutlet = () => {
   const { data, error } = useGetConfiguration<Configuration>();
   const setConfiguration = useSetAtom(configurationAtom);
   const configuration = useAtomValue(configurationAtom);
-  const selectedService = useAtomValue(selectedServiceAtom);
-  const queryClient = useQueryClient();
-  const prevSelectedServiceRef = React.useRef(selectedService);
   const { pathname, search } = useLocation();
   const application = getApplicationTypeAndName(pathname);
   const searchParameters = Object.fromEntries(new URLSearchParams(search));
   const setSearchParameters = useSetAtom(searchParametersAtom);
 
-  useExperimentals(data);
-  useServicesFetch(configuration);
-
-  // selectedService가 바뀌면 fetch 인터셉터가 주입하는 pServiceName 헤더 값이 달라진다.
-  // 하지만 queryKey에는 service가 포함되지 않아, 캐시된 쿼리는 새 헤더로 재요청되지 않는다.
-  // service 변경 시 캐시를 무효화하여 활성 쿼리가 새 service로 다시 요청되도록 한다.
-  // enableServiceMap이 꺼진 환경에서는 인터셉터가 헤더를 주입하지 않으므로 무효화도 불필요하다.
   const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
 
-  React.useEffect(() => {
-    if (prevSelectedServiceRef.current === selectedService) return;
-    prevSelectedServiceRef.current = selectedService;
-    if (!enableServiceMap) return;
-    queryClient.invalidateQueries();
-  }, [selectedService, enableServiceMap, queryClient]);
+  useExperimentals(data);
+  useServicesFetch(configuration);
+  useInvalidateQueriesOnServiceChange(enableServiceMap);
 
   React.useEffect(() => {
     if (application && searchParameters) {

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react';
+import { useAtomValue } from 'jotai';
+import {
+  DEFAULT_SERVICE,
+  RESERVED_SERVICE_NAMES,
+  isReservedServiceName,
+  selectedServiceAtom,
+} from './selectedService';
+
+describe('isReservedServiceName', () => {
+  test('returns true for every reserved name', () => {
+    RESERVED_SERVICE_NAMES.forEach((name) => {
+      expect(isReservedServiceName(name)).toBe(true);
+    });
+  });
+
+  test('is case-insensitive', () => {
+    expect(isReservedServiceName('default')).toBe(true);
+    expect(isReservedServiceName('Default')).toBe(true);
+    expect(isReservedServiceName('unknown')).toBe(true);
+  });
+
+  test('returns false for a normal service name', () => {
+    expect(isReservedServiceName('my-service')).toBe(false);
+    expect(isReservedServiceName('defaults')).toBe(false);
+  });
+
+  test('DEFAULT_SERVICE is itself reserved', () => {
+    expect(isReservedServiceName(DEFAULT_SERVICE)).toBe(true);
+  });
+});
+
+describe('selectedServiceAtom', () => {
+  test('initializes with DEFAULT_SERVICE', () => {
+    const { result } = renderHook(() => useAtomValue(selectedServiceAtom));
+    expect(result.current).toBe(DEFAULT_SERVICE);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/components/Layout/serviceMenu.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Layout/serviceMenu.test.tsx
@@ -1,0 +1,66 @@
+import { buildServiceAsideMenus, buildServiceSidebarItems } from './serviceMenu';
+import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
+import { DEFAULT_SERVICE } from '@pinpoint-fe/ui/src/atoms';
+
+describe('buildServiceSidebarItems', () => {
+  const noop = () => {};
+
+  test('returns an empty list when services is undefined', () => {
+    expect(buildServiceSidebarItems(undefined, DEFAULT_SERVICE, noop)).toEqual([]);
+  });
+
+  test('orders the selected service first, then DEFAULT, then the rest alphabetically', () => {
+    const items = buildServiceSidebarItems(
+      ['beta', DEFAULT_SERVICE, 'alpha', 'selected'],
+      'selected',
+      noop,
+    );
+
+    expect(items.map((i) => i.name)).toEqual(['selected', DEFAULT_SERVICE, 'alpha', 'beta']);
+  });
+
+  test('keeps DEFAULT first when the selected service is not in the list', () => {
+    const items = buildServiceSidebarItems(['b', DEFAULT_SERVICE, 'a'], 'missing', noop);
+
+    expect(items.map((i) => i.name)).toEqual([DEFAULT_SERVICE, 'a', 'b']);
+  });
+
+  test('marks only the selected service as selected and builds its path', () => {
+    const items = buildServiceSidebarItems(['a', 'b'], 'b', noop);
+    const selected = items.find((i) => i.name === 'b');
+    const other = items.find((i) => i.name === 'a');
+
+    expect(selected?.selected).toBe(true);
+    expect(other?.selected).toBe(false);
+    expect(selected?.path).toBe(`${APP_PATH.CONFIG_SERVICES}#b`);
+  });
+
+  test('invokes onSelect with the service name when an item is clicked', () => {
+    const onSelect = jest.fn();
+    const items = buildServiceSidebarItems(['a', 'b'], 'a', onSelect);
+
+    items.find((i) => i.name === 'b')?.onClick?.();
+
+    expect(onSelect).toHaveBeenCalledWith('b');
+  });
+
+  test('does not mutate the input services array while sorting', () => {
+    const services = ['b', 'a', DEFAULT_SERVICE];
+    buildServiceSidebarItems(services, 'a', noop);
+
+    expect(services).toEqual(['b', 'a', DEFAULT_SERVICE]);
+  });
+});
+
+describe('buildServiceAsideMenus', () => {
+  test('returns an empty list when services is undefined', () => {
+    expect(buildServiceAsideMenus(undefined)).toEqual([]);
+  });
+
+  test('maps each service to a config-services menu entry', () => {
+    expect(buildServiceAsideMenus(['a', 'b'])).toEqual([
+      { name: 'a', path: APP_PATH.CONFIG_SERVICES, href: APP_PATH.CONFIG_SERVICES },
+      { name: 'b', path: APP_PATH.CONFIG_SERVICES, href: APP_PATH.CONFIG_SERVICES },
+    ]);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
@@ -6,11 +6,7 @@ import {
   currentServerAtom,
   serverMapCurrentTargetAtom,
 } from '@pinpoint-fe/ui/src/atoms';
-import {
-  GetServerMap,
-  GetServiceMap,
-  EXPERIMENTAL_CONFIG_KEYS,
-} from '@pinpoint-fe/ui/src/constants';
+import { EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
 import {
   useExperimentals,
   useGetServiceMap,
@@ -18,6 +14,7 @@ import {
 } from '@pinpoint-fe/ui/src/hooks';
 import { useTranslation } from 'react-i18next';
 import {
+  flattenServiceMapResponse,
   getBaseNodeId,
   getServerImagePath,
   parseBaseNodeId,
@@ -29,96 +26,6 @@ export interface ServiceMapFetcherProps
   extends Pick<ServerMapCoreProps, 'onClickMenuItem' | 'onApplyChangedOption' | 'queryOption'> {
   shouldPoll?: boolean;
 }
-
-// /serviceMap 응답을 GetServerMap.Response 형태로 변환.
-// type:'service' 그룹은 그래프상 단일 노드로 그리되, 원본 자식 노드는 subNodes 필드에 보관해
-// 그래프에서 노드를 좌클릭했을 때 팝업으로 자식 리스트를 펼칠 수 있게 한다.
-const flattenServiceMapResponse = (
-  data: GetServiceMap.Response | undefined,
-): GetServerMap.Response | undefined => {
-  if (!data) return undefined;
-
-  const emptyResponseStatistics: GetServerMap.ResponseStatistics = {
-    Tot: 0,
-    Sum: 0,
-    Avg: 0,
-    Max: 0,
-  };
-  const emptyHistogram: GetServerMap.Histogram = {
-    '1s': 0,
-    '3s': 0,
-    '5s': 0,
-    Slow: 0,
-    Error: 0,
-  };
-
-  const nodeDataArray: GetServerMap.NodeData[] = [];
-  for (const entry of data.applicationMapData.nodeDataArray) {
-    if (entry.type === 'service') {
-      const innerNodes = entry.nodes;
-      const firstNode = innerNodes[0];
-      nodeDataArray.push({
-        key: entry.key,
-        applicationName: entry.serviceName,
-        serviceType: firstNode?.serviceType ?? 'UNKNOWN',
-        serviceTypeCode: firstNode?.serviceTypeCode ?? 0,
-        nodeCategory: firstNode?.nodeCategory ?? GetServerMap.NodeCategory.SERVER,
-        isAuthorized: true,
-        totalCount: innerNodes.reduce((acc, n) => acc + (n.totalCount ?? 0), 0),
-        errorCount: innerNodes.reduce((acc, n) => acc + (n.errorCount ?? 0), 0),
-        slowCount: innerNodes.reduce((acc, n) => acc + (n.slowCount ?? 0), 0),
-        hasAlert: innerNodes.some((n) => n.hasAlert),
-        responseStatistics: emptyResponseStatistics,
-        histogram: emptyHistogram,
-        apdex: {
-          apdexScore: 0,
-          apdexFormula: { satisfiedCount: 0, toleratingCount: 0, totalSamples: 0 },
-        },
-        timeSeriesHistogram: [],
-        instanceCount: innerNodes.length,
-        instanceErrorCount: 0,
-        agents: [],
-        subNodes: innerNodes,
-      });
-    } else {
-      nodeDataArray.push(entry);
-    }
-  }
-
-  const linkDataArray: GetServerMap.LinkData[] = [];
-  for (const entry of data.applicationMapData.linkDataArray) {
-    if (entry.type === 'service') {
-      const innerLinks = entry.links;
-      const firstLink = innerLinks[0];
-      linkDataArray.push({
-        key: entry.key,
-        from: entry.from,
-        to: entry.to,
-        sourceInfo: firstLink?.sourceInfo,
-        targetInfo: firstLink?.targetInfo,
-        filter: firstLink?.filter,
-        responseStatistics: emptyResponseStatistics,
-        histogram: emptyHistogram,
-        timeSeriesHistogram: [],
-        totalCount: innerLinks.reduce((acc, l) => acc + (l.totalCount ?? 0), 0),
-        errorCount: innerLinks.reduce((acc, l) => acc + (l.errorCount ?? 0), 0),
-        slowCount: innerLinks.reduce((acc, l) => acc + (l.slowCount ?? 0), 0),
-        hasAlert: innerLinks.some((l) => l.hasAlert),
-        subLinks: innerLinks,
-      } as GetServerMap.LinkData);
-    } else {
-      linkDataArray.push(entry);
-    }
-  }
-
-  return {
-    applicationMapData: {
-      ...data.applicationMapData,
-      nodeDataArray,
-      linkDataArray,
-    },
-  };
-};
 
 export const ServiceMapFetcher = ({ shouldPoll: _shouldPoll, ...props }: ServiceMapFetcherProps) => {
   const setDataAtom = useSetAtom(serverMapDataAtom);

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
@@ -3,6 +3,7 @@ export * from './useCaptureKeydown';
 export * from './useDateFormat';
 export * from './useExperimentals';
 export * from './useHeightToBottom';
+export * from './useInvalidateQueriesOnServiceChange';
 export * from './useLanguage';
 export * from './useLocalStorage';
 export * from './useServerMapLinkedData';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useInvalidateQueriesOnServiceChange.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useInvalidateQueriesOnServiceChange.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DEFAULT_SERVICE, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+import { useInvalidateQueriesOnServiceChange } from './useInvalidateQueriesOnServiceChange';
+
+const store = getDefaultStore();
+
+const renderWithClient = (enabled: boolean) => {
+  const client = new QueryClient();
+  const invalidateSpy = jest.spyOn(client, 'invalidateQueries').mockResolvedValue(undefined);
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  const utils = renderHook(
+    ({ enableServiceMap }) => useInvalidateQueriesOnServiceChange(enableServiceMap),
+    { initialProps: { enableServiceMap: enabled }, wrapper },
+  );
+  return { ...utils, invalidateSpy };
+};
+
+beforeEach(() => {
+  act(() => {
+    store.set(selectedServiceAtom, DEFAULT_SERVICE);
+  });
+});
+
+describe('useInvalidateQueriesOnServiceChange', () => {
+  test('does not invalidate on initial mount', () => {
+    const { invalidateSpy } = renderWithClient(true);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  test('invalidates queries when the selected service changes and serviceMap is enabled', () => {
+    const { invalidateSpy } = renderWithClient(true);
+
+    act(() => {
+      store.set(selectedServiceAtom, 'svc-a');
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not invalidate when serviceMap is disabled', () => {
+    const { invalidateSpy } = renderWithClient(false);
+
+    act(() => {
+      store.set(selectedServiceAtom, 'svc-a');
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  test('invalidates again on each subsequent service change', () => {
+    const { invalidateSpy } = renderWithClient(true);
+
+    act(() => {
+      store.set(selectedServiceAtom, 'svc-a');
+    });
+    act(() => {
+      store.set(selectedServiceAtom, 'svc-b');
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not invalidate when the service value is set but unchanged', () => {
+    const { invalidateSpy } = renderWithClient(true);
+
+    act(() => {
+      store.set(selectedServiceAtom, DEFAULT_SERVICE);
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useInvalidateQueriesOnServiceChange.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useInvalidateQueriesOnServiceChange.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useAtomValue } from 'jotai';
+import { useQueryClient } from '@tanstack/react-query';
+import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+
+/**
+ * selectedService가 바뀌면 fetch 인터셉터가 주입하는 pServiceName 헤더 값이 달라진다.
+ * 하지만 queryKey에는 service가 포함되지 않아, 캐시된 쿼리는 새 헤더로 재요청되지 않는다.
+ * service 변경 시 캐시를 무효화하여 활성 쿼리가 새 service로 다시 요청되도록 한다.
+ * enableServiceMap이 꺼진 환경에서는 인터셉터가 헤더를 주입하지 않으므로 무효화도 불필요하다.
+ */
+export const useInvalidateQueriesOnServiceChange = (enableServiceMap: boolean) => {
+  const selectedService = useAtomValue(selectedServiceAtom);
+  const queryClient = useQueryClient();
+  const prevSelectedServiceRef = React.useRef(selectedService);
+
+  React.useEffect(() => {
+    if (prevSelectedServiceRef.current === selectedService) return;
+    prevSelectedServiceRef.current = selectedService;
+    if (!enableServiceMap) return;
+    queryClient.invalidateQueries();
+  }, [selectedService, enableServiceMap, queryClient]);
+};

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import { servicesAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration } from '@pinpoint-fe/ui/src/constants';
+
+// useGetServices는 React Query/네트워크에 의존하므로 barrel을 모킹해 격리한다.
+jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
+  useGetServices: jest.fn(),
+}));
+
+import { useGetServices } from '@pinpoint-fe/ui/src/hooks';
+import { useServicesFetch } from './useServicesFetch';
+
+const mockedUseGetServices = useGetServices as unknown as jest.Mock;
+const store = getDefaultStore();
+
+const configWith = (enable: boolean) =>
+  ({ 'experimental.enableServiceMap.value': enable }) as unknown as Configuration;
+
+beforeEach(() => {
+  mockedUseGetServices.mockReset();
+  store.set(servicesAtom, undefined);
+});
+
+describe('useServicesFetch', () => {
+  test('keeps servicesAtom undefined and disables the query when enableServiceMap is off', () => {
+    mockedUseGetServices.mockReturnValue({ data: ['DEFAULT', 'a'] });
+
+    renderHook(() => useServicesFetch(configWith(false)));
+
+    expect(mockedUseGetServices).toHaveBeenCalledWith({ enabled: false });
+    expect(store.get(servicesAtom)).toBeUndefined();
+  });
+
+  test('syncs servicesAtom from the query and enables it when enableServiceMap is on', () => {
+    mockedUseGetServices.mockReturnValue({ data: ['DEFAULT', 'a', 'b'] });
+
+    renderHook(() => useServicesFetch(configWith(true)));
+
+    expect(mockedUseGetServices).toHaveBeenCalledWith({ enabled: true });
+    expect(store.get(servicesAtom)).toEqual(['DEFAULT', 'a', 'b']);
+  });
+
+  test('keeps servicesAtom undefined when configuration is undefined', () => {
+    mockedUseGetServices.mockReturnValue({ data: undefined });
+
+    renderHook(() => useServicesFetch(undefined));
+
+    expect(mockedUseGetServices).toHaveBeenCalledWith({ enabled: false });
+    expect(store.get(servicesAtom)).toBeUndefined();
+  });
+
+  test('resets servicesAtom to undefined when enableServiceMap is turned off', () => {
+    mockedUseGetServices.mockReturnValue({ data: ['DEFAULT', 'a'] });
+
+    const { rerender } = renderHook(({ config }) => useServicesFetch(config), {
+      initialProps: { config: configWith(true) },
+    });
+    expect(store.get(servicesAtom)).toEqual(['DEFAULT', 'a']);
+
+    rerender({ config: configWith(false) });
+    expect(store.get(servicesAtom)).toBeUndefined();
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/index.ts
@@ -5,4 +5,5 @@ export * from './route';
 export * from './routeV2';
 export * from './scatter';
 export * from './serverMap';
+export * from './serviceMap';
 export * from './transaction';

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.test.ts
@@ -1,0 +1,186 @@
+import { flattenServiceMapResponse } from './serviceMap';
+import { GetServerMap, GetServiceMap } from '@pinpoint-fe/ui/src/constants';
+
+const makeAppNode = (overrides: Partial<GetServiceMap.AppNode> = {}): GetServiceMap.AppNode =>
+  ({
+    type: 'app',
+    key: 'app^WAS',
+    applicationName: 'app',
+    serviceType: 'TOMCAT',
+    serviceTypeCode: 1010,
+    nodeCategory: GetServerMap.NodeCategory.SERVER,
+    serviceKey: 'svc',
+    serviceName: 'svc',
+    isQueue: false,
+    isAuthorized: true,
+    totalCount: 0,
+    errorCount: 0,
+    slowCount: 0,
+    hasAlert: false,
+    ...overrides,
+  }) as GetServiceMap.AppNode;
+
+const makeAppLink = (overrides: Partial<GetServerMap.LinkData> = {}): GetServerMap.LinkData =>
+  ({
+    key: 'from~to',
+    from: 'from',
+    to: 'to',
+    totalCount: 0,
+    errorCount: 0,
+    slowCount: 0,
+    hasAlert: false,
+    ...overrides,
+  }) as GetServerMap.LinkData;
+
+const makeResponse = (
+  nodeDataArray: GetServiceMap.NodeEntry[],
+  linkDataArray: GetServiceMap.LinkEntry[] = [],
+): GetServiceMap.Response => ({
+  applicationMapData: {
+    range: { from: 1, to: 2 } as GetServerMap.Range,
+    timestamp: [1, 2, 3],
+    nodeDataArray,
+    linkDataArray,
+  },
+});
+
+describe('flattenServiceMapResponse', () => {
+  test('returns undefined when data is undefined', () => {
+    expect(flattenServiceMapResponse(undefined)).toBeUndefined();
+  });
+
+  test('passes through non-service (app) nodes unchanged', () => {
+    const appNode = makeAppNode({ key: 'app^WAS', applicationName: 'app' });
+    const result = flattenServiceMapResponse(makeResponse([appNode]));
+
+    expect(result?.applicationMapData.nodeDataArray).toHaveLength(1);
+    expect(result?.applicationMapData.nodeDataArray[0]).toBe(appNode);
+  });
+
+  test('collapses a service group into a single node and aggregates child metrics', () => {
+    const child1 = makeAppNode({
+      key: 'svc^a^WAS',
+      serviceType: 'TOMCAT',
+      serviceTypeCode: 1010,
+      totalCount: 10,
+      errorCount: 1,
+      slowCount: 2,
+      hasAlert: false,
+    });
+    const child2 = makeAppNode({
+      key: 'svc^b^WAS',
+      serviceType: 'IGNORED_FOR_GROUP', // only the first child's serviceType is used
+      totalCount: 5,
+      errorCount: 3,
+      slowCount: 0,
+      hasAlert: true,
+    });
+    const group: GetServiceMap.ServiceGroupNode = {
+      key: 'svc-group',
+      type: 'service',
+      serviceName: 'my-service',
+      nodes: [child1, child2],
+    };
+
+    const result = flattenServiceMapResponse(makeResponse([group]));
+    const node = result?.applicationMapData.nodeDataArray[0];
+
+    expect(result?.applicationMapData.nodeDataArray).toHaveLength(1);
+    expect(node?.key).toBe('svc-group');
+    expect(node?.applicationName).toBe('my-service');
+    // serviceType / serviceTypeCode come from the first child node
+    expect(node?.serviceType).toBe('TOMCAT');
+    expect(node?.serviceTypeCode).toBe(1010);
+    // counts are summed across all children
+    expect(node?.totalCount).toBe(15);
+    expect(node?.errorCount).toBe(4);
+    expect(node?.slowCount).toBe(2);
+    // hasAlert is true when ANY child has an alert
+    expect(node?.hasAlert).toBe(true);
+    // instanceCount reflects the number of collapsed children
+    expect(node?.instanceCount).toBe(2);
+    expect(node?.isAuthorized).toBe(true);
+    // original children are preserved under subNodes for the popup list
+    expect(node?.subNodes).toEqual([child1, child2]);
+    // aggregated detail metrics are intentionally emptied on the group node
+    expect(node?.apdex?.apdexScore).toBe(0);
+    expect(node?.histogram).toEqual({ '1s': 0, '3s': 0, '5s': 0, Slow: 0, Error: 0 });
+    expect(node?.timeSeriesHistogram).toEqual([]);
+  });
+
+  test('falls back to safe defaults when a service group has no child nodes', () => {
+    const group: GetServiceMap.ServiceGroupNode = {
+      key: 'empty-group',
+      type: 'service',
+      serviceName: 'empty',
+      nodes: [],
+    };
+
+    const node = flattenServiceMapResponse(makeResponse([group]))?.applicationMapData
+      .nodeDataArray[0];
+
+    expect(node?.serviceType).toBe('UNKNOWN');
+    expect(node?.serviceTypeCode).toBe(0);
+    expect(node?.nodeCategory).toBe(GetServerMap.NodeCategory.SERVER);
+    expect(node?.instanceCount).toBe(0);
+    expect(node?.totalCount).toBe(0);
+    expect(node?.hasAlert).toBe(false);
+  });
+
+  test('passes through non-service (app) links unchanged', () => {
+    const appLink = makeAppLink({ key: 'a~b' });
+    const result = flattenServiceMapResponse(makeResponse([], [appLink as GetServiceMap.AppLink]));
+
+    expect(result?.applicationMapData.linkDataArray).toHaveLength(1);
+    expect(result?.applicationMapData.linkDataArray[0]).toBe(appLink);
+  });
+
+  test('collapses a service group link and aggregates child link metrics', () => {
+    const inner1 = makeAppLink({
+      key: 'l1',
+      totalCount: 7,
+      errorCount: 2,
+      slowCount: 1,
+      hasAlert: false,
+      sourceInfo: { foo: 'bar' } as unknown as GetServerMap.LinkData['sourceInfo'],
+    });
+    const inner2 = makeAppLink({
+      key: 'l2',
+      totalCount: 3,
+      errorCount: 0,
+      slowCount: 4,
+      hasAlert: true,
+    });
+    const groupLink: GetServiceMap.ServiceGroupLink = {
+      key: 'group-link',
+      from: 'svcA',
+      to: 'svcB',
+      type: 'service',
+      links: [inner1, inner2],
+    };
+
+    const link = flattenServiceMapResponse(makeResponse([], [groupLink]))?.applicationMapData
+      .linkDataArray[0];
+
+    expect(link?.key).toBe('group-link');
+    expect(link?.from).toBe('svcA');
+    expect(link?.to).toBe('svcB');
+    expect(link?.totalCount).toBe(10);
+    expect(link?.errorCount).toBe(2);
+    expect(link?.slowCount).toBe(5);
+    expect(link?.hasAlert).toBe(true);
+    // sourceInfo is taken from the first child link
+    expect(link?.sourceInfo).toEqual({ foo: 'bar' });
+    expect((link as GetServerMap.LinkData & { subLinks?: unknown }).subLinks).toEqual([
+      inner1,
+      inner2,
+    ]);
+  });
+
+  test('preserves range and timestamp from the original response', () => {
+    const result = flattenServiceMapResponse(makeResponse([makeAppNode()]));
+
+    expect(result?.applicationMapData.range).toEqual({ from: 1, to: 2 });
+    expect(result?.applicationMapData.timestamp).toEqual([1, 2, 3]);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.ts
@@ -1,0 +1,91 @@
+import { GetServerMap, GetServiceMap } from '@pinpoint-fe/ui/src/constants';
+
+// /serviceMap 응답을 GetServerMap.Response 형태로 변환.
+// type:'service' 그룹은 그래프상 단일 노드로 그리되, 원본 자식 노드는 subNodes 필드에 보관해
+// 그래프에서 노드를 좌클릭했을 때 팝업으로 자식 리스트를 펼칠 수 있게 한다.
+export const flattenServiceMapResponse = (
+  data: GetServiceMap.Response | undefined,
+): GetServerMap.Response | undefined => {
+  if (!data) return undefined;
+
+  const emptyResponseStatistics: GetServerMap.ResponseStatistics = {
+    Tot: 0,
+    Sum: 0,
+    Avg: 0,
+    Max: 0,
+  };
+  const emptyHistogram: GetServerMap.Histogram = {
+    '1s': 0,
+    '3s': 0,
+    '5s': 0,
+    Slow: 0,
+    Error: 0,
+  };
+
+  const nodeDataArray: GetServerMap.NodeData[] = [];
+  for (const entry of data.applicationMapData.nodeDataArray) {
+    if (entry.type === 'service') {
+      const innerNodes = entry.nodes;
+      const firstNode = innerNodes[0];
+      nodeDataArray.push({
+        key: entry.key,
+        applicationName: entry.serviceName,
+        serviceType: firstNode?.serviceType ?? 'UNKNOWN',
+        serviceTypeCode: firstNode?.serviceTypeCode ?? 0,
+        nodeCategory: firstNode?.nodeCategory ?? GetServerMap.NodeCategory.SERVER,
+        isAuthorized: true,
+        totalCount: innerNodes.reduce((acc, n) => acc + (n.totalCount ?? 0), 0),
+        errorCount: innerNodes.reduce((acc, n) => acc + (n.errorCount ?? 0), 0),
+        slowCount: innerNodes.reduce((acc, n) => acc + (n.slowCount ?? 0), 0),
+        hasAlert: innerNodes.some((n) => n.hasAlert),
+        responseStatistics: emptyResponseStatistics,
+        histogram: emptyHistogram,
+        apdex: {
+          apdexScore: 0,
+          apdexFormula: { satisfiedCount: 0, toleratingCount: 0, totalSamples: 0 },
+        },
+        timeSeriesHistogram: [],
+        instanceCount: innerNodes.length,
+        instanceErrorCount: 0,
+        agents: [],
+        subNodes: innerNodes,
+      });
+    } else {
+      nodeDataArray.push(entry);
+    }
+  }
+
+  const linkDataArray: GetServerMap.LinkData[] = [];
+  for (const entry of data.applicationMapData.linkDataArray) {
+    if (entry.type === 'service') {
+      const innerLinks = entry.links;
+      const firstLink = innerLinks[0];
+      linkDataArray.push({
+        key: entry.key,
+        from: entry.from,
+        to: entry.to,
+        sourceInfo: firstLink?.sourceInfo,
+        targetInfo: firstLink?.targetInfo,
+        filter: firstLink?.filter,
+        responseStatistics: emptyResponseStatistics,
+        histogram: emptyHistogram,
+        timeSeriesHistogram: [],
+        totalCount: innerLinks.reduce((acc, l) => acc + (l.totalCount ?? 0), 0),
+        errorCount: innerLinks.reduce((acc, l) => acc + (l.errorCount ?? 0), 0),
+        slowCount: innerLinks.reduce((acc, l) => acc + (l.slowCount ?? 0), 0),
+        hasAlert: innerLinks.some((l) => l.hasAlert),
+        subLinks: innerLinks,
+      } as GetServerMap.LinkData);
+    } else {
+      linkDataArray.push(entry);
+    }
+  }
+
+  return {
+    applicationMapData: {
+      ...data.applicationMapData,
+      nodeDataArray,
+      linkDataArray,
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- Extract `flattenServiceMapResponse` (the service-map → server-map response transform/aggregation) out of `ServiceMapFetcher` into a pure `utils/helper/serviceMap` module so it can be unit-tested without loading the component's heavy dependencies.
- Extract the selected-service cache-invalidation effect out of `InitialFetchOutlet` into a `useInvalidateQueriesOnServiceChange` hook so the behavior can be tested in isolation.
- Add unit tests covering the previously untested service-map logic (26 cases): the flatten/aggregation transform, service sidebar menu ordering/selection helpers, reserved-service-name validation, `useServicesFetch` atom sync, and the invalidation hook. No behavior changes.

## Test plan
- [ ] `yarn build` passes (tsc + vite build)
- [ ] `yarn test` passes (473/473)
- [ ] ServiceMap still renders and node/link group popups work
- [ ] Switching the selected service still invalidates active queries when serviceMap is enabled