### PR TITLE
[#noissue] Use vertex service uid for link row keys

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapInLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapInLinkDao.java
@@ -90,8 +90,7 @@ public class HbaseMapInLinkDao implements MapInLinkDao {
         }
 
         // make row key. rowkey is me
-        InLinkFactory.InLink inLink = inLinkFactory.newLink(inVertex.applicationName(), inVertex.serviceType(),
-                selfVertex.applicationName(), selfVertex.serviceType(), selfHost);
+        InLinkFactory.InLink inLink = inLinkFactory.newLink(inVertex, selfVertex, selfHost);
 
         final RowKey inLinkRowKey = inLink.rowkey(requestTime);
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -79,8 +79,7 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
         outHost = Objects.toString(outHost, "");
 
         // make row key. rowkey is me
-        OutLinkFactory.OutLink outLink = outLinkFactory.newOutLink(selfVertex.applicationName(), selfVertex.serviceType(), selfAgentId,
-                outVertex.applicationName(), outVertex.serviceType(), outHost);
+        OutLinkFactory.OutLink outLink = outLinkFactory.newOutLink(selfVertex, selfAgentId, outVertex, outHost);
 
         final RowKey selfLinkRowKey = outLink.rowkey(requestTime);
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/InLinkFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/InLinkFactory.java
@@ -16,13 +16,13 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.dao.hbase;
 
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public interface InLinkFactory {
 
-    InLink newLink(String inApplicationName, ServiceType inServiceType, String selfApplicationName, ServiceType selfServiceType, String selfSubLink);
+    InLink newLink(Vertex inVertex, Vertex selfVertex, String selfSubLink);
 
     interface InLink {
         RowKey rowkey(long requestTime);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/OutLinkFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/OutLinkFactory.java
@@ -16,14 +16,13 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.dao.hbase;
 
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 
 public interface OutLinkFactory {
 
-    OutLink newOutLink(String selfApplicationName, ServiceType selfServiceType, String selfAgentId,
-                              String outApplicationName, ServiceType outServiceType, String outSubLink);
+    OutLink newOutLink(Vertex selfVertex, String selfAgentId, Vertex outVertex, String outSubLink);
 
     interface OutLink {
         RowKey rowkey(long rowTimeSlot);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v2/InLinkFactoryV2.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v2/InLinkFactoryV2.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.collector.applicationmap.dao.v2;
 
 import com.navercorp.pinpoint.collector.applicationmap.dao.hbase.InLinkFactory;
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.LinkRowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
@@ -37,8 +38,10 @@ public class InLinkFactoryV2 implements InLinkFactory {
     }
 
     @Override
-    public InLink newLink(String inApplicationName, ServiceType inServiceType, String selfApplicationName, ServiceType selfServiceType, String selfSubLink) {
-        return new InLinkV2(inApplicationName, inServiceType, selfApplicationName, selfServiceType, selfSubLink);
+    public InLink newLink(Vertex inVertex, Vertex selfVertex, String selfSubLink) {
+        Objects.requireNonNull(inVertex, "inVertex");
+        Objects.requireNonNull(selfVertex, "selfVertex");
+        return new InLinkV2(inVertex.applicationName(), inVertex.serviceType(), selfVertex.applicationName(), selfVertex.serviceType(), selfSubLink);
     }
 
     public class InLinkV2 implements InLink {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v2/OutLinkFactoryV2.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v2/OutLinkFactoryV2.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.collector.applicationmap.dao.v2;
 
 import com.navercorp.pinpoint.collector.applicationmap.dao.hbase.OutLinkFactory;
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.LinkRowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
@@ -34,10 +35,12 @@ public class OutLinkFactoryV2 implements OutLinkFactory {
         this.timeSlot = Objects.requireNonNull(timeSlot, "timeSlot");
     }
 
-    public OutLink newOutLink(String selfApplicationName, ServiceType selfServiceType, String selfAgentId,
-                              String outApplicationName, ServiceType outServiceType, String outSubLink) {
-        return new OutLinkV2(selfApplicationName, selfServiceType, selfAgentId,
-                outApplicationName, outServiceType, outSubLink);
+    public OutLink newOutLink(Vertex selfVertex, String selfAgentId, Vertex outVertex, String outSubLink) {
+        Objects.requireNonNull(selfVertex, "selfVertex");
+        Objects.requireNonNull(outVertex, "outVertex");
+
+        return new OutLinkV2(selfVertex.applicationName(), selfVertex.serviceType(), selfAgentId,
+                outVertex.applicationName(), outVertex.serviceType(), outSubLink);
     }
 
     public class OutLinkV2 implements OutLink {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/InLinkFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/InLinkFactoryV3.java
@@ -17,20 +17,18 @@
 package com.navercorp.pinpoint.collector.applicationmap.dao.v3;
 
 import com.navercorp.pinpoint.collector.applicationmap.dao.hbase.InLinkFactory;
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.v3.ColumnNameV3;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 
 import java.util.Objects;
 
 public class InLinkFactoryV3 implements InLinkFactory {
-    public static final ServiceUid DEFAULT = ServiceUid.DEFAULT;
 
     private final TimeSlot timeSlot;
 
@@ -39,33 +37,29 @@ public class InLinkFactoryV3 implements InLinkFactory {
     }
 
     @Override
-    public InLink newLink(String inApplicationName, ServiceType inServiceType, String selfApplicationName, ServiceType selfServiceType, String selfSubLink) {
-
-        return new InLinkV3(inApplicationName, inServiceType, selfApplicationName, selfServiceType, selfSubLink);
+    public InLink newLink(Vertex inVertex, Vertex selfVertex, String selfSubLink) {
+        return new InLinkV3(inVertex, selfVertex, selfSubLink);
     }
 
     public class InLinkV3 implements InLink {
-
-        private final String inApplicationName;
-        private final ServiceType inServiceType;
-
-        private final String selfApplicationName;
-        private final ServiceType selfServiceType;
+        private final Vertex inVertex;
+        private final Vertex selfVertex;
         private final String selfSubLink;
 
-        public InLinkV3(String inApplicationName, ServiceType inServiceType, String selfApplicationName, ServiceType selfServiceType, String selfSubLink) {
-            this.inApplicationName = Objects.requireNonNull(inApplicationName, "inApplicationName");
-            this.inServiceType = Objects.requireNonNull(inServiceType, "inServiceType");
-
-            this.selfApplicationName = Objects.requireNonNull(selfApplicationName, "selfApplicationName");
-            this.selfServiceType = Objects.requireNonNull(selfServiceType, "selfServiceType");
+        public InLinkV3(Vertex inVertex, Vertex selfVertex, String selfSubLink) {
+            this.inVertex = Objects.requireNonNull(inVertex, "inVertex");
+            this.selfVertex = Objects.requireNonNull(selfVertex, "selfVertex");
             this.selfSubLink = selfSubLink;
         }
 
         @Override
         public RowKey rowkey(long requestTime) {
             final long timestamp = timeSlot.getTimeSlot(requestTime);
-            return UidLinkRowKey.of(DEFAULT.getUid(), inApplicationName, inServiceType, timestamp, selfApplicationName, selfServiceType.getCode(), selfSubLink);
+            return UidLinkRowKey.of(
+                    inVertex.serviceUid(), inVertex.applicationName(), inVertex.serviceType(),
+                    timestamp,
+                    selfVertex.applicationName(), selfVertex.serviceType().getCode(), selfSubLink
+            );
         }
 
         @Override
@@ -87,7 +81,7 @@ public class InLinkFactoryV3 implements InLinkFactory {
         }
 
         private HistogramSchema inSchema() {
-            return inServiceType.getHistogramSchema();
+            return inVertex.serviceType().getHistogramSchema();
         }
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/OutLinkFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/OutLinkFactoryV3.java
@@ -17,20 +17,18 @@
 package com.navercorp.pinpoint.collector.applicationmap.dao.v3;
 
 import com.navercorp.pinpoint.collector.applicationmap.dao.hbase.OutLinkFactory;
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidLinkRowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.v3.ColumnNameV3;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 
 import java.util.Objects;
 
 public class OutLinkFactoryV3 implements OutLinkFactory {
-    public static final ServiceUid DEFAULT = ServiceUid.DEFAULT;
 
     private final TimeSlot timeSlot;
 
@@ -38,33 +36,29 @@ public class OutLinkFactoryV3 implements OutLinkFactory {
         this.timeSlot = Objects.requireNonNull(timeSlot, "timeSlot");
     }
 
-    public OutLink newOutLink(String selfApplicationName, ServiceType selfServiceType, String selfAgentId,
-                              String outApplicationName, ServiceType outServiceType, String outSubLink) {
-        return new OutLinkV3(selfApplicationName, selfServiceType,
-                outApplicationName, outServiceType, outSubLink);
+    public OutLink newOutLink(Vertex selfVertex, String selfAgentId, Vertex outVertex, String outSubLink) {
+        return new OutLinkV3(selfVertex, outVertex, outSubLink);
     }
 
     public class OutLinkV3 implements OutLink {
-        private final String selfApplicationName;
-        private final ServiceType selfServiceType;
-
-        private final String outApplicationName;
-        private final ServiceType outServiceType;
+        private final Vertex selfVertex;
+        private final Vertex outVertex;
         private final String outSubLink;
 
-        public OutLinkV3(String selfApplicationName, ServiceType selfServiceType, String outApplicationName, ServiceType outServiceType, String outSubLink) {
-            this.selfApplicationName = Objects.requireNonNull(selfApplicationName, "selfApplicationName");
-            this.selfServiceType = Objects.requireNonNull(selfServiceType, "selfServiceType");
-
-            this.outApplicationName = Objects.requireNonNull(outApplicationName, "outApplicationName");
-            this.outServiceType = Objects.requireNonNull(outServiceType, "outServiceType");
+        public OutLinkV3(Vertex selfVertex, Vertex outVertex, String outSubLink) {
+            this.selfVertex = Objects.requireNonNull(selfVertex, "selfVertex");
+            this.outVertex = Objects.requireNonNull(outVertex, "outVertex");
             this.outSubLink = outSubLink;
         }
 
         @Override
         public RowKey rowkey(long requestTime) {
             long timestamp = timeSlot.getTimeSlot(requestTime);
-            return UidLinkRowKey.of(DEFAULT.getUid(), selfApplicationName, selfServiceType, timestamp, outApplicationName, outServiceType.getCode(), outSubLink);
+            return UidLinkRowKey.of(
+                    selfVertex.serviceUid(), selfVertex.applicationName(), selfVertex.serviceType(),
+                    timestamp,
+                    outVertex.applicationName(), outVertex.serviceType().getCode(), outSubLink
+            );
         }
 
         @Override
@@ -87,7 +81,7 @@ public class OutLinkFactoryV3 implements OutLinkFactory {
         }
 
         private HistogramSchema outSchema() {
-            return outServiceType.getHistogramSchema();
+            return outVertex.serviceType().getHistogramSchema();
         }
 
     }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.java
@@ -19,7 +19,6 @@ package com.navercorp.pinpoint.common.server.applicationmap.statistics;
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
-import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 
@@ -39,12 +38,6 @@ public class UidLinkRowKey implements UidRowKey {
     private final String linkApplicationName;
     private final int linkServiceType;
     private final String subLink;
-
-    public static RowKey of(Vertex selfVertex, long rowTimeSlot, String outApplicationName, int outServiceType, String outSubLink) {
-
-        String applicationName = selfVertex.applicationName();
-        return new UidLinkRowKey(selfVertex.serviceUid(), applicationName, selfVertex.serviceType().getCode(), rowTimeSlot, outApplicationName, outServiceType, outSubLink);
-    }
 
     public static RowKey of(int serviceUid, String applicationName, ServiceType serviceType, long rowTimeSlot,
                             String outApplicationName, int outServiceType, String outSubLink) {


### PR DESCRIPTION
This pull request refactors the link factory interfaces and their implementations to use the `Vertex` class directly, instead of passing individual application name and service type parameters. This change improves code clarity and type safety by encapsulating related properties in a single object. The update affects both the in-link and out-link creation processes across multiple versions of the factories, and also simplifies related method signatures.

**Refactoring to use `Vertex` in link factories:**

* Updated the `InLinkFactory` and `OutLinkFactory` interfaces to accept `Vertex` objects instead of separate application name and service type parameters in their `newLink`/`newOutLink` methods. [[1]](diffhunk://#diff-71174b13dfe6083ad1ec85d15eb25c501d003b551123351468523290d2a729f7R19-R25) [[2]](diffhunk://#diff-d68a7ce0e9c4a531aa4c30cf011e93e618e53984ade8462df4a98461296e9bc4R19-R25)
* Modified `HbaseMapInLinkDao.java` and `HbaseMapOutLinkDao.java` to use the new method signatures, passing `Vertex` instances directly when creating in-links and out-links. [[1]](diffhunk://#diff-d76d17c39980e928a6f9a494cb5a559f60cd97ff34ab37514663f1858290dacfL93-R93) [[2]](diffhunk://#diff-4b07ea846dfc607b73cacf60ac8f045ab8ac879a205654de45731ec9f1d2db80L82-R82)

**Implementation updates in factory classes:**

* Updated all `InLinkFactory` and `OutLinkFactory` implementations (`InLinkFactoryV2`, `OutLinkFactoryV3`, `OutLinkFactoryV2`, `OutLinkFactoryV3`) to use the new `Vertex`-based method signatures, including adding null checks and updating constructor parameters and member variables to use `Vertex`. [[1]](diffhunk://#diff-1907e9fd63da17ff811cee5aa733851e4a0e2d770e67f2a8c383e18f679f827fR20) [[2]](diffhunk://#diff-1907e9fd63da17ff811cee5aa733851e4a0e2d770e67f2a8c383e18f679f827fL40-R44) [[3]](diffhunk://#diff-3d807d77e538aa2cfcedf2326eccc040e13703d84b527631ad81c9493dd60787R20) [[4]](diffhunk://#diff-3d807d77e538aa2cfcedf2326eccc040e13703d84b527631ad81c9493dd60787L37-R43) [[5]](diffhunk://#diff-0d5d4dc11c0bc28650a85168b8999761cec7502b4908c624dfb0b2e456ba416bR20-L33) [[6]](diffhunk://#diff-0d5d4dc11c0bc28650a85168b8999761cec7502b4908c624dfb0b2e456ba416bL42-R62) [[7]](diffhunk://#diff-4639b36b45133324b5a1e736caf85760bfa960439661f69e33e176007629e50eR20-R61) [[8]](diffhunk://#diff-4639b36b45133324b5a1e736caf85760bfa960439661f69e33e176007629e50eL90-R84)

**Code cleanup and simplification:**

* Removed unused imports and obsolete static constants from the affected classes, and updated private helper methods to use the encapsulated `Vertex` objects instead of individual fields. [[1]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fL22) [[2]](diffhunk://#diff-0d5d4dc11c0bc28650a85168b8999761cec7502b4908c624dfb0b2e456ba416bR20-L33) [[3]](diffhunk://#diff-4639b36b45133324b5a1e736caf85760bfa960439661f69e33e176007629e50eR20-R61) [[4]](diffhunk://#diff-0d5d4dc11c0bc28650a85168b8999761cec7502b4908c624dfb0b2e456ba416bL90-R84) [[5]](diffhunk://#diff-4639b36b45133324b5a1e736caf85760bfa960439661f69e33e176007629e50eL90-R84) [[6]](diffhunk://#diff-03da6deb6be23a96ac2834242f4ed77ea367c8614c8f948a2148ad676dbced5fL43-L48)

These changes make the codebase more maintainable and less error-prone by leveraging the `Vertex` abstraction throughout the link factory logic.