### PR TITLE
[#noissue] Extract OtelLinkValue.parse into OtelLinkValueParser

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java
@@ -43,6 +43,7 @@ import com.navercorp.pinpoint.web.security.ServerMapDataFilter;
 import com.navercorp.pinpoint.web.service.DotExtractor;
 import com.navercorp.pinpoint.web.util.OpenTelemetryAnnotationValueUtils;
 import com.navercorp.pinpoint.web.util.OtelLinkValue;
+import com.navercorp.pinpoint.web.util.OtelLinkValueSerde;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseHistograms;
 import com.navercorp.pinpoint.web.vo.Service;
@@ -120,7 +121,7 @@ public class FilteredMapBuilder {
                     if (annotation.getKey() != AnnotationKey.OPENTELEMETRY_LINK.getCode()) {
                         continue;
                     }
-                    final OtelLinkValue value = OtelLinkValue.parse(annotation.getValue());
+                    final OtelLinkValue value = OtelLinkValueSerde.parse(annotation.getValue());
                     if (value == null || value.traceId() == null || value.spanId() == null) {
                         continue;
                     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/TraceConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/TraceConfiguration.java
@@ -16,9 +16,11 @@
 
 package com.navercorp.pinpoint.web.trace;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.config.SpanSerializeConfiguration;
 import com.navercorp.pinpoint.web.service.ProxyRequestTypeRegistryService;
 import com.navercorp.pinpoint.web.trace.callstacks.AnnotationRecordFormatter;
+import com.navercorp.pinpoint.web.trace.callstacks.AttributeBoWriter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -59,6 +61,13 @@ public class TraceConfiguration {
                 builder.addProxyHeaderAnnotationHeader(proxyRequestTypeRegistryService.get());
             }
             return builder.build();
+        }
+
+        // RecorderFactoryProvider (scanned above) requires this bean; keep it in this nested config
+        // so contexts importing only TraceServiceConfiguration (e.g. batch) can start.
+        @Bean
+        public AttributeBoWriter attributeBoWriter(ObjectMapper mapper) {
+            return new AttributeBoWriter(mapper);
         }
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/AttributeBoWriter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/AttributeBoWriter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.trace.callstacks;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.common.server.bo.AttributeBo;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValueList;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueArray;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueBoolean;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueBytes;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueDouble;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueLong;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueString;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Writes a list of {@link AttributeBo} to a JSON string by streaming the typed
+ * {@link AttributeValue} tree directly through a {@link JsonGenerator}, without building
+ * an intermediate {@code Map}.
+ */
+public class AttributeBoWriter {
+
+    static final String JSON_PROCESSING_ERROR = "json processing error";
+
+    private final ObjectMapper mapper;
+
+    public AttributeBoWriter(ObjectMapper mapper) {
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+    }
+
+    public String toJson(List<AttributeBo> attributeBoList) {
+        StringWriter writer = new StringWriter();
+        try (JsonGenerator gen = mapper.createGenerator(writer)) {
+            gen.writeStartObject();
+            for (AttributeBo attr : attributeBoList) {
+                gen.writeFieldName(attr.getKey());
+                writeValue(gen, attr.getValue());
+            }
+            gen.writeEndObject();
+        } catch (IOException e) {
+            return JSON_PROCESSING_ERROR;
+        }
+        return writer.toString();
+    }
+
+    private static void writeValue(JsonGenerator gen, AttributeValue value) throws IOException {
+        if (value == null) {
+            gen.writeNull();
+            return;
+        }
+        switch (value.getType()) {
+            case STRING -> gen.writeString(((AttributeValueString) value).getStringValue());
+            case BOOLEAN -> gen.writeBoolean(((AttributeValueBoolean) value).getBooleanValue());
+            case LONG -> gen.writeNumber(((AttributeValueLong) value).getLongValue());
+            case DOUBLE -> gen.writeNumber(((AttributeValueDouble) value).getDoubleValue());
+            case BYTES -> {
+                byte[] bytesValue = ((AttributeValueBytes) value).getRawBytesValue();
+                gen.writeString(Base64.getEncoder().encodeToString(bytesValue));
+            }
+            case ARRAY -> {
+                gen.writeStartArray();
+                for (AttributeValue item : ((AttributeValueArray) value).getArrayValue()) {
+                    writeValue(gen, item);
+                }
+                gen.writeEndArray();
+            }
+            case KEY_VALUE_LIST -> {
+                gen.writeStartObject();
+                for (AttributeKeyValue kv : ((AttributeKeyValueList) value).getKeyValueListValue()) {
+                    gen.writeFieldName(kv.getKey());
+                    writeValue(gen, kv.getValue());
+                }
+                gen.writeEndObject();
+            }
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java
@@ -15,8 +15,6 @@
  */
 package com.navercorp.pinpoint.web.trace.callstacks;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.ApiMetaDataBo;
 import com.navercorp.pinpoint.common.server.bo.AttributeBo;
@@ -30,11 +28,6 @@ import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.AnnotationKeyMatcher;
 import com.navercorp.pinpoint.common.trace.ErrorCategorySet;
 import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
-import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValueList;
-import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
-import com.navercorp.pinpoint.common.trace.attribute.AttributeValueArray;
-import com.navercorp.pinpoint.common.trace.attribute.AttributeValueBytes;
 import com.navercorp.pinpoint.loader.service.AnnotationKeyRegistryService;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.component.AnnotationKeyMatcherService;
@@ -44,8 +37,6 @@ import com.navercorp.pinpoint.web.util.OtelLinkValue;
 import com.navercorp.pinpoint.web.util.OtelLinkValueSerde;
 
 import java.util.ArrayList;
-import java.util.Base64;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -54,8 +45,6 @@ import java.util.Objects;
  * @author minwoo.jung
  */
 public class RecordFactory {
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     // spans with id = 0 are regarded as root - start at 1
     private int idGen = 1;
@@ -67,17 +56,21 @@ public class RecordFactory {
 
     private final ApiParserProvider apiParserProvider;
 
+    private final AttributeBoWriter attributeBoWriter;
+
     public RecordFactory(final AnnotationKeyMatcherService annotationKeyMatcherService,
                          final ServiceTypeRegistryService registry,
                          final AnnotationKeyRegistryService annotationKeyRegistryService,
                          final AnnotationRecordFormatter annotationRecordFormatter,
-                         final ApiParserProvider apiParserProvider) {
+                         final ApiParserProvider apiParserProvider,
+                         final AttributeBoWriter attributeBoWriter) {
         this.annotationKeyMatcherService = Objects.requireNonNull(annotationKeyMatcherService, "annotationKeyMatcherService");
         this.registry = Objects.requireNonNull(registry, "registry");
         this.annotationKeyRegistryService = Objects.requireNonNull(annotationKeyRegistryService, "annotationKeyRegistryService");
 
         this.annotationRecordFormatter = Objects.requireNonNull(annotationRecordFormatter, "annotationRecordFormatter");
         this.apiParserProvider = Objects.requireNonNull(apiParserProvider, "apiParserRegistry");
+        this.attributeBoWriter = Objects.requireNonNull(attributeBoWriter, "attributeBoWriter");
     }
 
     public Record get(final CallTreeNode node) {
@@ -255,45 +248,8 @@ public class RecordFactory {
         if (attributeBoList == null || attributeBoList.isEmpty()) {
             return null;
         }
-        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
-        for (AttributeBo attr : attributeBoList) {
-            map.put(attr.getKey(), toPlainObject(attr.getValue()));
-        }
-        try {
-            String arguments = OBJECT_MAPPER.writeValueAsString(map);
-            return new AnnotationRecord(depth, getNextId(), parentId, "Attribute", arguments, true);
-        } catch (JsonProcessingException e) {
-            return new AnnotationRecord(depth, getNextId(), parentId, "Attribute", "json processing error", true);
-        }
-    }
-
-    private static Object toPlainObject(AttributeValue value) {
-        if (value == null) {
-            return null;
-        }
-        return switch (value.getType()) {
-            case STRING, BOOLEAN, LONG, DOUBLE -> value.getValue();
-            case BYTES -> {
-                byte[] bytesValue = ((AttributeValueBytes) value).getRawBytesValue();
-                yield Base64.getEncoder().encodeToString(bytesValue);
-            }
-            case ARRAY -> {
-                List<AttributeValue> list = ((AttributeValueArray) value).getArrayValue();
-                List<Object> plainList = new ArrayList<>(list.size());
-                for (AttributeValue item : list) {
-                    plainList.add(toPlainObject(item));
-                }
-                yield plainList;
-            }
-            case KEY_VALUE_LIST -> {
-                List<AttributeKeyValue> kvList = ((AttributeKeyValueList) value).getKeyValueListValue();
-                LinkedHashMap<String, Object> kvMap = new LinkedHashMap<>();
-                for (AttributeKeyValue kv : kvList) {
-                    kvMap.put(kv.getKey(), toPlainObject(kv.getValue()));
-                }
-                yield kvMap;
-            }
-        };
+        String arguments = attributeBoWriter.toJson(attributeBoList);
+        return new AnnotationRecord(depth, getNextId(), parentId, "Attribute", arguments, true);
     }
 
     public Record getParameter(final int depth, final int parentId, final String method, final String argument) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java
@@ -41,6 +41,7 @@ import com.navercorp.pinpoint.web.component.AnnotationKeyMatcherService;
 import com.navercorp.pinpoint.web.trace.span.Align;
 import com.navercorp.pinpoint.web.trace.span.CallTreeNode;
 import com.navercorp.pinpoint.web.util.OtelLinkValue;
+import com.navercorp.pinpoint.web.util.OtelLinkValueSerde;
 
 import java.util.ArrayList;
 import java.util.Base64;
@@ -235,7 +236,7 @@ public class RecordFactory {
     private String augmentOtelLink(String arguments, Align align) {
         // traceId/spanId in the raw annotation point to the OTel Link target (upstream).
         // Augment with linkTraceId/linkSpanId of the current (downstream) span where the Link annotation lives.
-        final OtelLinkValue value = OtelLinkValue.parse(arguments);
+        final OtelLinkValue value = OtelLinkValueSerde.parse(arguments);
         if (value == null) {
             return arguments;
         }
@@ -245,8 +246,8 @@ public class RecordFactory {
         } catch (RuntimeException e) {
             return arguments;
         }
-        return value.withDownstream(linkTraceId, align.getSpanId(), align.getCollectorAcceptTime())
-                .toJson();
+        final OtelLinkValue downstream = value.withDownstream(linkTraceId, align.getSpanId(), align.getCollectorAcceptTime());
+        return OtelLinkValueSerde.toJson(downstream);
     }
 
     public Record getAttribute(final int depth, final int parentId, Align align) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/service/RecorderFactoryProvider.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/service/RecorderFactoryProvider.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.loader.service.AnnotationKeyRegistryService;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.component.AnnotationKeyMatcherService;
 import com.navercorp.pinpoint.web.trace.callstacks.AnnotationRecordFormatter;
+import com.navercorp.pinpoint.web.trace.callstacks.AttributeBoWriter;
 import com.navercorp.pinpoint.web.trace.callstacks.RecordFactory;
 import org.springframework.stereotype.Component;
 
@@ -39,19 +40,23 @@ public class RecorderFactoryProvider {
 
     private final ApiParserProvider apiParserProvider;
 
+    private final AttributeBoWriter attributeBoWriter;
+
     public RecorderFactoryProvider(ServiceTypeRegistryService registry,
                                    AnnotationKeyMatcherService annotationKeyMatcherService,
                                    AnnotationKeyRegistryService annotationKeyRegistryService,
                                    AnnotationRecordFormatter annotationRecordFormatter,
-                                   ApiParserProvider apiParserProvider) {
+                                   ApiParserProvider apiParserProvider,
+                                   AttributeBoWriter attributeBoWriter) {
         this.registry = Objects.requireNonNull(registry, "registry");
         this.annotationKeyMatcherService = Objects.requireNonNull(annotationKeyMatcherService, "annotationKeyMatcherService");
         this.annotationKeyRegistryService = Objects.requireNonNull(annotationKeyRegistryService, "annotationKeyRegistryService");
         this.annotationRecordFormatter = Objects.requireNonNull(annotationRecordFormatter, "annotationRecordFormatter");
         this.apiParserProvider = Objects.requireNonNull(apiParserProvider, "apiParserRegistry");
+        this.attributeBoWriter = Objects.requireNonNull(attributeBoWriter, "attributeBoWriter");
     }
 
     public RecordFactory getRecordFactory()  {
-        return new RecordFactory(annotationKeyMatcherService, registry, annotationKeyRegistryService, annotationRecordFormatter, apiParserProvider);
+        return new RecordFactory(annotationKeyMatcherService, registry, annotationKeyRegistryService, annotationRecordFormatter, apiParserProvider, attributeBoWriter);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/util/OtelLinkValue.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/util/OtelLinkValue.java
@@ -15,10 +15,7 @@
  */
 package com.navercorp.pinpoint.web.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.jspecify.annotations.Nullable;
 
@@ -26,7 +23,7 @@ import org.jspecify.annotations.Nullable;
  * Typed representation of an {@code OPENTELEMETRY_LINK} annotation value.
  *
  * <p>The annotation is persisted as a JSON string for compatibility with the existing
- * HBase wire format. This record centralizes parsing and serialization so that
+ * HBase wire format. {@link OtelLinkValueSerde} centralizes parsing and serialization so that
  * consumers can operate on typed fields instead of poking at JSON nodes.</p>
  *
  * <p>Fields mirror the JSON keys produced by the collector (raw) and by
@@ -47,100 +44,7 @@ public record OtelLinkValue(
         @Nullable JsonNode attributes
 ) {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    public static @Nullable OtelLinkValue parse(@Nullable Object annotationValue) {
-        if (!(annotationValue instanceof String json) || json.isEmpty()) {
-            return null;
-        }
-        try {
-            final JsonNode root = OBJECT_MAPPER.readTree(json);
-            if (!root.isObject()) {
-                return null;
-            }
-            return new OtelLinkValue(
-                    readTraceId(root.path("traceId")),
-                    readLong(root.path("spanId")),
-                    readTraceId(root.path("linkTraceId")),
-                    readLong(root.path("linkSpanId")),
-                    readLong(root.path("focusTimestamp")),
-                    extractNode(root.get("attributes"))
-            );
-        } catch (JsonProcessingException e) {
-            return null;
-        }
-    }
-
     public OtelLinkValue withDownstream(@Nullable ServerTraceId linkTraceId, long linkSpanId, long focusTimestamp) {
         return new OtelLinkValue(this.traceId, this.spanId, linkTraceId, linkSpanId, focusTimestamp, this.attributes);
-    }
-
-    public String toJson() {
-        final ObjectNode node = OBJECT_MAPPER.createObjectNode();
-        if (traceId != null) {
-            node.put("traceId", traceId.toString());
-        }
-        // long values serialized as String to avoid JS Number precision loss on the frontend
-        if (spanId != null) {
-            node.put("spanId", String.valueOf(spanId));
-        }
-        if (linkTraceId != null) {
-            node.put("linkTraceId", linkTraceId.toString());
-        }
-        if (linkSpanId != null) {
-            node.put("linkSpanId", String.valueOf(linkSpanId));
-        }
-        if (focusTimestamp != null) {
-            node.put("focusTimestamp", focusTimestamp.longValue());
-        }
-        if (attributes != null) {
-            node.set("attributes", attributes);
-        }
-        try {
-            return OBJECT_MAPPER.writeValueAsString(node);
-        } catch (JsonProcessingException e) {
-            return "{}";
-        }
-    }
-
-    private static @Nullable ServerTraceId readTraceId(@Nullable JsonNode node) {
-        final String text = readText(node);
-        if (text == null) {
-            return null;
-        }
-        try {
-            return ServerTraceId.of(text);
-        } catch (RuntimeException e) {
-            return null;
-        }
-    }
-
-    private static @Nullable String readText(@Nullable JsonNode node) {
-        if (node == null || node.isMissingNode() || node.isNull() || !node.isTextual()) {
-            return null;
-        }
-        final String text = node.asText();
-        return text.isEmpty() ? null : text;
-    }
-
-    private static @Nullable Long readLong(@Nullable JsonNode node) {
-        if (node == null || node.isMissingNode() || node.isNull()) {
-            return null;
-        }
-        if (node.isNumber()) {
-            return node.asLong();
-        }
-        if (node.isTextual()) {
-            try {
-                return Long.parseLong(node.asText());
-            } catch (NumberFormatException ignored) {
-                return null;
-            }
-        }
-        return null;
-    }
-
-    private static @Nullable JsonNode extractNode(@Nullable JsonNode node) {
-        return (node != null && !node.isMissingNode() && !node.isNull()) ? node : null;
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/util/OtelLinkValueSerde.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/util/OtelLinkValueSerde.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+/**
+ * Serializes and parses the {@code OPENTELEMETRY_LINK} annotation value, which is persisted
+ * as a JSON string for compatibility with the existing HBase wire format, to and from a
+ * typed {@link OtelLinkValue}.
+ */
+public final class OtelLinkValueSerde {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private OtelLinkValueSerde() {
+    }
+
+    public static @Nullable OtelLinkValue parse(@Nullable Object annotationValue) {
+        if (!(annotationValue instanceof String json) || json.isEmpty()) {
+            return null;
+        }
+        try {
+            final JsonNode root = OBJECT_MAPPER.readTree(json);
+            if (!root.isObject()) {
+                return null;
+            }
+            return new OtelLinkValue(
+                    readTraceId(root.path("traceId")),
+                    readLong(root.path("spanId")),
+                    readTraceId(root.path("linkTraceId")),
+                    readLong(root.path("linkSpanId")),
+                    readLong(root.path("focusTimestamp")),
+                    extractNode(root.get("attributes"))
+            );
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    private static @Nullable ServerTraceId readTraceId(@Nullable JsonNode node) {
+        final String text = readText(node);
+        if (text == null) {
+            return null;
+        }
+        try {
+            return ServerTraceId.of(text);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static @Nullable String readText(@Nullable JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull() || !node.isTextual()) {
+            return null;
+        }
+        final String text = node.asText();
+        return text.isEmpty() ? null : text;
+    }
+
+    private static @Nullable Long readLong(@Nullable JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (node.isNumber()) {
+            return node.asLong();
+        }
+        if (node.isTextual()) {
+            try {
+                return Long.parseLong(node.asText());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static @Nullable JsonNode extractNode(@Nullable JsonNode node) {
+        return (node != null && !node.isMissingNode() && !node.isNull()) ? node : null;
+    }
+
+    public static String toJson(OtelLinkValue value) {
+        final StringWriter writer = new StringWriter();
+        try (JsonGenerator gen = OBJECT_MAPPER.createGenerator(writer)) {
+            gen.writeStartObject();
+            if (value.traceId() != null) {
+                gen.writeStringField("traceId", value.traceId().toString());
+            }
+            // long values serialized as String to avoid JS Number precision loss on the frontend
+            if (value.spanId() != null) {
+                gen.writeStringField("spanId", String.valueOf(value.spanId()));
+            }
+            if (value.linkTraceId() != null) {
+                gen.writeStringField("linkTraceId", value.linkTraceId().toString());
+            }
+            if (value.linkSpanId() != null) {
+                gen.writeStringField("linkSpanId", String.valueOf(value.linkSpanId()));
+            }
+            if (value.focusTimestamp() != null) {
+                gen.writeNumberField("focusTimestamp", value.focusTimestamp());
+            }
+            if (value.attributes() != null) {
+                gen.writeFieldName("attributes");
+                gen.writeTree(value.attributes());
+            }
+            gen.writeEndObject();
+        } catch (IOException e) {
+            return "{}";
+        }
+        return writer.toString();
+    }
+}

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.web.trace.callstacks;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.common.profiler.trace.AnnotationKeyRegistry;
 import com.navercorp.pinpoint.common.profiler.trace.TraceMetadataLoader;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
@@ -80,8 +81,10 @@ public class RecordFactoryTest {
     private ApiParserProvider apiParserProvider;
 
     private RecordFactory newRecordFactory() {
+        AttributeBoWriter attributeBoWriter = new AttributeBoWriter(new ObjectMapper());
         RecorderFactoryProvider recorderFactoryProvider = new RecorderFactoryProvider(mockServiceTypeRegistryService,
-                mockAnnotationKeyMatcherService, mockAnnotationKeyRegistryService, mockAnnotationRecordFormatter, apiParserProvider);
+                mockAnnotationKeyMatcherService, mockAnnotationKeyRegistryService, mockAnnotationRecordFormatter, apiParserProvider,
+                attributeBoWriter);
         return recorderFactoryProvider.getRecordFactory();
     }
 
@@ -271,7 +274,10 @@ public class RecordFactoryTest {
         ServiceTypeRegistryService mockedRegistry = mock(ServiceTypeRegistryService.class);
         AnnotationRecordFormatter annotationRecordFormatter = mock(AnnotationRecordFormatter.class);
         ApiParserProvider mockedApiParserProvider = new ApiParserProvider();
-        when(mockedProvider.getRecordFactory()).thenReturn(new RecordFactory(mockedAnnotationKeyMatcherService, mockedRegistry, mockedAnnotationKeyRegistryService, annotationRecordFormatter, mockedApiParserProvider));
+        AttributeBoWriter attributeBoWriter = new AttributeBoWriter(new ObjectMapper());
+        when(mockedProvider.getRecordFactory()).thenReturn(
+                new RecordFactory(mockedAnnotationKeyMatcherService, mockedRegistry, mockedAnnotationKeyRegistryService, annotationRecordFormatter, mockedApiParserProvider, attributeBoWriter)
+        );
 
         TransactionInfoService dut = new TransactionInfoServiceImpl(mockedAnnotationKeyMatcherService, Optional.empty(), mockedProvider, mockServiceTypeRegistryService);
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/util/OtelLinkValueSerdeTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/util/OtelLinkValueSerdeTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtelLinkValueSerdeTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void roundTrip_allFields() {
+        ObjectNode attributes = mapper.createObjectNode();
+        attributes.put("http.method", "GET");
+        attributes.put("retry", 3);
+
+        OtelLinkValue original = new OtelLinkValue(
+                new PinpointServerTraceId("upstream-agent", 100, 200),
+                1234567890123456789L,
+                new PinpointServerTraceId("downstream-agent", 300, 400),
+                987654321098765432L,
+                1670305848569L,
+                attributes
+        );
+
+        OtelLinkValue parsed = OtelLinkValueSerde.parse(OtelLinkValueSerde.toJson(original));
+
+        assertThat(parsed).isEqualTo(original);
+    }
+
+    @Test
+    void roundTrip_otelTraceId() {
+        // 32 hex chars (16 bytes) without the pinpoint delimiter -> OtelServerTraceId
+        ServerTraceId otelTraceId = ServerTraceId.of("0123456789abcdef0123456789abcdef");
+
+        OtelLinkValue original = new OtelLinkValue(otelTraceId, 42L, null, null, null, null);
+
+        OtelLinkValue parsed = OtelLinkValueSerde.parse(OtelLinkValueSerde.toJson(original));
+
+        assertThat(parsed).isEqualTo(original);
+    }
+
+    @Test
+    void roundTrip_nullFieldsOmitted() {
+        // Only the upstream target is present; downstream/attributes are null.
+        OtelLinkValue original = new OtelLinkValue(
+                new PinpointServerTraceId("upstream-agent", 100, 200),
+                1L,
+                null,
+                null,
+                null,
+                null
+        );
+
+        String json = OtelLinkValueSerde.toJson(original);
+
+        assertThat(json).doesNotContain("linkTraceId", "linkSpanId", "focusTimestamp", "attributes");
+        assertThat(OtelLinkValueSerde.parse(json)).isEqualTo(original);
+    }
+
+    @Test
+    void toJson_wireFormat_longsAsString_timestampAsNumber() throws Exception {
+        OtelLinkValue value = new OtelLinkValue(
+                new PinpointServerTraceId("agent", 1, 2),
+                111L,
+                new PinpointServerTraceId("agent", 3, 4),
+                222L,
+                1670305848569L,
+                null
+        );
+
+        JsonNode node = mapper.readTree(OtelLinkValueSerde.toJson(value));
+
+        // long ids are serialized as JSON strings to avoid JS Number precision loss on the frontend
+        assertThat(node.get("spanId").isTextual()).isTrue();
+        assertThat(node.get("spanId").asText()).isEqualTo("111");
+        assertThat(node.get("linkSpanId").isTextual()).isTrue();
+        // focusTimestamp stays a JSON number
+        assertThat(node.get("focusTimestamp").isNumber()).isTrue();
+        assertThat(node.get("focusTimestamp").asLong()).isEqualTo(1670305848569L);
+    }
+
+    @Test
+    void parse_invalidInput_returnsNull() {
+        assertThat(OtelLinkValueSerde.parse(null)).isNull();
+        assertThat(OtelLinkValueSerde.parse("")).isNull();
+        assertThat(OtelLinkValueSerde.parse(123)).isNull();
+        assertThat(OtelLinkValueSerde.parse("not json")).isNull();
+        // valid JSON but not an object
+        assertThat(OtelLinkValueSerde.parse("[1,2,3]")).isNull();
+    }
+}


### PR DESCRIPTION
This pull request introduces two new utility classes to improve code modularity and maintainability: `AttributeBoWriter` for serializing attribute data to JSON and `OtelLinkValueParser` for parsing OpenTelemetry link annotations. It refactors existing code to use these utilities, removing redundant logic and simplifying related classes. The changes also update dependency injection and wiring to support these new utilities.

**Key changes include:**

### Attribute Serialization Refactoring
* Introduced the `AttributeBoWriter` class for efficient, streaming JSON serialization of `AttributeBo` lists, replacing custom and repetitive serialization logic in `RecordFactory`. (`web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/AttributeBoWriter.java` [web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/AttributeBoWriter.javaR1-R98](diffhunk://#diff-90cfea7bd4125db4c8e67ceeeb827685a6c57806e145c5f66358b1eba002f989R1-R98))
* Updated `RecordFactory` to use `AttributeBoWriter` for attribute serialization, removing the old manual conversion logic and direct use of `ObjectMapper`. (`web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactory.java` [[1]](diffhunk://#diff-41d924fe4255336cab0f9adb5ba438754af5c6ba0eab36bd4e08b5d5bd5e0883L57-L58) [[2]](diffhunk://#diff-41d924fe4255336cab0f9adb5ba438754af5c6ba0eab36bd4e08b5d5bd5e0883R59-R73) [[3]](diffhunk://#diff-41d924fe4255336cab0f9adb5ba438754af5c6ba0eab36bd4e08b5d5bd5e0883L257-L295)

### OpenTelemetry Link Parsing Refactoring
* Moved the parsing logic for OpenTelemetry link annotation values from `OtelLinkValue` to a new dedicated utility class, `OtelLinkValueParser`, and updated all usages to reference this new parser. (`web/src/main/java/com/navercorp/pinpoint/web/util/OtelLinkValueParser.java` [[1]](diffhunk://#diff-9aa37d71451a42c61375fc12cc1b0ff0b8d6ed43dbd5ae6e80829dacf93965c0R1-R97) [[2]](diffhunk://#diff-391cf5eafd5e0eacd7297befcb97d98db7c673b97b531f06730616b7b4a0138aR46) [[3]](diffhunk://#diff-391cf5eafd5e0eacd7297befcb97d98db7c673b97b531f06730616b7b4a0138aL123-R124) [[4]](diffhunk://#diff-41d924fe4255336cab0f9adb5ba438754af5c6ba0eab36bd4e08b5d5bd5e0883L33-L47) [[5]](diffhunk://#diff-41d924fe4255336cab0f9adb5ba438754af5c6ba0eab36bd4e08b5d5bd5e0883L238-R232) [[6]](diffhunk://#diff-1fb5342e9e65596d4027f8467b1ba0047025f4dde3f3a123764c3ce0abe980c3L52-L73) [[7]](diffhunk://#diff-1fb5342e9e65596d4027f8467b1ba0047025f4dde3f3a123764c3ce0abe980c3L105-L145)

### Dependency Injection and Wiring
* Registered `AttributeBoWriter` as a Spring bean and updated constructors in `RecordFactory` and `RecorderFactoryProvider` to accept and use it, ensuring proper dependency injection throughout the application. (`web/src/main/java/com/navercorp/pinpoint/web/trace/TraceConfiguration.java` [[1]](diffhunk://#diff-e84d79c309788958805b267c70c33f79719f5adc85b27636e98882983fcb2d8fR19-R23) [[2]](diffhunk://#diff-e84d79c309788958805b267c70c33f79719f5adc85b27636e98882983fcb2d8fR66-R70) `web/src/main/java/com/navercorp/pinpoint/web/trace/service/RecorderFactoryProvider.java` [[3]](diffhunk://#diff-c24693b0843aa23e204e1a11e340ecc6253e10ec60deeedabdc95b972af42df0R24) [[4]](diffhunk://#diff-c24693b0843aa23e204e1a11e340ecc6253e10ec60deeedabdc95b972af42df0R43-R60)

These changes modularize serialization and parsing logic, making the codebase cleaner, more testable, and easier to maintain.