### PR TITLE
[#noissue] Harden otlptrace-collector ingestion path

### DIFF
--- a/otlptrace/otlptrace-collector/README.md
+++ b/otlptrace/otlptrace-collector/README.md
@@ -1,0 +1,159 @@
+# otlptrace-collector
+
+The OTLP (OpenTelemetry Protocol) trace ingestion collector module. It receives the
+`ExportTraceServiceRequest` sent by an OTLP exporter over gRPC/HTTP, converts it into Pinpoint's
+SpanBo/SpanChunkBo, and stores it in HBase.
+
+This document summarizes the analysis of the gRPC/HTTP ingestion layer and the worker/HBase storage
+layer. (Analysis baseline: 2026-07 master branch)
+
+---
+
+## 1. Architecture Overview
+
+```
+OTLP exporter
+  ├─ gRPC  :9998 (plaintext) / :9448 (TLS, opt-in)  ── GrpcOtlpTraceService
+  └─ HTTP  :9997  POST /v1/traces (protobuf)        ── OtlpTraceController
+                     │
+                     ▼
+             OtlpTraceMapper (OTLP span → SpanBo/SpanChunkBo/AgentInfoBo/ExceptionMetaDataBo)
+                     │
+                     ▼
+             HbaseOtlpTraceService / HbaseOtlpAgentInfoService / HbaseOtlpApplicationIndexV2Service
+                     │
+                     ▼
+             HBase (TraceV2, TRACE_INDEX, AGENTINFO, APPLICATION/AGENT_ID, server-map stats)
+```
+
+- Startup: the multi-app starter in `collector-starter` boots it as a child context when
+  `CollectorType.OTLPTRACE` (`collector-starter/.../PinpointCollectorStarter.java:95-124`).
+  servlet port 9997, gRPC 9998, TLS 9448.
+- Module gate: `pinpoint.modules.collector.otlptrace.enabled=true` (`OtlpTraceCollectorModule.java:75`)
+- Properties: `otlptrace/collector/pinpoint-otlptrace-grpc-root.properties` + per-profile overrides
+
+---
+
+## 2. gRPC Layer
+
+### Server bootstrap
+
+- Reuses the collector module's shared `GrpcReceiver`/`ServerFactory` (`OtlpTraceCollectorModule.java:120-142`).
+  IP filter (`IgnoreAddressFilter`, skips L4 health-check IPs) and the TransportMetadata / StreamCount
+  interceptors are installed by default.
+- Service registration: a single service — `GrpcOtlpTraceService` + `MetricCollectingServerInterceptor`
+  (tagged `service=otlptrace`).
+- The SSL module (`OtlpTraceCollectorGrpcSslModule`) is opt-in (off by default). It binds a separate
+  `GrpcReceiver` on 9448 that shares the same serviceList / executor / ServerOption as the plaintext
+  receiver. Certificate config reuses the collector's shared prefix `collector.receiver.grpc.ssl.*`.
+
+### Key settings (pinpoint-otlptrace-grpc-root.properties)
+
+| Item | Value | Notes |
+|---|---|---|
+| inbound_message_size_max | 1MB | More conservative than the main collector's span receiver (4MB) |
+| HTTP/2 flow-control window | 512KB | |
+| Concurrent calls per connection | 128 | Conservative vs the main collector's 1024 |
+| keepalive | time 30s / timeout 60s, permit 10s + without_calls | Handles OTLP exporter idle PINGs (avoids GOAWAY too_many_pings) |
+| max header | 8KB | Accounts for the JWT Authorization header |
+| server executor | 4 threads / queue 256 | Serves both the gRPC handler and HBase async callbacks |
+| worker executor | 16 threads / queue 128 | Runs mapping + insert, AbortPolicy |
+| in-flight byte admission | 256MB (Semaphore) | The code `@Value` default is 64MB — note the mismatch |
+
+### Request handling flow (`GrpcOtlpTraceService.java:86-153`)
+
+1. **Byte admission**: `tryAcquire` on the Semaphore for `request.getSerializedSize()`; on failure,
+   return `UNAVAILABLE` immediately. The reason for using `UNAVAILABLE` instead of `RESOURCE_EXHAUSTED`
+   (OTLP exporters retry it unconditionally) is documented in a comment.
+2. **Worker offload**: submitted to the worker executor via `Context.current().wrap()` — non-blocking
+   for the gRPC handler thread. On queue saturation (`RejectedExecutionException`), release the permit
+   and return `UNAVAILABLE`.
+3. **Cancellation check**: if the client has cancelled by execution time, skip mapping; the permit is
+   released in a finally block.
+4. **Response semantics**:
+   - Server-side error (insert failure) → `UNAVAILABLE` for the whole batch (drives retry, prevents loss)
+   - Client data fault (mapping reject) → OTLP-spec `ExportTracePartialSuccess` (rejectedSpans + errorMessage)
+   - Unexpected exception in the worker → `INTERNAL` (prevents a poison-data retry storm)
+
+---
+
+## 3. HTTP Layer
+
+- Endpoint: a single mapping `POST /v1/traces`, `consumes = application/x-protobuf`
+  (`OtlpTraceController.java:67-68`). **OTLP/HTTP JSON encoding is not supported** (415),
+  **Content-Encoding: gzip is not supported** (parse failure 400 — beware exporters that default to gzip).
+- Body parsing: `ProtobufHttpMessageConverter` (`OtlpTraceCollectorHttpModule.java:36-40`)
+- Executed synchronously on the Tomcat request thread (no worker offload)
+
+### Admission Filter (`OtlpTraceHttpAdmissionFilter`)
+
+Registered only for `/v1/traces` with `Ordered.HIGHEST_PRECEDENCE`, so it runs **before** protobuf
+deserialization. A 3-stage gate:
+
+1. Content-Length > 4MB → **413**. If the length is unknown (chunked), pessimistically reserve 4MB and
+   block on overflow via `LimitedRequestWrapper`.
+2. Concurrent-request Semaphore(64) failure → **503 + Retry-After (1s)**
+3. in-flight byte Semaphore (256MB)
+
+Permits are released in a finally block after the entire request (parse + insert) completes.
+Config keys: `pinpoint.collector.otlptrace.http.*`
+
+### gRPC vs HTTP comparison
+
+| Item | gRPC | HTTP |
+|---|---|---|
+| Mapping/storage deps | Shares the same beans | Same |
+| export logic | Shared `OtlpTraceExportService` (single implementation) | Same |
+| agentId dedup cache | Shared Caffeine bean (`otlpAgentIdCache`, thread-safe, cross-transport) | Same |
+| Execution thread | Worker executor offload | Synchronous on the Tomcat request thread |
+| Backpressure | UNAVAILABLE | 503 + Retry-After |
+| partial success | Responds per spec | **Not emitted — always 200 (bug)** |
+| Server-side error | Drives retry via UNAVAILABLE | **Always 200 → silent loss (bug)** |
+
+---
+
+## 4. Worker / HBase Storage Layer
+
+### Thread-pool chain (per request)
+
+```
+gRPC server executor (4 threads / queue 256)
+  → [admission Semaphore: in-flight bytes 256MB]
+  → worker executor (16 threads / queue 128, AbortPolicy)   ← runs mapping + insert
+  → AsyncPollerThread[] (span: at least 4, queue 10000 each) ← actual HBase batch put (100 rows / 100ms)
+  → (completion callback) returns to the server executor
+```
+
+- HBase writes: `hbase.client.put-writer=asyncPoller` — `AsyncPollingPutWriter` distributes to pollers
+  by rowkey hash. On poller-queue saturation it returns a **failed future** carrying
+  `RequestNotPermittedException(OVERFLOW)` (not a synchronous exception).
+- `span-put-writer.concurrency-limit=0` on the span path (no rate limiter).
+- Server-map stats: `BulkWriter` aggregates in memory and flushes every 5s (`SchedulerConfiguration`).
+
+### Storage paths (per SpanBo)
+
+| Path | DAO | Table/CF | Write mode |
+|---|---|---|---|
+| span body | `HbaseTraceDaoV2.asyncInsert` | `TraceV2` / CF `S`, rowkey=salted transactionId | async (returns future, observed via callback) |
+| scatter index | `HbaseTraceIndexDao` (v2) | `TRACE_INDEX` / `TRACE_INDEX_META` | async — **future discarded** |
+| server-map stats | `BulkWriter.increment` | link/response-stats tables | in-memory aggregation + 5s flush |
+| store event | `SpanStorePublisher` | (Spring event) | published from the async callback |
+
+spanChunk uses only `TraceV2`/CF `S` (no scatter index). AgentInfo (`AGENTINFO`/CF `Info`,
+rowkey=`agentId+startTime`) and ApplicationIndex v2 (`APPLICATION`, `AGENT_ID`) are synchronous put +
+Caffeine dedup (`otlpAgentIdCache`, maxSize 10000, shared across transports). serviceUid is always
+`ServiceUid.DEFAULT` (TODO).
+
+### Loss analysis
+
+There is no internal retry; it relies entirely on the OTLP exporter's retries. The key question is
+whether a failure **surfaces before the response**:
+
+| Failure point | Outcome |
+|---|---|
+| admission / worker queue saturation | UNAVAILABLE → client retries, **no loss** |
+| synchronous exception during mapping | UNAVAILABLE → retry, **no loss** |
+| span put failure (incl. poller-queue overflow) | **Loss after a success response** — metric + throttled WARN only (Phase 1.5 constraint, documented at `HbaseOtlpTraceService.java:51-53`) |
+| spanChunk put failure | **Fully ignored** — future discarded + success event always published |
+| scatter index failure | future discarded, no metric — loss that is invisible in scatter |
+| server-map stats | Up to 5s of increments lost on process death (acceptable by design) |

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
@@ -24,16 +24,14 @@ import com.navercorp.pinpoint.collector.heatmap.HeatmapCollectorModule;
 import com.navercorp.pinpoint.collector.receiver.grpc.GrpcReceiver;
 import com.navercorp.pinpoint.collector.receiver.grpc.monitor.BasicMonitor;
 import com.navercorp.pinpoint.collector.receiver.grpc.monitor.Monitor;
-import com.navercorp.pinpoint.collector.service.ExceptionMetaDataService;
-import com.navercorp.pinpoint.collector.service.TraceService;
 import com.navercorp.pinpoint.common.server.config.TypeLoaderConfiguration;
 import com.navercorp.pinpoint.common.server.uid.ObjectNameVersion;
 import com.navercorp.pinpoint.common.server.util.IgnoreAddressFilter;
 import com.navercorp.pinpoint.grpc.channelz.ChannelzRegistry;
-import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapper;
 import com.navercorp.pinpoint.otlp.trace.collector.service.GrpcOtlpTraceService;
-import com.navercorp.pinpoint.otlp.trace.collector.service.HbaseOtlpAgentInfoService;
-import com.navercorp.pinpoint.otlp.trace.collector.service.HbaseOtlpApplicationIndexV2Service;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportService;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
@@ -51,7 +49,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import java.util.Optional;
 import java.util.concurrent.Executor;
 
 @Configuration
@@ -80,11 +77,21 @@ public class OtlpTraceCollectorModule {
         return ObjectNameVersion.getVersion(version);
     }
 
+    // Shared, thread-safe, bounded dedup of already-persisted agentIds. Injected into the single
+    // OtlpTraceExportService so gRPC and HTTP transports share one cache (dedup is effective across
+    // both) instead of the former per-instance, non-thread-safe LRUCache.
     @Bean
-    public ServerServiceDefinition serverServiceDefinition(TraceService[] traceServiceList, @Qualifier("hbaseOtlpAgentInfoService") HbaseOtlpAgentInfoService agentInfoService, @Qualifier("hbaseOtlpApplicationIndexV2Service") HbaseOtlpApplicationIndexV2Service applicationIndexV2Service, OtlpTraceMapper mapper, Optional<ExceptionMetaDataService> exceptionMetaDataService, @Qualifier("grpcOtlpTraceWorkerExecutor") Executor workerExecutor,
+    public Cache<String, Boolean> otlpAgentIdCache(
+            @Value("${pinpoint.collector.otlptrace.agent-id-cache.max-size:10000}") int maxSize) {
+        return Caffeine.newBuilder().maximumSize(maxSize).build();
+    }
+
+    @Bean
+    public ServerServiceDefinition serverServiceDefinition(OtlpTraceExportService exportService,
+                                                           @Qualifier("grpcOtlpTraceWorkerExecutor") Executor workerExecutor,
                                                            @Value("${pinpoint.collector.otlptrace.admission.max-in-flight-bytes:67108864}") int maxInFlightBytes,
                                                            MeterRegistry meterRegistry) {
-        BindableService spanService = new GrpcOtlpTraceService(traceServiceList, agentInfoService, applicationIndexV2Service, mapper, exceptionMetaDataService.orElse(null), workerExecutor, maxInFlightBytes);
+        BindableService spanService = new GrpcOtlpTraceService(exportService, workerExecutor, maxInFlightBytes);
         // gRPC server metrics (request count / latency / status code) for the OTLP trace endpoint,
         // tagged service=otlptrace to match the agent/stat/span receivers' metrics.
         final ServerInterceptor metricInterceptor = new MetricCollectingServerInterceptor(meterRegistry,

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceController.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceController.java
@@ -16,129 +16,36 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.controller;
 
-import com.navercorp.pinpoint.collector.service.ExceptionMetaDataService;
-import com.navercorp.pinpoint.collector.service.TraceService;
-import com.navercorp.pinpoint.common.cache.LRUCache;
-import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
-import com.navercorp.pinpoint.common.server.bo.SpanBo;
-import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
-import com.navercorp.pinpoint.common.server.bo.exception.ExceptionMetaDataBo;
-import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
-import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapper;
-import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperData;
-import com.navercorp.pinpoint.otlp.trace.collector.service.GrpcOtlpTraceService;
-import com.navercorp.pinpoint.otlp.trace.collector.service.HbaseOtlpAgentInfoService;
-import com.navercorp.pinpoint.otlp.trace.collector.service.HbaseOtlpApplicationIndexV2Service;
-import io.opentelemetry.proto.collector.trace.v1.ExportTracePartialSuccess;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportResult;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportService;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
-import jakarta.validation.constraints.NotNull;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 
 @RestController
 public class OtlpTraceController {
-    private final Logger logger = LogManager.getLogger(this.getClass());
 
-    @NotNull
-    private final TraceService[] traceService;
-    private final HbaseOtlpAgentInfoService agentInfoService;
-    private final HbaseOtlpApplicationIndexV2Service applicationIndexV2Service;
-    @NotNull
-    private final OtlpTraceMapper otlpTraceMapper;
-    private final ExceptionMetaDataService exceptionMetaDataService;
-    private final LRUCache<String, Boolean> agentIdCache = new LRUCache<>(10000);
+    private final OtlpTraceExportService exportService;
 
-    public OtlpTraceController(TraceService[] traceServiceList, HbaseOtlpAgentInfoService agentInfoService, HbaseOtlpApplicationIndexV2Service applicationIndexV2Service, OtlpTraceMapper otlpTraceMapper, Optional<ExceptionMetaDataService> exceptionMetaDataService) {
-        this.traceService = traceServiceList;
-        this.agentInfoService = agentInfoService;
-        this.applicationIndexV2Service = applicationIndexV2Service;
-        this.otlpTraceMapper = otlpTraceMapper;
-        this.exceptionMetaDataService = exceptionMetaDataService.orElse(null);
+    public OtlpTraceController(OtlpTraceExportService exportService) {
+        this.exportService = Objects.requireNonNull(exportService, "exportService");
     }
 
     @PostMapping(value = "/v1/traces", consumes = "application/x-protobuf")
     public ResponseEntity<Void> saveOtlpMetric(@RequestBody ExportTraceServiceRequest request) {
         final List<ResourceSpans> resourceSpanList = request.getResourceSpansList();
-        final OtlpTraceCollectorRejectedSpan rejectedSpan = export(resourceSpanList);
+        final OtlpTraceExportResult result = exportService.export(resourceSpanList);
 
-        if (rejectedSpan.count() > 0) {
-            final ExportTracePartialSuccess.Builder builder = ExportTracePartialSuccess.newBuilder();
-            builder.setErrorMessage(rejectedSpan.getMessage());
-            builder.setRejectedSpans(rejectedSpan.count());
-        }
-
+        // NOTE (M-1, out of scope for this change): the HTTP path currently returns 200 regardless of
+        // outcome and sends no ExportTraceServiceResponse body. result.serverErrorCount() /
+        // result.clientRejected() are now available here to implement proper OTLP/HTTP response
+        // semantics (5xx on server error, ExportTracePartialSuccess body on client rejects) later.
         return ResponseEntity.ok().build();
-    }
-
-    private OtlpTraceCollectorRejectedSpan export(List<ResourceSpans> resourceSpanList) {
-        final OtlpTraceMapperData otlpTraceMapperData = otlpTraceMapper.map(resourceSpanList);
-        int errorCount = 0;
-        for (SpanBo spanBo : otlpTraceMapperData.getSpanBoList()) {
-            for (TraceService traceService : traceService) {
-                try {
-                    traceService.insertSpan(spanBo);
-                } catch (Exception e) {
-                    errorCount++;
-                    logger.warn("Failed to insert spanBo", e);
-                }
-            }
-        }
-
-        for (SpanChunkBo spanChunkBo : otlpTraceMapperData.getSpanChunkBoList()) {
-            for (TraceService traceService : traceService) {
-                try {
-                    traceService.insertSpanChunk(spanChunkBo);
-                } catch (Exception e) {
-                    errorCount++;
-                    logger.warn("Failed to insert spanChunkBo", e);
-                }
-            }
-        }
-
-        if (errorCount > 0) {
-            OtlpTraceCollectorRejectedSpan rejectedSpan = otlpTraceMapperData.getRejectedSpan();
-            rejectedSpan.putMessage("insert error (" + errorCount + ")");
-            rejectedSpan.addCount(errorCount);
-        }
-
-        int agentInfoErrorCount = 0;
-        for (AgentInfoBo agentInfoBo : otlpTraceMapperData.getAgentInfoBoList()) {
-            if (agentIdCache.get(agentInfoBo.getAgentId()) == null) {
-                try {
-                    agentInfoService.insert(agentInfoBo);
-                    applicationIndexV2Service.insert(GrpcOtlpTraceService.DEFAULT_SERVICE_UID, agentInfoBo);
-                    agentIdCache.put(agentInfoBo.getAgentId(), true);
-                } catch (Exception e) {
-                    agentInfoErrorCount++;
-                    logger.warn("Failed to insert agentInfoBo", e);
-                }
-            }
-        }
-
-        if (agentInfoErrorCount > 0) {
-            OtlpTraceCollectorRejectedSpan rejectedSpan = otlpTraceMapperData.getRejectedSpan();
-            rejectedSpan.putMessage("agentInfo error (" + agentInfoErrorCount + ")");
-            rejectedSpan.addCount(agentInfoErrorCount);
-        }
-
-        if (exceptionMetaDataService != null) {
-            for (ExceptionMetaDataBo exceptionMetaDataBo : otlpTraceMapperData.getExceptionMetaDataBoList()) {
-                try {
-                    exceptionMetaDataService.save(exceptionMetaDataBo);
-                } catch (Exception e) {
-                    logger.warn("Failed to insert exceptionMetaData", e);
-                }
-            }
-        }
-
-        return otlpTraceMapperData.getRejectedSpan();
     }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapper.java
@@ -20,11 +20,15 @@ import com.navercorp.pinpoint.common.server.bo.exception.ExceptionMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.exception.ExceptionWrapperBo;
 import com.navercorp.pinpoint.common.server.bo.exception.StackTraceElementWrapperBo;
 import com.navercorp.pinpoint.common.server.trace.OtelServerTraceId;
+import com.navercorp.pinpoint.common.server.util.Utf8;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.proto.trace.v1.Span;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -40,6 +44,46 @@ import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceConsta
 public class OtlpExceptionMapper {
 
     private static final String EMPTY = "";
+
+    private static final String TRUNCATED_METRIC = "collector.otlptrace.exception.truncated";
+
+    // Byte-based caps for the client-supplied exception fields (unlike the native path, these arrive
+    // as free-form strings from a third-party exporter). Mirrors the module's attribute/SQL/event/link
+    // truncation convention (Utf8.truncate) rather than the native char-based abbreviate, since the
+    // goal is bounding HBase/Pinot storage size. Truncation is surfaced via a Micrometer counter
+    // (tagged by field) — the OPENTELEMETRY_TRUNCATED span annotation does not apply here because the
+    // exception is a separate entity written to its own store, not part of the span.
+    private final int messageMaxBytes;
+    // Max number of parsed stacktrace frames. OTel delivers one flattened stacktrace string, so the
+    // unbounded axis is the frame count (not the native exception-chain depth). <= 0 means unlimited.
+    private final int stackTraceMaxDepth;
+    private final int frameMaxBytes;
+
+    private final Counter messageTruncatedCounter;
+    private final Counter stackTraceDepthTruncatedCounter;
+    private final Counter frameValueTruncatedCounter;
+
+    public OtlpExceptionMapper(
+            @Value("${pinpoint.collector.otlptrace.exception.message-max-bytes:8192}") int messageMaxBytes,
+            @Value("${pinpoint.collector.otlptrace.exception.stacktrace.max-depth:256}") int stackTraceMaxDepth,
+            @Value("${pinpoint.collector.otlptrace.exception.stacktrace.frame-max-bytes:2048}") int frameMaxBytes,
+            MeterRegistry meterRegistry) {
+        // Byte caps must be >= 1: a cap of 0 (or negative) would truncate every value to "" and, for
+        // the non-empty-constrained className/methodName, make StackTraceElementWrapperBo throw.
+        // (stackTraceMaxDepth is intentionally unvalidated — <= 0 is the documented "unlimited".)
+        if (messageMaxBytes < 1) {
+            throw new IllegalArgumentException("messageMaxBytes must be >= 1: " + messageMaxBytes);
+        }
+        if (frameMaxBytes < 1) {
+            throw new IllegalArgumentException("frameMaxBytes must be >= 1: " + frameMaxBytes);
+        }
+        this.messageMaxBytes = messageMaxBytes;
+        this.stackTraceMaxDepth = stackTraceMaxDepth;
+        this.frameMaxBytes = frameMaxBytes;
+        this.messageTruncatedCounter = meterRegistry.counter(TRUNCATED_METRIC, "field", "message");
+        this.stackTraceDepthTruncatedCounter = meterRegistry.counter(TRUNCATED_METRIC, "field", "stacktrace_depth");
+        this.frameValueTruncatedCounter = meterRegistry.counter(TRUNCATED_METRIC, "field", "frame_value");
+    }
 
     /**
      * Maps an OTel 'exception' span event to an {@link ExceptionMetaDataBo}.
@@ -68,7 +112,7 @@ public class OtlpExceptionMapper {
             return Optional.empty();
         }
 
-        final String exceptionMessage = AttributeUtils.getAttributeStringValue(eventAttrs, ATTRIBUTE_KEY_EXCEPTION_MESSAGE, EMPTY);
+        final String exceptionMessage = cap(AttributeUtils.getAttributeStringValue(eventAttrs, ATTRIBUTE_KEY_EXCEPTION_MESSAGE, EMPTY), messageMaxBytes, messageTruncatedCounter);
         final String stackTraceStr = AttributeUtils.getAttributeStringValue(eventAttrs, ATTRIBUTE_KEY_EXCEPTION_STACKTRACE, EMPTY);
 
         final long eventTime = exceptionEvent.getTimeUnixNano() > 0
@@ -110,6 +154,13 @@ public class OtlpExceptionMapper {
         }
 
         for (String line : stackTrace.split("\n")) {
+            // Cap the number of frames: the flattened stacktrace is client-supplied, so its frame
+            // count is unbounded (up to the request-size limit) without this guard.
+            if (stackTraceMaxDepth > 0 && result.size() >= stackTraceMaxDepth) {
+                stackTraceDepthTruncatedCounter.increment();
+                break;
+            }
+
             final String trimmed = line.trim();
             if (!trimmed.startsWith("at ")) {
                 continue;
@@ -153,8 +204,35 @@ public class OtlpExceptionMapper {
                 lineNumber = "Native Method".equals(fileInfo) ? -2 : -1;
             }
 
-            result.add(new StackTraceElementWrapperBo(className, fileName, lineNumber, methodName));
+            result.add(new StackTraceElementWrapperBo(
+                    cap(className, frameMaxBytes, frameValueTruncatedCounter),
+                    cap(fileName, frameMaxBytes, frameValueTruncatedCounter),
+                    lineNumber,
+                    cap(methodName, frameMaxBytes, frameValueTruncatedCounter)));
         }
         return result;
+    }
+
+    /**
+     * Truncates {@code value} to at most {@code maxBytes} UTF-8 bytes (never splitting a multi-byte
+     * character) and increments {@code counter} when truncation actually occurred. Returns the
+     * original reference when already within the limit.
+     *
+     * <p>If truncation would yield an empty string for a non-empty input (i.e. {@code maxBytes} is
+     * smaller than the first code point's UTF-8 length), the original is kept instead: an empty
+     * value would violate {@link StackTraceElementWrapperBo}'s non-empty className/methodName
+     * contract. With the {@code >= 1} byte caps validated in the constructor this only applies to a
+     * leading multi-byte character.
+     */
+    private static String cap(String value, int maxBytes, Counter counter) {
+        final String truncated = Utf8.truncate(value, maxBytes);
+        if (truncated == null) {
+            return value; // already within the limit
+        }
+        if (truncated.isEmpty() && !value.isEmpty()) {
+            return value; // would drop the whole value; keep the original rather than emit ""
+        }
+        counter.increment();
+        return truncated;
     }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceService.java
@@ -16,17 +16,7 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.service;
 
-import com.navercorp.pinpoint.collector.service.ExceptionMetaDataService;
-import com.navercorp.pinpoint.collector.service.TraceService;
-import com.navercorp.pinpoint.common.cache.LRUCache;
-import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
-import com.navercorp.pinpoint.common.server.bo.SpanBo;
-import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
-import com.navercorp.pinpoint.common.server.bo.exception.ExceptionMetaDataBo;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
-import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapper;
-import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperData;
 import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
@@ -35,18 +25,16 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
-import jakarta.validation.constraints.NotNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
-import java.util.function.Supplier;
 
 public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase {
-    public static final Supplier<ServiceUid> DEFAULT_SERVICE_UID = () -> ServiceUid.DEFAULT;
 
     // UNAVAILABLE (not RESOURCE_EXHAUSTED): OTLP exporters retry UNAVAILABLE unconditionally,
     // whereas RESOURCE_EXHAUSTED is retried only when a RetryInfo is attached. Using UNAVAILABLE
@@ -56,28 +44,17 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
-    @NotNull
-    private final TraceService[] traceServiceList;
-    private final HbaseOtlpAgentInfoService agentInfoService;
-    private final HbaseOtlpApplicationIndexV2Service applicationIndexV2Service;
-    @NotNull
-    private final OtlpTraceMapper otlpTraceMapper;
-    private final ExceptionMetaDataService exceptionMetaDataService;
+    private final OtlpTraceExportService exportService;
     // Worker pool that runs the mapping/insert work, keeping it off the gRPC handler (server.executor).
     private final Executor workerExecutor;
     // Global byte-based admission: caps the total in-flight (queued + processing) request wire bytes
     // so concurrent requests cannot exhaust the heap regardless of request count or connection count.
     private final Semaphore admissionBytes;
     private final int maxInFlightBytes;
-    private final LRUCache<String, Boolean> agentIdCache = new LRUCache<>(10000);
 
-    public GrpcOtlpTraceService(TraceService[] traceServiceList, HbaseOtlpAgentInfoService agentInfoService, HbaseOtlpApplicationIndexV2Service applicationIndexV2Service, OtlpTraceMapper otlpTraceMapper, ExceptionMetaDataService exceptionMetaDataService, Executor workerExecutor, int maxInFlightBytes) {
-        this.traceServiceList = traceServiceList;
-        this.agentInfoService = agentInfoService;
-        this.applicationIndexV2Service = applicationIndexV2Service;
-        this.otlpTraceMapper = otlpTraceMapper;
-        this.exceptionMetaDataService = exceptionMetaDataService;
-        this.workerExecutor = workerExecutor;
+    public GrpcOtlpTraceService(OtlpTraceExportService exportService, Executor workerExecutor, int maxInFlightBytes) {
+        this.exportService = Objects.requireNonNull(exportService, "exportService");
+        this.workerExecutor = Objects.requireNonNull(workerExecutor, "workerExecutor");
         this.maxInFlightBytes = maxInFlightBytes;
         this.admissionBytes = new Semaphore(maxInFlightBytes);
     }
@@ -129,7 +106,7 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
     }
 
     private void handleExport(List<ResourceSpans> resourceSpanList, StreamObserver<ExportTraceServiceResponse> responseObserver) {
-        final ExportResult result = export(resourceSpanList);
+        final OtlpTraceExportResult result = exportService.export(resourceSpanList);
 
         if (result.serverErrorCount() > 0) {
             // Server-side / transient failures (HBase insert, agentInfo): ask the client to retry
@@ -174,76 +151,4 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
         }
     }
 
-    private ExportResult export(List<ResourceSpans> resourceSpanList) {
-        final OtlpTraceMapperData otlpTraceMapperData = otlpTraceMapper.map(resourceSpanList);
-        // Mapping rejects (invalid ids, unlinkable/orphan spans) are client-side data faults.
-        final OtlpTraceCollectorRejectedSpan clientRejected = otlpTraceMapperData.getRejectedSpan();
-
-        int insertErrorCount = 0;
-        for (SpanBo spanBo : otlpTraceMapperData.getSpanBoList()) {
-            for (TraceService traceService : traceServiceList) {
-                try {
-                    traceService.insertSpan(spanBo);
-                } catch (Exception e) {
-                    insertErrorCount++;
-                    logger.warn("Failed to insert spanBo", e);
-                }
-            }
-        }
-
-        for (SpanChunkBo spanChunkBo : otlpTraceMapperData.getSpanChunkBoList()) {
-            for (TraceService traceService : traceServiceList) {
-                try {
-                    traceService.insertSpanChunk(spanChunkBo);
-                } catch (Exception e) {
-                    insertErrorCount++;
-                    logger.warn("Failed to insert spanChunkBo", e);
-                }
-            }
-        }
-
-        int agentInfoErrorCount = 0;
-        for (AgentInfoBo agentInfoBo : otlpTraceMapperData.getAgentInfoBoList()) {
-            if (agentIdCache.get(agentInfoBo.getAgentId()) == null) {
-                try {
-                    agentInfoService.insert(agentInfoBo);
-                    applicationIndexV2Service.insert(DEFAULT_SERVICE_UID, agentInfoBo);
-                    agentIdCache.put(agentInfoBo.getAgentId(), true);
-                } catch (Exception e) {
-                    agentInfoErrorCount++;
-                    logger.warn("Failed to insert agentInfoBo", e);
-                }
-            }
-        }
-
-        if (exceptionMetaDataService != null) {
-            for (ExceptionMetaDataBo exceptionMetaDataBo : otlpTraceMapperData.getExceptionMetaDataBoList()) {
-                try {
-                    exceptionMetaDataService.save(exceptionMetaDataBo);
-                } catch (Exception e) {
-                    logger.warn("Failed to insert exceptionMetaData", e);
-                }
-            }
-        }
-
-        final int serverErrorCount = insertErrorCount + agentInfoErrorCount;
-        return new ExportResult(clientRejected, serverErrorCount, buildServerMessage(insertErrorCount, agentInfoErrorCount));
-    }
-
-    private static String buildServerMessage(int insertErrorCount, int agentInfoErrorCount) {
-        final StringBuilder sb = new StringBuilder();
-        if (insertErrorCount > 0) {
-            sb.append("insert error (").append(insertErrorCount).append(')');
-        }
-        if (agentInfoErrorCount > 0) {
-            if (!sb.isEmpty()) {
-                sb.append(", ");
-            }
-            sb.append("agentInfo error (").append(agentInfoErrorCount).append(')');
-        }
-        return sb.toString();
-    }
-
-    private record ExportResult(OtlpTraceCollectorRejectedSpan clientRejected, int serverErrorCount, String serverMessage) {
-    }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportResult.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportResult.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
+
+/**
+ * Transport-agnostic outcome of an OTLP trace export.
+ * <p>
+ * Splits the two failure classes so each transport can map them to its own response semantics:
+ * <ul>
+ *     <li>{@code serverErrorCount} / {@code serverMessage} — server-side/transient failures
+ *     (HBase insert, agentInfo). Retryable: gRPC returns UNAVAILABLE, HTTP should return 5xx.</li>
+ *     <li>{@code clientRejected} — deterministic client-side data faults (invalid/unlinkable spans).
+ *     Reported via OTLP partial success rather than a retryable error.</li>
+ * </ul>
+ */
+public record OtlpTraceExportResult(OtlpTraceCollectorRejectedSpan clientRejected,
+                                    int serverErrorCount,
+                                    String serverMessage) {
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.navercorp.pinpoint.collector.service.ExceptionMetaDataService;
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.common.profiler.logging.ThrottledLogger;
+import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import com.navercorp.pinpoint.common.server.bo.exception.ExceptionMetaDataBo;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapper;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperData;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import jakarta.validation.constraints.NotNull;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Transport-agnostic OTLP trace ingestion: maps the incoming {@link ResourceSpans} into
+ * SpanBo/SpanChunkBo/AgentInfoBo/ExceptionMetaDataBo and writes them to storage.
+ * <p>
+ * Shared by both the gRPC ({@code GrpcOtlpTraceService}) and HTTP ({@code OtlpTraceController})
+ * transports so the mapping/insert logic — and the agentId dedup cache — live in a single place
+ * (previously duplicated, with the two copies already diverging). The single {@code agentIdCache}
+ * bean makes dedup effective across both transports and is thread-safe (Caffeine), unlike the
+ * former per-instance {@code LRUCache} which was not safe under the worker/servlet threads.
+ */
+@Service
+public class OtlpTraceExportService {
+
+    public static final Supplier<ServiceUid> DEFAULT_SERVICE_UID = () -> ServiceUid.DEFAULT;
+
+    private static final String INSERT_ERROR_METRIC = "collector.otlptrace.insert.error";
+
+    private final Logger logger = LogManager.getLogger(this.getClass());
+    // Throttled so an HBase outage (every span/chunk failing synchronously) does not flood the log.
+    // Mirrors HbaseOtlpTraceService's async-path pattern (throttled WARN + a per-op error counter so
+    // the true failure rate stays observable even while logs are throttled).
+    private final ThrottledLogger throttledLogger = ThrottledLogger.getLogger(logger, 100);
+
+    @NotNull
+    private final TraceService[] traceServiceList;
+    private final HbaseOtlpAgentInfoService agentInfoService;
+    private final HbaseOtlpApplicationIndexV2Service applicationIndexV2Service;
+    @NotNull
+    private final OtlpTraceMapper otlpTraceMapper;
+    private final ExceptionMetaDataService exceptionMetaDataService;
+    // Thread-safe, bounded dedup of already-persisted agentIds. Shared across transports so an
+    // agentId first seen on gRPC is not re-inserted when it later arrives over HTTP (and vice versa).
+    private final Cache<String, Boolean> agentIdCache;
+
+    private final Counter spanInsertErrorCounter;
+    private final Counter spanChunkInsertErrorCounter;
+    private final Counter agentInfoInsertErrorCounter;
+    private final Counter exceptionInsertErrorCounter;
+
+    public OtlpTraceExportService(TraceService[] traceServiceList,
+                                  @Qualifier("hbaseOtlpAgentInfoService") HbaseOtlpAgentInfoService agentInfoService,
+                                  @Qualifier("hbaseOtlpApplicationIndexV2Service") HbaseOtlpApplicationIndexV2Service applicationIndexV2Service,
+                                  OtlpTraceMapper otlpTraceMapper,
+                                  Optional<ExceptionMetaDataService> exceptionMetaDataService,
+                                  @Qualifier("otlpAgentIdCache") Cache<String, Boolean> agentIdCache,
+                                  MeterRegistry meterRegistry) {
+        this.traceServiceList = Objects.requireNonNull(traceServiceList, "traceServiceList");
+        this.agentInfoService = Objects.requireNonNull(agentInfoService, "agentInfoService");
+        this.applicationIndexV2Service = Objects.requireNonNull(applicationIndexV2Service, "applicationIndexV2Service");
+        this.otlpTraceMapper = Objects.requireNonNull(otlpTraceMapper, "otlpTraceMapper");
+        this.exceptionMetaDataService = exceptionMetaDataService.orElse(null);
+        this.agentIdCache = Objects.requireNonNull(agentIdCache, "agentIdCache");
+        Objects.requireNonNull(meterRegistry, "meterRegistry");
+        this.spanInsertErrorCounter = insertErrorCounter(meterRegistry, "span");
+        this.spanChunkInsertErrorCounter = insertErrorCounter(meterRegistry, "spanChunk");
+        this.agentInfoInsertErrorCounter = insertErrorCounter(meterRegistry, "agentInfo");
+        this.exceptionInsertErrorCounter = insertErrorCounter(meterRegistry, "exception");
+    }
+
+    private static Counter insertErrorCounter(MeterRegistry meterRegistry, String op) {
+        return Counter.builder(INSERT_ERROR_METRIC)
+                .description("OTLP trace synchronous insert failures (HBase)")
+                .tag("op", op)
+                .register(meterRegistry);
+    }
+
+    public OtlpTraceExportResult export(List<ResourceSpans> resourceSpanList) {
+        final OtlpTraceMapperData otlpTraceMapperData = otlpTraceMapper.map(resourceSpanList);
+        // Mapping rejects (invalid ids, unlinkable/orphan spans) are client-side data faults.
+        final OtlpTraceCollectorRejectedSpan clientRejected = otlpTraceMapperData.getRejectedSpan();
+
+        int insertErrorCount = 0;
+        for (SpanBo spanBo : otlpTraceMapperData.getSpanBoList()) {
+            for (TraceService traceService : traceServiceList) {
+                try {
+                    traceService.insertSpan(spanBo);
+                } catch (Exception e) {
+                    insertErrorCount++;
+                    spanInsertErrorCounter.increment();
+                    throttledLogger.warn("Failed to insert spanBo", e);
+                }
+            }
+        }
+
+        for (SpanChunkBo spanChunkBo : otlpTraceMapperData.getSpanChunkBoList()) {
+            for (TraceService traceService : traceServiceList) {
+                try {
+                    traceService.insertSpanChunk(spanChunkBo);
+                } catch (Exception e) {
+                    insertErrorCount++;
+                    spanChunkInsertErrorCounter.increment();
+                    throttledLogger.warn("Failed to insert spanChunkBo", e);
+                }
+            }
+        }
+
+        int agentInfoErrorCount = 0;
+        for (AgentInfoBo agentInfoBo : otlpTraceMapperData.getAgentInfoBoList()) {
+            if (agentIdCache.getIfPresent(agentInfoBo.getAgentId()) == null) {
+                try {
+                    agentInfoService.insert(agentInfoBo);
+                    applicationIndexV2Service.insert(DEFAULT_SERVICE_UID, agentInfoBo);
+                    agentIdCache.put(agentInfoBo.getAgentId(), Boolean.TRUE);
+                } catch (Exception e) {
+                    agentInfoErrorCount++;
+                    agentInfoInsertErrorCounter.increment();
+                    throttledLogger.warn("Failed to insert agentInfoBo", e);
+                }
+            }
+        }
+
+        if (exceptionMetaDataService != null) {
+            for (ExceptionMetaDataBo exceptionMetaDataBo : otlpTraceMapperData.getExceptionMetaDataBoList()) {
+                try {
+                    exceptionMetaDataService.save(exceptionMetaDataBo);
+                } catch (Exception e) {
+                    exceptionInsertErrorCounter.increment();
+                    throttledLogger.warn("Failed to insert exceptionMetaData", e);
+                }
+            }
+        }
+
+        final int serverErrorCount = insertErrorCount + agentInfoErrorCount;
+        return new OtlpTraceExportResult(clientRejected, serverErrorCount, buildServerMessage(insertErrorCount, agentInfoErrorCount));
+    }
+
+    private static String buildServerMessage(int insertErrorCount, int agentInfoErrorCount) {
+        final StringBuilder sb = new StringBuilder();
+        if (insertErrorCount > 0) {
+            sb.append("insert error (").append(insertErrorCount).append(')');
+        }
+        if (agentInfoErrorCount > 0) {
+            if (!sb.isEmpty()) {
+                sb.append(", ");
+            }
+            sb.append("agentInfo error (").append(agentInfoErrorCount).append(')');
+        }
+        return sb.toString();
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/pinpoint-otlptrace-grpc-root.properties
+++ b/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/pinpoint-otlptrace-grpc-root.properties
@@ -48,6 +48,13 @@ pinpoint.collector.otlptrace.attribute.value-max-bytes=8192
 pinpoint.collector.otlptrace.sql.max-bytes=8192
 pinpoint.collector.otlptrace.event.value-max-bytes=8192
 pinpoint.collector.otlptrace.link.value-max-bytes=8192
+# Exception-trace field caps. Unlike attributes above these are not span annotations; truncation is
+# surfaced via the collector.otlptrace.exception.truncated meter (tag field=message|stacktrace_depth|
+# frame_value). max-depth is the parsed stacktrace frame count (OTel sends one flattened string, so the
+# unbounded axis is frame count, not the native exception-chain depth); <= 0 means unlimited.
+pinpoint.collector.otlptrace.exception.message-max-bytes=8192
+pinpoint.collector.otlptrace.exception.stacktrace.max-depth=256
+pinpoint.collector.otlptrace.exception.stacktrace.frame-max-bytes=2048
 # Global in-flight wire-byte ceiling (Semaphore admission). Bounds heap regardless of connection
 # count; export() reserves getSerializedSize() and returns UNAVAILABLE when exceeded. 256MB (8GB server).
 pinpoint.collector.otlptrace.admission.max-in-flight-bytes=268435456

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapperTest.java
@@ -19,16 +19,19 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.server.bo.exception.ExceptionMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.exception.ExceptionWrapperBo;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.trace.v1.Span;
 import io.opentelemetry.proto.trace.v1.Status;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.kv;
 import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.strVal;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class OtlpExceptionMapperTest {
 
@@ -39,7 +42,12 @@ class OtlpExceptionMapperTest {
     private static final long EXCEPTION_SPAN_ID_LONG = OtlpTraceMapperUtils.getSpanId(ByteString.copyFrom(EXCEPTION_SPAN_ID));
     private static final long ROOT_SPAN_ID_LONG = OtlpTraceMapperUtils.getSpanId(ByteString.copyFrom(ROOT_SPAN_ID));
 
-    private final OtlpExceptionMapper mapper = new OtlpExceptionMapper();
+    private static final int MESSAGE_MAX_BYTES = 8192;
+    private static final int STACKTRACE_MAX_DEPTH = 256;
+    private static final int FRAME_MAX_BYTES = 2048;
+
+    private final OtlpExceptionMapper mapper =
+            new OtlpExceptionMapper(MESSAGE_MAX_BYTES, STACKTRACE_MAX_DEPTH, FRAME_MAX_BYTES, new SimpleMeterRegistry());
 
     private static IdAndName id() {
         return new IdAndName("agent-1", "agent-1", "app-1", "default");
@@ -213,6 +221,89 @@ class OtlpExceptionMapperTest {
         assertThat(wrapper.getStackTraceElements()).hasSize(2);
         assertThat(wrapper.getStackTraceElements().get(0).getClassName()).isEqualTo("com.example.Service");
         assertThat(wrapper.getStackTraceElements().get(0).getMethodName()).isEqualTo("handle");
+    }
+
+    // =======================================================================
+    // truncation caps (message bytes / stacktrace frame count / per-frame value bytes)
+    // =======================================================================
+
+    @Test
+    void map_truncatesOverLongMessage() {
+        final String longMessage = "x".repeat(MESSAGE_MAX_BYTES + 100);
+        Span span = spanBuilder(EXCEPTION_SPAN_ID)
+                .addEvents(exceptionEvent(exceptionType("java.lang.RuntimeException"),
+                        kv("exception.message", strVal(longMessage))))
+                .build();
+
+        ExceptionWrapperBo wrapper = mapper.map(id(), span, ROOT_SPAN_ID_LONG, "/api/orders")
+                .orElseThrow().getExceptionWrapperBos().get(0);
+
+        // ASCII → 1 byte/char, so the UTF-8 byte cap equals the char count here.
+        assertThat(wrapper.getExceptionMessage()).hasSize(MESSAGE_MAX_BYTES);
+        assertThat(wrapper.getExceptionMessage().getBytes(StandardCharsets.UTF_8).length)
+                .isLessThanOrEqualTo(MESSAGE_MAX_BYTES);
+    }
+
+    @Test
+    void map_messageWithinLimitPreserved() {
+        Span span = spanBuilder(EXCEPTION_SPAN_ID)
+                .addEvents(exceptionEvent(exceptionType("java.lang.RuntimeException"),
+                        kv("exception.message", strVal("short"))))
+                .build();
+
+        ExceptionWrapperBo wrapper = mapper.map(id(), span, ROOT_SPAN_ID_LONG, "/api/orders")
+                .orElseThrow().getExceptionWrapperBos().get(0);
+
+        assertThat(wrapper.getExceptionMessage()).isEqualTo("short");
+    }
+
+    @Test
+    void map_capsStackTraceFrameCount() {
+        StringBuilder sb = new StringBuilder("java.lang.RuntimeException: boom\n");
+        final int frames = STACKTRACE_MAX_DEPTH + 50;
+        for (int i = 0; i < frames; i++) {
+            sb.append("\tat com.example.Service.m").append(i).append("(Service.java:").append(i + 1).append(")\n");
+        }
+        Span span = spanBuilder(EXCEPTION_SPAN_ID)
+                .addEvents(exceptionEvent(exceptionType("java.lang.RuntimeException"),
+                        kv("exception.stacktrace", strVal(sb.toString()))))
+                .build();
+
+        ExceptionWrapperBo wrapper = mapper.map(id(), span, ROOT_SPAN_ID_LONG, "/api/orders")
+                .orElseThrow().getExceptionWrapperBos().get(0);
+
+        assertThat(wrapper.getStackTraceElements()).hasSize(STACKTRACE_MAX_DEPTH);
+    }
+
+    @Test
+    void constructor_rejectsNonPositiveByteCaps() {
+        // A 0/negative byte cap would truncate every frame value to "" and make
+        // StackTraceElementWrapperBo throw on className/methodName — fail fast at construction instead.
+        assertThatThrownBy(() -> new OtlpExceptionMapper(0, STACKTRACE_MAX_DEPTH, FRAME_MAX_BYTES, new SimpleMeterRegistry()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new OtlpExceptionMapper(MESSAGE_MAX_BYTES, STACKTRACE_MAX_DEPTH, 0, new SimpleMeterRegistry()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void map_frameValueNeverEmptyWhenCapSmallerThanLeadingMultiByteChar() {
+        // frame-max-bytes=1 with a leading multi-byte (Korean) class-name char: Utf8.truncate would
+        // yield "", which StackTraceElementWrapperBo rejects. cap() must keep the original instead.
+        OtlpExceptionMapper tinyFrameMapper =
+                new OtlpExceptionMapper(MESSAGE_MAX_BYTES, STACKTRACE_MAX_DEPTH, 1, new SimpleMeterRegistry());
+        String stackTrace = "java.lang.RuntimeException: boom\n"
+                + "\tat 클래스.메서드(파일.java:42)\n";
+        Span span = spanBuilder(EXCEPTION_SPAN_ID)
+                .addEvents(exceptionEvent(exceptionType("java.lang.RuntimeException"),
+                        kv("exception.stacktrace", strVal(stackTrace))))
+                .build();
+
+        ExceptionWrapperBo wrapper = tinyFrameMapper.map(id(), span, ROOT_SPAN_ID_LONG, "/api/orders")
+                .orElseThrow().getExceptionWrapperBos().get(0);
+
+        assertThat(wrapper.getStackTraceElements()).hasSize(1);
+        assertThat(wrapper.getStackTraceElements().get(0).getClassName()).isEqualTo("클래스");
+        assertThat(wrapper.getStackTraceElements().get(0).getMethodName()).isEqualTo("메서드");
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.exception.ExceptionMetaDataBo;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.resource.v1.Resource;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
@@ -89,7 +90,7 @@ class OtlpTraceMapperTest {
                 8192);
         OtlpTraceSpanChunkMapper spanChunkMapper = new OtlpTraceSpanChunkMapper(spanEventMapper);
         return new OtlpTraceMapper(spanMapper, spanEventMapper, spanChunkMapper,
-                new OtlpAgentInfoMapper(), new OtlpExceptionMapper(), false);
+                new OtlpAgentInfoMapper(), new OtlpExceptionMapper(8192, 256, 2048, new SimpleMeterRegistry()), false);
     }
 
     private static Span.Event exceptionEvent(String type) {


### PR DESCRIPTION
- H-2: replace the per-instance thread-unsafe LRUCache with a single shared, thread-safe Caffeine agentId dedup cache bean (dedup effective across gRPC/HTTP).
- M-2: extract a transport-agnostic OtlpTraceExportService + OtlpTraceExportResult; gRPC and HTTP now share one mapping/insert implementation and one cache instead of ~60 lines of diverging duplicated logic.
- M-4: truncate client-supplied exception fields (message byte cap, stacktrace frame-count cap, per-frame value cap) via Utf8.truncate, surfaced through the collector.otlptrace.exception.truncated meter.
- M-5: throttle per-item synchronous insert WARN logging and add per-op error counters (collector.otlptrace.insert.error), mirroring the async path pattern.