### PR TITLE
[#noissue] Pass parent Vertex to HostApplicationMap insert

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/HostApplicationMapDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/HostApplicationMapDao.java
@@ -24,6 +24,6 @@ import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
  * 
  */
 public interface HostApplicationMapDao {
-    void insert(long requestTime, String parentApplicationName, int parentServiceType, Vertex selfVertex, String host);
+    void insert(long requestTime, Vertex parentVertex, Vertex selfVertex, String host);
 
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/HostApplicationMapDaoDelegate.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/HostApplicationMapDaoDelegate.java
@@ -32,12 +32,12 @@ public class HostApplicationMapDaoDelegate implements HostApplicationMapDao {
     }
 
     @Override
-    public void insert(long requestTime, String parentApplicationName, int parentServiceType, Vertex selfVertex, String host) {
+    public void insert(long requestTime, Vertex parentVertex, Vertex selfVertex, String host) {
         for (HostApplicationMapDao delegate : delegates) {
             try {
-                delegate.insert(requestTime, parentApplicationName, parentServiceType, selfVertex, host);
+                delegate.insert(requestTime, parentVertex, selfVertex, host);
             } catch (Exception e) {
-                logger.warn("Failed to insert host application map. parentApplicationName:{}, parentServiceType:{}, selfVertex:{}, host:{}", parentApplicationName, parentServiceType, selfVertex, host, e);
+                logger.warn("Failed to insert host application map. parentVertex:{}, selfVertex:{}, host:{}", parentVertex, selfVertex, host, e);
             }
         }}
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HbaseHostApplicationMapDao.java
@@ -23,7 +23,6 @@ import com.navercorp.pinpoint.common.hbase.HbaseOperations;
 import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.util.Puts;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
@@ -71,32 +70,32 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
 
 
     @Override
-    public void insert(long requestTime, String parentApplicationName, int parentServiceType, Vertex selfVertex, String host) {
+    public void insert(long requestTime, Vertex parentVertex, Vertex selfVertex, String host) {
         Objects.requireNonNull(host, "host");
+        Objects.requireNonNull(parentVertex, "parentVertex");
         Objects.requireNonNull(selfVertex, "selfVertex");
         if (logger.isDebugEnabled()) {
-            logger.debug("insert HostApplicationMap host:{}, self:{} parent:{}/{}", host, selfVertex, parentApplicationName, parentServiceType);
+            logger.debug("insert HostApplicationMap parent:{} self:{} host:{}", parentVertex, selfVertex, host);
         }
 
         final long statisticsRowSlot = timeSlot.getTimeSlot(requestTime);
 
-        final CacheKey cacheKey = new CacheKey(selfVertex.applicationName(), selfVertex.serviceType().getCode(), selfVertex.serviceUid(), host,
-                parentApplicationName, parentServiceType, ServiceUid.DEFAULT_SERVICE_UID_CODE);
+        final CacheKey cacheKey = new CacheKey(parentVertex, selfVertex, host);
         final boolean needUpdate = updater.update(cacheKey, statisticsRowSlot);
         if (needUpdate) {
-            insertHostVer2(parentApplicationName, parentServiceType, selfVertex, host, statisticsRowSlot);
+            insertHostVer2(statisticsRowSlot, parentVertex, selfVertex, host);
         }
     }
 
-    private void insertHostVer2(String parentApplicationName, int parentServiceType, Vertex selfVertex, String host, long timestamp) {
+    private void insertHostVer2(long timestamp, Vertex parentVertex, Vertex selfVertex, String host) {
         if (logger.isDebugEnabled()) {
-            logger.debug("Insert HostApplicationMap Ver2 host={}, self={}, parent={}/{}",
-                    host, selfVertex, parentApplicationName, parentServiceType);
+            logger.debug("Insert HostApplicationMap Ver2 parent={} self={} host={}",
+                    parentVertex, selfVertex, host);
         }
 
         // TODO should consider to add bellow codes again later.
         //String parentAgentId = null;
-        final byte[] rowKey = hostLinkFactory.rowkey(parentApplicationName, parentServiceType, ServiceUid.DEFAULT_SERVICE_UID_CODE, timestamp);
+        final byte[] rowKey = hostLinkFactory.rowkey(parentVertex, timestamp);
 
         byte[] columnName = hostLinkFactory.columnName(selfVertex, host);
 
@@ -107,11 +106,11 @@ public class HbaseHostApplicationMapDao implements HostApplicationMapDao {
 
     }
 
-    private record CacheKey(String applicationName, int serviceType, int serviceUid, String host,
-                            String parentApplicationName, int parentServiceType, int parentServiceUid) {
+    private record CacheKey(Vertex parent, Vertex self, String host) {
 
             private CacheKey {
-                Objects.requireNonNull(applicationName, "applicationName");
+                Objects.requireNonNull(parent, "parent");
+                Objects.requireNonNull(self, "self");
                 Objects.requireNonNull(host, "host");
             }
     }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HostLinkFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/hbase/HostLinkFactory.java
@@ -19,7 +19,7 @@ package com.navercorp.pinpoint.collector.applicationmap.dao.hbase;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 
 public interface HostLinkFactory {
-    byte[] rowkey(String parentApplicationName, int parentServiceType, int parentServiceUid, long timestamp);
+    byte[] rowkey(Vertex parent, long timestamp);
 
     byte[] columnName(Vertex self, String host);
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/HostLinkFactoryV3.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/dao/v3/HostLinkFactoryV3.java
@@ -33,8 +33,8 @@ public class HostLinkFactoryV3 implements HostLinkFactory {
     }
 
     @Override
-    public byte[] rowkey(String parentApplicationName, int parentServiceType, int parentServiceUid, long timestamp) {
-        return this.rowKeyEncoder.encodeRowKey(parentApplicationName, parentServiceType, parentServiceUid, timestamp);
+    public byte[] rowkey(Vertex parent, long timestamp) {
+        return this.rowKeyEncoder.encodeRowKey(parent.applicationName(), parent.serviceType().getCode(), parent.serviceUid(), timestamp);
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -114,7 +114,7 @@ public class HbaseApplicationMapService implements ApplicationMapService {
         }
         ServiceType serviceType = registry.findServiceType(spanEvent.getServiceType());
         Vertex rpcVertex = Vertex.of(selfVertex.serviceUid(), destinationId, serviceType);
-        hostApplicationMapDao.insert(requestTime, selfVertex.applicationName(), selfVertex.serviceType().getCode(), rpcVertex, endPoint);
+        hostApplicationMapDao.insert(requestTime, selfVertex, rpcVertex, endPoint);
     }
 
     private void insertAcceptorHost(SpanBo span, Vertex selfVertex) {
@@ -131,8 +131,7 @@ public class HbaseApplicationMapService implements ApplicationMapService {
             logger.debug("parentApplication is null agent: {}/{}/{}", span.getServiceName(), span.getApplicationName(), span.getAgentId());
             return;
         }
-        final String parentApplicationName = parentApplication.applicationName();
-        final int parentServiceType = parentApplication.applicationServiceType();
+        final Vertex parentVertex = getParentVertex(parentApplication);
         final ServiceType spanServiceType = registry.findServiceType(span.getServiceType());
         if (spanServiceType.isQueue()) {
             final String host = span.getEndPoint();
@@ -140,9 +139,9 @@ public class HbaseApplicationMapService implements ApplicationMapService {
                 logger.debug("endPoint is null agent: {}/{}/{}", span.getServiceName(), span.getApplicationName(), span.getAgentId());
                 return;
             }
-            hostApplicationMapDao.insert(span.getCollectorAcceptTime(), parentApplicationName, parentServiceType, selfVertex, host);
+            hostApplicationMapDao.insert(span.getCollectorAcceptTime(), parentVertex, selfVertex, host);
         } else {
-            hostApplicationMapDao.insert(span.getCollectorAcceptTime(), parentApplicationName, parentServiceType, selfVertex, acceptorHost);
+            hostApplicationMapDao.insert(span.getCollectorAcceptTime(), parentVertex, selfVertex, acceptorHost);
         }
     }
 
@@ -210,7 +209,7 @@ public class HbaseApplicationMapService implements ApplicationMapService {
                         if (logger.isDebugEnabled()) {
                             logger.debug("[Bind] child-queue {}:{} <- {}", queueAcceptVertex, span.getRemoteAddr(), parentVertex);
                         }
-                        hostApplicationMapDao.insert(span.getCollectorAcceptTime(), parentVertex.applicationName(), parentVertex.serviceType().getCode(), queueAcceptVertex, span.getRemoteAddr());
+                        hostApplicationMapDao.insert(span.getCollectorAcceptTime(), parentVertex, queueAcceptVertex, span.getRemoteAddr());
                         // emulate virtual queue node's send SpanEvent
 
                         if (logger.isDebugEnabled()) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostScanKeyFactoryV3.java
@@ -18,7 +18,6 @@ package com.navercorp.pinpoint.web.applicationmap.dao.v3;
 
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.server.applicationmap.statistics.UidAppRowKey;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.web.applicationmap.dao.mapper.HostScanKeyFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 
@@ -27,8 +26,10 @@ public class HostScanKeyFactoryV3 implements HostScanKeyFactory {
 
     @Override
     public byte[] scanKey(Application parentApplication, long timestamp) {
-        return UidAppRowKey.makeRowKey(saltKeySize, ServiceUid.DEFAULT_SERVICE_UID_CODE,
-                parentApplication.getApplicationName(), parentApplication.getServiceTypeCode(),
+        return UidAppRowKey.makeRowKey(saltKeySize,
+                parentApplication.getService().getServiceUid(),
+                parentApplication.getApplicationName(),
+                parentApplication.getServiceTypeCode(),
                 timestamp);
     }
 }


### PR DESCRIPTION
Replace the parent applicationName/serviceType parameter pair with a parent Vertex so the parent serviceUid is carried through to the host-application-map rowkey instead of being hardcoded to DEFAULT.

- HostApplicationMapDao.insert takes a parent Vertex; call sites pass selfVertex, getParentVertex(parentApplication), or the existing parentVertex directly (which was previously decomposed, losing uid).
- HostLinkFactory.rowkey takes a Vertex, symmetric with columnName.
- CacheKey simplified to record(Vertex self, String host, Vertex parent).
- Web HostScanKeyFactoryV3 scans with the parent application's serviceUid instead of the hardcoded DEFAULT, matching the write path.