### PR TITLE
[#noissue] Replace hardcoded UI strings with i18n keys

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { AgentActiveThread, GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { AgentActiveThreadView } from './AgentActiveThreadView';
 import { useAtomValue } from 'jotai';
@@ -24,6 +25,7 @@ import { useTimezone } from '@pinpoint-fe/ui/src/hooks';
 export interface ActiveRequestProps {}
 
 export const AgentActiveThreadFetcher = () => {
+  const { t } = useTranslation();
   const wsRef = React.useRef<WebSocket | undefined>(undefined);
   const [timezone] = useTimezone();
   const [webSocketState, setWebSocketState] = React.useState<number>(WebSocket.CLOSED);
@@ -143,7 +145,11 @@ export const AgentActiveThreadFetcher = () => {
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="left">
-                    <p>{isApplicationLocked ? 'Unlock current server' : 'Lock current server'}</p>
+                    <p>
+                      {isApplicationLocked
+                        ? t('SERVER_MAP.REAL_TIME.UNLOCK_SERVER')
+                        : t('SERVER_MAP.REAL_TIME.LOCK_SERVER')}
+                    </p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -190,13 +196,15 @@ export const AgentActiveThreadFetcher = () => {
           </div>
         ) : (
           <div className="flex justify-center items-center w-full h-full">
-            Selected target is not a WAS.
+            {t('SERVER_MAP.REAL_TIME.NOT_WAS')}
           </div>
         )
       ) : webSocketState === WebSocket.CONNECTING ? (
         <AgentActiveThreadSkeleton />
       ) : (
-        <div className="flex justify-center items-center w-full h-full">Connection closed.</div>
+        <div className="flex justify-center items-center w-full h-full">
+          {t('SERVER_MAP.REAL_TIME.CONNECTION_CLOSED')}
+        </div>
       )}
     </div>
   );

--- a/web-frontend/src/main/v3/packages/ui/src/components/Alarm/AlarmDetail.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Alarm/AlarmDetail.tsx
@@ -116,18 +116,6 @@ const parseAlarmType = (
   }
 };
 
-const formSchema = z.object({
-  checkerName: z.string({ required_error: 'Select Checker' }),
-  userGroupId: z.string({ required_error: 'Select User Group ID' }),
-  threshold: z
-    .number()
-    .min(0, { message: 'Must be greater than 0' })
-    .max(2147483647, { message: 'Must be less than 2147483647' }),
-  type: z.string(),
-  webhook: z.string().array().optional(),
-  notes: z.string().optional(),
-});
-
 export const AlarmDetail = ({
   data,
   editable,
@@ -136,6 +124,31 @@ export const AlarmDetail = ({
 }: AlarmDetailProps) => {
   const toast = useReactToastifyToast();
   const { t } = useTranslation();
+  const formSchema = React.useMemo(
+    () =>
+      z.object({
+        checkerName: z.string({
+          required_error: t('COMMON.REQUIRED_SELECT', {
+            requiredField: t('CONFIGURATION.COMMON.CHECKER'),
+          }),
+        }),
+        userGroupId: z.string({
+          required_error: t('COMMON.REQUIRED_SELECT', {
+            requiredField: t('CONFIGURATION.COMMON.USER_GROUP'),
+          }),
+        }),
+        threshold: z
+          .number()
+          .min(0, { message: t('CONFIGURATION.ALARM.THRESHOLD_MIN', { min: 0 }) })
+          .max(2147483647, {
+            message: t('CONFIGURATION.ALARM.THRESHOLD_MAX', { max: 2147483647 }),
+          }),
+        type: z.string(),
+        webhook: z.string().array().optional(),
+        notes: z.string().optional(),
+      }),
+    [t],
+  );
   const configuration = useAtomValue(configurationAtom);
   const [openWebhookDialog, setOpenWebhookDialog] = React.useState(false);
   const { data: chekerList } = useGetAlarmRuleChecker({ disableFetch: !editable });
@@ -225,7 +238,7 @@ export const AlarmDetail = ({
                           <SelectTrigger
                             className={cn('w-90', { 'border-destructive': fieldState.invalid })}
                           >
-                            <SelectValue placeholder="Select rule" />
+                            <SelectValue placeholder={t('CONFIGURATION.ALARM.SELECT_RULE')} />
                           </SelectTrigger>
                         ) : (
                           <Input className="w-90" value={field.value} disabled />
@@ -262,7 +275,7 @@ export const AlarmDetail = ({
                           <SelectTrigger
                             className={cn('w-90', { 'border-destructive': fieldState.invalid })}
                           >
-                            <SelectValue placeholder="Select user group" />
+                            <SelectValue placeholder={t('CONFIGURATION.ALARM.SELECT_USER_GROUP')} />
                           </SelectTrigger>
                         ) : (
                           <Input className="w-90" value={field.value} disabled />
@@ -321,7 +334,11 @@ export const AlarmDetail = ({
                     >
                       <FormControl>
                         <SelectTrigger className="w-40">
-                          <SelectValue placeholder="Select a verified email to display" />
+                          <SelectValue
+                            placeholder={t('COMMON.REQUIRED_SELECT', {
+                              requiredField: t('CONFIGURATION.COMMON.TYPE'),
+                            })}
+                          />
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>

--- a/web-frontend/src/main/v3/packages/ui/src/components/Alarm/AlarmTable.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Alarm/AlarmTable.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { AlarmRule } from '@pinpoint-fe/ui/src/constants';
 import { DataTable } from '../../components/DataTable';
 import { AlarmTableColumns, alarmTableColumns } from './alarmTableColumns';
@@ -9,14 +10,17 @@ export interface AlarmTableProps extends AlarmTableColumns {
 }
 
 export const AlarmTable = ({ data, onClickRowItem, ...props }: AlarmTableProps) => {
-  const columns = alarmTableColumns(props);
+  const { t } = useTranslation();
+  const columns = alarmTableColumns(props, t);
   return (
     <div className={cn('rounded-md border')}>
       <DataTable
         autoResize
         columns={columns}
         data={data || []}
-        emptyMessage={data?.length === 0 ? undefined : 'Select your application first.'}
+        emptyMessage={
+          data?.length === 0 ? undefined : t('CONFIGURATION.COMMON.SELECT_APPLICATION_FIRST')
+        }
         onClickRow={(data) => {
           onClickRowItem?.(data.original);
         }}

--- a/web-frontend/src/main/v3/packages/ui/src/components/Alarm/alarmTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Alarm/alarmTableColumns.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { AlarmRule } from '@pinpoint-fe/ui/src/constants';
 import { CellContext, ColumnDef } from '@tanstack/react-table';
@@ -40,16 +41,17 @@ export interface AlarmTableColumns {
 
 export const alarmTableColumns: (
   props: AlarmTableColumns,
-) => ColumnDef<AlarmRule.AlarmRuleData>[] = ({ onClickEdit, onClickDelete }) => [
+  t: TFunction,
+) => ColumnDef<AlarmRule.AlarmRuleData>[] = ({ onClickEdit, onClickDelete }, t) => [
   {
     accessorKey: 'checkerName',
-    header: () => 'Rule Name',
+    header: () => t('CONFIGURATION.ALARM.RULE_NAME'),
     cell: (props) => props.getValue(),
   },
 
   {
     accessorKey: 'userGroupId',
-    header: () => 'User Group',
+    header: () => t('CONFIGURATION.ALARM.USER_GROUP'),
     cell: (props) => props.getValue(),
     meta: {
       headerClassName: 'w-40',
@@ -58,7 +60,7 @@ export const alarmTableColumns: (
   },
   {
     accessorKey: 'threshold',
-    header: () => 'Threshold',
+    header: () => t('CONFIGURATION.COMMON.THRESHOLD'),
     cell: (props) => props.getValue(),
     meta: {
       headerClassName: 'w-36 px-4',
@@ -67,7 +69,7 @@ export const alarmTableColumns: (
   },
   {
     accessorKey: 'type',
-    header: () => 'Type',
+    header: () => t('CONFIGURATION.COMMON.TYPE'),
     cell: (props) => {
       return <AlarmTypes data={props.row.original} />;
     },
@@ -78,7 +80,7 @@ export const alarmTableColumns: (
   },
   {
     accessorKey: 'actions',
-    header: () => 'Actions',
+    header: () => t('CONFIGURATION.COMMON.LABEL.ACTIONS'),
     cell: (props) => {
       return <ActionButtons cellProps={props} columnProps={{ onClickEdit, onClickDelete }} />;
     },

--- a/web-frontend/src/main/v3/packages/ui/src/components/Alarm/alarmTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Alarm/alarmTableColumns.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TFunction } from 'i18next';
+import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { AlarmRule } from '@pinpoint-fe/ui/src/constants';
 import { CellContext, ColumnDef } from '@tanstack/react-table';

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMapQueryOptions/ServerMapQueryOption.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMapQueryOptions/ServerMapQueryOption.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { FaSignInAlt, FaSignOutAlt, FaMapSigns } from 'react-icons/fa';
 import { useUpdateEffect } from 'usehooks-ts';
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from '../ui/popover';
@@ -24,6 +25,7 @@ export interface ServerMapQueryOptionProps {
 const boundCount = [1, 2, 3, 4];
 
 export const ServerMapQueryOption = ({ queryOption, onApply }: ServerMapQueryOptionProps) => {
+  const { t } = useTranslation();
   const [open, setOpen] = React.useState(false);
   const [inbound, setInbound] = React.useState(queryOption?.inbound || 1);
   const [outbound, setOutbound] = React.useState(queryOption?.outbound || 1);
@@ -104,34 +106,34 @@ export const ServerMapQueryOption = ({ queryOption, onApply }: ServerMapQueryOpt
               </Button>
             </TooltipTrigger>
             <TooltipContent side="left">
-              <p>Server-map Query Option</p>
+              <p>{t('SERVER_MAP.QUERY_OPTION.TITLE')}</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
       </PopoverTrigger>
       <PopoverContent side={'left'} align="start" className="w-90">
         <div>
-          <div className="mb-1 font-semibold">Server-map Query Option</div>
+          <div className="mb-1 font-semibold">{t('SERVER_MAP.QUERY_OPTION.TITLE')}</div>
           <div className="text-sm font-light text-gray-400">
-            Set the query options for the Server-map
+            {t('SERVER_MAP.QUERY_OPTION.DESC')}
           </div>
           <Separator className="mt-2 mb-3" />
           <div className="grid grid-cols-[120px_auto] text-sm mb-10 h-40 items-center [&>*:nth-child(odd)]:text-right [&>*:nth-child(even)]:ml-5">
-            <div>Application Only</div>
+            <div>{t('SERVER_MAP.QUERY_OPTION.APPLICATION_ONLY')}</div>
             <Checkbox
               checked={wasOnly}
               onCheckedChange={(checked) => {
                 setWasOnly(checked as boolean);
               }}
             />
-            <div>Bidirectional</div>
+            <div>{t('SERVER_MAP.QUERY_OPTION.BIDIRECTIONAL')}</div>
             <Checkbox
               checked={bidirectional}
               onCheckedChange={(checked) => {
                 setBidirectional(checked as boolean);
               }}
             />
-            <div>Inbound</div>
+            <div>{t('SERVER_MAP.QUERY_OPTION.INBOUND')}</div>
             <ButtonGroup
               defaultValue={`${inbound}`}
               className="h-7"
@@ -145,7 +147,7 @@ export const ServerMapQueryOption = ({ queryOption, onApply }: ServerMapQueryOpt
                 </ButtonGroupItem>
               ))}
             </ButtonGroup>
-            <div>Outbound</div>
+            <div>{t('SERVER_MAP.QUERY_OPTION.OUTBOUND')}</div>
             <ButtonGroup
               className="h-7"
               defaultValue={`${outbound}`}
@@ -163,7 +165,7 @@ export const ServerMapQueryOption = ({ queryOption, onApply }: ServerMapQueryOpt
           <div className="flex justify-end gap-2 ">
             <PopoverClose asChild>
               <Button className="w-20 font-normal" variant="outline">
-                Cancel
+                {t('COMMON.CANCEL')}
               </Button>
             </PopoverClose>
             <PopoverClose asChild>
@@ -180,7 +182,7 @@ export const ServerMapQueryOption = ({ queryOption, onApply }: ServerMapQueryOpt
                   }, 100);
                 }}
               >
-                Apply
+                {t('COMMON.APPLY')}
               </Button>
             </PopoverClose>
           </div>

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/CallTree.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/CallTree.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { formatInTimeZone } from 'date-fns-tz';
 import { usePostBind, useTimezone } from '@pinpoint-fe/ui/src/hooks';
 import { useUpdateEffect } from 'usehooks-ts';
@@ -43,6 +44,7 @@ const filterList = [
 ];
 
 export const CallTree = ({ data, mapData, metaData }: CallTreeProps) => {
+  const { t } = useTranslation();
   const [openSheet, setSheetOpen] = React.useState<boolean>(false);
   const [openDialog, setDialogOpen] = React.useState<boolean>(false);
   const [content, setContent] = React.useState<string>('');
@@ -163,7 +165,7 @@ export const CallTree = ({ data, mapData, metaData }: CallTreeProps) => {
         />
         <Select value={filter} onValueChange={(value) => setFilter(value)}>
           <SelectTrigger className="w-24 h-full text-xs">
-            <SelectValue placeholder="Theme" />
+            <SelectValue placeholder={t('TRANSACTION_LIST.CALL_TREE_FILTER')} />
           </SelectTrigger>
           <SelectContent>
             {filterList.map((filter) => (
@@ -176,7 +178,7 @@ export const CallTree = ({ data, mapData, metaData }: CallTreeProps) => {
         <div className="border flex rounded pr-0.5 w-64">
           <Input
             className="h-full text-xs border-none shadow-none focus-visible:ring-0 placeholder:text-xs"
-            placeholder="Filter call tree..."
+            placeholder={t('TRANSACTION_LIST.CALL_TREE_FILTER_PLACEHOLDER')}
             value={input}
             onChange={(e) => setInput(e.currentTarget.value)}
             onKeyDown={(e) => {

--- a/web-frontend/src/main/v3/packages/ui/src/components/Webhook/WebhookDetail.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Webhook/WebhookDetail.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -25,20 +26,6 @@ export interface WebhookDetailProps {
   onCompleteMutation?: () => void;
 }
 
-const formSchema = z.object({
-  alias: z.string().max(256).optional(),
-  url: z
-    .string({ required_error: 'Url is required' })
-    .max(256)
-    .regex(
-      new RegExp(
-        // eslint-disable-next-line
-        /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/,
-      ),
-      'Invalied Url format',
-    ),
-});
-
 export const WebhookDetail = ({
   data,
   editable,
@@ -47,6 +34,27 @@ export const WebhookDetail = ({
 }: WebhookDetailProps) => {
   const toast = useReactToastifyToast();
   const { t } = useTranslation();
+  const formSchema = React.useMemo(
+    () =>
+      z.object({
+        alias: z.string().max(256).optional(),
+        url: z
+          .string({
+            required_error: t('COMMON.REQUIRED', {
+              requiredField: t('CONFIGURATION.WEBHOOK.URL'),
+            }),
+          })
+          .max(256)
+          .regex(
+            new RegExp(
+              // eslint-disable-next-line
+              /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/,
+            ),
+            t('CONFIGURATION.WEBHOOK.INVALID_URL_FORMAT'),
+          ),
+      }),
+    [t],
+  );
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -88,7 +96,7 @@ export const WebhookDetail = ({
                     <Input
                       {...field}
                       disabled={!editable}
-                      placeholder="If empty, it is set to the entered Url"
+                      placeholder={t('CONFIGURATION.WEBHOOK.ALIAS_PLACEHOLDER')}
                     />
                   </FormControl>
                   <FormDescription></FormDescription>
@@ -103,7 +111,7 @@ export const WebhookDetail = ({
             render={({ field, fieldState }) => {
               return (
                 <FormItem>
-                  <FormLabel>Url</FormLabel>
+                  <FormLabel>{t('CONFIGURATION.WEBHOOK.URL')}</FormLabel>
                   <FormControl>
                     <Input
                       {...field}

--- a/web-frontend/src/main/v3/packages/ui/src/components/Webhook/WebhookTable.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Webhook/WebhookTable.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Webhook } from '@pinpoint-fe/ui/src/constants';
 import { DataTable } from '../../components/DataTable/DataTable';
 import { cn } from '../../lib/utils';
@@ -9,14 +10,17 @@ export interface WebhookTableProps extends WebhookTableColumnsProps {
 }
 
 export const WebhookTable = ({ data, onClickRowItem, ...props }: WebhookTableProps) => {
-  const columns = webhookTableColumns(props);
+  const { t } = useTranslation();
+  const columns = webhookTableColumns(props, t);
   return (
     <div className={cn('rounded-md border')}>
       <DataTable
         autoResize
         columns={columns}
         data={data || []}
-        emptyMessage={data?.length === 0 ? undefined : 'Select your application first.'}
+        emptyMessage={
+          data?.length === 0 ? undefined : t('CONFIGURATION.COMMON.SELECT_APPLICATION_FIRST')
+        }
         onClickRow={(data) => {
           onClickRowItem?.(data.original);
         }}

--- a/web-frontend/src/main/v3/packages/ui/src/components/Webhook/webhookTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Webhook/webhookTableColumns.tsx
@@ -1,4 +1,4 @@
-import { TFunction } from 'i18next';
+import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { Webhook } from '@pinpoint-fe/ui/src/constants';
 import { CellContext, ColumnDef } from '@tanstack/react-table';

--- a/web-frontend/src/main/v3/packages/ui/src/components/Webhook/webhookTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Webhook/webhookTableColumns.tsx
@@ -1,3 +1,4 @@
+import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { Webhook } from '@pinpoint-fe/ui/src/constants';
 import { CellContext, ColumnDef } from '@tanstack/react-table';
@@ -18,21 +19,22 @@ export interface WebhookTableColumnsProps {
 
 export const webhookTableColumns: (
   props: WebhookTableColumnsProps,
-) => ColumnDef<Webhook.WebhookData>[] = ({ onClickEdit, onClickDelete }) => [
+  t: TFunction,
+) => ColumnDef<Webhook.WebhookData>[] = ({ onClickEdit, onClickDelete }, t) => [
   {
     accessorKey: 'alias',
-    header: () => 'Alias',
+    header: () => t('CONFIGURATION.WEBHOOK.ALIAS'),
     cell: (props) => props.getValue(),
   },
 
   {
     accessorKey: 'url',
-    header: () => 'Url',
+    header: () => t('CONFIGURATION.WEBHOOK.URL'),
     cell: (props) => props.getValue(),
   },
   {
     accessorKey: 'actions',
-    header: () => 'Actions',
+    header: () => t('CONFIGURATION.COMMON.LABEL.ACTIONS'),
     cell: (props) => {
       return <ActionButtons cellProps={props} columnProps={{ onClickEdit, onClickDelete }} />;
     },

--- a/web-frontend/src/main/v3/packages/ui/src/constants/locales/en.json
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/locales/en.json
@@ -26,6 +26,7 @@
     "CANCEL": "Cancel",
     "CLOSE": "Close",
     "CONTINUE": "Continue",
+    "APPLY": "Apply",
     "EDIT": "Edit",
     "SORT_STARTTIME_DESC": "Most Recent",
     "SORT_STARTTIME_ASC": "Oldest First",
@@ -61,12 +62,28 @@
   },
   "SERVER_MAP": {
     "SCATTER_CHART_STATIC_WARN": "To view the scatter chart by agent,\nplease switch the heatmap to a scatter chart.",
-    "HEATMAP_API_ERROR_MESSAGE": "If the heatmap call error persists,\nplease refer to the scatter chart."
+    "HEATMAP_API_ERROR_MESSAGE": "If the heatmap call error persists,\nplease refer to the scatter chart.",
+    "QUERY_OPTION": {
+      "TITLE": "Server-map Query Option",
+      "DESC": "Set the query options for the Server-map",
+      "APPLICATION_ONLY": "Application Only",
+      "BIDIRECTIONAL": "Bidirectional",
+      "INBOUND": "Inbound",
+      "OUTBOUND": "Outbound"
+    },
+    "REAL_TIME": {
+      "LOCK_SERVER": "Lock current server",
+      "UNLOCK_SERVER": "Unlock current server",
+      "NOT_WAS": "Selected target is not a WAS.",
+      "CONNECTION_CLOSED": "Connection closed."
+    }
   },
   "TRANSACTION_LIST": {
     "SELECT_TRANSACTION": "Select your transaction",
     "TRANSACTION_RETRIEVE_ERROR": "Transaction information is missing.",
-    "TRANSACTION_RETRIEVE_ERROR_DESC": "Please start it over from the Servermap/Filtered page.  (If you close this dialog, you will be redirected to the Servermap page.)"
+    "TRANSACTION_RETRIEVE_ERROR_DESC": "Please start it over from the Servermap/Filtered page.  (If you close this dialog, you will be redirected to the Servermap page.)",
+    "CALL_TREE_FILTER": "Filter",
+    "CALL_TREE_FILTER_PLACEHOLDER": "Filter call tree..."
   },
   "METRIC": {
     "HOST_GROUP_LIST": "Host-Group List",
@@ -165,7 +182,8 @@
       "THRESHOLD": "Threshold",
       "TYPE": "Type",
       "NOTES": "Notes",
-      "WEBHOOK": "Webhook"
+      "WEBHOOK": "Webhook",
+      "SELECT_APPLICATION_FIRST": "Select your application first."
     },
     "ALARM": {
       "NAME": "Alarm",
@@ -173,7 +191,13 @@
       "ADD": "Add Alarm",
       "EDIT": "Edit Alarm",
       "DETAIL": "Alarm Detail",
-      "DESC": "Application's status is periodically checked and alarm is triggered if certain pre-configured conditions (rules) are satisfied.\npinpoint-batch server checks every 3 minutes based on the last 5 minutes of data.\nAnd if the conditions are satisfied, it sends sms/email/webhook to the users listed in the user group."
+      "DESC": "Application's status is periodically checked and alarm is triggered if certain pre-configured conditions (rules) are satisfied.\npinpoint-batch server checks every 3 minutes based on the last 5 minutes of data.\nAnd if the conditions are satisfied, it sends sms/email/webhook to the users listed in the user group.",
+      "RULE_NAME": "Rule Name",
+      "USER_GROUP": "User Group",
+      "SELECT_RULE": "Select rule",
+      "SELECT_USER_GROUP": "Select user group",
+      "THRESHOLD_MIN": "Must be greater than {{min}}",
+      "THRESHOLD_MAX": "Must be less than {{max}}"
     },
     "WEBHOOK": {
       "NAME": "Webhook",
@@ -181,7 +205,10 @@
       "CREATE": "Create Webhook",
       "EDIT": "Edit Webhook",
       "DETAIL": "Webhook Detail",
-      "ALIAS": "Alias"
+      "ALIAS": "Alias",
+      "URL": "Url",
+      "INVALID_URL_FORMAT": "Invalid Url format",
+      "ALIAS_PLACEHOLDER": "If empty, it is set to the entered Url"
     },
     "SERVICE_SETTING": {
       "NEW_SERVICE": "New Service",

--- a/web-frontend/src/main/v3/packages/ui/src/constants/locales/ko.json
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/locales/ko.json
@@ -26,6 +26,7 @@
     "CANCEL": "취소",
     "CLOSE": "닫기",
     "CONTINUE": "계속",
+    "APPLY": "적용",
     "EDIT": "수정",
     "SORT_STARTTIME_DESC": "최근 순",
     "SORT_STARTTIME_ASC": "오래된 순",
@@ -61,12 +62,28 @@
   },
   "SERVER_MAP": {
     "SCATTER_CHART_STATIC_WARN": "Agent별 scatter chart를 보기 위해\nheatmap을 scatter chart로 변경해 주세요.",
-    "HEATMAP_API_ERROR_MESSAGE": "Heatmap 호출 에러가 반복될 경우,\nscatter 차트를 참고해 주세요."
+    "HEATMAP_API_ERROR_MESSAGE": "Heatmap 호출 에러가 반복될 경우,\nscatter 차트를 참고해 주세요.",
+    "QUERY_OPTION": {
+      "TITLE": "서버맵 조회 옵션",
+      "DESC": "서버맵 조회 옵션을 설정합니다",
+      "APPLICATION_ONLY": "애플리케이션만 보기",
+      "BIDIRECTIONAL": "양방향",
+      "INBOUND": "인바운드",
+      "OUTBOUND": "아웃바운드"
+    },
+    "REAL_TIME": {
+      "LOCK_SERVER": "현재 서버 고정",
+      "UNLOCK_SERVER": "현재 서버 고정 해제",
+      "NOT_WAS": "선택한 대상이 WAS가 아닙니다.",
+      "CONNECTION_CLOSED": "연결이 종료되었습니다."
+    }
   },
   "TRANSACTION_LIST": {
     "SELECT_TRANSACTION": "Transaction을 선택하세요.",
     "TRANSACTION_RETRIEVE_ERROR": "Transaction 정보가 없습니다.",
-    "TRANSACTION_RETRIEVE_ERROR_DESC": "Servermap/Filtered 페이지에서 다시 시도해 주세요. (이 창을 닫으면 Servermap 페이지로 이동합니다)"
+    "TRANSACTION_RETRIEVE_ERROR_DESC": "Servermap/Filtered 페이지에서 다시 시도해 주세요. (이 창을 닫으면 Servermap 페이지로 이동합니다)",
+    "CALL_TREE_FILTER": "필터",
+    "CALL_TREE_FILTER_PLACEHOLDER": "콜 트리 필터..."
   },
   "METRIC": {
     "HOST_GROUP_LIST": "호스트 그룹 목록",
@@ -165,7 +182,8 @@
       "THRESHOLD": "기준점",
       "TYPE": "알림 형식",
       "NOTES": "메모",
-      "WEBHOOK": "웹훅"
+      "WEBHOOK": "웹훅",
+      "SELECT_APPLICATION_FIRST": "먼저 애플리케이션을 선택해 주세요."
     },
     "ALARM": {
       "NAME": "알람",
@@ -173,7 +191,13 @@
       "ADD": "알람 등록",
       "EDIT": "알람 수정",
       "DETAIL": "알람 상세",
-      "DESC": "애플리케이션의 상태는 주기적으로 확인되며 사전 구성된 특정 조건(규칙)이 충족되면 알람이 트리거됩니다.\npinpoint-batch 서버는 매 3분간 최근 5분간의 데이터를 기반으로 체크를 하며, 조건이 충족되면 사용자 그룹에 나열된 사용자에게 sms/email/webhook을 전송합니다."
+      "DESC": "애플리케이션의 상태는 주기적으로 확인되며 사전 구성된 특정 조건(규칙)이 충족되면 알람이 트리거됩니다.\npinpoint-batch 서버는 매 3분간 최근 5분간의 데이터를 기반으로 체크를 하며, 조건이 충족되면 사용자 그룹에 나열된 사용자에게 sms/email/webhook을 전송합니다.",
+      "RULE_NAME": "규칙 이름",
+      "USER_GROUP": "사용자 그룹",
+      "SELECT_RULE": "규칙을 선택하세요",
+      "SELECT_USER_GROUP": "사용자 그룹을 선택하세요",
+      "THRESHOLD_MIN": "{{min}}보다 커야 합니다",
+      "THRESHOLD_MAX": "{{max}}보다 작아야 합니다"
     },
     "WEBHOOK": {
       "NAME": "웹훅",
@@ -181,7 +205,10 @@
       "CREATE": "웹훅 생성",
       "EDIT": "웹훅 수정",
       "DETAIL": "웹훅 상세",
-      "ALIAS": "별칭"
+      "ALIAS": "별칭",
+      "URL": "URL",
+      "INVALID_URL_FORMAT": "올바르지 않은 URL 형식입니다",
+      "ALIAS_PLACEHOLDER": "입력하지 않으면 입력한 URL로 설정됩니다"
     },
     "SERVICE_SETTING": {
       "NEW_SERVICE": "새 서비스",


### PR DESCRIPTION
## Summary
- Replace hardcoded English UI strings with `t()` calls across Webhook, Alarm, ServerMap query option, real-time active thread, and call-tree components.
- Add the corresponding keys to both `en.json` and `ko.json` (with natural Korean translations), reusing existing keys where possible.
- Move the Webhook/Alarm zod schemas inside their components so validation messages are localized; also fixes a typo (`Invalied` → `Invalid`).

## Test plan
- [ ] `yarn build` passes (tsc + vite)
- [ ] `yarn test` passes (534/534)
- [ ] Webhook create/edit dialog and table render localized labels in both EN/KO
- [ ] Alarm detail form validation messages and table headers are localized
- [ ] ServerMap query option popover labels are localized
- [ ] Real-time active thread states (lock/unlock, not-a-WAS, connection closed) are localized
- [ ] Call-tree filter placeholders are localized
