### PR TITLE
[#13924] Add BatchServiceModule for batch module service bean configuration

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/BatchModule.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/BatchModule.java
@@ -38,7 +38,6 @@ import com.navercorp.pinpoint.mybatis.MyBatisConfiguration;
 import com.navercorp.pinpoint.user.UserModule;
 import com.navercorp.pinpoint.web.WebHbaseModule;
 import com.navercorp.pinpoint.web.WebServiceConfig;
-import com.navercorp.pinpoint.web.applicationmap.servicemap.ServiceResolver;
 import com.navercorp.pinpoint.web.component.config.ComponentConfiguration;
 import com.navercorp.pinpoint.web.hyperlink.HyperLinkConfiguration;
 import com.navercorp.pinpoint.web.scatter.config.ScatterWebConfiguration;
@@ -46,7 +45,7 @@ import com.navercorp.pinpoint.web.trace.TraceConfiguration;
 import com.navercorp.pinpoint.web.uid.WebUidConfiguration;
 import com.navercorp.pinpoint.web.webhook.WebhookModule;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -59,6 +58,7 @@ import java.util.List;
         TransactionAutoConfiguration.class,
         BatchAppPropertySources.class,
 
+        BatchServiceModule.class,
         ComponentConfiguration.class,
         HyperLinkConfiguration.class,
 
@@ -102,12 +102,6 @@ import java.util.List;
         }
 )
 public class BatchModule {
-
-    @Bean
-    @ConditionalOnMissingBean(ServiceResolver.class)
-    public ServiceResolver serviceResolver() {
-        return ServiceResolver.emptyResolver();
-    }
 
     @Bean
     public AgentProperties agentProperties() {

--- a/batch/src/main/java/com/navercorp/pinpoint/batch/BatchServiceModule.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/BatchServiceModule.java
@@ -1,0 +1,41 @@
+package com.navercorp.pinpoint.batch;
+
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.util.IdGenerator;
+import com.navercorp.pinpoint.common.server.util.RandomServiceUidGenerator;
+import com.navercorp.pinpoint.service.config.ServiceMysqlConfiguration;
+import com.navercorp.pinpoint.service.service.ServiceRegistryService;
+import com.navercorp.pinpoint.web.applicationmap.servicemap.ServiceResolver;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+
+@Import({
+        ServiceMysqlConfiguration.class,
+})
+@ComponentScan(
+        basePackages = {
+                "com.navercorp.pinpoint.service.service",
+        }
+)
+public class BatchServiceModule {
+
+    @Bean
+    @ConditionalOnMissingBean(ServiceResolver.class)
+    public ServiceResolver serviceResolver() {
+        return ServiceResolver.emptyResolver();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "serviceUidGenerator")
+    public IdGenerator<ServiceUid> serviceUidGenerator() {
+        return new RandomServiceUidGenerator();
+    }
+
+    @Bean
+    public ServiceModelResolver serviceModelResolver(ServiceRegistryService serviceRegistryService) {
+        return new ServiceModelResolver(serviceRegistryService);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BatchServiceModule` to provide service-related beans (`ServiceResolver`, `ServiceMysqlConfiguration`, `ServiceModelResolver`, etc.) needed by the batch module
- Import `BatchServiceModule` in `BatchModule`