### PR TITLE
[#noissue] Make SpanOwner a final constructor argument of SpanBo/SpanChunkBo

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.server.bo.ParentApplication;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUidService;
@@ -73,18 +74,19 @@ public class HbaseApplicationMapService implements ApplicationMapService {
         if (CollectionUtils.isEmpty(spanEventList)) {
             return;
         }
+        final SpanOwner owner = spanChunkBo.getSpanOwner();
         if (logger.isDebugEnabled()) {
-            logger.debug("handle insertSpanChunk {}/{}/{} size:{}", spanChunkBo.getServiceName(), spanChunkBo.getApplicationName(), spanChunkBo.getAgentId(), spanEventList.size());
+            logger.debug("handle insertSpanChunk {}/{}/{} size:{}", owner.getServiceName(), owner.getApplicationName(), owner.getAgentId(), spanEventList.size());
         }
         Vertex selfVertex = getSelfVertex(spanChunkBo);
         // TODO need to batch update later.
-        insertSpanEventList(spanEventList, selfVertex, spanChunkBo.getAgentId(), spanChunkBo.getEndPoint(), spanChunkBo.getCollectorAcceptTime());
+        insertSpanEventList(spanEventList, selfVertex, owner.getAgentId(), spanChunkBo.getEndPoint(), spanChunkBo.getCollectorAcceptTime());
     }
 
     private Vertex getSelfVertex(BasicSpan basicSpan) {
         final ServiceType applicationServiceType = getApplicationServiceType(basicSpan);
-        ServiceUid serviceUid = basicSpan.getServiceUid();
-        return Vertex.of(serviceUid.getUid(), basicSpan.getApplicationName(), applicationServiceType);
+        final SpanOwner owner = basicSpan.getSpanOwner();
+        return Vertex.of(owner.getServiceUid().getUid(), owner.getApplicationName(), applicationServiceType);
     }
 
     private ServiceType getApplicationServiceType(BasicSpan basicSpan) {
@@ -122,15 +124,16 @@ public class HbaseApplicationMapService implements ApplicationMapService {
     private void insertAcceptorHost(SpanBo span, Vertex selfVertex) {
         // save host application map
         // acceptor host is set at profiler module only when the span is not the kind of root span
+        final SpanOwner owner = span.getSpanOwner();
         final String acceptorHost = span.getAcceptorHost();
         if (acceptorHost == null) {
-            logger.debug("acceptorHost is null agent: {}/{}/{}", span.getServiceName(), span.getApplicationName(), span.getAgentId());
+            logger.debug("acceptorHost is null agent: {}/{}/{}", owner.getServiceName(), owner.getApplicationName(), owner.getAgentId());
             return;
         }
 
         final ParentApplication parentApplication = span.getParentApplication();
         if (parentApplication == null) {
-            logger.debug("parentApplication is null agent: {}/{}/{}", span.getServiceName(), span.getApplicationName(), span.getAgentId());
+            logger.debug("parentApplication is null agent: {}/{}/{}", owner.getServiceName(), owner.getApplicationName(), owner.getAgentId());
             return;
         }
         final Vertex parentVertex = getParentVertex(parentApplication);
@@ -138,7 +141,7 @@ public class HbaseApplicationMapService implements ApplicationMapService {
         if (spanServiceType.isQueue()) {
             final String host = span.getEndPoint();
             if (host == null) {
-                logger.debug("endPoint is null agent: {}/{}/{}", span.getServiceName(), span.getApplicationName(), span.getAgentId());
+                logger.debug("endPoint is null agent: {}/{}/{}", owner.getServiceName(), owner.getApplicationName(), owner.getAgentId());
                 return;
             }
             hostApplicationMapDao.insert(span.getCollectorAcceptTime(), parentVertex, selfVertex, host);
@@ -247,7 +250,8 @@ public class HbaseApplicationMapService implements ApplicationMapService {
         // where the same reason genuinely signals lost propagation.
         final Level level = resolveInvalidSpanLevel(span);
         if (logger.isEnabled(level)) {
-            logger.log(level, "Invalid span found. reason:{} span {}/{}/{}", reason, span.getServiceName(), span.getApplicationName(), span.getAgentId());
+            final SpanOwner owner = span.getSpanOwner();
+            logger.log(level, "Invalid span found. reason:{} span {}/{}/{}", reason, owner.getServiceName(), owner.getApplicationName(), owner.getAgentId());
         }
         if (logger.isDebugEnabled()) {
             logger.debug("Invalid span found. reason:{} detailed span {}", reason, span);
@@ -278,12 +282,13 @@ public class HbaseApplicationMapService implements ApplicationMapService {
         if (CollectionUtils.isEmpty(spanEventList)) {
             return;
         }
+        SpanOwner owner = span.getSpanOwner();
         if (logger.isDebugEnabled()) {
-            logger.debug("handle insertSpanEventStat {}/{}/{} size:{}", span.getServiceName(), span.getApplicationName(), span.getAgentId(), spanEventList.size());
+            logger.debug("handle insertSpanEventStat {}/{}/{} size:{}", owner.getServiceName(), owner.getApplicationName(), owner.getAgentId(), spanEventList.size());
         }
 
         // TODO need to batch update later.
-        insertSpanEventList(spanEventList, selfVertex, span.getAgentId(), span.getEndPoint(), span.getCollectorAcceptTime());
+        insertSpanEventList(spanEventList, selfVertex, owner.getAgentId(), span.getEndPoint(), span.getCollectorAcceptTime());
     }
 
     private void insertSpanEventList(List<SpanEventBo> spanEventList, Vertex selfVertex,

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/encode/TraceIndexRowKeyEncoder.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/dao/hbase/encode/TraceIndexRowKeyEncoder.java
@@ -19,9 +19,9 @@ package com.navercorp.pinpoint.collector.dao.hbase.encode;
 import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
 import com.navercorp.pinpoint.common.server.scatter.TraceIndexRowKeyUtils;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 
 import java.util.Objects;
 
@@ -44,19 +44,19 @@ public class TraceIndexRowKeyEncoder implements RowKeyEncoder<SpanBo> {
 
     @Override
     public byte[] encodeRowKey(SpanBo span) {
-        ServiceUid serviceUid = span.getServiceUid();
+        final SpanOwner owner = span.getSpanOwner();
         return encodeRowKey(hasher.getSaltKey().size(),
-                serviceUid.getUid(), span.getApplicationName(), span.getApplicationServiceType(),
-                span.getCollectorAcceptTime(), span.getAgentId(),
+                owner.getServiceUid().getUid(), owner.getApplicationName(), span.getApplicationServiceType(),
+                span.getCollectorAcceptTime(), owner.getAgentId(),
                 span.getSpanId(), span.getElapsed(), span.getErrCode());
     }
 
     @Override
     public byte[] encodeRowKey(int saltKeySize, SpanBo span) {
-        ServiceUid serviceUid = span.getServiceUid();
+        final SpanOwner owner = span.getSpanOwner();
         return encodeRowKey(saltKeySize,
-                serviceUid.getUid(), span.getApplicationName(), span.getApplicationServiceType(),
-                span.getCollectorAcceptTime(), span.getAgentId(),
+                owner.getServiceUid().getUid(), owner.getApplicationName(), span.getApplicationServiceType(),
+                span.getCollectorAcceptTime(), owner.getAgentId(),
                 span.getSpanId(), span.getElapsed(), span.getErrCode());
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/BasicSpan.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/BasicSpan.java
@@ -20,8 +20,6 @@ import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import org.jspecify.annotations.NonNull;
 
-import java.util.function.Supplier;
-
 /**
  * @author Woonduk Kang(emeroad)
  */
@@ -33,7 +31,6 @@ public interface BasicSpan {
     TraceSourceType getTraceSourceType();
 
     SpanOwner getSpanOwner();
-    void setSpanOwner(SpanOwner owner);
 
     String getAgentId();
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/BasicSpan.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/BasicSpan.java
@@ -32,23 +32,20 @@ public interface BasicSpan {
     @NonNull
     TraceSourceType getTraceSourceType();
 
+    SpanOwner getSpanOwner();
+    void setSpanOwner(SpanOwner owner);
+
     String getAgentId();
-    void setAgentId(String agentId);
 
     String getAgentName();
-    void setAgentName(String agentName);
 
     String getApplicationName();
-    void setApplicationName(String applicationName);
 
     String getServiceName();
-    void setServiceName(String serviceName);
 
     ServiceUid getServiceUid();
-    void setServiceUid(Supplier<ServiceUid> serviceUidSupplier);
 
     long getAgentStartTime();
-    void setAgentStartTime(long agentStartTime);
 
     long getSpanId();
     void setSpanId(long spanId);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 /**
  * @author emeroad
@@ -43,7 +42,7 @@ public class SpanBo implements BasicSpan {
     @NonNull
     private final TraceSourceType traceSourceType;
 
-    private SpanOwner owner = new SpanOwner();
+    private final SpanOwner owner;
 
     private ServerTraceId transactionId;
 
@@ -84,11 +83,16 @@ public class SpanBo implements BasicSpan {
     private List<AttributeBo> attributeBoList = new ArrayList<>();
 
     public SpanBo() {
-        this(TraceSourceType.PINPOINT);
+        this(TraceSourceType.PINPOINT, new SpanOwner());
     }
 
     public SpanBo(TraceSourceType traceSourceType) {
+        this(traceSourceType, new SpanOwner());
+    }
+
+    public SpanBo(TraceSourceType traceSourceType, SpanOwner owner) {
         this.traceSourceType = Objects.requireNonNull(traceSourceType, "traceSourceType");
+        this.owner = Objects.requireNonNull(owner, "owner");
     }
 
     @Override
@@ -122,11 +126,6 @@ public class SpanBo implements BasicSpan {
     @Override
     public SpanOwner getSpanOwner() {
         return owner;
-    }
-
-    @Override
-    public void setSpanOwner(SpanOwner owner) {
-        this.owner = Objects.requireNonNull(owner, "owner");
     }
 
     @NonNull

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
@@ -19,8 +19,6 @@ package com.navercorp.pinpoint.common.server.bo;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.ByteUtils;
-import com.navercorp.pinpoint.common.server.util.NumberPrecondition;
-import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.io.SpanVersion;
 import org.jspecify.annotations.NonNull;
@@ -45,19 +43,7 @@ public class SpanBo implements BasicSpan {
     @NonNull
     private final TraceSourceType traceSourceType;
 
-    //  private AgentKeyBo agentKeyBo;
-    @NonNull
-    private String agentId;
-    private String agentName;
-
-    @NonNull
-    private String applicationName;
-
-    @NonNull
-    private String serviceName = ServiceUid.DEFAULT_SERVICE_UID_NAME;
-    private Supplier<ServiceUid> serviceUidSupplier = () -> ServiceUid.DEFAULT;
-
-    private long agentStartTime;
+    private SpanOwner owner = new SpanOwner();
 
     private ServerTraceId transactionId;
 
@@ -133,70 +119,50 @@ public class SpanBo implements BasicSpan {
         this.transactionId = transactionId;
     }
 
-    @NonNull
     @Override
-    public String getAgentId() {
-        return agentId;
+    public SpanOwner getSpanOwner() {
+        return owner;
     }
 
     @Override
-    public void setAgentId(String agentId) {
-        this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
+    public void setSpanOwner(SpanOwner owner) {
+        this.owner = Objects.requireNonNull(owner, "owner");
+    }
+
+    @NonNull
+    @Override
+    public String getAgentId() {
+        return owner.getAgentId();
     }
 
     @Override
     public String getAgentName() {
-        return agentName;
-    }
-
-    @Override
-    public void setAgentName(String agentName) {
-        this.agentName = agentName;
+        return owner.getAgentName();
     }
 
 
     @NonNull
     @Override
     public String getApplicationName() {
-        return applicationName;
-    }
-
-    @Override
-    public void setApplicationName(String applicationName) {
-        this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
+        return owner.getApplicationName();
     }
 
     @NonNull
     @Override
     public String getServiceName() {
-        return serviceName;
-    }
-
-    @Override
-    public void setServiceName(String serviceName) {
-        this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
+        return owner.getServiceName();
     }
 
     @Override
     public ServiceUid getServiceUid() {
-        return serviceUidSupplier.get();
-    }
-
-    @Override
-    public void setServiceUid(Supplier<ServiceUid> serviceUidSupplier) {
-        this.serviceUidSupplier = Objects.requireNonNull(serviceUidSupplier, "serviceUidSupplier");
+        return owner.getServiceUid();
     }
 
     //------------
 
     @Override
     public long getAgentStartTime() {
-        return agentStartTime;
-    }
-
-    @Override
-    public void setAgentStartTime(long agentStartTime) {
-        this.agentStartTime = NumberPrecondition.requirePositiveOrZero(agentStartTime, "agentStartTime");
+        return owner.getAgentStartTime();
     }
 
     public long getStartTimeMillis() {
@@ -524,12 +490,7 @@ public class SpanBo implements BasicSpan {
         return "SpanBo{" +
                 "version=" + version +
                 ", traceSourceType=" + traceSourceType +
-                ", agentId='" + agentId + '\'' +
-                ", agentName='" + agentName + '\'' +
-                ", applicationName='" + applicationName + '\'' +
-                ", serviceName='" + serviceName + '\'' +
-                ", serviceUid='" + serviceUidSupplier.get() + '\'' +
-                ", agentStartTime=" + agentStartTime +
+                ", owner=" + owner +
                 ", transactionId=" + transactionId +
                 ", spanId=" + spanId +
                 ", parentSpanId=" + parentSpanId +

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -39,8 +38,7 @@ public class SpanChunkBo implements BasicSpan {
     private byte version = 0;
     @NonNull
     private final TraceSourceType traceSourceType;
-
-    private SpanOwner owner = new SpanOwner();
+    private final SpanOwner owner;
 
     private ServerTraceId transactionId;
 
@@ -58,11 +56,16 @@ public class SpanChunkBo implements BasicSpan {
 
 
     public SpanChunkBo() {
-        this(TraceSourceType.PINPOINT);
+        this(TraceSourceType.PINPOINT, new SpanOwner());
     }
 
     public SpanChunkBo(TraceSourceType traceSourceType) {
+        this(traceSourceType, new SpanOwner());
+    }
+
+    public SpanChunkBo(TraceSourceType traceSourceType, SpanOwner owner) {
         this.traceSourceType = Objects.requireNonNull(traceSourceType, "traceSourceType");
+        this.owner = Objects.requireNonNull(owner, "owner");
     }
 
     @Override
@@ -83,11 +86,6 @@ public class SpanChunkBo implements BasicSpan {
     @Override
     public SpanOwner getSpanOwner() {
         return owner;
-    }
-
-    @Override
-    public void setSpanOwner(SpanOwner owner) {
-        this.owner = Objects.requireNonNull(owner, "owner");
     }
 
     @Override

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
@@ -19,8 +19,6 @@ package com.navercorp.pinpoint.common.server.bo;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.ByteUtils;
-import com.navercorp.pinpoint.common.server.util.NumberPrecondition;
-import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.io.SpanVersion;
 import org.jspecify.annotations.NonNull;
@@ -42,16 +40,7 @@ public class SpanChunkBo implements BasicSpan {
     @NonNull
     private final TraceSourceType traceSourceType;
 
-    @NonNull
-    private String agentId;
-    private String agentName;
-    @NonNull
-    private String applicationName;
-    @NonNull
-    private String serviceName = ServiceUid.DEFAULT_SERVICE_UID_NAME;
-    private Supplier<ServiceUid> serviceUidSupplier = () -> ServiceUid.DEFAULT;
-
-    private long agentStartTime;
+    private SpanOwner owner = new SpanOwner();
 
     private ServerTraceId transactionId;
 
@@ -92,61 +81,45 @@ public class SpanChunkBo implements BasicSpan {
     }
 
     @Override
-    public String getAgentId() {
-        return agentId;
+    public SpanOwner getSpanOwner() {
+        return owner;
     }
 
-    public void setAgentId(String agentId) {
-        this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
+    @Override
+    public void setSpanOwner(SpanOwner owner) {
+        this.owner = Objects.requireNonNull(owner, "owner");
+    }
+
+    @Override
+    public String getAgentId() {
+        return owner.getAgentId();
     }
 
     @Override
     public String getAgentName() {
-        return agentName;
-    }
-
-    public void setAgentName(String agentName) {
-        this.agentName = agentName;
+        return owner.getAgentName();
     }
 
     @NonNull
     @Override
     public String getApplicationName() {
-        return applicationName;
-    }
-
-    public void setApplicationName(String applicationName) {
-        this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
+        return owner.getApplicationName();
     }
 
     @NonNull
     @Override
     public String getServiceName() {
-        return serviceName;
-    }
-
-    @Override
-    public void setServiceName(String serviceName) {
-        this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
+        return owner.getServiceName();
     }
 
     @Override
     public ServiceUid getServiceUid() {
-        return serviceUidSupplier.get();
-    }
-
-    @Override
-    public void setServiceUid(Supplier<ServiceUid> serviceUidSupplier) {
-        this.serviceUidSupplier = Objects.requireNonNull(serviceUidSupplier, "serviceUidSupplier");
+        return owner.getServiceUid();
     }
 
     @Override
     public long getAgentStartTime() {
-        return agentStartTime;
-    }
-
-    public void setAgentStartTime(long agentStartTime) {
-        this.agentStartTime = NumberPrecondition.requirePositiveOrZero(agentStartTime, "agentStartTime");
+        return owner.getAgentStartTime();
     }
 
     @Override
@@ -262,12 +235,7 @@ public class SpanChunkBo implements BasicSpan {
         return "SpanChunkBo{" +
                 "version=" + version +
                 ", traceSourceType=" + traceSourceType +
-                ", agentId='" + agentId + '\'' +
-                ", agentName='" + agentName + '\'' +
-                ", applicationName='" + applicationName + '\'' +
-                ", serviceName='" + serviceName + '\'' +
-                ", serviceUid='" + serviceUidSupplier.get() + '\'' +
-                ", agentStartTime=" + agentStartTime +
+                ", owner=" + owner +
                 ", transactionId=" + transactionId +
                 ", spanId=" + spanId +
                 ", endPoint='" + endPoint + '\'' +

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanOwner.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanOwner.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo;
+
+import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.util.NumberPrecondition;
+import com.navercorp.pinpoint.common.server.util.StringPrecondition;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Identifies the source of a span: the service/application and the agent
+ * instance (agentId + agentStartTime) that produced it.
+ * <p>
+ * Mutable by design: the write path fills every field at once from
+ * {@link ServerHeader} ({@link #from(ServerHeader)}), while the read path
+ * (span decoder) restores only agentId/applicationName/agentStartTime from
+ * storage and leaves the service fields at their defaults.
+ */
+public class SpanOwner {
+
+    @NonNull
+    private String agentId;
+    private String agentName;
+
+    @NonNull
+    private String applicationName;
+
+    @NonNull
+    private String serviceName = ServiceUid.DEFAULT_SERVICE_UID_NAME;
+    private Supplier<ServiceUid> serviceUidSupplier = () -> ServiceUid.DEFAULT;
+
+    private long agentStartTime;
+
+    public static SpanOwner from(ServerHeader header) {
+        Objects.requireNonNull(header, "header");
+
+        final SpanOwner owner = new SpanOwner();
+        owner.setAgentId(header.getAgentId());
+        owner.setAgentName(header.getAgentName());
+        owner.setApplicationName(header.getApplicationName());
+        owner.setServiceName(header.getServiceName());
+        owner.setServiceUid(header.getServiceUid());
+        owner.setAgentStartTime(header.getAgentStartTime());
+        return owner;
+    }
+
+    @NonNull
+    public String getAgentId() {
+        return agentId;
+    }
+
+    public void setAgentId(String agentId) {
+        this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
+    }
+
+    public String getAgentName() {
+        return agentName;
+    }
+
+    public void setAgentName(String agentName) {
+        this.agentName = agentName;
+    }
+
+    @NonNull
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public void setApplicationName(String applicationName) {
+        this.applicationName = StringPrecondition.requireHasLength(applicationName, "applicationName");
+    }
+
+    @NonNull
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
+    }
+
+    public ServiceUid getServiceUid() {
+        return serviceUidSupplier.get();
+    }
+
+    public void setServiceUid(Supplier<ServiceUid> serviceUidSupplier) {
+        this.serviceUidSupplier = Objects.requireNonNull(serviceUidSupplier, "serviceUidSupplier");
+    }
+
+    public long getAgentStartTime() {
+        return agentStartTime;
+    }
+
+    public void setAgentStartTime(long agentStartTime) {
+        this.agentStartTime = NumberPrecondition.requirePositiveOrZero(agentStartTime, "agentStartTime");
+    }
+
+    @Override
+    public String toString() {
+        return "SpanOwner{" +
+                "agentId='" + agentId + '\'' +
+                ", agentName='" + agentName + '\'' +
+                ", applicationName='" + applicationName + '\'' +
+                ", serviceName='" + serviceName + '\'' +
+                ", serviceUid='" + serviceUidSupplier.get() + '\'' +
+                ", agentStartTime=" + agentStartTime +
+                '}';
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.common.server.bo.LocalAsyncIdBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.bo.filter.SequenceSpanEventFilter;
 import com.navercorp.pinpoint.common.server.bo.filter.SpanEventFilter;
@@ -416,14 +417,16 @@ public class SpanDecoderV0 implements SpanDecoder {
     }
 
     private void readQualifier(BasicSpan basicSpan, Buffer buffer, SpanDecodingContext decodingContext) {
+        final SpanOwner owner = basicSpan.getSpanOwner();
+
         String applicationName = decodingContext.encoding(buffer.readPrefixedBytes());
-        basicSpan.setApplicationName(applicationName);
+        owner.setApplicationName(applicationName);
 
         String agentId = decodingContext.encoding(buffer.readPrefixedBytes());
-        basicSpan.setAgentId(agentId);
+        owner.setAgentId(agentId);
 
         long agentStartTime = buffer.readVLong();
-        basicSpan.setAgentStartTime(agentStartTime);
+        owner.setAgentStartTime(agentStartTime);
 
         long spanId = buffer.readLong();
         basicSpan.setSpanId(spanId);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
@@ -76,7 +76,7 @@ public class SpanDecoderV0 implements SpanDecoder {
 
     private SpanChunkBo readSpanChunk(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext,
                                       TraceSourceType traceSourceType) {
-        final SpanChunkBo spanChunk = new SpanChunkBo(traceSourceType);
+        final SpanChunkBo spanChunk = new SpanChunkBo(traceSourceType, new SpanOwner());
 
         final ServerTraceId transactionId = decodingContext.getTransactionId();
         spanChunk.setTransactionId(transactionId);
@@ -93,7 +93,7 @@ public class SpanDecoderV0 implements SpanDecoder {
 
     private SpanBo readSpan(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext,
                             TraceSourceType traceSourceType) {
-        final SpanBo span = new SpanBo(traceSourceType);
+        final SpanBo span = new SpanBo(traceSourceType, new SpanOwner());
 
         final ServerTraceId transactionId = decodingContext.getTransactionId();
         span.setTransactionId(transactionId);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderV0.java
@@ -12,6 +12,7 @@ import com.navercorp.pinpoint.common.server.bo.LocalAsyncIdBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.SpanBitField;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.SpanEventBitField;
@@ -60,11 +61,12 @@ public class SpanEncoderV0 implements SpanEncoder {
     }
 
     private ByteBuffer encodeQualifier(byte type, BasicSpan basicSpan, SpanEventBo firstEvent, LocalAsyncIdBo localAsyncId) {
+        final SpanOwner owner = basicSpan.getSpanOwner();
         final Buffer buffer = new AutomaticBuffer(128);
         buffer.putByte(type);
-        buffer.putPrefixedString(basicSpan.getApplicationName());
-        buffer.putPrefixedString(basicSpan.getAgentId());
-        buffer.putVLong(basicSpan.getAgentStartTime());
+        buffer.putPrefixedString(owner.getApplicationName());
+        buffer.putPrefixedString(owner.getAgentId());
+        buffer.putVLong(owner.getAgentStartTime());
         buffer.putLong(basicSpan.getSpanId());
 
         if (firstEvent != null) {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SimpleContextSupplier.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/event/SimpleContextSupplier.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.common.server.event;
 
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 
 import java.util.Map;
 
@@ -25,12 +26,14 @@ public class SimpleContextSupplier implements ContextSupplier {
 
     @Override
     public ContextData applyAsContext(SpanBo spanBo) {
-        return new ContextData(spanBo.getApplicationName(), spanBo.getAgentId(), spanBo.getStartTimeMillis(), Map.of());
+        SpanOwner owner = spanBo.getSpanOwner();
+        return new ContextData(owner.getApplicationName(), owner.getAgentId(), spanBo.getStartTimeMillis(), Map.of());
     }
 
     @Override
     public ContextData applyAsContext(SpanChunkBo spanChunkBo) {
-        return new ContextData(spanChunkBo.getApplicationName(), spanChunkBo.getAgentId(), -1, Map.of());
+        SpanOwner owner = spanChunkBo.getSpanOwner();
+        return new ContextData(owner.getApplicationName(), owner.getAgentId(), -1, Map.of());
     }
 
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/GrpcSpanBinder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/GrpcSpanBinder.java
@@ -30,6 +30,7 @@ import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventComparator;
 import com.navercorp.pinpoint.common.server.bo.SpanOwner;
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
@@ -91,11 +92,12 @@ public class GrpcSpanBinder {
 
     // for test
     SpanBo newSpanBo(PSpan pSpan, ServerHeader serverHeader, long requestTime) {
-        return bind(new SpanBo(), pSpan, serverHeader, requestTime);
+        SpanOwner spanOwner = SpanOwner.from(serverHeader);
+        SpanBo spanBo = new SpanBo(TraceSourceType.PINPOINT, spanOwner);
+        return bind(spanBo, pSpan, serverHeader, requestTime);
     }
 
     public SpanBo bind(SpanBo spanBo, PSpan pSpan, ServerHeader serverHeader, long requestTime) {
-        spanBo.setSpanOwner(SpanOwner.from(serverHeader));
         spanBo.setCollectorAcceptTime(requestTime);
 
         if (!pSpan.hasTransactionId()) {
@@ -277,11 +279,12 @@ public class GrpcSpanBinder {
 
     // for test
     SpanChunkBo newSpanChunkBo(PSpanChunk pSpanChunk, ServerHeader serverHeader, long requestTime) {
-        return bind(new SpanChunkBo(), pSpanChunk, serverHeader, requestTime);
+        SpanOwner owner = SpanOwner.from(serverHeader);
+        SpanChunkBo spanChunkBo = new SpanChunkBo(TraceSourceType.PINPOINT, owner);
+        return bind(spanChunkBo, pSpanChunk, serverHeader, requestTime);
     }
 
     public SpanChunkBo bind(SpanChunkBo spanChunkBo, PSpanChunk pSpanChunk, ServerHeader serverHeader, long requestTime) {
-        spanChunkBo.setSpanOwner(SpanOwner.from(serverHeader));
         spanChunkBo.setCollectorAcceptTime(requestTime);
 
         spanChunkBo.setApplicationServiceType((short) pSpanChunk.getApplicationServiceType());

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/GrpcSpanBinder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/GrpcSpanBinder.java
@@ -29,6 +29,7 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventComparator;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
@@ -94,13 +95,7 @@ public class GrpcSpanBinder {
     }
 
     public SpanBo bind(SpanBo spanBo, PSpan pSpan, ServerHeader serverHeader, long requestTime) {
-        spanBo.setAgentId(serverHeader.getAgentId());
-        spanBo.setAgentName(serverHeader.getAgentName());
-        spanBo.setApplicationName(serverHeader.getApplicationName());
-        spanBo.setServiceName(serverHeader.getServiceName());
-        spanBo.setServiceUid(serverHeader.getServiceUid());
-
-        spanBo.setAgentStartTime(serverHeader.getAgentStartTime());
+        spanBo.setSpanOwner(SpanOwner.from(serverHeader));
         spanBo.setCollectorAcceptTime(requestTime);
 
         if (!pSpan.hasTransactionId()) {
@@ -286,13 +281,7 @@ public class GrpcSpanBinder {
     }
 
     public SpanChunkBo bind(SpanChunkBo spanChunkBo, PSpanChunk pSpanChunk, ServerHeader serverHeader, long requestTime) {
-        spanChunkBo.setAgentId(serverHeader.getAgentId());
-        spanChunkBo.setAgentName(serverHeader.getAgentName());
-        spanChunkBo.setApplicationName(serverHeader.getApplicationName());
-        spanChunkBo.setServiceName(serverHeader.getServiceName());
-        spanChunkBo.setServiceUid(serverHeader.getServiceUid());
-
-        spanChunkBo.setAgentStartTime(serverHeader.getAgentStartTime());
+        spanChunkBo.setSpanOwner(SpanOwner.from(serverHeader));
         spanChunkBo.setCollectorAcceptTime(requestTime);
 
         spanChunkBo.setApplicationServiceType((short) pSpanChunk.getApplicationServiceType());

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0Test.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0Test.java
@@ -92,9 +92,9 @@ class SpanDecoderV0Test {
 
     private SpanBo newMinimalSpan(TraceSourceType type) {
         SpanBo span = new SpanBo(type);
-        span.setAgentId("agent");
-        span.setApplicationName("app");
-        span.setAgentStartTime(100L);
+        span.getSpanOwner().setAgentId("agent");
+        span.getSpanOwner().setApplicationName("app");
+        span.getSpanOwner().setAgentStartTime(100L);
         span.setSpanId(1L);
         span.setParentSpanId(-1L);
         span.setServiceType((short) 1000);
@@ -105,9 +105,9 @@ class SpanDecoderV0Test {
 
     private SpanChunkBo newMinimalSpanChunk(TraceSourceType type) {
         SpanChunkBo chunk = new SpanChunkBo(type);
-        chunk.setAgentId("agent");
-        chunk.setApplicationName("app");
-        chunk.setAgentStartTime(100L);
+        chunk.getSpanOwner().setAgentId("agent");
+        chunk.getSpanOwner().setApplicationName("app");
+        chunk.getSpanOwner().setAgentStartTime(100L);
         chunk.setSpanId(1L);
         chunk.setCollectorAcceptTime(System.currentTimeMillis());
         return chunk;

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0Test.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0Test.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.buffer.FixedBuffer;
 import com.navercorp.pinpoint.common.server.bo.BasicSpan;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
@@ -91,10 +92,12 @@ class SpanDecoderV0Test {
     }
 
     private SpanBo newMinimalSpan(TraceSourceType type) {
-        SpanBo span = new SpanBo(type);
-        span.getSpanOwner().setAgentId("agent");
-        span.getSpanOwner().setApplicationName("app");
-        span.getSpanOwner().setAgentStartTime(100L);
+        SpanOwner spanOwner = new SpanOwner();
+        spanOwner.setAgentId("agent");
+        spanOwner.setApplicationName("app");
+        spanOwner.setAgentStartTime(100L);
+
+        SpanBo span = new SpanBo(type, spanOwner);
         span.setSpanId(1L);
         span.setParentSpanId(-1L);
         span.setServiceType((short) 1000);
@@ -104,10 +107,12 @@ class SpanDecoderV0Test {
     }
 
     private SpanChunkBo newMinimalSpanChunk(TraceSourceType type) {
-        SpanChunkBo chunk = new SpanChunkBo(type);
-        chunk.getSpanOwner().setAgentId("agent");
-        chunk.getSpanOwner().setApplicationName("app");
-        chunk.getSpanOwner().setAgentStartTime(100L);
+        SpanOwner spanOwner = new SpanOwner();
+        spanOwner.setAgentId("agent");
+        spanOwner.setApplicationName("app");
+        spanOwner.setAgentStartTime(100L);
+
+        SpanChunkBo chunk = new SpanChunkBo(type, spanOwner);
         chunk.setSpanId(1L);
         chunk.setCollectorAcceptTime(System.currentTimeMillis());
         return chunk;

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
@@ -115,7 +115,7 @@ public class SpanEncoderTest {
 
     @RepeatedTest(REPEAT_COUNT)
     public void testEncodeSpanChunk_otelSource_qualifierByteAndRoundTrip() {
-        SpanChunkBo spanChunkBo = randomComplexSpanChunk(TraceSourceType.OPENTELEMETRY);
+        SpanChunkBo spanChunkBo = randomComplexSpanChunk();
 
         SpanEncodingContext<SpanChunkBo> ctx = new SpanEncodingContext<>(spanChunkBo);
         ByteBuffer qualifier = spanEncoder.encodeSpanChunkQualifier(ctx);
@@ -188,10 +188,6 @@ public class SpanEncoderTest {
     }
 
     public SpanChunkBo randomComplexSpanChunk() {
-        return randomComplexSpanChunk(TraceSourceType.PINPOINT);
-    }
-
-    public SpanChunkBo randomComplexSpanChunk(TraceSourceType traceSourceType) {
         PSpanChunk.Builder spanChunk = randomTSpan.randomTSpanChunk();
         PSpanEvent spanEvent1 = randomTSpan.randomTSpanEvent((short) 1);
         PSpanEvent spanEvent2 = randomTSpan.randomTSpanEvent((short) 2);
@@ -200,7 +196,7 @@ public class SpanEncoderTest {
 
         spanChunk.addAllSpanEvent(List.of(spanEvent1, spanEvent2, spanEvent3, spanEvent4));
         PSpanChunk chunk = spanChunk.build();
-        SpanChunkBo spanChunkBo = grpcSpanBinder.bind(new SpanChunkBo(traceSourceType), chunk, header, requestTime);
+        SpanChunkBo spanChunkBo = grpcSpanBinder.bind(new SpanChunkBo(), chunk, header, requestTime);
         spanChunkBo.addSpanEventBoList(grpcSpanBinder.bindSpanEventBoList(chunk.getSpanEventList()));
         return spanChunkBo;
     }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
@@ -218,7 +218,7 @@ public class SpanEncoderTest {
 
         SpanBo decode = (SpanBo) spanDecoder.decode(qualifier, column, decodingContext);
 
-        List<String> excludeField = List.of("parentApplication", "annotationBoList", "spanEventBoList", "agentName");
+        List<String> excludeField = List.of("parentApplication", "annotationBoList", "spanEventBoList", "owner.agentName");
         Assertions.assertThat(decode)
                 .usingRecursiveComparison()
                 .ignoringFields(excludeField.toArray(new String[0]))
@@ -257,7 +257,7 @@ public class SpanEncoderTest {
         // logger.debug("spanChunk dump \noriginal spanChunkBo:{} \ndecode spanChunkBo:{} ", spanChunkBo, decode);
 
         List<String> notSerializedField = Lists.newArrayList("endPoint", "serviceType", "applicationServiceType");
-        List<String> excludeField = List.of("spanEventBoList", "localAsyncId", "agentName");
+        List<String> excludeField = List.of("spanEventBoList", "localAsyncId", "owner.agentName");
         notSerializedField.addAll(excludeField);
         Assertions.assertThat(decode)
                 .usingRecursiveComparison()

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentInfoMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentInfoMapper.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import org.springframework.stereotype.Component;
@@ -28,14 +29,15 @@ import java.util.Map;
 public class OtlpAgentInfoMapper {
 
     public AgentInfoBo map(SpanBo spanBo, Map<String, AttributeValue> resourceAttributeMap) {
+        final SpanOwner owner = spanBo.getSpanOwner();
         final AgentInfoBo.Builder builder = new AgentInfoBo.Builder();
-        builder.setAgentId(spanBo.getAgentId());
-        if (spanBo.getAgentName() != null) {
-            builder.setAgentName(spanBo.getAgentName());
+        builder.setAgentId(owner.getAgentId());
+        if (owner.getAgentName() != null) {
+            builder.setAgentName(owner.getAgentName());
         }
-        builder.setApplicationName(spanBo.getApplicationName());
+        builder.setApplicationName(owner.getApplicationName());
         builder.setServiceTypeCode(spanBo.getServiceType());
-        builder.setStartTime(spanBo.getAgentStartTime());
+        builder.setStartTime(owner.getAgentStartTime());
 
         final String hostName = AttributeUtils.getAttributeStringValue(resourceAttributeMap, OtlpTraceConstants.ATTRIBUTE_KEY_HOST_NAME, null);
         if (hostName != null) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanChunkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanChunkMapper.java
@@ -43,19 +43,19 @@ public class OtlpTraceSpanChunkMapper {
     }
 
     SpanChunkBo map(IdAndName idAndName, Span span) {
-        SpanChunkBo spanChunkBo = new SpanChunkBo(TraceSourceType.OPENTELEMETRY);
-
-        final SpanOwner owner = spanChunkBo.getSpanOwner();
+        final SpanOwner owner = new SpanOwner();
         owner.setAgentId(idAndName.agentId());
         if (idAndName.agentName() != null) {
             owner.setAgentName(idAndName.agentName());
         }
         owner.setApplicationName(idAndName.applicationName());
         owner.setServiceName(idAndName.serviceName());
-
-        final long startTimeNanos = span.getStartTimeUnixNano();
         // The sequence value is 0, so make a difference with the agentStartTime value.
         owner.setAgentStartTime(generateAgentStartTime());
+
+        SpanChunkBo spanChunkBo = new SpanChunkBo(TraceSourceType.OPENTELEMETRY, owner);
+
+        final long startTimeNanos = span.getStartTimeUnixNano();
         spanChunkBo.setTransactionId(new OtelServerTraceId(span.getTraceId().toByteArray()));
         spanChunkBo.setSpanId(OtlpTraceMapperUtils.getSpanId(span.getParentSpanId()));
         // spanChunkBo.setEndPoint();

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanChunkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanChunkMapper.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.OtelServerTraceId;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -44,16 +45,17 @@ public class OtlpTraceSpanChunkMapper {
     SpanChunkBo map(IdAndName idAndName, Span span) {
         SpanChunkBo spanChunkBo = new SpanChunkBo(TraceSourceType.OPENTELEMETRY);
 
-        spanChunkBo.setAgentId(idAndName.agentId());
+        final SpanOwner owner = spanChunkBo.getSpanOwner();
+        owner.setAgentId(idAndName.agentId());
         if (idAndName.agentName() != null) {
-            spanChunkBo.setAgentName(idAndName.agentName());
+            owner.setAgentName(idAndName.agentName());
         }
-        spanChunkBo.setApplicationName(idAndName.applicationName());
-        spanChunkBo.setServiceName(idAndName.serviceName());
+        owner.setApplicationName(idAndName.applicationName());
+        owner.setServiceName(idAndName.serviceName());
 
         final long startTimeNanos = span.getStartTimeUnixNano();
         // The sequence value is 0, so make a difference with the agentStartTime value.
-        spanChunkBo.setAgentStartTime(generateAgentStartTime());
+        owner.setAgentStartTime(generateAgentStartTime());
         spanChunkBo.setTransactionId(new OtelServerTraceId(span.getTraceId().toByteArray()));
         spanChunkBo.setSpanId(OtlpTraceMapperUtils.getSpanId(span.getParentSpanId()));
         // spanChunkBo.setEndPoint();

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.bo.ExceptionInfo;
 import com.navercorp.pinpoint.common.server.bo.ParentApplication;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.OtelServerTraceId;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
@@ -71,12 +72,13 @@ public class OtlpTraceSpanMapper {
 
     SpanBo map(IdAndName idAndName, Span span) {
         SpanBo spanBo = new SpanBo(TraceSourceType.OPENTELEMETRY);
-        spanBo.setAgentId(idAndName.agentId());
+        final SpanOwner owner = spanBo.getSpanOwner();
+        owner.setAgentId(idAndName.agentId());
         if (idAndName.agentName() != null) {
-            spanBo.setAgentName(idAndName.agentName());
+            owner.setAgentName(idAndName.agentName());
         }
-        spanBo.setApplicationName(idAndName.applicationName());
-        spanBo.setServiceName(idAndName.serviceName());
+        owner.setApplicationName(idAndName.applicationName());
+        owner.setServiceName(idAndName.serviceName());
 
         spanBo.setTransactionId(new OtelServerTraceId(span.getTraceId().toByteArray()));
         spanBo.setSpanId(OtlpTraceMapperUtils.getSpanId(span.getSpanId()));
@@ -86,7 +88,7 @@ public class OtlpTraceSpanMapper {
         final long elapsedNanos = endTimeNanos - startTimeNanos;
         int elapsed = (int) TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
         spanBo.setTraceTime(SpanVersion.TRACE_V3, startTimeNanos, endTimeNanos, elapsed);
-        spanBo.setAgentStartTime(TimeUnit.NANOSECONDS.toMillis(startTimeNanos));
+        owner.setAgentStartTime(TimeUnit.NANOSECONDS.toMillis(startTimeNanos));
         spanBo.setCollectorAcceptTime(System.currentTimeMillis());
         spanBo.setFlag((short) 0);
         spanBo.setExceptionClass(null);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -71,24 +71,25 @@ public class OtlpTraceSpanMapper {
     }
 
     SpanBo map(IdAndName idAndName, Span span) {
-        SpanBo spanBo = new SpanBo(TraceSourceType.OPENTELEMETRY);
-        final SpanOwner owner = spanBo.getSpanOwner();
+        final long startTimeNanos = span.getStartTimeUnixNano();
+
+        final SpanOwner owner = new SpanOwner();
         owner.setAgentId(idAndName.agentId());
         if (idAndName.agentName() != null) {
             owner.setAgentName(idAndName.agentName());
         }
         owner.setApplicationName(idAndName.applicationName());
         owner.setServiceName(idAndName.serviceName());
+        owner.setAgentStartTime(TimeUnit.NANOSECONDS.toMillis(startTimeNanos));
 
+        SpanBo spanBo = new SpanBo(TraceSourceType.OPENTELEMETRY, owner);
         spanBo.setTransactionId(new OtelServerTraceId(span.getTraceId().toByteArray()));
         spanBo.setSpanId(OtlpTraceMapperUtils.getSpanId(span.getSpanId()));
         spanBo.setParentSpanId(OtlpTraceMapperUtils.getParentSpanId(span.getParentSpanId()));
-        final long startTimeNanos = span.getStartTimeUnixNano();
         final long endTimeNanos = Math.max(span.getEndTimeUnixNano(), startTimeNanos);
         final long elapsedNanos = endTimeNanos - startTimeNanos;
         int elapsed = (int) TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
         spanBo.setTraceTime(SpanVersion.TRACE_V3, startTimeNanos, endTimeNanos, elapsed);
-        owner.setAgentStartTime(TimeUnit.NANOSECONDS.toMillis(startTimeNanos));
         spanBo.setCollectorAcceptTime(System.currentTimeMillis());
         spanBo.setFlag((short) 0);
         spanBo.setExceptionClass(null);

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2.java
@@ -28,6 +28,7 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventComparator;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoder;
@@ -220,10 +221,12 @@ public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
                 return false;
             }
         }
-        if (!Strings.CS.equals(spanBo.getAgentId(), spanChunkBo.getAgentId())) {
+        final SpanOwner spanOwner = spanBo.getSpanOwner();
+        final SpanOwner chunkOwner = spanChunkBo.getSpanOwner();
+        if (!Strings.CS.equals(spanOwner.getAgentId(), chunkOwner.getAgentId())) {
             return false;
         }
-        if (!Strings.CS.equals(spanBo.getApplicationName(), spanChunkBo.getApplicationName())) {
+        if (!Strings.CS.equals(spanOwner.getApplicationName(), chunkOwner.getApplicationName())) {
             return false;
         }
         return true;
@@ -256,7 +259,8 @@ public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
 
 
     private AgentKey newAgentKey(BasicSpan basicSpan) {
-        return new AgentKey(basicSpan.getApplicationName(), basicSpan.getAgentId(), basicSpan.getSpanId());
+        final SpanOwner owner = basicSpan.getSpanOwner();
+        return new AgentKey(owner.getApplicationName(), owner.getAgentId(), basicSpan.getSpanId());
     }
 
     private record AgentKey(String applicationName, String agentId, long spanId) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/service/SpanServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/service/SpanServiceImpl.java
@@ -360,7 +360,7 @@ public class SpanServiceImpl implements SpanService {
         for (SpanBo spanBo : list) {
             AgentIdStartTimeKey key = new AgentIdStartTimeKey(spanBo.getAgentId(), spanBo.getAgentStartTime());
             Optional<String> agentName = agentNameMap.get(key);
-            spanBo.setAgentName(agentName.orElse(StringUtils.EMPTY));
+            spanBo.getSpanOwner().setAgentName(agentName.orElse(StringUtils.EMPTY));
         }
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/span/MetaSpanCallTreeFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/span/MetaSpanCallTreeFactory.java
@@ -45,8 +45,8 @@ public class MetaSpanCallTreeFactory {
     public CallTree unknown(final long startTimeMillis) {
         final SpanBo rootSpan = new SpanBo();
         rootSpan.setTransactionId(new PinpointServerTraceId(UNKNOWN_AGENT_ID, AGENT_START_TIME, 0));
-        rootSpan.setAgentId(UNKNOWN_AGENT_ID);
-        rootSpan.setApplicationName("UNKNOWN");
+        rootSpan.getSpanOwner().setAgentId(UNKNOWN_AGENT_ID);
+        rootSpan.getSpanOwner().setApplicationName("UNKNOWN");
         rootSpan.setTraceTime(SpanVersion.TRACE_V1, startTimeMillis, 0);
         rootSpan.setServiceType(ServiceType.UNKNOWN.getCode());
 
@@ -71,8 +71,8 @@ public class MetaSpanCallTreeFactory {
         rootSpan.setTraceTime(SpanVersion.TRACE_V1, startTimeMillis, 0);
 
         rootSpan.setTransactionId(new PinpointServerTraceId(CORRUPTED_AGENT_ID, AGENT_START_TIME, 0));
-        rootSpan.setAgentId(CORRUPTED_AGENT_ID);
-        rootSpan.setApplicationName("CORRUPTED");
+        rootSpan.getSpanOwner().setAgentId(CORRUPTED_AGENT_ID);
+        rootSpan.getSpanOwner().setApplicationName("CORRUPTED");
         rootSpan.setServiceType(ServiceType.UNKNOWN.getCode());
 
         ApiMetaDataBo apiMetaData = new ApiMetaDataBo(CORRUPTED_AGENT_ID, AGENT_START_TIME, 0, LineNumber.NO_LINE_NUMBER,

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/span/MetaSpanCallTreeFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/span/MetaSpanCallTreeFactory.java
@@ -20,6 +20,8 @@ import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -43,10 +45,12 @@ public class MetaSpanCallTreeFactory {
     private final long timeoutMillisec = DEFAULT_TIMEOUT_MILLISEC;
 
     public CallTree unknown(final long startTimeMillis) {
-        final SpanBo rootSpan = new SpanBo();
+        SpanOwner spanOwner = new SpanOwner();
+        spanOwner.setAgentId(UNKNOWN_AGENT_ID);
+        spanOwner.setApplicationName("UNKNOWN");
+
+        final SpanBo rootSpan = new SpanBo(TraceSourceType.PINPOINT, spanOwner);
         rootSpan.setTransactionId(new PinpointServerTraceId(UNKNOWN_AGENT_ID, AGENT_START_TIME, 0));
-        rootSpan.getSpanOwner().setAgentId(UNKNOWN_AGENT_ID);
-        rootSpan.getSpanOwner().setApplicationName("UNKNOWN");
         rootSpan.setTraceTime(SpanVersion.TRACE_V1, startTimeMillis, 0);
         rootSpan.setServiceType(ServiceType.UNKNOWN.getCode());
 
@@ -65,14 +69,16 @@ public class MetaSpanCallTreeFactory {
     }
 
     public SpanCallTree corrupted(final String title, final long parentSpanId, final long spanId, final long startTimeMillis) {
-        final SpanBo rootSpan = new SpanBo();
+        SpanOwner spanOwner = new SpanOwner();
+        spanOwner.setAgentId(CORRUPTED_AGENT_ID);
+        spanOwner.setApplicationName("CORRUPTED");
+
+        final SpanBo rootSpan = new SpanBo(TraceSourceType.PINPOINT, spanOwner);
         rootSpan.setParentSpanId(parentSpanId);
         rootSpan.setSpanId(spanId);
         rootSpan.setTraceTime(SpanVersion.TRACE_V1, startTimeMillis, 0);
 
         rootSpan.setTransactionId(new PinpointServerTraceId(CORRUPTED_AGENT_ID, AGENT_START_TIME, 0));
-        rootSpan.getSpanOwner().setAgentId(CORRUPTED_AGENT_ID);
-        rootSpan.getSpanOwner().setApplicationName("CORRUPTED");
         rootSpan.setServiceType(ServiceType.UNKNOWN.getCode());
 
         ApiMetaDataBo apiMetaData = new ApiMetaDataBo(CORRUPTED_AGENT_ID, AGENT_START_TIME, 0, LineNumber.NO_LINE_NUMBER,

--- a/web/src/test/java/com/navercorp/pinpoint/web/TestTraceUtils.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/TestTraceUtils.java
@@ -171,8 +171,8 @@ public class TestTraceUtils {
 
         public SpanBo build() {
             SpanBo spanBo = new SpanBo();
-            spanBo.setApplicationName(applicationName);
-            spanBo.setAgentId(agentId);
+            spanBo.getSpanOwner().setApplicationName(applicationName);
+            spanBo.getSpanOwner().setAgentId(agentId);
             long spanId = this.spanId;
             if (spanId == SpanId.NULL) {
                 spanId = random.nextLong();

--- a/web/src/test/java/com/navercorp/pinpoint/web/TestTraceUtils.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/TestTraceUtils.java
@@ -19,6 +19,8 @@ package com.navercorp.pinpoint.web;
 import com.navercorp.pinpoint.bootstrap.context.SpanId;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -170,9 +172,11 @@ public class TestTraceUtils {
         }
 
         public SpanBo build() {
-            SpanBo spanBo = new SpanBo();
-            spanBo.getSpanOwner().setApplicationName(applicationName);
-            spanBo.getSpanOwner().setAgentId(agentId);
+            SpanOwner spanOwner = new SpanOwner();
+            spanOwner.setApplicationName(applicationName);
+            spanOwner.setAgentId(agentId);
+
+            SpanBo spanBo = new SpanBo(TraceSourceType.PINPOINT, spanOwner);
             long spanId = this.spanId;
             if (spanId == SpanId.NULL) {
                 spanId = random.nextLong();

--- a/web/src/test/java/com/navercorp/pinpoint/web/filter/LinkFilterTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/filter/LinkFilterTest.java
@@ -90,22 +90,22 @@ public class LinkFilterTest {
         logger.debug("{}", linkFilter);
 
         SpanBo fromSpanBo = new SpanBo();
-        fromSpanBo.setApplicationName("APP_A");
+        fromSpanBo.getSpanOwner().setApplicationName("APP_A");
 
         fromSpanBo.setServiceType(tomcatServiceType);
-        fromSpanBo.setAgentId("AGENT_A");
+        fromSpanBo.getSpanOwner().setAgentId("AGENT_A");
         fromSpanBo.setSpanId(100);
 
         SpanBo toSpanBO = new SpanBo();
-        toSpanBO.setApplicationName("APP_B");
+        toSpanBO.getSpanOwner().setApplicationName("APP_B");
         toSpanBO.setServiceType(tomcatServiceType);
-        toSpanBO.setAgentId("AGENT_B");
+        toSpanBO.getSpanOwner().setAgentId("AGENT_B");
         toSpanBO.setParentSpanId(100);
 
         SpanBo spanBoC = new SpanBo();
-        spanBoC.setApplicationName("APP_C");
+        spanBoC.getSpanOwner().setApplicationName("APP_C");
         spanBoC.setServiceType(tomcatServiceType);
-        spanBoC.setAgentId("AGENT_C");
+        spanBoC.getSpanOwner().setAgentId("AGENT_C");
 
         Assertions.assertTrue(linkFilter.include(List.of(fromSpanBo, toSpanBO)));
         Assertions.assertFalse(linkFilter.include(List.of(fromSpanBo, spanBoC)));
@@ -130,22 +130,22 @@ public class LinkFilterTest {
         logger.debug("{}", linkFilter);
 
         SpanBo fromSpanBo = new SpanBo();
-        fromSpanBo.setApplicationName("APP_A");
+        fromSpanBo.getSpanOwner().setApplicationName("APP_A");
 
         fromSpanBo.setServiceType(tomcatServiceType);
-        fromSpanBo.setAgentId("AGENT_A");
+        fromSpanBo.getSpanOwner().setAgentId("AGENT_A");
         fromSpanBo.setSpanId(100);
 
         SpanBo toSpanBO = new SpanBo();
-        toSpanBO.setApplicationName("APP_B");
+        toSpanBO.getSpanOwner().setApplicationName("APP_B");
         toSpanBO.setServiceType(tomcatServiceType);
-        toSpanBO.setAgentId("AGENT_B");
+        toSpanBO.getSpanOwner().setAgentId("AGENT_B");
         toSpanBO.setParentSpanId(100);
 
         SpanBo spanBoC = new SpanBo();
-        spanBoC.setApplicationName("APP_C");
+        spanBoC.getSpanOwner().setApplicationName("APP_C");
         spanBoC.setServiceType(tomcatServiceType);
-        spanBoC.setAgentId("AGENT_C");
+        spanBoC.getSpanOwner().setAgentId("AGENT_C");
 
         Assertions.assertTrue(linkFilter.include(List.of(fromSpanBo, toSpanBO)));
         Assertions.assertFalse(linkFilter.include(List.of(fromSpanBo, spanBoC)));
@@ -171,17 +171,17 @@ public class LinkFilterTest {
         SpanBo user_appA = new SpanBo();
         user_appA.setSpanId(1);
         user_appA.setParentSpanId(-1);
-        user_appA.setApplicationName("APP_A");
+        user_appA.getSpanOwner().setApplicationName("APP_A");
         user_appA.setApplicationServiceType(tomcat.getCode());
         SpanBo appA_appB = new SpanBo();
         appA_appB.setSpanId(2);
         appA_appB.setParentSpanId(1);
-        appA_appB.setApplicationName("APP_B");
+        appA_appB.getSpanOwner().setApplicationName("APP_B");
         appA_appB.setApplicationServiceType(tomcat.getCode());
         SpanBo appB_appA = new SpanBo();
         appB_appA.setSpanId(3);
         appB_appA.setParentSpanId(2);
-        appB_appA.setApplicationName("APP_A");
+        appB_appA.getSpanOwner().setApplicationName("APP_A");
         appB_appA.setApplicationServiceType(tomcat.getCode());
 
         Assertions.assertTrue(linkFilter.include(List.of(user_appA)));
@@ -219,7 +219,7 @@ public class LinkFilterTest {
         SpanBo spanBo = new SpanBo();
         spanBo.setSpanId(1);
         spanBo.setParentSpanId(-1);
-        spanBo.setApplicationName("APP_A");
+        spanBo.getSpanOwner().setApplicationName("APP_A");
         spanBo.setApplicationServiceType(tomcat.getCode());
         Assertions.assertFalse(linkFilter.include(List.of(spanBo)));
 
@@ -253,12 +253,12 @@ public class LinkFilterTest {
         SpanBo user_appA = new SpanBo();
         user_appA.setSpanId(1);
         user_appA.setParentSpanId(-1);
-        user_appA.setApplicationName("APP_A");
+        user_appA.getSpanOwner().setApplicationName("APP_A");
         user_appA.setApplicationServiceType(tomcat.getCode());
         SpanBo appA_appB = new SpanBo();
         appA_appB.setSpanId(2);
         appA_appB.setParentSpanId(1);
-        appA_appB.setApplicationName("APP_B");
+        appA_appB.getSpanOwner().setApplicationName("APP_B");
         appA_appB.setApplicationServiceType(tomcat.getCode());
         Assertions.assertTrue(linkFilter.include(List.of(user_appA, appA_appB)));
     }
@@ -283,12 +283,12 @@ public class LinkFilterTest {
         SpanBo user_appC = new SpanBo();
         user_appC.setSpanId(1);
         user_appC.setParentSpanId(-1);
-        user_appC.setApplicationName("APP_C");
+        user_appC.getSpanOwner().setApplicationName("APP_C");
         user_appC.setApplicationServiceType(tomcat.getCode());
         SpanBo appC_appB = new SpanBo();
         appC_appB.setSpanId(2);
         appC_appB.setParentSpanId(1);
-        appC_appB.setApplicationName("APP_B");
+        appC_appB.getSpanOwner().setApplicationName("APP_B");
         appC_appB.setApplicationServiceType(tomcat.getCode());
         Assertions.assertFalse(linkFilter.include(List.of(user_appC, appC_appB)));
 
@@ -296,12 +296,12 @@ public class LinkFilterTest {
         SpanBo user_appA = new SpanBo();
         user_appA.setSpanId(1);
         user_appA.setParentSpanId(-1);
-        user_appA.setApplicationName("APP_A");
+        user_appA.getSpanOwner().setApplicationName("APP_A");
         user_appA.setApplicationServiceType(tomcat.getCode());
         SpanBo appA_appC = new SpanBo();
         appA_appC.setSpanId(2);
         appA_appC.setParentSpanId(1);
-        appA_appC.setApplicationName("APP_C");
+        appA_appC.getSpanOwner().setApplicationName("APP_C");
         appA_appC.setApplicationServiceType(tomcat.getCode());
         Assertions.assertFalse(linkFilter.include(List.of(user_appA, appA_appC)));
     }
@@ -339,7 +339,7 @@ public class LinkFilterTest {
         SpanBo fromSpan = new SpanBo();
         fromSpan.setSpanId(1);
         fromSpan.setParentSpanId(-1);
-        fromSpan.setApplicationName("APP_A");
+        fromSpan.getSpanOwner().setApplicationName("APP_A");
         fromSpan.setApplicationServiceType(tomcat.getCode());
         AnnotationBo rpcAnnotation = AnnotationBo.of(RPC_ANNOTATION_CODE, rpcUrl);
         SpanEventBo rpcSpanEvent = new SpanEventBo();
@@ -388,7 +388,7 @@ public class LinkFilterTest {
         logger.debug("{}", linkFilter);
 
         SpanBo matchingSpan = new SpanBo();
-        matchingSpan.setApplicationName("APP_A");
+        matchingSpan.getSpanOwner().setApplicationName("APP_A");
         matchingSpan.setApplicationServiceType(tomcat.getCode());
         SpanEventBo spanEventDestinationA = new SpanEventBo();
         spanEventDestinationA.setDestinationId(destinationA);
@@ -397,7 +397,7 @@ public class LinkFilterTest {
         Assertions.assertTrue(linkFilter.include(List.of(matchingSpan)));
 
         SpanBo unmatchingSpan = new SpanBo();
-        unmatchingSpan.setApplicationName("APP_A");
+        unmatchingSpan.getSpanOwner().setApplicationName("APP_A");
         unmatchingSpan.setApplicationServiceType(tomcat.getCode());
         SpanEventBo spanEventDestinationB = new SpanEventBo();
         spanEventDestinationB.setDestinationId(destinationB);
@@ -408,7 +408,7 @@ public class LinkFilterTest {
         Assertions.assertTrue(linkFilter.include(List.of(matchingSpan, unmatchingSpan)));
 
         SpanBo bothSpan = new SpanBo();
-        bothSpan.setApplicationName("APP_A");
+        bothSpan.getSpanOwner().setApplicationName("APP_A");
         bothSpan.setApplicationServiceType(tomcat.getCode());
         bothSpan.addSpanEventBoList(List.of(spanEventDestinationA, spanEventDestinationB));
         Assertions.assertTrue(linkFilter.include(List.of(bothSpan)));
@@ -435,7 +435,7 @@ public class LinkFilterTest {
         logger.debug("{}", linkFilter);
 
         SpanBo matchingSpan = new SpanBo();
-        matchingSpan.setApplicationName("APP_A");
+        matchingSpan.getSpanOwner().setApplicationName("APP_A");
         matchingSpan.setApplicationServiceType(tomcat.getCode());
         SpanEventBo spanEventDestinationA = new SpanEventBo();
         spanEventDestinationA.setDestinationId(messageQueueA);
@@ -444,7 +444,7 @@ public class LinkFilterTest {
         Assertions.assertTrue(linkFilter.include(List.of(matchingSpan)));
 
         SpanBo unmatchingSpan = new SpanBo();
-        unmatchingSpan.setApplicationName("APP_A");
+        unmatchingSpan.getSpanOwner().setApplicationName("APP_A");
         unmatchingSpan.setApplicationServiceType(tomcat.getCode());
         SpanEventBo spanEventDestinationB = new SpanEventBo();
         spanEventDestinationB.setDestinationId(messageQueueB);
@@ -455,7 +455,7 @@ public class LinkFilterTest {
         Assertions.assertTrue(linkFilter.include(List.of(matchingSpan, unmatchingSpan)));
 
         SpanBo bothSpan = new SpanBo();
-        bothSpan.setApplicationName("APP_A");
+        bothSpan.getSpanOwner().setApplicationName("APP_A");
         bothSpan.setApplicationServiceType(tomcat.getCode());
         bothSpan.addSpanEventBoList(List.of(spanEventDestinationA, spanEventDestinationB));
         Assertions.assertTrue(linkFilter.include(List.of(bothSpan)));
@@ -482,13 +482,13 @@ public class LinkFilterTest {
         logger.debug("{}", linkFilter);
 
         SpanBo matchingSpan = new SpanBo();
-        matchingSpan.setApplicationName("APP_A");
+        matchingSpan.getSpanOwner().setApplicationName("APP_A");
         matchingSpan.setApplicationServiceType(tomcat.getCode());
         matchingSpan.setAcceptorHost(messageQueueA);
         Assertions.assertTrue(linkFilter.include(List.of(matchingSpan)));
 
         SpanBo unmatchingSpan = new SpanBo();
-        unmatchingSpan.setApplicationName("APP_A");
+        unmatchingSpan.getSpanOwner().setApplicationName("APP_A");
         unmatchingSpan.setApplicationServiceType(tomcat.getCode());
         unmatchingSpan.setAcceptorHost(messageQueueB);
         Assertions.assertFalse(linkFilter.include(List.of(unmatchingSpan)));

--- a/web/src/test/java/com/navercorp/pinpoint/web/filter/LinkFilterTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/filter/LinkFilterTest.java
@@ -3,6 +3,8 @@ package com.navercorp.pinpoint.web.filter;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.AnnotationKeyFactory;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -70,6 +72,19 @@ public class LinkFilterTest {
         return new FilterDescriptor.Node(FilterDescriptor.Node.NodeType.SELF, DEFAULT_SERVICE, null, null, null);
     }
 
+    private static SpanBo newSpanBo(String applicationName) {
+        SpanOwner owner = new SpanOwner();
+        owner.setApplicationName(applicationName);
+        return new SpanBo(TraceSourceType.PINPOINT, owner);
+    }
+
+    private static SpanBo newSpanBo(String applicationName, String agentId) {
+        SpanOwner owner = new SpanOwner();
+        owner.setApplicationName(applicationName);
+        owner.setAgentId(agentId);
+        return new SpanBo(TraceSourceType.PINPOINT, owner);
+    }
+
     @Test
     public void fromToFilterTest() {
         ServiceType tomcat = serviceTypeRegistryService.findServiceTypeByName(TOMCAT_TYPE_NAME);
@@ -89,23 +104,16 @@ public class LinkFilterTest {
         LinkFilter linkFilter = newLinkFilter(descriptor, hint);
         logger.debug("{}", linkFilter);
 
-        SpanBo fromSpanBo = new SpanBo();
-        fromSpanBo.getSpanOwner().setApplicationName("APP_A");
-
+        SpanBo fromSpanBo = newSpanBo("APP_A", "AGENT_A");
         fromSpanBo.setServiceType(tomcatServiceType);
-        fromSpanBo.getSpanOwner().setAgentId("AGENT_A");
         fromSpanBo.setSpanId(100);
 
-        SpanBo toSpanBO = new SpanBo();
-        toSpanBO.getSpanOwner().setApplicationName("APP_B");
+        SpanBo toSpanBO = newSpanBo("APP_B", "AGENT_B");
         toSpanBO.setServiceType(tomcatServiceType);
-        toSpanBO.getSpanOwner().setAgentId("AGENT_B");
         toSpanBO.setParentSpanId(100);
 
-        SpanBo spanBoC = new SpanBo();
-        spanBoC.getSpanOwner().setApplicationName("APP_C");
+        SpanBo spanBoC = newSpanBo("APP_C", "AGENT_C");
         spanBoC.setServiceType(tomcatServiceType);
-        spanBoC.getSpanOwner().setAgentId("AGENT_C");
 
         Assertions.assertTrue(linkFilter.include(List.of(fromSpanBo, toSpanBO)));
         Assertions.assertFalse(linkFilter.include(List.of(fromSpanBo, spanBoC)));
@@ -129,23 +137,16 @@ public class LinkFilterTest {
         LinkFilter linkFilter = newLinkFilter(descriptor, hint);
         logger.debug("{}", linkFilter);
 
-        SpanBo fromSpanBo = new SpanBo();
-        fromSpanBo.getSpanOwner().setApplicationName("APP_A");
-
+        SpanBo fromSpanBo = newSpanBo("APP_A", "AGENT_A");
         fromSpanBo.setServiceType(tomcatServiceType);
-        fromSpanBo.getSpanOwner().setAgentId("AGENT_A");
         fromSpanBo.setSpanId(100);
 
-        SpanBo toSpanBO = new SpanBo();
-        toSpanBO.getSpanOwner().setApplicationName("APP_B");
+        SpanBo toSpanBO = newSpanBo("APP_B", "AGENT_B");
         toSpanBO.setServiceType(tomcatServiceType);
-        toSpanBO.getSpanOwner().setAgentId("AGENT_B");
         toSpanBO.setParentSpanId(100);
 
-        SpanBo spanBoC = new SpanBo();
-        spanBoC.getSpanOwner().setApplicationName("APP_C");
+        SpanBo spanBoC = newSpanBo("APP_C", "AGENT_C");
         spanBoC.setServiceType(tomcatServiceType);
-        spanBoC.getSpanOwner().setAgentId("AGENT_C");
 
         Assertions.assertTrue(linkFilter.include(List.of(fromSpanBo, toSpanBO)));
         Assertions.assertFalse(linkFilter.include(List.of(fromSpanBo, spanBoC)));
@@ -168,20 +169,17 @@ public class LinkFilterTest {
         LinkFilter linkFilter = newLinkFilter(descriptor, hint);
         logger.debug("{}", linkFilter);
 
-        SpanBo user_appA = new SpanBo();
+        SpanBo user_appA = newSpanBo("APP_A");
         user_appA.setSpanId(1);
         user_appA.setParentSpanId(-1);
-        user_appA.getSpanOwner().setApplicationName("APP_A");
         user_appA.setApplicationServiceType(tomcat.getCode());
-        SpanBo appA_appB = new SpanBo();
+        SpanBo appA_appB = newSpanBo("APP_B");
         appA_appB.setSpanId(2);
         appA_appB.setParentSpanId(1);
-        appA_appB.getSpanOwner().setApplicationName("APP_B");
         appA_appB.setApplicationServiceType(tomcat.getCode());
-        SpanBo appB_appA = new SpanBo();
+        SpanBo appB_appA = newSpanBo("APP_A");
         appB_appA.setSpanId(3);
         appB_appA.setParentSpanId(2);
-        appB_appA.getSpanOwner().setApplicationName("APP_A");
         appB_appA.setApplicationServiceType(tomcat.getCode());
 
         Assertions.assertTrue(linkFilter.include(List.of(user_appA)));
@@ -216,10 +214,9 @@ public class LinkFilterTest {
         logger.debug("{}", linkFilter);
 
         // Reject - no rpc span event
-        SpanBo spanBo = new SpanBo();
+        SpanBo spanBo = newSpanBo("APP_A");
         spanBo.setSpanId(1);
         spanBo.setParentSpanId(-1);
-        spanBo.getSpanOwner().setApplicationName("APP_A");
         spanBo.setApplicationServiceType(tomcat.getCode());
         Assertions.assertFalse(linkFilter.include(List.of(spanBo)));
 
@@ -250,15 +247,13 @@ public class LinkFilterTest {
         logger.debug("{}", linkFilter);
 
         // Accept - perfect match
-        SpanBo user_appA = new SpanBo();
+        SpanBo user_appA = newSpanBo("APP_A");
         user_appA.setSpanId(1);
         user_appA.setParentSpanId(-1);
-        user_appA.getSpanOwner().setApplicationName("APP_A");
         user_appA.setApplicationServiceType(tomcat.getCode());
-        SpanBo appA_appB = new SpanBo();
+        SpanBo appA_appB = newSpanBo("APP_B");
         appA_appB.setSpanId(2);
         appA_appB.setParentSpanId(1);
-        appA_appB.getSpanOwner().setApplicationName("APP_B");
         appA_appB.setApplicationServiceType(tomcat.getCode());
         Assertions.assertTrue(linkFilter.include(List.of(user_appA, appA_appB)));
     }
@@ -280,28 +275,24 @@ public class LinkFilterTest {
         logger.debug("{}", linkFilter);
 
         // Reject - fromNode different
-        SpanBo user_appC = new SpanBo();
+        SpanBo user_appC = newSpanBo("APP_C");
         user_appC.setSpanId(1);
         user_appC.setParentSpanId(-1);
-        user_appC.getSpanOwner().setApplicationName("APP_C");
         user_appC.setApplicationServiceType(tomcat.getCode());
-        SpanBo appC_appB = new SpanBo();
+        SpanBo appC_appB = newSpanBo("APP_B");
         appC_appB.setSpanId(2);
         appC_appB.setParentSpanId(1);
-        appC_appB.getSpanOwner().setApplicationName("APP_B");
         appC_appB.setApplicationServiceType(tomcat.getCode());
         Assertions.assertFalse(linkFilter.include(List.of(user_appC, appC_appB)));
 
         // Reject - toNode different
-        SpanBo user_appA = new SpanBo();
+        SpanBo user_appA = newSpanBo("APP_A");
         user_appA.setSpanId(1);
         user_appA.setParentSpanId(-1);
-        user_appA.getSpanOwner().setApplicationName("APP_A");
         user_appA.setApplicationServiceType(tomcat.getCode());
-        SpanBo appA_appC = new SpanBo();
+        SpanBo appA_appC = newSpanBo("APP_C");
         appA_appC.setSpanId(2);
         appA_appC.setParentSpanId(1);
-        appA_appC.getSpanOwner().setApplicationName("APP_C");
         appA_appC.setApplicationServiceType(tomcat.getCode());
         Assertions.assertFalse(linkFilter.include(List.of(user_appA, appA_appC)));
     }
@@ -336,10 +327,9 @@ public class LinkFilterTest {
         logger.debug("unmatchingHintLinkFilter : {}", unmatchingHintLinkFilter.toString());
         logger.debug("matchingHintLinkFilter : {}", matchingHintLinkFilter.toString());
 
-        SpanBo fromSpan = new SpanBo();
+        SpanBo fromSpan = newSpanBo("APP_A");
         fromSpan.setSpanId(1);
         fromSpan.setParentSpanId(-1);
-        fromSpan.getSpanOwner().setApplicationName("APP_A");
         fromSpan.setApplicationServiceType(tomcat.getCode());
         AnnotationBo rpcAnnotation = AnnotationBo.of(RPC_ANNOTATION_CODE, rpcUrl);
         SpanEventBo rpcSpanEvent = new SpanEventBo();
@@ -387,8 +377,7 @@ public class LinkFilterTest {
         LinkFilter linkFilter = newLinkFilter(descriptor, hint);
         logger.debug("{}", linkFilter);
 
-        SpanBo matchingSpan = new SpanBo();
-        matchingSpan.getSpanOwner().setApplicationName("APP_A");
+        SpanBo matchingSpan = newSpanBo("APP_A");
         matchingSpan.setApplicationServiceType(tomcat.getCode());
         SpanEventBo spanEventDestinationA = new SpanEventBo();
         spanEventDestinationA.setDestinationId(destinationA);
@@ -396,8 +385,7 @@ public class LinkFilterTest {
         matchingSpan.addSpanEvent(spanEventDestinationA);
         Assertions.assertTrue(linkFilter.include(List.of(matchingSpan)));
 
-        SpanBo unmatchingSpan = new SpanBo();
-        unmatchingSpan.getSpanOwner().setApplicationName("APP_A");
+        SpanBo unmatchingSpan = newSpanBo("APP_A");
         unmatchingSpan.setApplicationServiceType(tomcat.getCode());
         SpanEventBo spanEventDestinationB = new SpanEventBo();
         spanEventDestinationB.setDestinationId(destinationB);
@@ -407,8 +395,7 @@ public class LinkFilterTest {
 
         Assertions.assertTrue(linkFilter.include(List.of(matchingSpan, unmatchingSpan)));
 
-        SpanBo bothSpan = new SpanBo();
-        bothSpan.getSpanOwner().setApplicationName("APP_A");
+        SpanBo bothSpan = newSpanBo("APP_A");
         bothSpan.setApplicationServiceType(tomcat.getCode());
         bothSpan.addSpanEventBoList(List.of(spanEventDestinationA, spanEventDestinationB));
         Assertions.assertTrue(linkFilter.include(List.of(bothSpan)));
@@ -434,8 +421,7 @@ public class LinkFilterTest {
         LinkFilter linkFilter = newLinkFilter(descriptor, hint);
         logger.debug("{}", linkFilter);
 
-        SpanBo matchingSpan = new SpanBo();
-        matchingSpan.getSpanOwner().setApplicationName("APP_A");
+        SpanBo matchingSpan = newSpanBo("APP_A");
         matchingSpan.setApplicationServiceType(tomcat.getCode());
         SpanEventBo spanEventDestinationA = new SpanEventBo();
         spanEventDestinationA.setDestinationId(messageQueueA);
@@ -443,8 +429,7 @@ public class LinkFilterTest {
         matchingSpan.addSpanEvent(spanEventDestinationA);
         Assertions.assertTrue(linkFilter.include(List.of(matchingSpan)));
 
-        SpanBo unmatchingSpan = new SpanBo();
-        unmatchingSpan.getSpanOwner().setApplicationName("APP_A");
+        SpanBo unmatchingSpan = newSpanBo("APP_A");
         unmatchingSpan.setApplicationServiceType(tomcat.getCode());
         SpanEventBo spanEventDestinationB = new SpanEventBo();
         spanEventDestinationB.setDestinationId(messageQueueB);
@@ -454,8 +439,7 @@ public class LinkFilterTest {
 
         Assertions.assertTrue(linkFilter.include(List.of(matchingSpan, unmatchingSpan)));
 
-        SpanBo bothSpan = new SpanBo();
-        bothSpan.getSpanOwner().setApplicationName("APP_A");
+        SpanBo bothSpan = newSpanBo("APP_A");
         bothSpan.setApplicationServiceType(tomcat.getCode());
         bothSpan.addSpanEventBoList(List.of(spanEventDestinationA, spanEventDestinationB));
         Assertions.assertTrue(linkFilter.include(List.of(bothSpan)));
@@ -481,14 +465,12 @@ public class LinkFilterTest {
         LinkFilter linkFilter = newLinkFilter(descriptor, hint);
         logger.debug("{}", linkFilter);
 
-        SpanBo matchingSpan = new SpanBo();
-        matchingSpan.getSpanOwner().setApplicationName("APP_A");
+        SpanBo matchingSpan = newSpanBo("APP_A");
         matchingSpan.setApplicationServiceType(tomcat.getCode());
         matchingSpan.setAcceptorHost(messageQueueA);
         Assertions.assertTrue(linkFilter.include(List.of(matchingSpan)));
 
-        SpanBo unmatchingSpan = new SpanBo();
-        unmatchingSpan.getSpanOwner().setApplicationName("APP_A");
+        SpanBo unmatchingSpan = newSpanBo("APP_A");
         unmatchingSpan.setApplicationServiceType(tomcat.getCode());
         unmatchingSpan.setAcceptorHost(messageQueueB);
         Assertions.assertFalse(linkFilter.include(List.of(unmatchingSpan)));

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
@@ -289,12 +289,12 @@ public class RecordFactoryTest {
 
     private static SpanBo newSpanBo(SpanEventBo spanEventBo1) {
         SpanBo spanBo = new SpanBo();
-        spanBo.setAgentId("express-node-sample-id");
-        spanBo.setAgentName("");
-        spanBo.setApplicationName("express-node-sample-name");
-        spanBo.setServiceName("express-node-sample-service");
-        spanBo.setServiceUid(() -> ServiceUid.of(100));
-        spanBo.setAgentStartTime(1670293953108L);
+        spanBo.getSpanOwner().setAgentId("express-node-sample-id");
+        spanBo.getSpanOwner().setAgentName("");
+        spanBo.getSpanOwner().setApplicationName("express-node-sample-name");
+        spanBo.getSpanOwner().setServiceName("express-node-sample-service");
+        spanBo.getSpanOwner().setServiceUid(() -> ServiceUid.of(100));
+        spanBo.getSpanOwner().setAgentStartTime(1670293953108L);
         spanBo.setTransactionId(new PinpointServerTraceId("express-node-sample-id", 1670293953108L, 30));
         spanBo.setSpanId(8174884636707391L);
         spanBo.setParentSpanId(-1);

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/hbase/SpanQueryBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/hbase/SpanQueryBuilderTest.java
@@ -46,8 +46,8 @@ public class SpanQueryBuilderTest {
         span.setTransactionId(new PinpointServerTraceId("agent", 1, 2));
         span.setCollectorAcceptTime(100);
         span.setElapsed(200);
-        span.setApplicationName("appName");
-        span.setAgentId("agentId");
+        span.getSpanOwner().setApplicationName("appName");
+        span.getSpanOwner().setAgentId("agentId");
 
         Assertions.assertEquals(spanQuery.getTransactionId(), span.getTransactionId());
         Assertions.assertTrue(spanQuery.getSpanFilter().test(span));
@@ -65,7 +65,7 @@ public class SpanQueryBuilderTest {
         span.setTransactionId(txId);
         span.setCollectorAcceptTime(100);
         span.setElapsed(200);
-        span.setApplicationName("appName");
+        span.getSpanOwner().setApplicationName("appName");
 
         Assertions.assertTrue(filter.test(span));
     }
@@ -135,7 +135,7 @@ public class SpanQueryBuilderTest {
         Predicate<SpanBo> filter = SpanFilters.agentIdFilter("agentId");
 
         SpanBo span = new SpanBo();
-        span.setAgentId("agentId");
+        span.getSpanOwner().setAgentId("agentId");
 
         Assertions.assertTrue(filter.test(span));
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/mapper/FilteringSpanDecoderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/mapper/FilteringSpanDecoderTest.java
@@ -230,7 +230,7 @@ public class FilteringSpanDecoderTest {
             spanBo.setElapsed(createElapsed());
 
             if (applicationName != null) {
-                spanBo.setApplicationName("appName");
+                spanBo.getSpanOwner().setApplicationName("appName");
             }
 
             return spanBo;

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/span/CallTreeTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/span/CallTreeTest.java
@@ -19,6 +19,8 @@ package com.navercorp.pinpoint.web.trace.span;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.io.SpanVersion;
 import org.junit.jupiter.api.Test;
 
@@ -312,11 +314,16 @@ public class CallTreeTest {
         return makeSpanAlign(0, 0);
     }
 
+    private static SpanBo newSpanBo(String applicationName, String agentId) {
+        SpanOwner owner = new SpanOwner();
+        owner.setApplicationName(applicationName);
+        owner.setAgentId(agentId);
+        return new SpanBo(TraceSourceType.PINPOINT, owner);
+    }
+
     private Align makeSpanAlign(long startTime, int elapsed) {
-        SpanBo span = new SpanBo();
+        SpanBo span = newSpanBo("applicationId", "agentId");
         span.setTraceTime(SpanVersion.TRACE_V1, startTime, elapsed);
-        span.getSpanOwner().setAgentId("agentId");
-        span.getSpanOwner().setApplicationName("applicationId");
 
         return new SpanAlign(span);
     }
@@ -326,9 +333,7 @@ public class CallTreeTest {
     }
 
     private Align makeSpanAlign(final boolean async, final short sequence, final int nextAsyncId, final int asyncId) {
-        SpanBo span = new SpanBo();
-        span.getSpanOwner().setAgentId("agentId");
-        span.getSpanOwner().setApplicationName("applicationName");
+        SpanBo span = newSpanBo("applicationName", "agentId");
         return makeSpanAlign(span, async, sequence, nextAsyncId, asyncId, -1, -1);
     }
 
@@ -344,13 +349,17 @@ public class CallTreeTest {
             return new SpanEventAlign(span, event);
         }
 
-        SpanChunkBo spanChunkBo = new SpanChunkBo();
+        SpanOwner spanOwner = span.getSpanOwner();
+        SpanOwner chunkOwner = new SpanOwner();
+        chunkOwner.setAgentId(spanOwner.getAgentId());
+        chunkOwner.setAgentName(spanOwner.getAgentName());
+        chunkOwner.setApplicationName(spanOwner.getApplicationName());
+        chunkOwner.setAgentStartTime(spanOwner.getAgentStartTime());
+
+        SpanChunkBo spanChunkBo = new SpanChunkBo(TraceSourceType.PINPOINT, chunkOwner);
         spanChunkBo.setVersion(span.getVersion());
         spanChunkBo.setTransactionId(span.getTransactionId());
         spanChunkBo.setSpanId(span.getSpanId());
-        spanChunkBo.getSpanOwner().setAgentId(span.getAgentId());
-        spanChunkBo.getSpanOwner().setAgentName(span.getAgentName());
-        spanChunkBo.getSpanOwner().setApplicationName(span.getApplicationName());
         spanChunkBo.setApplicationServiceType(span.getApplicationServiceType());
         spanChunkBo.setCollectorAcceptTime(span.getCollectorAcceptTime());
         spanChunkBo.setEndPoint(span.getEndPoint());

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/span/CallTreeTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/span/CallTreeTest.java
@@ -315,8 +315,8 @@ public class CallTreeTest {
     private Align makeSpanAlign(long startTime, int elapsed) {
         SpanBo span = new SpanBo();
         span.setTraceTime(SpanVersion.TRACE_V1, startTime, elapsed);
-        span.setAgentId("agentId");
-        span.setApplicationName("applicationId");
+        span.getSpanOwner().setAgentId("agentId");
+        span.getSpanOwner().setApplicationName("applicationId");
 
         return new SpanAlign(span);
     }
@@ -327,8 +327,8 @@ public class CallTreeTest {
 
     private Align makeSpanAlign(final boolean async, final short sequence, final int nextAsyncId, final int asyncId) {
         SpanBo span = new SpanBo();
-        span.setAgentId("agentId");
-        span.setApplicationName("applicationName");
+        span.getSpanOwner().setAgentId("agentId");
+        span.getSpanOwner().setApplicationName("applicationName");
         return makeSpanAlign(span, async, sequence, nextAsyncId, asyncId, -1, -1);
     }
 
@@ -348,9 +348,9 @@ public class CallTreeTest {
         spanChunkBo.setVersion(span.getVersion());
         spanChunkBo.setTransactionId(span.getTransactionId());
         spanChunkBo.setSpanId(span.getSpanId());
-        spanChunkBo.setAgentId(span.getAgentId());
-        spanChunkBo.setAgentName(span.getAgentName());
-        spanChunkBo.setApplicationName(span.getApplicationName());
+        spanChunkBo.getSpanOwner().setAgentId(span.getAgentId());
+        spanChunkBo.getSpanOwner().setAgentName(span.getAgentName());
+        spanChunkBo.getSpanOwner().setApplicationName(span.getApplicationName());
         spanChunkBo.setApplicationServiceType(span.getApplicationServiceType());
         spanChunkBo.setCollectorAcceptTime(span.getCollectorAcceptTime());
         spanChunkBo.setEndPoint(span.getEndPoint());

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/span/SpanCallTreeTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/span/SpanCallTreeTest.java
@@ -28,7 +28,7 @@ public class SpanCallTreeTest {
     @Test
     public void hasFocusSpan1() {
         SpanBo root = new SpanBo();
-        root.setAgentId("root");
+        root.getSpanOwner().setAgentId("root");
         Align rootAlign = new SpanAlign(root);
 
         SpanCallTree callTreeNodes = new SpanCallTree(rootAlign);
@@ -40,7 +40,7 @@ public class SpanCallTreeTest {
     @Test
     public void hasFocusSpan2() {
         SpanBo root = new SpanBo();
-        root.setAgentId("root");
+        root.getSpanOwner().setAgentId("root");
         Align rootAlign = new SpanAlign(root);
 
         SpanCallTree callTreeNodes = new SpanCallTree(rootAlign);
@@ -74,14 +74,14 @@ public class SpanCallTreeTest {
     private SpanCallTree childTree(String parentAgentId, String childAgentId1, String childAgentId2) {
         SpanBo root = new SpanBo();
 //        root.setSpanId(100);
-        root.setAgentId(parentAgentId);
+        root.getSpanOwner().setAgentId(parentAgentId);
         Align rootAlign = new SpanAlign(root);
         SpanCallTree rootCallTreeNodes = new SpanCallTree(rootAlign);
 
         SpanBo childSpan1 = new SpanBo();
 //        childSpan1.setParentSpanId(100);
 //        childSpan1.setSpanId(200);
-        childSpan1.setAgentId(childAgentId1);
+        childSpan1.getSpanOwner().setAgentId(childAgentId1);
         Align childAlign1 = new SpanAlign(childSpan1);
         SpanCallTree childCallTreeNodes1 = new SpanCallTree(childAlign1);
         rootCallTreeNodes.add(childCallTreeNodes1);
@@ -89,7 +89,7 @@ public class SpanCallTreeTest {
         SpanBo childSpan2 = new SpanBo();
 //        childSpan2.setParentSpanId(200);
 //        childSpan2.setSpanId(300);
-        childSpan2.setAgentId(childAgentId2);
+        childSpan2.getSpanOwner().setAgentId(childAgentId2);
         Align childAlign2 = new SpanAlign(childSpan2);
         SpanCallTree childCallTreeNodes2 = new SpanCallTree(childAlign2);
         rootCallTreeNodes.add(childCallTreeNodes2);

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/span/SpanCallTreeTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/span/SpanCallTreeTest.java
@@ -17,6 +17,8 @@
 package com.navercorp.pinpoint.web.trace.span;
 
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -27,8 +29,10 @@ public class SpanCallTreeTest {
 
     @Test
     public void hasFocusSpan1() {
-        SpanBo root = new SpanBo();
-        root.getSpanOwner().setAgentId("root");
+        SpanOwner spanOwner = new SpanOwner();
+        spanOwner.setAgentId("root");
+
+        SpanBo root = new SpanBo(TraceSourceType.PINPOINT, spanOwner);
         Align rootAlign = new SpanAlign(root);
 
         SpanCallTree callTreeNodes = new SpanCallTree(rootAlign);
@@ -39,8 +43,10 @@ public class SpanCallTreeTest {
 
     @Test
     public void hasFocusSpan2() {
-        SpanBo root = new SpanBo();
-        root.getSpanOwner().setAgentId("root");
+        SpanOwner spanOwner = new SpanOwner();
+        spanOwner.setAgentId("root");
+
+        SpanBo root = new SpanBo(TraceSourceType.PINPOINT, spanOwner);
         Align rootAlign = new SpanAlign(root);
 
         SpanCallTree callTreeNodes = new SpanCallTree(rootAlign);

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/span/SpanFiltersTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/span/SpanFiltersTest.java
@@ -17,6 +17,8 @@
 package com.navercorp.pinpoint.web.trace.span;
 
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -45,9 +47,11 @@ public class SpanFiltersTest {
     public void buildViewPointFilter() {
 
         Predicate<SpanBo> filter = SpanFilters.spanFilter(spanId, agentId, collectorAcceptTime);
-        SpanBo spanBo = new SpanBo();
+        SpanOwner owner = new SpanOwner();
+        owner.setAgentId(agentId);
+
+        SpanBo spanBo = new SpanBo(TraceSourceType.PINPOINT, owner);
         spanBo.setCollectorAcceptTime(collectorAcceptTime);
-        spanBo.getSpanOwner().setAgentId(agentId);
         spanBo.setSpanId(spanId);
         Assertions.assertTrue(filter.test(spanBo));
     }
@@ -55,9 +59,12 @@ public class SpanFiltersTest {
     @Test
     public void buildViewPointFilter_empty_spanId() {
         Predicate<SpanBo> filter = SpanFilters.spanFilter(-1, agentId, collectorAcceptTime);
-        SpanBo spanBo = new SpanBo();
+
+        SpanOwner owner = new SpanOwner();
+        owner.setAgentId(agentId);
+
+        SpanBo spanBo = new SpanBo(TraceSourceType.PINPOINT, owner);
         spanBo.setCollectorAcceptTime(collectorAcceptTime);
-        spanBo.getSpanOwner().setAgentId(agentId);
         spanBo.setSpanId(1234);
         Assertions.assertTrue(filter.test(spanBo));
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/span/SpanFiltersTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/span/SpanFiltersTest.java
@@ -47,7 +47,7 @@ public class SpanFiltersTest {
         Predicate<SpanBo> filter = SpanFilters.spanFilter(spanId, agentId, collectorAcceptTime);
         SpanBo spanBo = new SpanBo();
         spanBo.setCollectorAcceptTime(collectorAcceptTime);
-        spanBo.setAgentId(agentId);
+        spanBo.getSpanOwner().setAgentId(agentId);
         spanBo.setSpanId(spanId);
         Assertions.assertTrue(filter.test(spanBo));
     }
@@ -57,7 +57,7 @@ public class SpanFiltersTest {
         Predicate<SpanBo> filter = SpanFilters.spanFilter(-1, agentId, collectorAcceptTime);
         SpanBo spanBo = new SpanBo();
         spanBo.setCollectorAcceptTime(collectorAcceptTime);
-        spanBo.setAgentId(agentId);
+        spanBo.getSpanOwner().setAgentId(agentId);
         spanBo.setSpanId(1234);
         Assertions.assertTrue(filter.test(spanBo));
     }


### PR DESCRIPTION
This pull request refactors how agent, service, and application identity information is accessed and stored in the core tracing data objects. The main change is the introduction and use of a new `SpanOwner` class, which centralizes ownership information for both `SpanBo` and `SpanChunkBo`. This results in cleaner code and more consistent access to identity fields throughout the codebase.

Key changes:

**Refactoring data ownership and access:**

* Introduced the `SpanOwner` class and updated both `SpanBo` and `SpanChunkBo` to store ownership and identity fields (agentId, agentName, applicationName, serviceName, serviceUid, agentStartTime) in a single `owner` field, removing redundant fields and setters/getters from these classes. (`SpanBo.java`, `SpanChunkBo.java`, `BasicSpan.java`) [[1]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL48-R45) [[2]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cL44-R41) [[3]](diffhunk://#diff-7ad1631ecb4e72ee628f32197b53b57a61a5e3df01b34c2ffaa24960f0b52514R33-L51)
* Updated constructors for `SpanBo` and `SpanChunkBo` to require a `SpanOwner` instance and adjusted their `toString()` methods to reflect the new structure. [[1]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL101-R95) [[2]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cL72-R68) [[3]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL527-R492) [[4]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cL265-R236)

**API and interface changes:**

* Modified the `BasicSpan` interface to add a `getSpanOwner()` method and removed now-redundant identity-related methods.
* Updated all usages in the codebase to retrieve identity information via `getSpanOwner()` instead of direct fields or methods. [[1]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0R77-R89) [[2]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0R127-R144) [[3]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0L250-R254) [[4]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0R285-R291) [[5]](diffhunk://#diff-e96ac9bd5e2cbea18436ffb9c3465960ec515a6d6270ea97bbcd3d256c2652a1L47-R59)

**Code cleanup:**

* Removed unused imports and supplier logic related to identity fields, as this is now handled by `SpanOwner`. [[1]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL22-L23) [[2]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL32) [[3]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cL22-L23) [[4]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cL32) [[5]](diffhunk://#diff-7ad1631ecb4e72ee628f32197b53b57a61a5e3df01b34c2ffaa24960f0b52514L23-L24)

These changes improve maintainability and ensure that span ownership and identity are managed in a single, consistent place across the application.