### PR TITLE
[#noissue] Stream tag list JSON directly with Jackson core in TagList…

### DIFF
--- a/metric-module/metric-commons/pom.xml
+++ b/metric-module/metric-commons/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>mybatis</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/mybatis/typehandler/TagListSerializer.java
+++ b/metric-module/metric-commons/src/main/java/com/navercorp/pinpoint/metric/common/mybatis/typehandler/TagListSerializer.java
@@ -16,16 +16,20 @@
 
 package com.navercorp.pinpoint.metric.common.mybatis.typehandler;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.navercorp.pinpoint.common.server.util.json.JsonRuntimeException;
 import com.navercorp.pinpoint.metric.common.model.Tag;
-import com.navercorp.pinpoint.metric.common.model.Tags;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,30 +40,47 @@ public class TagListSerializer {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
-    private final ObjectWriter writer;
-    private final ObjectReader reader;
+    private final JsonFactory jsonFactory;
 
     public TagListSerializer(ObjectMapper mapper) {
         Objects.requireNonNull(mapper, "mapper");
-        this.writer = mapper.writerFor(Tags.class);
-        this.reader = mapper.readerFor(Tags.class);
+        this.jsonFactory = mapper.getFactory();
     }
 
     public String serialize(List<Tag> tagList) {
         try {
-            Tags tags = new Tags(tagList);
-            return writer.writeValueAsString(tags);
-        } catch (JsonProcessingException e) {
+            final StringBuilderWriter buffer = new StringBuilderWriter();
+            try (JsonGenerator generator = jsonFactory.createGenerator(buffer)) {
+                generator.writeStartObject();
+                for (Tag tag : tagList) {
+                    generator.writeStringField(tag.getName(), tag.getValue());
+                }
+                generator.writeEndObject();
+            }
+            return buffer.toString();
+        } catch (IOException e) {
             logger.error("Error serializing List<Tag> : {}", tagList, e);
             throw new JsonRuntimeException("Error serializing tagList", e);
         }
     }
 
     public List<Tag> deserialize(String tagListJson) {
-        try {
-            Tags tags = reader.readValue(tagListJson);
-            return tags.getTags();
-        } catch (JsonProcessingException e) {
+        try (JsonParser parser = jsonFactory.createParser(tagListJson)) {
+            if (parser.nextToken() != JsonToken.START_OBJECT) {
+                throw new JsonParseException(parser, "expected JSON object");
+            }
+            final List<Tag> tagList = new ArrayList<>();
+            while (parser.nextToken() == JsonToken.FIELD_NAME) {
+                final String name = parser.currentName();
+                final JsonToken valueToken = parser.nextToken();
+                // VALUE_NULL is also rejected — Tag does not allow a null value
+                if (valueToken == null || valueToken == JsonToken.VALUE_NULL || !valueToken.isScalarValue()) {
+                    throw new JsonParseException(parser, "expected non-null scalar tag value");
+                }
+                tagList.add(new Tag(name, parser.getValueAsString()));
+            }
+            return tagList;
+        } catch (IOException e) {
             logger.error("Error deserializing tagList json : {}", tagListJson, e);
             throw new JsonRuntimeException("Error deserializing tagListJson", e);
         }

--- a/metric-module/metric-commons/src/test/java/com/navercorp/pinpoint/metric/common/mybatis/typehandler/TagListSerializerTest.java
+++ b/metric-module/metric-commons/src/test/java/com/navercorp/pinpoint/metric/common/mybatis/typehandler/TagListSerializerTest.java
@@ -1,6 +1,7 @@
 package com.navercorp.pinpoint.metric.common.mybatis.typehandler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.common.server.util.json.JsonRuntimeException;
 import com.navercorp.pinpoint.metric.common.model.Tag;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -20,10 +21,24 @@ class TagListSerializerTest {
         List<Tag> tagList = List.of(new Tag("name1", "1"), new Tag("name2", "2"));
 
         String json = serializer.serialize(tagList);
+        String expectedJson = """
+                {"name1":"1","name2":"2"}""";
+
+        Assertions.assertEquals(expectedJson, json);
 
         List<Tag> newTagList = serializer.deserialize(json);
 
         Assertions.assertEquals(tagList, newTagList);
 
+    }
+
+    @Test
+    void deserialize_nullTagValue() {
+        TagListSerializer serializer = new TagListSerializer(mapper);
+
+        String json = """
+                {"name1":"1","name2":null}""";
+
+        Assertions.assertThrows(JsonRuntimeException.class, () -> serializer.deserialize(json));
     }
 }


### PR DESCRIPTION
…Serializer

Replace the intermediate Tags + ObjectWriter/ObjectReader round-trip with direct Jackson streaming: serialize writes each tag via JsonGenerator over a StringBuilderWriter, and deserialize reads tokens via JsonParser, producing/accepting the same {"name":"value"} JSON. Non-object roots and non-scalar tag values fail with JsonParseException, wrapped in JsonRuntimeException as before. Add commons-io as a direct dependency.