### PR TITLE
[#noissue] Stream JSON directly with Jackson core in MapStructUtils

### DIFF
--- a/commons-server/pom.xml
+++ b/commons-server/pom.xml
@@ -41,6 +41,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-commons</artifactId>
         </dependency>

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/mapper/MapStructUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/mapper/MapStructUtils.java
@@ -16,22 +16,27 @@
 
 package com.navercorp.pinpoint.common.server.mapper;
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.navercorp.pinpoint.common.server.util.json.JsonRuntimeException;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.common.util.StringUtils;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.mapstruct.Qualifier;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -39,22 +44,12 @@ import java.util.Objects;
 @Component
 public class MapStructUtils {
 
-    private final ObjectReader integerListReader;
-    private final ObjectReader longListReader;
-    private final ObjectReader stringListReader;
-    private final ObjectReader stringMapListReader;
-
-    private final ObjectWriter listWriter;
+    private final JsonFactory jsonFactory;
 
     public MapStructUtils(ObjectMapper mapper) {
         Objects.requireNonNull(mapper, "mapper");
 
-        this.integerListReader = mapper.readerForListOf(Integer.class);
-        this.longListReader = mapper.readerForListOf(Long.class);
-        this.stringListReader = mapper.readerForListOf(String.class);
-        this.stringMapListReader = mapper.readerFor(new TypeReference<List<Map<String, String>>>() {});
-
-        this.listWriter = mapper.writerFor(List.class);
+        this.jsonFactory = mapper.getFactory();
     }
 
     @Qualifier
@@ -69,22 +64,33 @@ public class MapStructUtils {
         if (StringUtils.isEmpty(json)) {
             return Collections.emptyList();
         }
-        try {
-            return stringMapListReader.readValue(json);
-        } catch (JacksonException e) {
-            throw new JsonRuntimeException("Json read error", e);
+        return parseList(json, MapStructUtils::readStringMap);
+    }
+
+    private static Map<String, String> readStringMap(JsonParser parser, JsonToken token) throws IOException {
+        if (token != JsonToken.START_OBJECT) {
+            throw new JsonParseException(parser, "expected JSON object");
         }
+        final Map<String, String> map = new LinkedHashMap<>();
+        while (parser.nextToken() == JsonToken.FIELD_NAME) {
+            final String name = parser.currentName();
+            final JsonToken valueToken = parser.nextToken();
+            if (valueToken == JsonToken.VALUE_NULL) {
+                map.put(name, null);
+            } else if (valueToken != null && valueToken.isScalarValue()) {
+                map.put(name, parser.getText());
+            } else {
+                throw new JsonParseException(parser, "expected scalar value");
+            }
+        }
+        return map;
     }
 
     public List<String> jsonToStringList(String json) {
         if (StringUtils.isEmpty(json)) {
             return Collections.emptyList();
         }
-        try {
-            return stringListReader.readValue(json);
-        } catch (JacksonException e) {
-            throw new JsonRuntimeException("Json read error", e);
-        }
+        return parseList(json, MapStructUtils::readString);
     }
 
     @Qualifier
@@ -99,11 +105,7 @@ public class MapStructUtils {
         if (StringUtils.isEmpty(json)) {
             return Collections.emptyList();
         }
-        try {
-            return integerListReader.readValue(json);
-        } catch (JacksonException e) {
-            throw new JsonRuntimeException("Json read error", e);
-        }
+        return parseList(json, MapStructUtils::readInteger);
     }
 
     @Qualifier
@@ -118,11 +120,57 @@ public class MapStructUtils {
         if (StringUtils.isEmpty(json)) {
             return Collections.emptyList();
         }
-        try {
-            return longListReader.readValue(json);
-        } catch (JacksonException e) {
+        return parseList(json, MapStructUtils::readLong);
+    }
+
+    @FunctionalInterface
+    private interface ElementReader<T> {
+        T read(JsonParser parser, JsonToken token) throws IOException;
+    }
+
+    /**
+     * Parses a JSON array, mapping {@code null} elements to {@code null} and delegating
+     * non-null elements to {@code elementReader}.
+     */
+    private <T> List<T> parseList(String json, ElementReader<T> elementReader) {
+        try (JsonParser parser = jsonFactory.createParser(json)) {
+            if (parser.nextToken() != JsonToken.START_ARRAY) {
+                throw new JsonParseException(parser, "expected JSON array");
+            }
+            final List<T> list = new ArrayList<>();
+            JsonToken token;
+            while ((token = parser.nextToken()) != JsonToken.END_ARRAY) {
+                if (token == JsonToken.VALUE_NULL) {
+                    list.add(null);
+                } else {
+                    list.add(elementReader.read(parser, token));
+                }
+            }
+            return list;
+        } catch (IOException e) {
             throw new JsonRuntimeException("Json read error", e);
         }
+    }
+
+    private static String readString(JsonParser parser, JsonToken token) throws IOException {
+        if (token == null || !token.isScalarValue()) {
+            throw new JsonParseException(parser, "expected scalar value");
+        }
+        return parser.getText();
+    }
+
+    private static Integer readInteger(JsonParser parser, JsonToken token) throws IOException {
+        if (token != JsonToken.VALUE_NUMBER_INT) {
+            throw new JsonParseException(parser, "expected integer value");
+        }
+        return parser.getIntValue();
+    }
+
+    private static Long readLong(JsonParser parser, JsonToken token) throws IOException {
+        if (token != JsonToken.VALUE_NUMBER_INT) {
+            throw new JsonParseException(parser, "expected integer value");
+        }
+        return parser.getLongValue();
     }
 
     @Qualifier
@@ -138,9 +186,34 @@ public class MapStructUtils {
             return "";
         }
         try {
-            return listWriter.writeValueAsString(lists);
-        } catch (JacksonException e) {
+            final StringBuilderWriter buffer = new StringBuilderWriter();
+            try (JsonGenerator generator = jsonFactory.createGenerator(buffer)) {
+                generator.writeStartArray();
+                for (T element : lists) {
+                    writeElement(generator, element);
+                }
+                generator.writeEndArray();
+            }
+            return buffer.toString();
+        } catch (IOException e) {
             throw new JsonRuntimeException("Json Write error", e);
+        }
+    }
+
+    private void writeElement(JsonGenerator generator, Object element) throws IOException {
+        if (element == null) {
+            generator.writeNull();
+        } else if (element instanceof String string) {
+            generator.writeString(string);
+        } else if (element instanceof Integer number) {
+            generator.writeNumber(number);
+        } else if (element instanceof Long number) {
+            generator.writeNumber(number);
+        } else if (element instanceof Boolean bool) {
+            generator.writeBoolean(bool);
+        } else {
+            // non-scalar element — delegate to the mapper codec bound to the factory
+            generator.writeObject(element);
         }
     }
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/mapper/MapStructUtilsTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/mapper/MapStructUtilsTest.java
@@ -60,7 +60,8 @@ class MapStructUtilsTest {
         ObjectMapper mapper = Jackson.newMapper();
         MapStructUtils mapStructUtils = new MapStructUtils(mapper);
 
-        List<Map<String, String>> maps = mapStructUtils.jsonToStringMapList("[{\"key\": \"value\"}, {\"key2\": \"value2\"}, {\"key3\": \"value3\"}]");
+        List<Map<String, String>> maps = mapStructUtils.jsonToStringMapList("""
+                [{"key": "value"}, {"key2": "value2"}, {"key3": "value3"}]""");
         assertThat(maps).containsExactlyInAnyOrder(
                 Map.of("key", "value"),
                 Map.of("key2", "value2"),


### PR DESCRIPTION
Replace all ObjectWriter/ObjectReader usage with direct Jackson
streaming. listToJsonStr writes elements via JsonGenerator over a
StringBuilderWriter (writeObject fallback for non-scalar elements).
The four readers parse tokens via JsonParser through a shared
parseList/ElementReader helper: scalar lists preserve null elements
and reject non-scalar tokens, and jsonToStringMapList reads each
element into a LinkedHashMap with scalar-only values, matching the
reader's ArrayList<LinkedHashMap> shape and key order. Add commons-io
as a direct dependency.
