### PR TITLE
[#13958] Add caching to ServiceModelResolver

### DIFF
--- a/service-module/src/main/java/com/navercorp/pinpoint/service/service/ServiceRegistryService.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/service/ServiceRegistryService.java
@@ -10,6 +10,8 @@ public interface ServiceRegistryService {
 
     List<String> getServiceNames();
 
+    List<ServiceEntity> getServiceList(int limit);
+
     ServiceEntity getService(String name);
 
     ServiceEntity getService(int uid);

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/service/ServiceRegistryServiceImpl.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/service/ServiceRegistryServiceImpl.java
@@ -46,6 +46,12 @@ public class ServiceRegistryServiceImpl implements ServiceRegistryService {
 
     @Override
     @Transactional(readOnly = true)
+    public List<ServiceEntity> getServiceList(int limit) {
+        return serviceRegistryDao.selectServiceList(limit);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public ServiceEntity getService(String name) {
         Objects.requireNonNull(name, "name");
         return serviceRegistryDao.selectService(name);

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolver.java
@@ -1,0 +1,132 @@
+package com.navercorp.pinpoint.web.service;
+
+import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
+import com.navercorp.pinpoint.service.service.ServiceRegistryService;
+import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.web.vo.Service;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class CachingServiceModelResolver extends ServiceModelResolver implements ApplicationRunner {
+
+    private static final int DEFAULT_LOAD_LIMIT_PERCENT = 90;
+
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    private final ServiceRegistryService serviceRegistryService;
+    private final CaffeineCacheProperties cacheProperties;
+    private final ServiceModelLoadProperties loadProperties;
+    private final Cache serviceByNameCache;
+    private final Cache serviceByUidCache;
+    private final AtomicBoolean loading = new AtomicBoolean(false);
+
+    public CachingServiceModelResolver(ServiceRegistryService serviceRegistryService,
+                                       CacheManager cacheManager,
+                                       CaffeineCacheProperties cacheProperties,
+                                       ServiceModelLoadProperties loadProperties) {
+        super(serviceRegistryService);
+        this.serviceRegistryService = serviceRegistryService;
+        Objects.requireNonNull(cacheManager, "cacheManager");
+        this.serviceByNameCache = Objects.requireNonNull(
+                cacheManager.getCache(ServiceModelCacheConfiguration.SERVICE_BY_NAME_CACHE_NAME), "serviceByNameCache");
+        this.serviceByUidCache = Objects.requireNonNull(
+                cacheManager.getCache(ServiceModelCacheConfiguration.SERVICE_BY_UID_CACHE_NAME), "serviceByUidCache");
+        this.cacheProperties = Objects.requireNonNull(cacheProperties, "cacheProperties");
+        this.loadProperties = Objects.requireNonNull(loadProperties, "loadProperties");
+    }
+
+    @Override
+    protected Service resolveService(int serviceUid) {
+        return serviceByUidCache.get(serviceUid, () -> super.resolveService(serviceUid));
+    }
+
+    @Override
+    protected Service resolveService(String serviceName) {
+        return serviceByNameCache.get(serviceName, () -> super.resolveService(serviceName));
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        warmup();
+    }
+
+    public void warmup() {
+        if (!loadProperties.isWarmupEnabled()) {
+            logger.info("Skip service model cache startup warmup.");
+            return;
+        }
+        long startTime = System.currentTimeMillis();
+        int count = doLoad("Warm up");
+        if (count < 0) {
+            return;
+        }
+        logger.info("Warm up service model cache. {} entries, Time taken: {} ms",
+                count, System.currentTimeMillis() - startTime);
+    }
+
+    @Scheduled(
+            initialDelayString = "#{@webServiceModelLoadProperties.refreshInterval}",
+            fixedRateString = "#{@webServiceModelLoadProperties.refreshInterval}")
+    public void refresh() {
+        if (!loadProperties.isRefreshEnabled()) {
+            logger.debug("Skip service model cache scheduled refresh.");
+            return;
+        }
+        int count = doLoad("Refresh");
+        if (count < 0) {
+            return;
+        }
+        logger.debug("Refresh service model cache. {} entries", count);
+    }
+
+    private int doLoad(String operation) {
+        int limit = getLoadLimit(loadProperties.getLimit(), cacheProperties.getMaximumSize());
+        if (limit <= 0) {
+            logger.info("Skip service model cache {}. limit={}", operation, limit);
+            return -1;
+        }
+        return load(limit, operation);
+    }
+
+    private int load(int limit, String operation) {
+        if (!loading.compareAndSet(false, true)) {
+            logger.debug("Skip service model cache {}. Previous load is still running.", operation);
+            return -1;
+        }
+
+        try {
+            List<ServiceEntity> serviceList = serviceRegistryService.getServiceList(limit);
+            for (ServiceEntity entity : serviceList) {
+                Service service = toService(entity);
+                serviceByNameCache.put(service.getServiceName(), service);
+                serviceByUidCache.put(service.getServiceUid(), service);
+            }
+            return serviceList.size();
+        } catch (Exception e) {
+            logger.error("Failed to load service model cache. operation={}", operation, e);
+            return -1;
+        } finally {
+            loading.set(false);
+        }
+    }
+
+    private int getLoadLimit(long configuredLimit, long maximumSize) {
+        if (configuredLimit >= 0) {
+            return (int) Math.min(configuredLimit, Integer.MAX_VALUE);
+        }
+        if (maximumSize <= 0) {
+            return 0;
+        }
+        long limit = Math.max(1, (long) Math.ceil(maximumSize * (DEFAULT_LOAD_LIMIT_PERCENT / 100.0)));
+        return (int) Math.min(limit, Integer.MAX_VALUE);
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelCacheConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelCacheConfiguration.java
@@ -1,0 +1,76 @@
+package com.navercorp.pinpoint.web.service;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.navercorp.pinpoint.common.server.cache.NullValueExpiry;
+import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
+import com.navercorp.pinpoint.service.service.ServiceRegistryService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.time.Duration;
+
+@Configuration
+@EnableScheduling
+public class ServiceModelCacheConfiguration {
+
+    public static final String CACHE_MANAGER_NAME = "webServiceModelCacheManager";
+    public static final String SERVICE_BY_NAME_CACHE_NAME = "serviceModelByNameCache";
+    public static final String SERVICE_BY_UID_CACHE_NAME = "serviceModelByUidCache";
+
+    @Bean
+    @ConfigurationProperties(prefix = "web.service.registry.cache")
+    public CaffeineCacheProperties webServiceModelCacheProperties() {
+        return new CaffeineCacheProperties();
+    }
+
+    @Bean
+    public ServiceModelLoadProperties webServiceModelLoadProperties() {
+        return new ServiceModelLoadProperties();
+    }
+
+    @Bean(CACHE_MANAGER_NAME)
+    public CacheManager webServiceModelCacheManager(
+            @Qualifier("webServiceModelCacheProperties") CaffeineCacheProperties properties,
+            @Value("${web.service.registry.cache.missingExpireAfterWrite:5m}") Duration missingExpireAfterWrite) {
+
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(SERVICE_BY_NAME_CACHE_NAME, SERVICE_BY_UID_CACHE_NAME);
+        cacheManager.setCaffeine(buildCaffeine(properties, missingExpireAfterWrite));
+        cacheManager.setAllowNullValues(true);
+        return cacheManager;
+    }
+
+    private Caffeine<Object, Object> buildCaffeine(CaffeineCacheProperties properties,
+                                                   Duration missingExpireAfterWrite) {
+        Caffeine<Object, Object> builder = Caffeine.newBuilder();
+        if (properties.getInitialCapacity() >= 0) {
+            builder.initialCapacity(properties.getInitialCapacity());
+        }
+        if (properties.getMaximumSize() >= 0) {
+            builder.maximumSize(properties.getMaximumSize());
+        }
+        if (properties.isRecordStats()) {
+            builder.recordStats();
+        }
+
+        builder.expireAfter(new NullValueExpiry<>(
+                properties.getExpireAfterWrite(),
+                properties.getExpireAfterAccess(),
+                missingExpireAfterWrite));
+        return builder;
+    }
+
+    @Bean
+    public ServiceModelResolver serviceModelResolver(
+            ServiceRegistryService serviceRegistryService,
+            @Qualifier(CACHE_MANAGER_NAME) CacheManager cacheManager,
+            @Qualifier("webServiceModelCacheProperties") CaffeineCacheProperties cacheProperties,
+            ServiceModelLoadProperties loadProperties) {
+        return new CachingServiceModelResolver(serviceRegistryService, cacheManager, cacheProperties, loadProperties);
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelLoadProperties.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelLoadProperties.java
@@ -1,0 +1,47 @@
+package com.navercorp.pinpoint.web.service;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public class ServiceModelLoadProperties {
+
+    @Value("${web.service.registry.cache.load.warmup.enabled:true}")
+    private boolean warmupEnabled = true;
+    @Value("${web.service.registry.cache.load.refresh.enabled:true}")
+    private boolean refreshEnabled = true;
+    @Value("${web.service.registry.cache.load.refresh.interval:300000}")
+    private long refreshInterval = 300000;
+    @Value("${web.service.registry.cache.load.limit:-1}")
+    private long limit = -1;
+
+    public boolean isWarmupEnabled() {
+        return warmupEnabled;
+    }
+
+    public void setWarmupEnabled(boolean warmupEnabled) {
+        this.warmupEnabled = warmupEnabled;
+    }
+
+    public boolean isRefreshEnabled() {
+        return refreshEnabled;
+    }
+
+    public void setRefreshEnabled(boolean refreshEnabled) {
+        this.refreshEnabled = refreshEnabled;
+    }
+
+    public long getRefreshInterval() {
+        return refreshInterval;
+    }
+
+    public void setRefreshInterval(long refreshInterval) {
+        this.refreshInterval = refreshInterval;
+    }
+
+    public long getLimit() {
+        return limit;
+    }
+
+    public void setLimit(long limit) {
+        this.limit = limit;
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
@@ -3,11 +3,9 @@ package com.navercorp.pinpoint.web.service;
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
 import com.navercorp.pinpoint.service.vo.ServiceEntity;
 import com.navercorp.pinpoint.web.vo.Service;
-import org.springframework.stereotype.Component;
 
 import java.util.Objects;
 
-@Component
 public class ServiceModelResolver {
 
     private final ServiceRegistryService serviceRegistryService;
@@ -23,12 +21,11 @@ public class ServiceModelResolver {
         if (Service.TEST_SERVICE.getServiceUid() == serviceUid) {
             return Service.TEST_SERVICE;
         }
-        ServiceEntity entity = serviceRegistryService.getService(serviceUid);
-        if (entity == null) {
+        Service service = resolveService(serviceUid);
+        if (service == null) {
             return Service.DEFAULT;
         }
-
-        return new Service(entity.getName(), entity.getUid());
+        return service;
     }
 
     public Service getService(String serviceName) {
@@ -38,11 +35,25 @@ public class ServiceModelResolver {
         if (Service.TEST_SERVICE.getServiceName().equals(serviceName)) {
             return Service.TEST_SERVICE;
         }
-        ServiceEntity entity = serviceRegistryService.getService(serviceName);
-        if (entity == null) {
+        Service service = resolveService(serviceName);
+        if (service == null) {
             return Service.DEFAULT;
         }
+        return service;
+    }
 
+    protected Service resolveService(int serviceUid) {
+        return toService(serviceRegistryService.getService(serviceUid));
+    }
+
+    protected Service resolveService(String serviceName) {
+        return toService(serviceRegistryService.getService(serviceName));
+    }
+
+    protected static Service toService(ServiceEntity entity) {
+        if (entity == null) {
+            return null;
+        }
         return new Service(entity.getName(), entity.getUid());
     }
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
@@ -1,0 +1,156 @@
+package com.navercorp.pinpoint.web.service;
+
+import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
+import com.navercorp.pinpoint.service.service.ServiceRegistryService;
+import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.web.vo.Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.cache.CacheManager;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.times;
+
+class CachingServiceModelResolverTest {
+
+    private final ServiceModelCacheConfiguration cacheConfiguration = new ServiceModelCacheConfiguration();
+    private final CaffeineCacheProperties properties = new CaffeineCacheProperties();
+    private final ServiceRegistryService serviceRegistryService = Mockito.mock(ServiceRegistryService.class);
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(serviceRegistryService);
+        properties.setMaximumSize(200);
+        properties.setExpireAfterWrite(Duration.ofSeconds(-1));
+    }
+
+    @Test
+    void cacheServiceByName() {
+        String serviceName = "serviceName";
+        CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
+
+        Mockito.when(serviceRegistryService.getService(serviceName)).thenReturn(serviceEntity(100001, serviceName));
+
+        assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100001));
+        assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100001));
+
+        Mockito.verify(serviceRegistryService, times(1)).getService(serviceName);
+    }
+
+    @Test
+    void cacheServiceByUid() {
+        String serviceName = "serviceName";
+        int serviceUid = 100002;
+        CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
+
+        Mockito.when(serviceRegistryService.getService(serviceUid)).thenReturn(serviceEntity(serviceUid, serviceName));
+
+        assertThat(resolver.getService(serviceUid)).isEqualTo(new Service(serviceName, serviceUid));
+        assertThat(resolver.getService(serviceUid)).isEqualTo(new Service(serviceName, serviceUid));
+
+        Mockito.verify(serviceRegistryService, times(1)).getService(serviceUid);
+    }
+
+    @Test
+    void getStaticService() {
+        CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
+
+        assertThat(resolver.getService(Service.DEFAULT.getServiceName())).isEqualTo(Service.DEFAULT);
+        assertThat(resolver.getService(Service.DEFAULT.getServiceUid())).isEqualTo(Service.DEFAULT);
+        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceName())).isEqualTo(Service.TEST_SERVICE);
+        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceUid())).isEqualTo(Service.TEST_SERVICE);
+
+        Mockito.verifyNoInteractions(serviceRegistryService);
+    }
+
+    @Test
+    void cacheMissingService() {
+        String unRegisteredServiceName = "unRegisteredServiceName";
+        CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
+
+        Mockito.when(serviceRegistryService.getService(unRegisteredServiceName)).thenReturn(null);
+
+        assertThat(resolver.getService(unRegisteredServiceName)).isEqualTo(Service.DEFAULT);
+        assertThat(resolver.getService(unRegisteredServiceName)).isEqualTo(Service.DEFAULT);
+
+        Mockito.verify(serviceRegistryService, times(1)).getService(unRegisteredServiceName);
+    }
+
+    @Test
+    void cacheMissingServiceExpire() {
+        String serviceName = "registeredServiceName";
+        String unRegisteredServiceName = "unRegisteredServiceName";
+        CachingServiceModelResolver resolver = newResolver(Duration.ZERO);
+
+        Mockito.when(serviceRegistryService.getService(serviceName)).thenReturn(serviceEntity(100004, serviceName));
+        Mockito.when(serviceRegistryService.getService(unRegisteredServiceName)).thenReturn(null);
+
+        assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100004));
+        assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100004));
+        assertThat(resolver.getService(unRegisteredServiceName)).isEqualTo(Service.DEFAULT);
+
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertThat(resolver.getService(unRegisteredServiceName)).isEqualTo(Service.DEFAULT);
+            Mockito.verify(serviceRegistryService, atLeast(2)).getService(unRegisteredServiceName);
+        });
+
+        Mockito.verify(serviceRegistryService, times(1)).getService(serviceName);
+    }
+
+    @Test
+    void refreshLoadsBothCaches() {
+        String serviceName = "loadedServiceName";
+        int serviceUid = 100005;
+        CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
+
+        Mockito.when(serviceRegistryService.getServiceList(anyInt()))
+                .thenReturn(List.of(serviceEntity(serviceUid, serviceName)));
+
+        resolver.refresh();
+
+        assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, serviceUid));
+        assertThat(resolver.getService(serviceUid)).isEqualTo(new Service(serviceName, serviceUid));
+
+        Mockito.verify(serviceRegistryService, times(0)).getService(serviceName);
+        Mockito.verify(serviceRegistryService, times(0)).getService(serviceUid);
+    }
+
+    @Test
+    void warmupLoadsBothCaches() {
+        String serviceName = "warmedUpServiceName";
+        int serviceUid = 100006;
+        CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
+
+        Mockito.when(serviceRegistryService.getServiceList(anyInt()))
+                .thenReturn(List.of(serviceEntity(serviceUid, serviceName)));
+
+        resolver.warmup();
+
+        assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, serviceUid));
+        assertThat(resolver.getService(serviceUid)).isEqualTo(new Service(serviceName, serviceUid));
+
+        Mockito.verify(serviceRegistryService, times(0)).getService(serviceName);
+        Mockito.verify(serviceRegistryService, times(0)).getService(serviceUid);
+    }
+
+    private CachingServiceModelResolver newResolver(Duration missingExpireAfterWrite) {
+        CacheManager cacheManager = cacheConfiguration.webServiceModelCacheManager(properties, missingExpireAfterWrite);
+        ServiceModelLoadProperties loadProperties = new ServiceModelLoadProperties();
+        return new CachingServiceModelResolver(serviceRegistryService, cacheManager, properties, loadProperties);
+    }
+
+    private ServiceEntity serviceEntity(int uid, String name) {
+        ServiceEntity service = new ServiceEntity();
+        service.setUid(uid);
+        service.setName(name);
+        return service;
+    }
+}

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
@@ -1,0 +1,57 @@
+package com.navercorp.pinpoint.web.service;
+
+import com.navercorp.pinpoint.service.service.ServiceRegistryService;
+import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.web.vo.Service;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+
+class ServiceModelResolverTest {
+
+    private final ServiceRegistryService serviceRegistryService = Mockito.mock(ServiceRegistryService.class);
+
+    @Test
+    void lookupEveryTime() {
+        String serviceName = "serviceName";
+        ServiceModelResolver resolver = new ServiceModelResolver(serviceRegistryService);
+
+        Mockito.when(serviceRegistryService.getService(serviceName)).thenReturn(serviceEntity(100000, serviceName));
+
+        assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100000));
+        assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100000));
+
+        Mockito.verify(serviceRegistryService, times(2)).getService(serviceName);
+    }
+
+    @Test
+    void getStaticService() {
+        ServiceModelResolver resolver = new ServiceModelResolver(serviceRegistryService);
+
+        assertThat(resolver.getService(Service.DEFAULT.getServiceName())).isEqualTo(Service.DEFAULT);
+        assertThat(resolver.getService(Service.DEFAULT.getServiceUid())).isEqualTo(Service.DEFAULT);
+        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceName())).isEqualTo(Service.TEST_SERVICE);
+        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceUid())).isEqualTo(Service.TEST_SERVICE);
+
+        Mockito.verifyNoInteractions(serviceRegistryService);
+    }
+
+    @Test
+    void missingServiceReturnsDefault() {
+        String unRegisteredServiceName = "unRegisteredServiceName";
+        ServiceModelResolver resolver = new ServiceModelResolver(serviceRegistryService);
+
+        Mockito.when(serviceRegistryService.getService(unRegisteredServiceName)).thenReturn(null);
+
+        assertThat(resolver.getService(unRegisteredServiceName)).isEqualTo(Service.DEFAULT);
+    }
+
+    private ServiceEntity serviceEntity(int uid, String name) {
+        ServiceEntity service = new ServiceEntity();
+        service.setUid(uid);
+        service.setName(name);
+        return service;
+    }
+}


### PR DESCRIPTION
issue: https://github.com/pinpoint-apm/pinpoint/issues/13958

ServiceModelResolver queries the service registry database on every request. This PR adds a caching layer to reduce database load.

- `CachingServiceModelResolver` extends `ServiceModelResolver` and caches lookups with a single Caffeine cache using `NullValueExpiry`: long TTL for resolved services, short TTL for missing services so newly registered services are picked up quickly
- Two named caches for lookup by serviceName and by serviceUid; startup warmup (`ApplicationRunner`) and scheduled refresh load the service list with a single query and populate both caches
- Cache load failures are logged and do not block application startup
- Add `ServiceRegistryService.getServiceList(limit)` so the resolver goes through the service layer instead of accessing `ServiceRegistryDao` directly
- Cache/load settings are configurable via `web.service.registry.cache.*` properties