### PR TITLE
[#noissue] Map OTel span errors to Pinpoint Span/SpanEvent exceptions

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/ExceptionInfo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/ExceptionInfo.java
@@ -2,4 +2,56 @@ package com.navercorp.pinpoint.common.server.bo;
 
 public record ExceptionInfo(int id, String message) {
 
+    /**
+     * Placeholder id used for OpenTelemetry-sourced exceptions. Unlike the native agent path,
+     * OTel has no {@code StringMetaData} entry backing the exception class name, so the class
+     * name cannot be resolved from {@link #id()}. Instead the class name is encoded into
+     * {@link #message()} together with the exception message (see {@link #OTEL_MESSAGE_DELIMITER}),
+     * and this id is left as a fixed placeholder. The web side distinguishes the OTel encoding
+     * via the span's {@code TraceSourceType}, not via this id.
+     */
+    public static final int OTEL_EXCEPTION_ID = 0;
+
+    /**
+     * Separates the exception class name from the exception message inside {@link #message()}
+     * for OpenTelemetry-sourced exceptions, encoded as {@code "<className><delimiter><message>"}.
+     * <p>
+     * The class name is always written as the prefix (an empty string when unknown) and never
+     * contains this character (Java fully-qualified class names have no {@code ':'}), so a reader
+     * splits on the FIRST occurrence: the prefix is the class name (empty ⇒ unknown) and the
+     * remainder — which may itself contain {@code ':'} — is the message.
+     */
+    public static final char OTEL_MESSAGE_DELIMITER = ':';
+
+    /**
+     * Extracts the exception class name from an OTel-encoded {@link #message()} — the prefix
+     * before the first {@link #OTEL_MESSAGE_DELIMITER}. Returns {@code null} when the class name
+     * is unknown (empty prefix / no delimiter), so the caller renders no exception type.
+     */
+    public static String otelClassName(String message) {
+        if (message == null) {
+            return null;
+        }
+        final int idx = message.indexOf(OTEL_MESSAGE_DELIMITER);
+        if (idx <= 0) {
+            return null;
+        }
+        return message.substring(0, idx);
+    }
+
+    /**
+     * Extracts the exception message from an OTel-encoded {@link #message()} — everything after
+     * the first {@link #OTEL_MESSAGE_DELIMITER} (which may itself contain the delimiter). Falls
+     * back to the whole string when no delimiter is present.
+     */
+    public static String otelMessageBody(String message) {
+        if (message == null) {
+            return null;
+        }
+        final int idx = message.indexOf(OTEL_MESSAGE_DELIMITER);
+        if (idx < 0) {
+            return message;
+        }
+        return message.substring(idx + 1);
+    }
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/ExceptionInfoTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/ExceptionInfoTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExceptionInfoTest {
+
+    @Test
+    void otelClassName_present() {
+        assertThat(ExceptionInfo.otelClassName("java.io.IOException:disk full"))
+                .isEqualTo("java.io.IOException");
+    }
+
+    @Test
+    void otelClassName_emptyPrefix_isNull() {
+        // message-only encoding starts with the delimiter → no class name
+        assertThat(ExceptionInfo.otelClassName(":Connection refused")).isNull();
+    }
+
+    @Test
+    void otelClassName_noDelimiter_isNull() {
+        assertThat(ExceptionInfo.otelClassName("no delimiter")).isNull();
+    }
+
+    @Test
+    void otelClassName_null_isNull() {
+        assertThat(ExceptionInfo.otelClassName(null)).isNull();
+    }
+
+    @Test
+    void otelMessageBody_present() {
+        assertThat(ExceptionInfo.otelMessageBody("java.io.IOException:disk full"))
+                .isEqualTo("disk full");
+    }
+
+    @Test
+    void otelMessageBody_keepsColonsInMessage() {
+        // split on the FIRST delimiter only; the message may contain further colons
+        assertThat(ExceptionInfo.otelMessageBody(":Connection refused: localhost:8080"))
+                .isEqualTo("Connection refused: localhost:8080");
+    }
+
+    @Test
+    void otelMessageBody_emptyMessage() {
+        assertThat(ExceptionInfo.otelMessageBody("java.io.IOException:")).isEmpty();
+    }
+
+    @Test
+    void otelMessageBody_noDelimiter_returnsWhole() {
+        assertThat(ExceptionInfo.otelMessageBody("plain")).isEqualTo("plain");
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/ExceptionAttributeUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/ExceptionAttributeUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
+import io.opentelemetry.proto.trace.v1.Span;
+
+import java.util.Map;
+
+/**
+ * Shared helpers for reading the OTel {@code exception} span event and its attributes.
+ * Used both by {@link OtlpExceptionMapper} (exception-trace metadata) and by
+ * {@link OtlpTraceSpanMapper#resolveErrorExceptionInfo} (SpanBo/SpanEventBo exceptionInfo),
+ * so the exception class-name resolution stays consistent between the two.
+ */
+public final class ExceptionAttributeUtils {
+
+    private ExceptionAttributeUtils() {
+    }
+
+    /**
+     * Returns the first {@code exception} event on the span, or {@code null} when absent.
+     */
+    public static Span.Event findExceptionEvent(Span span) {
+        for (Span.Event event : span.getEventsList()) {
+            if (OtlpTraceConstants.EVENT_NAME_EXCEPTION.equals(event.getName())) {
+                return event;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the exception class name, preferring the event's {@code exception.type} and
+     * falling back to the span attribute {@code error.type}. Returns {@code null} when neither
+     * is present.
+     */
+    public static String resolveExceptionType(Map<String, AttributeValue> eventAttributes,
+                                              Map<String, AttributeValue> spanAttributes) {
+        final String eventType = AttributeUtils.getAttributeStringValue(eventAttributes, OtlpTraceConstants.ATTRIBUTE_KEY_EXCEPTION_TYPE, null);
+        if (StringUtils.hasLength(eventType)) {
+            return eventType;
+        }
+        return AttributeUtils.getAttributeStringValue(spanAttributes, OtlpTraceConstants.ATTRIBUTE_KEY_ERROR_TYPE, null);
+    }
+
+    /**
+     * Returns the event's {@code exception.message}, or {@code null} when absent.
+     */
+    public static String getExceptionMessage(Map<String, AttributeValue> eventAttributes) {
+        return AttributeUtils.getAttributeStringValue(eventAttributes, OtlpTraceConstants.ATTRIBUTE_KEY_EXCEPTION_MESSAGE, null);
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapper.java
@@ -33,11 +33,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceConstants.ATTRIBUTE_KEY_ERROR_TYPE;
 import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceConstants.ATTRIBUTE_KEY_EXCEPTION_MESSAGE;
 import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceConstants.ATTRIBUTE_KEY_EXCEPTION_STACKTRACE;
-import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceConstants.ATTRIBUTE_KEY_EXCEPTION_TYPE;
-import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceConstants.EVENT_NAME_EXCEPTION;
 
 @Component
 public class OtlpExceptionMapper {
@@ -59,17 +56,14 @@ public class OtlpExceptionMapper {
      * exceptionId discriminator instead.
      */
     public Optional<ExceptionMetaDataBo> map(IdAndName idAndName, Span exceptionSpan, long rootSpanId, String uriTemplate) {
-        Span.Event exceptionEvent = findExceptionEvent(exceptionSpan);
+        Span.Event exceptionEvent = ExceptionAttributeUtils.findExceptionEvent(exceptionSpan);
         if (exceptionEvent == null) {
             return Optional.empty();
         }
 
         final Map<String, AttributeValue> eventAttrs = OtlpTraceMapperUtils.getAttributeValueMap(exceptionEvent.getAttributesList());
-        String exceptionType = AttributeUtils.getAttributeStringValue(eventAttrs, ATTRIBUTE_KEY_EXCEPTION_TYPE, null);
-        if (exceptionType == null) {
-            final Map<String, AttributeValue> spanAttrs = OtlpTraceMapperUtils.getAttributeValueMap(exceptionSpan.getAttributesList());
-            exceptionType = AttributeUtils.getAttributeStringValue(spanAttrs, ATTRIBUTE_KEY_ERROR_TYPE, null);
-        }
+        final Map<String, AttributeValue> spanAttrs = OtlpTraceMapperUtils.getAttributeValueMap(exceptionSpan.getAttributesList());
+        final String exceptionType = ExceptionAttributeUtils.resolveExceptionType(eventAttrs, spanAttrs);
         if (!StringUtils.hasLength(exceptionType)) {
             return Optional.empty();
         }
@@ -107,15 +101,6 @@ public class OtlpExceptionMapper {
         );
         bo.setExceptionWrapperBos(List.of(wrapper));
         return Optional.of(bo);
-    }
-
-    private Span.Event findExceptionEvent(Span span) {
-        for (Span.Event event : span.getEventsList()) {
-            if (EVENT_NAME_EXCEPTION.equals(event.getName())) {
-                return event;
-            }
-        }
-        return null;
     }
 
     List<StackTraceElementWrapperBo> parseStackTrace(String stackTrace) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
@@ -18,9 +18,11 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
@@ -308,11 +310,20 @@ public class OtlpTraceMapper {
     }
 
     List<SpanEventBo> findLinkSpan(long startTime, List<Span> childSpanList, ByteString parentSpanId, int depth) {
-        // Orphan/spanChunk traversal: no exception processing (no root span to link against).
-        return findLinkSpan(startTime, childSpanList, parentSpanId, depth, span -> {});
+        // Orphan/spanChunk traversal: no exception processing (no root span to link against) and
+        // no exception-trace deep-link annotation — orphan spans have no stored exceptiontrace row
+        // to link to (see recordException skip in the caller).
+        return findLinkSpan(startTime, childSpanList, parentSpanId, depth, span -> {}, false);
     }
 
     List<SpanEventBo> findLinkSpan(long startTime, List<Span> childSpanList, ByteString parentSpanId, int depth, Consumer<Span> spanConsumer) {
+        // Root-linked traversal: exceptions are recorded to exception-trace here, so emit the
+        // deep-link annotation on the exception-bearing SpanEvent.
+        return findLinkSpan(startTime, childSpanList, parentSpanId, depth, spanConsumer, true);
+    }
+
+    private List<SpanEventBo> findLinkSpan(long startTime, List<Span> childSpanList, ByteString parentSpanId, int depth,
+                                           Consumer<Span> spanConsumer, boolean emitExceptionLink) {
         List<SpanEventBo> spanEventList = new ArrayList<>();
         if (depth > 99) {
             // defensive check
@@ -334,9 +345,17 @@ public class OtlpTraceMapper {
         for (Span span : linkSpanList) {
             spanConsumer.accept(span);
             final SpanEventBo spanEventBo = spanEventMapper.map(startTime, span, depth);
+            // Link the SpanEvent's inline exception to its exceptiontrace record. The id matches
+            // OtlpExceptionMapper's ExceptionWrapperBo.exceptionId (getSpanId of the same span);
+            // only emitted on the root-linked path where an exceptiontrace row actually exists.
+            if (emitExceptionLink && OtlpTraceSpanMapper.isExceptionClassCaptured(spanEventBo.getExceptionInfo())) {
+                spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.EXCEPTION_CHAIN_ID.getCode(),
+                        OtlpTraceMapperUtils.getSpanId(span.getSpanId())));
+            }
             spanEventList.add(spanEventBo);
-            List<SpanEventBo> list = findLinkSpan(startTime, childSpanList, span.getSpanId(), depth + 1, spanConsumer);
+            List<SpanEventBo> list = findLinkSpan(startTime, childSpanList, span.getSpanId(), depth + 1, spanConsumer, emitExceptionLink);
             spanEventList.addAll(list);
+
         }
 
         return spanEventList;

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.AttributeBo;
+import com.navercorp.pinpoint.common.server.bo.ExceptionInfo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
 import com.navercorp.pinpoint.common.server.util.Utf8;
@@ -129,6 +130,14 @@ public class OtlpTraceSpanEventMapper {
                     : ServiceType.INTERNAL_METHOD.getCode());
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.API.getCode(), getSpanNameOrDefault(span, OtlpTraceMapper.INTERNAL_METHOD_NAME)));
         }
+        // error status → SpanEvent exception (mirrors the root SpanBo error rule). A SpanEventBo
+        // has no transaction-level errCode flag, so exceptionInfo is the only error marker.
+        final ExceptionInfo exceptionInfo = OtlpTraceSpanMapper.resolveErrorExceptionInfo(span, attributes);
+        if (exceptionInfo != null) {
+            spanEventBo.setExceptionInfo(exceptionInfo);
+        }
+        final boolean skipExceptionEvent = OtlpTraceSpanMapper.isExceptionClassCaptured(exceptionInfo);
+
         // api
         spanEventBo.setApiId(0);
         spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_SPAN_ID.getCode(), OtlpTraceMapperUtils.getSpanId(span.getSpanId())));
@@ -143,6 +152,11 @@ public class OtlpTraceSpanEventMapper {
         }
         // event
         for (Span.Event event : span.getEventsList()) {
+            // The exception event's class name is captured into exceptionInfo and its message/
+            // stacktrace into exception-trace metadata, so skip its (redundant) annotation.
+            if (skipExceptionEvent && OtlpTraceConstants.EVENT_NAME_EXCEPTION.equals(event.getName())) {
+                continue;
+            }
             truncatedEvents += eventMapper.addEventToAnnotation(event, spanEventBo::addAnnotation);
         }
         // SDK-side data-loss hints (Span proto fields 10/12/14). Only emit when > 0.

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -46,6 +46,11 @@ import java.util.function.Consumer;
 
 @Component
 public class OtlpTraceSpanMapper {
+    // Upper bound for the exception message body stored inline on SpanBo/SpanEventBo, mirroring
+    // the native agent's 256-char abbreviation. The class-name prefix is not counted (it is
+    // naturally bounded) and survives truncation because it precedes the body.
+    static final int EXCEPTION_MESSAGE_MAX_LENGTH = 256;
+
     private final OtlpTraceEventMapper eventMapper;
     private final OtlpTraceLinkMapper linkMapper;
     private final OtlpMessagingTypeResolver messagingTypeResolver;
@@ -106,15 +111,16 @@ public class OtlpTraceSpanMapper {
             }
         }
 
+        // errCode is the transaction-level error flag and is set whenever the (root) span status
+        // is ERROR, independently of whether an exceptionInfo can be built.
+        final ExceptionInfo exceptionInfo = resolveErrorExceptionInfo(span, attributes);
         if (Status.StatusCode.STATUS_CODE_ERROR.getNumber() == span.getStatus().getCodeValue()) {
             spanBo.setErrCode(1);
-            final String errorType = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_ERROR_TYPE, null);
-            if (StringUtils.hasLength(errorType)) {
-                spanBo.setExceptionInfo(new ExceptionInfo(1, errorType));
-            } else if (StringUtils.hasLength(span.getStatus().getMessage())) {
-                spanBo.setExceptionInfo(new ExceptionInfo(1, span.getStatus().getMessage()));
+            if (exceptionInfo != null) {
+                spanBo.setExceptionInfo(exceptionInfo);
             }
         }
+        final boolean skipExceptionEvent = isExceptionClassCaptured(exceptionInfo);
         // response
         final int responseStatusCode = (int) getServerSpanToResponseStatusCode(attributes);
         if (responseStatusCode != -1) {
@@ -133,6 +139,11 @@ public class OtlpTraceSpanMapper {
         // event
         int truncatedEvents = 0;
         for (Span.Event event : span.getEventsList()) {
+            // The exception event's class name is captured into exceptionInfo and its message/
+            // stacktrace into exception-trace metadata, so skip its (redundant) annotation.
+            if (skipExceptionEvent && OtlpTraceConstants.EVENT_NAME_EXCEPTION.equals(event.getName())) {
+                continue;
+            }
             truncatedEvents += eventMapper.addEventToAnnotation(event, spanBo::addAnnotation);
         }
         // link
@@ -149,6 +160,84 @@ public class OtlpTraceSpanMapper {
                 span.getDroppedLinksCount());
 
         return spanBo;
+    }
+
+    /**
+     * Builds the SpanBo/SpanEventBo {@link ExceptionInfo} for an OTel span whose status is ERROR,
+     * or {@code null} when the span is not ERROR (or is ERROR but carries no usable signal).
+     *
+     * <p>Shared by {@link OtlpTraceSpanMapper} (root → SpanBo) and {@link OtlpTraceSpanEventMapper}
+     * (non-root → SpanEventBo) so both apply the identical rule. When an {@code exception} event is
+     * present, its type ({@code exception.type} → {@code error.type}) is treated as the exception
+     * class name; otherwise the free-form status message (with {@code error.type} appended) is used.
+     *
+     * <p>OTel has no {@code StringMetaData} for the class name, so both the class name and the
+     * message are encoded into the single {@link ExceptionInfo#message()} field as
+     * {@code "<className><delimiter><message>"} — the class-name prefix is always present (empty
+     * when unknown). See {@link ExceptionInfo#OTEL_MESSAGE_DELIMITER}.
+     */
+    static ExceptionInfo resolveErrorExceptionInfo(Span span, Map<String, AttributeValue> attributes) {
+        if (Status.StatusCode.STATUS_CODE_ERROR.getNumber() != span.getStatus().getCodeValue()) {
+            return null;
+        }
+
+        final Span.Event exceptionEvent = ExceptionAttributeUtils.findExceptionEvent(span);
+        if (exceptionEvent != null) {
+            final Map<String, AttributeValue> eventAttrs = OtlpTraceMapperUtils.getAttributeValueMap(exceptionEvent.getAttributesList());
+            final String className = ExceptionAttributeUtils.resolveExceptionType(eventAttrs, attributes);
+            if (StringUtils.hasLength(className)) {
+                final String message = ExceptionAttributeUtils.getExceptionMessage(eventAttrs);
+                return buildOtelExceptionInfo(className, message);
+            }
+        }
+
+        // No exception event (or unresolved type): use the free-form message. This is a plain
+        // message, so the class-name prefix stays empty.
+        final String errorType = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_ERROR_TYPE, null);
+        final String messageBody = buildExceptionMessageBody(span.getStatus().getMessage(), errorType);
+        if (!StringUtils.hasLength(messageBody)) {
+            return null;
+        }
+        return buildOtelExceptionInfo("", messageBody);
+    }
+
+    /**
+     * Combines the OTel status message and {@code error.type} into a single message body,
+     * status message first: {@code "status (error.type)"} when both are present, otherwise
+     * whichever is present, or {@code null} when neither is.
+     */
+    static String buildExceptionMessageBody(String statusMessage, String errorType) {
+        final boolean hasMessage = StringUtils.hasLength(statusMessage);
+        final boolean hasType = StringUtils.hasLength(errorType);
+        if (hasMessage && hasType) {
+            return statusMessage + " (" + errorType + ")";
+        }
+        if (hasMessage) {
+            return statusMessage;
+        }
+        if (hasType) {
+            return errorType;
+        }
+        return null;
+    }
+
+    private static ExceptionInfo buildOtelExceptionInfo(String className, String messageBody) {
+        final String body = (messageBody == null) ? "" : StringUtils.abbreviate(messageBody, EXCEPTION_MESSAGE_MAX_LENGTH);
+        final String message = className + ExceptionInfo.OTEL_MESSAGE_DELIMITER + body;
+        return new ExceptionInfo(ExceptionInfo.OTEL_EXCEPTION_ID, message);
+    }
+
+    /**
+     * True when {@code exceptionInfo} carries a non-empty exception class name prefix — i.e. the
+     * span's {@code exception} event was captured. The exception event annotation is then skipped
+     * to avoid duplicating what exceptionInfo + exception-trace metadata already hold.
+     */
+    static boolean isExceptionClassCaptured(ExceptionInfo exceptionInfo) {
+        if (exceptionInfo == null || exceptionInfo.message() == null) {
+            return false;
+        }
+        // className is the prefix before the first delimiter; index > 0 ⇒ non-empty class name.
+        return exceptionInfo.message().indexOf(ExceptionInfo.OTEL_MESSAGE_DELIMITER) > 0;
     }
 
     /**

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -18,7 +18,9 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
+import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.exception.ExceptionMetaDataBo;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import io.opentelemetry.proto.common.v1.KeyValue;
@@ -26,6 +28,7 @@ import io.opentelemetry.proto.resource.v1.Resource;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.ScopeSpans;
 import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.Status;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -221,5 +224,51 @@ class OtlpTraceMapperTest {
 
         assertThat(data.getExceptionMetaDataBoList()).isEmpty();
         assertThat(data.getSpanChunkBoList()).isNotEmpty();
+    }
+
+    // =======================================================================
+    // exception-trace deep-link annotation (EXCEPTION_CHAIN_ID) — linked only
+    // =======================================================================
+
+    private static Long exceptionChainId(SpanEventBo event) {
+        return event.getAnnotationBoList().stream()
+                .filter(a -> a.getKey() == AnnotationKey.EXCEPTION_CHAIN_ID.getCode())
+                .map(a -> (Long) a.getValue())
+                .findFirst()
+                .orElse(null);
+    }
+
+    // status ERROR triggers the inline exceptionInfo, which the deep-link annotation attaches to.
+    private static Span withError(Span span) {
+        return span.toBuilder()
+                .setStatus(Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_ERROR))
+                .build();
+    }
+
+    @Test
+    void linkedChildException_emitsExceptionChainIdMatchingExceptionId() {
+        Span root = serverRoot(ROOT_A, "/api/orders", false);
+        Span child = withError(clientChild(CHILD, ROOT_A, true));
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(root, child));
+
+        SpanEventBo childEvent = data.getSpanBoList().get(0).getSpanEventBoList().get(0);
+        // deep-link id equals the stored exceptiontrace exceptionId (the child span id)
+        assertThat(exceptionChainId(childEvent)).isEqualTo(spanId(CHILD));
+        assertThat(data.getExceptionMetaDataBoList().get(0)
+                .getExceptionWrapperBos().get(0).getExceptionId()).isEqualTo(spanId(CHILD));
+    }
+
+    @Test
+    void orphanChunkException_doesNotEmitExceptionChainId() {
+        // orphan chunk has no exceptiontrace row → must not carry a (dead) deep-link
+        Span orphan = withError(clientChild(ORPHAN, ABSENT_PARENT, true));
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(orphan));
+
+        SpanEventBo orphanEvent = data.getSpanChunkBoList().get(0).getSpanEventBoList().get(0);
+        assertThat(exceptionChainId(orphanEvent)).isNull();
+        // but the inline exception marker is still present
+        assertThat(orphanEvent.hasException()).isTrue();
     }
 }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -9,6 +9,7 @@ import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.Status;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -541,5 +542,82 @@ class OtlpTraceSpanEventMapperTest {
         assertThat(event.getAnnotationBoList())
                 .extracting(com.navercorp.pinpoint.common.server.bo.AnnotationBo::getKey)
                 .doesNotContain(com.navercorp.pinpoint.common.trace.AnnotationKey.OPENTELEMETRY_DROPPED.getCode());
+    }
+
+    // =======================================================================
+    // map() — error status → SpanEvent exceptionInfo (className:message encoding)
+    // =======================================================================
+
+    private static Span.Event exceptionEvent(KeyValue... attrs) {
+        Span.Event.Builder event = Span.Event.newBuilder().setName("exception");
+        for (KeyValue attr : attrs) {
+            event.addAttributes(attr);
+        }
+        return event.build();
+    }
+
+    private static Span errorClientSpan(Status.StatusCode code, String statusMessage, KeyValue[] attrs, Span.Event... events) {
+        Span.Builder builder = Span.newBuilder()
+                .setName("op")
+                .setTraceId(ByteString.copyFrom(TRACE_ID))
+                .setSpanId(ByteString.copyFrom(SPAN_ID))
+                .setKindValue(Span.SpanKind.SPAN_KIND_CLIENT_VALUE)
+                .setStatus(Status.newBuilder().setCode(code).setMessage(statusMessage == null ? "" : statusMessage));
+        for (KeyValue attr : attrs) {
+            builder.addAttributes(attr);
+        }
+        for (Span.Event event : events) {
+            builder.addEvents(event);
+        }
+        return builder.build();
+    }
+
+    private static long countEventAnnotations(SpanEventBo event) {
+        return event.getAnnotationBoList().stream()
+                .filter(a -> a.getKey() == com.navercorp.pinpoint.common.trace.AnnotationKey.OPENTELEMETRY_EVENT.getCode())
+                .count();
+    }
+
+    @Test
+    void map_error_exceptionEvent_setsExceptionInfo_andSkipsEventAnnotation() {
+        Span span = errorClientSpan(Status.StatusCode.STATUS_CODE_ERROR, "ignored", new KeyValue[]{},
+                exceptionEvent(kv("exception.type", strVal("java.io.IOException")),
+                        kv("exception.message", strVal("disk full"))));
+
+        SpanEventBo event = mapSingle(span);
+
+        assertThat(event.hasException()).isTrue();
+        assertThat(event.getExceptionInfo().id()).isEqualTo(0);
+        assertThat(event.getExceptionInfo().message()).isEqualTo("java.io.IOException:disk full");
+        assertThat(countEventAnnotations(event)).isZero();
+    }
+
+    @Test
+    void map_error_noEvent_statusMessageOnly_emptyClassPrefix() {
+        Span span = errorClientSpan(Status.StatusCode.STATUS_CODE_ERROR, "Connection refused: host", new KeyValue[]{});
+
+        SpanEventBo event = mapSingle(span);
+
+        assertThat(event.getExceptionInfo().message()).isEqualTo(":Connection refused: host");
+    }
+
+    @Test
+    void map_error_noSignal_noExceptionInfo() {
+        Span span = errorClientSpan(Status.StatusCode.STATUS_CODE_ERROR, "", new KeyValue[]{});
+
+        SpanEventBo event = mapSingle(span);
+
+        assertThat(event.hasException()).isFalse();
+    }
+
+    @Test
+    void map_okStatus_noExceptionInfo_keepsEventAnnotation() {
+        Span span = errorClientSpan(Status.StatusCode.STATUS_CODE_UNSET, "", new KeyValue[]{},
+                exceptionEvent(kv("exception.type", strVal("java.lang.RuntimeException"))));
+
+        SpanEventBo event = mapSingle(span);
+
+        assertThat(event.hasException()).isFalse();
+        assertThat(countEventAnnotations(event)).isEqualTo(1);
     }
 }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -12,6 +12,7 @@ import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.Status;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -784,5 +785,138 @@ class OtlpTraceSpanMapperTest {
         assertThat(bo.getParentApplication())
                 .isEqualTo(new ParentApplication(ServiceUid.DEFAULT_SERVICE_UID_NAME, "upstream-app",
                         ServiceType.OPENTELEMETRY_SERVER.getCode()));
+    }
+
+    // =======================================================================
+    // map() — error status → SpanBo exceptionInfo (className:message encoding)
+    // =======================================================================
+
+    private static Span.Event exceptionEvent(KeyValue... attrs) {
+        Span.Event.Builder event = Span.Event.newBuilder().setName("exception");
+        for (KeyValue attr : attrs) {
+            event.addAttributes(attr);
+        }
+        return event.build();
+    }
+
+    private static Span errorServerSpan(Status.StatusCode code, String statusMessage, KeyValue[] attrs, Span.Event... events) {
+        Span.Builder builder = Span.newBuilder()
+                .setName("op")
+                .setTraceId(ByteString.copyFrom(TRACE_ID))
+                .setSpanId(ByteString.copyFrom(SPAN_ID))
+                .setKindValue(Span.SpanKind.SPAN_KIND_SERVER_VALUE)
+                .setStatus(Status.newBuilder().setCode(code).setMessage(statusMessage == null ? "" : statusMessage));
+        for (KeyValue attr : attrs) {
+            builder.addAttributes(attr);
+        }
+        for (Span.Event event : events) {
+            builder.addEvents(event);
+        }
+        return builder.build();
+    }
+
+    private static long countEventAnnotations(SpanBo bo) {
+        return bo.getAnnotationBoList().stream()
+                .filter(a -> a.getKey() == AnnotationKey.OPENTELEMETRY_EVENT.getCode())
+                .count();
+    }
+
+    @Test
+    void map_error_exceptionEvent_encodesClassAndMessage_andSkipsEventAnnotation() {
+        Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_ERROR, "ignored status", new KeyValue[]{},
+                exceptionEvent(kv("exception.type", strVal("java.io.IOException")),
+                        kv("exception.message", strVal("disk full"))));
+
+        SpanBo bo = newMapper().map(id(), span);
+
+        assertThat(bo.getErrCode()).isEqualTo(1);
+        assertThat(bo.getExceptionInfo().id()).isEqualTo(0);
+        assertThat(bo.getExceptionInfo().message()).isEqualTo("java.io.IOException:disk full");
+        // exception event is captured into exceptionInfo → its annotation is skipped
+        assertThat(countEventAnnotations(bo)).isZero();
+    }
+
+    @Test
+    void map_error_exceptionEvent_typeFromEventPreferredOverErrorType() {
+        Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_ERROR, "",
+                new KeyValue[]{kv("error.type", strVal("500"))},
+                exceptionEvent(kv("exception.type", strVal("java.lang.RuntimeException")),
+                        kv("exception.message", strVal("boom"))));
+
+        SpanBo bo = newMapper().map(id(), span);
+
+        assertThat(bo.getExceptionInfo().message()).isEqualTo("java.lang.RuntimeException:boom");
+    }
+
+    @Test
+    void map_error_exceptionEvent_typeFallsBackToErrorType_whenEventTypeMissing() {
+        Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_ERROR, "",
+                new KeyValue[]{kv("error.type", strVal("java.net.SocketTimeoutException"))},
+                exceptionEvent(kv("exception.message", strVal("timeout"))));
+
+        SpanBo bo = newMapper().map(id(), span);
+
+        assertThat(bo.getExceptionInfo().message()).isEqualTo("java.net.SocketTimeoutException:timeout");
+        assertThat(countEventAnnotations(bo)).isZero();
+    }
+
+    @Test
+    void map_error_noEvent_statusMessageAndErrorType_emptyClassPrefix() {
+        Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_ERROR, "Connection refused",
+                new KeyValue[]{kv("error.type", strVal("500"))});
+
+        SpanBo bo = newMapper().map(id(), span);
+
+        assertThat(bo.getErrCode()).isEqualTo(1);
+        // empty class-name prefix (leading delimiter) → message-only
+        assertThat(bo.getExceptionInfo().message()).isEqualTo(":Connection refused (500)");
+    }
+
+    @Test
+    void map_error_noEvent_statusMessageOnly() {
+        Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_ERROR, "Connection refused: host", new KeyValue[]{});
+
+        SpanBo bo = newMapper().map(id(), span);
+
+        assertThat(bo.getExceptionInfo().message()).isEqualTo(":Connection refused: host");
+    }
+
+    @Test
+    void map_error_noSignal_setsErrCodeButNoExceptionInfo() {
+        Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_ERROR, "", new KeyValue[]{});
+
+        SpanBo bo = newMapper().map(id(), span);
+
+        assertThat(bo.getErrCode()).isEqualTo(1);
+        assertThat(bo.getExceptionInfo()).isNull();
+    }
+
+    @Test
+    void map_okStatus_noErrorRecorded() {
+        Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_OK, "should be ignored",
+                new KeyValue[]{kv("error.type", strVal("500"))},
+                exceptionEvent(kv("exception.type", strVal("java.lang.RuntimeException"))));
+
+        SpanBo bo = newMapper().map(id(), span);
+
+        assertThat(bo.getErrCode()).isEqualTo(0);
+        assertThat(bo.getExceptionInfo()).isNull();
+        // not an error → exception event is kept as an annotation
+        assertThat(countEventAnnotations(bo)).isEqualTo(1);
+    }
+
+    @Test
+    void map_error_messageTruncatedTo256() {
+        String longMessage = "x".repeat(300);
+        Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_ERROR, "",
+                new KeyValue[]{},
+                exceptionEvent(kv("exception.type", strVal("E")),
+                        kv("exception.message", strVal(longMessage))));
+
+        SpanBo bo = newMapper().map(id(), span);
+
+        String message = bo.getExceptionInfo().message();
+        assertThat(message).startsWith("E:" + "x".repeat(256));
+        assertThat(message).contains("...(300)");
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/ExceptionRecord.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/ExceptionRecord.java
@@ -30,6 +30,11 @@ import java.util.Objects;
  */
 public class ExceptionRecord extends BaseRecord {
 
+    // Fallback title for an OTel error that carries no exception class name (status ERROR
+    // without an exception event). "ERROR" is OpenTelemetry's language-agnostic term for a
+    // general failure, unlike the language-specific "Exception".
+    static final String OTEL_UNKNOWN_EXCEPTION_TITLE = "ERROR";
+
     public ExceptionRecord(
             final int tab, final int id, final int parentId, final Align align,
             ServiceType applicationServiceType
@@ -41,7 +46,10 @@ public class ExceptionRecord extends BaseRecord {
         this.tab = tab;
         this.id = id;
         this.parentId = parentId;
-        this.title = toSimpleExceptionName(align.getExceptionClass());
+        final String simpleName = toSimpleExceptionName(align.getExceptionClass());
+        this.title = (align.isOpenTelemetry() && simpleName.isEmpty())
+                ? OTEL_UNKNOWN_EXCEPTION_TITLE
+                : simpleName;
         this.arguments = buildArgument(align);
         this.isAuthorized = true;
         this.hasException = !align.isSpan();
@@ -77,6 +85,11 @@ public class ExceptionRecord extends BaseRecord {
         final ExceptionInfo exceptionInfo = align.getExceptionInfo();
         if (exceptionInfo == null) {
             return "";
+        }
+        if (align.isOpenTelemetry()) {
+            // OTel encodes "<className>:<message>" in exceptionInfo.message; the class name is
+            // shown as the title, so the argument is only the message part.
+            return Objects.toString(ExceptionInfo.otelMessageBody(exceptionInfo.message()), "");
         }
         return Objects.toString(exceptionInfo.message(), "");
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/service/SpanServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/service/SpanServiceImpl.java
@@ -672,6 +672,14 @@ public class SpanServiceImpl implements SpanService {
             public void replacement(Align align, List<AnnotationBo> annotationBoList) {
                 if (align.hasException()) {
                     ExceptionInfo exceptionInfo = align.getExceptionInfo();
+                    if (align.isOpenTelemetry()) {
+                        // OTel has no StringMetaData for the exception class name; it is encoded
+                        // into exceptionInfo.message as "<className>:<message>" (empty className
+                        // when unknown). Resolve the class name from the prefix and skip the
+                        // (always-missing) StringMetaData lookup.
+                        align.setExceptionClass(ExceptionInfo.otelClassName(exceptionInfo.message()));
+                        return;
+                    }
                     StringMetaDataBo stringMetaData = selectStringMetaData(align.getAgentId(), exceptionInfo.id(), align.getAgentStartTime());
                     align.setExceptionClass(stringMetaData.getStringValue());
                 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
@@ -103,6 +103,39 @@ public class RecordFactoryTest {
 
 
     @Test
+    public void getException_otel_blankClassName_fallsBackToError() {
+        final RecordFactory factory = newRecordFactory();
+
+        SpanBo spanBo = new SpanBo();
+        spanBo.setTransactionId(new PinpointServerTraceId("test", 0, 0));
+        // OTel message-only encoding: empty class-name prefix (leading delimiter)
+        spanBo.setExceptionInfo(new ExceptionInfo(ExceptionInfo.OTEL_EXCEPTION_ID, ":Connection refused"));
+        Align align = new SpanAlign(spanBo, false, true); // openTelemetry = true
+
+        Record exceptionRecord = factory.getException(0, 0, align);
+
+        assertThat(exceptionRecord.getTitle()).isEqualTo("ERROR");
+        assertThat(exceptionRecord.getArguments()).isEqualTo("Connection refused");
+    }
+
+    @Test
+    public void getException_otel_withClassName_usesSimpleName() {
+        final RecordFactory factory = newRecordFactory();
+
+        SpanBo spanBo = new SpanBo();
+        spanBo.setTransactionId(new PinpointServerTraceId("test", 0, 0));
+        spanBo.setExceptionInfo(new ExceptionInfo(ExceptionInfo.OTEL_EXCEPTION_ID, "java.io.IOException:disk full"));
+        // exceptionClass is populated by SpanServiceImpl.transitionException from the message prefix
+        spanBo.setExceptionClass("java.io.IOException");
+        Align align = new SpanAlign(spanBo, false, true); // openTelemetry = true
+
+        Record exceptionRecord = factory.getException(0, 0, align);
+
+        assertThat(exceptionRecord.getTitle()).isEqualTo("IOException");
+        assertThat(exceptionRecord.getArguments()).isEqualTo("disk full");
+    }
+
+    @Test
     public void getParameter_check_argument() {
 
         final RecordFactory factory = newRecordFactory();


### PR DESCRIPTION
Record OTel span status=ERROR as Pinpoint errors: root span -> SpanBo (errCode + exceptionInfo), non-root -> SpanEvent exceptionInfo. Encode exception class and message into ExceptionInfo.message ("class:message") since OTel has no StringMetaData backing, and render it in the web call tree with an "ERROR" fallback title. Emit EXCEPTION_CHAIN_ID on root-linked spans to deep-link the exception trace.