### PR TITLE
[#noissue] Store counterpart serviceUid in application-map link rowkey

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -69,7 +69,7 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
     public void outLink(long requestTime, Vertex selfVertex, String selfAgentId,
                         Vertex outVertex, String outHost, int elapsed, boolean isError) {
         Objects.requireNonNull(selfVertex, "selfVertex");
-        Objects.requireNonNull(outVertex, "inVertex");
+        Objects.requireNonNull(outVertex, "outVertex");
 
         if (logger.isDebugEnabled()) {
             logger.debug("[OutLink] {}/{} -> {}/{}", selfVertex, selfAgentId, outVertex, outHost);

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/InLinkFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/InLinkFactoryV3.java
@@ -58,7 +58,7 @@ public class InLinkFactoryV3 implements InLinkFactory {
             return UidLinkRowKey.of(
                     inVertex.serviceUid(), inVertex.applicationName(), inVertex.serviceType(),
                     timestamp,
-                    selfVertex.applicationName(), selfVertex.serviceType().getCode(), selfSubLink
+                    selfVertex.serviceUid(), selfVertex.applicationName(), selfVertex.serviceType().getCode(), selfSubLink
             );
         }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/OutLinkFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/OutLinkFactoryV3.java
@@ -57,7 +57,7 @@ public class OutLinkFactoryV3 implements OutLinkFactory {
             return UidLinkRowKey.of(
                     selfVertex.serviceUid(), selfVertex.applicationName(), selfVertex.serviceType(),
                     timestamp,
-                    outVertex.applicationName(), outVertex.serviceType().getCode(), outSubLink
+                    outVertex.serviceUid(), outVertex.applicationName(), outVertex.serviceType().getCode(), outSubLink
             );
         }
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKey.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.common.server.applicationmap.statistics;
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.BytesUtils;
 
@@ -38,19 +39,22 @@ public class UidLinkRowKey implements UidRowKey {
     private final String linkApplicationName;
     private final int linkServiceType;
     private final String subLink;
+    private final int linkServiceUid;
 
-    public static RowKey of(int serviceUid, String applicationName, ServiceType serviceType, long rowTimeSlot,
-                            String outApplicationName, int outServiceType, String outSubLink) {
-        return new UidLinkRowKey(serviceUid, applicationName, serviceType.getCode(), rowTimeSlot, outApplicationName, outServiceType, outSubLink);
+    public static RowKey of(int serviceUid, String applicationName, ServiceType serviceType,
+                            long rowTimeSlot,
+                            int outServiceUid, String outApplicationName, int outServiceType, String outSubLink) {
+        return new UidLinkRowKey(serviceUid, applicationName, serviceType.getCode(), rowTimeSlot, outServiceUid, outApplicationName, outServiceType, outSubLink);
     }
 
     public UidLinkRowKey(int serviceUid, String applicationName, int serviceType, long timestamp,
-                         String outApplicationName, int outServiceType, String subLink) {
+                         int outServiceUid, String outApplicationName, int outServiceType, String subLink) {
         this.serviceUid = serviceUid;
         this.applicationName = UidPrefix.requireNameLength(applicationName, "applicationName");
         this.serviceType = serviceType;
         this.timestamp = timestamp;
 
+        this.linkServiceUid = outServiceUid;
         this.linkApplicationName = Objects.requireNonNull(outApplicationName, "linkApplicationName");
         this.linkServiceType = outServiceType;
         this.subLink = Objects.requireNonNull(subLink, "outSubLink");
@@ -85,23 +89,30 @@ public class UidLinkRowKey implements UidRowKey {
         return linkServiceType;
     }
 
+    public int getLinkServiceUid() {
+        return linkServiceUid;
+    }
+
     public String getSubLink() {
         return subLink;
     }
 
     /**
      * <pre>
-     * rowkey format = "UidPrefix(16) + outApplicationNameHash(4) + outServiceType(4) + applicationName + outApplicationName + outSubLink"
+     * rowkey format = "UidPrefix(16) + outApplicationNameHash(4) + outServiceType(4) + applicationName + outApplicationName + outSubLink + outServiceUid(4)"
+     * outServiceUid is always appended at the tail. Legacy rows written before this field omit it; {@link #read} treats a
+     * missing tail as {@link ServiceUid#DEFAULT_SERVICE_UID_CODE} (no non-DEFAULT legacy data exists).
      * </pre>
      *
      * @param saltKeySize
      */
     public byte[] getRowKey(int saltKeySize) {
-        return makeRowKey(saltKeySize, serviceUid, applicationName, serviceType, timestamp, linkApplicationName, linkServiceType, subLink);
+        return makeRowKey(saltKeySize, serviceUid, applicationName, serviceType, timestamp, linkServiceUid, linkApplicationName, linkServiceType, subLink);
     }
 
-    public static byte[] makeRowKey(int saltKeySize, int serviceUid, String applicationName, int serviceType, long timestamp,
-                                    String outApplicationName, int outServiceType, String outSubLink) {
+    public static byte[] makeRowKey(int saltKeySize, int serviceUid, String applicationName, int serviceType,
+                                    long timestamp,
+                                    int outServiceUid, String outApplicationName, int outServiceType, String outSubLink) {
         UidPrefix.requireNameLength(applicationName, "applicationName");
 
         byte[] applicationNameBytes = BytesUtils.toBytes(applicationName);
@@ -115,7 +126,8 @@ public class UidLinkRowKey implements UidRowKey {
                                                   BytesUtils.INT_BYTE_LENGTH +
                                                   BytesUtils.computeSVar32ByteArraySize(applicationNameBytes) +
                                                   BytesUtils.computeSVar32ByteArraySize(outApplicationNameBytes) +
-                                                  BytesUtils.computeSVar32ByteArraySize(outSubLinkBytes)
+                                                  BytesUtils.computeSVar32ByteArraySize(outSubLinkBytes) +
+                                                  BytesUtils.INT_BYTE_LENGTH
         );
         buffer.skip(saltKeySize);
         UidPrefix.writePrefix(buffer, serviceUid, applicationNameBytes, serviceType, timestamp);
@@ -127,6 +139,9 @@ public class UidLinkRowKey implements UidRowKey {
         buffer.putPrefixedBytes(applicationNameBytes);
         buffer.putPrefixedBytes(outApplicationNameBytes);
         buffer.putPrefixedBytes(outSubLinkBytes);
+
+        // tail-appended link serviceUid (kept last for backward compatibility with legacy rows that omit it)
+        buffer.putInt(outServiceUid);
 
         return buffer.getBuffer();
     }
@@ -156,8 +171,24 @@ public class UidLinkRowKey implements UidRowKey {
         String outApplicationName = buffer.readPrefixedString();
         String outSubLink = buffer.readPrefixedString();
 
+        // tail-appended link serviceUid; absent in legacy rows -> assume DEFAULT service (no non-DEFAULT legacy data exists)
+        int outServiceUid = getOutServiceUid(buffer);
 
-        return new UidLinkRowKey(serviceUid, applicationName, serviceType, timestamp, outApplicationName, outServiceType, outSubLink);
+        return new UidLinkRowKey(serviceUid, applicationName, serviceType,
+                timestamp,
+                outServiceUid, outApplicationName, outServiceType, outSubLink);
+    }
+
+    private static int getOutServiceUid(Buffer buffer) {
+        final int remaining = buffer.remaining();
+        if (remaining == 0) {
+            return ServiceUid.DEFAULT_SERVICE_UID_CODE;
+        }
+        // fail fast on a truncated tail: readInt() does not check the slice bound
+        if (remaining < BytesUtils.INT_BYTE_LENGTH) {
+            throw new IllegalArgumentException("truncated outServiceUid tail, remaining:" + remaining);
+        }
+        return buffer.readInt();
     }
 
 
@@ -166,7 +197,7 @@ public class UidLinkRowKey implements UidRowKey {
         if (o == null || getClass() != o.getClass()) return false;
 
         UidLinkRowKey that = (UidLinkRowKey) o;
-        return serviceUid == that.serviceUid && serviceType == that.serviceType && timestamp == that.timestamp && linkServiceType == that.linkServiceType && Objects.equals(applicationName, that.applicationName) && Objects.equals(linkApplicationName, that.linkApplicationName) && Objects.equals(subLink, that.subLink);
+        return serviceUid == that.serviceUid && serviceType == that.serviceType && timestamp == that.timestamp && linkServiceType == that.linkServiceType && linkServiceUid == that.linkServiceUid && Objects.equals(applicationName, that.applicationName) && Objects.equals(linkApplicationName, that.linkApplicationName) && Objects.equals(subLink, that.subLink);
     }
 
     @Override
@@ -177,6 +208,7 @@ public class UidLinkRowKey implements UidRowKey {
         result = 31 * result + Long.hashCode(timestamp);
         result = 31 * result + Objects.hashCode(linkApplicationName);
         result = 31 * result + linkServiceType;
+        result = 31 * result + linkServiceUid;
         result = 31 * result + Objects.hashCode(subLink);
         return result;
     }
@@ -184,13 +216,11 @@ public class UidLinkRowKey implements UidRowKey {
     @Override
     public String toString() {
         return "UidLinkRowKey{" +
-               "serviceUid=" + serviceUid +
-               ", applicationName='" + applicationName + '\'' +
-               ", serviceType=" + serviceType +
-               ", timestamp=" + timestamp +
-               ", linkApplicationName='" + linkApplicationName + '\'' +
-               ", linkServiceType=" + linkServiceType +
-               ", outSubLink='" + subLink + '\'' +
+               serviceUid + '/' + applicationName + '/' + serviceType +
+               " -> " +
+               linkServiceUid + '/' + linkApplicationName + '/' + linkServiceType +
+               ", t=" + timestamp +
+               ", subLink='" + subLink + '\'' +
                '}';
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidPrefix.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidPrefix.java
@@ -126,10 +126,8 @@ public class UidPrefix {
     @Override
     public String toString() {
         return "UidPrefix{" +
-               "serviceUid=" + serviceUid +
-               ", applicationNameHash=" + applicationNameHash +
-               ", serviceType=" + serviceType +
-               ", timestamp=" + timestamp +
+               serviceUid + '/' + applicationNameHash + '/' + serviceType +
+               ", t=" + timestamp +
                '}';
     }
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKeyTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/applicationmap/statistics/UidLinkRowKeyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.applicationmap.statistics;
+
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UidLinkRowKeyTest {
+
+    @Test
+    void roundTrip_withLinkServiceUid() {
+        UidLinkRowKey key = (UidLinkRowKey) UidLinkRowKey.of(
+                1, "self-app", ServiceType.STAND_ALONE, 3000,
+                7, "link-app", ServiceType.JAVA.getCode(), "sub-link");
+
+        byte[] bytes = key.getRowKey(1);
+        UidLinkRowKey read = UidLinkRowKey.read(1, bytes);
+
+        assertThat(read).isEqualTo(key);
+        assertThat(read.getLinkServiceUid()).isEqualTo(7);
+    }
+
+    @Test
+    void roundTrip_defaultServiceUid_isStored() {
+        // DEFAULT(0) is a real serviceUid and must be persisted, not treated as unknown
+        UidLinkRowKey key = (UidLinkRowKey) UidLinkRowKey.of(
+                1, "self-app", ServiceType.STAND_ALONE, 3000,
+                ServiceUid.DEFAULT_SERVICE_UID_CODE, "link-app", ServiceType.JAVA.getCode(), "sub-link");
+
+        byte[] bytes = key.getRowKey(1);
+        UidLinkRowKey read = UidLinkRowKey.read(1, bytes);
+
+        assertThat(read.getLinkServiceUid()).isEqualTo(ServiceUid.DEFAULT_SERVICE_UID_CODE);
+        assertThat(read).isEqualTo(key);
+    }
+
+    @Test
+    void legacyRow_withoutTail_readsAsDefault() {
+        // a legacy row omits the trailing serviceUid; simulate it by stripping the tail int
+        byte[] rowKey = UidLinkRowKey.makeRowKey(0,
+                1, "self-app", ServiceType.STAND_ALONE.getCode(), 3000,
+                7, "link-app", ServiceType.JAVA.getCode(), "sub-link");
+        byte[] legacy = Arrays.copyOf(rowKey, rowKey.length - 4);
+
+        UidLinkRowKey read = UidLinkRowKey.read(0, legacy);
+
+        assertThat(read.getServiceUid()).isEqualTo(1);
+        assertThat(read.getLinkApplicationName()).isEqualTo("link-app");
+        assertThat(read.getLinkServiceType()).isEqualTo(ServiceType.JAVA.getCode());
+        // no non-DEFAULT legacy data exists, so a missing tail resolves to DEFAULT
+        assertThat(read.getLinkServiceUid()).isEqualTo(ServiceUid.DEFAULT_SERVICE_UID_CODE);
+    }
+
+    @Test
+    void truncatedTail_failsFast() {
+        byte[] rowKey = UidLinkRowKey.makeRowKey(0,
+                1, "self-app", ServiceType.STAND_ALONE.getCode(), 3000,
+                7, "link-app", ServiceType.JAVA.getCode(), "sub-link");
+
+        // 1~3 trailing bytes is neither a legacy row (0) nor a valid tail (4) -> corrupt
+        for (int truncated = 1; truncated <= 3; truncated++) {
+            byte[] corrupt = Arrays.copyOf(rowKey, rowKey.length - truncated);
+            assertThatThrownBy(() -> UidLinkRowKey.read(0, corrupt))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -23,7 +23,6 @@ import com.navercorp.pinpoint.common.hbase.ResultsExtractor;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowFunction;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapOutLinkDao;
@@ -88,7 +87,7 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
 
         ResultsExtractor<LinkDataMap> resultExtractor = new RowMapReduceResultExtractor<>(rowMapper, new LinkTimeWindowReducer(timeWindow));
 
-        final Scan scan = scanFactory.createScan("MOutLink", ServiceUid.DEFAULT_SERVICE_UID_CODE, outApplication, timeWindow.getWindowRange(), table.getName());
+        final Scan scan = scanFactory.createScan("MOutLink", outApplication.getService().getServiceUid(), outApplication, timeWindow.getWindowRange(), table.getName());
         final LinkDataMap linkDataMap = selectOutLink(scan, table.getTable(), resultExtractor, NUM_PARTITIONS);
         if (logger.isDebugEnabled()) {
             logger.debug("selectOutLink {} {}", outApplication, linkDataMap.getLinkDataSize());

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/InLinkV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/InLinkV3Mapper.java
@@ -161,7 +161,7 @@ public class InLinkV3Mapper implements RowMapper<LinkDataMap> {
     }
 
     private Application readSelfApplication(UidLinkRowKey self, ServiceType inServiceType) {
-        int serviceUid = self.getServiceUid();
+        int serviceUid = self.getLinkServiceUid();
         String selfApplicationName = self.getLinkApplicationName();
         int selfServiceType = self.getLinkServiceType();
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/OutLinkV3Mapper.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/OutLinkV3Mapper.java
@@ -122,7 +122,7 @@ public class OutLinkV3Mapper implements RowMapper<LinkDataMap> {
 
 
     private Application inApplication(UidLinkRowKey rowKey) {
-        int serviceUid = rowKey.getServiceUid();
+        int serviceUid = rowKey.getLinkServiceUid();
         String inApplicationName = rowKey.getLinkApplicationName();
         int inServiceType = rowKey.getLinkServiceType();
         return applicationFactory.createApplication(serviceUid, inApplicationName, inServiceType);


### PR DESCRIPTION
UidLinkRowKey now records the counterpart serviceUid as a mandatory tail field so reverse (inLink) lookups resolve cross-service links to the correct service instead of the row owner's serviceUid.

- makeRowKey always appends outServiceUid at the tail; read() treats a missing tail (legacy rows) as DEFAULT service (no non-DEFAULT legacy data exists), so no migration is required.
- Collector InLink/OutLink factories pass the counterpart serviceUid.
- Web mappers read getLinkServiceUid() directly (removed row-owner fallback).
- Compact toString for UidLinkRowKey/UidPrefix (uid/name/type).