### PR TITLE
[#noissue] Extract DroppedCounts/TruncatedCounts for annotation values

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/DroppedCounts.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/DroppedCounts.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+/**
+ * Per-label counts of span data dropped on the SDK side (Span proto fields
+ * 10/12/14), for the OPENTELEMETRY_DROPPED annotation value. {@link #toString()}
+ * formats them as space-separated {@code label=count} pairs in declaration order
+ * (e.g. {@code "attributes=12 events=5 links=3"}); non-positive counts are omitted.
+ */
+final class DroppedCounts {
+
+    private int attributes;
+    private int events;
+    private int links;
+
+    DroppedCounts attributes(int count) {
+        this.attributes = count;
+        return this;
+    }
+
+    DroppedCounts events(int count) {
+        this.events = count;
+        return this;
+    }
+
+    DroppedCounts links(int count) {
+        this.links = count;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buffer = new StringBuilder();
+        append(buffer, "attributes", attributes);
+        append(buffer, "events", events);
+        append(buffer, "links", links);
+        return buffer.toString();
+    }
+
+    private static void append(StringBuilder buffer, String label, int count) {
+        if (count > 0) {
+            if (!buffer.isEmpty()) {
+                buffer.append(' ');
+            }
+            buffer.append(label).append('=').append(count);
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -164,20 +164,12 @@ public class OtlpTraceSpanMapper {
         if (droppedAttributes == 0 && droppedEvents == 0 && droppedLinks == 0) {
             return;
         }
-        StringBuilder sb = new StringBuilder();
-        appendDroppedCount(sb, "attributes", droppedAttributes);
-        appendDroppedCount(sb, "events", droppedEvents);
-        appendDroppedCount(sb, "links", droppedLinks);
-        sink.accept(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_DROPPED.getCode(), sb.toString()));
-    }
-
-    private static void appendDroppedCount(StringBuilder sb, String label, int count) {
-        if (count > 0) {
-            if (!sb.isEmpty()) {
-                sb.append(' ');
-            }
-            sb.append(label).append('=').append(count);
-        }
+        String label = new DroppedCounts()
+                .attributes(droppedAttributes)
+                .events(droppedEvents)
+                .links(droppedLinks)
+                .toString();
+        sink.accept(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_DROPPED.getCode(), label));
     }
 
     /**
@@ -191,12 +183,13 @@ public class OtlpTraceSpanMapper {
         if (truncatedAttributes == 0 && truncatedSql == 0 && truncatedEvents == 0 && truncatedLinks == 0) {
             return;
         }
-        StringBuilder sb = new StringBuilder();
-        appendDroppedCount(sb, "attributes", truncatedAttributes);
-        appendDroppedCount(sb, "sql", truncatedSql);
-        appendDroppedCount(sb, "events", truncatedEvents);
-        appendDroppedCount(sb, "links", truncatedLinks);
-        sink.accept(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_TRUNCATED.getCode(), sb.toString()));
+        String label = new TruncatedCounts()
+                .attributes(truncatedAttributes)
+                .sql(truncatedSql)
+                .events(truncatedEvents)
+                .links(truncatedLinks)
+                .toString();
+        sink.accept(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_TRUNCATED.getCode(), label));
     }
 
     /**

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/TruncatedCounts.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/TruncatedCounts.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+/**
+ * Per-label counts of span data truncated by the collector, for the
+ * OPENTELEMETRY_TRUNCATED annotation value. {@link #toString()} formats them
+ * as space-separated {@code label=count} pairs in declaration order
+ * (e.g. {@code "attributes=3 sql=1"}); non-positive counts are omitted.
+ */
+final class TruncatedCounts {
+
+    private int attributes;
+    private int sql;
+    private int events;
+    private int links;
+
+    TruncatedCounts attributes(int count) {
+        this.attributes = count;
+        return this;
+    }
+
+    TruncatedCounts sql(int count) {
+        this.sql = count;
+        return this;
+    }
+
+    TruncatedCounts events(int count) {
+        this.events = count;
+        return this;
+    }
+
+    TruncatedCounts links(int count) {
+        this.links = count;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buffer = new StringBuilder();
+        append(buffer, "attributes", attributes);
+        append(buffer, "sql", sql);
+        append(buffer, "events", events);
+        append(buffer, "links", links);
+        return buffer.toString();
+    }
+
+    private static void append(StringBuilder buffer, String label, int count) {
+        if (count > 0) {
+            if (!buffer.isEmpty()) {
+                buffer.append(' ');
+            }
+            buffer.append(label).append('=').append(count);
+        }
+    }
+}


### PR DESCRIPTION
Replace the StringBuilder + appendDroppedCount helper with one value
object per annotation: DroppedCounts (attributes/events/links) for
OPENTELEMETRY_DROPPED and TruncatedCounts (attributes/sql/events/links)
for OPENTELEMETRY_TRUNCATED. Counts are set via per-label chaining
methods and toString formats the space-separated label=count string,
omitting non-positive counts.
