### PR TITLE
[#13864] Skip duplicate accessor member injection in ASMClass

### DIFF
--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/instrument/InstrumentClass.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/instrument/InstrumentClass.java
@@ -72,12 +72,28 @@ public interface InstrumentClass {
     void weave(String adviceClassName) throws InstrumentException;
 
 
+    /**
+     * Adds a field, an accessor interface and its getter/setter methods to this class.
+     * <p>
+     * Idempotent - members already declared in this class are skipped so that re-instrumentation
+     * (e.g. a CGLIB proxy that copied the injected members of an instrumented class, or duplicate
+     * injection by multiple plugins) does not produce a duplicate declaration({@link ClassFormatError}).
+     * Members declared only in a super class are still added.
+     */
     void addField(Class<?> accessorClass) throws InstrumentException;
 
 
+    /**
+     * Adds a getter interface and its getter method for an existing field to this class.
+     * Idempotent - see {@link #addField(Class)}.
+     */
     void addGetter(Class<?> getterClass, String fieldName) throws InstrumentException;
 
 
+    /**
+     * Adds a setter interface and its setter method for an existing field to this class.
+     * Idempotent - see {@link #addField(Class)}.
+     */
     void addSetter(Class<?> setterClass, String fieldName) throws InstrumentException;
 
     void addSetter(Class<?> setterClass, String fieldName, boolean removeFinal) throws InstrumentException;

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClass.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClass.java
@@ -270,11 +270,21 @@ public class ASMClass implements InstrumentClass {
             final Type type = accessorDetails.getFieldType();
             final String accessorTypeName = accessorClass.getName();
             final String fieldName = FIELD_PREFIX + JavaAssistUtils.javaClassNameToVariableName(accessorTypeName);
-            final ASMFieldNodeAdapter fieldNode = this.classNode.addField(fieldName, type.getDescriptor());
-            this.classNode.addInterface(accessorTypeName);
-            this.classNode.addGetterMethod(accessorDetails.getGetter().getName(), fieldNode);
-            this.classNode.addSetterMethod(accessorDetails.getSetter().getName(), fieldNode);
-            setModified(true);
+            // skip members already declared in this class. e.g. a CGLIB proxy copies the injected members of an instrumented class
+            boolean modified = false;
+            ASMFieldNodeAdapter fieldNode = this.classNode.getDeclaredField(fieldName, type.getDescriptor());
+            if (fieldNode == null) {
+                fieldNode = this.classNode.addField(fieldName, type.getDescriptor());
+                modified = true;
+            }
+            modified |= this.classNode.addInterface(accessorTypeName);
+            modified |= this.classNode.addGetterMethod(accessorDetails.getGetter().getName(), fieldNode);
+            modified |= this.classNode.addSetterMethod(accessorDetails.getSetter().getName(), fieldNode);
+            if (modified) {
+                setModified(true);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("Skip addField, accessor already declared. class={}, accessor={}", getName(), accessorTypeName);
+            }
         } catch (Exception e) {
             throw new InstrumentException("Failed to add field with accessor [" + accessorClass.getName() + "]. Cause:" + e.getMessage(), e);
         }
@@ -296,9 +306,13 @@ public class ASMClass implements InstrumentClass {
                 throw new IllegalArgumentException("different return type. return=" + fieldType + ", field=" + fieldNode.getJavaType());
             }
 
-            this.classNode.addGetterMethod(getterDetails.getGetter().getName(), fieldNode);
-            this.classNode.addInterface(getterClass.getName());
-            setModified(true);
+            boolean modified = this.classNode.addGetterMethod(getterDetails.getGetter().getName(), fieldNode);
+            modified |= this.classNode.addInterface(getterClass.getName());
+            if (modified) {
+                setModified(true);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("Skip addGetter, getter already declared. class={}, getter={}", getName(), getterClass.getName());
+            }
         } catch (Exception e) {
             throw new InstrumentException("Failed to add getter: " + getterClass.getName(), e);
         }
@@ -341,9 +355,14 @@ public class ASMClass implements InstrumentClass {
             }
 
             try {
-                this.classNode.addSetterMethod(setterDetails.getSetter().getName(), fieldNode);
-                this.classNode.addInterface(setterClass.getName());
-                setModified(true);
+                boolean modified = finalRemoved;
+                modified |= this.classNode.addSetterMethod(setterDetails.getSetter().getName(), fieldNode);
+                modified |= this.classNode.addInterface(setterClass.getName());
+                if (modified) {
+                    setModified(true);
+                } else if (logger.isDebugEnabled()) {
+                    logger.debug("Skip addSetter, setter already declared. class={}, setter={}", getName(), setterClass.getName());
+                }
             } catch (Exception e) {
                 if (finalRemoved) {
                     fieldNode.setAccess(original);

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClassNodeAdapter.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMClassNodeAdapter.java
@@ -298,17 +298,10 @@ public class ASMClassNodeAdapter {
     public ASMFieldNodeAdapter getField(final String fieldName, final String fieldDesc) {
         Objects.requireNonNull(fieldName, "fieldName");
 
-        final List<FieldNode> fields = this.classNode.fields;
-        if (fields == null) {
-            return null;
+        final ASMFieldNodeAdapter declaredFieldNode = getDeclaredField(fieldName, fieldDesc);
+        if (declaredFieldNode != null) {
+            return declaredFieldNode;
         }
-
-        for (FieldNode fieldNode : fields) {
-            if (StringMatchUtils.equals(fieldNode.name, fieldName) && (fieldDesc == null || (StringMatchUtils.equals(fieldNode.desc, fieldDesc)))) {
-                return new ASMFieldNodeAdapter(fieldNode);
-            }
-        }
-
 
         // find interface.
         final List<String> interfaces = this.classNode.interfaces;
@@ -343,9 +336,31 @@ public class ASMClassNodeAdapter {
         return null;
     }
 
+    public ASMFieldNodeAdapter getDeclaredField(final String fieldName, final String fieldDesc) {
+        Objects.requireNonNull(fieldName, "fieldName");
+
+        final List<FieldNode> fields = this.classNode.fields;
+        if (fields == null) {
+            return null;
+        }
+
+        for (FieldNode fieldNode : fields) {
+            if (StringMatchUtils.equals(fieldNode.name, fieldName) && (fieldDesc == null || (StringMatchUtils.equals(fieldNode.desc, fieldDesc)))) {
+                return new ASMFieldNodeAdapter(fieldNode);
+            }
+        }
+
+        return null;
+    }
+
     public ASMFieldNodeAdapter addField(final String fieldName, final String fieldDesc) {
         Objects.requireNonNull(fieldName, "fieldName");
         Objects.requireNonNull(fieldDesc, "fieldDesc");
+        // a duplicate field declaration in a single class file causes ClassFormatError
+        final ASMFieldNodeAdapter declaredFieldNode = getDeclaredField(fieldName, fieldDesc);
+        if (declaredFieldNode != null) {
+            return declaredFieldNode;
+        }
         final FieldNode fieldNode = new FieldNode(getFieldAccessFlags(), fieldName, fieldDesc, null, null);
         addFieldNode0(fieldNode);
 
@@ -385,13 +400,18 @@ public class ASMClassNodeAdapter {
         return superMethodNodeExceptions.toArray(EMPTY_STRING_ARRAY);
     }
 
-    public void addGetterMethod(final String methodName, final ASMFieldNodeAdapter fieldNode) {
+    public boolean addGetterMethod(final String methodName, final ASMFieldNodeAdapter fieldNode) {
         Objects.requireNonNull(methodName, "methodName");
         Objects.requireNonNull(fieldNode, "fieldNode");
 
 
         // no argument is ().
         final String desc = "()" + fieldNode.getDesc();
+        // a duplicate method declaration in a single class file causes ClassFormatError.
+        // declared-only check - a method inherited from an instrumented super class must still be added.
+        if (hasDeclaredMethod(methodName, desc)) {
+            return false;
+        }
         final MethodNode methodNode = new MethodNode(Opcodes.ACC_PUBLIC, methodName, desc, null, null);
         final InsnList instructions = getInsnList(methodNode);
         // load this.
@@ -403,6 +423,7 @@ public class ASMClassNodeAdapter {
         instructions.add(new InsnNode(type.getOpcode(Opcodes.IRETURN)));
 
         addMethodNode0(methodNode);
+        return true;
     }
 
     private void addMethodNode0(MethodNode methodNode) {
@@ -412,13 +433,18 @@ public class ASMClassNodeAdapter {
         this.classNode.methods.add(methodNode);
     }
 
-    public void addSetterMethod(final String methodName, final ASMFieldNodeAdapter fieldNode) {
+    public boolean addSetterMethod(final String methodName, final ASMFieldNodeAdapter fieldNode) {
         Objects.requireNonNull(methodName, "methodName");
         Objects.requireNonNull(fieldNode, "fieldNode");
 
 
         // void is V.
         final String desc = "(" + fieldNode.getDesc() + ")V";
+        // a duplicate method declaration in a single class file causes ClassFormatError.
+        // declared-only check - a method inherited from an instrumented super class must still be added.
+        if (hasDeclaredMethod(methodName, desc)) {
+            return false;
+        }
         final MethodNode methodNode = new MethodNode(Opcodes.ACC_PUBLIC, methodName, desc, null, null);
         final InsnList instructions = getInsnList(methodNode);
         // load this.
@@ -431,6 +457,7 @@ public class ASMClassNodeAdapter {
         instructions.add(new InsnNode(Opcodes.RETURN));
 
         addMethodNode0(methodNode);
+        return true;
     }
 
     private InsnList getInsnList(MethodNode methodNode) {
@@ -440,13 +467,19 @@ public class ASMClassNodeAdapter {
         return methodNode.instructions;
     }
 
-    public void addInterface(final String interfaceName) {
+    public boolean addInterface(final String interfaceName) {
         Objects.requireNonNull(interfaceName, "interfaceName");
 
         if (this.classNode.interfaces == null) {
             this.classNode.interfaces = new ArrayList<>();
         }
-        this.classNode.interfaces.add(JavaAssistUtils.javaNameToJvmName(interfaceName));
+        final String interfaceInternalName = JavaAssistUtils.javaNameToJvmName(interfaceName);
+        // a duplicate interface declaration in a single class file causes ClassFormatError
+        if (this.classNode.interfaces.contains(interfaceInternalName)) {
+            return false;
+        }
+        this.classNode.interfaces.add(interfaceInternalName);
+        return true;
     }
 
     public void copyMethod(final ASMMethodNodeAdapter methodNode) {

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMClassNodeAdapterTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMClassNodeAdapterTest.java
@@ -220,6 +220,66 @@ public class ASMClassNodeAdapterTest {
         logger.debug("{}", result);
     }
 
+    @Test
+    public void addField_alreadyDeclared() throws Exception {
+        // simulates a CGLIB proxy that copied the injected accessor members of an instrumented class.
+        // duplicate member declarations cause ClassFormatError at defineClass. issue #13864, #11012
+        final String targetClassName = "com.navercorp.pinpoint.profiler.instrument.mock.ProxyLikeClass";
+        final String accessorClassName = "com.navercorp.pinpoint.profiler.instrument.mock.accessor.IntAccessor";
+        final String fieldName = "_$PINPOINT$_" + JavaAssistUtils.javaClassNameToVariableName(accessorClassName);
+        final ASMClassNodeLoader.TestClassLoader classLoader = ASMClassNodeLoader.getClassLoader();
+        classLoader.setTargetClassName(targetClassName);
+        classLoader.setCallbackHandler(new ASMClassNodeLoader.CallbackHandler() {
+            @Override
+            public void handle(ClassNode classNode) {
+                ASMClassNodeAdapter classNodeAdapter = new ASMClassNodeAdapter(pluginClassInputStreamProvider, null, getClass().getProtectionDomain(), classNode);
+                ASMFieldNodeAdapter fieldNode = classNodeAdapter.addField(fieldName, Type.getDescriptor(int.class));
+                assertFalse(classNodeAdapter.addInterface(accessorClassName));
+                assertFalse(classNodeAdapter.addGetterMethod("_$PINPOINT$_getTraceInt", fieldNode));
+                assertFalse(classNodeAdapter.addSetterMethod("_$PINPOINT$_setTraceInt", fieldNode));
+            }
+        });
+        Class<?> clazz = classLoader.loadClass(targetClassName);
+        assertEquals(1, clazz.getInterfaces().length);
+        Object instance = clazz.newInstance();
+
+        Method setMethod = clazz.getDeclaredMethod("_$PINPOINT$_setTraceInt", int.class);
+        setMethod.invoke(instance, 10);
+
+        Method getMethod = clazz.getDeclaredMethod("_$PINPOINT$_getTraceInt");
+        assertEquals(10, getMethod.invoke(instance));
+    }
+
+    @Test
+    public void addField_declaredOnlyInSuper() throws Exception {
+        // members inherited from an instrumented super class must still be added to the child class
+        final String targetClassName = "com.navercorp.pinpoint.profiler.instrument.mock.ProxyLikeChildClass";
+        final String accessorClassName = "com.navercorp.pinpoint.profiler.instrument.mock.accessor.IntAccessor";
+        final String fieldName = "_$PINPOINT$_" + JavaAssistUtils.javaClassNameToVariableName(accessorClassName);
+        final ASMClassNodeLoader.TestClassLoader classLoader = ASMClassNodeLoader.getClassLoader();
+        classLoader.setTargetClassName(targetClassName);
+        classLoader.setCallbackHandler(new ASMClassNodeLoader.CallbackHandler() {
+            @Override
+            public void handle(ClassNode classNode) {
+                ASMClassNodeAdapter classNodeAdapter = new ASMClassNodeAdapter(pluginClassInputStreamProvider, null, getClass().getProtectionDomain(), classNode);
+                ASMFieldNodeAdapter fieldNode = classNodeAdapter.addField(fieldName, Type.getDescriptor(int.class));
+                assertNotNull(fieldNode);
+                assertTrue(classNodeAdapter.addInterface(accessorClassName));
+                assertTrue(classNodeAdapter.addGetterMethod("_$PINPOINT$_getTraceInt", fieldNode));
+                assertTrue(classNodeAdapter.addSetterMethod("_$PINPOINT$_setTraceInt", fieldNode));
+            }
+        });
+        Class<?> clazz = classLoader.loadClass(targetClassName);
+        Object instance = clazz.newInstance();
+
+        // methods must be declared in the child class itself
+        Method setMethod = clazz.getDeclaredMethod("_$PINPOINT$_setTraceInt", int.class);
+        setMethod.invoke(instance, 10);
+
+        Method getMethod = clazz.getDeclaredMethod("_$PINPOINT$_getTraceInt");
+        assertEquals(10, getMethod.invoke(instance));
+    }
+
 
     @Test
     public void hasAnnotation() {

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMClassTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMClassTest.java
@@ -92,6 +92,7 @@ import org.mockito.stubbing.Answer;
 import org.objectweb.asm.tree.ClassNode;
 
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -429,6 +430,35 @@ public class ASMClassTest {
         clazz.addField(ThrowExceptionAccessor.class);
         assertNotNull(clazz.getDeclaredMethod("_$PINPOINT$_setTraceDefaultStr", "java.lang.String"));
         assertNotNull(clazz.getDeclaredMethod("_$PINPOINT$_getTraceDefaultStr"));
+    }
+
+    @Test
+    public void addFieldDuplicated() throws Exception {
+        // duplicate injection must not produce duplicate member declarations. issue #13864
+        final String targetClassName = "com.navercorp.pinpoint.profiler.instrument.mock.BaseClass";
+        final ASMClassNodeLoader.TestClassLoader classLoader = ASMClassNodeLoader.getClassLoader();
+        classLoader.setTargetClassName(targetClassName);
+        classLoader.setCallbackHandler(new ASMClassNodeLoader.CallbackHandler() {
+            @Override
+            public void handle(ClassNode classNode) {
+                ASMClass clazz = ASMClass.load(engineComponent, pluginContext, classLoader, getClass().getProtectionDomain(), classNode);
+                try {
+                    clazz.addField(ObjectAccessor.class);
+                    clazz.addField(ObjectAccessor.class);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        // duplicate members would cause ClassFormatError at defineClass
+        Class<?> clazz = classLoader.loadClass(targetClassName);
+        Object instance = clazz.newInstance();
+
+        Method setMethod = clazz.getDeclaredMethod("_$PINPOINT$_setTraceObject", Object.class);
+        setMethod.invoke(instance, "foo");
+
+        Method getMethod = clazz.getDeclaredMethod("_$PINPOINT$_getTraceObject");
+        assertEquals("foo", getMethod.invoke(instance));
     }
 
     @Test

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/mock/ProxyLikeChildClass.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/mock/ProxyLikeChildClass.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.profiler.instrument.mock;
+
+/**
+ * Inherits the accessor members from {@link ProxyLikeClass} but declares none of them.
+ * Instrumentation must still add its own members to this class.
+ */
+public class ProxyLikeChildClass extends ProxyLikeClass {
+}

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/mock/ProxyLikeClass.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/mock/ProxyLikeClass.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.profiler.instrument.mock;
+
+import com.navercorp.pinpoint.profiler.instrument.mock.accessor.IntAccessor;
+
+/**
+ * Simulates a CGLIB proxy class that copied the accessor members injected into an instrumented class.
+ * The accessor interface and getter/setter methods are already declared before instrumentation.
+ */
+public class ProxyLikeClass implements IntAccessor {
+    private int traceInt;
+
+    @Override
+    public void _$PINPOINT$_setTraceInt(int value) {
+        this.traceInt = value;
+    }
+
+    @Override
+    public int _$PINPOINT$_getTraceInt() {
+        return this.traceInt;
+    }
+}


### PR DESCRIPTION
Injecting an accessor into a class that already declares the same members(e.g. a CGLIB proxy that copied the injected members of an instrumented class) produced a duplicate field/interface/method declaration and failed class loading with ClassFormatError.

Make accessor injection idempotent with declared-only checks so that members inherited from an instrumented super class are still added.