### PR TITLE
[#noissue] Add RMI/JMX logging config and fix hadoop logger levels

### DIFF
--- a/batch/src/main/resources/log4j2-spring.xml
+++ b/batch/src/main/resources/log4j2-spring.xml
@@ -122,13 +122,24 @@
             <AppenderRef ref="console"/>
         </Logger>
 
-        <Logger name="org.apache.hadoop.hbase" level="${logger_level}" additivity="false">
+        <Logger name="org.apache.hadoop.hbase" level="INFO" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
-        <Logger name="org.apache.hadoop.ipc" level="${logger_level}" additivity="false">
+        <Logger name="org.apache.hadoop.ipc" level="INFO" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
-        <Logger name="org.apache.hadoop" level="${logger_level}" additivity="false">
+        <Logger name="org.apache.hadoop" level="INFO" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+
+        <!-- rmi logging -->
+        <Logger name="sun.datatransfer" level="INFO" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="sun.rmi" level="INFO" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="javax.management.remote" level="INFO" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
 

--- a/collector/src/main/resources/log4j2-spring.xml
+++ b/collector/src/main/resources/log4j2-spring.xml
@@ -143,6 +143,17 @@
             <!--<Appender-ref ref="console"/>-->
         </Logger>
 
+        <!-- rmi logging -->
+        <Logger name="sun.datatransfer" level="INFO" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="sun.rmi" level="INFO" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="javax.management.remote" level="INFO" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+
         <Root level="INFO">
             <AppenderRef ref="console"/>
             <AppenderRef ref="rollingFile"/>

--- a/web/src/main/resources/log4j2-spring.xml
+++ b/web/src/main/resources/log4j2-spring.xml
@@ -129,18 +129,30 @@
             <AppenderRef ref="console"/>
         </Logger>
 
-        <Logger name="org.apache.hadoop.hbase" level="${logger_level}" additivity="false">
+        <Logger name="org.apache.hadoop.hbase" level="INFO" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
-        <Logger name="org.apache.hadoop.ipc" level="${logger_level}" additivity="false">
+        <Logger name="org.apache.hadoop.ipc" level="INFO" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
-        <Logger name="org.apache.hadoop" level="${logger_level}" additivity="false">
+        <Logger name="org.apache.hadoop" level="INFO" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
         <Logger name="org.apache.pinot.client.Connection" level="FATAL" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
+
+        <!-- rmi logging -->
+        <Logger name="sun.datatransfer" level="INFO" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="sun.rmi" level="INFO" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="javax.management.remote" level="INFO" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+
         <Root level="INFO">
             <AppenderRef ref="console"/>
             <AppenderRef ref="rollingFile"/>


### PR DESCRIPTION
This pull request updates logging configurations across the `batch`, `collector`, and `web` modules to standardize log levels for Hadoop-related loggers and to add explicit logging for RMI-related classes. These changes help ensure consistent logging behavior and improve visibility into RMI operations.

**Logging configuration updates:**

* Set the log level for `org.apache.hadoop.hbase`, `org.apache.hadoop.ipc`, and `org.apache.hadoop` loggers to `INFO` instead of using the `${logger_level}` variable in `batch/src/main/resources/log4j2-spring.xml` and `web/src/main/resources/log4j2-spring.xml`. [[1]](diffhunk://#diff-64428e027f482e204f062480c3cc93d906cb16e2af77cd12b6f3cb5ed5316032L125-R142) [[2]](diffhunk://#diff-e3029a7e1a93cd131ed88c6130135f3dab887cef220537daf799a6a319de71c3L132-R155)

**RMI logging additions:**

* Added new loggers for `sun.datatransfer`, `sun.rmi`, and `javax.management.remote` at `INFO` level with console output in all three modules' `log4j2-spring.xml` files to improve monitoring of RMI-related activities. [[1]](diffhunk://#diff-64428e027f482e204f062480c3cc93d906cb16e2af77cd12b6f3cb5ed5316032L125-R142) [[2]](diffhunk://#diff-e3029a7e1a93cd131ed88c6130135f3dab887cef220537daf799a6a319de71c3L132-R155) [[3]](diffhunk://#diff-a900e92b77267cb05e9f566e7d4bc758b6ec3e63c0d197d4627f98d836bc0019R146-R156)