### PR TITLE
[#noissue] Share JsonNodeUtils.isNull with OtelLinkValueSerde

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/FilterDescriptor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/FilterDescriptor.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.web.util.JsonNodeUtils;
 import com.navercorp.pinpoint.web.vo.Service;
 import org.jspecify.annotations.Nullable;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/util/JsonNodeUtils.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/util/JsonNodeUtils.java
@@ -1,6 +1,7 @@
-package com.navercorp.pinpoint.web.filter;
+package com.navercorp.pinpoint.web.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.jspecify.annotations.Nullable;
 
 public final class JsonNodeUtils {
 
@@ -35,7 +36,7 @@ public final class JsonNodeUtils {
         return node.asBoolean();
     }
 
-    private static boolean isNull(JsonNode node) {
-        return node == null || node.isNull();
+    public static boolean isNull(@Nullable JsonNode node) {
+        return node == null || node.isNull() || node.isMissingNode();
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/util/OtelLinkValueSerde.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/util/OtelLinkValueSerde.java
@@ -72,7 +72,7 @@ public final class OtelLinkValueSerde {
     }
 
     private static @Nullable String readText(@Nullable JsonNode node) {
-        if (node == null || node.isMissingNode() || node.isNull() || !node.isTextual()) {
+        if (JsonNodeUtils.isNull(node) || !node.isTextual()) {
             return null;
         }
         final String text = node.asText();
@@ -80,7 +80,7 @@ public final class OtelLinkValueSerde {
     }
 
     private static @Nullable Long readLong(@Nullable JsonNode node) {
-        if (node == null || node.isMissingNode() || node.isNull()) {
+        if (JsonNodeUtils.isNull(node)) {
             return null;
         }
         if (node.isNumber()) {
@@ -97,7 +97,7 @@ public final class OtelLinkValueSerde {
     }
 
     private static @Nullable JsonNode extractNode(@Nullable JsonNode node) {
-        return (node != null && !node.isMissingNode() && !node.isNull()) ? node : null;
+        return JsonNodeUtils.isNull(node) ? null : node;
     }
 
     public static String toJson(OtelLinkValue value) {


### PR DESCRIPTION
Move JsonNodeUtils from web.filter to web.util so the shared utility does not
live in a domain package, make isNull public, and cover MissingNode alongside
null/NullNode. Replace the hand-rolled absent-node checks in
OtelLinkValueSerde's readText/readLong/extractNode with it.
