### PR TITLE
[#noissue] Make SpanBo/SpanChunkBo traceSourceType a final constructor argument

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/BasicSpan.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/BasicSpan.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.common.server.bo;
 
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import org.jspecify.annotations.NonNull;
 
 import java.util.function.Supplier;
 
@@ -27,6 +28,9 @@ import java.util.function.Supplier;
 public interface BasicSpan {
 
     int getVersion();
+
+    @NonNull
+    TraceSourceType getTraceSourceType();
 
     String getAgentId();
     void setAgentId(String agentId);
@@ -51,9 +55,6 @@ public interface BasicSpan {
 
     ServerTraceId getTransactionId();
 //    void setTransactionId(TransactionId transactionId);
-
-    TraceSourceType getTraceSourceType();
-    void setTraceSourceType(TraceSourceType traceSourceType);
 
     int getApplicationServiceType();
     void setApplicationServiceType(int applicationServiceType);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
@@ -42,6 +42,9 @@ public class SpanBo implements BasicSpan {
     // version 0 means that the type of prefix's size is int
     private byte version = 0;
 
+    @NonNull
+    private final TraceSourceType traceSourceType;
+
     //  private AgentKeyBo agentKeyBo;
     @NonNull
     private String agentId;
@@ -57,8 +60,6 @@ public class SpanBo implements BasicSpan {
     private long agentStartTime;
 
     private ServerTraceId transactionId;
-
-    private TraceSourceType traceSourceType = TraceSourceType.PINPOINT;
 
     private long spanId;
     private long parentSpanId;
@@ -97,6 +98,11 @@ public class SpanBo implements BasicSpan {
     private List<AttributeBo> attributeBoList = new ArrayList<>();
 
     public SpanBo() {
+        this(TraceSourceType.PINPOINT);
+    }
+
+    public SpanBo(TraceSourceType traceSourceType) {
+        this.traceSourceType = Objects.requireNonNull(traceSourceType, "traceSourceType");
     }
 
     @Override
@@ -112,6 +118,12 @@ public class SpanBo implements BasicSpan {
         this.version = ByteUtils.toUnsignedByte(version);
     }
 
+    @NonNull
+    @Override
+    public TraceSourceType getTraceSourceType() {
+        return traceSourceType;
+    }
+
     @Override
     public ServerTraceId getTransactionId() {
         return this.transactionId;
@@ -119,16 +131,6 @@ public class SpanBo implements BasicSpan {
 
     public void setTransactionId(ServerTraceId transactionId) {
         this.transactionId = transactionId;
-    }
-
-    @Override
-    public TraceSourceType getTraceSourceType() {
-        return traceSourceType;
-    }
-
-    @Override
-    public void setTraceSourceType(TraceSourceType traceSourceType) {
-        this.traceSourceType = Objects.requireNonNull(traceSourceType, "traceSourceType");
     }
 
     @NonNull
@@ -521,6 +523,7 @@ public class SpanBo implements BasicSpan {
     public String toString() {
         return "SpanBo{" +
                 "version=" + version +
+                ", traceSourceType=" + traceSourceType +
                 ", agentId='" + agentId + '\'' +
                 ", agentName='" + agentName + '\'' +
                 ", applicationName='" + applicationName + '\'' +
@@ -528,7 +531,6 @@ public class SpanBo implements BasicSpan {
                 ", serviceUid='" + serviceUidSupplier.get() + '\'' +
                 ", agentStartTime=" + agentStartTime +
                 ", transactionId=" + transactionId +
-                ", traceSourceType=" + traceSourceType +
                 ", spanId=" + spanId +
                 ", parentSpanId=" + parentSpanId +
                 ", parentApplication=" + parentApplication +

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
@@ -39,6 +39,8 @@ public class SpanChunkBo implements BasicSpan {
     private static final int UNDEFINED = ServiceType.UNDEFINED.getCode();
 
     private byte version = 0;
+    @NonNull
+    private final TraceSourceType traceSourceType;
 
     @NonNull
     private String agentId;
@@ -52,8 +54,6 @@ public class SpanChunkBo implements BasicSpan {
     private long agentStartTime;
 
     private ServerTraceId transactionId;
-
-    private TraceSourceType traceSourceType = TraceSourceType.PINPOINT;
 
     private long spanId;
     private String endPoint;
@@ -69,6 +69,11 @@ public class SpanChunkBo implements BasicSpan {
 
 
     public SpanChunkBo() {
+        this(TraceSourceType.PINPOINT);
+    }
+
+    public SpanChunkBo(TraceSourceType traceSourceType) {
+        this.traceSourceType = Objects.requireNonNull(traceSourceType, "traceSourceType");
     }
 
     @Override
@@ -78,6 +83,12 @@ public class SpanChunkBo implements BasicSpan {
 
     public void setVersion(int version) {
         this.version = ByteUtils.toUnsignedByte(version);
+    }
+
+    @NonNull
+    @Override
+    public TraceSourceType getTraceSourceType() {
+        return traceSourceType;
     }
 
     @Override
@@ -145,16 +156,6 @@ public class SpanChunkBo implements BasicSpan {
 
     public void setTransactionId(ServerTraceId transactionId) {
         this.transactionId = transactionId;
-    }
-
-    @Override
-    public TraceSourceType getTraceSourceType() {
-        return traceSourceType;
-    }
-
-    @Override
-    public void setTraceSourceType(TraceSourceType traceSourceType) {
-        this.traceSourceType = Objects.requireNonNull(traceSourceType, "traceSourceType");
     }
 
     @Override
@@ -260,6 +261,7 @@ public class SpanChunkBo implements BasicSpan {
     public String toString() {
         return "SpanChunkBo{" +
                 "version=" + version +
+                ", traceSourceType=" + traceSourceType +
                 ", agentId='" + agentId + '\'' +
                 ", agentName='" + agentName + '\'' +
                 ", applicationName='" + applicationName + '\'' +
@@ -267,7 +269,6 @@ public class SpanChunkBo implements BasicSpan {
                 ", serviceUid='" + serviceUidSupplier.get() + '\'' +
                 ", agentStartTime=" + agentStartTime +
                 ", transactionId=" + transactionId +
-                ", traceSourceType=" + traceSourceType +
                 ", spanId=" + spanId +
                 ", endPoint='" + endPoint + '\'' +
                 ", applicationServiceType=" + applicationServiceType +

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
@@ -75,11 +75,10 @@ public class SpanDecoderV0 implements SpanDecoder {
 
     private SpanChunkBo readSpanChunk(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext,
                                       TraceSourceType traceSourceType) {
-        final SpanChunkBo spanChunk = new SpanChunkBo();
+        final SpanChunkBo spanChunk = new SpanChunkBo(traceSourceType);
 
         final ServerTraceId transactionId = decodingContext.getTransactionId();
         spanChunk.setTransactionId(transactionId);
-        spanChunk.setTraceSourceType(traceSourceType);
         spanChunk.setCollectorAcceptTime(decodingContext.getCollectorAcceptedTime());
 
 
@@ -93,11 +92,10 @@ public class SpanDecoderV0 implements SpanDecoder {
 
     private SpanBo readSpan(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext,
                             TraceSourceType traceSourceType) {
-        final SpanBo span = new SpanBo();
+        final SpanBo span = new SpanBo(traceSourceType);
 
         final ServerTraceId transactionId = decodingContext.getTransactionId();
         span.setTransactionId(transactionId);
-        span.setTraceSourceType(traceSourceType);
         span.setCollectorAcceptTime(decodingContext.getCollectorAcceptedTime());
 
         readQualifier(span, qualifier, decodingContext);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/GrpcSpanBinder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/GrpcSpanBinder.java
@@ -90,7 +90,10 @@ public class GrpcSpanBinder {
 
     // for test
     SpanBo newSpanBo(PSpan pSpan, ServerHeader serverHeader, long requestTime) {
-        final SpanBo spanBo = new SpanBo();
+        return bind(new SpanBo(), pSpan, serverHeader, requestTime);
+    }
+
+    public SpanBo bind(SpanBo spanBo, PSpan pSpan, ServerHeader serverHeader, long requestTime) {
         spanBo.setAgentId(serverHeader.getAgentId());
         spanBo.setAgentName(serverHeader.getAgentName());
         spanBo.setApplicationName(serverHeader.getApplicationName());
@@ -279,7 +282,10 @@ public class GrpcSpanBinder {
 
     // for test
     SpanChunkBo newSpanChunkBo(PSpanChunk pSpanChunk, ServerHeader serverHeader, long requestTime) {
-        final SpanChunkBo spanChunkBo = new SpanChunkBo();
+        return bind(new SpanChunkBo(), pSpanChunk, serverHeader, requestTime);
+    }
+
+    public SpanChunkBo bind(SpanChunkBo spanChunkBo, PSpanChunk pSpanChunk, ServerHeader serverHeader, long requestTime) {
         spanChunkBo.setAgentId(serverHeader.getAgentId());
         spanChunkBo.setAgentName(serverHeader.getAgentName());
         spanChunkBo.setApplicationName(serverHeader.getApplicationName());

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0Test.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0Test.java
@@ -91,7 +91,7 @@ class SpanDecoderV0Test {
     }
 
     private SpanBo newMinimalSpan(TraceSourceType type) {
-        SpanBo span = new SpanBo();
+        SpanBo span = new SpanBo(type);
         span.setAgentId("agent");
         span.setApplicationName("app");
         span.setAgentStartTime(100L);
@@ -100,18 +100,16 @@ class SpanDecoderV0Test {
         span.setServiceType((short) 1000);
         span.setTraceTime(SpanVersion.TRACE_V2, System.currentTimeMillis(), 0);
         span.setCollectorAcceptTime(System.currentTimeMillis());
-        span.setTraceSourceType(type);
         return span;
     }
 
     private SpanChunkBo newMinimalSpanChunk(TraceSourceType type) {
-        SpanChunkBo chunk = new SpanChunkBo();
+        SpanChunkBo chunk = new SpanChunkBo(type);
         chunk.setAgentId("agent");
         chunk.setApplicationName("app");
         chunk.setAgentStartTime(100L);
         chunk.setSpanId(1L);
         chunk.setCollectorAcceptTime(System.currentTimeMillis());
-        chunk.setTraceSourceType(type);
         return chunk;
     }
 

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
@@ -102,8 +102,7 @@ public class SpanEncoderTest {
 
     @RepeatedTest(REPEAT_COUNT)
     public void testEncodeSpan_otelSource_qualifierByteAndRoundTrip() {
-        SpanBo spanBo = randomComplexSpan();
-        spanBo.setTraceSourceType(TraceSourceType.OPENTELEMETRY);
+        SpanBo spanBo = randomComplexSpan(TraceSourceType.OPENTELEMETRY);
 
         SpanEncodingContext<SpanBo> ctx = new SpanEncodingContext<>(spanBo);
         ByteBuffer qualifier = spanEncoder.encodeSpanQualifier(ctx);
@@ -116,8 +115,7 @@ public class SpanEncoderTest {
 
     @RepeatedTest(REPEAT_COUNT)
     public void testEncodeSpanChunk_otelSource_qualifierByteAndRoundTrip() {
-        SpanChunkBo spanChunkBo = randomComplexSpanChunk();
-        spanChunkBo.setTraceSourceType(TraceSourceType.OPENTELEMETRY);
+        SpanChunkBo spanChunkBo = randomComplexSpanChunk(TraceSourceType.OPENTELEMETRY);
 
         SpanEncodingContext<SpanChunkBo> ctx = new SpanEncodingContext<>(spanChunkBo);
         ByteBuffer qualifier = spanEncoder.encodeSpanChunkQualifier(ctx);
@@ -167,6 +165,10 @@ public class SpanEncoderTest {
     }
 
     public SpanBo randomComplexSpan() {
+        return randomComplexSpan(TraceSourceType.PINPOINT);
+    }
+
+    public SpanBo randomComplexSpan(TraceSourceType traceSourceType) {
         PSpan.Builder pSpan = randomTSpan.randomPSpan();
         PSpanEvent spanEvent1 = randomTSpan.randomTSpanEvent((short) 1);
         PSpanEvent spanEvent2 = randomTSpan.randomTSpanEvent((short) 2);
@@ -174,7 +176,10 @@ public class SpanEncoderTest {
         PSpanEvent spanEvent4 = randomTSpan.randomTSpanEvent((short) 5);
 
         pSpan.addAllSpanEvent(List.of(spanEvent1, spanEvent2, spanEvent3, spanEvent4));
-        return grpcSpanFactory.buildSpanBo(pSpan.build(), header, requestTime);
+        PSpan span = pSpan.build();
+        SpanBo spanBo = grpcSpanBinder.bind(new SpanBo(traceSourceType), span, header, requestTime);
+        spanBo.addSpanEventBoList(grpcSpanBinder.bindSpanEventBoList(span.getSpanEventList()));
+        return spanBo;
     }
 
     private SpanChunkBo randomSpanChunk() {
@@ -183,6 +188,10 @@ public class SpanEncoderTest {
     }
 
     public SpanChunkBo randomComplexSpanChunk() {
+        return randomComplexSpanChunk(TraceSourceType.PINPOINT);
+    }
+
+    public SpanChunkBo randomComplexSpanChunk(TraceSourceType traceSourceType) {
         PSpanChunk.Builder spanChunk = randomTSpan.randomTSpanChunk();
         PSpanEvent spanEvent1 = randomTSpan.randomTSpanEvent((short) 1);
         PSpanEvent spanEvent2 = randomTSpan.randomTSpanEvent((short) 2);
@@ -190,7 +199,10 @@ public class SpanEncoderTest {
         PSpanEvent spanEvent4 = randomTSpan.randomTSpanEvent((short) 5);
 
         spanChunk.addAllSpanEvent(List.of(spanEvent1, spanEvent2, spanEvent3, spanEvent4));
-        return grpcSpanFactory.buildSpanChunkBo(spanChunk.build(), header, requestTime);
+        PSpanChunk chunk = spanChunk.build();
+        SpanChunkBo spanChunkBo = grpcSpanBinder.bind(new SpanChunkBo(traceSourceType), chunk, header, requestTime);
+        spanChunkBo.addSpanEventBoList(grpcSpanBinder.bindSpanEventBoList(chunk.getSpanEventList()));
+        return spanChunkBo;
     }
 
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanChunkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanChunkMapper.java
@@ -42,8 +42,7 @@ public class OtlpTraceSpanChunkMapper {
     }
 
     SpanChunkBo map(IdAndName idAndName, Span span) {
-        SpanChunkBo spanChunkBo = new SpanChunkBo();
-        spanChunkBo.setTraceSourceType(TraceSourceType.OPENTELEMETRY);
+        SpanChunkBo spanChunkBo = new SpanChunkBo(TraceSourceType.OPENTELEMETRY);
 
         spanChunkBo.setAgentId(idAndName.agentId());
         if (idAndName.agentName() != null) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -65,8 +65,7 @@ public class OtlpTraceSpanMapper {
     }
 
     SpanBo map(IdAndName idAndName, Span span) {
-        SpanBo spanBo = new SpanBo();
-        spanBo.setTraceSourceType(TraceSourceType.OPENTELEMETRY);
+        SpanBo spanBo = new SpanBo(TraceSourceType.OPENTELEMETRY);
         spanBo.setAgentId(idAndName.agentId());
         if (idAndName.agentName() != null) {
             spanBo.setAgentName(idAndName.agentName());


### PR DESCRIPTION
The trace source type classifies a span record at creation time (the
decoder even dispatches on it before reading the version), so it should
never change after construction.

- SpanBo/SpanChunkBo take TraceSourceType in the constructor; the
  no-arg constructor defaults to PINPOINT. The field is final, declared
  next to version, and the setter is removed from BasicSpan and the Bo
  classes.
- SpanDecoderV0 and the OTel trace mappers pass the source type at
  construction instead of mutating it afterwards.
- GrpcSpanBinder splits creation from binding: newSpanBo/newSpanChunkBo
  delegate to a public bind(target, ...) so tests can bind proto data
  onto an OTel-sourced instance without widening the production
  factory API.
- SpanEncoderTest builds OTel spans via randomComplexSpan(sourceType)
  overloads (including the span-event binding step); SpanDecoderV0Test
  uses the constructors.
