### PR TITLE
[#noissue] Refactor queue accept vertex creation

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -32,6 +32,7 @@ import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -161,11 +162,8 @@ public class HbaseApplicationMapService implements ApplicationMapService {
         if (span.getParentSpanId() == SpanId.NULL) {
             if (spanServiceType.isQueue()) {
                 // create virtual queue node
-                String applicationName = span.getAcceptorHost();
-                if (applicationName == null) {
-                    applicationName = span.getRemoteAddr();
-                }
-                Vertex acceptVertex = Vertex.of(applicationName, spanServiceType);
+                Vertex acceptVertex = getQueueAcceptVertex(span, spanServiceType);
+
                 linkService.updateOutLink(span.getCollectorAcceptTime(), acceptVertex, span.getRemoteAddr(),
                         selfVertex, MERGE_QUEUE, span.getElapsed(), span.hasError());
 
@@ -199,11 +197,7 @@ public class HbaseApplicationMapService implements ApplicationMapService {
             if (spanServiceType.isQueue()) {
                 if (!selfVertex.serviceType().isQueue() && !parentVertex.serviceType().isQueue()) {
                     // emulate virtual queue node's accept Span and record it's acceptor host
-                    String applicationName = span.getAcceptorHost();
-                    if (applicationName == null) {
-                        applicationName = span.getRemoteAddr();
-                    }
-                    final Vertex queueAcceptVertex = Vertex.of(applicationName, spanServiceType);
+                    final Vertex queueAcceptVertex = getQueueAcceptVertex(span, spanServiceType);
 
                     if (logger.isDebugEnabled()) {
                         logger.debug("[Bind] child-queue {}:{} <- {}", queueAcceptVertex, span.getRemoteAddr(), parentVertex);
@@ -241,6 +235,15 @@ public class HbaseApplicationMapService implements ApplicationMapService {
                 logger.debug("ambiguous span found(bug). detailed span {}", span);
             }
         }
+    }
+
+    private @NonNull Vertex getQueueAcceptVertex(SpanBo span, ServiceType spanServiceType) {
+        String applicationName = span.getAcceptorHost();
+        if (applicationName == null) {
+            applicationName = span.getRemoteAddr();
+        }
+        ServiceUid serviceUid = span.getServiceUid();
+        return Vertex.of(serviceUid.getUid(), applicationName, spanServiceType);
     }
 
     private void insertSpanEventStat(SpanBo span, Vertex selfVertex) {


### PR DESCRIPTION
This pull request refactors the creation of queue accept vertices in the `HbaseApplicationMapService` class to improve code reuse and clarity. The logic for constructing queue accept vertices is now encapsulated in a new helper method, reducing duplication and making the codebase easier to maintain.

**Refactoring and Code Reuse:**

* Introduced a new private method `getQueueAcceptVertex` to encapsulate the logic for creating a queue accept `Vertex`, centralizing the construction logic and reducing code duplication. This method uses both the `serviceUid` and `applicationName` (falling back to `remoteAddr` if necessary) when creating the vertex. (`collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java`)
* Updated two locations in `insertSpanStat` to use the new `getQueueAcceptVertex` method instead of duplicating the vertex creation logic. (`collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java`) [[1]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0L164-R166) [[2]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0L202-R200)

**Annotations and Imports:**

* Added the `@NonNull` annotation and its import from `org.jspecify.annotations` to improve null-safety and clarify intent in the new helper method. (`collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java`)