### PR TITLE
[#13875] Add serviceName filter to inspector Pinot queries

### DIFF
--- a/inspector-module/inspector-web/src/main/resources/inspector/web/mapper/pinot/agentInspectorMapper.xml
+++ b/inspector-module/inspector-web/src/main/resources/inspector/web/mapper/pinot/agentInspectorMapper.xml
@@ -27,9 +27,8 @@
             DATETIME_CONVERT(eventTime, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '#{timePrecision.timeSize}:${timePrecision.timeUnit}') AS avgTime
         FROM ${tableName}
         WHERE
-      <!--  tenantId = #{tenantId}
-            AND serviceName = #{serviceName} -->
             sortKey = #{sortKey}
+            AND serviceName = #{serviceName}
             AND fieldName = #{fieldName}
             AND eventTime BETWEEN #{range.from} AND #{range.to}
             <foreach collection="tagList" item="tag" separator=" ">
@@ -46,9 +45,8 @@
             DATETIME_CONVERT(eventTime, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '#{timePrecision.timeSize}:${timePrecision.timeUnit}') AS avgTime
         FROM ${tableName}
         WHERE
-            <!--  tenantId = #{tenantId}
-                  AND serviceName = #{serviceName} -->
             sortKey = #{sortKey}
+            AND serviceName = #{serviceName}
             AND fieldName = #{fieldName}
             AND eventTime BETWEEN #{range.from} AND #{range.to}
             <foreach collection="tagList" item="tag" separator=" ">
@@ -65,9 +63,8 @@
             DATETIME_CONVERT(eventTime, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '#{timePrecision.timeSize}:${timePrecision.timeUnit}') AS avgTime
         FROM ${tableName}
         WHERE
-            <!--  tenantId = #{tenantId}
-                  AND serviceName = #{serviceName} -->
             sortKey = #{sortKey}
+            AND serviceName = #{serviceName}
             AND fieldName = #{fieldName}
             AND eventTime BETWEEN #{range.from} AND #{range.to}
             <foreach collection="tagList" item="tag" separator=" ">
@@ -84,9 +81,8 @@
             cast(eventTime AS long) AS avgTime
         FROM ${tableName}
         WHERE
-        <!--  tenantId = #{tenantId}
-              AND serviceName = #{serviceName} -->
         sortKey = #{sortKey}
+        AND serviceName = #{serviceName}
         AND fieldName = #{fieldName}
         AND eventTime BETWEEN #{range.from} AND #{range.to}
         <foreach collection="tagList" item="tag" separator=" ">
@@ -113,6 +109,7 @@
         WHERE
             sortKey IN
             <foreach collection="sortKeys" item="sortKey" open="(" separator="," close=")">#{sortKey}</foreach>
+            AND serviceName = #{serviceName}
             AND fieldName = #{fieldName}
             AND eventTime BETWEEN #{range.from} AND #{range.to}
             <foreach collection="tagList" item="tag" separator=" ">
@@ -132,6 +129,7 @@
         WHERE
             sortKey IN
             <foreach collection="sortKeys" item="sortKey" open="(" separator="," close=")">#{sortKey}</foreach>
+            AND serviceName = #{serviceName}
             AND fieldName = #{fieldName}
             AND eventTime BETWEEN #{range.from} AND #{range.to}
             <foreach collection="tagList" item="tag" separator=" ">
@@ -151,6 +149,7 @@
         WHERE
             sortKey IN
             <foreach collection="sortKeys" item="sortKey" open="(" separator="," close=")">#{sortKey}</foreach>
+            AND serviceName = #{serviceName}
             AND fieldName = #{fieldName}
             AND eventTime BETWEEN #{range.from} AND #{range.to}
             <foreach collection="tagList" item="tag" separator=" ">
@@ -166,6 +165,7 @@
         FROM ${tableName}
         WHERE
             sortKey = #{sortKey}
+            AND serviceName = #{serviceName}
             AND fieldName = #{fieldName}
             AND eventTime BETWEEN #{range.from} AND #{range.to}
     </select>
@@ -175,6 +175,7 @@
         FROM ${tableName}
         WHERE
             sortKey = #{sortKey}
+            AND serviceName = #{serviceName}
             AND fieldName = #{fieldName}
             AND eventTime BETWEEN #{range.from} AND #{range.to}
             <foreach collection="tagList" item="tag" separator=" ">

--- a/inspector-module/inspector-web/src/main/resources/inspector/web/mapper/pinot/applicationInspectorMapper.xml
+++ b/inspector-module/inspector-web/src/main/resources/inspector/web/mapper/pinot/applicationInspectorMapper.xml
@@ -62,9 +62,8 @@
             DATETIME_CONVERT(roundedEventTime, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '#{timePrecision.timeSize}:${timePrecision.timeUnit}') AS aggregatedTime
         FROM inspectorStatApp
         WHERE
-        <!--  tenantId = #{tenantId}
-              AND serviceName = #{serviceName} -->
             sortKey = #{sortKey}
+            AND serviceName = #{serviceName}
             AND fieldName = #{fieldName}
             AND roundedEventTime BETWEEN #{range.from} AND #{range.to}
             <foreach collection="tagList" item="tag" separator=" ">
@@ -81,9 +80,8 @@
         DATETIME_CONVERT(roundedEventTime, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '#{timePrecision.timeSize}:${timePrecision.timeUnit}') AS aggregatedTime
         FROM inspectorStatApp
         WHERE
-        <!--  tenantId = #{tenantId}
-              AND serviceName = #{serviceName} -->
         sortKey = #{sortKey}
+        AND serviceName = #{serviceName}
         AND fieldName = #{fieldName}
         AND roundedEventTime BETWEEN #{range.from} AND #{range.to}
         <foreach collection="tagList" item="tag" separator=" ">
@@ -101,9 +99,8 @@
         DATETIME_CONVERT(roundedEventTime, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '#{timePrecision.timeSize}:${timePrecision.timeUnit}') AS aggregatedTime
         FROM inspectorStatApp
         WHERE
-        <!--  tenantId = #{tenantId}
-              AND serviceName = #{serviceName} -->
         sortKey = #{sortKey}
+        AND serviceName = #{serviceName}
         AND fieldName = #{fieldName}
         AND roundedEventTime BETWEEN #{range.from} AND #{range.to}
         <foreach collection="tagList" item="tag" separator=" ">
@@ -121,9 +118,8 @@
         DATETIME_CONVERT(roundedEventTime, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '#{timePrecision.timeSize}:${timePrecision.timeUnit}') AS aggregatedTime
         FROM inspectorStatApp
         WHERE
-        <!--  tenantId = #{tenantId}
-              AND serviceName = #{serviceName} -->
         sortKey = #{sortKey}
+        AND serviceName = #{serviceName}
         AND fieldName = #{fieldName}
         AND roundedEventTime BETWEEN #{range.from} AND #{range.to}
         <if test="tagList != null and tagList.size() > 0">
@@ -140,9 +136,8 @@
         DATETIME_CONVERT(roundedEventTime, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '#{timePrecision.timeSize}:${timePrecision.timeUnit}') AS aggregatedTime
         FROM inspectorStatApp
         WHERE
-        <!--  tenantId = #{tenantId}
-              AND serviceName = #{serviceName} -->
         sortKey = #{sortKey}
+        AND serviceName = #{serviceName}
         AND fieldName = #{fieldName}
         AND roundedEventTime BETWEEN #{range.from} AND #{range.to}
         <if test="tagList != null and tagList.size() > 0">
@@ -158,6 +153,7 @@
         FROM inspectorStatApp
         WHERE
             sortKey = #{sortKey}
+            AND serviceName = #{serviceName}
             AND fieldName = #{fieldName}
             AND roundedEventTime BETWEEN #{range.from} AND #{range.to}
     </select>

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/web/resolver/QueryParamServiceNameExtractor.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/web/resolver/QueryParamServiceNameExtractor.java
@@ -26,6 +26,6 @@ public class QueryParamServiceNameExtractor implements ServiceNameExtractor {
 
     @Override
     public String extract(HttpServletRequest request) {
-        return request.getParameter(ServiceConstants.KEY);
+        return request.getParameter(ServiceConstants.QUERY_PARAM_KEY);
     }
 }

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/web/vo/ServiceConstants.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/web/vo/ServiceConstants.java
@@ -23,8 +23,11 @@ import com.navercorp.pinpoint.common.server.uid.ServiceUid;
  */
 public final class ServiceConstants {
 
-    /** Key used in HTTP header, cookie, and query-param to carry the service name. */
+    /** Key used in HTTP header and cookie to carry the service name. */
     public static final String KEY = "pServiceName";
+
+    /** Key used in URL query parameters. */
+    public static final String QUERY_PARAM_KEY = "serviceName";
 
     /** Fallback value returned when no service name can be resolved. */
     public static final String DEFAULT = ServiceUid.DEFAULT_SERVICE_UID_NAME;

--- a/service-module/src/test/java/com/navercorp/pinpoint/service/web/resolver/QueryParamServiceNameExtractorTest.java
+++ b/service-module/src/test/java/com/navercorp/pinpoint/service/web/resolver/QueryParamServiceNameExtractorTest.java
@@ -47,7 +47,7 @@ class QueryParamServiceNameExtractorTest {
     void extract_WithValidParameter_ReturnsServiceName() {
         String expectedServiceName = "queryService";
 
-        when(request.getParameter(ServiceConstants.KEY)).thenReturn(expectedServiceName);
+        when(request.getParameter(ServiceConstants.QUERY_PARAM_KEY)).thenReturn(expectedServiceName);
 
         String result = extractor.extract(request);
 
@@ -56,7 +56,7 @@ class QueryParamServiceNameExtractorTest {
 
     @Test
     void extract_WithoutParameter_ReturnsNull() {
-        when(request.getParameter(ServiceConstants.KEY)).thenReturn(null);
+        when(request.getParameter(ServiceConstants.QUERY_PARAM_KEY)).thenReturn(null);
 
         String result = extractor.extract(request);
 
@@ -65,7 +65,7 @@ class QueryParamServiceNameExtractorTest {
 
     @Test
     void extract_WithEmptyParameter_ReturnsEmptyString() {
-        when(request.getParameter(ServiceConstants.KEY)).thenReturn("");
+        when(request.getParameter(ServiceConstants.QUERY_PARAM_KEY)).thenReturn("");
 
         String result = extractor.extract(request);
 
@@ -76,7 +76,7 @@ class QueryParamServiceNameExtractorTest {
     void extract_WithDifferentParameterKey_ChecksCorrectKey() {
         String expectedServiceName = "myService";
 
-        when(request.getParameter(ServiceConstants.KEY)).thenReturn(expectedServiceName);
+        when(request.getParameter(ServiceConstants.QUERY_PARAM_KEY)).thenReturn(expectedServiceName);
 
         String result = extractor.extract(request);
 


### PR DESCRIPTION
## Summary
- Enable `serviceName` filtering in inspector Pinot queries for both agent-level and application-level stats
- Add `serviceName` WHERE condition to all queries in `agentInspectorMapper.xml` (9 queries) and `applicationInspectorMapper.xml` (6 queries)
- Separate URL query parameter key (`serviceName`) from HTTP header/cookie key (`pServiceName`) in `ServiceConstants`
- Update `QueryParamServiceNameExtractor` to use the new `QUERY_PARAM_KEY`

## Test plan
- [x] Verified agent-level inspector API returns correct data with `serviceName=DEFAULT`
- [x] Verified application-level inspector API returns correct data with `serviceName=DEFAULT`
- [x] Verified filtering works with non-default serviceName values
- [x] Confirmed collector stores `serviceName='DEFAULT'` for V1 agents