### PR TITLE
[#noissue] Map OTLP Envoy proxy spans to Envoy service types

### DIFF
--- a/otlptrace/otlptrace-collector/README.md
+++ b/otlptrace/otlptrace-collector/README.md
@@ -157,3 +157,76 @@ whether a failure **surfaces before the response**:
 | spanChunk put failure | **Fully ignored** — future discarded + success event always published |
 | scatter index failure | future discarded, no metric — loss that is invisible in scatter |
 | server-map stats | Up to 5s of increments lost on process death (acceptable by design) |
+
+---
+
+## 5. ServiceType Resolution (OTLP → Pinpoint)
+
+An OTLP span carries no Pinpoint ServiceType, so the mapper derives one. The **primary key is
+`span.kind`**; attributes refine it. All resolvers look up the target code by ServiceType **name**
+in the registry, so a plugin re-mapping its code is followed automatically and a missing plugin
+falls back to the generic `OPENTELEMETRY_*` type instead of failing.
+
+### Node vs. call — why the category matters
+
+`ServiceTypeCategory` maps a code range to a role:
+
+| Code range | Category | Role on the ServerMap |
+|---|---|---|
+| 1000–1999 | SERVER | **node** (a box) |
+| 2000–2999 | DATABASE | node |
+| 8000–8799 | CACHE/MESSAGE_BROKER | node |
+| 9000–9999 | RPC | **call** (an outgoing arc / SpanEvent) |
+
+A SERVER-kind span becomes a **root SpanBo** — it *is* the node — so it must carry a SERVER-category
+type. A CLIENT/PRODUCER span becomes a **SpanEventBo** — an outgoing call — so it carries an
+RPC/messaging-category type. Assigning a call-category code to a node (or vice versa) miscategorizes
+the ServerMap element.
+
+### Dispatch table
+
+| span.kind | Target BO | Resolver | Attribute key | Default (fallback) |
+|---|---|---|---|---|
+| SERVER | root SpanBo (node) | `OtlpServerTypeResolver` | `rpc.system` → `GRPC_SERVER` / `APACHE_DUBBO_PROVIDER` | `OPENTELEMETRY_SERVER` (1220) |
+| SERVER + Envoy tags | root SpanBo (node) | `OtlpEnvoyTypeResolver` | Envoy gate (below) | `ENVOY` (1550) → `OPENTELEMETRY_SERVER` |
+| CLIENT | SpanEventBo (call) | `OtlpClientTypeResolver` | `rpc.system` → `GRPC` / `APACHE_DUBBO_CONSUMER` | `OPENTELEMETRY_CLIENT` (9310) |
+| CLIENT + Envoy tags | SpanEventBo (call) | `OtlpEnvoyTypeResolver` | Envoy gate (below) | `ENVOY_EGRESS` (9302) → `OPENTELEMETRY_CLIENT` |
+| CLIENT + `db.system` | SpanEventBo (call) | `OtlpDbSystemTypeResolver` | `db.system` / `db.system.name` | per DB system |
+| PRODUCER | SpanEventBo (call) | `OtlpMessagingTypeResolver` | `messaging.system` | `OPENTELEMETRY_CLIENT` |
+| INTERNAL / other | SpanEventBo | — | — | `OPENTELEMETRY_INTERNAL` (1221) / `INTERNAL_METHOD` |
+
+HTTP client/server *framework* (Tomcat, OkHttp, …) cannot be derived from OTel attributes, so plain
+HTTP spans stay on the `OPENTELEMETRY_SERVER` / `OPENTELEMETRY_CLIENT` generics.
+
+### Envoy proxy spans
+
+`OtlpEnvoyTypeResolver` detects Envoy spans and overrides the generic OTel types with the dedicated
+Envoy types, mirroring the native pinpoint-cpp Envoy tracer.
+
+- **Detection gate**: presence of `upstream_cluster`, `upstream_cluster.name`, or `response_flags`
+  (Envoy-only tags). `component=proxy` is intentionally **not** used — it is deprecated in OTel
+  semconv and set by other proxies, so it has no reliable discriminating power on its own.
+- **Direction**: `span.kind` SERVER → ingress node, CLIENT → egress call.
+- **Annotations**: `envoy.operation` (9441, `Ingress`/`Egress`) and `upstream.cluster` (9442).
+- Hooks: `OtlpTraceSpanMapper#recordServer` (server) and `OtlpTraceSpanEventMapper` client branch.
+
+| span.kind | ServiceType | Category | Note |
+|---|---|---|---|
+| SERVER (ingress) | `ENVOY` (1550) | SERVER (node) | ingress node |
+| CLIENT (egress) | `ENVOY_EGRESS` (9302) | RPC (call) | egress call to the upstream cluster |
+
+### Why `ENVOY_INGRESS` (9301) is not used
+
+The native pinpoint-cpp tracer models one Envoy request as **one span plus child SpanEvents**: the
+span (the node) is `ENVOY` (1550), and it carries an `ENVOY_INGRESS` (9301) SpanEvent for the received
+request and an `ENVOY_EGRESS` (9302) SpanEvent for the upstream call. `ENVOY_INGRESS` and
+`ENVOY_EGRESS` are both **RPC-category (9000–9999) *call* types**, not node types.
+
+The OTLP model is different: **one span per request with an explicit `span.kind`**, and a SERVER-kind
+ingress span maps to a **root SpanBo — which is already the ServerMap node**. A node must carry a
+SERVER-category type, so the ingress node uses `ENVOY` (1550), exactly as a generic OTLP server node
+uses `OPENTELEMETRY_SERVER` (1220). Assigning the RPC-category `ENVOY_INGRESS` (9301) to a root node
+would miscategorize it (`NodeCategory.UNKNOWN`). There is no separate ingress SpanEvent in the OTLP
+mapping for `ENVOY_INGRESS` to attach to, so it is intentionally left unused; the ingress direction is
+still recorded via the `envoy.operation=Ingress` annotation. `ENVOY_EGRESS` (9302), being a call type,
+is category-correct for the CLIENT-kind egress SpanEvent and is used as-is.

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyTypeResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyTypeResolver.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Detects Envoy proxy spans that arrive via OTLP and maps them to the dedicated Envoy
+ * ServiceTypes — {@code ENVOY} (1550) for the SERVER-kind ingress node and
+ * {@code ENVOY_EGRESS} (9302) for the CLIENT-kind egress call. This complements the native
+ * pinpoint-cpp Envoy tracer (which sets SVC_TYPE_ENVOY 1550 on the span and
+ * SVC_TYPE_ENVOY_INGRESS 9301 / SVC_TYPE_ENVOY_EGRESS 9302 on its child SpanEvents).
+ *
+ * <p><b>Detection gate.</b> Envoy is identified by the presence of Envoy-specific span tags
+ * ({@code upstream_cluster} / {@code upstream_cluster.name} / {@code response_flags}). These
+ * are emitted only by Envoy, so they do not collide with other instrumentations.
+ * {@code component=proxy} is intentionally not used — it is deprecated in OTel semconv and
+ * emitted by other proxies as well, so it has no reliable discriminating power on its own.</p>
+ *
+ * <p><b>Direction.</b> The caller decides ingress vs egress from {@code span.kind}
+ * (SERVER → ingress, CLIENT → egress), matching how Envoy's OTLP exporter derives span kind
+ * from the listener operation name.</p>
+ *
+ * <p><b>ServiceType category matters.</b> A SERVER-kind Envoy span becomes a root SpanBo — a
+ * ServerMap <em>node</em> — so it must carry a SERVER-category type: {@code ENVOY} (1550),
+ * NOT {@code ENVOY_INGRESS} (9301, an RPC-category <em>call</em> type used by the native tracer
+ * on a child SpanEvent). A CLIENT-kind Envoy span becomes a SpanEvent — an outbound
+ * <em>call</em> — so it carries the RPC-category {@code ENVOY_EGRESS} (9302). The ingress
+ * direction is otherwise preserved via the {@code envoy.operation} annotation. This mirrors how
+ * OTLP server nodes use {@code OPENTELEMETRY_SERVER} (1220) while client events use
+ * {@code OPENTELEMETRY_CLIENT} (9310).</p>
+ *
+ * <p><b>Graceful fallback.</b> ServiceType codes are resolved from
+ * {@link ServiceTypeRegistryService} by <em>name</em>. When the {@code envoy-type-provider}
+ * is not deployed on the collector classpath the resolver falls back to
+ * {@link ServiceType#OPENTELEMETRY_SERVER} / {@link ServiceType#OPENTELEMETRY_CLIENT}, so the
+ * mapping degrades to today's behavior instead of failing.</p>
+ */
+@Component
+public class OtlpEnvoyTypeResolver {
+
+    private static final String SERVICE_TYPE_NAME_ENVOY = "ENVOY";
+    private static final String SERVICE_TYPE_NAME_ENVOY_EGRESS = "ENVOY_EGRESS";
+
+    // envoy.operation annotation values, mirroring the native tracer's AppendString(...).
+    private static final String OPERATION_INGRESS = "Ingress";
+    private static final String OPERATION_EGRESS = "Egress";
+
+    private final int nodeCode;
+    private final int egressCode;
+
+    public OtlpEnvoyTypeResolver(ServiceTypeRegistryService registry) {
+        Objects.requireNonNull(registry, "registry");
+        this.nodeCode = resolve(registry, SERVICE_TYPE_NAME_ENVOY, ServiceType.OPENTELEMETRY_SERVER.getCode());
+        this.egressCode = resolve(registry, SERVICE_TYPE_NAME_ENVOY_EGRESS, ServiceType.OPENTELEMETRY_CLIENT.getCode());
+    }
+
+    private static int resolve(ServiceTypeRegistryService registry, String typeName, int fallback) {
+        ServiceType type = registry.findServiceTypeByName(typeName);
+        return (type == null || type == ServiceType.UNDEFINED) ? fallback : type.getCode();
+    }
+
+    /**
+     * Envoy detection gate. Keyed on Envoy-specific tags only (see class Javadoc).
+     */
+    public boolean isEnvoy(Map<String, AttributeValue> attributes) {
+        return attributes.containsKey(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER)
+                || attributes.containsKey(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME)
+                || attributes.containsKey(OtlpTraceConstants.ATTRIBUTE_KEY_RESPONSE_FLAGS);
+    }
+
+    /**
+     * Envoy node (SERVER-category) code for a SERVER-kind ingress span, or OPENTELEMETRY_SERVER
+     * when the Envoy plugin is not deployed.
+     */
+    public int resolveNodeServiceType() {
+        return nodeCode;
+    }
+
+    /** ENVOY_EGRESS code, or OPENTELEMETRY_CLIENT when the Envoy plugin is not deployed. */
+    public int resolveEgressServiceType() {
+        return egressCode;
+    }
+
+    /**
+     * Attaches the Envoy annotations (upstream.cluster + envoy.operation) to a Span/SpanEvent.
+     * upstream_cluster.name is preferred over the legacy upstream_cluster tag.
+     */
+    public void recordAnnotations(Consumer<AnnotationBo> sink, Map<String, AttributeValue> attributes, boolean ingress) {
+        String cluster = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME, null);
+        if (cluster == null) {
+            cluster = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER, null);
+        }
+        if (cluster != null) {
+            sink.accept(AnnotationBo.of(OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER, cluster));
+        }
+        sink.accept(AnnotationBo.of(OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION,
+                ingress ? OPERATION_INGRESS : OPERATION_EGRESS));
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -94,6 +94,12 @@ public class OtlpTraceConstants {
     // ACTIVEMQ_BROKER_ADDRESS is plugin-defined; queue name reuses the built-in AnnotationKey.MESSAGE_QUEUE_URI (100).
     public static final int ANNOTATION_KEY_ACTIVEMQ_BROKER_ADDRESS = 101;
     public static final int ANNOTATION_KEY_MESSAGE_QUEUE_URI = 100;
+
+    // AnnotationKey codes mirrored from agent-module/plugins/external envoy-type-provider.yml.
+    // Display names ("envoy.operation", "upstream.cluster") are registered there so the web UI
+    // resolves them. Attached by OtlpEnvoyTypeResolver when an Envoy span is detected.
+    public static final int ANNOTATION_KEY_ENVOY_OPERATION = 9441;
+    public static final int ANNOTATION_KEY_UPSTREAM_CLUSTER = 9442;
     // OTel HTTP server semconv: the matched route template (low-cardinality, e.g. "/users/{id}").
     // Takes precedence over url.path/http.url/http.target so the rpc field groups by endpoint
     // pattern instead of the raw, high-cardinality request path. This is the OTel equivalent of
@@ -117,6 +123,13 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_DB_NAME = "db.name";
     public static final String ATTRIBUTE_KEY_DB_NAMESPACE = "db.namespace";
     public static final String ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME = "upstream_cluster.name";
+    // Envoy-specific span tags. upstream_cluster (no ".name" suffix) is the legacy Zipkin-style
+    // tag; response_flags is Envoy's connection/response flag string ("-" when none). Both are
+    // emitted only by Envoy, so they serve as the Envoy detection gate in OtlpEnvoyTypeResolver.
+    // component=proxy is intentionally NOT used — it is deprecated in OTel semconv and set by
+    // other proxies too, so it has no reliable discriminating power on its own.
+    public static final String ATTRIBUTE_KEY_UPSTREAM_CLUSTER = "upstream_cluster";
+    public static final String ATTRIBUTE_KEY_RESPONSE_FLAGS = "response_flags";
     public static final String ATTRIBUTE_KEY_DB_STATEMENT = "db.statement";
     public static final String ATTRIBUTE_KEY_DB_QUERY_TEXT = "db.query.text";
     public static final String ATTRIBUTE_KEY_DB_SYSTEM = "db.system";

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -54,6 +54,7 @@ public class OtlpTraceSpanEventMapper {
     private final OtlpDbSystemTypeResolver dbSystemTypeResolver;
     private final OtlpMessagingTypeResolver messagingTypeResolver;
     private final OtlpClientTypeResolver clientTypeResolver;
+    private final OtlpEnvoyTypeResolver envoyTypeResolver;
     private final OtlpExceptionInfoResolver exceptionInfoResolver;
     private final OtlpAttributeBoMapper attributeBoMapper;
     private final int sqlMaxBytes;
@@ -62,6 +63,7 @@ public class OtlpTraceSpanEventMapper {
                                     ServiceTypeRegistryService serviceTypeRegistryService,
                                     OtlpMessagingTypeResolver messagingTypeResolver,
                                     OtlpClientTypeResolver clientTypeResolver,
+                                    OtlpEnvoyTypeResolver envoyTypeResolver,
                                     OtlpExceptionInfoResolver exceptionInfoResolver,
                                     OtlpAttributeBoMapper attributeBoMapper,
                                     @Value("${pinpoint.collector.otlptrace.sql.max-bytes:8192}") int sqlMaxBytes) {
@@ -70,6 +72,7 @@ public class OtlpTraceSpanEventMapper {
                 Objects.requireNonNull(serviceTypeRegistryService, "serviceTypeRegistryService"));
         this.messagingTypeResolver = Objects.requireNonNull(messagingTypeResolver, "messagingTypeResolver");
         this.clientTypeResolver = Objects.requireNonNull(clientTypeResolver, "clientTypeResolver");
+        this.envoyTypeResolver = Objects.requireNonNull(envoyTypeResolver, "envoyTypeResolver");
         this.exceptionInfoResolver = Objects.requireNonNull(exceptionInfoResolver, "exceptionInfoResolver");
         this.attributeBoMapper = Objects.requireNonNull(attributeBoMapper, "attributeBoMapper");
         if (sqlMaxBytes < 0) {
@@ -117,10 +120,16 @@ public class OtlpTraceSpanEventMapper {
         } else if (isClient(span)) {
             spanEventBo.setEndPoint(getClientSpanToEndPoint(attributes));
             spanEventBo.setDestinationId(getClientSpanToDestinationId(attributes));
-            // rpc.system dispatch: grpc → GRPC, apache_dubbo → APACHE_DUBBO_CONSUMER.
+            // An Envoy egress span (detected via Envoy-specific tags) maps to ENVOY_EGRESS;
+            // otherwise rpc.system dispatch: grpc → GRPC, apache_dubbo → APACHE_DUBBO_CONSUMER.
             // HTTP clients emit no rpc.system → OPENTELEMETRY_CLIENT fallback.
-            final String rpcSystem = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null);
-            spanEventBo.setServiceType(clientTypeResolver.resolveClientServiceType(rpcSystem));
+            if (envoyTypeResolver.isEnvoy(attributes)) {
+                spanEventBo.setServiceType(envoyTypeResolver.resolveEgressServiceType());
+                envoyTypeResolver.recordAnnotations(spanEventBo::addAnnotation, attributes, false);
+            } else {
+                final String rpcSystem = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null);
+                spanEventBo.setServiceType(clientTypeResolver.resolveClientServiceType(rpcSystem));
+            }
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.API.getCode(), getSpanNameOrDefault(span, OtlpTraceMapper.CLIENT_METHOD_NAME)));
         } else if (isProducer(span)) {
             final String messagingSystem = MessagingAttributeUtils.getSystem(attributes);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -50,6 +50,7 @@ public class OtlpTraceSpanMapper {
     private final OtlpTraceEventMapper eventMapper;
     private final OtlpTraceLinkMapper linkMapper;
     private final OtlpServerTypeResolver serverTypeResolver;
+    private final OtlpEnvoyTypeResolver envoyTypeResolver;
     private final OtlpExceptionInfoResolver exceptionInfoResolver;
     private final OtlpMessagingConsumerResolver messagingConsumerResolver;
     private final OtlpAttributeBoMapper attributeBoMapper;
@@ -57,12 +58,14 @@ public class OtlpTraceSpanMapper {
     public OtlpTraceSpanMapper(OtlpTraceEventMapper eventMapper,
                                OtlpTraceLinkMapper linkMapper,
                                OtlpServerTypeResolver serverTypeResolver,
+                               OtlpEnvoyTypeResolver envoyTypeResolver,
                                OtlpExceptionInfoResolver exceptionInfoResolver,
                                OtlpMessagingConsumerResolver messagingConsumerResolver,
                                OtlpAttributeBoMapper attributeBoMapper) {
         this.eventMapper = Objects.requireNonNull(eventMapper, "eventMapper");
         this.linkMapper = Objects.requireNonNull(linkMapper, "linkMapper");
         this.serverTypeResolver = Objects.requireNonNull(serverTypeResolver, "serverTypeResolver");
+        this.envoyTypeResolver = Objects.requireNonNull(envoyTypeResolver, "envoyTypeResolver");
         this.exceptionInfoResolver = Objects.requireNonNull(exceptionInfoResolver, "exceptionInfoResolver");
         this.messagingConsumerResolver = Objects.requireNonNull(messagingConsumerResolver, "messagingConsumerResolver");
         this.attributeBoMapper = Objects.requireNonNull(attributeBoMapper, "attributeBoMapper");
@@ -245,14 +248,22 @@ public class OtlpTraceSpanMapper {
             spanBo.setAcceptorHost(spanBo.getEndPoint());
         }
 
-        // SERVER kind only: dispatch ServiceType via rpc.system (grpc → GRPC_SERVER,
-        // apache_dubbo → APACHE_DUBBO_PROVIDER). INTERNAL and unsupported-messaging consumer
-        // fallthrough stay on OPENTELEMETRY_SERVER. HTTP server framework cannot be derived
-        // from OTel attributes — verified against OTel Java agent source.
-        final String rpcSystem = (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE)
-                ? AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null)
-                : null;
-        spanBo.setServiceType(serverTypeResolver.resolveServerServiceType(rpcSystem));
+        // SERVER kind only: an Envoy ingress span (detected via Envoy-specific tags) becomes a
+        // ServerMap node, so it maps to the SERVER-category ENVOY (1550) node type — NOT the
+        // RPC-category ENVOY_INGRESS (9301), which the native tracer uses on a child SpanEvent.
+        // Otherwise dispatch ServiceType via rpc.system (grpc → GRPC_SERVER, apache_dubbo →
+        // APACHE_DUBBO_PROVIDER). INTERNAL and unsupported-messaging consumer fallthrough stay on
+        // OPENTELEMETRY_SERVER. HTTP server framework cannot be derived from OTel attributes.
+        final boolean isServerKind = span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE;
+        if (isServerKind && envoyTypeResolver.isEnvoy(attributes)) {
+            spanBo.setServiceType(envoyTypeResolver.resolveNodeServiceType());
+            envoyTypeResolver.recordAnnotations(spanBo::addAnnotation, attributes, true);
+        } else {
+            final String rpcSystem = isServerKind
+                    ? AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null)
+                    : null;
+            spanBo.setServiceType(serverTypeResolver.resolveServerServiceType(rpcSystem));
+        }
 
         final String apiName = isConsumer(span) ? OtlpTraceMapper.CONSUMER_METHOD_NAME : OtlpTraceMapper.SERVER_METHOD_NAME;
         spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.API.getCode(), apiName));

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyTypeResolverTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyTypeResolverTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpEnvoyTypeResolverTest {
+
+    private static final short ENVOY_NODE_CODE = 1550;
+    private static final short ENVOY_EGRESS_CODE = 9302;
+
+    private static final ServiceTypeRegistryService FULL_REGISTRY = buildRegistry(Map.of(
+            "ENVOY", ENVOY_NODE_CODE,
+            "ENVOY_EGRESS", ENVOY_EGRESS_CODE));
+
+    private final OtlpEnvoyTypeResolver resolver = new OtlpEnvoyTypeResolver(FULL_REGISTRY);
+
+    // =======================================================================
+    // isEnvoy — detection gate
+    // =======================================================================
+
+    @Test
+    void isEnvoy_true_whenUpstreamCluster() {
+        assertThat(resolver.isEnvoy(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER, AttributeValue.of("frontend")))).isTrue();
+    }
+
+    @Test
+    void isEnvoy_true_whenUpstreamClusterName() {
+        assertThat(resolver.isEnvoy(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME, AttributeValue.of("frontend")))).isTrue();
+    }
+
+    @Test
+    void isEnvoy_true_whenResponseFlags() {
+        assertThat(resolver.isEnvoy(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_RESPONSE_FLAGS, AttributeValue.of("-")))).isTrue();
+    }
+
+    @Test
+    void isEnvoy_false_whenNoEnvoyMarkers() {
+        // component=proxy alone is intentionally NOT a discriminator.
+        Map<String, AttributeValue> attrs = new HashMap<>();
+        attrs.put("component", AttributeValue.of("proxy"));
+        attrs.put(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, AttributeValue.of("http://x/y"));
+        assertThat(resolver.isEnvoy(attrs)).isFalse();
+    }
+
+    @Test
+    void isEnvoy_false_whenEmpty() {
+        assertThat(resolver.isEnvoy(Map.of())).isFalse();
+    }
+
+    // =======================================================================
+    // resolve — ServiceType codes
+    // =======================================================================
+
+    @Test
+    void resolveNode_returnsEnvoy() {
+        // SERVER-kind ingress span → SERVER-category ENVOY (1550) node type, not ENVOY_INGRESS.
+        assertThat(resolver.resolveNodeServiceType()).isEqualTo(ENVOY_NODE_CODE);
+    }
+
+    @Test
+    void resolveEgress_returnsEnvoyEgress() {
+        assertThat(resolver.resolveEgressServiceType()).isEqualTo(ENVOY_EGRESS_CODE);
+    }
+
+    @Test
+    void resolve_pluginMissingFromRegistry_fallsBackToOtel() {
+        // Collector without the envoy-type-provider on its classpath: degrade to the generic
+        // OpenTelemetry server/client types instead of failing.
+        OtlpEnvoyTypeResolver r = new OtlpEnvoyTypeResolver(buildRegistry(Map.of()));
+        assertThat(r.resolveNodeServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getCode());
+        assertThat(r.resolveEgressServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_CLIENT.getCode());
+    }
+
+    // =======================================================================
+    // recordAnnotations
+    // =======================================================================
+
+    @Test
+    void recordAnnotations_egress_upstreamClusterNamePreferred() {
+        Map<String, AttributeValue> attrs = new HashMap<>();
+        attrs.put(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME, AttributeValue.of("frontend"));
+        attrs.put(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER, AttributeValue.of("legacy"));
+
+        List<AnnotationBo> out = new ArrayList<>();
+        resolver.recordAnnotations(out::add, attrs, false);
+
+        assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isEqualTo("frontend");
+        assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Egress");
+    }
+
+    @Test
+    void recordAnnotations_ingress_fallsBackToLegacyUpstreamCluster() {
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER, AttributeValue.of("frontend"));
+
+        List<AnnotationBo> out = new ArrayList<>();
+        resolver.recordAnnotations(out::add, attrs, true);
+
+        assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isEqualTo("frontend");
+        assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Ingress");
+    }
+
+    @Test
+    void recordAnnotations_noCluster_onlyOperationRecorded() {
+        // response_flags-only Envoy span: no cluster annotation, but operation is still tagged.
+        List<AnnotationBo> out = new ArrayList<>();
+        resolver.recordAnnotations(out::add, Map.of(), false);
+
+        assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isNull();
+        assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Egress");
+    }
+
+    private static Object annotationValue(List<AnnotationBo> annotations, int key) {
+        return annotations.stream()
+                .filter(a -> a.getKey() == key)
+                .map(AnnotationBo::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static ServiceTypeRegistryService buildRegistry(Map<String, Short> entries) {
+        Map<String, ServiceType> byName = new HashMap<>();
+        entries.forEach((name, code) -> byName.put(name, ServiceTypeFactory.of(code, name, name)));
+        return new ServiceTypeRegistryService() {
+            @Override
+            public ServiceType findServiceType(int code) {
+                return byName.values().stream()
+                        .filter(t -> t.getCode() == code)
+                        .findFirst()
+                        .orElse(ServiceType.UNDEFINED);
+            }
+
+            @Override
+            public ServiceType findServiceTypeByName(String typeName) {
+                return byName.getOrDefault(typeName, ServiceType.UNDEFINED);
+            }
+
+            @Override
+            public List<ServiceType> findDesc(String desc) {
+                return List.of();
+            }
+        };
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -87,6 +87,7 @@ class OtlpTraceMapperTest {
                 eventMapper,
                 new OtlpTraceLinkMapper(json, 8192),
                 new OtlpServerTypeResolver(REGISTRY),
+                new OtlpEnvoyTypeResolver(REGISTRY),
                 exceptionInfoResolver,
                 new OtlpMessagingConsumerResolver(List.of(
                         new KafkaMessagingConsumerHandler(),
@@ -100,6 +101,7 @@ class OtlpTraceMapperTest {
                 REGISTRY,
                 new OtlpMessagingTypeResolver(REGISTRY),
                 new OtlpClientTypeResolver(REGISTRY),
+                new OtlpEnvoyTypeResolver(REGISTRY),
                 exceptionInfoResolver,
                 new OtlpAttributeBoMapper(8192),
                 8192);

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -34,6 +34,7 @@ class OtlpTraceSpanEventMapperTest {
         Map<String, ServiceType> byName = new HashMap<>();
         byName.put("GRPC",                   ServiceTypeFactory.of(9160, "GRPC",                   "GRPC"));
         byName.put("APACHE_DUBBO_CONSUMER",  ServiceTypeFactory.of(9997, "APACHE_DUBBO_CONSUMER",  "APACHE_DUBBO_CONSUMER"));
+        byName.put("ENVOY_EGRESS",           ServiceTypeFactory.of(9302, "ENVOY_EGRESS",           "ENVOY_EGRESS"));
         return new ServiceTypeRegistryService() {
             @Override
             public ServiceType findServiceType(int serviceType) {
@@ -64,6 +65,7 @@ class OtlpTraceSpanEventMapperTest {
                 TEST_REGISTRY,
                 new OtlpMessagingTypeResolver(TEST_REGISTRY),
                 new OtlpClientTypeResolver(TEST_REGISTRY),
+                new OtlpEnvoyTypeResolver(TEST_REGISTRY),
                 new OtlpExceptionInfoResolver(),
                 new OtlpAttributeBoMapper(8192),
                 8192);
@@ -463,6 +465,81 @@ class OtlpTraceSpanEventMapperTest {
 
         SpanEventBo event = mapSingle(span);
         assertThat(event.getServiceType()).isEqualTo((short) 9160);
+    }
+
+    @Test
+    void map_client_envoy_setsEnvoyEgressAndUpstreamClusterAnnotation() {
+        // Envoy egress leg over OTLP: upstream_cluster tags trigger the Envoy branch, which
+        // overrides the generic OPENTELEMETRY_CLIENT with ENVOY_EGRESS and records the
+        // upstream.cluster / envoy.operation annotations.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("response_flags", strVal("-")),
+                kv("http.status_code", strVal("200")),
+                kv("upstream_cluster", strVal("frontend")),
+                kv("upstream_cluster.name", strVal("frontend")),
+                kv("upstream_address", strVal("172.18.0.27:8080")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(event.getServiceType()).isEqualTo((short) 9302); // ENVOY_EGRESS
+        assertThat(event.getEndPoint()).isEqualTo("172.18.0.27:8080");
+        assertThat(event.getDestinationId()).isEqualTo("frontend");
+        assertThat(annotationValue(event.getAnnotationBoList(), OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER))
+                .isEqualTo("frontend");
+        assertThat(annotationValue(event.getAnnotationBoList(), OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION))
+                .isEqualTo("Egress");
+    }
+
+    @Test
+    void map_client_envoy_absentEnvoyType_fallsBackToOpenTelemetryClient() {
+        // A collector without the envoy-type-provider still ingests the span; it just keeps the
+        // generic OPENTELEMETRY_CLIENT type (resolver fallback), never failing.
+        OtlpTraceSpanEventMapper noEnvoy = new OtlpTraceSpanEventMapper(
+                new OtlpTraceEventMapper(new ObjectMapper(), 8192),
+                TEST_REGISTRY,
+                new OtlpMessagingTypeResolver(TEST_REGISTRY),
+                new OtlpClientTypeResolver(TEST_REGISTRY),
+                new OtlpEnvoyTypeResolver(buildRegistryWithout("ENVOY_EGRESS")),
+                new OtlpExceptionInfoResolver(),
+                new OtlpAttributeBoMapper(8192),
+                8192);
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("upstream_cluster.name", strVal("frontend")));
+
+        SpanEventBo event = noEnvoy.map(0L, span).get(0);
+        assertThat(event.getServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_CLIENT.getCode());
+    }
+
+    private static Object annotationValue(List<com.navercorp.pinpoint.common.server.bo.AnnotationBo> annotations, int key) {
+        return annotations.stream()
+                .filter(a -> a.getKey() == key)
+                .map(com.navercorp.pinpoint.common.server.bo.AnnotationBo::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static ServiceTypeRegistryService buildRegistryWithout(String excludedName) {
+        Map<String, ServiceType> byName = new HashMap<>();
+        byName.put("GRPC", ServiceTypeFactory.of(9160, "GRPC", "GRPC"));
+        byName.remove(excludedName);
+        return new ServiceTypeRegistryService() {
+            @Override
+            public ServiceType findServiceType(int serviceType) {
+                return byName.values().stream()
+                        .filter(t -> t.getCode() == serviceType)
+                        .findFirst()
+                        .orElse(ServiceType.UNDEFINED);
+            }
+
+            @Override
+            public ServiceType findServiceTypeByName(String typeName) {
+                return byName.getOrDefault(typeName, ServiceType.UNDEFINED);
+            }
+
+            @Override
+            public List<ServiceType> findDesc(String desc) {
+                return List.of();
+            }
+        };
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -163,6 +163,7 @@ class OtlpTraceSpanMapperTest {
         byName.put("ACTIVEMQ_CLIENT",       ServiceTypeFactory.of(8310, "ACTIVEMQ_CLIENT",       "ACTIVEMQ_CLIENT"));
         byName.put("GRPC_SERVER",           ServiceTypeFactory.of(1130, "GRPC_SERVER",           "GRPC_SERVER"));
         byName.put("APACHE_DUBBO_PROVIDER", ServiceTypeFactory.of(1999, "APACHE_DUBBO_PROVIDER", "APACHE_DUBBO_PROVIDER"));
+        byName.put("ENVOY",                 ServiceTypeFactory.of(1550, "ENVOY",                 "ENVOY"));
         return new ServiceTypeRegistryService() {
             @Override
             public ServiceType findServiceType(int code) {
@@ -190,6 +191,7 @@ class OtlpTraceSpanMapperTest {
                 new OtlpTraceEventMapper(json, 8192),
                 new OtlpTraceLinkMapper(json, 8192),
                 new OtlpServerTypeResolver(MESSAGING_REGISTRY),
+                new OtlpEnvoyTypeResolver(MESSAGING_REGISTRY),
                 new OtlpExceptionInfoResolver(),
                 new OtlpMessagingConsumerResolver(List.of(
                         new KafkaMessagingConsumerHandler(),
@@ -535,6 +537,29 @@ class OtlpTraceSpanMapperTest {
                 kv("network.protocol.name", strVal("http")));
         SpanBo bo = newMapper().map(id(), span);
         assertThat(bo.getServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getCode());
+    }
+
+    @Test
+    void map_server_envoy_setsEnvoyNodeAndUpstreamClusterAnnotation() {
+        // Envoy ingress span over OTLP becomes a ServerMap node, so it maps to the SERVER-category
+        // ENVOY (1550) node type — not the RPC-category ENVOY_INGRESS (9301) — overriding the
+        // generic OPENTELEMETRY_SERVER and recording the upstream.cluster / envoy.operation annotations.
+        Span span = serverSpan(
+                kv("response_flags", strVal("-")),
+                kv("upstream_cluster", strVal("frontend")),
+                kv("upstream_cluster.name", strVal("frontend")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(bo.getServiceType()).isEqualTo((short) 1550); // ENVOY (SERVER-category node)
+        assertThat(annotationValue(bo, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isEqualTo("frontend");
+        assertThat(annotationValue(bo, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Ingress");
+    }
+
+    private static Object annotationValue(SpanBo spanBo, int key) {
+        return spanBo.getAnnotationBoList().stream()
+                .filter(a -> a.getKey() == key)
+                .map(com.navercorp.pinpoint.common.server.bo.AnnotationBo::getValue)
+                .findFirst()
+                .orElse(null);
     }
 
     @Test


### PR DESCRIPTION
Detect Envoy proxy spans arriving via OTLP (upstream_cluster / upstream_cluster.name / response_flags) and map them to the dedicated Envoy service types instead of the generic OpenTelemetry ones:

- SERVER-kind ingress span -> ENVOY (1550) node (SERVER category)
- CLIENT-kind egress span  -> ENVOY_EGRESS (9302) call (RPC category)

Record envoy.operation (9441) and upstream.cluster (9442) annotations, mirroring the native pinpoint-cpp Envoy tracer. ServiceType codes are resolved by name, so a collector without the envoy-type-provider falls back to OPENTELEMETRY_SERVER / OPENTELEMETRY_CLIENT.

component=proxy is intentionally not used as a detection signal (deprecated in OTel semconv, set by other proxies).