### PR TITLE
[#noissue] Add standalone OTLPTRACE collector type with OTLP/HTTP adm…

### DIFF
--- a/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/PinpointCollectorStarter.java
+++ b/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/PinpointCollectorStarter.java
@@ -92,12 +92,13 @@ public class PinpointCollectorStarter {
             metricAppBuilder.build().run(args);
         }
 
-        // OTLP Trace must run with metric.
-        // gRPC 9998 port is used for OTLP Trace.
-        if (types.hasType(CollectorType.METRIC)) {
-            logger.info(String.format("Start OTLP trace collector"));
-            SpringApplicationBuilder logAppBuilder = createAppBuilder(builder, 9999, OtlpTraceCollectorApp.class);
-            logAppBuilder.build().run(args);
+        // OTLP Trace runs as its own collector type (decoupled from METRIC).
+        // gRPC 9998 is used for OTLP/gRPC ingestion; the servlet port (9997) hosts the OTLP/HTTP
+        // endpoint (POST /v1/traces) and keeps the JVM alive when this app runs standalone.
+        if (types.hasType(CollectorType.OTLPTRACE)) {
+            logger.info(String.format("Start %s collector", CollectorType.OTLPTRACE));
+            SpringApplicationBuilder otlpTraceAppBuilder = createAppBuilder(builder, 9997, OtlpTraceCollectorApp.class);
+            otlpTraceAppBuilder.build().run(args);
         }
 
         if (types.hasType(CollectorType.LOG)) {

--- a/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/type/CollectorType.java
+++ b/collector-starter/src/main/java/com/navercorp/pinpoint/collector/starter/multi/application/type/CollectorType.java
@@ -25,6 +25,7 @@ public enum CollectorType {
     METRIC,
     LEGACY, // added type to change metric port temporarily.
     LOG,
+    OTLPTRACE,
     BASIC_WITH_INSPECTOR;
 
     public boolean hasType(CollectorType type) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorHttpModule.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorHttpModule.java
@@ -16,7 +16,12 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector;
 
+import com.navercorp.pinpoint.otlp.trace.collector.controller.OtlpTraceHttpAdmissionFilter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -26,9 +31,31 @@ import java.util.List;
 @Configuration
 public class OtlpTraceCollectorHttpModule implements WebMvcConfigurer {
 
+    public static final String OTLP_HTTP_TRACES_PATH = "/v1/traces";
+
     @Override
     public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
         ProtobufHttpMessageConverter protobufHttpMessageConverter = new ProtobufHttpMessageConverter();
         converters.add(protobufHttpMessageConverter);
+    }
+
+    /**
+     * Admission control for OTLP/HTTP trace ingestion, scoped to {@value #OTLP_HTTP_TRACES_PATH} so
+     * the actuator/management endpoints on the same port are unaffected. Runs first (highest
+     * precedence) to reject before the protobuf body is buffered/parsed. Mirrors the gRPC path's
+     * in-flight byte budget; kept as an independent (HTTP-only) budget for now.
+     */
+    @Bean
+    public FilterRegistrationBean<OtlpTraceHttpAdmissionFilter> otlpTraceHttpAdmissionFilter(
+            @Value("${pinpoint.collector.otlptrace.http.max-request-bytes:4194304}") int maxRequestBytes,
+            @Value("${pinpoint.collector.otlptrace.http.admission.max-in-flight-bytes:268435456}") int maxInFlightBytes,
+            @Value("${pinpoint.collector.otlptrace.http.max-concurrent-requests:64}") int maxConcurrentRequests,
+            @Value("${pinpoint.collector.otlptrace.http.rejected.retry-after-seconds:1}") int retryAfterSeconds) {
+        OtlpTraceHttpAdmissionFilter filter =
+                new OtlpTraceHttpAdmissionFilter(maxRequestBytes, maxInFlightBytes, maxConcurrentRequests, retryAfterSeconds);
+        FilterRegistrationBean<OtlpTraceHttpAdmissionFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.addUrlPatterns(OTLP_HTTP_TRACES_PATH);
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
     }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceHttpAdmissionFilter.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceHttpAdmissionFilter.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.controller;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+
+/**
+ * Admission control for the OTLP/HTTP trace ingestion endpoint (POST /v1/traces).
+ *
+ * <p>Mirrors the gRPC path ({@code GrpcOtlpTraceService}) safeguards on the servlet side, but
+ * enforced in a filter <b>before</b> the protobuf body is materialized by
+ * {@code ProtobufHttpMessageConverter}:
+ * <ul>
+ *   <li>per-request size cap &rarr; 413 (Content-Length check; unknown-length bodies are bounded
+ *       by a limiting input stream)</li>
+ *   <li>global in-flight byte budget (Semaphore) &rarr; 503 + Retry-After</li>
+ *   <li>concurrent request cap (Semaphore) &rarr; 503 + Retry-After</li>
+ * </ul>
+ * Permits are released in {@code finally} after the whole request (parse + insert) completes.
+ *
+ * <p>The byte budget is kept separate from the gRPC {@code admission.max-in-flight-bytes} for now
+ * (independent tuning / fault isolation); it can be unified behind a shared admission bean later.
+ */
+public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
+
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    private final int maxRequestBytes;
+    private final int maxInFlightBytes;
+    private final int maxConcurrentRequests;
+    private final int retryAfterSeconds;
+
+    // Global byte-based admission: caps the total in-flight request bytes so concurrent requests
+    // cannot exhaust the heap regardless of request count.
+    private final Semaphore admissionBytes;
+    // Request-count gate: guards the servlet thread pool against a flood of small requests.
+    private final Semaphore concurrency;
+
+    public OtlpTraceHttpAdmissionFilter(int maxRequestBytes, int maxInFlightBytes, int maxConcurrentRequests, int retryAfterSeconds) {
+        this.maxRequestBytes = maxRequestBytes;
+        this.maxInFlightBytes = maxInFlightBytes;
+        this.maxConcurrentRequests = maxConcurrentRequests;
+        this.retryAfterSeconds = retryAfterSeconds;
+        this.admissionBytes = new Semaphore(maxInFlightBytes);
+        this.concurrency = new Semaphore(maxConcurrentRequests);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 1) Size cap: reject before the body is buffered/parsed.
+        final long contentLength = request.getContentLengthLong();
+        if (contentLength > maxRequestBytes) {
+            reject(response, HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, false,
+                    "payload too large: contentLength=" + contentLength + ", max=" + maxRequestBytes);
+            return;
+        }
+        // Reserve the known length, or the max (pessimistic) when the length is unknown (chunked).
+        // contentLength is already <= maxRequestBytes (an int) here, so the cast is safe.
+        final int reserveBytes = contentLength >= 0 ? (int) contentLength : maxRequestBytes;
+
+        // 2) Concurrency gate.
+        if (!concurrency.tryAcquire()) {
+            reject(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, true,
+                    "concurrency limit exceeded: max=" + maxConcurrentRequests);
+            return;
+        }
+        // 3) In-flight byte gate.
+        if (!admissionBytes.tryAcquire(reserveBytes)) {
+            concurrency.release();
+            reject(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, true,
+                    "in-flight byte budget exhausted: reserve=" + reserveBytes + ", budget=" + maxInFlightBytes);
+            return;
+        }
+
+        try {
+            final HttpServletRequest effectiveRequest = contentLength >= 0
+                    ? request
+                    // Unknown length: cap the stream so a chunked body cannot exceed maxRequestBytes in heap.
+                    : new LimitedRequestWrapper(request, maxRequestBytes);
+            filterChain.doFilter(effectiveRequest, response);
+        } finally {
+            admissionBytes.release(reserveBytes);
+            concurrency.release();
+        }
+    }
+
+    private void reject(HttpServletResponse response, int status, boolean retryable, String reason) {
+        if (retryable) {
+            response.setHeader("Retry-After", Integer.toString(retryAfterSeconds));
+        }
+        response.setStatus(status);
+        logger.warn("OTLP/HTTP trace request rejected. status={}, reason={}", status, reason);
+    }
+
+    /**
+     * Wraps the request so an unknown-length (chunked) body is read through a size-limited stream.
+     */
+    private static final class LimitedRequestWrapper extends HttpServletRequestWrapper {
+        private final long limit;
+
+        private LimitedRequestWrapper(HttpServletRequest request, long limit) {
+            super(request);
+            this.limit = limit;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            return new LimitedServletInputStream(super.getInputStream(), limit);
+        }
+    }
+
+    /**
+     * Counting {@link ServletInputStream} that aborts once the body exceeds {@code limit} bytes.
+     * The resulting {@link IOException} surfaces to the protobuf converter as a read failure
+     * (HTTP 400), bounding heap usage for bodies without a Content-Length.
+     */
+    private static final class LimitedServletInputStream extends ServletInputStream {
+        private final ServletInputStream delegate;
+        private final long limit;
+        private long count;
+
+        private LimitedServletInputStream(ServletInputStream delegate, long limit) {
+            this.delegate = delegate;
+            this.limit = limit;
+        }
+
+        private void add(int read) throws IOException {
+            if (read <= 0) {
+                return;
+            }
+            count += read;
+            if (count > limit) {
+                throw new IOException("OTLP/HTTP request body exceeded max size: limit=" + limit);
+            }
+        }
+
+        @Override
+        public int read() throws IOException {
+            final int b = delegate.read();
+            add(b < 0 ? 0 : 1);
+            return b;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            final int n = delegate.read(b, off, len);
+            add(n);
+            return n;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return delegate.isFinished();
+        }
+
+        @Override
+        public boolean isReady() {
+            return delegate.isReady();
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            delegate.setReadListener(readListener);
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/pinpoint-otlptrace-grpc-root.properties
+++ b/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/pinpoint-otlptrace-grpc-root.properties
@@ -31,10 +31,10 @@ collector.receiver.grpc.otlp.trace.channel-type=AUTO
 
 # --- Flow control / message size (rate protection) ---
 # Bound concurrent calls per connection (ServerOption default is unlimited) and cap inbound
-# message size so a single OTLP exporter cannot overwhelm the receiver. Sized for a ~4GB server:
-# each in-flight call holds up to inbound_message_size_max of wire buffer, so 64 caps that to
-# ~64MB/connection of direct memory (the global ceiling is admission.max-in-flight-bytes below).
-collector.receiver.grpc.otlp.trace.concurrent-calls_per-connection_max=64
+# message size so a single OTLP exporter cannot overwhelm the receiver. Sized for a ~8GB server:
+# each in-flight call holds up to inbound_message_size_max of wire buffer, so 128 caps that to
+# ~128MB/connection of direct memory (the global ceiling is admission.max-in-flight-bytes below).
+collector.receiver.grpc.otlp.trace.concurrent-calls_per-connection_max=128
 collector.receiver.grpc.otlp.trace.flow-control_window_size_init=512KB
 collector.receiver.grpc.otlp.trace.inbound_message_size_max=1MB
 
@@ -49,8 +49,23 @@ pinpoint.collector.otlptrace.sql.max-bytes=8192
 pinpoint.collector.otlptrace.event.value-max-bytes=8192
 pinpoint.collector.otlptrace.link.value-max-bytes=8192
 # Global in-flight wire-byte ceiling (Semaphore admission). Bounds heap regardless of connection
-# count; export() reserves getSerializedSize() and returns UNAVAILABLE when exceeded. 128MB (4GB server).
-pinpoint.collector.otlptrace.admission.max-in-flight-bytes=134217728
+# count; export() reserves getSerializedSize() and returns UNAVAILABLE when exceeded. 256MB (8GB server).
+pinpoint.collector.otlptrace.admission.max-in-flight-bytes=268435456
+
+# --- OTLP/HTTP (POST /v1/traces) admission — servlet counterpart of the gRPC safeguards above,
+# enforced in OtlpTraceHttpAdmissionFilter *before* the protobuf body is materialized. Sized for an
+# ~8GB server. Kept as a separate (HTTP-only) budget for now; may be unified with the gRPC budget later.
+# Per-request body cap: 413 when Content-Length exceeds it (unknown-length bodies bounded by a
+# limiting stream -> 400). 4MB.
+pinpoint.collector.otlptrace.http.max-request-bytes=4194304
+# Global in-flight byte ceiling for HTTP (Semaphore). 256MB (~3% of an 8GB heap); 503 + Retry-After
+# when exceeded. At 4MB/request this admits up to ~64 max-size requests concurrently.
+pinpoint.collector.otlptrace.http.admission.max-in-flight-bytes=268435456
+# Concurrent in-flight HTTP requests (503 + Retry-After when exceeded); mirrors the gRPC
+# concurrent-calls_per-connection_max above.
+pinpoint.collector.otlptrace.http.max-concurrent-requests=64
+# Retry-After (seconds) returned on 503 backpressure.
+pinpoint.collector.otlptrace.http.rejected.retry-after-seconds=1
 
 # --- TLS (in-app) ---
 # Activated by pinpoint.modules.collector.grpc.otlptrace.ssl.enabled=true (default off).

--- a/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/profiles/local/pinpoint-otlptrace-grpc.properties
+++ b/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/profiles/local/pinpoint-otlptrace-grpc.properties
@@ -10,9 +10,11 @@ collector.receiver.grpc.otlp.trace.server.executor.queueCapacity=256
 collector.receiver.grpc.otlp.trace.server.executor.monitor-enable=true
 
 # Worker executor: runs export() mapping + insert (injected into GrpcOtlpTraceService).
+# queueCapacity aligned with the release profile (memory-bounded ~8GB); 1024 could queue ~3GB of
+# parsed requests, which is unbounded for any realistic dev heap.
 collector.receiver.grpc.otlp.trace.worker.executor.corePoolSize=16
 collector.receiver.grpc.otlp.trace.worker.executor.maxPoolSize=16
-collector.receiver.grpc.otlp.trace.worker.executor.queueCapacity=1024
+collector.receiver.grpc.otlp.trace.worker.executor.queueCapacity=128
 collector.receiver.grpc.otlp.trace.worker.executor.monitor-enable=true
 
 # Stream scheduler for rejected execution

--- a/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/profiles/release/pinpoint-otlptrace-grpc.properties
+++ b/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/profiles/release/pinpoint-otlptrace-grpc.properties
@@ -14,11 +14,12 @@ collector.receiver.grpc.otlp.trace.server.executor.monitor.duration.enable=false
 # Worker executor: runs export() mapping + span/spanChunk insert (injected into
 # GrpcOtlpTraceService). This is the real throughput/backpressure knob - a full queue
 # returns UNAVAILABLE (retryable) to the exporter.
-# Sized for a ~4GB server (>=4 cores): each queued task retains a whole parsed request
-# (<= inbound 1MB) ~3MB, each in-flight task ~6MB. 16/16/64 => ~96MB in-flight + ~192MB queued ~= ~288MB.
+# Sized for a ~8GB server (>=4 cores): each queued task retains a whole parsed request
+# (<= inbound 1MB) ~3MB, each in-flight task ~6MB. 16/16/128 => ~96MB in-flight + ~384MB queued ~= ~480MB.
+# Pool size is CPU-bound (raise with core count); queueCapacity is the memory knob scaled for 8GB.
 collector.receiver.grpc.otlp.trace.worker.executor.corePoolSize=16
 collector.receiver.grpc.otlp.trace.worker.executor.maxPoolSize=16
-collector.receiver.grpc.otlp.trace.worker.executor.queueCapacity=64
+collector.receiver.grpc.otlp.trace.worker.executor.queueCapacity=128
 collector.receiver.grpc.otlp.trace.worker.executor.monitor-enable=true
 collector.receiver.grpc.otlp.trace.worker.executor.monitor.duration.enable=true
 


### PR DESCRIPTION
Decouple OTLP trace ingestion from the METRIC collector: add a dedicated OTLPTRACE collector type started on servlet port 9997 (OTLP/gRPC stays on 9998), so it can run standalone.

Add an HTTP admission filter scoped to POST /v1/traces that enforces request-size, in-flight-byte, and concurrency limits before the protobuf body is materialized, mirroring the gRPC ingestion budget. Raise the gRPC worker/queue sizing to an ~8GB-server profile.