### PR TITLE
[#noissue] Extract OtlpAttributeBoMapper bean 

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapper.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.server.bo.AttributeBo;
+import com.navercorp.pinpoint.common.server.util.Utf8;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+@Component
+public class OtlpAttributeBoMapper {
+
+    private final int attributeValueMaxBytes;
+
+    public OtlpAttributeBoMapper(@Value("${pinpoint.collector.otlptrace.attribute.value-max-bytes:8192}") int attributeValueMaxBytes) {
+        if (attributeValueMaxBytes < 0) {
+            throw new IllegalArgumentException("attributeValueMaxBytes must be >= 0: " + attributeValueMaxBytes);
+        }
+        this.attributeValueMaxBytes = attributeValueMaxBytes;
+    }
+
+    /**
+     * Converts attributes to an {@link AttributeBo} list, applying {@code excludeFilter} and
+     * truncating over-long string (UTF-8 byte length) and byte (raw byte length) values in the
+     * same pass, recursing into ARRAY / KVLIST. Numeric and boolean values are left untouched,
+     * matching the OTel spec (only string and byte values are length-limited). The truncated leaf
+     * count accumulates in {@code counter} so the caller can emit a single per-span
+     * {@code OPENTELEMETRY_TRUNCATED} summary.
+     */
+    public List<AttributeBo> toAttributeBoList(Map<String, AttributeValue> attributes, Predicate<String> excludeFilter, TruncationCounter counter) {
+        Objects.requireNonNull(counter, "counter");
+        if (attributes.isEmpty()) {
+            return List.of();
+        }
+        List<AttributeBo> result = new ArrayList<>();
+        for (Map.Entry<String, AttributeValue> entry : attributes.entrySet()) {
+            if (excludeFilter.test(entry.getKey())) {
+                continue;
+            }
+            final AttributeValue value = truncateValue(entry.getValue(), counter);
+            result.add(new AttributeBo(entry.getKey(), value));
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private AttributeValue truncateValue(AttributeValue value, TruncationCounter counter) {
+        switch (value.getType()) {
+            case STRING: {
+                final String truncated = Utf8.truncate((String) value.getValue(), attributeValueMaxBytes);
+                if (truncated == null) {
+                    return value;
+                }
+                counter.truncated();
+                return AttributeValue.of(truncated);
+            }
+            case BYTES: {
+                final byte[] bytes = (byte[]) value.getValue();
+                if (bytes.length <= attributeValueMaxBytes) {
+                    return value;
+                }
+                counter.truncated();
+                return AttributeValue.of(Arrays.copyOf(bytes, attributeValueMaxBytes));
+            }
+            case ARRAY: {
+                final List<AttributeValue> array = (List<AttributeValue>) value.getValue();
+                boolean changed = false;
+                final List<AttributeValue> result = new ArrayList<>(array.size());
+                for (AttributeValue item : array) {
+                    final AttributeValue newItem = truncateValue(item, counter);
+                    result.add(newItem);
+                    changed |= (newItem != item);
+                }
+                return changed ? AttributeValue.of(result) : value;
+            }
+            case KEY_VALUE_LIST: {
+                final List<AttributeKeyValue> kvList = (List<AttributeKeyValue>) value.getValue();
+                boolean changed = false;
+                final AttributeKeyValue[] result = new AttributeKeyValue[kvList.size()];
+                for (int i = 0; i < kvList.size(); i++) {
+                    final AttributeKeyValue entry = kvList.get(i);
+                    final AttributeValue newValue = truncateValue(entry.getValue(), counter);
+                    final boolean entryChanged = newValue != entry.getValue();
+                    result[i] = entryChanged ? AttributeKeyValue.of(entry.getKey(), newValue) : entry;
+                    changed |= entryChanged;
+                }
+                return changed ? AttributeValue.ofAttributeKeyValueList(result) : value;
+            }
+            default:
+                // BOOLEAN / LONG / DOUBLE — never truncated (per OTel spec)
+                return value;
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapper.java
@@ -46,12 +46,12 @@ public class OtlpAttributeBoMapper {
      * Converts attributes to an {@link AttributeBo} list, applying {@code excludeFilter} and
      * truncating over-long string (UTF-8 byte length) and byte (raw byte length) values in the
      * same pass, recursing into ARRAY / KVLIST. Numeric and boolean values are left untouched,
-     * matching the OTel spec (only string and byte values are length-limited). The truncated leaf
-     * count accumulates in {@code counter} so the caller can emit a single per-span
+     * matching the OTel spec (only string and byte values are length-limited). {@code onTruncated}
+     * is invoked once per truncated leaf so the caller can emit a single per-span
      * {@code OPENTELEMETRY_TRUNCATED} summary.
      */
-    public List<AttributeBo> toAttributeBoList(Map<String, AttributeValue> attributes, Predicate<String> excludeFilter, TruncationCounter counter) {
-        Objects.requireNonNull(counter, "counter");
+    public List<AttributeBo> toAttributeBoList(Map<String, AttributeValue> attributes, Predicate<String> excludeFilter, TruncationListener onTruncated) {
+        Objects.requireNonNull(onTruncated, "onTruncated");
         if (attributes.isEmpty()) {
             return List.of();
         }
@@ -60,21 +60,21 @@ public class OtlpAttributeBoMapper {
             if (excludeFilter.test(entry.getKey())) {
                 continue;
             }
-            final AttributeValue value = truncateValue(entry.getValue(), counter);
+            final AttributeValue value = truncateValue(entry.getValue(), onTruncated);
             result.add(new AttributeBo(entry.getKey(), value));
         }
         return result;
     }
 
     @SuppressWarnings("unchecked")
-    private AttributeValue truncateValue(AttributeValue value, TruncationCounter counter) {
+    private AttributeValue truncateValue(AttributeValue value, TruncationListener onTruncated) {
         switch (value.getType()) {
             case STRING: {
                 final String truncated = Utf8.truncate((String) value.getValue(), attributeValueMaxBytes);
                 if (truncated == null) {
                     return value;
                 }
-                counter.truncated();
+                onTruncated.truncated();
                 return AttributeValue.of(truncated);
             }
             case BYTES: {
@@ -82,7 +82,7 @@ public class OtlpAttributeBoMapper {
                 if (bytes.length <= attributeValueMaxBytes) {
                     return value;
                 }
-                counter.truncated();
+                onTruncated.truncated();
                 return AttributeValue.of(Arrays.copyOf(bytes, attributeValueMaxBytes));
             }
             case ARRAY: {
@@ -90,7 +90,7 @@ public class OtlpAttributeBoMapper {
                 boolean changed = false;
                 final List<AttributeValue> result = new ArrayList<>(array.size());
                 for (AttributeValue item : array) {
-                    final AttributeValue newItem = truncateValue(item, counter);
+                    final AttributeValue newItem = truncateValue(item, onTruncated);
                     result.add(newItem);
                     changed |= (newItem != item);
                 }
@@ -102,7 +102,7 @@ public class OtlpAttributeBoMapper {
                 final AttributeKeyValue[] result = new AttributeKeyValue[kvList.size()];
                 for (int i = 0; i < kvList.size(); i++) {
                     final AttributeKeyValue entry = kvList.get(i);
-                    final AttributeValue newValue = truncateValue(entry.getValue(), counter);
+                    final AttributeValue newValue = truncateValue(entry.getValue(), onTruncated);
                     final boolean entryChanged = newValue != entry.getValue();
                     result[i] = entryChanged ? AttributeKeyValue.of(entry.getKey(), newValue) : entry;
                     changed |= entryChanged;

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapper.java
@@ -31,6 +31,9 @@ public class OtlpTraceEventMapper {
                                 @Value("${pinpoint.collector.otlptrace.event.value-max-bytes:8192}") int valueMaxBytes) {
         Objects.requireNonNull(objectMapper, "objectMapper");
         this.mapWriter = objectMapper.writerFor(new TypeReference<Map<String, Object>>() {});
+        if (valueMaxBytes < 0) {
+            throw new IllegalArgumentException("valueMaxBytes must be >= 0: " + valueMaxBytes);
+        }
         this.valueMaxBytes = valueMaxBytes;
     }
 
@@ -53,10 +56,10 @@ public class OtlpTraceEventMapper {
             if (event.getAttributesCount() > 0) {
                 // Cap over-long string values (notably exception.stacktrace, which is also kept in
                 // full in exception metadata) so a single event cannot bloat the span row.
-                final TransformContext context = new TransformContext(valueMaxBytes);
+                final TruncationCounter counter = new TruncationCounter();
                 final Map<String, Object> eventAttributes =
-                        getAttributeToMap(event.getAttributesList(), context);
-                truncated = context.truncatedCount();
+                        getAttributeToMap(event.getAttributesList(), valueMaxBytes, counter);
+                truncated = counter.truncatedCount();
                 inner.put(FIELD_ATTRIBUTES, eventAttributes);
             }
             Map<String, Object> map = Map.of(event.getName(), inner);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapper.java
@@ -42,24 +42,22 @@ public class OtlpTraceEventMapper {
      * <pre>{@code {"<event.name>": {"time": <unix_nano>, "attributes": {...}}}}</pre>
      * The {@code attributes} field is omitted when the event has none, so empty events
      * produce {@code {"<event.name>": {"time": N}}} (no longer a heterogeneous string/object
-     * value). Emitted under {@link AnnotationKey#OPENTELEMETRY_EVENT}.
+     * value). Emitted under {@link AnnotationKey#OPENTELEMETRY_EVENT}. {@code onTruncated} is
+     * invoked once per truncated attribute leaf.
      */
-    public int addEventToAnnotation(Span.Event event, AnnotationWriter annotationWriter) {
+    public void addEventToAnnotation(Span.Event event, AnnotationWriter annotationWriter, TruncationListener onTruncated) {
         if (StringUtils.isEmpty(event.getName())) {
-            return 0;
+            return;
         }
 
-        int truncated = 0;
         try {
             Map<String, Object> inner = new HashMap<>(2);
             inner.put(FIELD_TIME, event.getTimeUnixNano());
             if (event.getAttributesCount() > 0) {
                 // Cap over-long string values (notably exception.stacktrace, which is also kept in
                 // full in exception metadata) so a single event cannot bloat the span row.
-                final TruncationCounter counter = new TruncationCounter();
                 final Map<String, Object> eventAttributes =
-                        getAttributeToMap(event.getAttributesList(), valueMaxBytes, counter);
-                truncated = counter.truncatedCount();
+                        getAttributeToMap(event.getAttributesList(), valueMaxBytes, onTruncated);
                 inner.put(FIELD_ATTRIBUTES, eventAttributes);
             }
             Map<String, Object> map = Map.of(event.getName(), inner);
@@ -68,7 +66,6 @@ public class OtlpTraceEventMapper {
         } catch (JsonProcessingException e) {
             annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), "json processing error"));
         }
-        return truncated;
     }
 
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
@@ -29,6 +29,9 @@ public class OtlpTraceLinkMapper {
                                @Value("${pinpoint.collector.otlptrace.link.value-max-bytes:8192}") int valueMaxBytes) {
         Objects.requireNonNull(objectMapper, "objectMapper");
         this.mapWriter = objectMapper.writerFor(new TypeReference<Map<String, Object>>() {});
+        if (valueMaxBytes < 0) {
+            throw new IllegalArgumentException("valueMaxBytes must be >= 0: " + valueMaxBytes);
+        }
         this.valueMaxBytes = valueMaxBytes;
     }
 
@@ -70,9 +73,9 @@ public class OtlpTraceLinkMapper {
                 map.put("traceState", traceState);
             }
             if (link.getAttributesCount() > 0) {
-                final TransformContext context = new TransformContext(valueMaxBytes);
-                final Map<String, Object> linkAttributes = getAttributeToMap(link.getAttributesList(), context);
-                truncated += context.truncatedCount();
+                final TruncationCounter counter = new TruncationCounter();
+                final Map<String, Object> linkAttributes = getAttributeToMap(link.getAttributesList(), valueMaxBytes, counter);
+                truncated += counter.truncatedCount();
                 map.put("attributes", linkAttributes);
             }
             // SDK-side data-loss counter for link attributes. Same convention as Span/SpanEvent

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
@@ -43,12 +43,13 @@ public class OtlpTraceLinkMapper {
      *
      * <p>Skips entirely when both traceId and spanId are empty — OTel spec requires links to
      * carry a non-empty SpanContext, so a fully-empty link is invalid input we drop silently.</p>
+     *
+     * <p>{@code onTruncated} is invoked once per truncated value (traceState or attribute leaf).</p>
      */
-    public int addLinkToAnnotation(Span.Link link, AnnotationWriter annotationWriter) {
+    public void addLinkToAnnotation(Span.Link link, AnnotationWriter annotationWriter, TruncationListener onTruncated) {
         if (link.getTraceId().isEmpty() && link.getSpanId().isEmpty()) {
-            return 0;
+            return;
         }
-        int truncated = 0;
         try {
             Map<String, Object> map = new HashMap<>();
             if (!link.getTraceId().isEmpty()) {
@@ -68,14 +69,12 @@ public class OtlpTraceLinkMapper {
                 final String truncatedTraceState = Utf8.truncate(traceState, valueMaxBytes);
                 if (truncatedTraceState != null) {
                     traceState = truncatedTraceState;
-                    truncated++;
+                    onTruncated.truncated();
                 }
                 map.put("traceState", traceState);
             }
             if (link.getAttributesCount() > 0) {
-                final TruncationCounter counter = new TruncationCounter();
-                final Map<String, Object> linkAttributes = getAttributeToMap(link.getAttributesList(), valueMaxBytes, counter);
-                truncated += counter.truncatedCount();
+                final Map<String, Object> linkAttributes = getAttributeToMap(link.getAttributesList(), valueMaxBytes, onTruncated);
                 map.put("attributes", linkAttributes);
             }
             // SDK-side data-loss counter for link attributes. Same convention as Span/SpanEvent
@@ -88,6 +87,5 @@ public class OtlpTraceLinkMapper {
         } catch (JsonProcessingException e) {
             annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), "json processing error"));
         }
-        return truncated;
     }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -19,7 +19,6 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.profiler.name.Base64Utils;
-import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.Base16Utils;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
@@ -31,7 +30,6 @@ import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.ArrayValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -39,7 +37,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -224,24 +221,24 @@ public class OtlpTraceMapperUtils {
     }
 
     public static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList) {
-        // no context: plain conversion without truncation ((TransformContext) cast disambiguates the null)
-        return getAttributeToMap(keyValueList, (TransformContext) null);
+        // no counter: plain conversion without truncation (maxBytes is never read on that path)
+        return getAttributeToMap(keyValueList, 0, null);
     }
 
     /**
      * Converts OTel attributes to a JSON-serializable map, recursing into nested arrays/maps. When
-     * {@code context} is non-null, over-long string / byte leaf values are truncated (bytes on their
-     * hex form) in the same pass and the count accumulates in the context; a {@code null} context
-     * renders without truncation.
+     * {@code counter} is non-null, over-long string / byte leaf values are truncated to
+     * {@code maxBytes} (bytes on their hex form) in the same pass and the count accumulates in the
+     * counter; a {@code null} counter renders without truncation.
      */
-    public static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList, @Nullable TransformContext context) {
+    public static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList, int maxBytes, @Nullable TruncationCounter counter) {
         final int size = keyValueList.size();
         if (size == 0) {
             return Map.of();
         }
         Map<String, Object> map = new HashMap<>(size);
         for (KeyValue kv : keyValueList) {
-            map.put(kv.getKey(), getAttributeValueToValue(kv.getValue(), context));
+            map.put(kv.getKey(), getAttributeValueToValue(kv.getValue(), maxBytes, counter));
         }
         return map;
     }
@@ -263,10 +260,10 @@ public class OtlpTraceMapperUtils {
     }
 
     public static List<Object> getArrayValueToList(ArrayValue arrayValue) {
-        return getArrayValueToList(arrayValue, null);
+        return getArrayValueToList(arrayValue, 0, null);
     }
 
-    public static List<Object> getArrayValueToList(ArrayValue arrayValue, @Nullable TransformContext context) {
+    public static List<Object> getArrayValueToList(ArrayValue arrayValue, int maxBytes, @Nullable TruncationCounter counter) {
         final int size = arrayValue.getValuesCount();
         if (size == 0) {
             return List.of();
@@ -275,49 +272,49 @@ public class OtlpTraceMapperUtils {
         final List<AnyValue> valuesList = arrayValue.getValuesList();
         List<Object> list = new ArrayList<>(valuesList.size());
         for (AnyValue anyValue : valuesList) {
-            list.add(getAttributeValueToValue(anyValue, context));
+            list.add(getAttributeValueToValue(anyValue, maxBytes, counter));
         }
         return list;
     }
 
     public static Object getAttributeValueToValue(AnyValue anyValue) {
-        return getAttributeValueToValue(anyValue, null);
+        return getAttributeValueToValue(anyValue, 0, null);
     }
 
-    public static Object getAttributeValueToValue(AnyValue anyValue, @Nullable TransformContext context) {
+    public static Object getAttributeValueToValue(AnyValue anyValue, int maxBytes, @Nullable TruncationCounter counter) {
         return switch (anyValue.getValueCase()) {
             case INT_VALUE -> anyValue.getIntValue();
             case DOUBLE_VALUE -> anyValue.getDoubleValue();
             case BOOL_VALUE -> anyValue.getBoolValue();
-            case STRING_VALUE -> transformString(anyValue.getStringValue(), context);
-            case BYTES_VALUE -> transformBytes(anyValue.getBytesValue(), context);
-            case ARRAY_VALUE -> getArrayValueToList(anyValue.getArrayValue(), context);
-            case KVLIST_VALUE -> getAttributeToMap(anyValue.getKvlistValue().getValuesList(), context);
+            case STRING_VALUE -> transformString(anyValue.getStringValue(), maxBytes, counter);
+            case BYTES_VALUE -> transformBytes(anyValue.getBytesValue(), maxBytes, counter);
+            case ARRAY_VALUE -> getArrayValueToList(anyValue.getArrayValue(), maxBytes, counter);
+            case KVLIST_VALUE -> getAttributeToMap(anyValue.getKvlistValue().getValuesList(), maxBytes, counter);
             default -> null;
         };
     }
 
-    private static String transformString(String value, @Nullable TransformContext context) {
-        if (context == null) {
+    private static String transformString(String value, int maxBytes, @Nullable TruncationCounter counter) {
+        if (counter == null) {
             return value;
         }
-        final String truncated = Utf8.truncate(value, context.maxBytes());
+        final String truncated = Utf8.truncate(value, maxBytes);
         if (truncated != null) {
-            context.truncated();
+            counter.truncated();
             return truncated;
         }
         return value;
     }
 
-    private static Object transformBytes(ByteString bytes, @Nullable TransformContext context) {
+    private static Object transformBytes(ByteString bytes, int maxBytes, @Nullable TruncationCounter counter) {
         // empty bytes -> "" (Base16 of an empty array), symmetric with the empty STRING case
-        if (context == null) {
+        if (counter == null) {
             return ByteStringUtils.encodeBase16(bytes);
         }
-        if (Base16Utils.encodedLength(bytes.size()) > context.maxBytes()) {
-            context.truncated();
+        if (Base16Utils.encodedLength(bytes.size()) > maxBytes) {
+            counter.truncated();
         }
-        return ByteStringUtils.encodeBase16(bytes, context.maxBytes());
+        return ByteStringUtils.encodeBase16(bytes, maxBytes);
     }
 
     public static AttributeValue toAttributeValue(AnyValue anyValue) {
@@ -352,89 +349,4 @@ public class OtlpTraceMapperUtils {
         };
     }
 
-    public static List<AttributeBo> toAttributeBoList(Map<String, AttributeValue> attributes, Predicate<String> excludeFilter) {
-        // no context: plain conversion without truncation
-        return toAttributeBoList(attributes, excludeFilter, null);
-    }
-
-    /**
-     * Converts attributes to an {@link AttributeBo} list, applying {@code excludeFilter} and — when
-     * {@code context} is non-null — truncating over-long string (UTF-8 byte length) and byte (raw
-     * byte length) values in the same pass, recursing into ARRAY / KVLIST. Numeric and boolean
-     * values are left untouched, matching the OTel spec (only string and byte values are
-     * length-limited). The truncated leaf count accumulates in {@code context} so the caller can
-     * emit a single per-span {@code OPENTELEMETRY_TRUNCATED} summary.
-     */
-    public static List<AttributeBo> toAttributeBoList(Map<String, AttributeValue> attributes, Predicate<String> excludeFilter, @Nullable TransformContext context) {
-        if (attributes.isEmpty()) {
-            return List.of();
-        }
-        List<AttributeBo> result = new ArrayList<>();
-        for (Map.Entry<String, AttributeValue> entry : attributes.entrySet()) {
-            if (excludeFilter.test(entry.getKey())) {
-                continue;
-            }
-            final AttributeValue value = transformValue(entry.getValue(), context);
-            result.add(new AttributeBo(entry.getKey(), value));
-        }
-        return result;
-    }
-
-    private static AttributeValue transformValue(AttributeValue value, @Nullable TransformContext context) {
-        if (context == null) {
-            return value;
-        }
-        return truncateValue(value, context);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static AttributeValue truncateValue(AttributeValue value, @NonNull TransformContext context) {
-        Objects.requireNonNull(context, "context");
-
-        switch (value.getType()) {
-            case STRING: {
-                final String truncated = Utf8.truncate((String) value.getValue(), context.maxBytes());
-                if (truncated == null) {
-                    return value;
-                }
-                context.truncated();
-                return AttributeValue.of(truncated);
-            }
-            case BYTES: {
-                final byte[] bytes = (byte[]) value.getValue();
-                if (bytes.length <= context.maxBytes()) {
-                    return value;
-                }
-                context.truncated();
-                return AttributeValue.of(Arrays.copyOf(bytes, context.maxBytes()));
-            }
-            case ARRAY: {
-                final List<AttributeValue> array = (List<AttributeValue>) value.getValue();
-                boolean changed = false;
-                final List<AttributeValue> result = new ArrayList<>(array.size());
-                for (AttributeValue item : array) {
-                    final AttributeValue newItem = truncateValue(item, context);
-                    result.add(newItem);
-                    changed |= (newItem != item);
-                }
-                return changed ? AttributeValue.of(result) : value;
-            }
-            case KEY_VALUE_LIST: {
-                final List<AttributeKeyValue> kvList = (List<AttributeKeyValue>) value.getValue();
-                boolean changed = false;
-                final AttributeKeyValue[] result = new AttributeKeyValue[kvList.size()];
-                for (int i = 0; i < kvList.size(); i++) {
-                    final AttributeKeyValue entry = kvList.get(i);
-                    final AttributeValue newValue = truncateValue(entry.getValue(), context);
-                    final boolean entryChanged = newValue != entry.getValue();
-                    result[i] = entryChanged ? AttributeKeyValue.of(entry.getKey(), newValue) : entry;
-                    changed |= entryChanged;
-                }
-                return changed ? AttributeValue.ofAttributeKeyValueList(result) : value;
-            }
-            default:
-                // BOOLEAN / LONG / DOUBLE — never truncated (per OTel spec)
-                return value;
-        }
-    }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -221,24 +221,24 @@ public class OtlpTraceMapperUtils {
     }
 
     public static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList) {
-        // no counter: plain conversion without truncation (maxBytes is never read on that path)
+        // no listener: plain conversion without truncation (maxBytes is never read on that path)
         return getAttributeToMap(keyValueList, 0, null);
     }
 
     /**
      * Converts OTel attributes to a JSON-serializable map, recursing into nested arrays/maps. When
-     * {@code counter} is non-null, over-long string / byte leaf values are truncated to
-     * {@code maxBytes} (bytes on their hex form) in the same pass and the count accumulates in the
-     * counter; a {@code null} counter renders without truncation.
+     * {@code onTruncated} is non-null, over-long string / byte leaf values are truncated to
+     * {@code maxBytes} (bytes on their hex form) in the same pass, invoking the listener once per
+     * truncated leaf; a {@code null} listener renders without truncation.
      */
-    public static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList, int maxBytes, @Nullable TruncationCounter counter) {
+    public static Map<String, Object> getAttributeToMap(List<KeyValue> keyValueList, int maxBytes, @Nullable TruncationListener onTruncated) {
         final int size = keyValueList.size();
         if (size == 0) {
             return Map.of();
         }
         Map<String, Object> map = new HashMap<>(size);
         for (KeyValue kv : keyValueList) {
-            map.put(kv.getKey(), getAttributeValueToValue(kv.getValue(), maxBytes, counter));
+            map.put(kv.getKey(), getAttributeValueToValue(kv.getValue(), maxBytes, onTruncated));
         }
         return map;
     }
@@ -263,7 +263,7 @@ public class OtlpTraceMapperUtils {
         return getArrayValueToList(arrayValue, 0, null);
     }
 
-    public static List<Object> getArrayValueToList(ArrayValue arrayValue, int maxBytes, @Nullable TruncationCounter counter) {
+    public static List<Object> getArrayValueToList(ArrayValue arrayValue, int maxBytes, @Nullable TruncationListener onTruncated) {
         final int size = arrayValue.getValuesCount();
         if (size == 0) {
             return List.of();
@@ -272,7 +272,7 @@ public class OtlpTraceMapperUtils {
         final List<AnyValue> valuesList = arrayValue.getValuesList();
         List<Object> list = new ArrayList<>(valuesList.size());
         for (AnyValue anyValue : valuesList) {
-            list.add(getAttributeValueToValue(anyValue, maxBytes, counter));
+            list.add(getAttributeValueToValue(anyValue, maxBytes, onTruncated));
         }
         return list;
     }
@@ -281,38 +281,38 @@ public class OtlpTraceMapperUtils {
         return getAttributeValueToValue(anyValue, 0, null);
     }
 
-    public static Object getAttributeValueToValue(AnyValue anyValue, int maxBytes, @Nullable TruncationCounter counter) {
+    public static Object getAttributeValueToValue(AnyValue anyValue, int maxBytes, @Nullable TruncationListener onTruncated) {
         return switch (anyValue.getValueCase()) {
             case INT_VALUE -> anyValue.getIntValue();
             case DOUBLE_VALUE -> anyValue.getDoubleValue();
             case BOOL_VALUE -> anyValue.getBoolValue();
-            case STRING_VALUE -> transformString(anyValue.getStringValue(), maxBytes, counter);
-            case BYTES_VALUE -> transformBytes(anyValue.getBytesValue(), maxBytes, counter);
-            case ARRAY_VALUE -> getArrayValueToList(anyValue.getArrayValue(), maxBytes, counter);
-            case KVLIST_VALUE -> getAttributeToMap(anyValue.getKvlistValue().getValuesList(), maxBytes, counter);
+            case STRING_VALUE -> transformString(anyValue.getStringValue(), maxBytes, onTruncated);
+            case BYTES_VALUE -> transformBytes(anyValue.getBytesValue(), maxBytes, onTruncated);
+            case ARRAY_VALUE -> getArrayValueToList(anyValue.getArrayValue(), maxBytes, onTruncated);
+            case KVLIST_VALUE -> getAttributeToMap(anyValue.getKvlistValue().getValuesList(), maxBytes, onTruncated);
             default -> null;
         };
     }
 
-    private static String transformString(String value, int maxBytes, @Nullable TruncationCounter counter) {
-        if (counter == null) {
+    private static String transformString(String value, int maxBytes, @Nullable TruncationListener onTruncated) {
+        if (onTruncated == null) {
             return value;
         }
         final String truncated = Utf8.truncate(value, maxBytes);
         if (truncated != null) {
-            counter.truncated();
+            onTruncated.truncated();
             return truncated;
         }
         return value;
     }
 
-    private static Object transformBytes(ByteString bytes, int maxBytes, @Nullable TruncationCounter counter) {
+    private static Object transformBytes(ByteString bytes, int maxBytes, @Nullable TruncationListener onTruncated) {
         // empty bytes -> "" (Base16 of an empty array), symmetric with the empty STRING case
-        if (counter == null) {
+        if (onTruncated == null) {
             return ByteStringUtils.encodeBase16(bytes);
         }
         if (Base16Utils.encodedLength(bytes.size()) > maxBytes) {
-            counter.truncated();
+            onTruncated.truncated();
         }
         return ByteStringUtils.encodeBase16(bytes, maxBytes);
     }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -55,7 +55,7 @@ public class OtlpTraceSpanEventMapper {
     private final OtlpMessagingTypeResolver messagingTypeResolver;
     private final OtlpClientTypeResolver clientTypeResolver;
     private final OtlpExceptionInfoResolver exceptionInfoResolver;
-    private final int attributeValueMaxBytes;
+    private final OtlpAttributeBoMapper attributeBoMapper;
     private final int sqlMaxBytes;
 
     public OtlpTraceSpanEventMapper(OtlpTraceEventMapper eventMapper,
@@ -63,7 +63,7 @@ public class OtlpTraceSpanEventMapper {
                                     OtlpMessagingTypeResolver messagingTypeResolver,
                                     OtlpClientTypeResolver clientTypeResolver,
                                     OtlpExceptionInfoResolver exceptionInfoResolver,
-                                    @Value("${pinpoint.collector.otlptrace.attribute.value-max-bytes:8192}") int attributeValueMaxBytes,
+                                    OtlpAttributeBoMapper attributeBoMapper,
                                     @Value("${pinpoint.collector.otlptrace.sql.max-bytes:8192}") int sqlMaxBytes) {
         this.eventMapper = Objects.requireNonNull(eventMapper, "eventMapper");
         this.dbSystemTypeResolver = new OtlpDbSystemTypeResolver(
@@ -71,7 +71,7 @@ public class OtlpTraceSpanEventMapper {
         this.messagingTypeResolver = Objects.requireNonNull(messagingTypeResolver, "messagingTypeResolver");
         this.clientTypeResolver = Objects.requireNonNull(clientTypeResolver, "clientTypeResolver");
         this.exceptionInfoResolver = Objects.requireNonNull(exceptionInfoResolver, "exceptionInfoResolver");
-        this.attributeValueMaxBytes = attributeValueMaxBytes;
+        this.attributeBoMapper = Objects.requireNonNull(attributeBoMapper, "attributeBoMapper");
         this.sqlMaxBytes = sqlMaxBytes;
     }
 
@@ -154,10 +154,10 @@ public class OtlpTraceSpanEventMapper {
         spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_PARENT_SPAN_ID.getCode(), OtlpTraceMapperUtils.getParentSpanId(span.getParentSpanId())));
         // attributes
         if (!attributes.isEmpty()) {
-            final TransformContext context = new TransformContext(attributeValueMaxBytes);
-            List<AttributeBo> attributeBoList = OtlpTraceMapperUtils.toAttributeBoList(
-                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, context);
-            truncatedAttributes = context.truncatedCount();
+            final TruncationCounter counter = new TruncationCounter();
+            List<AttributeBo> attributeBoList = attributeBoMapper.toAttributeBoList(
+                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, counter);
+            truncatedAttributes = counter.truncatedCount();
             spanEventBo.setAttributeBoList(attributeBoList);
         }
         // event

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -72,6 +72,9 @@ public class OtlpTraceSpanEventMapper {
         this.clientTypeResolver = Objects.requireNonNull(clientTypeResolver, "clientTypeResolver");
         this.exceptionInfoResolver = Objects.requireNonNull(exceptionInfoResolver, "exceptionInfoResolver");
         this.attributeBoMapper = Objects.requireNonNull(attributeBoMapper, "attributeBoMapper");
+        if (sqlMaxBytes < 0) {
+            throw new IllegalArgumentException("sqlMaxBytes must be >= 0: " + sqlMaxBytes);
+        }
         this.sqlMaxBytes = sqlMaxBytes;
     }
 
@@ -92,9 +95,7 @@ public class OtlpTraceSpanEventMapper {
         spanEventBo.setTraceTime(SpanVersion.TRACE_V3, eventStartTimeNanos, eventEndTimeNanos, startElapsed);
 
         final Map<String, AttributeValue> attributes = OtlpTraceMapperUtils.getAttributeValueMap(span.getAttributesList());
-        int truncatedAttributes = 0;
-        int truncatedSql = 0;
-        int truncatedEvents = 0;
+        final TruncatedCounts truncatedCounts = new TruncatedCounts();
 
         // Keep the order
         if (isDatabase(attributes)) {
@@ -108,7 +109,7 @@ public class OtlpTraceSpanEventMapper {
                 final String truncatedStatement = (statement == null) ? null : Utf8.truncate(statement, sqlMaxBytes);
                 if (truncatedStatement != null) {
                     statement = truncatedStatement;
-                    truncatedSql = 1;
+                    truncatedCounts.sql();
                 }
                 spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.SQL.getCode(), statement));
             }
@@ -154,10 +155,8 @@ public class OtlpTraceSpanEventMapper {
         spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_PARENT_SPAN_ID.getCode(), OtlpTraceMapperUtils.getParentSpanId(span.getParentSpanId())));
         // attributes
         if (!attributes.isEmpty()) {
-            final TruncationCounter counter = new TruncationCounter();
             List<AttributeBo> attributeBoList = attributeBoMapper.toAttributeBoList(
-                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, counter);
-            truncatedAttributes = counter.truncatedCount();
+                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, truncatedCounts::attribute);
             spanEventBo.setAttributeBoList(attributeBoList);
         }
         // event
@@ -167,7 +166,7 @@ public class OtlpTraceSpanEventMapper {
             if (skipExceptionEvent && OtlpTraceConstants.EVENT_NAME_EXCEPTION.equals(event.getName())) {
                 continue;
             }
-            truncatedEvents += eventMapper.addEventToAnnotation(event, spanEventBo::addAnnotation);
+            eventMapper.addEventToAnnotation(event, spanEventBo::addAnnotation, truncatedCounts::event);
         }
         // SDK-side data-loss hints (Span proto fields 10/12/14). Only emit when > 0.
         OtlpTraceSpanMapper.addDroppedAnnotations(spanEventBo::addAnnotation,
@@ -182,7 +181,10 @@ public class OtlpTraceSpanEventMapper {
             spanEventBo.setNextSpanId(nextSpanId);
         }
 
-        OtlpTraceSpanMapper.addTruncatedAnnotation(spanEventBo::addAnnotation, truncatedAttributes, truncatedSql, truncatedEvents, 0);
+        final AnnotationBo truncatedAnnotation = OtlpTraceSpanMapper.toTruncatedAnnotation(truncatedCounts);
+        if (truncatedAnnotation != null) {
+            spanEventBo.addAnnotation(truncatedAnnotation);
+        }
 
         return spanEventBo;
     }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -127,32 +127,31 @@ public class OtlpTraceSpanMapper {
         if (responseStatusCode != -1) {
             spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatusCode));
         }
+        final TruncatedCounts truncatedCounts = new TruncatedCounts();
         // attributes
-        int truncatedAttributes = 0;
         if (!attributes.isEmpty()) {
-            final TruncationCounter counter = new TruncationCounter();
             List<AttributeBo> attributeBoList = attributeBoMapper.toAttributeBoList(
-                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, counter);
-            truncatedAttributes = counter.truncatedCount();
+                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, truncatedCounts::attribute);
             spanBo.setAttributeBoList(attributeBoList);
         }
 
         // event
-        int truncatedEvents = 0;
         for (Span.Event event : span.getEventsList()) {
             // The exception event's class name is captured into exceptionInfo and its message/
             // stacktrace into exception-trace metadata, so skip its (redundant) annotation.
             if (skipExceptionEvent && OtlpTraceConstants.EVENT_NAME_EXCEPTION.equals(event.getName())) {
                 continue;
             }
-            truncatedEvents += eventMapper.addEventToAnnotation(event, spanBo::addAnnotation);
+            eventMapper.addEventToAnnotation(event, spanBo::addAnnotation, truncatedCounts::event);
         }
         // link
-        int truncatedLinks = 0;
         for (Span.Link link : span.getLinksList()) {
-            truncatedLinks += linkMapper.addLinkToAnnotation(link, spanBo::addAnnotation);
+            linkMapper.addLinkToAnnotation(link, spanBo::addAnnotation, truncatedCounts::link);
         }
-        addTruncatedAnnotation(spanBo::addAnnotation, truncatedAttributes, 0, truncatedEvents, truncatedLinks);
+        final AnnotationBo truncatedAnnotation = toTruncatedAnnotation(truncatedCounts);
+        if (truncatedAnnotation != null) {
+            spanBo.addAnnotation(truncatedAnnotation);
+        }
         // SDK-side data-loss hints (Span proto fields 10/12/14). Only emit when > 0 so
         // well-behaved spans stay annotation-free.
         addDroppedAnnotations(spanBo::addAnnotation,
@@ -186,23 +185,17 @@ public class OtlpTraceSpanMapper {
     }
 
     /**
-     * Emits a single OPENTELEMETRY_TRUNCATED annotation when the collector truncated over-long
+     * Builds the single OPENTELEMETRY_TRUNCATED annotation when the collector truncated over-long
      * attribute values or SQL on this span. Value format mirrors OPENTELEMETRY_DROPPED:
      * space-separated {@code label=count} pairs (e.g. {@code "attributes=3 sql=1"}); zero
-     * components are omitted and the annotation is suppressed when nothing was truncated. Shared
+     * components are omitted and {@code null} is returned when nothing was truncated. Shared
      * by {@link OtlpTraceSpanMapper} (root spans) and {@link OtlpTraceSpanEventMapper} (child spans).
      */
-    static void addTruncatedAnnotation(Consumer<AnnotationBo> sink, int truncatedAttributes, int truncatedSql, int truncatedEvents, int truncatedLinks) {
-        if (truncatedAttributes == 0 && truncatedSql == 0 && truncatedEvents == 0 && truncatedLinks == 0) {
-            return;
+    static @Nullable AnnotationBo toTruncatedAnnotation(TruncatedCounts truncatedCounts) {
+        if (truncatedCounts.isEmpty()) {
+            return null;
         }
-        String label = new TruncatedCounts()
-                .attributes(truncatedAttributes)
-                .sql(truncatedSql)
-                .events(truncatedEvents)
-                .links(truncatedLinks)
-                .toString();
-        sink.accept(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_TRUNCATED.getCode(), label));
+        return AnnotationBo.of(AnnotationKey.OPENTELEMETRY_TRUNCATED.getCode(), truncatedCounts.toString());
     }
 
     /**

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -38,7 +38,6 @@ import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import io.opentelemetry.proto.trace.v1.Span;
 import io.opentelemetry.proto.trace.v1.Status;
 import org.jspecify.annotations.Nullable;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -54,20 +53,20 @@ public class OtlpTraceSpanMapper {
     private final OtlpServerTypeResolver serverTypeResolver;
     private final OtlpExceptionInfoResolver exceptionInfoResolver;
     private final OtlpMessagingConsumerResolver messagingConsumerResolver;
-    private final int attributeValueMaxBytes;
+    private final OtlpAttributeBoMapper attributeBoMapper;
 
     public OtlpTraceSpanMapper(OtlpTraceEventMapper eventMapper,
                                OtlpTraceLinkMapper linkMapper,
                                OtlpServerTypeResolver serverTypeResolver,
                                OtlpExceptionInfoResolver exceptionInfoResolver,
                                OtlpMessagingConsumerResolver messagingConsumerResolver,
-                               @Value("${pinpoint.collector.otlptrace.attribute.value-max-bytes:8192}") int attributeValueMaxBytes) {
+                               OtlpAttributeBoMapper attributeBoMapper) {
         this.eventMapper = Objects.requireNonNull(eventMapper, "eventMapper");
         this.linkMapper = Objects.requireNonNull(linkMapper, "linkMapper");
         this.serverTypeResolver = Objects.requireNonNull(serverTypeResolver, "serverTypeResolver");
         this.exceptionInfoResolver = Objects.requireNonNull(exceptionInfoResolver, "exceptionInfoResolver");
         this.messagingConsumerResolver = Objects.requireNonNull(messagingConsumerResolver, "messagingConsumerResolver");
-        this.attributeValueMaxBytes = attributeValueMaxBytes;
+        this.attributeBoMapper = Objects.requireNonNull(attributeBoMapper, "attributeBoMapper");
     }
 
     SpanBo map(IdAndName idAndName, Span span) {
@@ -131,10 +130,10 @@ public class OtlpTraceSpanMapper {
         // attributes
         int truncatedAttributes = 0;
         if (!attributes.isEmpty()) {
-            final TransformContext context = new TransformContext(attributeValueMaxBytes);
-            List<AttributeBo> attributeBoList = OtlpTraceMapperUtils.toAttributeBoList(
-                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, context);
-            truncatedAttributes = context.truncatedCount();
+            final TruncationCounter counter = new TruncationCounter();
+            List<AttributeBo> attributeBoList = attributeBoMapper.toAttributeBoList(
+                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, counter);
+            truncatedAttributes = counter.truncatedCount();
             spanBo.setAttributeBoList(attributeBoList);
         }
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/TruncatedCounts.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/TruncatedCounts.java
@@ -18,9 +18,11 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 /**
  * Per-label counts of span data truncated by the collector, for the
- * OPENTELEMETRY_TRUNCATED annotation value. {@link #toString()} formats them
+ * OPENTELEMETRY_TRUNCATED annotation value. Each category is incremented through a no-arg
+ * method so it can be handed out as a {@link TruncationListener} method reference
+ * (e.g. {@code truncatedCounts::attribute}). {@link #toString()} formats the counts
  * as space-separated {@code label=count} pairs in declaration order
- * (e.g. {@code "attributes=3 sql=1"}); non-positive counts are omitted.
+ * (e.g. {@code "attributes=3 sql=1"}); zero counts are omitted.
  */
 final class TruncatedCounts {
 
@@ -29,24 +31,24 @@ final class TruncatedCounts {
     private int events;
     private int links;
 
-    TruncatedCounts attributes(int count) {
-        this.attributes = count;
-        return this;
+    void attribute() {
+        attributes++;
     }
 
-    TruncatedCounts sql(int count) {
-        this.sql = count;
-        return this;
+    void sql() {
+        sql++;
     }
 
-    TruncatedCounts events(int count) {
-        this.events = count;
-        return this;
+    void event() {
+        events++;
     }
 
-    TruncatedCounts links(int count) {
-        this.links = count;
-        return this;
+    void link() {
+        links++;
+    }
+
+    boolean isEmpty() {
+        return attributes == 0 && sql == 0 && events == 0 && links == 0;
     }
 
     @Override

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/TruncationCounter.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/TruncationCounter.java
@@ -17,24 +17,13 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 /**
- * Carries the byte limit and accumulates the number of leaf values truncated across a single
- * attribute-tree transform pass (including nested ARRAY / KVLIST values). Create one instance per
- * pass; not thread-safe.
+ * Accumulates the number of leaf values truncated across a single attribute-tree transform pass
+ * (including nested ARRAY / KVLIST values). Create one instance per pass — truncation totals are
+ * reported per category (attributes / sql / events / links), so a counter must not be reused
+ * across categories or spans. Not thread-safe.
  */
-public final class TransformContext {
-    private final int maxBytes;
+public final class TruncationCounter {
     private int truncatedCount;
-
-    public TransformContext(int maxBytes) {
-        if (maxBytes < 0) {
-            throw new IllegalArgumentException("maxBytes must be >= 0: " + maxBytes);
-        }
-        this.maxBytes = maxBytes;
-    }
-
-    public int maxBytes() {
-        return maxBytes;
-    }
 
     public void truncated() {
         truncatedCount++;

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/TruncationListener.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/TruncationListener.java
@@ -17,19 +17,13 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 /**
- * Accumulates the number of leaf values truncated across a single attribute-tree transform pass
- * (including nested ARRAY / KVLIST values). Create one instance per pass — truncation totals are
- * reported per category (attributes / sql / events / links), so a counter must not be reused
- * across categories or spans. Not thread-safe.
+ * Invoked once per leaf value truncated during an attribute transform pass (including nested
+ * ARRAY / KVLIST values). Callers typically hand out a category increment of
+ * {@code TruncatedCounts} as a method reference (e.g. {@code truncatedCounts::attribute}) so
+ * truncations are counted per category (attributes / sql / events / links) for the per-span
+ * {@code OPENTELEMETRY_TRUNCATED} summary.
  */
-public final class TruncationCounter {
-    private int truncatedCount;
-
-    public void truncated() {
-        truncatedCount++;
-    }
-
-    public int truncatedCount() {
-        return truncatedCount;
-    }
+@FunctionalInterface
+public interface TruncationListener {
+    void truncated();
 }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapperTest.java
@@ -1,0 +1,241 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.server.bo.AttributeBo;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OtlpAttributeBoMapperTest {
+
+    // large enough that no test value is truncated
+    private static final int NO_TRUNCATION_MAX_BYTES = 8192;
+
+    @Test
+    void negativeMaxBytes_rejected() {
+        assertThatThrownBy(() -> new OtlpAttributeBoMapper(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // =======================================================================
+    // filtering
+    // =======================================================================
+
+    @Test
+    void toAttributeBoList_emptyMap_returnsEmptyList() {
+        OtlpAttributeBoMapper mapper = new OtlpAttributeBoMapper(NO_TRUNCATION_MAX_BYTES);
+
+        List<AttributeBo> result = mapper.toAttributeBoList(Map.of(), key -> false, new TruncationCounter());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void toAttributeBoList_noFilter_returnsAllEntries() {
+        OtlpAttributeBoMapper mapper = new OtlpAttributeBoMapper(NO_TRUNCATION_MAX_BYTES);
+        Map<String, AttributeValue> attrs = new HashMap<>();
+        attrs.put("k1", AttributeValue.of("v1"));
+        attrs.put("k2", AttributeValue.of(42L));
+
+        List<AttributeBo> result = mapper.toAttributeBoList(attrs, key -> false, new TruncationCounter());
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(AttributeBo::getKey).containsExactlyInAnyOrder("k1", "k2");
+    }
+
+    @Test
+    void toAttributeBoList_excludeFilter_removesKeys() {
+        OtlpAttributeBoMapper mapper = new OtlpAttributeBoMapper(NO_TRUNCATION_MAX_BYTES);
+        Map<String, AttributeValue> attrs = new HashMap<>();
+        attrs.put("keep", AttributeValue.of("ok"));
+        attrs.put("drop", AttributeValue.of("bye"));
+
+        List<AttributeBo> result = mapper.toAttributeBoList(attrs, key -> key.equals("drop"), new TruncationCounter());
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getKey()).isEqualTo("keep");
+        assertThat(result.get(0).getValue().getValue()).isEqualTo("ok");
+    }
+
+    // =======================================================================
+    // single-pass truncation
+    // =======================================================================
+
+    private static List<AttributeBo> truncate(int maxBytes, TruncationCounter counter, AttributeValue value) {
+        final Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+        attrs.put("k", value);
+        return new OtlpAttributeBoMapper(maxBytes).toAttributeBoList(attrs, key -> false, counter);
+    }
+
+    @Test
+    void truncateAttributeValues_emptyMap_returnsZero() {
+        TruncationCounter counter = new TruncationCounter();
+
+        List<AttributeBo> result = new OtlpAttributeBoMapper(8).toAttributeBoList(Map.of(), key -> false, counter);
+
+        assertThat(result).isEmpty();
+        assertThat(counter.truncatedCount()).isZero();
+    }
+
+    @Test
+    void truncateAttributeValues_shortString_unchanged() {
+        TruncationCounter counter = new TruncationCounter();
+
+        List<AttributeBo> list = truncate(64, counter, AttributeValue.of("ok"));
+
+        assertThat(counter.truncatedCount()).isZero();
+        assertThat(list.get(0).getValue().getValue()).isEqualTo("ok");
+    }
+
+    @Test
+    void truncateAttributeValues_overLongString_truncatedAndCounted() {
+        TruncationCounter counter = new TruncationCounter();
+
+        List<AttributeBo> list = truncate(10, counter, AttributeValue.of("a".repeat(100)));
+
+        assertThat(counter.truncatedCount()).isEqualTo(1);
+        AttributeValue value = list.get(0).getValue();
+        assertThat(value.getType()).isEqualTo(AttributeValueType.STRING);
+        assertThat((String) value.getValue()).isEqualTo("a".repeat(10));
+    }
+
+    @Test
+    void truncateAttributeValues_numericAndBoolean_neverTruncated() {
+        TruncationCounter counter = new TruncationCounter();
+        Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+        attrs.put("i", AttributeValue.of(1234567890L));
+        attrs.put("d", AttributeValue.of(3.14159d));
+        attrs.put("b", AttributeValue.of(true));
+
+        // maxBytes=1: would truncate any string, but numbers/booleans are exempt per OTel spec
+        List<AttributeBo> list = new OtlpAttributeBoMapper(1).toAttributeBoList(attrs, key -> false, counter);
+
+        assertThat(counter.truncatedCount()).isZero();
+        assertThat(list.get(0).getValue().getValue()).isEqualTo(1234567890L);
+        assertThat(list.get(1).getValue().getValue()).isEqualTo(3.14159d);
+        assertThat(list.get(2).getValue().getValue()).isEqualTo(true);
+    }
+
+    @Test
+    void truncateAttributeValues_overLongBytes_truncatedToMaxBytes() {
+        byte[] payload = new byte[100];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) i;
+        }
+        TruncationCounter counter = new TruncationCounter();
+
+        List<AttributeBo> list = truncate(16, counter, AttributeValue.of(payload));
+
+        assertThat(counter.truncatedCount()).isEqualTo(1);
+        AttributeValue value = list.get(0).getValue();
+        assertThat(value.getType()).isEqualTo(AttributeValueType.BYTES);
+        assertThat((byte[]) value.getValue()).hasSize(16)
+                .containsExactly(Arrays.copyOf(payload, 16));
+    }
+
+    @Test
+    void truncateAttributeValues_bytesWithinLimit_unchanged() {
+        byte[] payload = new byte[]{1, 2, 3};
+        TruncationCounter counter = new TruncationCounter();
+
+        List<AttributeBo> list = truncate(16, counter, AttributeValue.of(payload));
+
+        assertThat(counter.truncatedCount()).isZero();
+        assertThat((byte[]) list.get(0).getValue().getValue()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void truncateAttributeValues_array_recursesAndCountsEachLeaf() {
+        AttributeValue array = AttributeValue.of(
+                AttributeValue.of("a".repeat(100)),
+                AttributeValue.of("short"),
+                AttributeValue.of("b".repeat(100))
+        );
+        TruncationCounter counter = new TruncationCounter();
+
+        List<AttributeBo> list = truncate(10, counter, array);
+
+        // two over-long leaves truncated, the "short" one untouched
+        assertThat(counter.truncatedCount()).isEqualTo(2);
+        @SuppressWarnings("unchecked")
+        List<AttributeValue> result = (List<AttributeValue>) list.get(0).getValue().getValue();
+        assertThat(result).extracting(AttributeValue::getValue)
+                .containsExactly("a".repeat(10), "short", "b".repeat(10));
+    }
+
+    @Test
+    void truncateAttributeValues_array_noOverLongLeaf_unchanged() {
+        AttributeValue array = AttributeValue.of(AttributeValue.of("x"), AttributeValue.of("y"));
+        TruncationCounter counter = new TruncationCounter();
+
+        List<AttributeBo> list = truncate(10, counter, array);
+
+        assertThat(counter.truncatedCount()).isZero();
+        @SuppressWarnings("unchecked")
+        List<AttributeValue> result = (List<AttributeValue>) list.get(0).getValue().getValue();
+        assertThat(result).extracting(AttributeValue::getValue).containsExactly("x", "y");
+    }
+
+    @Test
+    void truncateAttributeValues_keyValueList_recurses() {
+        AttributeValue kvList = AttributeValue.ofAttributeKeyValueList(
+                AttributeKeyValue.of("big", AttributeValue.of("a".repeat(100))),
+                AttributeKeyValue.of("small", AttributeValue.of("ok"))
+        );
+        TruncationCounter counter = new TruncationCounter();
+
+        List<AttributeBo> list = truncate(10, counter, kvList);
+
+        assertThat(counter.truncatedCount()).isEqualTo(1);
+        @SuppressWarnings("unchecked")
+        List<AttributeKeyValue> result = (List<AttributeKeyValue>) list.get(0).getValue().getValue();
+        assertThat(result.get(0).getKey()).isEqualTo("big");
+        assertThat(result.get(0).getValue().getValue()).isEqualTo("a".repeat(10));
+        assertThat(result.get(1).getValue().getValue()).isEqualTo("ok");
+    }
+
+    @Test
+    void truncateAttributeValues_nestedArrayInsideKeyValueList_recursesDeeply() {
+        AttributeValue kvList = AttributeValue.ofAttributeKeyValueList(
+                AttributeKeyValue.of("tags", AttributeValue.of(
+                        AttributeValue.of("a".repeat(100)),
+                        AttributeValue.of("b".repeat(100))))
+        );
+        TruncationCounter counter = new TruncationCounter();
+
+        List<AttributeBo> list = truncate(10, counter, kvList);
+
+        assertThat(counter.truncatedCount()).isEqualTo(2);
+        @SuppressWarnings("unchecked")
+        List<AttributeKeyValue> outer = (List<AttributeKeyValue>) list.get(0).getValue().getValue();
+        @SuppressWarnings("unchecked")
+        List<AttributeValue> inner = (List<AttributeValue>) outer.get(0).getValue().getValue();
+        assertThat(inner).extracting(AttributeValue::getValue)
+                .containsExactly("a".repeat(10), "b".repeat(10));
+    }
+
+    @Test
+    void truncateAttributeValues_multipleBos_sumsTruncations() {
+        TruncationCounter counter = new TruncationCounter();
+        Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+        attrs.put("a", AttributeValue.of("a".repeat(100)));
+        attrs.put("b", AttributeValue.of("ok"));
+        attrs.put("c", AttributeValue.of("c".repeat(100)));
+
+        List<AttributeBo> list = new OtlpAttributeBoMapper(10).toAttributeBoList(attrs, key -> false, counter);
+
+        assertThat(counter.truncatedCount()).isEqualTo(2);
+        assertThat(list.get(0).getValue().getValue()).isEqualTo("a".repeat(10));
+        assertThat(list.get(1).getValue().getValue()).isEqualTo("ok");
+        assertThat(list.get(2).getValue().getValue()).isEqualTo("c".repeat(10));
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapperTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,7 +35,7 @@ class OtlpAttributeBoMapperTest {
     void toAttributeBoList_emptyMap_returnsEmptyList() {
         OtlpAttributeBoMapper mapper = new OtlpAttributeBoMapper(NO_TRUNCATION_MAX_BYTES);
 
-        List<AttributeBo> result = mapper.toAttributeBoList(Map.of(), key -> false, new TruncationCounter());
+        List<AttributeBo> result = mapper.toAttributeBoList(Map.of(), key -> false, () -> {});
 
         assertThat(result).isEmpty();
     }
@@ -46,7 +47,7 @@ class OtlpAttributeBoMapperTest {
         attrs.put("k1", AttributeValue.of("v1"));
         attrs.put("k2", AttributeValue.of(42L));
 
-        List<AttributeBo> result = mapper.toAttributeBoList(attrs, key -> false, new TruncationCounter());
+        List<AttributeBo> result = mapper.toAttributeBoList(attrs, key -> false, () -> {});
 
         assertThat(result).hasSize(2);
         assertThat(result).extracting(AttributeBo::getKey).containsExactlyInAnyOrder("k1", "k2");
@@ -59,7 +60,7 @@ class OtlpAttributeBoMapperTest {
         attrs.put("keep", AttributeValue.of("ok"));
         attrs.put("drop", AttributeValue.of("bye"));
 
-        List<AttributeBo> result = mapper.toAttributeBoList(attrs, key -> key.equals("drop"), new TruncationCounter());
+        List<AttributeBo> result = mapper.toAttributeBoList(attrs, key -> key.equals("drop"), () -> {});
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getKey()).isEqualTo("keep");
@@ -70,39 +71,39 @@ class OtlpAttributeBoMapperTest {
     // single-pass truncation
     // =======================================================================
 
-    private static List<AttributeBo> truncate(int maxBytes, TruncationCounter counter, AttributeValue value) {
+    private static List<AttributeBo> truncate(int maxBytes, AtomicInteger counter, AttributeValue value) {
         final Map<String, AttributeValue> attrs = new LinkedHashMap<>();
         attrs.put("k", value);
-        return new OtlpAttributeBoMapper(maxBytes).toAttributeBoList(attrs, key -> false, counter);
+        return new OtlpAttributeBoMapper(maxBytes).toAttributeBoList(attrs, key -> false, counter::incrementAndGet);
     }
 
     @Test
     void truncateAttributeValues_emptyMap_returnsZero() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
-        List<AttributeBo> result = new OtlpAttributeBoMapper(8).toAttributeBoList(Map.of(), key -> false, counter);
+        List<AttributeBo> result = new OtlpAttributeBoMapper(8).toAttributeBoList(Map.of(), key -> false, counter::incrementAndGet);
 
         assertThat(result).isEmpty();
-        assertThat(counter.truncatedCount()).isZero();
+        assertThat(counter.get()).isZero();
     }
 
     @Test
     void truncateAttributeValues_shortString_unchanged() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         List<AttributeBo> list = truncate(64, counter, AttributeValue.of("ok"));
 
-        assertThat(counter.truncatedCount()).isZero();
+        assertThat(counter.get()).isZero();
         assertThat(list.get(0).getValue().getValue()).isEqualTo("ok");
     }
 
     @Test
     void truncateAttributeValues_overLongString_truncatedAndCounted() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         List<AttributeBo> list = truncate(10, counter, AttributeValue.of("a".repeat(100)));
 
-        assertThat(counter.truncatedCount()).isEqualTo(1);
+        assertThat(counter.get()).isEqualTo(1);
         AttributeValue value = list.get(0).getValue();
         assertThat(value.getType()).isEqualTo(AttributeValueType.STRING);
         assertThat((String) value.getValue()).isEqualTo("a".repeat(10));
@@ -110,16 +111,16 @@ class OtlpAttributeBoMapperTest {
 
     @Test
     void truncateAttributeValues_numericAndBoolean_neverTruncated() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
         Map<String, AttributeValue> attrs = new LinkedHashMap<>();
         attrs.put("i", AttributeValue.of(1234567890L));
         attrs.put("d", AttributeValue.of(3.14159d));
         attrs.put("b", AttributeValue.of(true));
 
         // maxBytes=1: would truncate any string, but numbers/booleans are exempt per OTel spec
-        List<AttributeBo> list = new OtlpAttributeBoMapper(1).toAttributeBoList(attrs, key -> false, counter);
+        List<AttributeBo> list = new OtlpAttributeBoMapper(1).toAttributeBoList(attrs, key -> false, counter::incrementAndGet);
 
-        assertThat(counter.truncatedCount()).isZero();
+        assertThat(counter.get()).isZero();
         assertThat(list.get(0).getValue().getValue()).isEqualTo(1234567890L);
         assertThat(list.get(1).getValue().getValue()).isEqualTo(3.14159d);
         assertThat(list.get(2).getValue().getValue()).isEqualTo(true);
@@ -131,11 +132,11 @@ class OtlpAttributeBoMapperTest {
         for (int i = 0; i < payload.length; i++) {
             payload[i] = (byte) i;
         }
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         List<AttributeBo> list = truncate(16, counter, AttributeValue.of(payload));
 
-        assertThat(counter.truncatedCount()).isEqualTo(1);
+        assertThat(counter.get()).isEqualTo(1);
         AttributeValue value = list.get(0).getValue();
         assertThat(value.getType()).isEqualTo(AttributeValueType.BYTES);
         assertThat((byte[]) value.getValue()).hasSize(16)
@@ -145,11 +146,11 @@ class OtlpAttributeBoMapperTest {
     @Test
     void truncateAttributeValues_bytesWithinLimit_unchanged() {
         byte[] payload = new byte[]{1, 2, 3};
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         List<AttributeBo> list = truncate(16, counter, AttributeValue.of(payload));
 
-        assertThat(counter.truncatedCount()).isZero();
+        assertThat(counter.get()).isZero();
         assertThat((byte[]) list.get(0).getValue().getValue()).containsExactly(1, 2, 3);
     }
 
@@ -160,12 +161,12 @@ class OtlpAttributeBoMapperTest {
                 AttributeValue.of("short"),
                 AttributeValue.of("b".repeat(100))
         );
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         List<AttributeBo> list = truncate(10, counter, array);
 
         // two over-long leaves truncated, the "short" one untouched
-        assertThat(counter.truncatedCount()).isEqualTo(2);
+        assertThat(counter.get()).isEqualTo(2);
         @SuppressWarnings("unchecked")
         List<AttributeValue> result = (List<AttributeValue>) list.get(0).getValue().getValue();
         assertThat(result).extracting(AttributeValue::getValue)
@@ -175,11 +176,11 @@ class OtlpAttributeBoMapperTest {
     @Test
     void truncateAttributeValues_array_noOverLongLeaf_unchanged() {
         AttributeValue array = AttributeValue.of(AttributeValue.of("x"), AttributeValue.of("y"));
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         List<AttributeBo> list = truncate(10, counter, array);
 
-        assertThat(counter.truncatedCount()).isZero();
+        assertThat(counter.get()).isZero();
         @SuppressWarnings("unchecked")
         List<AttributeValue> result = (List<AttributeValue>) list.get(0).getValue().getValue();
         assertThat(result).extracting(AttributeValue::getValue).containsExactly("x", "y");
@@ -191,11 +192,11 @@ class OtlpAttributeBoMapperTest {
                 AttributeKeyValue.of("big", AttributeValue.of("a".repeat(100))),
                 AttributeKeyValue.of("small", AttributeValue.of("ok"))
         );
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         List<AttributeBo> list = truncate(10, counter, kvList);
 
-        assertThat(counter.truncatedCount()).isEqualTo(1);
+        assertThat(counter.get()).isEqualTo(1);
         @SuppressWarnings("unchecked")
         List<AttributeKeyValue> result = (List<AttributeKeyValue>) list.get(0).getValue().getValue();
         assertThat(result.get(0).getKey()).isEqualTo("big");
@@ -210,11 +211,11 @@ class OtlpAttributeBoMapperTest {
                         AttributeValue.of("a".repeat(100)),
                         AttributeValue.of("b".repeat(100))))
         );
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         List<AttributeBo> list = truncate(10, counter, kvList);
 
-        assertThat(counter.truncatedCount()).isEqualTo(2);
+        assertThat(counter.get()).isEqualTo(2);
         @SuppressWarnings("unchecked")
         List<AttributeKeyValue> outer = (List<AttributeKeyValue>) list.get(0).getValue().getValue();
         @SuppressWarnings("unchecked")
@@ -225,15 +226,15 @@ class OtlpAttributeBoMapperTest {
 
     @Test
     void truncateAttributeValues_multipleBos_sumsTruncations() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
         Map<String, AttributeValue> attrs = new LinkedHashMap<>();
         attrs.put("a", AttributeValue.of("a".repeat(100)));
         attrs.put("b", AttributeValue.of("ok"));
         attrs.put("c", AttributeValue.of("c".repeat(100)));
 
-        List<AttributeBo> list = new OtlpAttributeBoMapper(10).toAttributeBoList(attrs, key -> false, counter);
+        List<AttributeBo> list = new OtlpAttributeBoMapper(10).toAttributeBoList(attrs, key -> false, counter::incrementAndGet);
 
-        assertThat(counter.truncatedCount()).isEqualTo(2);
+        assertThat(counter.get()).isEqualTo(2);
         assertThat(list.get(0).getValue().getValue()).isEqualTo("a".repeat(10));
         assertThat(list.get(1).getValue().getValue()).isEqualTo("ok");
         assertThat(list.get(2).getValue().getValue()).isEqualTo("c".repeat(10));

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapperTest.java
@@ -46,7 +46,7 @@ class OtlpTraceEventMapperTest {
                 .setTimeUnixNano(1716200000000000000L)
                 .build();
 
-        mapper.addEventToAnnotation(event, writer);
+        mapper.addEventToAnnotation(event, writer, () -> {});
 
         assertThat(annotations).hasSize(1);
         AnnotationBo bo = annotations.get(0);
@@ -77,7 +77,7 @@ class OtlpTraceEventMapperTest {
                 .addAllAttributes(attrs)
                 .build();
 
-        mapper.addEventToAnnotation(event, writer);
+        mapper.addEventToAnnotation(event, writer, () -> {});
 
         assertThat(annotations).hasSize(1);
         ObjectMapper om = new ObjectMapper();
@@ -107,7 +107,7 @@ class OtlpTraceEventMapperTest {
                 .addAllAttributes(attrs)
                 .build();
 
-        mapper.addEventToAnnotation(event, writer);
+        mapper.addEventToAnnotation(event, writer, () -> {});
 
         assertThat(annotations).hasSize(1);
         String json = (String) annotations.get(0).getValue();
@@ -142,7 +142,7 @@ class OtlpTraceEventMapperTest {
                 .addAttributes(kv("tags", AnyValue.newBuilder().setArrayValue(arrayValue).build()))
                 .build();
 
-        mapper.addEventToAnnotation(event, writer);
+        mapper.addEventToAnnotation(event, writer, () -> {});
 
         assertThat(annotations).hasSize(1);
         String json = (String) annotations.get(0).getValue();
@@ -167,7 +167,7 @@ class OtlpTraceEventMapperTest {
     void annotationKey_isOpentelemetryEvent() {
         Span.Event event = Span.Event.newBuilder().setName("check").build();
 
-        mapper.addEventToAnnotation(event, writer);
+        mapper.addEventToAnnotation(event, writer, () -> {});
 
         assertThat(annotations.get(0).getKey())
                 .isEqualTo(AnnotationKey.OPENTELEMETRY_EVENT.getCode());

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapperTest.java
@@ -42,7 +42,7 @@ class OtlpTraceLinkMapperTest {
                 .setSpanId(ByteString.copyFrom(SPAN_ID))
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer);
+        mapper.addLinkToAnnotation(link, writer, () -> {});
 
         assertThat(annotations).hasSize(1);
         AnnotationBo bo = annotations.get(0);
@@ -66,7 +66,7 @@ class OtlpTraceLinkMapperTest {
                 .setTraceState("aws=t61rcWkgMzE,dd=s:1;o:rum")
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer);
+        mapper.addLinkToAnnotation(link, writer, () -> {});
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")
@@ -81,7 +81,7 @@ class OtlpTraceLinkMapperTest {
                 .setSpanId(ByteString.copyFrom(SPAN_ID))
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer);
+        mapper.addLinkToAnnotation(link, writer, () -> {});
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")
@@ -97,7 +97,7 @@ class OtlpTraceLinkMapperTest {
                 .addAttributes(kv("link.kind", strVal("follows_from")))
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer);
+        mapper.addLinkToAnnotation(link, writer, () -> {});
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")
@@ -115,7 +115,7 @@ class OtlpTraceLinkMapperTest {
                 .setDroppedAttributesCount(5)
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer);
+        mapper.addLinkToAnnotation(link, writer, () -> {});
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")
@@ -130,7 +130,7 @@ class OtlpTraceLinkMapperTest {
                 .setSpanId(ByteString.copyFrom(SPAN_ID))
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer);
+        mapper.addLinkToAnnotation(link, writer, () -> {});
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")
@@ -143,7 +143,7 @@ class OtlpTraceLinkMapperTest {
         // Both traceId and spanId empty — OTel spec violation, skip silently.
         Span.Link link = Span.Link.newBuilder().build();
 
-        mapper.addLinkToAnnotation(link, writer);
+        mapper.addLinkToAnnotation(link, writer, () -> {});
 
         assertThat(annotations).isEmpty();
     }
@@ -156,7 +156,7 @@ class OtlpTraceLinkMapperTest {
                 .addAttributes(kv("orphan", strVal("yes")))
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer);
+        mapper.addLinkToAnnotation(link, writer, () -> {});
 
         assertThat(annotations).isEmpty();
     }
@@ -171,7 +171,7 @@ class OtlpTraceLinkMapperTest {
                 .setDroppedAttributesCount(2)
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer);
+        mapper.addLinkToAnnotation(link, writer, () -> {});
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -94,14 +94,14 @@ class OtlpTraceMapperTest {
                         new PulsarMessagingConsumerHandler(),
                         new RocketMQMessagingConsumerHandler(),
                         new ActiveMQMessagingConsumerHandler()), messagingTypeResolver),
-                8192);
+                new OtlpAttributeBoMapper(8192));
         OtlpTraceSpanEventMapper spanEventMapper = new OtlpTraceSpanEventMapper(
                 eventMapper,
                 REGISTRY,
                 new OtlpMessagingTypeResolver(REGISTRY),
                 new OtlpClientTypeResolver(REGISTRY),
                 exceptionInfoResolver,
-                8192,
+                new OtlpAttributeBoMapper(8192),
                 8192);
         OtlpTraceSpanChunkMapper spanChunkMapper = new OtlpTraceSpanChunkMapper(spanEventMapper);
         return new OtlpTraceMapper(spanMapper, spanEventMapper, spanChunkMapper,

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -14,6 +14,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.arrayVal;
 import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.boolVal;
@@ -917,35 +918,35 @@ class OtlpTraceMapperUtilsTest {
     }
 
     // =======================================================================
-    // getAttributeToMap(List<KeyValue>, int, TruncationCounter) — single-pass truncation
+    // getAttributeToMap(List<KeyValue>, int, TruncationListener) — single-pass truncation
     // =======================================================================
 
     @SuppressWarnings("unchecked")
     @Test
     void truncatingTransform_overLongString_truncatedAndCounted() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("big", strVal("a".repeat(100))),
                 kv("small", strVal("ok"))
-        ), 10, counter);
+        ), 10, counter::incrementAndGet);
 
-        assertThat(counter.truncatedCount()).isEqualTo(1);
+        assertThat(counter.get()).isEqualTo(1);
         assertThat(map).containsEntry("big", "a".repeat(10));
         assertThat(map).containsEntry("small", "ok");
     }
 
     @Test
     void truncatingTransform_nonStringValues_untouched() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("i", intVal(1234567890L)),
                 kv("b", boolVal(true)),
                 kv("d", doubleVal(3.14d))
-        ), 1, counter);
+        ), 1, counter::incrementAndGet);
 
-        assertThat(counter.truncatedCount()).isZero();
+        assertThat(counter.get()).isZero();
         assertThat(map).containsEntry("i", 1234567890L);
         assertThat(map).containsEntry("b", true);
         assertThat(map).containsEntry("d", 3.14d);
@@ -954,65 +955,65 @@ class OtlpTraceMapperUtilsTest {
     @SuppressWarnings("unchecked")
     @Test
     void truncatingTransform_nestedMapAndList_recurses() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("map", kvlistVal(kv("inner", strVal("a".repeat(100))))),
                 kv("list", arrayVal(strVal("b".repeat(100)), strVal("ok")))
-        ), 10, counter);
+        ), 10, counter::incrementAndGet);
 
-        assertThat(counter.truncatedCount()).isEqualTo(2);
+        assertThat(counter.get()).isEqualTo(2);
         assertThat((Map<String, Object>) map.get("map")).containsEntry("inner", "a".repeat(10));
         assertThat((List<Object>) map.get("list")).containsExactly("b".repeat(10), "ok");
     }
 
     @Test
     void truncatingTransform_withinLimit_countsZero() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("k", strVal("short"))
-        ), 64, counter);
+        ), 64, counter::incrementAndGet);
 
-        assertThat(counter.truncatedCount()).isZero();
+        assertThat(counter.get()).isZero();
         assertThat(map).containsEntry("k", "short");
     }
 
     @SuppressWarnings("unchecked")
     @Test
     void truncatingTransform_arrayOverLongStrings_truncatedInPlace() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("list", arrayVal(strVal("a".repeat(100)), strVal("ok"), strVal("b".repeat(100))))
-        ), 10, counter);
+        ), 10, counter::incrementAndGet);
 
-        assertThat(counter.truncatedCount()).isEqualTo(2);
+        assertThat(counter.get()).isEqualTo(2);
         assertThat((List<Object>) map.get("list")).containsExactly("a".repeat(10), "ok", "b".repeat(10));
     }
 
     @Test
     void truncatingTransform_bytesWithinLimit_notTruncated() {
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("bin", bytesVal(new byte[]{0x0a, (byte) 0xbc})) // 2 bytes -> 4 hex chars
-        ), 64, counter);
+        ), 64, counter::incrementAndGet);
 
-        assertThat(counter.truncatedCount()).isZero();
+        assertThat(counter.get()).isZero();
         assertThat((String) map.get("bin")).hasSize(4);
     }
 
     @Test
     void truncatingTransform_bytesHexString_truncated() {
         // BYTES values are rendered as a hex string and subject to the same cap.
-        TruncationCounter counter = new TruncationCounter();
+        AtomicInteger counter = new AtomicInteger();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("bin", bytesVal(new byte[16])) // 16 bytes -> 32 hex chars, exceeds 10
-        ), 10, counter);
+        ), 10, counter::incrementAndGet);
 
-        assertThat(counter.truncatedCount()).isEqualTo(1);
+        assertThat(counter.get()).isEqualTo(1);
         assertThat((String) map.get("bin")).hasSize(10);
     }
 

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -1,7 +1,6 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.google.protobuf.ByteString;
-import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
@@ -12,8 +11,6 @@ import io.opentelemetry.proto.common.v1.KeyValue;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -920,245 +917,35 @@ class OtlpTraceMapperUtilsTest {
     }
 
     // =======================================================================
-    // toAttributeBoList(Map<String, AttributeValue>, Predicate)
-    // =======================================================================
-
-    @Test
-    void toAttributeBoList_emptyMap_returnsEmptyList() {
-        List<AttributeBo> result = OtlpTraceMapperUtils.toAttributeBoList(Map.of(), key -> false);
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    void toAttributeBoList_noFilter_returnsAllEntries() {
-        Map<String, AttributeValue> attrs = new HashMap<>();
-        attrs.put("k1", AttributeValue.of("v1"));
-        attrs.put("k2", AttributeValue.of(42L));
-
-        List<AttributeBo> result = OtlpTraceMapperUtils.toAttributeBoList(attrs, key -> false);
-
-        assertThat(result).hasSize(2);
-        assertThat(result).extracting(AttributeBo::getKey).containsExactlyInAnyOrder("k1", "k2");
-    }
-
-    @Test
-    void toAttributeBoList_excludeFilter_removesKeys() {
-        Map<String, AttributeValue> attrs = new HashMap<>();
-        attrs.put("keep", AttributeValue.of("ok"));
-        attrs.put("drop", AttributeValue.of("bye"));
-
-        List<AttributeBo> result = OtlpTraceMapperUtils.toAttributeBoList(
-                attrs, key -> key.equals("drop"));
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getKey()).isEqualTo("keep");
-        assertThat(result.get(0).getValue().getValue()).isEqualTo("ok");
-    }
-
-    // =======================================================================
-    // toAttributeBoList(Map, Predicate, TransformContext) — single-pass truncation
-    // =======================================================================
-
-    private static List<AttributeBo> truncate(TransformContext context, AttributeValue value) {
-        final Map<String, AttributeValue> attrs = new LinkedHashMap<>();
-        attrs.put("k", value);
-        return OtlpTraceMapperUtils.toAttributeBoList(attrs, key -> false, context);
-    }
-
-    @Test
-    void truncateAttributeValues_emptyMap_returnsZero() {
-        TransformContext context = new TransformContext(8);
-
-        List<AttributeBo> result = OtlpTraceMapperUtils.toAttributeBoList(Map.of(), key -> false, context);
-
-        assertThat(result).isEmpty();
-        assertThat(context.truncatedCount()).isZero();
-    }
-
-    @Test
-    void truncateAttributeValues_shortString_unchanged() {
-        TransformContext context = new TransformContext(64);
-
-        List<AttributeBo> list = truncate(context, AttributeValue.of("ok"));
-
-        assertThat(context.truncatedCount()).isZero();
-        assertThat(list.get(0).getValue().getValue()).isEqualTo("ok");
-    }
-
-    @Test
-    void truncateAttributeValues_overLongString_truncatedAndCounted() {
-        TransformContext context = new TransformContext(10);
-
-        List<AttributeBo> list = truncate(context, AttributeValue.of("a".repeat(100)));
-
-        assertThat(context.truncatedCount()).isEqualTo(1);
-        AttributeValue value = list.get(0).getValue();
-        assertThat(value.getType()).isEqualTo(AttributeValueType.STRING);
-        assertThat((String) value.getValue()).isEqualTo("a".repeat(10));
-    }
-
-    @Test
-    void truncateAttributeValues_numericAndBoolean_neverTruncated() {
-        TransformContext context = new TransformContext(1);
-        Map<String, AttributeValue> attrs = new LinkedHashMap<>();
-        attrs.put("i", AttributeValue.of(1234567890L));
-        attrs.put("d", AttributeValue.of(3.14159d));
-        attrs.put("b", AttributeValue.of(true));
-
-        // maxBytes=1: would truncate any string, but numbers/booleans are exempt per OTel spec
-        List<AttributeBo> list = OtlpTraceMapperUtils.toAttributeBoList(attrs, key -> false, context);
-
-        assertThat(context.truncatedCount()).isZero();
-        assertThat(list.get(0).getValue().getValue()).isEqualTo(1234567890L);
-        assertThat(list.get(1).getValue().getValue()).isEqualTo(3.14159d);
-        assertThat(list.get(2).getValue().getValue()).isEqualTo(true);
-    }
-
-    @Test
-    void truncateAttributeValues_overLongBytes_truncatedToMaxBytes() {
-        byte[] payload = new byte[100];
-        for (int i = 0; i < payload.length; i++) {
-            payload[i] = (byte) i;
-        }
-        TransformContext context = new TransformContext(16);
-
-        List<AttributeBo> list = truncate(context, AttributeValue.of(payload));
-
-        assertThat(context.truncatedCount()).isEqualTo(1);
-        AttributeValue value = list.get(0).getValue();
-        assertThat(value.getType()).isEqualTo(AttributeValueType.BYTES);
-        assertThat((byte[]) value.getValue()).hasSize(16)
-                .containsExactly(java.util.Arrays.copyOf(payload, 16));
-    }
-
-    @Test
-    void truncateAttributeValues_bytesWithinLimit_unchanged() {
-        byte[] payload = new byte[]{1, 2, 3};
-        TransformContext context = new TransformContext(16);
-
-        List<AttributeBo> list = truncate(context, AttributeValue.of(payload));
-
-        assertThat(context.truncatedCount()).isZero();
-        assertThat((byte[]) list.get(0).getValue().getValue()).containsExactly(1, 2, 3);
-    }
-
-    @Test
-    void truncateAttributeValues_array_recursesAndCountsEachLeaf() {
-        AttributeValue array = AttributeValue.of(
-                AttributeValue.of("a".repeat(100)),
-                AttributeValue.of("short"),
-                AttributeValue.of("b".repeat(100))
-        );
-        TransformContext context = new TransformContext(10);
-
-        List<AttributeBo> list = truncate(context, array);
-
-        // two over-long leaves truncated, the "short" one untouched
-        assertThat(context.truncatedCount()).isEqualTo(2);
-        @SuppressWarnings("unchecked")
-        List<AttributeValue> result = (List<AttributeValue>) list.get(0).getValue().getValue();
-        assertThat(result).extracting(AttributeValue::getValue)
-                .containsExactly("a".repeat(10), "short", "b".repeat(10));
-    }
-
-    @Test
-    void truncateAttributeValues_array_noOverLongLeaf_unchanged() {
-        AttributeValue array = AttributeValue.of(AttributeValue.of("x"), AttributeValue.of("y"));
-        TransformContext context = new TransformContext(10);
-
-        List<AttributeBo> list = truncate(context, array);
-
-        assertThat(context.truncatedCount()).isZero();
-        @SuppressWarnings("unchecked")
-        List<AttributeValue> result = (List<AttributeValue>) list.get(0).getValue().getValue();
-        assertThat(result).extracting(AttributeValue::getValue).containsExactly("x", "y");
-    }
-
-    @Test
-    void truncateAttributeValues_keyValueList_recurses() {
-        AttributeValue kvList = AttributeValue.ofAttributeKeyValueList(
-                AttributeKeyValue.of("big", AttributeValue.of("a".repeat(100))),
-                AttributeKeyValue.of("small", AttributeValue.of("ok"))
-        );
-        TransformContext context = new TransformContext(10);
-
-        List<AttributeBo> list = truncate(context, kvList);
-
-        assertThat(context.truncatedCount()).isEqualTo(1);
-        @SuppressWarnings("unchecked")
-        List<AttributeKeyValue> result = (List<AttributeKeyValue>) list.get(0).getValue().getValue();
-        assertThat(result.get(0).getKey()).isEqualTo("big");
-        assertThat(result.get(0).getValue().getValue()).isEqualTo("a".repeat(10));
-        assertThat(result.get(1).getValue().getValue()).isEqualTo("ok");
-    }
-
-    @Test
-    void truncateAttributeValues_nestedArrayInsideKeyValueList_recursesDeeply() {
-        AttributeValue kvList = AttributeValue.ofAttributeKeyValueList(
-                AttributeKeyValue.of("tags", AttributeValue.of(
-                        AttributeValue.of("a".repeat(100)),
-                        AttributeValue.of("b".repeat(100))))
-        );
-        TransformContext context = new TransformContext(10);
-
-        List<AttributeBo> list = truncate(context, kvList);
-
-        assertThat(context.truncatedCount()).isEqualTo(2);
-        @SuppressWarnings("unchecked")
-        List<AttributeKeyValue> outer = (List<AttributeKeyValue>) list.get(0).getValue().getValue();
-        @SuppressWarnings("unchecked")
-        List<AttributeValue> inner = (List<AttributeValue>) outer.get(0).getValue().getValue();
-        assertThat(inner).extracting(AttributeValue::getValue)
-                .containsExactly("a".repeat(10), "b".repeat(10));
-    }
-
-    @Test
-    void truncateAttributeValues_multipleBos_sumsTruncations() {
-        TransformContext context = new TransformContext(10);
-        Map<String, AttributeValue> attrs = new LinkedHashMap<>();
-        attrs.put("a", AttributeValue.of("a".repeat(100)));
-        attrs.put("b", AttributeValue.of("ok"));
-        attrs.put("c", AttributeValue.of("c".repeat(100)));
-
-        List<AttributeBo> list = OtlpTraceMapperUtils.toAttributeBoList(attrs, key -> false, context);
-
-        assertThat(context.truncatedCount()).isEqualTo(2);
-        assertThat(list.get(0).getValue().getValue()).isEqualTo("a".repeat(10));
-        assertThat(list.get(1).getValue().getValue()).isEqualTo("ok");
-        assertThat(list.get(2).getValue().getValue()).isEqualTo("c".repeat(10));
-    }
-
-    // =======================================================================
-    // getAttributeToMap(List<KeyValue>, TransformContext) — single-pass truncation
+    // getAttributeToMap(List<KeyValue>, int, TruncationCounter) — single-pass truncation
     // =======================================================================
 
     @SuppressWarnings("unchecked")
     @Test
     void truncatingTransform_overLongString_truncatedAndCounted() {
-        TransformContext context = new TransformContext(10);
+        TruncationCounter counter = new TruncationCounter();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("big", strVal("a".repeat(100))),
                 kv("small", strVal("ok"))
-        ), context);
+        ), 10, counter);
 
-        assertThat(context.truncatedCount()).isEqualTo(1);
+        assertThat(counter.truncatedCount()).isEqualTo(1);
         assertThat(map).containsEntry("big", "a".repeat(10));
         assertThat(map).containsEntry("small", "ok");
     }
 
     @Test
     void truncatingTransform_nonStringValues_untouched() {
-        TransformContext context = new TransformContext(1);
+        TruncationCounter counter = new TruncationCounter();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("i", intVal(1234567890L)),
                 kv("b", boolVal(true)),
                 kv("d", doubleVal(3.14d))
-        ), context);
+        ), 1, counter);
 
-        assertThat(context.truncatedCount()).isZero();
+        assertThat(counter.truncatedCount()).isZero();
         assertThat(map).containsEntry("i", 1234567890L);
         assertThat(map).containsEntry("b", true);
         assertThat(map).containsEntry("d", 3.14d);
@@ -1167,65 +954,65 @@ class OtlpTraceMapperUtilsTest {
     @SuppressWarnings("unchecked")
     @Test
     void truncatingTransform_nestedMapAndList_recurses() {
-        TransformContext context = new TransformContext(10);
+        TruncationCounter counter = new TruncationCounter();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("map", kvlistVal(kv("inner", strVal("a".repeat(100))))),
                 kv("list", arrayVal(strVal("b".repeat(100)), strVal("ok")))
-        ), context);
+        ), 10, counter);
 
-        assertThat(context.truncatedCount()).isEqualTo(2);
+        assertThat(counter.truncatedCount()).isEqualTo(2);
         assertThat((Map<String, Object>) map.get("map")).containsEntry("inner", "a".repeat(10));
         assertThat((List<Object>) map.get("list")).containsExactly("b".repeat(10), "ok");
     }
 
     @Test
     void truncatingTransform_withinLimit_countsZero() {
-        TransformContext context = new TransformContext(64);
+        TruncationCounter counter = new TruncationCounter();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("k", strVal("short"))
-        ), context);
+        ), 64, counter);
 
-        assertThat(context.truncatedCount()).isZero();
+        assertThat(counter.truncatedCount()).isZero();
         assertThat(map).containsEntry("k", "short");
     }
 
     @SuppressWarnings("unchecked")
     @Test
     void truncatingTransform_arrayOverLongStrings_truncatedInPlace() {
-        TransformContext context = new TransformContext(10);
+        TruncationCounter counter = new TruncationCounter();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("list", arrayVal(strVal("a".repeat(100)), strVal("ok"), strVal("b".repeat(100))))
-        ), context);
+        ), 10, counter);
 
-        assertThat(context.truncatedCount()).isEqualTo(2);
+        assertThat(counter.truncatedCount()).isEqualTo(2);
         assertThat((List<Object>) map.get("list")).containsExactly("a".repeat(10), "ok", "b".repeat(10));
     }
 
     @Test
     void truncatingTransform_bytesWithinLimit_notTruncated() {
-        TransformContext context = new TransformContext(64);
+        TruncationCounter counter = new TruncationCounter();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("bin", bytesVal(new byte[]{0x0a, (byte) 0xbc})) // 2 bytes -> 4 hex chars
-        ), context);
+        ), 64, counter);
 
-        assertThat(context.truncatedCount()).isZero();
+        assertThat(counter.truncatedCount()).isZero();
         assertThat((String) map.get("bin")).hasSize(4);
     }
 
     @Test
     void truncatingTransform_bytesHexString_truncated() {
         // BYTES values are rendered as a hex string and subject to the same cap.
-        TransformContext context = new TransformContext(10);
+        TruncationCounter counter = new TruncationCounter();
 
         Map<String, Object> map = OtlpTraceMapperUtils.getAttributeToMap(List.of(
                 kv("bin", bytesVal(new byte[16])) // 16 bytes -> 32 hex chars, exceeds 10
-        ), context);
+        ), 10, counter);
 
-        assertThat(context.truncatedCount()).isEqualTo(1);
+        assertThat(counter.truncatedCount()).isEqualTo(1);
         assertThat((String) map.get("bin")).hasSize(10);
     }
 

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -65,7 +65,7 @@ class OtlpTraceSpanEventMapperTest {
                 new OtlpMessagingTypeResolver(TEST_REGISTRY),
                 new OtlpClientTypeResolver(TEST_REGISTRY),
                 new OtlpExceptionInfoResolver(),
-                8192,
+                new OtlpAttributeBoMapper(8192),
                 8192);
     }
 

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -197,7 +197,7 @@ class OtlpTraceSpanMapperTest {
                         new PulsarMessagingConsumerHandler(),
                         new RocketMQMessagingConsumerHandler(),
                         new ActiveMQMessagingConsumerHandler()), messagingTypeResolver),
-                8192);
+                new OtlpAttributeBoMapper(8192));
     }
 
     private static IdAndName id() {


### PR DESCRIPTION
This pull request refactors and improves how attribute value truncation is handled in OTLP trace mappers, making truncation listener-based and more consistent across event and link attributes. It also adds input validation for maximum byte values and introduces a new `OtlpAttributeBoMapper` component for attribute mapping and truncation. The most important changes are grouped below.

### Attribute Truncation Refactoring

* Refactored attribute truncation logic in `OtlpTraceEventMapper` and `OtlpTraceLinkMapper` to use a `TruncationListener` callback instead of returning a count, and updated method signatures and logic accordingly. This ensures a listener is notified for each truncated attribute, improving traceability and consistency. [[1]](diffhunk://#diff-3ab15f154577f362e1dadd3ec5dda4000f23e367a721a75e6109c1e6beb2a4d3R34-R36) [[2]](diffhunk://#diff-3ab15f154577f362e1dadd3ec5dda4000f23e367a721a75e6109c1e6beb2a4d3L42-R60) [[3]](diffhunk://#diff-3ab15f154577f362e1dadd3ec5dda4000f23e367a721a75e6109c1e6beb2a4d3L68) [[4]](diffhunk://#diff-f20b0368bc14cf2f8b25671ed4ee5b505bb1485e4d3c13c38f144ce38dece9e5R32-R34) [[5]](diffhunk://#diff-f20b0368bc14cf2f8b25671ed4ee5b505bb1485e4d3c13c38f144ce38dece9e5R46-L48) [[6]](diffhunk://#diff-f20b0368bc14cf2f8b25671ed4ee5b505bb1485e4d3c13c38f144ce38dece9e5L68-R77) [[7]](diffhunk://#diff-f20b0368bc14cf2f8b25671ed4ee5b505bb1485e4d3c13c38f144ce38dece9e5L88)

* Updated `OtlpTraceMapperUtils` utility methods to remove `TransformContext` in favor of direct `maxBytes` and `TruncationListener` parameters, and refactored all relevant attribute, array, and value transformation methods to use this new approach. [[1]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L227-R241) [[2]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L266-R266) [[3]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L278-R317)

### Input Validation

* Added validation to ensure the configured maximum byte values for attribute, event, and link values are non-negative, throwing an `IllegalArgumentException` if violated. [[1]](diffhunk://#diff-3ab15f154577f362e1dadd3ec5dda4000f23e367a721a75e6109c1e6beb2a4d3R34-R36) [[2]](diffhunk://#diff-f20b0368bc14cf2f8b25671ed4ee5b505bb1485e4d3c13c38f144ce38dece9e5R32-R34)

### Attribute Mapping Component

* Introduced a new `OtlpAttributeBoMapper` Spring component for mapping and truncating attributes to `AttributeBo` objects, supporting exclusion filters and recursive truncation, with listener notification on truncation.

### Code Cleanup

* Removed unused imports and code related to the old truncation context in `OtlpTraceMapperUtils`. [[1]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L22) [[2]](diffhunk://#diff-f3c0b605f40262541003668a21e6d5320071d7645673edf4cb2ea4e81b3c27b1L34-L42)

These changes collectively improve maintainability, configurability, and observability of attribute truncation in OTLP trace ingestion.