### PR TITLE
[#noissue] Fix flaky MariaDB CallableStatement plugin IT

### DIFF
--- a/agent-module/plugins-it/mariadb-jdbc-it/src/test/java/com/navercorp/pinpoint/it/plugin/jdbc/MariaDB_3_x_IT.java
+++ b/agent-module/plugins-it/mariadb-jdbc-it/src/test/java/com/navercorp/pinpoint/it/plugin/jdbc/MariaDB_3_x_IT.java
@@ -138,8 +138,12 @@ public class MariaDB_3_x_IT extends MariaDB_IT_Base {
         Method executeQuery = jdbcApi.getPreparedStatement().getExecuteQuery();
         verifier.verifyTrace(event(DB_EXECUTE_QUERY, executeQuery, null, URL, DATABASE_NAME, sql(CALLABLE_STATEMENT_QUERY, null, CALLABLE_STATEMENT_INPUT_PARAM)));
 
-        Method executeQueryMethod = getMethod("org.mariadb.jdbc.ClientPreparedStatement", "executeQuery");
-        verifier.verifyTrace(event(DB_EXECUTE_QUERY, executeQueryMethod, null, URL, DATABASE_NAME, sql(CALLABLE_QUERY_META_INFOS_QUERY, null, "getPlaygroundByName, test")));
+        // The CallableParameterMetaData query is issued lazily/conditionally by the driver,
+        // so it is only present when traceCount == 6 (see the count check above).
+        if (traceCount == 6) {
+            Method executeQueryMethod = getMethod("org.mariadb.jdbc.ClientPreparedStatement", "executeQuery");
+            verifier.verifyTrace(event(DB_EXECUTE_QUERY, executeQueryMethod, null, URL, DATABASE_NAME, sql(CALLABLE_QUERY_META_INFOS_QUERY, null, "getPlaygroundByName, test")));
+        }
     }
 
     private Method getMethod(String className, String methodName, Class<?>... parameterTypes) {


### PR DESCRIPTION
The CallableParameterMetaData query (information_schema.PARAMETERS) is issued lazily and conditionally by the mariadb-java-client driver, so the testCallableStatement trace count is allowed to be 5 or 6. However the metadata-query trace was verified unconditionally, causing a NoSuchElementException in getSqlId when the query was not issued (traceCount == 5). Guard the verification with traceCount == 6.