### PR TITLE
fix(web-ui): load users list on initial config users page visit

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useConfigUsers.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useConfigUsers.ts
@@ -19,7 +19,7 @@ export const useGetConfigUsers = (
   const { data, isLoading, refetch } = useQuery<ConfigUsers.Response>({
     queryKey: [END_POINTS.CONFIG_USERS, params],
     queryFn: queryFn(`${END_POINTS.CONFIG_USERS}${queryString}`),
-    enabled: !!queryString,
+    enabled: true,
     throwOnError,
   });
   return { data, isLoading, refetch };


### PR DESCRIPTION
## Summary

Fix an issue where existing users were not displayed when first opening the `/config/users` page.

The query was disabled when no search keyword was provided:

```ts
enabled: !!queryString