### PR TITLE
[#noissue] Add byte array indexOf helper

### DIFF
--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtils.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtils.java
@@ -95,6 +95,26 @@ public final class ByteArrayUtils {
     }
 
     /**
+     * Searches {@code bytes} in the range {@code [offset, offset + length)}.
+     *
+     * @return the absolute index of the first matching byte, or {@code -1} if not found
+     */
+    static int indexOf(byte[] bytes, byte value, int offset, int length) {
+        if (bytes == null) {
+            throw new NullPointerException("bytes");
+        }
+        BytesUtils.checkBounds(bytes, offset, length);
+
+        final int endOffset = offset + length;
+        for (int i = offset; i < endOffset; i++) {
+            if (bytes[i] == value) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
      * Compares two byte arrays starting from the specified offset.
      *
      * @param bytes1 the first byte array to compare

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java
@@ -138,10 +138,9 @@ public class FixedBuffer implements Buffer {
 
     protected void putNullTerminatedBytes(final byte[] bytes) {
         // a NUL would be misread as the terminator by readNullTerminatedString()
-        for (int i = 0; i < bytes.length; i++) {
-            if (bytes[i] == NUL_DELIMITER) {
-                throw new IllegalArgumentException("embedded NUL(0x00) byte at index " + i + "; not allowed in null-terminated value");
-            }
+        final int nulIndex = ByteArrayUtils.indexOf(bytes, NUL_DELIMITER, 0, bytes.length);
+        if (nulIndex != -1) {
+            throw new IllegalArgumentException("embedded NUL(0x00) byte at index " + nulIndex + "; not allowed in null-terminated value");
         }
         putBytes(bytes);
         putByte(NUL_DELIMITER);
@@ -602,14 +601,13 @@ public class FixedBuffer implements Buffer {
     @Override
     public String readNullTerminatedString() {
         final int start = this.offset;
-        for (int off = this.offset; off < getEndOffset(); off++) {
-            if (this.buffer[off] == NUL_DELIMITER) {
-                String s = newString(off - start);
-                this.offset = off + 1;
-                return s;
-            }
+        final int nulIndex = ByteArrayUtils.indexOf(this.buffer, NUL_DELIMITER, start, remaining());
+        if (nulIndex == -1) {
+            throw new IllegalStateException("Delimiter not found");
         }
-        throw new IllegalStateException("Delimiter not found");
+        String s = newString(nulIndex - start);
+        this.offset = nulIndex + 1;
+        return s;
     }
 
     protected String readString(final int size) {

--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtilsTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/ByteArrayUtilsTest.java
@@ -125,6 +125,34 @@ class ByteArrayUtilsTest {
     }
 
     @Test
+    void indexOf() {
+        byte[] bytes = {9, 0, 7, 0, 8};
+
+        assertEquals(1, ByteArrayUtils.indexOf(bytes, (byte) 0, 0, bytes.length));
+        assertEquals(3, ByteArrayUtils.indexOf(bytes, (byte) 0, 2, 3));
+        assertEquals(4, ByteArrayUtils.indexOf(bytes, (byte) 8, 4, 1));
+    }
+
+    @Test
+    void indexOf_notFound() {
+        byte[] bytes = {1, 2, 3};
+
+        assertEquals(-1, ByteArrayUtils.indexOf(bytes, (byte) 4, 0, bytes.length));
+        assertEquals(-1, ByteArrayUtils.indexOf(bytes, (byte) 1, 1, 2));
+        assertEquals(-1, ByteArrayUtils.indexOf(bytes, (byte) 3, bytes.length, 0));
+    }
+
+    @Test
+    void indexOf_boundaryCheck() {
+        byte[] bytes = {1, 2, 3};
+
+        Assertions.assertThrows(NullPointerException.class, () -> ByteArrayUtils.indexOf(null, (byte) 1, 0, 1));
+        Assertions.assertThrows(ArrayIndexOutOfBoundsException.class, () -> ByteArrayUtils.indexOf(bytes, (byte) 1, -1, 1));
+        Assertions.assertThrows(ArrayIndexOutOfBoundsException.class, () -> ByteArrayUtils.indexOf(bytes, (byte) 1, 0, -1));
+        Assertions.assertThrows(ArrayIndexOutOfBoundsException.class, () -> ByteArrayUtils.indexOf(bytes, (byte) 1, 2, 2));
+    }
+
+    @Test
     void compareRowKey_true() {
         byte[] row1 = BytesUtils.add((byte) 1, toInt(1));
         byte[] row2 = BytesUtils.add((byte) 2, toInt(1));


### PR DESCRIPTION
This pull request refactors how null-terminated strings are handled in `FixedBuffer` by introducing a reusable `indexOf` method in `ByteArrayUtils` for searching bytes within arrays. This change improves code clarity and consistency, and comprehensive tests have been added for the new utility method.

**Core utility improvements:**

* Added a static `indexOf` method to `ByteArrayUtils` for searching a byte value within a range of a byte array, with bounds checking and null safety.

**Refactoring of string handling in `FixedBuffer`:**

* Updated `putNullTerminatedBytes` to use `ByteArrayUtils.indexOf` for detecting embedded NUL bytes, simplifying the logic and error reporting.
* Refactored `readNullTerminatedString` to use `ByteArrayUtils.indexOf` for finding the NUL delimiter, improving readability and consistency.

**Testing:**

* Added comprehensive tests for `ByteArrayUtils.indexOf`, covering normal cases, not-found scenarios, and boundary checks.