### PR TITLE
[#noissue] Simplify TraceSourceType.of with explicit branches

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/TraceSourceType.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/TraceSourceType.java
@@ -39,13 +39,12 @@ public enum TraceSourceType {
     }
 
     public static TraceSourceType of(byte code) {
-        for (TraceSourceType type : VALUES) {
-            if (type.code == code) {
-                return type;
-            }
+        if (code == PINPOINT.code) {
+            return PINPOINT;
+        }
+        if (code == OPENTELEMETRY.code) {
+            return OPENTELEMETRY;
         }
         throw new IllegalArgumentException("unknown TraceSourceType code:" + code);
     }
-
-    private static final TraceSourceType[] VALUES = values();
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/TraceSourceTypeTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/TraceSourceTypeTest.java
@@ -43,6 +43,9 @@ class TraceSourceTypeTest {
 
     @Test
     void of_roundTrip() {
+        // of() is a hand-written if-else: this exhaustive values() sweep fails when a new
+        // constant is added without extending of(), and isSameAs also fails when a constant
+        // reuses another's code (of() would resolve to the first match).
         for (TraceSourceType type : TraceSourceType.values()) {
             assertThat(TraceSourceType.of(type.getCode())).isSameAs(type);
         }


### PR DESCRIPTION
Replace the cached values() loop with two explicit branches -- clearer
for a two-constant enum and removes the VALUES field. The exhaustive
of_roundTrip sweep guards future additions: a missing branch fails with
IllegalArgumentException (or a mismatch when a code is reused), so the
comment documents that role.
