### PR TITLE
[#noissue] Extract OtelLink record and stream link annotation JSON directly

### DIFF
--- a/otlptrace/otlptrace-collector/pom.xml
+++ b/otlptrace/otlptrace-collector/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>pinpoint-collector</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-pinot-kafka</artifactId>
         </dependency>

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtelLink.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtelLink.java
@@ -1,0 +1,31 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.google.protobuf.ByteString;
+import io.opentelemetry.proto.common.v1.KeyValue;
+
+import java.util.List;
+
+/**
+ * Write-side model of the {@code OPENTELEMETRY_LINK} annotation JSON. Absent fields are
+ * omitted from the output, matching the wire format read back by the web-side
+ * {@code OtelLinkSerde}.
+ *
+ * @param traceId    raw OTel trace id bytes — hex-encoded at serialization time, only
+ *                   serialized when non-empty
+ * @param spanId     OTel span id as long, 0 when absent (an all-zero span id is invalid per
+ *                   the OTel spec) — serialized as a decimal string to avoid JS Number
+ *                   precision loss for any consumer that reads the raw annotation JSON
+ *                   directly; Java readers accept both number and decimal-string forms
+ * @param traceState raw W3C tracestate (vendor propagation context — AWS, Datadog, Sentry,
+ *                   etc.) — capped at serialization time, only serialized when non-empty
+ * @param attributes raw OTel link attributes — transformed (value capping) at serialization
+ *                   time, only serialized when non-empty
+ * @param dropped    SDK-side data-loss counter for link attributes, same convention as
+ *                   Span/SpanEvent {@code OPENTELEMETRY_DROPPED} — only serialized when > 0
+ */
+public record OtelLink(ByteString traceId,
+                            long spanId,
+                            String traceState,
+                            List<KeyValue> attributes,
+                            int dropped) {
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
@@ -1,34 +1,39 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
-import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
 import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
 import com.navercorp.pinpoint.common.server.util.Utf8;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import io.opentelemetry.proto.trace.v1.Span;
+import org.apache.commons.io.output.StringBuilderWriter;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 import java.util.Objects;
 
-import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperUtils.getAttributeToMap;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperUtils.writeAttributes;
 
 @Component
 public class OtlpTraceLinkMapper {
 
-    private final ObjectWriter mapWriter;
+    private static final String FIELD_TRACE_ID = "traceId";
+    private static final String FIELD_SPAN_ID = "spanId";
+    private static final String FIELD_TRACE_STATE = "traceState";
+    private static final String FIELD_ATTRIBUTES = "attributes";
+    private static final String FIELD_DROPPED = "dropped";
+
+    private final JsonFactory jsonFactory;
     private final int valueMaxBytes;
 
     public OtlpTraceLinkMapper(ObjectMapper objectMapper,
                                @Value("${pinpoint.collector.otlptrace.link.value-max-bytes:8192}") int valueMaxBytes) {
         Objects.requireNonNull(objectMapper, "objectMapper");
-        this.mapWriter = objectMapper.writerFor(new TypeReference<Map<String, Object>>() {});
+        this.jsonFactory = objectMapper.getFactory();
         if (valueMaxBytes < 0) {
             throw new IllegalArgumentException("valueMaxBytes must be >= 0: " + valueMaxBytes);
         }
@@ -36,56 +41,66 @@ public class OtlpTraceLinkMapper {
     }
 
     /**
-     * Serializes an OTel {@link Span.Link} as JSON under {@link AnnotationKey#OPENTELEMETRY_LINK}.
-     * Fields: {@code traceId} (hex), {@code spanId} (decimal string — see inline note),
-     * {@code traceState} (W3C tracestate, only when non-empty), {@code attributes} (only when
-     * non-empty), {@code dropped} (link-level dropped_attributes_count, only when > 0).
+     * Serializes an OTel {@link Span.Link} as {@link OtelLink} JSON into an
+     * {@link AnnotationKey#OPENTELEMETRY_LINK} annotation.
      *
-     * <p>Skips entirely when both traceId and spanId are empty — OTel spec requires links to
-     * carry a non-empty SpanContext, so a fully-empty link is invalid input we drop silently.</p>
+     * <p>Returns {@code null} when both traceId and spanId are empty — OTel spec requires links
+     * to carry a non-empty SpanContext, so a fully-empty link is invalid input we drop silently.</p>
      *
      * <p>{@code onTruncated} is invoked once per truncated value (traceState or attribute leaf).</p>
      */
-    public void addLinkToAnnotation(Span.Link link, AnnotationWriter annotationWriter, TruncationListener onTruncated) {
+    public @Nullable AnnotationBo toAnnotation(Span.Link link, TruncationListener onTruncated) {
         if (link.getTraceId().isEmpty() && link.getSpanId().isEmpty()) {
-            return;
+            return null;
         }
         try {
-            Map<String, Object> map = new HashMap<>();
-            if (!link.getTraceId().isEmpty()) {
-                map.put("traceId", ByteStringUtils.encodeBase16(link.getTraceId()));
+            final OtelLink otelLink = toOtelLink(link);
+            final String value = toJson(otelLink, onTruncated);
+            return AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), value);
+        } catch (IOException e) {
+            return AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), "json processing error");
+        }
+    }
+
+    private String toJson(OtelLink otelLink, TruncationListener onTruncated) throws IOException {
+        final StringBuilderWriter buffer = new StringBuilderWriter();
+        try (JsonGenerator generator = jsonFactory.createGenerator(buffer)) {
+            generator.writeStartObject();
+            if (!otelLink.traceId().isEmpty()) {
+                generator.writeStringField(FIELD_TRACE_ID, ByteStringUtils.encodeBase16(otelLink.traceId()));
             }
-            if (!link.getSpanId().isEmpty()) {
-                // Stored as decimal String to avoid JS Number precision loss for any consumer that
-                // reads the raw annotation JSON directly. Java readers (OtelLinkValue.readLong)
-                // accept both number and decimal-string forms, preserving backward compatibility.
-                map.put("spanId", String.valueOf(ByteStringUtils.parseLong(link.getSpanId())));
+            if (otelLink.spanId() != 0) {
+                generator.writeStringField(FIELD_SPAN_ID, String.valueOf(otelLink.spanId()));
             }
-            // W3C tracestate (vendor propagation context — AWS, Datadog, Sentry, etc.). Only
-            // emit when non-empty to keep well-behaved links compact. Capped like attribute values
-            // since chained vendor entries can grow long.
-            if (!link.getTraceState().isEmpty()) {
-                String traceState = link.getTraceState();
+            // Only emit traceState when non-empty to keep well-behaved links compact. Capped like
+            // attribute values since chained vendor entries can grow long.
+            if (!otelLink.traceState().isEmpty()) {
+                String traceState = otelLink.traceState();
                 final String truncatedTraceState = Utf8.truncate(traceState, valueMaxBytes);
                 if (truncatedTraceState != null) {
                     traceState = truncatedTraceState;
                     onTruncated.truncated();
                 }
-                map.put("traceState", traceState);
+                generator.writeStringField(FIELD_TRACE_STATE, traceState);
             }
-            if (link.getAttributesCount() > 0) {
-                final Map<String, Object> linkAttributes = getAttributeToMap(link.getAttributesList(), valueMaxBytes, onTruncated);
-                map.put("attributes", linkAttributes);
+            if (!otelLink.attributes().isEmpty()) {
+                // Attribute values are capped at write time, invoking onTruncated per truncated leaf.
+                generator.writeFieldName(FIELD_ATTRIBUTES);
+                writeAttributes(generator, otelLink.attributes(), valueMaxBytes, onTruncated);
             }
-            // SDK-side data-loss counter for link attributes. Same convention as Span/SpanEvent
-            // OPENTELEMETRY_DROPPED — only included when > 0.
-            if (link.getDroppedAttributesCount() > 0) {
-                map.put("dropped", link.getDroppedAttributesCount());
+            if (otelLink.dropped() > 0) {
+                generator.writeNumberField(FIELD_DROPPED, otelLink.dropped());
             }
-            final String value = mapWriter.writeValueAsString(map);
-            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), value));
-        } catch (JsonProcessingException e) {
-            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(), "json processing error"));
+            generator.writeEndObject();
         }
+        return buffer.toString();
+    }
+
+    private OtelLink toOtelLink(Span.Link link) {
+        long spanId = 0;
+        if (!link.getSpanId().isEmpty()) {
+            spanId = ByteStringUtils.parseLong(link.getSpanId());
+        }
+        return new OtelLink(link.getTraceId(), spanId, link.getTraceState(), link.getAttributesList(), link.getDroppedAttributesCount());
     }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.profiler.name.Base64Utils;
@@ -32,6 +33,7 @@ import io.opentelemetry.proto.common.v1.ArrayValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import org.jspecify.annotations.Nullable;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -294,6 +296,39 @@ public class OtlpTraceMapperUtils {
         };
     }
 
+    /**
+     * Streams OTel attributes as a JSON object directly to {@code generator}, recursing into
+     * nested arrays/maps — the streaming counterpart of
+     * {@link #getAttributeToMap(List, int, TruncationListener)} with the same truncation semantics.
+     */
+    public static void writeAttributes(JsonGenerator generator, List<KeyValue> keyValueList, int maxBytes, @Nullable TruncationListener onTruncated) throws IOException {
+        generator.writeStartObject();
+        for (KeyValue kv : keyValueList) {
+            generator.writeFieldName(kv.getKey());
+            writeAnyValue(generator, kv.getValue(), maxBytes, onTruncated);
+        }
+        generator.writeEndObject();
+    }
+
+    public static void writeAnyValue(JsonGenerator generator, AnyValue anyValue, int maxBytes, @Nullable TruncationListener onTruncated) throws IOException {
+        switch (anyValue.getValueCase()) {
+            case INT_VALUE -> generator.writeNumber(anyValue.getIntValue());
+            case DOUBLE_VALUE -> generator.writeNumber(anyValue.getDoubleValue());
+            case BOOL_VALUE -> generator.writeBoolean(anyValue.getBoolValue());
+            case STRING_VALUE -> generator.writeString(transformString(anyValue.getStringValue(), maxBytes, onTruncated));
+            case BYTES_VALUE -> generator.writeString(transformBytes(anyValue.getBytesValue(), maxBytes, onTruncated));
+            case ARRAY_VALUE -> {
+                generator.writeStartArray();
+                for (AnyValue element : anyValue.getArrayValue().getValuesList()) {
+                    writeAnyValue(generator, element, maxBytes, onTruncated);
+                }
+                generator.writeEndArray();
+            }
+            case KVLIST_VALUE -> writeAttributes(generator, anyValue.getKvlistValue().getValuesList(), maxBytes, onTruncated);
+            default -> generator.writeNull();
+        }
+    }
+
     private static String transformString(String value, int maxBytes, @Nullable TruncationListener onTruncated) {
         if (onTruncated == null) {
             return value;
@@ -306,7 +341,7 @@ public class OtlpTraceMapperUtils {
         return value;
     }
 
-    private static Object transformBytes(ByteString bytes, int maxBytes, @Nullable TruncationListener onTruncated) {
+    private static String transformBytes(ByteString bytes, int maxBytes, @Nullable TruncationListener onTruncated) {
         // empty bytes -> "" (Base16 of an empty array), symmetric with the empty STRING case
         if (onTruncated == null) {
             return ByteStringUtils.encodeBase16(bytes);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -149,7 +149,10 @@ public class OtlpTraceSpanMapper {
         }
         // link
         for (Span.Link link : span.getLinksList()) {
-            linkMapper.addLinkToAnnotation(link, spanBo::addAnnotation, truncatedCounts::link);
+            final AnnotationBo linkAnnotation = linkMapper.toAnnotation(link, truncatedCounts::link);
+            if (linkAnnotation != null) {
+                spanBo.addAnnotation(linkAnnotation);
+            }
         }
         final AnnotationBo truncatedAnnotation = toTruncatedAnnotation(truncatedCounts);
         if (truncatedAnnotation != null) {

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapperTest.java
@@ -3,7 +3,6 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
-import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import io.opentelemetry.proto.trace.v1.Span;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,13 +25,18 @@ class OtlpTraceLinkMapperTest {
 
     private OtlpTraceLinkMapper mapper;
     private List<AnnotationBo> annotations;
-    private AnnotationWriter writer;
 
     @BeforeEach
     void setUp() {
         mapper = new OtlpTraceLinkMapper(new ObjectMapper(), 8192);
         annotations = new ArrayList<>();
-        writer = annotations::add;
+    }
+
+    private void addLink(Span.Link link) {
+        AnnotationBo annotation = mapper.toAnnotation(link, () -> {});
+        if (annotation != null) {
+            annotations.add(annotation);
+        }
     }
 
     @Test
@@ -42,7 +46,7 @@ class OtlpTraceLinkMapperTest {
                 .setSpanId(ByteString.copyFrom(SPAN_ID))
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer, () -> {});
+        addLink(link);
 
         assertThat(annotations).hasSize(1);
         AnnotationBo bo = annotations.get(0);
@@ -66,7 +70,7 @@ class OtlpTraceLinkMapperTest {
                 .setTraceState("aws=t61rcWkgMzE,dd=s:1;o:rum")
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer, () -> {});
+        addLink(link);
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")
@@ -81,7 +85,7 @@ class OtlpTraceLinkMapperTest {
                 .setSpanId(ByteString.copyFrom(SPAN_ID))
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer, () -> {});
+        addLink(link);
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")
@@ -97,7 +101,7 @@ class OtlpTraceLinkMapperTest {
                 .addAttributes(kv("link.kind", strVal("follows_from")))
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer, () -> {});
+        addLink(link);
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")
@@ -115,7 +119,7 @@ class OtlpTraceLinkMapperTest {
                 .setDroppedAttributesCount(5)
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer, () -> {});
+        addLink(link);
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")
@@ -130,7 +134,7 @@ class OtlpTraceLinkMapperTest {
                 .setSpanId(ByteString.copyFrom(SPAN_ID))
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer, () -> {});
+        addLink(link);
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")
@@ -143,7 +147,7 @@ class OtlpTraceLinkMapperTest {
         // Both traceId and spanId empty — OTel spec violation, skip silently.
         Span.Link link = Span.Link.newBuilder().build();
 
-        mapper.addLinkToAnnotation(link, writer, () -> {});
+        addLink(link);
 
         assertThat(annotations).isEmpty();
     }
@@ -156,7 +160,7 @@ class OtlpTraceLinkMapperTest {
                 .addAttributes(kv("orphan", strVal("yes")))
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer, () -> {});
+        addLink(link);
 
         assertThat(annotations).isEmpty();
     }
@@ -171,7 +175,7 @@ class OtlpTraceLinkMapperTest {
                 .setDroppedAttributesCount(2)
                 .build();
 
-        mapper.addLinkToAnnotation(link, writer, () -> {});
+        addLink(link);
 
         ObjectMapper om = new ObjectMapper();
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
Replace the HashMap + ObjectWriter serialization in OtlpTraceLinkMapper
with a typed OtelLink record written directly via JsonGenerator,
mirroring the web-side OtelLinkValueSerde pattern. The record carries
raw proto values — traceId as ByteString, spanId as long (0 = absent;
an all-zero span id is invalid per the OTel spec), raw traceState, and
the attribute KeyValue list — so toOtelLink is pure extraction and
every transform (hex encoding, decimal-string conversion, tracestate
truncation, attribute value capping) happens once in toJson, with
onTruncated invoked at write time. Attributes stream straight from
proto via new OtlpTraceMapperUtils.writeAttributes/writeAnyValue,
sharing the same truncation transforms as the map path. The mapper now
returns the OPENTELEMETRY_LINK AnnotationBo (null for an invalid
fully-empty link) instead of writing into an AnnotationWriter, and
OtlpTraceSpanMapper adds it to the span. Add commons-io as a direct
dependency.
