### PR TITLE
Migrate Error Analysis and System Metric charts from billboard.js to ECharts

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/charts/ErrorAnalysisChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/charts/ErrorAnalysisChartFetcher.tsx
@@ -1,13 +1,25 @@
-import 'billboard.js/dist/billboard.css';
 import React from 'react';
+import * as echarts from 'echarts/core';
+import { LineChart } from 'echarts/charts';
+import { GridComponent, TooltipComponent, LegendComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
 import { useGetErrorAnalysisChartData } from '@pinpoint-fe/ui/src/hooks';
-import bb, { ChartOptions, line, canvas, grid } from 'billboard.js/canvas';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import BillboardJS, { IChart } from '@billboard.js/react';
-import { abbreviateNumber, formatNewLinedDateString } from '@pinpoint-fe/ui/src/utils';
-import { isValid } from 'date-fns';
+import { abbreviateNumber } from '@pinpoint-fe/ui/src/utils';
 import { cn } from '../../../lib';
+import {
+  getGridBottom,
+  LEGEND_ICON_WIDTH,
+  LEGEND_ITEM_GAP,
+} from '../../../lib/charts/echartsLegendLayout';
+import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
+import {
+  formatAxisTooltip,
+  formatCategoryDateLabel,
+} from '../../../lib/charts/echartsTimeSeriesFormat';
+
+echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent, CanvasRenderer]);
+
+const formatErrorCount = (value: number) => abbreviateNumber(value, ['', 'K', 'M', 'G']);
 
 export interface ErrorAnalysisChartFetcherProps {
   className?: string;
@@ -19,105 +31,121 @@ export const ErrorAnalysisChartFetcher = ({
   emptyMessage = 'No Data',
 }: ErrorAnalysisChartFetcherProps) => {
   const { data } = useGetErrorAnalysisChartData();
-  const chartComponent = React.useRef<IChart>(null);
-  const options: ChartOptions = {
-    // v4 ESM: canvas 렌더링 모드 사용. grid 모듈은 더 이상 자동 번들되지 않아 명시적으로 등록한다.
-    render: {
-      mode: canvas(),
-    },
-    ...grid(),
-    data: {
-      x: 'dates',
-      columns: [],
-      empty: {
-        label: {
-          text: emptyMessage,
-        },
-      },
-      type: line(),
-    },
-    padding: {
-      mode: 'fit',
-      top: 20,
-      bottom: 10,
-      right: 25,
-      left: 15,
-    },
-    axis: {
-      x: {
-        type: 'timeseries',
-        tick: {
-          count: 6,
-          show: false,
-          format: (date: Date) => {
-            if (isValid(date)) {
-              return `${formatNewLinedDateString(date)}`;
-            }
-            return '';
-          },
-        },
-      },
-      y: {
-        label: {
-          text: 'Error Count',
-          position: 'outer-middle',
-        },
-        tick: {
-          format: (v: number) => abbreviateNumber(v, ['', 'K', 'M', 'G']),
-        },
-        padding: {
-          bottom: 0,
-        },
-        min: 0,
-        default: [0, 10],
-      },
-    },
-    grid: {
-      y: {
-        show: false,
-      },
-    },
-    point: {
-      show: false,
-    },
-    transition: {
-      duration: 0,
-    },
-    tooltip: {
-      order: '',
-      format: {
-        value: (v: number) => abbreviateNumber(v, ['', 'K', 'M', 'G']),
-      },
-    },
-    resize: {
-      auto: 'parent',
-      timer: false,
-    },
-  };
+  const { chartRef, chartInstanceRef, renderRef } = useEChartsInstance();
 
   React.useEffect(() => {
-    const chart = chartComponent.current?.instance;
+    if (!chartInstanceRef.current) return;
 
-    chart?.load({
-      columns: data
-        ? [
-            ['dates', ...data.timestamp],
-            ...data.metricValueGroups[0].metricValues.map(({ fieldName, values }) => {
-              return [fieldName, ...values.map((v: number) => (v < 0 ? null : v))];
-            }),
-          ]
-        : [],
-      unload: true,
-      resizeAfter: true,
-    });
-  }, [data]);
+    const timestamps = data?.timestamp ?? [];
+    const metricValues = data?.metricValueGroups[0]?.metricValues ?? [];
+    const hasData =
+      timestamps.length > 0 &&
+      metricValues.some((mv) => mv.values && mv.values.some((v) => v >= 0));
 
-  return (
-    <BillboardJS
-      bb={bb}
-      ref={chartComponent}
-      className={cn('w-full h-full', className)}
-      options={options}
-    />
-  );
+    const series = metricValues.map(({ fieldName, values }) => ({
+      name: fieldName,
+      type: 'line' as const,
+      data: values.map((v) => (v < 0 ? null : v)),
+      showSymbol: false,
+      smooth: false,
+      lineStyle: {
+        width: 1,
+      },
+      emphasis: {
+        focus: 'series' as const,
+      },
+    }));
+
+    const legendNames = metricValues.map((mv) => mv.fieldName);
+
+    const render = () => {
+      const chart = chartInstanceRef.current;
+      if (!chart) return;
+
+      const containerWidth = chartRef.current?.clientWidth ?? 0;
+      // legend가 줄바꿈되는 행 수를 반영해 하단 여백을 확보 → legend(하단)와 x축 라벨이 겹치지 않음.
+      const gridBottom = getGridBottom(legendNames, containerWidth);
+
+      chart.setOption(
+        {
+          animation: false,
+          legend: {
+            data: legendNames,
+            bottom: 0,
+            icon: 'square',
+            itemWidth: LEGEND_ICON_WIDTH,
+            itemHeight: 10,
+            itemGap: LEGEND_ITEM_GAP,
+          },
+          grid: {
+            top: 20,
+            bottom: gridBottom,
+            right: 25,
+            left: 0,
+          },
+          xAxis: {
+            type: 'category',
+            data: timestamps,
+            axisLabel: {
+              show: true,
+              formatter: formatCategoryDateLabel,
+              showMaxLabel: true,
+              showMinLabel: true,
+            },
+            axisTick: { show: false },
+            zlevel: 1,
+          },
+          yAxis: {
+            type: 'value',
+            name: 'Error Count',
+            nameGap: 40,
+            nameLocation: 'middle',
+            min: 0,
+            axisLabel: {
+              formatter: (value: number) => formatErrorCount(value),
+            },
+            axisLine: {
+              show: true,
+            },
+            axisTick: {
+              show: true,
+            },
+            splitLine: {
+              show: false,
+            },
+            zlevel: 1,
+          },
+          tooltip: {
+            show: true,
+            trigger: 'axis',
+            confine: true,
+            formatter: (params: unknown) => formatAxisTooltip(params, formatErrorCount),
+          },
+          series,
+          graphic: !hasData
+            ? [
+                {
+                  type: 'text',
+                  left: 'center',
+                  top: 'middle',
+                  style: {
+                    text: emptyMessage,
+                    fontSize: 18,
+                    fill: '#999',
+                    textAlign: 'center',
+                  },
+                },
+              ]
+            : [],
+        },
+        // groupBy 변경 등으로 series 수가 줄어도 이전 series가 병합되어 잔존하지 않도록 항상 교체한다.
+        { replaceMerge: ['series'] },
+      );
+    };
+
+    renderRef.current = render;
+    render();
+  }, [data, emptyMessage, chartInstanceRef, chartRef, renderRef]);
+
+  return <div className={cn('w-full h-full', className)} ref={chartRef} />;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartFetcher.tsx
@@ -1,12 +1,11 @@
-import 'billboard.js/dist/billboard.css';
 import React from 'react';
+import * as echarts from 'echarts/core';
+import { LineChart } from 'echarts/charts';
+import { GridComponent, TooltipComponent, LegendComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
 import { SystemMetricMetricInfo } from '@pinpoint-fe/ui/src/constants';
 import { useGetSystemMetricChartData, useGetSystemMetricTagsData } from '@pinpoint-fe/ui/src/hooks';
-import bb, { ChartOptions, line, canvas } from 'billboard.js/canvas';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import BillboardJS, { IChart } from '@billboard.js/react';
-import { isValid } from 'date-fns';
+import { getFormat } from '@pinpoint-fe/ui/src/utils';
 import { cn } from '../../../lib';
 import {
   Card,
@@ -23,7 +22,22 @@ import {
   SelectItem,
   Separator,
 } from '../../ui';
-import { formatNewLinedDateString, getFormat } from '@pinpoint-fe/ui/src/utils';
+import {
+  getGridBottom,
+  LEGEND_ICON_WIDTH,
+  LEGEND_ITEM_GAP,
+} from '../../../lib/charts/echartsLegendLayout';
+import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
+import {
+  formatAxisTooltip,
+  formatCategoryDateLabel,
+} from '../../../lib/charts/echartsTimeSeriesFormat';
+
+echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent, CanvasRenderer]);
+
+// 페이지의 모든 System Metric 차트를 하나의 echarts 그룹으로 묶어 tooltip/axisPointer를 동기화한다.
+// (billboard 의 tooltip.linked: true 대체)
+const SYSTEM_METRIC_CHART_GROUP = 'system-metric-chart';
 
 export interface SystemMetricChartFetcherProps {
   chartInfo: SystemMetricMetricInfo.MetricInfoData;
@@ -54,116 +68,120 @@ export const SystemMetricChartFetcher = ({
   const dataUnit = chartData?.metricValueGroups?.[0]?.unit || '';
   const title = chartData?.title || '';
 
-  const chartComponent = React.useRef<IChart>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  // canvas 모드는 차트 높이를 스스로 측정해 캔버스 크기로 쓰는데, Group 변경 시 suspense 리마운트 순간
-  // 높이가 0으로 측정되면 billboard 기본값(320px)으로 그려져 박스보다 커지며 잘린다. 컨테이너 높이를
-  // 직접 측정해 size.height로 넘기면 billboard가 측정/폴백 없이 그 높이로 그리고, 리사이즈에도 대응한다.
-  const [measuredHeight, setMeasuredHeight] = React.useState<number>();
-  React.useLayoutEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-    const updateHeight = () => {
-      const height = container.clientHeight;
-      if (height > 0) {
-        setMeasuredHeight(height);
-        chartComponent.current?.instance?.resize({ height });
-      }
-    };
-    updateHeight();
-    const resizeObserver = new ResizeObserver(updateHeight);
-    resizeObserver.observe(container);
-    return () => resizeObserver.disconnect();
-  }, []);
-  const options: ChartOptions = {
-    // v4 ESM: canvas 렌더링 모드 사용.
-    render: {
-      mode: canvas(),
-    },
-    ...(measuredHeight ? { size: { height: measuredHeight } } : {}),
-    data: {
-      x: 'dates',
-      columns: [],
-      empty: {
-        label: {
-          text: emptyMessage,
-        },
-      },
-      type: line(),
-    },
-    padding: {
-      mode: 'fit',
-      top: 20,
-      bottom: 10,
-      right: 25,
-      left: 15,
-    },
-    axis: {
-      x: {
-        type: 'timeseries',
-        tick: {
-          count: 4,
-          format: (date: Date) => {
-            if (isValid(date)) {
-              return `${formatNewLinedDateString(date)}`;
-            }
-            return '';
-          },
-        },
-      },
-      y: {
-        tick: {
-          format: getFormat(dataUnit),
-        },
-        padding: {
-          bottom: 0,
-        },
-        min: 0,
-        default: [0, 10],
-      },
-    },
-    point: {
-      r: 0,
-      focus: {
-        only: true,
-        expand: {
-          r: 3,
-        },
-      },
-    },
-    resize: {
-      auto: 'parent',
-      timer: false,
-    },
-    transition: {
-      duration: 0,
-    },
-    tooltip: {
-      linked: true,
-      order: '',
-      format: {
-        value: getFormat(dataUnit),
-      },
-    },
-  };
+  const { chartRef, chartInstanceRef, renderRef } = useEChartsInstance({
+    group: SYSTEM_METRIC_CHART_GROUP,
+  });
 
   React.useEffect(() => {
-    const chart = chartComponent.current?.instance;
+    if (!chartInstanceRef.current) return;
 
-    chart?.load({
-      columns: chartData
-        ? [
-            ['dates', ...chartData.timestamp],
-            ...(chartData.metricValueGroups?.[0]?.metricValues ?? []).map(
-              ({ fieldName, values }) => {
-                return [fieldName, ...values.map((v: number) => (v < 0 ? null : v))];
-              },
-            ),
-          ]
-        : [],
-      resizeAfter: true,
-    });
-  }, [chartData]);
+    const formatValue = getFormat(dataUnit);
+    const timestamps = chartData?.timestamp ?? [];
+    const metricValues = chartData?.metricValueGroups?.[0]?.metricValues ?? [];
+    const hasData =
+      timestamps.length > 0 &&
+      metricValues.some((mv) => mv.values && mv.values.some((v) => v >= 0));
+
+    const series = metricValues.map(({ fieldName, values }) => ({
+      name: fieldName,
+      type: 'line' as const,
+      data: values.map((v) => (v < 0 ? null : v)),
+      showSymbol: false,
+      smooth: false,
+      lineStyle: {
+        width: 1,
+      },
+      emphasis: {
+        focus: 'series' as const,
+      },
+    }));
+
+    const legendNames = metricValues.map((mv) => mv.fieldName);
+
+    const render = () => {
+      const chart = chartInstanceRef.current;
+      if (!chart) return;
+
+      const containerWidth = chartRef.current?.clientWidth ?? 0;
+      const gridBottom = getGridBottom(legendNames, containerWidth);
+
+      chart.setOption(
+        {
+          animation: false,
+          legend: {
+            data: legendNames,
+            bottom: 0,
+            icon: 'square',
+            itemWidth: LEGEND_ICON_WIDTH,
+            itemHeight: 10,
+            itemGap: LEGEND_ITEM_GAP,
+          },
+          grid: {
+            top: 20,
+            bottom: gridBottom,
+            right: 25,
+            left: 0,
+          },
+          xAxis: {
+            type: 'category',
+            data: timestamps,
+            axisLabel: {
+              show: true,
+              formatter: formatCategoryDateLabel,
+              showMaxLabel: true,
+              showMinLabel: true,
+            },
+            axisTick: { show: false },
+            zlevel: 1,
+          },
+          yAxis: {
+            type: 'value',
+            min: 0,
+            axisLabel: {
+              formatter: formatValue,
+            },
+            axisLine: {
+              show: true,
+            },
+            axisTick: {
+              show: true,
+            },
+            splitLine: {
+              show: false,
+            },
+            zlevel: 1,
+          },
+          tooltip: {
+            show: true,
+            trigger: 'axis',
+            confine: true,
+            formatter: (params: unknown) => formatAxisTooltip(params, formatValue),
+          },
+          series,
+          graphic: !hasData
+            ? [
+                {
+                  type: 'text',
+                  left: 'center',
+                  top: 'middle',
+                  style: {
+                    text: emptyMessage,
+                    fontSize: 18,
+                    fill: '#999',
+                    textAlign: 'center',
+                  },
+                },
+              ]
+            : [],
+        },
+        // tag/metric 변경으로 series 수가 줄어도 이전 series가 병합되어 잔존하지 않도록 항상 교체한다.
+        { replaceMerge: ['series'] },
+      );
+    };
+
+    renderRef.current = render;
+    render();
+  }, [chartData, dataUnit, emptyMessage, chartInstanceRef, chartRef, renderRef]);
 
   return (
     <Card className="rounded-lg">
@@ -192,10 +210,8 @@ export const SystemMetricChartFetcher = ({
         )}
       </CardHeader>
       <Separator />
-      <CardContent className="p-0 pb-1">
-        <div ref={containerRef} className={cn('w-full h-full min-h-0 overflow-hidden', className)}>
-          <BillboardJS bb={bb} ref={chartComponent} className="h-full w-full" options={options} />
-        </div>
+      <CardContent className="p-0 px-3 pb-2">
+        <div ref={chartRef} className={cn('w-full aspect-video', className)} />
       </CardContent>
     </Card>
   );

--- a/web-frontend/src/main/v3/packages/ui/src/components/URL/charts/UrlStatEChartsChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/URL/charts/UrlStatEChartsChart.tsx
@@ -3,10 +3,18 @@ import * as echarts from 'echarts/core';
 import { BarChart as BarChartEcharts, LineChart as LineChartEcharts } from 'echarts/charts';
 import { GridComponent, TooltipComponent, LegendComponent } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
-import { formatNewLinedDateString } from '@pinpoint-fe/ui/src/utils';
-import { isValid } from 'date-fns';
 import { UrlStatChartType as UrlStatChartApi } from '@pinpoint-fe/ui/src/constants';
 import { cn } from '../../../lib';
+import {
+  getGridBottom,
+  LEGEND_ICON_WIDTH,
+  LEGEND_ITEM_GAP,
+} from '../../../lib/charts/echartsLegendLayout';
+import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
+import {
+  formatAxisTooltip,
+  formatCategoryDateLabel,
+} from '../../../lib/charts/echartsTimeSeriesFormat';
 
 echarts.use([
   BarChartEcharts,
@@ -16,46 +24,6 @@ echarts.use([
   LegendComponent,
   CanvasRenderer,
 ]);
-
-// legend가 차트 폭에 따라 몇 줄로 줄바꿈되는지 계산해 grid.bottom을 동적으로 잡기 위한 상수/헬퍼.
-// 이렇게 해야 legend를 하단에 둔 채로 2줄짜리 x축 라벨과 겹치지 않는다.
-const LEGEND_FONT = '12px sans-serif'; // echarts legend 기본 폰트
-const LEGEND_ICON_WIDTH = 10; // legend.itemWidth
-const LEGEND_ICON_TEXT_GAP = 5; // 아이콘과 텍스트 사이 기본 간격
-const LEGEND_ITEM_GAP = 15; // legend.itemGap
-const LEGEND_PADDING = 5; // legend 기본 좌우 padding
-const LEGEND_ROW_HEIGHT = 20; // legend 한 줄 높이
-const X_AXIS_LABEL_HEIGHT = 38; // x축 2줄(날짜/시간) 라벨 높이 + 여백
-const BOTTOM_GAP = 12; // x축 라벨과 legend 사이 간격
-
-const measureCanvas = typeof document !== 'undefined' ? document.createElement('canvas') : null;
-const measureCtx = measureCanvas?.getContext('2d') ?? null;
-
-const getLegendRowCount = (names: string[], availableWidth: number) => {
-  if (!measureCtx || availableWidth <= 0 || names.length === 0) return 1;
-  measureCtx.font = LEGEND_FONT;
-
-  let rows = 1;
-  let lineWidth = 0;
-  for (const name of names) {
-    const textWidth = measureCtx.measureText(name).width;
-    const itemWidth = LEGEND_ICON_WIDTH + LEGEND_ICON_TEXT_GAP + textWidth;
-    const nextWidth = lineWidth === 0 ? itemWidth : lineWidth + LEGEND_ITEM_GAP + itemWidth;
-    if (nextWidth > availableWidth && lineWidth > 0) {
-      rows += 1;
-      lineWidth = itemWidth;
-    } else {
-      lineWidth = nextWidth;
-    }
-  }
-  return rows;
-};
-
-const getGridBottom = (names: string[], containerWidth: number) => {
-  const availableWidth = containerWidth - LEGEND_PADDING * 2;
-  const rows = getLegendRowCount(names, availableWidth);
-  return X_AXIS_LABEL_HEIGHT + BOTTOM_GAP + rows * LEGEND_ROW_HEIGHT;
-};
 
 export interface UrlStatEChartsChartProps {
   chartType: 'bar' | 'line';
@@ -76,31 +44,7 @@ export const UrlStatEChartsChart = ({
   className,
   emptyMessage = 'No Data',
 }: UrlStatEChartsChartProps) => {
-  const chartRef = React.useRef<HTMLDivElement>(null);
-  const chartInstanceRef = React.useRef<echarts.EChartsType | null>(null);
-  // 데이터 effect에서 만든 렌더 함수를 보관해, resize 시 폭에 맞춰 grid.bottom을 다시 계산한다.
-  const renderRef = React.useRef<(() => void) | null>(null);
-
-  React.useEffect(() => {
-    if (!chartRef.current) return;
-
-    const chart = echarts.init(chartRef.current);
-    chartInstanceRef.current = chart;
-
-    const wrapperElement = chartRef.current;
-    const resizeObserver = new ResizeObserver(() => {
-      chart.resize();
-      // 폭이 바뀌면 legend 줄바꿈 행 수가 달라지므로 grid.bottom을 다시 계산한다.
-      renderRef.current?.();
-    });
-    resizeObserver.observe(wrapperElement);
-
-    return () => {
-      resizeObserver.disconnect();
-      chart.dispose();
-      chartInstanceRef.current = null;
-    };
-  }, []);
+  const { chartRef, chartInstanceRef, renderRef } = useEChartsInstance();
 
   React.useEffect(() => {
     if (!chartInstanceRef.current) return;
@@ -178,14 +122,7 @@ export const UrlStatEChartsChart = ({
             data: timestamps,
             axisLabel: {
               show: true,
-              formatter: (value: number | string) => {
-                const ts = typeof value === 'string' ? Number(value) : value;
-                const date = new Date(ts);
-                if (isValid(date)) {
-                  return formatNewLinedDateString(date);
-                }
-                return String(value);
-              },
+              formatter: formatCategoryDateLabel,
               showMaxLabel: true,
               showMinLabel: true,
             },
@@ -217,39 +154,8 @@ export const UrlStatEChartsChart = ({
             show: true,
             trigger: 'axis',
             confine: true,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            formatter: (params: any) => {
-              if (!Array.isArray(params) || params.length === 0) return '';
-              const firstParam = params[0];
-              const axisValue = firstParam.axisValue;
-              const axisValueNum = typeof axisValue === 'number' ? axisValue : Number(axisValue);
-              const dateStr = isValid(new Date(axisValueNum))
-                ? formatNewLinedDateString(axisValueNum).replace('\n', ' ')
-                : String(axisValue);
-              const rows = params
-                .map(
-                  (param: {
-                    value?: number | [number, number];
-                    seriesName?: string;
-                    color?: string;
-                  }) => {
-                    const yValue = typeof param.value === 'number' ? param.value : param.value?.[1];
-                    if (yValue == null) return null;
-                    return `<div style="display: flex; justify-content: space-between; gap: 12px; align-items: center;">
-                  <div style="display: flex; gap: 5px; align-items: center;">
-                    <div style="width: 10px; height: 10px; background: ${param.color};"></div>${param.seriesName}
-                  </div>
-                  <div>${formatter ? formatter(yValue) : String(yValue)}</div>
-                </div>`;
-                  },
-                )
-                .filter(Boolean)
-                .join('');
-              return `<div>
-            <div style="margin-bottom: 5px;"><strong>${dateStr}</strong></div>
-            ${rows}
-          </div>`;
-            },
+            formatter: (params: unknown) =>
+              formatAxisTooltip(params, formatter ?? ((value: number) => String(value))),
           },
           series,
           graphic: !hasData
@@ -276,7 +182,17 @@ export const UrlStatEChartsChart = ({
 
     renderRef.current = render;
     render();
-  }, [data, emptyMessage, chartType, yAxisName, chartColors, formatter]);
+  }, [
+    data,
+    emptyMessage,
+    chartType,
+    yAxisName,
+    chartColors,
+    formatter,
+    chartInstanceRef,
+    chartRef,
+    renderRef,
+  ]);
 
   return <div className={cn('w-full h-full', className)} ref={chartRef} />;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsLegendLayout.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsLegendLayout.ts
@@ -1,0 +1,42 @@
+// 하단(bottom) legend를 쓰는 echarts 차트에서, legend가 차트 폭에 따라 몇 줄로 줄바꿈되는지
+// 계산해 grid.bottom을 동적으로 잡기 위한 상수/헬퍼. 이렇게 해야 legend를 하단에 둔 채로
+// 2줄짜리 x축 라벨과 겹치지 않는다.
+const LEGEND_FONT = '12px sans-serif'; // echarts legend 기본 폰트
+export const LEGEND_ICON_WIDTH = 10; // legend.itemWidth
+const LEGEND_ICON_TEXT_GAP = 5; // 아이콘과 텍스트 사이 기본 간격
+export const LEGEND_ITEM_GAP = 15; // legend.itemGap
+const LEGEND_PADDING = 5; // legend 기본 좌우 padding
+const LEGEND_ROW_HEIGHT = 20; // legend 한 줄 높이
+const X_AXIS_LABEL_HEIGHT = 38; // x축 2줄(날짜/시간) 라벨 높이 + 여백
+const BOTTOM_GAP = 12; // x축 라벨과 legend 사이 간격
+
+const measureCanvas = typeof document !== 'undefined' ? document.createElement('canvas') : null;
+const measureCtx = measureCanvas?.getContext('2d') ?? null;
+
+const getLegendRowCount = (names: string[], availableWidth: number) => {
+  if (!measureCtx || availableWidth <= 0 || names.length === 0) return 1;
+  measureCtx.font = LEGEND_FONT;
+
+  let rows = 1;
+  let lineWidth = 0;
+  for (const name of names) {
+    const textWidth = measureCtx.measureText(name).width;
+    const itemWidth = LEGEND_ICON_WIDTH + LEGEND_ICON_TEXT_GAP + textWidth;
+    const nextWidth = lineWidth === 0 ? itemWidth : lineWidth + LEGEND_ITEM_GAP + itemWidth;
+    if (nextWidth > availableWidth && lineWidth > 0) {
+      rows += 1;
+      lineWidth = itemWidth;
+    } else {
+      lineWidth = nextWidth;
+    }
+  }
+  return rows;
+};
+
+export const getGridBottom = (names: string[], containerWidth: number) => {
+  // 시리즈(=legend 항목)가 없으면(빈/No Data 상태) legend 공간을 예약하지 않는다.
+  if (names.length === 0) return X_AXIS_LABEL_HEIGHT;
+  const availableWidth = containerWidth - LEGEND_PADDING * 2;
+  const rows = getLegendRowCount(names, availableWidth);
+  return X_AXIS_LABEL_HEIGHT + BOTTOM_GAP + rows * LEGEND_ROW_HEIGHT;
+};

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsTimeSeriesFormat.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsTimeSeriesFormat.ts
@@ -1,0 +1,51 @@
+import { isValid } from 'date-fns';
+import { escapeHTMLEntities, formatNewLinedDateString } from '@pinpoint-fe/ui/src/utils';
+
+// category x축(timestamp) 라벨을 2줄짜리 날짜/시간 문자열로 포맷한다.
+export const formatCategoryDateLabel = (value: number | string) => {
+  const ts = typeof value === 'string' ? Number(value) : value;
+  const date = new Date(ts);
+  if (isValid(date)) {
+    return formatNewLinedDateString(date);
+  }
+  return String(value);
+};
+
+// trigger: 'axis' 툴팁의 공통 포맷터. 날짜 헤더 + 시리즈별 색상 스와치/값 행을 그린다.
+// 값 포맷은 차트마다 다르므로 formatValue 로 주입받는다.
+export const formatAxisTooltip = (
+  // echarts 툴팁 params 는 라이브러리 타입이 느슨해 any 로 받고 내부에서 좁힌다.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params: any,
+  formatValue: (value: number) => string,
+) => {
+  if (!Array.isArray(params) || params.length === 0) return '';
+  const axisValue = params[0].axisValue;
+  const axisValueNum = typeof axisValue === 'number' ? axisValue : Number(axisValue);
+  const dateStr = isValid(new Date(axisValueNum))
+    ? formatNewLinedDateString(axisValueNum).replace('\n', ' ')
+    : String(axisValue);
+  const rows = params
+    .map(
+      (param: {
+        value?: number | [number, number] | null;
+        seriesName?: string;
+        color?: string;
+      }) => {
+        const yValue = typeof param.value === 'number' ? param.value : param.value?.[1];
+        if (yValue == null) return null;
+        return `<div style="display: flex; justify-content: space-between; gap: 12px; align-items: center;">
+                  <div style="display: flex; gap: 5px; align-items: center;">
+                    <div style="width: 10px; height: 10px; background: ${param.color};"></div>${escapeHTMLEntities(String(param.seriesName ?? ''))}
+                  </div>
+                  <div>${formatValue(yValue)}</div>
+                </div>`;
+      },
+    )
+    .filter(Boolean)
+    .join('');
+  return `<div>
+            <div style="margin-bottom: 5px;"><strong>${escapeHTMLEntities(dateStr)}</strong></div>
+            ${rows}
+          </div>`;
+};

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/index.ts
@@ -1,4 +1,7 @@
+export * from './echartsLegendLayout';
+export * from './echartsTimeSeriesFormat';
 export * from './useChartAxis';
+export * from './useEChartsInstance';
 export * from './useChartConfig';
 export * from './useChartParseData';
 export * from './useChartTooltip';

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/useEChartsInstance.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/useEChartsInstance.ts
@@ -1,0 +1,44 @@
+import React from 'react';
+import * as echarts from 'echarts/core';
+
+export interface UseEChartsInstanceOptions {
+  // echarts.connect 그룹 id. 지정하면 같은 그룹의 차트끼리 tooltip/axisPointer 등이 동기화된다.
+  // (billboard 의 tooltip.linked 를 대체)
+  group?: string;
+}
+
+// 하단 legend를 쓰는 echarts 차트들이 공유하는 인스턴스 라이프사이클 훅.
+// echarts.init + ResizeObserver(resize 후 render 재호출) + dispose 를 담당하고,
+// 데이터 effect에서 만든 render 함수를 renderRef에 보관해 resize 시 다시 호출한다.
+export const useEChartsInstance = ({ group }: UseEChartsInstanceOptions = {}) => {
+  const chartRef = React.useRef<HTMLDivElement>(null);
+  const chartInstanceRef = React.useRef<echarts.EChartsType | null>(null);
+  const renderRef = React.useRef<(() => void) | null>(null);
+
+  React.useEffect(() => {
+    if (!chartRef.current) return;
+
+    const chart = echarts.init(chartRef.current);
+    chartInstanceRef.current = chart;
+    if (group) {
+      chart.group = group;
+      echarts.connect(group);
+    }
+
+    const wrapperElement = chartRef.current;
+    const resizeObserver = new ResizeObserver(() => {
+      chart.resize();
+      // 폭이 바뀌면 legend 줄바꿈 행 수가 달라지므로 render를 다시 호출해 grid.bottom을 재계산한다.
+      renderRef.current?.();
+    });
+    resizeObserver.observe(wrapperElement);
+
+    return () => {
+      resizeObserver.disconnect();
+      chart.dispose();
+      chartInstanceRef.current = null;
+    };
+  }, [group]);
+
+  return { chartRef, chartInstanceRef, renderRef };
+};

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ErrorAnalysis.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ErrorAnalysis.tsx
@@ -116,7 +116,7 @@ export const ErrorAnalysisPage = ({
         >
           <ErrorAnalysisSidebar />
           <>
-            <div className="py-2 bg-white border rounded h-72">
+            <div className="px-6 py-2 bg-white border rounded h-72">
               <ErrorAnalysisChart emptyMessage={t('COMMON.NO_DATA')} />
             </div>
             {groupBy ? (

--- a/web-frontend/src/main/v3/packages/ui/src/utils/string.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/string.test.ts
@@ -2,6 +2,7 @@ import {
   convertParamsToQueryString,
   extractStringAfterSubstring,
   decodeHTMLEntities,
+  escapeHTMLEntities,
 } from './string';
 
 describe('Test string utils', () => {
@@ -114,6 +115,33 @@ describe('Test string utils', () => {
       const text = 'Text &lt;tag&gt; with &amp; entities';
       const result = decodeHTMLEntities(text);
       expect(result).toBe('Text <tag> with & entities');
+    });
+  });
+
+  describe('Test "escapeHTMLEntities"', () => {
+    test('Escape HTML special characters', () => {
+      const text = '<img src=x onerror="alert(\'x\')">';
+      const result = escapeHTMLEntities(text);
+      expect(result).toBe('&lt;img src=x onerror=&quot;alert(&#39;x&#39;)&quot;&gt;');
+    });
+
+    test('Escape multiple special characters in a single pass', () => {
+      const result = escapeHTMLEntities('a & b < c');
+      expect(result).toBe('a &amp; b &lt; c');
+    });
+
+    test('Handle text without special characters', () => {
+      const text = 'plain text';
+      expect(escapeHTMLEntities(text)).toBe('plain text');
+    });
+
+    test('Handle empty string', () => {
+      expect(escapeHTMLEntities('')).toBe('');
+    });
+
+    test('Round-trip with decodeHTMLEntities', () => {
+      const text = '<div>&"test"\'value\'</div>';
+      expect(decodeHTMLEntities(escapeHTMLEntities(text))).toBe(text);
     });
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/utils/string.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/string.ts
@@ -26,3 +26,16 @@ export function decodeHTMLEntities(text: string): string {
 
   return text.replace(/&lt;|&gt;|&amp;|&quot;|&#39;/g, (match) => entities[match]);
 }
+
+// HTML 문자열에 서버 제공 값을 삽입할 때 인젝션을 막기 위해 특수문자를 엔티티로 이스케이프한다.
+export function escapeHTMLEntities(text: string): string {
+  const entities: { [key: string]: string } = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  };
+
+  return text.replace(/[&<>"']/g, (match) => entities[match]);
+}


### PR DESCRIPTION
## Summary
- Reimplement the **Error Analysis** and **System Metric** charts with ECharts (`LineChart` + `CanvasRenderer`), replacing billboard.js, following the pattern already used by the migrated URL Statistic chart.
- Extract the shared echarts scaffolding into `lib/charts` (`echartsLegendLayout`, `echartsTimeSeriesFormat`, `useEChartsInstance`) and consume it from Error Analysis, URL Statistic, and System Metric — removing duplication.
- Preserve original behavior: negative values rendered as gaps, per-unit / abbreviated y-axis, two-line date x-axis labels, dynamic bottom margin so the legend never overlaps x-axis labels, and empty-state message.
- System Metric cross-chart tooltip sync (previously billboard `tooltip.linked`) is restored via `echarts.connect` over a shared group; the tag Group selector is unchanged.
- Add horizontal padding to the Error Analysis chart card so axis labels are not flush against the border.

## Test plan
- [ ] Error Analysis & System Metric charts render with single and multiple series
- [ ] System Metric: hovering one chart shows a synchronized tooltip across the others
- [ ] System Metric: tag Group selector still switches data
- [ ] Empty/No Data state shows the placeholder text
- [ ] URL Statistic chart still renders (bar & line) after the shared-helper refactor
- [ ] `yarn build` passes
- [ ] `yarn test` passes (58 suites / 482 tests)