### PR TITLE
[#noissue] Document requesting Copilot PR review via the MCP tool

### DIFF
--- a/web-frontend/src/main/v3/.claude/rules/git-workflow.md
+++ b/web-frontend/src/main/v3/.claude/rules/git-workflow.md
@@ -63,16 +63,15 @@ git push -u origin <branch-name>
 - **언어: PR 제목과 본문은 항상 영어로 작성** — 예외 없음. (한글 금지)
 - PR은 `upstream` (pinpoint-apm/pinpoint) master 브랜치를 대상으로 합니다.
 - **항상** 사용자(jihea-park)를 PR에 어사인하세요.
-- **GitHub 저장소에서**, REST API로 Copilot 코드 리뷰를 요청하세요. Copilot의 리뷰어 로그인은 봇이며 **대문자 `Copilot`**으로 잡힙니다:
-  ```bash
-  gh api repos/{owner}/{repo}/pulls/{number}/requested_reviewers \
-    --method POST -f 'reviewers[]=Copilot'
+- **GitHub 저장소에서 Copilot 코드 리뷰를 요청할 때는 MCP 도구 `mcp__github__request_copilot_review` 를 사용하세요.** (CLI 우선 원칙의 예외 — 아래처럼 REST/CLI 로는 이 저장소에서 조용히 무시되는 것이 확인됨)
   ```
-  참고: `gh pr create --reviewer copilot`은 Copilot에 작동하지 않으므로 REST API를 사용하세요.
-- **요청 후 반드시 검증하세요.** 이 엔드포인트는 못 알아듣는 리뷰어 값(예: 소문자 `copilot`, 오타)이 오면 422 에러 대신 **200 + 빈 `requested_reviewers`**를 돌려주며 조용히 무시합니다. 응답이나 호출 결과의 `requested_reviewers`가 비어 있으면 **성공이 아니라 실패**입니다. "비동기 반영"으로 넘기지 말고 즉시 재시도하세요:
+  mcp__github__request_copilot_review(owner, repo, pullNumber)
+  ```
+- **하지 말 것:** `gh api .../requested_reviewers -f 'reviewers[]=Copilot'` (REST) 와 `gh pr create --reviewer copilot` 은 `pinpoint-apm/pinpoint` 에서 **422 없이 200 + 빈 `requested_reviewers`** 를 돌려주며 조용히 무시됩니다(대문자 `Copilot` 으로 해도 동일). Copilot 봇이 이 방식으로는 리뷰어로 해석되지 않기 때문입니다.
+- **요청 후 반드시 검증하세요.** `requested_reviewers` 가 비어 있으면 성공이 아니라 실패입니다:
   ```bash
-  gh api repos/{owner}/{repo}/pulls/{number}/requested_reviewers \
-    --jq '.users[].login'   # Copilot이 보이지 않으면 실패 → 로그인 철자(대문자 Copilot) 확인 후 재요청
+  gh api repos/{owner}/{repo}/pulls/{number} --jq '.requested_reviewers[].login'
+  # Copilot 이 보이면 성공. 비어 있으면 MCP 도구로 다시 요청.
   ```
 - **PR 리뷰 피드백**: 사용자가 리뷰 코멘트를 제공하면 각각을 평가하세요. 피드백이 유효하고 필요한 경우에만 코드를 변경하세요. 불필요하거나 잘못된 코멘트에는 코드를 수정하지 말고 이유를 설명하세요.
 - PR 본문 형식:


### PR DESCRIPTION
The REST requested_reviewers endpoint and 'gh pr --reviewer copilot' silently return 200 with an empty requested_reviewers on this repo, so use the mcp__github__request_copilot_review tool instead and verify the reviewer afterward.