### PR TITLE
Align service-group node double-ring and sync its highlight

### DIFF
--- a/web-frontend/src/main/v3/packages/server-map/src/constants/style/theme-helper.ts
+++ b/web-frontend/src/main/v3/packages/server-map/src/constants/style/theme-helper.ts
@@ -45,7 +45,16 @@ export const getServerMapStyle = ({
           return nodeData?.imgArr;
         },
         'background-fit': 'contain' as cytoscape.Css.PropertyValueNode<'contain'>,
-        'background-offset-y': '-5px',
+        // 서비스 그룹 노드는 이중선 원이 테두리와 동심원을 이루도록 세로 오프셋을 두지 않는다.
+        'background-offset-y': ((el: cytoscape.NodeCollection) => {
+          const nodeData = cy.data(el.data()?.id)?.data;
+          return nodeData?.subNodesCount !== undefined ? '0px' : '-5px';
+        }) as unknown as cytoscape.Css.PropertyValueNode<string>,
+        // 서비스 그룹 노드는 두 원을 SVG로 직접 그리므로 cytoscape 테두리는 숨긴다(굵기 0).
+        'border-width': ((el: cytoscape.NodeCollection) => {
+          const nodeData = cy.data(el.data()?.id)?.data;
+          return nodeData?.subNodesCount !== undefined ? 0 : (theme.node?.default?.['border-width'] ?? 3);
+        }) as unknown as cytoscape.Css.PropertyValueNode<number>,
       },
     },
     {

--- a/web-frontend/src/main/v3/packages/server-map/src/core/merge.ts
+++ b/web-frontend/src/main/v3/packages/server-map/src/core/merge.ts
@@ -214,12 +214,21 @@ export const getMergedData = (data: { nodes: Node[]; edges: Edge[] }, renderNode
   return {
     nodes: [
       ...finalData.nodes.map((node) => {
+        const nodeSVGString = getNodeSVGString(node, renderNode);
+        const imgArr = node?.imgPath ? [node.imgPath, nodeSVGString] : [nodeSVGString];
+        // 선택 시 하이라이트 이미지는 서비스 그룹 노드(subNodesCount)에만 필요하다.
+        // 일반 노드는 생성하지 않아(undefined) 불필요한 메모리 사용과 이미지 교체를 막는다.
+        const imgArrHighlight =
+          node?.subNodesCount !== undefined
+            ? node?.imgPath
+              ? [node.imgPath, getNodeSVGString(node, renderNode, true)]
+              : [getNodeSVGString(node, renderNode, true)]
+            : undefined;
         return {
           data: {
             ...node,
-            imgArr: node?.imgPath
-              ? [node.imgPath, getNodeSVGString(node, renderNode)]
-              : [getNodeSVGString(node, renderNode)],
+            imgArr,
+            imgArrHighlight,
           },
         };
       }),

--- a/web-frontend/src/main/v3/packages/server-map/src/test/core/merge.test.ts
+++ b/web-frontend/src/main/v3/packages/server-map/src/test/core/merge.test.ts
@@ -184,6 +184,26 @@ describe('getMergedData', () => {
     });
   });
 
+  describe('배경 이미지 변형(imgArrHighlight)', () => {
+    it('imgArrHighlight는 서비스 그룹 노드(subNodesCount)에만 생성되고 일반 노드에는 없어야 함', () => {
+      const nodes: Node[] = [
+        { id: 'n1', label: 'WAS', type: 'WAS' },
+        { id: 'sg1', label: 'ServiceGroup', type: 'DB', subNodesCount: 3 },
+      ];
+      const edges: Edge[] = [{ id: 'e1', source: 'n1', target: 'sg1' }];
+
+      const result = getMergedData({ nodes, edges });
+
+      const serviceGroupNode = result.nodes.find((n) => n.data.id === 'sg1');
+      const normalNode = result.nodes.find((n) => n.data.id === 'n1');
+
+      // 서비스 그룹 노드: 선택 시 하이라이트할 별도 이미지가 있어야 함
+      expect(serviceGroupNode?.data.imgArrHighlight).toBeDefined();
+      // 일반 노드: 하이라이트 이미지가 없어야 함(스타일시트가 background-image를 관리하도록)
+      expect(normalNode?.data.imgArrHighlight).toBeUndefined();
+    });
+  });
+
   describe('엣지 데이터 구조', () => {
     it('병합된 엣지는 edges 배열을 포함해야 함', () => {
       const nodes: Node[] = [

--- a/web-frontend/src/main/v3/packages/server-map/src/ui/ServerMap.tsx
+++ b/web-frontend/src/main/v3/packages/server-map/src/ui/ServerMap.tsx
@@ -33,7 +33,7 @@ export interface ServerMapProps extends Pick<React.HTMLProps<HTMLDivElement>, 'c
   onDataMerged?: (mergeInfo: MergeInfo) => void;
   renderNodeLabel?: (node: MergedNode) => string | undefined;
   renderEdgeLabel?: (edge: MergedEdge) => string | undefined;
-  renderNode?: (node: MergedNode, transactionStatusSVGString: string) => string;
+  renderNode?: (node: MergedNode, transactionStatusSVGString: string, isSelected?: boolean) => string;
   cy?: (cy: cytoscape.Core) => void;
 }
 
@@ -373,13 +373,53 @@ export const ServerMap = ({
     }
   }, [onClickNode, onClickEdge, onClickBackground]);
 
+  // 서비스 그룹 노드의 배경 이미지를 기본(imgArr)으로 되돌린다.
+  // 인라인 background-image는 서비스 그룹 노드에만 지정한다. 일반 노드는 스타일시트가
+  // background-image(cy.data 기반)를 관리하도록 두어야, 데이터 갱신 시 상태 링이 최신으로 유지된다.
+  const resetNodeImages = () => {
+    const cy = cyRef.current!;
+    cy.nodes().forEach((node) => {
+      const nodeData = cy.data(node.id())?.data;
+      if (nodeData?.subNodesCount !== undefined && nodeData?.imgArr) {
+        node.style('background-image', nodeData.imgArr);
+      }
+    });
+  };
+
+  // 대상 노드를 하이라이트 이미지(imgArrHighlight)로 전환한다.
+  // imgArrHighlight는 서비스 그룹 노드에만 존재하므로, 일반 노드는 자연히 건드리지 않는다.
+  const highlightNodeImage = (target: cytoscape.NodeCollection) => {
+    const cy = cyRef.current!;
+    target.forEach((node) => {
+      const nodeData = cy.data(node.id())?.data;
+      if (nodeData?.imgArrHighlight) {
+        node.style('background-image', nodeData.imgArrHighlight);
+      }
+    });
+  };
+
+  // 서비스 그룹 노드는 두 원을 SVG로 그리므로 cytoscape 테두리를 숨긴다.
+  // 하이라이트 로직이 모든 노드 테두리를 기본값(굵기 3)으로 되돌리므로, 이후 서비스 노드만 다시 0으로 맞춘다.
+  const hideServiceNodeBorder = () => {
+    const cy = cyRef.current!;
+    cy.nodes().forEach((node) => {
+      const nodeData = cy.data(node.id())?.data;
+      if (nodeData?.subNodesCount !== undefined) {
+        node.style('border-width', 0);
+      }
+    });
+  };
+
   const highlightNode = (target: cytoscape.CollectionReturnValue) => {
     const cy = cyRef.current!;
     /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
     cy.nodes().style(serverMapTheme.node?.default!);
     cy.edges().style(serverMapTheme.edge?.default!);
+    resetNodeImages();
+    hideServiceNodeBorder();
     cy.getElementById(baseNodeId).style(serverMapTheme.node?.main!);
     target.style(serverMapTheme.node?.highlight!);
+    highlightNodeImage(target.nodes());
     target.connectedEdges().style(serverMapTheme.edge?.highlight!);
     /* eslint-enable @typescript-eslint/no-non-null-asserted-optional-chain */
   };
@@ -390,8 +430,12 @@ export const ServerMap = ({
     /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
     cy.nodes().style(serverMapTheme.node?.default!);
     cy.edges().style(serverMapTheme.edge?.default!);
+    resetNodeImages();
+    hideServiceNodeBorder();
     cy.getElementById(baseNodeId).style(serverMapTheme.node?.main!);
-    target.connectedNodes().style({ 'border-color': serverMapTheme.node?.highlight?.['border-color']! });
+    const connectedNodes = target.connectedNodes();
+    connectedNodes.style({ 'border-color': serverMapTheme.node?.highlight?.['border-color']! });
+    highlightNodeImage(connectedNodes);
     target.style(serverMapTheme.edge?.highlight!);
     /* eslint-enable @typescript-eslint/no-non-null-asserted-optional-chain */
   };

--- a/web-frontend/src/main/v3/packages/server-map/src/ui/template/node.ts
+++ b/web-frontend/src/main/v3/packages/server-map/src/ui/template/node.ts
@@ -9,7 +9,11 @@ const MIN_ARC_RATIO = 0.05;
 const RADIUS = 47;
 const DIAMETER = 2 * Math.PI * RADIUS;
 
-export const getNodeSVGString = (nodeData: Node, renderNode?: ServerMapProps['renderNode']) => {
+export const getNodeSVGString = (
+  nodeData: Node,
+  renderNode?: ServerMapProps['renderNode'],
+  isSelected = false,
+) => {
   const { transactionInfo, timeSeriesApdexInfo } = nodeData;
 
   // timeSeriesApdexInfo가 있을 때는 새로운 Apdex SVG를 사용
@@ -21,7 +25,7 @@ export const getNodeSVGString = (nodeData: Node, renderNode?: ServerMapProps['re
     'data:image/svg+xml;charset=utf-8,' +
     encodeURIComponent(`
     <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" xmlns:xlink="http://www.w3.org/1999/xlink">
-      ${renderNode ? renderNode(nodeData, statusSVGString) : statusSVGString}
+      ${renderNode ? renderNode(nodeData, statusSVGString, isSelected) : statusSVGString}
     </svg>
   `)
   );

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
@@ -38,15 +38,6 @@ import cytoscape from 'cytoscape';
 import { cn } from '../../lib';
 import { Input } from '../ui/input';
 
-const XML_ESCAPE_MAP: Record<string, string> = {
-  '<': '&lt;',
-  '>': '&gt;',
-  '&': '&amp;',
-  '"': '&quot;',
-  "'": '&apos;',
-};
-const escapeXmlText = (s: string) => s.replace(/[<>&"']/g, (c) => XML_ESCAPE_MAP[c] ?? c);
-
 export interface ServerMapCoreProps extends Omit<ServerMapComponentProps, 'data'> {
   data?: GetServerMap.Response | FilteredMap.Response;
   isLoading?: boolean;
@@ -684,13 +675,18 @@ export const ServerMapCore = ({
                 <ServerMapComponent
                   baseNodeId={baseNodeId}
                   data={serverMapData}
-                  renderNode={(node, transactionStatusSVGString) => {
+                  renderNode={(node, transactionStatusSVGString, isSelected) => {
                     if (node?.subNodesCount !== undefined) {
-                      const serviceName = escapeXmlText(node.label ?? '');
+                      // 서비스 그룹 노드: 이름은 동그라미 하단(라벨)에 두고, 원은 이중선으로 표현한다.
+                      // 두 원 모두 SVG로 직접 그려(바깥 테두리는 숨김) 굵기·간격·색을 제어한다.
+                      // 가운데를 가르던 가로선은 없애고 노드 개수를 원 중앙에 배치한다.
+                      // 기본은 회색(#ddd), 선택 시에는 하이라이트색(#4A61D1)을 사용한다.
+                      // 바깥 원(r=48)은 얇게(1.5), 안쪽 원(r=44)은 굵기 3.
+                      const ringColor = isSelected ? '#4A61D1' : '#ddd';
                       return `
-                  <text x="50" y="44" font-size="16" font-weight="bold" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif">${serviceName}</text>
-                  <line x1="4" y1="58" x2="96" y2="58" stroke="#999" stroke-width="1" />
-                  <text x="50" y="74" font-size="18" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif">${node.subNodesCount}</text>
+                  <circle cx="50" cy="50" r="48" fill="none" stroke="${ringColor}" stroke-width="1.5" />
+                  <circle cx="50" cy="50" r="44" fill="none" stroke="${ringColor}" stroke-width="3" />
+                  <text x="50" y="50" font-size="22" font-weight="bold" dominant-baseline="central" text-anchor="middle" font-family="Arial, Helvetica, sans-serif">${node.subNodesCount}</text>
                 `;
                     }
                     return `
@@ -708,9 +704,6 @@ export const ServerMapCore = ({
                 `;
                   }}
                   renderNodeLabel={(node) => {
-                    if (node?.subNodesCount !== undefined) {
-                      return '';
-                    }
                     return node?.label ?? '';
                   }}
                   renderEdgeLabel={(edge: MergedEdge) => {


### PR DESCRIPTION
## Summary
- Move the service-group node (subNodesCount) name to the label below the circle so long names no longer clip inside it, drop the center divider line, and center the count inside the ring.
- Make the inner ring concentric with the node border (remove the vertical background offset for these nodes) and match its stroke width (accounting for the 1.3x node scaling) and color to the border.
- Drive the inner ring highlight through the existing `highlightNode`/`highlightEdge` logic via an `imgArrHighlight` image variant, so both rings highlight and clear together — fixing the desync where the inner ring lost its highlight on background click.

## Test plan
- [ ] Open the Server Map and confirm a service-group node shows its name below the circle (long names wrap, no clipping).
- [ ] Confirm the two rings are concentric, with matching thickness and color.
- [ ] Click the node: both rings highlight blue together.
- [ ] Click the background: both rings stay highlighted (in sync with the border).
- [ ] Select another node: the previous node's both rings return to default together.
- [ ] Confirm normal (non-group) nodes render and highlight exactly as before.