### PR TITLE
[#noissue] Use vertex service uid for self rows

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapAgentResponseDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapAgentResponseDao.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.logging.log4j.LogManager;
@@ -73,7 +74,7 @@ public class HbaseMapAgentResponseDao implements MapAgentResponseDao {
             logger.debug("[Self] {}/[{}]", selfVertex, agentId);
         }
 
-        SelfAgentNodeFactory.Node node = selfAgentNodeFactory.newNode(selfVertex.applicationName(), selfVertex.serviceType(), agentId);
+        SelfAgentNodeFactory.Node node = selfAgentNodeFactory.newNode(selfVertex, agentId);
         // make row key. rowkey is me
         final RowKey selfRowKey = node.rowkey(requestTime);
 
@@ -101,7 +102,8 @@ public class HbaseMapAgentResponseDao implements MapAgentResponseDao {
             logger.debug("[Self] {} ({})[{}]", applicationName, applicationServiceType, agentId);
         }
 
-        SelfAgentNodeFactory.Node node = selfAgentNodeFactory.newNode(applicationName, applicationServiceType, agentId);
+        Vertex selfVertex = Vertex.of(ServiceUid.DEFAULT_SERVICE_UID_CODE, applicationName, applicationServiceType);
+        SelfAgentNodeFactory.Node node = selfAgentNodeFactory.newNode(selfVertex, agentId);
         // make row key. rowkey is me
         final RowKey selfRowKey = node.rowkey(requestTime);
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapResponseDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapResponseDao.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.logging.log4j.LogManager;
@@ -73,7 +74,7 @@ public class HbaseMapResponseDao implements MapAgentResponseDao {
             logger.debug("[Self] {}/[{}]", selfVertex, agentId);
         }
 
-        SelfAgentNodeFactory.Node node = selfAgentNodeFactory.newNode(selfVertex.applicationName(), selfVertex.serviceType(), agentId);
+        SelfAgentNodeFactory.Node node = selfAgentNodeFactory.newNode(selfVertex, agentId);
         // make row key. rowkey is me
         final RowKey selfRowKey = node.rowkey(requestTime);
 
@@ -100,8 +101,9 @@ public class HbaseMapResponseDao implements MapAgentResponseDao {
         if (logger.isDebugEnabled()) {
             logger.debug("[Self] {} ({})[{}]", applicationName, applicationServiceType, agentId);
         }
-
-        SelfAgentNodeFactory.Node node = selfAgentNodeFactory.newNode(applicationName, applicationServiceType, agentId);
+        // TODO serviceUid
+        Vertex selfVertex = Vertex.of(ServiceUid.DEFAULT_SERVICE_UID_CODE, applicationName, applicationServiceType);
+        SelfAgentNodeFactory.Node node = selfAgentNodeFactory.newNode(selfVertex, agentId);
         // make row key. rowkey is me
         final RowKey selfRowKey = node.rowkey(requestTime);
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/SelfAgentNodeFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/SelfAgentNodeFactory.java
@@ -18,11 +18,11 @@ package com.navercorp.pinpoint.collector.applicationmap.dao.hbase;
 
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
-import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 
 public interface SelfAgentNodeFactory {
 
-    Node newNode(String applicationName, ServiceType serviceType, String agentId) ;
+    Node newNode(Vertex selfVertex, String agentId);
 
     interface Node {
         RowKey rowkey (long requestTime);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/HbaseMapApplicationResponseDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/HbaseMapApplicationResponseDao.java
@@ -65,7 +65,7 @@ public class HbaseMapApplicationResponseDao implements MapApplicationResponseDao
         }
 
         // make row key. rowkey is me
-        SelfAppNodeFactory.Node node = selfAppNodeFactory.newNode(selfVertex.applicationName(), selfVertex.serviceType());
+        SelfAppNodeFactory.Node node = selfAppNodeFactory.newNode(selfVertex);
         final RowKey selfRowKey = node.rowkey(requestTime);
 
         final ColumnName selfColumnName = node.histogram(elapsed, isError);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/SelfAgentNodeFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/SelfAgentNodeFactoryV3.java
@@ -17,21 +17,18 @@
 package com.navercorp.pinpoint.collector.applicationmap.dao.v3;
 
 import com.navercorp.pinpoint.collector.applicationmap.dao.hbase.SelfAgentNodeFactory;
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidAgentRowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.v3.ColumnNameV3;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 
 import java.util.Objects;
 
 public class SelfAgentNodeFactoryV3 implements SelfAgentNodeFactory {
-    public static final ServiceUid DEFAULT = ServiceUid.DEFAULT;
-
     private final TimeSlot timeSlot;
 
     public SelfAgentNodeFactoryV3(TimeSlot timeSlot) {
@@ -39,27 +36,28 @@ public class SelfAgentNodeFactoryV3 implements SelfAgentNodeFactory {
     }
 
     @Override
-    public Node newNode(String applicationName, ServiceType serviceType, String agentId) {
-        return new SelfAgentNode(applicationName, serviceType, agentId);
+    public Node newNode(Vertex selfVertex, String agentId) {
+        return new SelfAgentNode(selfVertex, agentId);
     }
 
 
     public class SelfAgentNode implements Node {
 
-        private final String applicationName;
-        private final ServiceType serviceType;
+        private final Vertex selfVertex;
         private final String agentId;
 
-        public SelfAgentNode(String applicationName, ServiceType serviceType, String agentId) {
-            this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
-            this.serviceType = Objects.requireNonNull(serviceType, "serviceType");
+        public SelfAgentNode(Vertex selfVertex, String agentId) {
+            this.selfVertex = Objects.requireNonNull(selfVertex, "selfVertex");
             this.agentId = agentId;
         }
 
         @Override
         public RowKey rowkey(long requestTime) {
             long timestamp = timeSlot.getTimeSlot(requestTime);
-            return UidAgentRowKey.of(DEFAULT.getUid(), applicationName, serviceType, timestamp, agentId);
+            return UidAgentRowKey.of(
+                    selfVertex.serviceUid(), selfVertex.applicationName(), selfVertex.serviceType(),
+                    timestamp,
+                    agentId);
         }
 
         @Override
@@ -87,7 +85,7 @@ public class SelfAgentNodeFactoryV3 implements SelfAgentNodeFactory {
         }
 
         private HistogramSchema getHistogramSchema() {
-            return serviceType.getHistogramSchema();
+            return selfVertex.serviceType().getHistogramSchema();
         }
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/SelfAppNodeFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/SelfAppNodeFactory.java
@@ -18,11 +18,11 @@ package com.navercorp.pinpoint.collector.applicationmap.dao.v3;
 
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
-import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 
 public interface SelfAppNodeFactory {
 
-    SelfAppNodeFactory.Node newNode(String applicationName, ServiceType serviceType);
+    SelfAppNodeFactory.Node newNode(Vertex selfVertex);
 
     interface Node {
         RowKey rowkey(long rowTimeSlot);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/SelfAppNodeFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/SelfAppNodeFactoryV3.java
@@ -16,21 +16,18 @@
 
 package com.navercorp.pinpoint.collector.applicationmap.dao.v3;
 
+import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.ColumnName;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.RowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidAppRowKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.v3.ColumnNameV3;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 
 import java.util.Objects;
 
 public class SelfAppNodeFactoryV3 implements SelfAppNodeFactory {
-
-    public static final ServiceUid DEFAULT = ServiceUid.DEFAULT;
 
     private final TimeSlot timeSlot;
 
@@ -39,24 +36,23 @@ public class SelfAppNodeFactoryV3 implements SelfAppNodeFactory {
     }
 
     @Override
-    public SelfAppNodeFactory.Node newNode(String applicationName, ServiceType serviceType) {
-        return new SelfAppNode(applicationName, serviceType);
+    public SelfAppNodeFactory.Node newNode(Vertex selfVertex) {
+        return new SelfAppNode(selfVertex);
     }
 
     public class SelfAppNode implements Node {
 
-        private final String applicationName;
-        private final ServiceType serviceType;
+        private final Vertex selfVertex;
 
-        public SelfAppNode(String applicationName, ServiceType serviceType) {
-            this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
-            this.serviceType = Objects.requireNonNull(serviceType, "serviceType");
+        public SelfAppNode(Vertex selfVertex) {
+            this.selfVertex = Objects.requireNonNull(selfVertex, "selfVertex");
         }
 
         @Override
         public RowKey rowkey(long requestTime) {
             final long timestamp = timeSlot.getTimeSlot(requestTime);
-            return UidAppRowKey.of(DEFAULT.getUid(), applicationName, serviceType, timestamp);
+            return UidAppRowKey.of(selfVertex.serviceUid(), selfVertex.applicationName(),
+                    selfVertex.serviceType(), timestamp);
         }
 
         @Override
@@ -78,7 +74,7 @@ public class SelfAppNodeFactoryV3 implements SelfAppNodeFactory {
         }
 
         private HistogramSchema getHistogramSchema() {
-            return serviceType.getHistogramSchema();
+            return selfVertex.serviceType().getHistogramSchema();
         }
     }
 }


### PR DESCRIPTION
This pull request refactors the construction and usage of self-node factories in the application map DAOs to use the `Vertex` class instead of separate application name and service type parameters. This change improves type safety, code clarity, and prepares the codebase for better handling of service UIDs.

**Factory interface and implementation refactoring:**

* Refactored `SelfAgentNodeFactory` and `SelfAppNodeFactory` interfaces and their V3 implementations to accept a `Vertex` object instead of separate `applicationName` and `ServiceType` parameters, simplifying their method signatures and internal logic. (`SelfAgentNodeFactory.java` [[1]](diffhunk://#diff-efc0c962f5509aa5a8bdda85841ece75a70c6e84db67a777704a4d1d21b865c4L21-R25) `SelfAppNodeFactory.java` [[2]](diffhunk://#diff-33f67defd890cd6729d288ac54d786563124043ee6dec95271339362d9f343c1L21-R25) `SelfAgentNodeFactoryV3.java` [[3]](diffhunk://#diff-c12191336d43ff8153d5d15449c17f22318be9e7cc2e821dec088f54afab4698R20-R60) `SelfAppNodeFactoryV3.java` [[4]](diffhunk://#diff-cababd9ea7f428df99a5906ee17512fbe0fde09908972a6fa178974db538f304R19-R55)

* Updated the inner `Node` classes in both factories to store and use the `Vertex` object, ensuring that service UID, application name, and service type are consistently available and reducing potential errors. (`SelfAgentNodeFactoryV3.java` [[1]](diffhunk://#diff-c12191336d43ff8153d5d15449c17f22318be9e7cc2e821dec088f54afab4698R20-R60) `SelfAppNodeFactoryV3.java` [[2]](diffhunk://#diff-cababd9ea7f428df99a5906ee17512fbe0fde09908972a6fa178974db538f304R19-R55)

**DAO method updates:**

* Updated `HbaseMapAgentResponseDao` and `HbaseMapResponseDao` to construct `SelfAgentNodeFactory.Node` using a `Vertex` object, and to use `Vertex.of()` with the default service UID where necessary. (`HbaseMapAgentResponseDao.java` [[1]](diffhunk://#diff-ba1cbace891afae21ce936c887433b83292f7a2e9b91d643f4e4d86364477d42L76-R77) [[2]](diffhunk://#diff-ba1cbace891afae21ce936c887433b83292f7a2e9b91d643f4e4d86364477d42L104-R106); `HbaseMapResponseDao.java` [[3]](diffhunk://#diff-efd93e592594bc26ce3858b6ff9ffcc8d2fcb110224022be55c69afb4364b3e5L76-R77) [[4]](diffhunk://#diff-efd93e592594bc26ce3858b6ff9ffcc8d2fcb110224022be55c69afb4364b3e5L103-R106)

* Updated `HbaseMapApplicationResponseDao` to construct `SelfAppNodeFactory.Node` using a `Vertex` object instead of separate parameters. (`HbaseMapApplicationResponseDao.java` [collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/HbaseMapApplicationResponseDao.javaL68-R68](diffhunk://#diff-c7df8c4235da846bf400fed26dbb12c6badba67058cafe3b6c0f91f0d8c17fadL68-R68))

**Other improvements:**

* Replaced direct access to `serviceType` for histogram schema with access via `selfVertex` in both factories, ensuring consistency and future-proofing. (`SelfAgentNodeFactoryV3.java` [[1]](diffhunk://#diff-c12191336d43ff8153d5d15449c17f22318be9e7cc2e821dec088f54afab4698L90-R88) `SelfAppNodeFactoryV3.java` [[2]](diffhunk://#diff-cababd9ea7f428df99a5906ee17512fbe0fde09908972a6fa178974db538f304L81-R77)