### PR TITLE
[#noissue] Use commons-io StringBuilderWriter for JSON string building

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -132,6 +132,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.collections</groupId>

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/AttributeBoWriter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/AttributeBoWriter.java
@@ -27,9 +27,9 @@ import com.navercorp.pinpoint.common.trace.attribute.AttributeValueBytes;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValueDouble;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValueLong;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValueString;
+import org.apache.commons.io.output.StringBuilderWriter;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
@@ -50,7 +50,7 @@ public class AttributeBoWriter {
     }
 
     public String toJson(List<AttributeBo> attributeBoList) {
-        StringWriter writer = new StringWriter();
+        StringBuilderWriter writer = new StringBuilderWriter();
         try (JsonGenerator gen = mapper.createGenerator(writer)) {
             gen.writeStartObject();
             for (AttributeBo attr : attributeBoList) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/util/OtelLinkValueSerde.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/util/OtelLinkValueSerde.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
-import java.io.StringWriter;
 
 /**
  * Serializes and parses the {@code OPENTELEMETRY_LINK} annotation value, which is persisted
@@ -101,7 +101,7 @@ public final class OtelLinkValueSerde {
     }
 
     public static String toJson(OtelLinkValue value) {
-        final StringWriter writer = new StringWriter();
+        final StringBuilderWriter writer = new StringBuilderWriter();
         try (JsonGenerator gen = OBJECT_MAPPER.createGenerator(writer)) {
             gen.writeStartObject();
             if (value.traceId() != null) {


### PR DESCRIPTION
Replace java.io.StringWriter (synchronized StringBuffer) with the unsynchronized StringBuilderWriter in AttributeBoWriter and OtelLinkValueSerde, and declare the commons-io dependency explicitly in the web module.