### PR TITLE
Refine ECharts charts after the billboard.js migration

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Chart/Load/LoadChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Chart/Load/LoadChart.tsx
@@ -8,6 +8,10 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { cn } from '../../../lib/utils';
 import { colors } from '@pinpoint-fe/ui/src/constants';
 import { useTimezone } from '@pinpoint-fe/ui/src/hooks';
+import { buildBottomLegend, getGridBottom } from '../../../lib/charts/echartsLegendLayout';
+import { buildEmptyMessageGraphic } from '../../../lib/charts/echartsCommonOptions';
+import { formatAxisTooltip } from '../../../lib/charts/echartsTimeSeriesFormat';
+import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
 
 echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent, CanvasRenderer]);
 
@@ -49,30 +53,7 @@ export const LoadChart = ({
 }: LoadChartProps) => {
   const [timezone] = useTimezone();
   const chartData = typeof datas === 'function' ? datas?.(chartColors) : datas;
-  const chartRef = React.useRef<HTMLDivElement>(null);
-  const chartInstanceRef = React.useRef<echarts.EChartsType | null>(null);
-  // console.log('datas11', chartData);
-
-  // 차트 초기화
-  React.useEffect(() => {
-    if (!chartRef.current) return;
-
-    const chart = echarts.init(chartRef.current);
-    chartInstanceRef.current = chart;
-
-    // chart resize
-    const wrapperElement = chartRef.current;
-    if (!wrapperElement) return;
-    const resizeObserver = new ResizeObserver(() => {
-      chart.resize();
-    });
-    resizeObserver.observe(wrapperElement);
-
-    return () => {
-      resizeObserver.disconnect();
-      chart.dispose();
-    };
-  }, []);
+  const { chartRef, chartInstanceRef, renderRef } = useEChartsInstance();
 
   // 데이터 변경 시 차트 업데이트
   React.useEffect(() => {
@@ -89,13 +70,9 @@ export const LoadChart = ({
     const series = dataKeys.map((key) => ({
       name: key,
       type: 'line' as const,
-      // 데이터 값이 0임에도 stacked area chart 에 표현되는 버그가 있음
-      // 그래서 0인 값은 아예 그려지지 않도록 null 로 변환
-      // (https://github.com/apache/echarts/issues/16739)
-      // data: chartData[key]?.map((value) => (value === 0 ? null : value)) || [],
-      data: chartData[key]?.map((value, index) => {
-        return [dates[index], value === 0 ? null : value];
-      }),
+      // 데이터 값이 0임에도 stacked area chart 에 표현되는 버그가 있어 0인 값은 아예 그려지지 않도록
+      // null 로 변환한다. (https://github.com/apache/echarts/issues/16739)
+      data: chartData[key]?.map((value, index) => [dates[index], value === 0 ? null : value]),
       stack: 'total',
       areaStyle: {},
       smooth: false,
@@ -108,108 +85,92 @@ export const LoadChart = ({
         color: chartColors[key] || colors.fast,
       },
       emphasis: {
-        focus: 'series',
+        focus: 'series' as const,
       },
     }));
 
-    chartInstanceRef.current.setOption({
-      legend: {
-        data: dataKeys,
-        bottom: 0,
-        icon: 'square',
-        itemWidth: 10,
-        itemHeight: 10,
-        itemGap: 15,
-      },
-      grid: {
-        top: 20,
-        bottom: 60,
-        right: 25,
-        left: 0,
-      },
-      xAxis: {
-        type: 'time',
-        boundaryGap: false,
-        splitNumber: 4,
-        axisLabel: {
-          showMinLabel: true,
-          showMaxLabel: true,
-          fontSize: 10,
-          formatter: (value: number) => {
-            try {
-              return `${formatInTimeZone(value, timezone, 'MM.dd')}\n${formatInTimeZone(
-                value,
-                timezone,
-                'HH:mm',
-              )}`;
-            } catch (error) {
-              return '';
-            }
+    const render = () => {
+      const chart = chartInstanceRef.current;
+      if (!chart) return;
+
+      const containerWidth = chartRef.current?.clientWidth ?? 0;
+      const gridBottom = getGridBottom(dataKeys, containerWidth);
+
+      chart.setOption({
+        legend: buildBottomLegend(dataKeys),
+        grid: {
+          top: 20,
+          bottom: gridBottom,
+          right: 25,
+          left: 0,
+        },
+        xAxis: {
+          type: 'time',
+          boundaryGap: false,
+          splitNumber: 4,
+          axisLabel: {
+            showMinLabel: true,
+            showMaxLabel: true,
+            fontSize: 10,
+            formatter: (value: number) => {
+              try {
+                return `${formatInTimeZone(value, timezone, 'MM.dd')}\n${formatInTimeZone(
+                  value,
+                  timezone,
+                  'HH:mm',
+                )}`;
+              } catch (error) {
+                return '';
+              }
+            },
+          },
+          zlevel: 1,
+        },
+        yAxis: {
+          type: 'value',
+          min: 0,
+          axisLine: {
+            show: true,
+          },
+          zlevel: 1,
+          splitNumber: 2,
+          axisLabel: {
+            formatter: (value: number): string => abbreviateNumber(value, ['', 'K', 'M', 'G']),
+          },
+          splitLine: {
+            show: true,
+            lineStyle: {
+              type: 'dashed',
+            },
           },
         },
-        zlevel: 1,
-      },
-      yAxis: {
-        type: 'value',
-        min: 0,
-        axisLine: {
-          show: true,
-        },
-        zlevel: 1,
-        splitNumber: 2,
-        axisLabel: {
-          formatter: (value: number): string => abbreviateNumber(value, ['', 'K', 'M', 'G']),
-        },
-        splitLine: {
-          show: true,
-          lineStyle: {
-            type: 'dashed',
+        tooltip: {
+          trigger: 'axis',
+          axisPointer: {
+            type: 'line',
           },
+          // 0 은 stacked area 버그 때문에 null 로 치환돼 있으므로 tooltip 에선 0 으로 표시하고,
+          // 날짜 헤더는 사용자 지정 타임존을 반영한다.
+          formatter: (params: unknown) =>
+            formatAxisTooltip(params, (value) => addCommas(String(value)), {
+              nullBehavior: 'zero',
+              formatDate: (axisValue) => {
+                try {
+                  return formatInTimeZone(axisValue, timezone, 'MM.dd HH:mm');
+                } catch (error) {
+                  return '';
+                }
+              },
+            }),
         },
-      },
-      tooltip: {
-        trigger: 'axis',
-        axisPointer: {
-          type: 'line',
-        },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        formatter: (params: any) => {
-          if (!Array.isArray(params) || params.length === 0) return '';
-          const firstParam = params[0];
-          const dateIndex = firstParam.dataIndex;
-          const date = dates[dateIndex];
-          const dateStr = date
-            ? `${formatInTimeZone(new Date(date), timezone, 'MM.dd HH:mm')}`
-            : '';
-          const rows = params
-            .map((param: { value: [number, number]; color: string; seriesName: string }) => {
-              const value = addCommas(param.value?.[1]?.toString() || '0');
-              const color = param.color;
-              return `<div style="display: flex; align-items: center; gap: 8px;">
-                <span style="display: inline-block; width: 10px; height: 10px; background-color: ${color};"></span>
-                <span>${param.seriesName}: ${value}</span>
-              </div>`;
-            })
-            .join('');
-          return `<div style="margin-bottom: 4px;">${dateStr}</div>${rows}`;
-        },
-      },
-      series,
-      graphic: [
-        {
-          type: 'text',
-          left: 'center',
-          top: '30%',
-          style: {
-            text: hasData ? '' : emptyMessage,
-            fontSize: 14,
-            fill: '#999',
-            textAlign: 'center',
-          },
-        },
-      ],
-    });
-  }, [chartData, chartColors, timezone, emptyMessage]);
+        series,
+        graphic: buildEmptyMessageGraphic(hasData, emptyMessage, { fontSize: 14, top: '30%' }),
+      });
+    };
+
+    renderRef.current = render;
+    render();
+  }, [chartData, chartColors, timezone, emptyMessage, chartInstanceRef, chartRef, renderRef]);
 
   return (
     <div className="w-full h-full">

--- a/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseAvgMax/ResponseAvgMaxChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseAvgMax/ResponseAvgMaxChart.tsx
@@ -40,7 +40,9 @@ export const ResponseAvgMaxChart = ({
   React.useEffect(() => {
     if (!chartInstanceRef.current) return;
 
-    const yAxisMax = chartData.length > 0 ? getMaxTickValue([chartData]) : undefined;
+    // 데이터가 없거나 전부 0이면 값축 범위가 [0,0]으로 붕괴돼 축이 사라진다. 이때만 기본 최대값을
+    // 줘서 축이 정상적으로 그려지게 한다. (값이 있으면 tick 기준 최대값으로 스케일)
+    const valueMax = chartData.some((v) => v > 0) ? getMaxTickValue([chartData]) : 1;
 
     chartInstanceRef.current.setOption({
       grid: {
@@ -52,7 +54,7 @@ export const ResponseAvgMaxChart = ({
       xAxis: {
         type: 'value',
         min: 0,
-        ...(yAxisMax != null && { max: yAxisMax }),
+        max: valueMax,
         splitNumber: 3,
         zlevel: 1, // 그리드 라인이 데이터 막대 앞에 오도록
         axisLabel: {

--- a/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseAvgMax/ResponseAvgMaxChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseAvgMax/ResponseAvgMaxChart.tsx
@@ -5,6 +5,8 @@ import { GridComponent } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
 import { abbreviateNumber, getMaxTickValue } from '@pinpoint-fe/ui/src/utils';
 import { cn } from '../../../lib';
+import { buildEmptyMessageGraphic } from '../../../lib/charts/echartsCommonOptions';
+import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
 
 echarts.use([BarChartEcharts, GridComponent, CanvasRenderer]);
 
@@ -28,32 +30,11 @@ export const ResponseAvgMaxChart = ({
   className,
   emptyMessage = 'No Data',
 }: ResponseAvgMaxChartProps) => {
-  const chartRef = React.useRef<HTMLDivElement>(null);
-  const chartInstanceRef = React.useRef<echarts.EChartsType | null>(null);
+  const { chartRef, chartInstanceRef } = useEChartsInstance();
   const chartData = React.useMemo(
     () => (typeof data === 'function' ? data(categories) : data || []),
     [data, categories],
   );
-
-  // 차트 초기화
-  React.useEffect(() => {
-    if (!chartRef.current) return;
-
-    const chart = echarts.init(chartRef.current);
-    chartInstanceRef.current = chart;
-
-    const wrapperElement = chartRef.current;
-    if (!wrapperElement) return;
-    const resizeObserver = new ResizeObserver(() => {
-      chart.resize();
-    });
-    resizeObserver.observe(wrapperElement);
-
-    return () => {
-      resizeObserver.disconnect();
-      chart.dispose();
-    };
-  }, []);
 
   // 데이터/옵션 변경 시 차트 업데이트
   React.useEffect(() => {
@@ -113,21 +94,9 @@ export const ResponseAvgMaxChart = ({
           },
         },
       ],
-      graphic: [
-        {
-          type: 'text',
-          left: 'center',
-          top: 'middle',
-          style: {
-            text: chartData.length === 0 ? emptyMessage : '',
-            fontSize: 14,
-            fill: '#999',
-            textAlign: 'center',
-          },
-        },
-      ],
+      graphic: buildEmptyMessageGraphic(chartData.length > 0, emptyMessage, { fontSize: 14 }),
     });
-  }, [chartData, categories, colors, emptyMessage]);
+  }, [chartData, categories, colors, emptyMessage, chartInstanceRef]);
 
   return (
     <div className="w-full h-full">

--- a/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseSummary/ResponseSummaryChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseSummary/ResponseSummaryChart.tsx
@@ -123,6 +123,9 @@ export const ResponseSummaryChart = ({
       yAxis: {
         type: 'value',
         min: 0,
+        // 데이터가 없거나 전부 0이면 값축 범위가 [0,0]으로 붕괴돼 x축(하단 선)이 사라진다.
+        // 이때만 기본 최대값을 줘서 축이 정상적으로 그려지게 한다. (값이 있으면 auto-scale)
+        max: chartData.some((v) => v > 0) ? undefined : 1,
         axisLine: {
           show: true,
         },

--- a/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseSummary/ResponseSummaryChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseSummary/ResponseSummaryChart.tsx
@@ -124,8 +124,9 @@ export const ResponseSummaryChart = ({
         type: 'value',
         min: 0,
         // 데이터가 없거나 전부 0이면 값축 범위가 [0,0]으로 붕괴돼 x축(하단 선)이 사라진다.
-        // 이때만 기본 최대값을 줘서 축이 정상적으로 그려지게 한다. (값이 있으면 auto-scale)
-        max: chartData.some((v) => v > 0) ? undefined : 1,
+        // 이때만 기본 최대값을 준다. 값이 있으면 auto-scale 로 되돌리는데, undefined 는 setOption
+        // 병합 시 이전에 설정된 max(예: 직전 all-zero 상태의 1)를 못 지우므로 null 로 명시해 리셋한다.
+        max: chartData.some((v) => v > 0) ? null : 1,
         axisLine: {
           show: true,
         },

--- a/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseSummary/ResponseSummaryChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Chart/ResponseSummary/ResponseSummaryChart.tsx
@@ -7,6 +7,8 @@ import { AxisBreak } from 'echarts/features';
 import { GridComponent } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
 import { cn } from '../../../lib';
+import { buildEmptyMessageGraphic } from '../../../lib/charts/echartsCommonOptions';
+import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
 
 echarts.use([BarChartEcharts, AxisBreak, GridComponent, CanvasRenderer]);
 
@@ -41,8 +43,7 @@ export const ResponseSummaryChart = ({
   emptyMessage = 'No Data',
   disabledBreak,
 }: ResponseSummaryChartProps) => {
-  const chartRef = React.useRef(null);
-  const chartInstanceRef = React.useRef<echarts.EChartsType | null>(null);
+  const { chartRef, chartInstanceRef } = useEChartsInstance();
   const chartData = React.useMemo(
     () => (typeof data === 'function' ? data(categories) : data || []),
     [data, categories],
@@ -100,27 +101,6 @@ export const ResponseSummaryChart = ({
 
     return breakArr;
   }, [chartData, disabledBreak]);
-
-  // 차트 초기화
-  React.useEffect(() => {
-    if (!chartRef.current) return;
-
-    const chart = echarts.init(chartRef.current);
-    chartInstanceRef.current = chart;
-
-    // chart resize
-    const wrapperElement = chartRef.current;
-    if (!wrapperElement) return;
-    const resizeObserver = new ResizeObserver(() => {
-      chart.resize();
-    });
-    resizeObserver.observe(wrapperElement);
-
-    return () => {
-      resizeObserver.disconnect();
-      chart.dispose();
-    };
-  }, []);
 
   // data 변경 시 업데이트
   React.useEffect(() => {
@@ -185,21 +165,9 @@ export const ResponseSummaryChart = ({
           },
         },
       ],
-      graphic: [
-        {
-          type: 'text',
-          left: 'center',
-          top: 'middle',
-          style: {
-            text: chartData.length === 0 ? emptyMessage : '',
-            fontSize: 14,
-            fill: '#999',
-            textAlign: 'center',
-          },
-        },
-      ],
+      graphic: buildEmptyMessageGraphic(chartData.length > 0, emptyMessage, { fontSize: 14 }),
     });
-  }, [categories, chartData, colors, breakConfig, emptyMessage]);
+  }, [categories, chartData, colors, breakConfig, emptyMessage, chartInstanceRef]);
 
   return (
     <div className="w-full h-full">

--- a/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/charts/ErrorAnalysisChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/charts/ErrorAnalysisChartFetcher.tsx
@@ -6,11 +6,8 @@ import { CanvasRenderer } from 'echarts/renderers';
 import { useGetErrorAnalysisChartData } from '@pinpoint-fe/ui/src/hooks';
 import { abbreviateNumber } from '@pinpoint-fe/ui/src/utils';
 import { cn } from '../../../lib';
-import {
-  getGridBottom,
-  LEGEND_ICON_WIDTH,
-  LEGEND_ITEM_GAP,
-} from '../../../lib/charts/echartsLegendLayout';
+import { buildBottomLegend, getGridBottom } from '../../../lib/charts/echartsLegendLayout';
+import { buildEmptyMessageGraphic } from '../../../lib/charts/echartsCommonOptions';
 import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
 import {
   formatAxisTooltip,
@@ -69,14 +66,7 @@ export const ErrorAnalysisChartFetcher = ({
       chart.setOption(
         {
           animation: false,
-          legend: {
-            data: legendNames,
-            bottom: 0,
-            icon: 'square',
-            itemWidth: LEGEND_ICON_WIDTH,
-            itemHeight: 10,
-            itemGap: LEGEND_ITEM_GAP,
-          },
+          legend: buildBottomLegend(legendNames),
           grid: {
             top: 20,
             bottom: gridBottom,
@@ -122,21 +112,7 @@ export const ErrorAnalysisChartFetcher = ({
             formatter: (params: unknown) => formatAxisTooltip(params, formatErrorCount),
           },
           series,
-          graphic: !hasData
-            ? [
-                {
-                  type: 'text',
-                  left: 'center',
-                  top: 'middle',
-                  style: {
-                    text: emptyMessage,
-                    fontSize: 18,
-                    fill: '#999',
-                    textAlign: 'center',
-                  },
-                },
-              ]
-            : [],
+          graphic: buildEmptyMessageGraphic(hasData, emptyMessage),
         },
         // groupBy 변경 등으로 series 수가 줄어도 이전 series가 병합되어 잔존하지 않도록 항상 교체한다.
         { replaceMerge: ['series'] },

--- a/web-frontend/src/main/v3/packages/ui/src/components/Inspector/charts/ChartCore.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Inspector/charts/ChartCore.test.tsx
@@ -24,6 +24,10 @@ jest.mock('../../../lib/charts/echartsLegendLayout', () => ({
   getGridBottom: () => 60,
   LEGEND_ICON_WIDTH: 10,
   LEGEND_ITEM_GAP: 8,
+  buildBottomLegend: (names: string[], extra?: Record<string, unknown>) => ({
+    data: names,
+    ...extra,
+  }),
 }));
 jest.mock('../../../lib/charts/useEChartsInstance', () => ({
   useEChartsInstance: () => ({
@@ -111,9 +115,7 @@ describe('ChartCore', () => {
     expect(msAxis.min).toBe(0); // not -10: no symmetric/centered range
     expect(msAxis.max).toBe(10);
 
-    const gcSeries = option.series.find(
-      (s: { name: string }) => s.name === 'gcTime',
-    );
+    const gcSeries = option.series.find((s: { name: string }) => s.name === 'gcTime');
     expect(gcSeries.data).toEqual([0, 0, 0]); // real 0s drawn at the baseline, not filled/nulled
     expect(gcSeries.lineStyle.type).toBeUndefined(); // not forced dashed
   });
@@ -126,11 +128,13 @@ describe('ChartCore', () => {
     expect(option.graphic[0].style.text).toBe('No Data');
   });
 
-  it('renders no empty-message graphic when data exists', () => {
+  it('blanks the empty-message graphic text when data exists', () => {
     const { option } = renderChart(
       makeData([{ fieldName: 'cpu', unit: 'percent', chartType: 'line', valueList: [0, 1, 2] }]),
     );
-    expect(option.graphic).toEqual([]);
+    // graphic 요소는 항상 하나 유지하되(잔존 방지), 데이터가 있으면 텍스트를 비운다.
+    expect(option.graphic).toHaveLength(1);
+    expect(option.graphic[0].style.text).toBe('');
   });
 
   it('marks a series dashed when seriesOption.dashed is set', () => {

--- a/web-frontend/src/main/v3/packages/ui/src/components/Inspector/charts/ChartCore.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Inspector/charts/ChartCore.test.tsx
@@ -183,4 +183,11 @@ describe('ChartCore', () => {
     expect(option.legend.data).toEqual([]);
     expect(option.series).toHaveLength(1); // series still drawn
   });
+
+  it('focuses the hovered series so the others dim on hover (like SystemMetric charts)', () => {
+    const { option } = renderChart(
+      makeData([{ fieldName: 'cpu', unit: 'percent', chartType: 'line', valueList: [1, 2, 3] }]),
+    );
+    expect(option.series[0].emphasis.focus).toBe('series');
+  });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/components/Inspector/charts/ChartCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Inspector/charts/ChartCore.tsx
@@ -11,11 +11,8 @@ import { CanvasRenderer } from 'echarts/renderers';
 import { cn, DEFAULT_CHART_CONFIG, InspectorChartOptions } from '../../../lib';
 import { InspectorAgentChart, InspectorApplicationChart } from '@pinpoint-fe/ui/src/constants';
 import { getFormat } from '@pinpoint-fe/ui/src/utils';
-import {
-  getGridBottom,
-  LEGEND_ICON_WIDTH,
-  LEGEND_ITEM_GAP,
-} from '../../../lib/charts/echartsLegendLayout';
+import { buildBottomLegend, getGridBottom } from '../../../lib/charts/echartsLegendLayout';
+import { buildEmptyMessageGraphic } from '../../../lib/charts/echartsCommonOptions';
 import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
 import {
   formatAxisTooltip,
@@ -147,15 +144,7 @@ export const ChartCore = ({
       chart.setOption(
         {
           animation: false,
-          legend: {
-            show: legendShow,
-            data: legendNames,
-            bottom: 0,
-            icon: 'square',
-            itemWidth: LEGEND_ICON_WIDTH,
-            itemHeight: 10,
-            itemGap: LEGEND_ITEM_GAP,
-          },
+          legend: buildBottomLegend(legendNames, { show: legendShow }),
           grid: {
             top: DEFAULT_CHART_CONFIG.GRID_TOP,
             bottom: gridBottom,
@@ -184,21 +173,7 @@ export const ChartCore = ({
               ((params: unknown) => formatAxisTooltip(params, getFormat(yAxisList[0].unit))),
           },
           series,
-          graphic: !hasData
-            ? [
-                {
-                  type: 'text',
-                  left: 'center',
-                  top: 'middle',
-                  style: {
-                    text: emptyMessage,
-                    fontSize: 18,
-                    fill: '#999',
-                    textAlign: 'center',
-                  },
-                },
-              ]
-            : [],
+          graphic: buildEmptyMessageGraphic(hasData, emptyMessage),
         },
         // agent/시간/지표 변경으로 series 나 y축 수가 줄어도 이전 것이 잔존하지 않도록 항상 교체한다.
         { replaceMerge: ['series', 'yAxis'] },

--- a/web-frontend/src/main/v3/packages/ui/src/components/Inspector/charts/ChartCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Inspector/charts/ChartCore.tsx
@@ -101,9 +101,10 @@ export const ChartCore = ({
           ...(dashed ? { type: 'dashed' as const } : {}),
         },
         ...(seriesOption?.color ? { itemStyle: { color: seriesOption.color } } : {}),
-        // hover 시 다른 시리즈를 흐리게 하지 않는다.
+        // 그래프 또는 legend 항목에 hover 하면 다른 시리즈를 흐리게 해 hover 한 값을 강조한다.
+        // (SystemMetric 차트와 동일한 동작)
         emphasis: {
-          focus: 'none' as const,
+          focus: 'series' as const,
         },
       };
     });

--- a/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/charts/SystemMetricChartFetcher.tsx
@@ -22,11 +22,8 @@ import {
   SelectItem,
   Separator,
 } from '../../ui';
-import {
-  getGridBottom,
-  LEGEND_ICON_WIDTH,
-  LEGEND_ITEM_GAP,
-} from '../../../lib/charts/echartsLegendLayout';
+import { buildBottomLegend, getGridBottom } from '../../../lib/charts/echartsLegendLayout';
+import { buildEmptyMessageGraphic } from '../../../lib/charts/echartsCommonOptions';
 import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
 import {
   formatAxisTooltip,
@@ -108,14 +105,7 @@ export const SystemMetricChartFetcher = ({
       chart.setOption(
         {
           animation: false,
-          legend: {
-            data: legendNames,
-            bottom: 0,
-            icon: 'square',
-            itemWidth: LEGEND_ICON_WIDTH,
-            itemHeight: 10,
-            itemGap: LEGEND_ITEM_GAP,
-          },
+          legend: buildBottomLegend(legendNames),
           grid: {
             top: 20,
             bottom: gridBottom,
@@ -158,21 +148,7 @@ export const SystemMetricChartFetcher = ({
             formatter: (params: unknown) => formatAxisTooltip(params, formatValue),
           },
           series,
-          graphic: !hasData
-            ? [
-                {
-                  type: 'text',
-                  left: 'center',
-                  top: 'middle',
-                  style: {
-                    text: emptyMessage,
-                    fontSize: 18,
-                    fill: '#999',
-                    textAlign: 'center',
-                  },
-                },
-              ]
-            : [],
+          graphic: buildEmptyMessageGraphic(hasData, emptyMessage),
         },
         // tag/metric 변경으로 series 수가 줄어도 이전 series가 병합되어 잔존하지 않도록 항상 교체한다.
         { replaceMerge: ['series'] },

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/charts/TransactionCharts.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/charts/TransactionCharts.tsx
@@ -52,9 +52,9 @@ export const TransactionCharts = () => {
   const toDate = addMinutes(focusTimestamp, 10);
 
   return (
-    <div ref={containerRef} className="h-full p-3">
+    <div ref={containerRef} className="h-full px-8 py-3">
       {isAboveXl && (
-        <div className="grid h-full grid-cols-3 gap-4 text-xs">
+        <div className="grid h-full grid-cols-3 gap-12 text-xs">
           {chartIdList.map((chartId) => (
             <ErrorBoundary key={chartId}>
               <React.Suspense

--- a/web-frontend/src/main/v3/packages/ui/src/components/URL/charts/UrlStatDefaultChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/URL/charts/UrlStatDefaultChart.tsx
@@ -4,6 +4,8 @@ import { LineChart } from 'echarts/charts';
 import { GridComponent } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
 import { cn } from '../../../lib';
+import { buildEmptyMessageGraphic } from '../../../lib/charts/echartsCommonOptions';
+import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
 
 echarts.use([LineChart, GridComponent, CanvasRenderer]);
 
@@ -16,27 +18,7 @@ export const UrlStatDefaultChart = ({
   className,
   emptyMessage = 'No Data',
 }: UrlStatDefaultChartProps) => {
-  const chartRef = React.useRef<HTMLDivElement>(null);
-  const chartInstanceRef = React.useRef<echarts.EChartsType | null>(null);
-
-  React.useEffect(() => {
-    if (!chartRef.current) return;
-
-    const chart = echarts.init(chartRef.current);
-    chartInstanceRef.current = chart;
-
-    const wrapperElement = chartRef.current;
-    const resizeObserver = new ResizeObserver(() => {
-      chart.resize();
-    });
-    resizeObserver.observe(wrapperElement);
-
-    return () => {
-      resizeObserver.disconnect();
-      chart.dispose();
-      chartInstanceRef.current = null;
-    };
-  }, []);
+  const { chartRef, chartInstanceRef } = useEChartsInstance();
 
   React.useEffect(() => {
     if (!chartInstanceRef.current) return;
@@ -76,21 +58,9 @@ export const UrlStatDefaultChart = ({
           lineStyle: { width: 0 },
         },
       ],
-      graphic: [
-        {
-          type: 'text',
-          left: 'center',
-          top: 'middle',
-          style: {
-            text: emptyMessage,
-            fontSize: 18,
-            fill: '#999',
-            textAlign: 'center',
-          },
-        },
-      ],
+      graphic: buildEmptyMessageGraphic(false, emptyMessage),
     });
-  }, [emptyMessage]);
+  }, [emptyMessage, chartInstanceRef]);
 
   return <div className={cn('w-full h-full', className)} ref={chartRef} />;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/components/URL/charts/UrlStatEChartsChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/URL/charts/UrlStatEChartsChart.tsx
@@ -5,11 +5,8 @@ import { GridComponent, TooltipComponent, LegendComponent } from 'echarts/compon
 import { CanvasRenderer } from 'echarts/renderers';
 import { UrlStatChartType as UrlStatChartApi } from '@pinpoint-fe/ui/src/constants';
 import { cn } from '../../../lib';
-import {
-  getGridBottom,
-  LEGEND_ICON_WIDTH,
-  LEGEND_ITEM_GAP,
-} from '../../../lib/charts/echartsLegendLayout';
+import { buildBottomLegend, getGridBottom } from '../../../lib/charts/echartsLegendLayout';
+import { buildEmptyMessageGraphic } from '../../../lib/charts/echartsCommonOptions';
 import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
 import {
   formatAxisTooltip,
@@ -103,14 +100,7 @@ export const UrlStatEChartsChart = ({
       chart.setOption(
         {
           animation: false,
-          legend: {
-            data: legendNames,
-            bottom: 0,
-            icon: 'square',
-            itemWidth: LEGEND_ICON_WIDTH,
-            itemHeight: 10,
-            itemGap: LEGEND_ITEM_GAP,
-          },
+          legend: buildBottomLegend(legendNames),
           grid: {
             top: 20,
             bottom: gridBottom,
@@ -158,21 +148,7 @@ export const UrlStatEChartsChart = ({
               formatAxisTooltip(params, formatter ?? ((value: number) => String(value))),
           },
           series,
-          graphic: !hasData
-            ? [
-                {
-                  type: 'text',
-                  left: 'center',
-                  top: 'middle',
-                  style: {
-                    text: emptyMessage,
-                    fontSize: 18,
-                    fill: '#999',
-                    textAlign: 'center',
-                  },
-                },
-              ]
-            : [],
+          graphic: buildEmptyMessageGraphic(!!hasData, emptyMessage),
         },
         // chartType/data 변경(예: bar→line 탭 전환)으로 series 수가 줄어도
         // 이전 series가 병합되어 잔존하지 않도록 series는 항상 교체한다.

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsCommonOptions.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsCommonOptions.test.ts
@@ -1,0 +1,22 @@
+import { buildEmptyMessageGraphic } from './echartsCommonOptions';
+
+describe('buildEmptyMessageGraphic', () => {
+  it('shows the message when there is no data', () => {
+    const [graphic] = buildEmptyMessageGraphic(false, 'No Data');
+    expect(graphic.style.text).toBe('No Data');
+    expect(graphic.style.fontSize).toBe(18);
+    expect(graphic.top).toBe('middle');
+  });
+
+  it('keeps a single element but blanks the text when data exists', () => {
+    const graphic = buildEmptyMessageGraphic(true, 'No Data');
+    expect(graphic).toHaveLength(1);
+    expect(graphic[0].style.text).toBe('');
+  });
+
+  it('honors fontSize and top overrides', () => {
+    const [graphic] = buildEmptyMessageGraphic(false, 'x', { fontSize: 14, top: '30%' });
+    expect(graphic.style.fontSize).toBe(14);
+    expect(graphic.top).toBe('30%');
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsCommonOptions.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsCommonOptions.ts
@@ -1,0 +1,27 @@
+// echarts 차트들이 공통으로 쓰는 option 조각 헬퍼.
+
+interface EmptyMessageGraphicOptions {
+  fontSize?: number;
+  top?: number | string;
+}
+
+// 데이터가 없을 때 차트 가운데 "No Data" 같은 안내 문구를 그리는 graphic 배열을 만든다.
+// hasData 가 true 면 텍스트를 비워(빈 문자열) 아무것도 보이지 않게 한다. graphic 요소 자체는 항상
+// 하나 유지하므로, replaceMerge 없이 setOption 을 반복 호출해도 이전 문구가 잔존하지 않는다.
+export const buildEmptyMessageGraphic = (
+  hasData: boolean,
+  message: string,
+  { fontSize = 18, top = 'middle' }: EmptyMessageGraphicOptions = {},
+) => [
+  {
+    type: 'text' as const,
+    left: 'center' as const,
+    top,
+    style: {
+      text: hasData ? '' : message,
+      fontSize,
+      fill: '#999',
+      textAlign: 'center' as const,
+    },
+  },
+];

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsLegendLayout.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsLegendLayout.test.ts
@@ -1,0 +1,18 @@
+import { buildBottomLegend, LEGEND_ICON_WIDTH, LEGEND_ITEM_GAP } from './echartsLegendLayout';
+
+describe('buildBottomLegend', () => {
+  it('builds a bottom legend with shared icon/spacing and the given names', () => {
+    const legend = buildBottomLegend(['a', 'b']);
+    expect(legend.data).toEqual(['a', 'b']);
+    expect(legend.bottom).toBe(0);
+    expect(legend.icon).toBe('square');
+    expect(legend.itemWidth).toBe(LEGEND_ICON_WIDTH);
+    expect(legend.itemHeight).toBe(10);
+    expect(legend.itemGap).toBe(LEGEND_ITEM_GAP);
+  });
+
+  it('merges extra options (e.g. show)', () => {
+    const legend = buildBottomLegend([], { show: false });
+    expect(legend).toMatchObject({ show: false, data: [] });
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsLegendLayout.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsLegendLayout.ts
@@ -35,6 +35,18 @@ const getLegendRowCount = (names: string[], availableWidth: number) => {
   return rows;
 };
 
+// 하단(bottom) legend 의 공통 설정. names(=legend 항목)만 넘기면 icon/itemWidth/itemGap 등 스타일은
+// 모든 차트에서 동일한 값을 쓴다. show 같은 차트별 옵션은 extra 로 덮어쓴다.
+export const buildBottomLegend = (names: string[], extra?: Record<string, unknown>) => ({
+  data: names,
+  bottom: 0,
+  icon: 'square' as const,
+  itemWidth: LEGEND_ICON_WIDTH,
+  itemHeight: 10,
+  itemGap: LEGEND_ITEM_GAP,
+  ...extra,
+});
+
 export const getGridBottom = (names: string[], containerWidth: number) => {
   // 시리즈(=legend 항목)가 없으면(빈/No Data 상태) legend 공간을 예약하지 않는다.
   if (names.length === 0) return X_AXIS_LABEL_HEIGHT;
@@ -42,7 +54,6 @@ export const getGridBottom = (names: string[], containerWidth: number) => {
   const rows = getLegendRowCount(names, availableWidth);
   // 실제 legend 높이: 줄 높이 * 줄 수 + 줄 사이 간격 * (줄 수 - 1). 마지막 줄엔 trailing gap 이 없으므로
   // rows * (줄높이 + gap) 로 잡으면 gap 하나만큼 과다 예약되어 x축과의 간격이 필요 이상 벌어진다.
-  const legendHeight =
-    rows * LEGEND_ROW_CONTENT_HEIGHT + Math.max(0, rows - 1) * LEGEND_ITEM_GAP;
+  const legendHeight = rows * LEGEND_ROW_CONTENT_HEIGHT + Math.max(0, rows - 1) * LEGEND_ITEM_GAP;
   return X_AXIS_LABEL_HEIGHT + BOTTOM_GAP + legendHeight;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsTimeSeriesFormat.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsTimeSeriesFormat.test.ts
@@ -1,0 +1,57 @@
+import { formatAxisTooltip } from './echartsTimeSeriesFormat';
+
+describe('formatAxisTooltip', () => {
+  it('returns an empty string for empty/invalid params', () => {
+    expect(formatAxisTooltip([], (v) => String(v))).toBe('');
+    expect(formatAxisTooltip(null, (v) => String(v))).toBe('');
+  });
+
+  it('renders a row per series and applies formatValue', () => {
+    const html = formatAxisTooltip(
+      [
+        { axisValue: 0, seriesName: 'cpu', color: '#f00', value: 5 },
+        { axisValue: 0, seriesName: 'mem', color: '#0f0', value: 10 },
+      ],
+      (v) => `${v}%`,
+    );
+    expect(html).toContain('cpu');
+    expect(html).toContain('5%');
+    expect(html).toContain('mem');
+    expect(html).toContain('10%');
+  });
+
+  it('hides null-valued series by default (uncollected → gap)', () => {
+    const html = formatAxisTooltip(
+      [{ axisValue: 0, seriesName: 'cpu', color: '#f00', value: null }],
+      (v) => String(v),
+    );
+    expect(html).not.toContain('cpu');
+  });
+
+  it('shows null-valued series as zero when nullBehavior is "zero"', () => {
+    const html = formatAxisTooltip(
+      [{ axisValue: 0, seriesName: 'req', color: '#f00', value: [123, null] }],
+      (v) => String(v),
+      { nullBehavior: 'zero' },
+    );
+    expect(html).toContain('req');
+    expect(html).toContain('>0<'); // formatValue(0)
+  });
+
+  it('uses the injected formatDate for the header', () => {
+    const html = formatAxisTooltip(
+      [{ axisValue: 1700000000000, seriesName: 'a', color: '#000', value: 1 }],
+      (v) => String(v),
+      { formatDate: () => 'CUSTOM_DATE' },
+    );
+    expect(html).toContain('CUSTOM_DATE');
+  });
+
+  it('escapes HTML in series names', () => {
+    const html = formatAxisTooltip(
+      [{ axisValue: 0, seriesName: '<img src=x onerror=alert(1)>', color: '#000', value: 1 }],
+      (v) => String(v),
+    );
+    expect(html).not.toContain('<img src=x');
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsTimeSeriesFormat.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/echartsTimeSeriesFormat.ts
@@ -11,6 +11,15 @@ export const formatCategoryDateLabel = (value: number | string) => {
   return String(value);
 };
 
+interface AxisTooltipOptions {
+  // 날짜 헤더 포맷을 주입한다. 기본은 브라우저 로컬 타임존 기준(formatNewLinedDateString).
+  // 사용자 지정 타임존을 반영해야 하는 차트는 여기서 timezone 기반 포맷터를 넘긴다.
+  formatDate?: (axisValue: number) => string;
+  // 값이 null 인 시리즈 처리. 'hide'(기본): 행을 숨긴다(미수집=선 끊김 차트용).
+  // 'zero': 0 으로 표시한다(0 을 렌더링 이슈로 null 치환한 차트용).
+  nullBehavior?: 'hide' | 'zero';
+}
+
 // trigger: 'axis' 툴팁의 공통 포맷터. 날짜 헤더 + 시리즈별 색상 스와치/값 행을 그린다.
 // 값 포맷은 차트마다 다르므로 formatValue 로 주입받는다.
 export const formatAxisTooltip = (
@@ -18,13 +27,16 @@ export const formatAxisTooltip = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   params: any,
   formatValue: (value: number) => string,
+  { formatDate, nullBehavior = 'hide' }: AxisTooltipOptions = {},
 ) => {
   if (!Array.isArray(params) || params.length === 0) return '';
   const axisValue = params[0].axisValue;
   const axisValueNum = typeof axisValue === 'number' ? axisValue : Number(axisValue);
-  const dateStr = isValid(new Date(axisValueNum))
-    ? formatNewLinedDateString(axisValueNum).replace('\n', ' ')
-    : String(axisValue);
+  const dateStr = formatDate
+    ? formatDate(axisValueNum)
+    : isValid(new Date(axisValueNum))
+      ? formatNewLinedDateString(axisValueNum).replace('\n', ' ')
+      : String(axisValue);
   const rows = params
     .map(
       (param: {
@@ -32,7 +44,8 @@ export const formatAxisTooltip = (
         seriesName?: string;
         color?: string;
       }) => {
-        const yValue = typeof param.value === 'number' ? param.value : param.value?.[1];
+        const rawValue = typeof param.value === 'number' ? param.value : param.value?.[1];
+        const yValue = rawValue == null && nullBehavior === 'zero' ? 0 : rawValue;
         if (yValue == null) return null;
         return `<div style="display: flex; justify-content: space-between; gap: 12px; align-items: center;">
                   <div style="display: flex; gap: 5px; align-items: center;">

--- a/web-frontend/src/main/v3/packages/ui/src/lib/charts/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/charts/index.ts
@@ -1,3 +1,4 @@
+export * from './echartsCommonOptions';
 export * from './echartsLegendLayout';
 export * from './echartsTimeSeriesFormat';
 export * from './useEChartsInstance';


### PR DESCRIPTION
## Summary
- Dim the other series when hovering a graph line or a legend item on the Inspector charts, so the hovered series stands out (same behavior as the System Metric charts).
- Deduplicate the repeated ECharts option building that had grown across chart components: shared `buildBottomLegend` / `buildEmptyMessageGraphic` helpers and a `formatDate` / `nullBehavior` option on the shared `formatAxisTooltip`, plus moving the Load / Response / URL-default charts onto the shared `useEChartsInstance` lifecycle hook. Removes duplicated `echarts.init` + `ResizeObserver` + `dispose` boilerplate and dead code.
- Fix the Response Summary / Avg & Max value axis collapsing to a `[0,0]` range (hiding an axis line) when a node has no or all-zero data, by giving the axis a default max only when there is no positive value.
- Widen the Transaction Detail chart spacing and add horizontal page padding in the wide (xl+) layout.

## Test plan
- [x] `yarn build` passes (TypeScript check + Vite production build)
- [x] `yarn test` passes (507 tests, 61 suites)
- [ ] Inspector (Agent/Application, Data Source) and Transaction Detail charts: hovering a line or a legend item dims the other series
- [ ] Load / Response Summary / Response Avg & Max / URL / System Metric / Error Analysis charts still render; legends wrap correctly, "No Data" shows and clears, resize recomputes layout
- [ ] FilteredMap -> VIEW SERVERS: Response Summary / Avg & Max axes stay visible when there is no data
- [ ] Load chart tooltip keeps the selected timezone and still shows zero-count buckets
- [ ] Transaction Detail (xl+ width): charts have wider spacing and left/right page padding
