### PR TITLE
[#noissue] Keep message-only OTel exception events in span exceptionInfo

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -184,9 +184,16 @@ public class OtlpTraceSpanMapper {
         if (exceptionEvent != null) {
             final Map<String, AttributeValue> eventAttrs = OtlpTraceMapperUtils.getAttributeValueMap(exceptionEvent.getAttributesList());
             final String className = ExceptionAttributeUtils.resolveExceptionType(eventAttrs, attributes);
+            final String message = ExceptionAttributeUtils.getExceptionMessage(eventAttrs);
             if (StringUtils.hasLength(className)) {
-                final String message = ExceptionAttributeUtils.getExceptionMessage(eventAttrs);
                 return buildOtelExceptionInfo(className, message);
+            }
+            // OTel allows an exception event with only exception.message (no exception.type /
+            // error.type). Keep that message rather than dropping it and falling back to the
+            // (often empty) status message — the empty class-name prefix lets the web side render
+            // it under the "ERROR" fallback title.
+            if (StringUtils.hasLength(message)) {
+                return buildOtelExceptionInfo("", message);
             }
         }
 

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -861,6 +861,35 @@ class OtlpTraceSpanMapperTest {
     }
 
     @Test
+    void map_error_exceptionEvent_messageOnly_keepsMessageWithEmptyClassPrefix() {
+        // OTel permits an exception event with only exception.message (no exception.type),
+        // and here no error.type either. The event message is the only error signal and must
+        // not be dropped; it is encoded with an empty class-name prefix.
+        Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_ERROR, "", new KeyValue[]{},
+                exceptionEvent(kv("exception.message", strVal("something broke"))));
+
+        SpanBo bo = newMapper().map(id(), span);
+
+        assertThat(bo.getErrCode()).isEqualTo(1);
+        assertThat(bo.getExceptionInfo().id()).isEqualTo(0);
+        assertThat(bo.getExceptionInfo().message()).isEqualTo(":something broke");
+        // empty class-name prefix → not treated as "captured", so the event annotation is kept
+        assertThat(countEventAnnotations(bo)).isEqualTo(1);
+    }
+
+    @Test
+    void map_error_exceptionEvent_messageOnly_fallsBackToStatusMessageWhenEventMessageEmpty() {
+        // Exception event present but carrying neither type nor message: fall through to the
+        // free-form status message rather than fabricating an empty exceptionInfo.
+        Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_ERROR, "status fallback",
+                new KeyValue[]{}, exceptionEvent());
+
+        SpanBo bo = newMapper().map(id(), span);
+
+        assertThat(bo.getExceptionInfo().message()).isEqualTo(":status fallback");
+    }
+
+    @Test
     void map_error_noEvent_statusMessageAndErrorType_emptyClassPrefix() {
         Span span = errorServerSpan(Status.StatusCode.STATUS_CODE_ERROR, "Connection refused",
                 new KeyValue[]{kv("error.type", strVal("500"))});


### PR DESCRIPTION
When an OTel span's exception event carries only exception.message (no exception.type and no error.type), resolveErrorExceptionInfo() dropped the event message and fell back to the (often empty) status message, yielding errCode=1 with no exceptionInfo. OTel permits message-only exception events, so treat a non-empty exception.message as sufficient and encode it with an empty class-name prefix, keeping the exception event annotation.

Add mapper tests for the message-only case and the empty-event fallback.