### PR TITLE
[#noissue] Extract OtelEvent record and stream event annotation JSON …

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtelEvent.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtelEvent.java
@@ -1,0 +1,20 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import io.opentelemetry.proto.common.v1.KeyValue;
+
+import java.util.List;
+
+/**
+ * Write-side model of the {@code OPENTELEMETRY_EVENT} annotation JSON, wrapped in the
+ * parent event name:
+ * <pre>{@code {"<name>": {"time": <unix_nano>, "attributes": {...}}}}</pre>
+ *
+ * @param name       OTel event name — an event with an empty name is invalid and skipped
+ * @param time       event timestamp in unix nanos
+ * @param attributes raw OTel event attributes — transformed (value capping) at serialization
+ *                   time, only serialized when non-empty
+ */
+public record OtelEvent(String name,
+                        long time,
+                        List<KeyValue> attributes) {
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapper.java
@@ -1,22 +1,20 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
-import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import io.opentelemetry.proto.trace.v1.Span;
+import org.apache.commons.io.output.StringBuilderWriter;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 import java.util.Objects;
 
-import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperUtils.getAttributeToMap;
 
 @Component
 public class OtlpTraceEventMapper {
@@ -24,13 +22,13 @@ public class OtlpTraceEventMapper {
     private static final String FIELD_TIME = "time";
     private static final String FIELD_ATTRIBUTES = "attributes";
 
-    private final ObjectWriter mapWriter;
+    private final JsonFactory jsonFactory;
     private final int valueMaxBytes;
 
     public OtlpTraceEventMapper(ObjectMapper objectMapper,
                                 @Value("${pinpoint.collector.otlptrace.event.value-max-bytes:8192}") int valueMaxBytes) {
         Objects.requireNonNull(objectMapper, "objectMapper");
-        this.mapWriter = objectMapper.writerFor(new TypeReference<Map<String, Object>>() {});
+        this.jsonFactory = objectMapper.getFactory();
         if (valueMaxBytes < 0) {
             throw new IllegalArgumentException("valueMaxBytes must be >= 0: " + valueMaxBytes);
         }
@@ -38,34 +36,50 @@ public class OtlpTraceEventMapper {
     }
 
     /**
-     * Serializes an OTel {@link Span.Event} as JSON wrapped in the parent event name:
-     * <pre>{@code {"<event.name>": {"time": <unix_nano>, "attributes": {...}}}}</pre>
-     * The {@code attributes} field is omitted when the event has none, so empty events
-     * produce {@code {"<event.name>": {"time": N}}} (no longer a heterogeneous string/object
-     * value). Emitted under {@link AnnotationKey#OPENTELEMETRY_EVENT}. {@code onTruncated} is
-     * invoked once per truncated attribute leaf.
+     * Serializes an OTel {@link Span.Event} as {@link OtelEvent} JSON into an
+     * {@link AnnotationKey#OPENTELEMETRY_EVENT} annotation.
+     *
+     * <p>Returns {@code null} when the event name is empty — such an event is invalid input
+     * we drop silently.</p>
+     *
+     * <p>{@code onTruncated} is invoked once per truncated attribute leaf.</p>
      */
-    public void addEventToAnnotation(Span.Event event, AnnotationWriter annotationWriter, TruncationListener onTruncated) {
+    public @Nullable AnnotationBo toAnnotation(Span.Event event, TruncationListener onTruncated) {
         if (StringUtils.isEmpty(event.getName())) {
-            return;
+            return null;
         }
-
         try {
-            Map<String, Object> inner = new HashMap<>(2);
-            inner.put(FIELD_TIME, event.getTimeUnixNano());
-            if (event.getAttributesCount() > 0) {
+            final OtelEvent otelEvent = toOtelEvent(event);
+            final String value = toJson(otelEvent, onTruncated);
+            return AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), value);
+        } catch (IOException e) {
+            return AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), "json processing error");
+        }
+    }
+
+    private OtelEvent toOtelEvent(Span.Event event) {
+        return new OtelEvent(event.getName(), event.getTimeUnixNano(), event.getAttributesList());
+    }
+
+    private String toJson(OtelEvent otelEvent, TruncationListener onTruncated) throws IOException {
+        final StringBuilderWriter buffer = new StringBuilderWriter();
+        try (JsonGenerator generator = jsonFactory.createGenerator(buffer)) {
+            generator.writeStartObject();
+            generator.writeFieldName(otelEvent.name());
+
+            generator.writeStartObject();
+            generator.writeNumberField(FIELD_TIME, otelEvent.time());
+            if (!otelEvent.attributes().isEmpty()) {
                 // Cap over-long string values (notably exception.stacktrace, which is also kept in
                 // full in exception metadata) so a single event cannot bloat the span row.
-                final Map<String, Object> eventAttributes =
-                        getAttributeToMap(event.getAttributesList(), valueMaxBytes, onTruncated);
-                inner.put(FIELD_ATTRIBUTES, eventAttributes);
+                generator.writeFieldName(FIELD_ATTRIBUTES);
+                OtlpTraceMapperUtils.writeAttributes(generator, otelEvent.attributes(), valueMaxBytes, onTruncated);
             }
-            Map<String, Object> map = Map.of(event.getName(), inner);
-            final String value = mapWriter.writeValueAsString(map);
-            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), value));
-        } catch (JsonProcessingException e) {
-            annotationWriter.write(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_EVENT.getCode(), "json processing error"));
+            generator.writeEndObject();
+
+            generator.writeEndObject();
         }
+        return buffer.toString();
     }
 
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -166,7 +166,10 @@ public class OtlpTraceSpanEventMapper {
             if (skipExceptionEvent && OtlpTraceConstants.EVENT_NAME_EXCEPTION.equals(event.getName())) {
                 continue;
             }
-            eventMapper.addEventToAnnotation(event, spanEventBo::addAnnotation, truncatedCounts::event);
+            final AnnotationBo eventAnnotation = eventMapper.toAnnotation(event, truncatedCounts::event);
+            if (eventAnnotation != null) {
+                spanEventBo.addAnnotation(eventAnnotation);
+            }
         }
         // SDK-side data-loss hints (Span proto fields 10/12/14). Only emit when > 0.
         final AnnotationBo droppedAnnotation = OtlpTraceSpanMapper.toDroppedAnnotation(

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -141,7 +141,10 @@ public class OtlpTraceSpanMapper {
             if (skipExceptionEvent && OtlpTraceConstants.EVENT_NAME_EXCEPTION.equals(event.getName())) {
                 continue;
             }
-            eventMapper.addEventToAnnotation(event, spanBo::addAnnotation, truncatedCounts::event);
+            final AnnotationBo eventAnnotation = eventMapper.toAnnotation(event, truncatedCounts::event);
+            if (eventAnnotation != null) {
+                spanBo.addAnnotation(eventAnnotation);
+            }
         }
         // link
         for (Span.Link link : span.getLinksList()) {

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceEventMapperTest.java
@@ -2,7 +2,6 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
-import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.ArrayValue;
@@ -26,13 +25,18 @@ class OtlpTraceEventMapperTest {
 
     private OtlpTraceEventMapper mapper;
     private List<AnnotationBo> annotations;
-    private AnnotationWriter writer;
 
     @BeforeEach
     void setUp() {
         mapper = new OtlpTraceEventMapper(new ObjectMapper(), 8192);
         annotations = new ArrayList<>();
-        writer = annotations::add;
+    }
+
+    private void addEvent(Span.Event event) {
+        AnnotationBo annotation = mapper.toAnnotation(event, () -> {});
+        if (annotation != null) {
+            annotations.add(annotation);
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -46,7 +50,7 @@ class OtlpTraceEventMapperTest {
                 .setTimeUnixNano(1716200000000000000L)
                 .build();
 
-        mapper.addEventToAnnotation(event, writer, () -> {});
+        addEvent(event);
 
         assertThat(annotations).hasSize(1);
         AnnotationBo bo = annotations.get(0);
@@ -77,7 +81,7 @@ class OtlpTraceEventMapperTest {
                 .addAllAttributes(attrs)
                 .build();
 
-        mapper.addEventToAnnotation(event, writer, () -> {});
+        addEvent(event);
 
         assertThat(annotations).hasSize(1);
         ObjectMapper om = new ObjectMapper();
@@ -107,7 +111,7 @@ class OtlpTraceEventMapperTest {
                 .addAllAttributes(attrs)
                 .build();
 
-        mapper.addEventToAnnotation(event, writer, () -> {});
+        addEvent(event);
 
         assertThat(annotations).hasSize(1);
         String json = (String) annotations.get(0).getValue();
@@ -142,7 +146,7 @@ class OtlpTraceEventMapperTest {
                 .addAttributes(kv("tags", AnyValue.newBuilder().setArrayValue(arrayValue).build()))
                 .build();
 
-        mapper.addEventToAnnotation(event, writer, () -> {});
+        addEvent(event);
 
         assertThat(annotations).hasSize(1);
         String json = (String) annotations.get(0).getValue();
@@ -167,7 +171,7 @@ class OtlpTraceEventMapperTest {
     void annotationKey_isOpentelemetryEvent() {
         Span.Event event = Span.Event.newBuilder().setName("check").build();
 
-        mapper.addEventToAnnotation(event, writer, () -> {});
+        addEvent(event);
 
         assertThat(annotations.get(0).getKey())
                 .isEqualTo(AnnotationKey.OPENTELEMETRY_EVENT.getCode());


### PR DESCRIPTION
…directly

Apply the OtelLink pattern to OtlpTraceEventMapper: an OtelEvent record carries the raw proto values (name, unix-nano time, attribute KeyValue list), toOtelEvent is pure extraction, and toJson streams the {"<name>": {"time": N, "attributes": {...}}} JSON via JsonGenerator with attribute capping applied at write time through OtlpTraceMapperUtils.writeAttributes. The mapper now returns the OPENTELEMETRY_EVENT AnnotationBo (null for an empty-name event) instead of writing into an AnnotationWriter; both span mappers add it themselves.