### PR TITLE
[#noissue] Upgrade billboard.js to v4 and render charts with canvas

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/package.json
+++ b/web-frontend/src/main/v3/packages/ui/package.json
@@ -57,7 +57,7 @@
     "@tanstack/react-table": "^8.10.7",
     "@tanstack/react-virtual": "^3.0.1",
     "@types/react-text-truncate": "^0.14.3",
-    "billboard.js": "^3.18.0",
+    "billboard.js": "^4.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.0.0",
     "cmdk": "^1.0.0",

--- a/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/charts/ErrorAnalysisChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/charts/ErrorAnalysisChartFetcher.tsx
@@ -1,7 +1,7 @@
 import 'billboard.js/dist/billboard.css';
 import React from 'react';
 import { useGetErrorAnalysisChartData } from '@pinpoint-fe/ui/src/hooks';
-import bb, { ChartOptions, line } from 'billboard.js';
+import bb, { ChartOptions, line, canvas, grid } from 'billboard.js/canvas';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import BillboardJS, { IChart } from '@billboard.js/react';
@@ -21,6 +21,11 @@ export const ErrorAnalysisChartFetcher = ({
   const { data } = useGetErrorAnalysisChartData();
   const chartComponent = React.useRef<IChart>(null);
   const options: ChartOptions = {
+    // v4 ESM: canvas 렌더링 모드 사용. grid 모듈은 더 이상 자동 번들되지 않아 명시적으로 등록한다.
+    render: {
+      mode: canvas(),
+    },
+    ...grid(),
     data: {
       x: 'dates',
       columns: [],

--- a/web-frontend/src/main/v3/packages/ui/src/components/Inspector/charts/ChartCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Inspector/charts/ChartCore.tsx
@@ -1,6 +1,6 @@
 import 'billboard.js/dist/billboard.css';
 import React from 'react';
-import bb, { ChartOptions } from 'billboard.js';
+import bb, { ChartOptions, canvas, regions } from 'billboard.js/canvas';
 import { isValid } from 'date-fns';
 import deepmerge from 'deepmerge';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -27,7 +27,35 @@ export const ChartCore = ({
 }: ChartCoreProps) => {
   const prevData = React.useRef([] as (string | number | null)[][]);
   const chartComponent = React.useRef<IChart>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  // canvas 모드는 차트 높이를 스스로 측정해 캔버스 크기로 쓰는데, suspense 리마운트(agent/시간/지표 변경)
+  // 순간 높이가 0으로 측정되면 billboard 기본값(320px)으로 그려져 박스보다 커지며 잘린다. 컨테이너 높이를
+  // 직접 측정해 size.height로 넘기면 billboard가 측정/폴백 없이 그 높이로 그린다. 컨테이너가 aspect-video든
+  // 고정 높이(h-80)든 실제 높이를 따르므로 소비처별 높이를 모두 지원하고, 리사이즈에도 대응한다.
+  const [measuredHeight, setMeasuredHeight] = React.useState<number>();
+  React.useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const updateHeight = () => {
+      const height = container.clientHeight;
+      if (height > 0) {
+        setMeasuredHeight(height);
+        chartComponent.current?.instance?.resize({ height });
+      }
+    };
+    updateHeight();
+    const resizeObserver = new ResizeObserver(updateHeight);
+    resizeObserver.observe(container);
+    return () => resizeObserver.disconnect();
+  }, []);
   const defaultOptions = {
+    // v4 ESM: canvas 렌더링 모드 사용. regions 모듈은 더 이상 자동 번들되지 않아 명시적으로 등록한다
+    // (application 차트가 data.regions로 점선 영역을 그림).
+    render: {
+      mode: canvas(),
+    },
+    ...regions(),
+    ...(measuredHeight ? { size: { height: measuredHeight } } : {}),
     data: {
       x: 'dates',
       columns: [],
@@ -116,12 +144,12 @@ export const ChartCore = ({
   }, [data]);
 
   return (
-    <BillboardJS
-      bb={bb}
-      ref={chartComponent}
+    <div
+      ref={containerRef}
       style={style}
       className={cn('w-full h-full min-h-0 overflow-hidden', className)}
-      options={options}
-    />
+    >
+      <BillboardJS bb={bb} ref={chartComponent} className="h-full w-full" options={options} />
+    </div>
   );
 };

--- a/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartFetcher.tsx
@@ -2,7 +2,7 @@ import 'billboard.js/dist/billboard.css';
 import React from 'react';
 import { SystemMetricMetricInfo } from '@pinpoint-fe/ui/src/constants';
 import { useGetSystemMetricChartData, useGetSystemMetricTagsData } from '@pinpoint-fe/ui/src/hooks';
-import bb, { ChartOptions, line } from 'billboard.js';
+import bb, { ChartOptions, line, canvas } from 'billboard.js/canvas';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import BillboardJS, { IChart } from '@billboard.js/react';
@@ -55,7 +55,32 @@ export const SystemMetricChartFetcher = ({
   const title = chartData?.title || '';
 
   const chartComponent = React.useRef<IChart>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  // canvas 모드는 차트 높이를 스스로 측정해 캔버스 크기로 쓰는데, Group 변경 시 suspense 리마운트 순간
+  // 높이가 0으로 측정되면 billboard 기본값(320px)으로 그려져 박스보다 커지며 잘린다. 컨테이너 높이를
+  // 직접 측정해 size.height로 넘기면 billboard가 측정/폴백 없이 그 높이로 그리고, 리사이즈에도 대응한다.
+  const [measuredHeight, setMeasuredHeight] = React.useState<number>();
+  React.useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const updateHeight = () => {
+      const height = container.clientHeight;
+      if (height > 0) {
+        setMeasuredHeight(height);
+        chartComponent.current?.instance?.resize({ height });
+      }
+    };
+    updateHeight();
+    const resizeObserver = new ResizeObserver(updateHeight);
+    resizeObserver.observe(container);
+    return () => resizeObserver.disconnect();
+  }, []);
   const options: ChartOptions = {
+    // v4 ESM: canvas 렌더링 모드 사용.
+    render: {
+      mode: canvas(),
+    },
+    ...(measuredHeight ? { size: { height: measuredHeight } } : {}),
     data: {
       x: 'dates',
       columns: [],
@@ -168,12 +193,9 @@ export const SystemMetricChartFetcher = ({
       </CardHeader>
       <Separator />
       <CardContent className="p-0 pb-1">
-        <BillboardJS
-          bb={bb}
-          ref={chartComponent}
-          className={cn('w-full h-full', className)}
-          options={options}
-        />
+        <div ref={containerRef} className={cn('w-full h-full min-h-0 overflow-hidden', className)}>
+          <BillboardJS bb={bb} ref={chartComponent} className="h-full w-full" options={options} />
+        </div>
       </CardContent>
     </Card>
   );

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/useChartConfig.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/useChartConfig.test.ts
@@ -2,7 +2,7 @@ import { useChartConfig, DEFAULT_CHART_CONFIG } from './useChartConfig';
 import { InspectorAgentChart } from '@pinpoint-fe/ui/src/constants';
 
 // Mock billboard.js
-jest.mock('billboard.js', () => ({
+jest.mock('billboard.js/canvas', () => ({
   spline: jest.fn(() => ({ type: 'spline' })),
   areaSpline: jest.fn(() => ({ type: 'areaSpline' })),
   bar: jest.fn(() => ({ type: 'bar' })),

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/useChartConfig.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/useChartConfig.ts
@@ -1,5 +1,5 @@
 import { InspectorAgentChart, InspectorApplicationChart } from '@pinpoint-fe/ui/src/constants';
-import { ChartOptions, Data } from 'billboard.js';
+import { ChartOptions, Data } from 'billboard.js/canvas';
 import { getFormat } from '@pinpoint-fe/ui/src/utils';
 import { useChartAxis } from './useChartAxis';
 import { useChartParseData } from './useChartParseData';

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/useChartType.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/useChartType.test.ts
@@ -1,7 +1,7 @@
 import { useChartType } from './useChartType';
 
 // Mock billboard.js
-jest.mock('billboard.js', () => ({
+jest.mock('billboard.js/canvas', () => ({
   spline: jest.fn(() => ({ type: 'spline' })),
   areaSpline: jest.fn(() => ({ type: 'areaSpline' })),
   bar: jest.fn(() => ({ type: 'bar' })),

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/useChartType.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/useChartType.ts
@@ -1,4 +1,4 @@
-import { spline, areaSpline, bar, line } from 'billboard.js';
+import { spline, areaSpline, bar, line } from 'billboard.js/canvas';
 
 export const useChartType = () => {
   const getChartType = (chartType: string) => {

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/useDataSourceChartConfig.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/useDataSourceChartConfig.test.ts
@@ -2,7 +2,7 @@ import { useDataSourceChartConfig } from './useDataSourceChartConfig';
 import { InspectorAgentDataSourceChart } from '@pinpoint-fe/ui/src/constants';
 
 // Mock billboard.js
-jest.mock('billboard.js', () => ({
+jest.mock('billboard.js/canvas', () => ({
   spline: jest.fn(() => ({ type: 'spline' })),
   areaSpline: jest.fn(() => ({ type: 'areaSpline' })),
   bar: jest.fn(() => ({ type: 'bar' })),

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/useDataSourceChartConfig.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/useDataSourceChartConfig.ts
@@ -1,4 +1,4 @@
-import { ChartOptions } from 'billboard.js';
+import { ChartOptions } from 'billboard.js/canvas';
 import { InspectorAgentDataSourceChart } from '@pinpoint-fe/ui/src/constants';
 import { useChartAxis } from './useChartAxis';
 import { useChartType } from './useChartType';

--- a/web-frontend/src/main/v3/yarn.lock
+++ b/web-frontend/src/main/v3/yarn.lock
@@ -4984,18 +4984,16 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-billboard.js@^3.18.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/billboard.js/-/billboard.js-3.18.0.tgz#20d0f9588e5631a94df66fedd5c35fc851e2ff59"
-  integrity sha512-aci69MLwOX0HfdmQHk+v/iA7L4R+wG53hW9VwhkYzMOyqemWLjscf229XsQRrTau9EJSVyOHnr/rpVukoqppXw==
+billboard.js@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/billboard.js/-/billboard.js-4.0.1.tgz#ca98b01038b84c8baf2bc50a86cde3ec8dc8fd8f"
+  integrity sha512-/o6iuVIwH5/hufm/hAHg4h4acx2563ePGejaXpdyaoGfyInuO1pJxy3Ya1iQXLCTZzv6HKCHPq+dJkuHqIIb+Q==
   dependencies:
     "@types/d3-selection" "^3.0.11"
     "@types/d3-transition" "^3.0.9"
     d3-axis "^3.0.0"
     d3-brush "^3.0.0"
     d3-drag "^3.0.0"
-    d3-dsv "^3.0.1"
-    d3-ease "^3.0.1"
     d3-hierarchy "^3.1.2"
     d3-interpolate "^3.0.1"
     d3-scale "^4.0.2"
@@ -5277,11 +5275,6 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@7:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
-  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
-
 commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -5490,15 +5483,6 @@ d3-brush@^3.0.0:
   dependencies:
     d3-dispatch "1 - 3"
     d3-selection "3"
-
-d3-dsv@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
-  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
-  dependencies:
-    commander "7"
-    iconv-lite "0.6"
-    rw "1"
 
 "d3-ease@1 - 3", d3-ease@^3.0.1:
   version "3.0.1"
@@ -6682,7 +6666,7 @@ i18next@^23.2.11:
   dependencies:
     "@babel/runtime" "^7.23.2"
 
-iconv-lite@0.6, iconv-lite@0.6.3:
+iconv-lite@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -8906,11 +8890,6 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
-
-rw@1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
-  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 safe-buffer@^5.2.0:
   version "5.2.1"


### PR DESCRIPTION
## Summary
- Upgrade `billboard.js` to v4 (`^4.0.1`) and switch chart rendering to the new **canvas** mode (`render.mode = canvas()`) for better performance on dense time-series charts.
- Import from the `billboard.js/canvas` entry everywhere so a single module registry is shared, and explicitly register `grid()`/`regions()` resolvers that v4 ESM no longer auto-bundles.
- Size canvas charts by measuring the container and passing `size.height`, so they render at the correct height across suspense remounts instead of falling back to billboard's default 320px (which caused charts to grow/clip on Group/agent/time changes).

## Test plan
- [x] `yarn build` passes (tsc + vite)
- [x] `yarn test` passes (57 suites / 473 tests)
- [ ] Inspector charts (regular + data-source) render and resize correctly on agent/time/metric change
- [ ] SystemMetric charts render and resize correctly on Group change
- [ ] ErrorAnalysis chart renders correctly