### PR TITLE
[#13983] Apply service concept to /api/agents

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/job/ApplicationCleanupTasklet.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/job/ApplicationCleanupTasklet.java
@@ -105,7 +105,7 @@ public class ApplicationCleanupTasklet implements Tasklet {
     }
 
     private void processApplication(Application application, long baseTimestamp) {
-        int serviceUid = application.getService().getServiceUid();
+        int serviceUid = application.getService().getServiceUid().getUid();
         String applicationName = application.getApplicationName();
         int serviceTypeCode = application.getServiceTypeCode();
         int agentCount = agentIdDao.countAgentIdEntry(serviceUid, applicationName, serviceTypeCode);
@@ -252,7 +252,7 @@ public class ApplicationCleanupTasklet implements Tasklet {
 
     private Dot getTraceIndexData(Application application, long baseTimestamp) {
         Range range = Range.between(baseTimestamp - Duration.ofDays(inactiveDays).toMillis(), baseTimestamp);
-        LimitedScanResult<List<Dot>> result = traceIndexDao.scanTraceScatterData(application.getService().getServiceUid(), application.getApplicationName(), application.getServiceTypeCode(), range, 1);
+        LimitedScanResult<List<Dot>> result = traceIndexDao.scanTraceScatterData(application.getService().getServiceUid().getUid(), application.getApplicationName(), application.getServiceTypeCode(), range, 1);
         if (!result.scanData().isEmpty()) {
             return result.scanData().get(0);
         }
@@ -266,7 +266,7 @@ public class ApplicationCleanupTasklet implements Tasklet {
         }
         logger.info("delete application. application={}", application);
         applicationDao.deleteApplication(
-                application.getService().getServiceUid(),
+                application.getService().getServiceUid().getUid(),
                 application.getApplicationName(),
                 application.getServiceTypeCode(),
                 baseTimestamp - Duration.ofHours(1).toMillis()

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/service/ServiceRegistryServiceImpl.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/service/ServiceRegistryServiceImpl.java
@@ -4,6 +4,7 @@ import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.IdGenerator;
 import com.navercorp.pinpoint.service.dao.ServiceRegistryDao;
 import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
@@ -30,7 +31,14 @@ public class ServiceRegistryServiceImpl implements ServiceRegistryService {
     public ServiceEntity insertService(String name) {
         Objects.requireNonNull(name, "name");
         int uid = serviceUidGenerator.generate().getUid();
-        serviceRegistryDao.insertService(uid, name);
+        try {
+            serviceRegistryDao.insertService(uid, name);
+        } catch (DuplicateKeyException e) {
+            if (serviceRegistryDao.selectService(name) != null) {
+                throw new DataIntegrityViolationException("Duplicate service name: " + name, e);
+            }
+            throw e;
+        }
 
         ServiceEntity entity = new ServiceEntity();
         entity.setUid(uid);

--- a/service-module/src/main/resources/service/web/mapper/ServiceRegistryMapper.xml
+++ b/service-module/src/main/resources/service/web/mapper/ServiceRegistryMapper.xml
@@ -3,7 +3,7 @@
 
 <mapper namespace="com.navercorp.pinpoint.service.dao.ServiceRegistryDao">
 
-    <insert id="insertService" parameterType="ServiceParam" useGeneratedKeys="true" keyProperty="uid">
+    <insert id="insertService" parameterType="ServiceParam">
         INSERT INTO service (uid, name)
         VALUES (#{uid}, #{name})
     </insert>

--- a/service-module/src/test/java/com/navercorp/pinpoint/service/service/ServiceRegistryServiceImplTest.java
+++ b/service-module/src/test/java/com/navercorp/pinpoint/service/service/ServiceRegistryServiceImplTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,6 +55,32 @@ class ServiceRegistryServiceImplTest {
     void insertService_nullName() {
         assertThatThrownBy(() -> serviceRegistryService.insertService(null))
                 .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void insertService_duplicateName_notRetryable() {
+        ServiceUid serviceUid = ServiceUid.of(12345);
+        when(serviceUidGenerator.generate()).thenReturn(serviceUid);
+        when(serviceRegistryDao.insertService(12345, "my-service")).thenThrow(new DuplicateKeyException("duplicate"));
+        ServiceEntity existing = new ServiceEntity();
+        existing.setUid(99999);
+        existing.setName("my-service");
+        when(serviceRegistryDao.selectService("my-service")).thenReturn(existing);
+
+        assertThatThrownBy(() -> serviceRegistryService.insertService("my-service"))
+                .isInstanceOf(DataIntegrityViolationException.class)
+                .isNotInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    void insertService_uidCollision_retryable() {
+        ServiceUid serviceUid = ServiceUid.of(12345);
+        when(serviceUidGenerator.generate()).thenReturn(serviceUid);
+        when(serviceRegistryDao.insertService(12345, "my-service")).thenThrow(new DuplicateKeyException("duplicate"));
+        when(serviceRegistryDao.selectService("my-service")).thenReturn(null);
+
+        assertThatThrownBy(() -> serviceRegistryService.insertService("my-service"))
+                .isInstanceOf(DuplicateKeyException.class);
     }
 
     @Test

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/datasource/AgentInfoServerGroupListDataSource.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/appender/server/datasource/AgentInfoServerGroupListDataSource.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.web.applicationmap.appender.server.datasource;
 
 import com.navercorp.pinpoint.common.server.bo.SimpleAgentKey;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.applicationmap.histogram.Histogram;
@@ -130,7 +129,7 @@ public class AgentInfoServerGroupListDataSource implements ServerGroupListDataSo
     private ServerGroupList createServerGroupListV2(Node node, Range range) {
         Application application = node.getApplication();
         List<AgentIdEntry> agentIdEntries = agentListV2Service.getActiveAgentList(
-                ServiceUid.DEFAULT, application.getApplicationName(), application.getServiceType(), range);
+                application.getService(), application.getApplicationName(), application.getServiceType(), range);
 
         if (CollectionUtils.isEmpty(agentIdEntries)) {
             logger.info("agentIdEntry not found. application:{}", application);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java
@@ -88,7 +88,7 @@ public class HbaseMapInLinkDao implements MapInLinkDao {
         RowMapper<LinkDataMap> rowMapper = this.inLinkMapperFactory.newMapper(mapperWindow, inApplication);
         ResultsExtractor<LinkDataMap> resultExtractor = new RowMapReduceResultExtractor<>(rowMapper, new LinkTimeWindowReducer(timeWindow));
 
-        final Scan scan = scanFactory.createScan("MInLink", inApplication.getService().getServiceUid(), inApplication, timeWindow.getWindowRange(), table.getName());
+        final Scan scan = scanFactory.createScan("MInLink", inApplication.getService().getServiceUid().getUid(), inApplication, timeWindow.getWindowRange(), table.getName());
 
         final LinkDataMap linkDataMap = selectInLink(scan, table.getTable(), resultExtractor, NUM_PARTITIONS);
         if (logger.isDebugEnabled()) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -87,7 +87,7 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
 
         ResultsExtractor<LinkDataMap> resultExtractor = new RowMapReduceResultExtractor<>(rowMapper, new LinkTimeWindowReducer(timeWindow));
 
-        final Scan scan = scanFactory.createScan("MOutLink", outApplication.getService().getServiceUid(), outApplication, timeWindow.getWindowRange(), table.getName());
+        final Scan scan = scanFactory.createScan("MOutLink", outApplication.getService().getServiceUid().getUid(), outApplication, timeWindow.getWindowRange(), table.getName());
         final LinkDataMap linkDataMap = selectOutLink(scan, table.getTable(), resultExtractor, NUM_PARTITIONS);
         if (logger.isDebugEnabled()) {
             logger.debug("selectOutLink {} {}", outApplication, linkDataMap.getLinkDataSize());

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostScanKeyFactoryV3.java
@@ -27,7 +27,7 @@ public class HostScanKeyFactoryV3 implements HostScanKeyFactory {
     @Override
     public byte[] scanKey(Application parentApplication, long timestamp) {
         return UidAppRowKey.makeRowKey(saltKeySize,
-                parentApplication.getService().getServiceUid(),
+                parentApplication.getService().getServiceUid().getUid(),
                 parentApplication.getApplicationName(),
                 parentApplication.getServiceTypeCode(),
                 timestamp);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/RowFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/RowFilter.java
@@ -31,7 +31,7 @@ public class RowFilter<T extends UidRowKey> implements Predicate<T> {
     }
 
     public boolean test(UidRowKey row) {
-        return this.application.getService().getServiceUid() == row.getServiceUid()
+        return this.application.getService().getServiceUid().getUid() == row.getServiceUid()
                 &&  application.getApplicationName().equals(row.getApplicationName())
                 && application.getServiceTypeCode() == row.getServiceType();
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentV2Controller.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentV2Controller.java
@@ -31,8 +31,10 @@ import com.navercorp.pinpoint.web.agentlist.service.AgentsService;
 import com.navercorp.pinpoint.web.config.ConfigProperties;
 import com.navercorp.pinpoint.web.service.AgentListV2Service;
 import com.navercorp.pinpoint.web.service.ApplicationAgentListQueryRule;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.view.tree.AgentIdView;
 import com.navercorp.pinpoint.web.vo.Application;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilters;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatus;
@@ -63,17 +65,20 @@ public class AgentV2Controller {
 
     private final AgentListV2Service agentListV2Service;
     private final AgentsService agentsService;
+    private final ServiceModelResolver serviceModelResolver;
     private final RangeValidator rangeValidator;
     private final boolean agentReadV2;
 
     public AgentV2Controller(ServiceTypeRegistryService serviceTypeRegistryService,
                              AgentListV2Service agentListV2Service,
                              AgentsService agentsService,
+                             ServiceModelResolver serviceModelResolver,
                              ConfigProperties configProperties,
                              @Value("${pinpoint.web.application.index.read.v2:true}") boolean readAgentV2) {
         this.serviceTypeRegistryService = Objects.requireNonNull(serviceTypeRegistryService, "serviceTypeRegistryService");
         this.agentListV2Service = Objects.requireNonNull(agentListV2Service, "agentListV2Service");
         this.agentsService = Objects.requireNonNull(agentsService, "agentsService");
+        this.serviceModelResolver = Objects.requireNonNull(serviceModelResolver, "serviceModelResolver");
         this.rangeValidator = new ForwardRangeValidator(Duration.ofDays(configProperties.getInspectorPeriodMax()));
         this.agentReadV2 = readAgentV2;
     }
@@ -96,7 +101,7 @@ public class AgentV2Controller {
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
             @RequestParam("from") Timestamp from,
             @RequestParam("to") Timestamp to) {
-        ServiceUid serviceUid = ServiceUid.DEFAULT;
+        final Service service = serviceModelResolver.getService(serviceName.getName());
         final ServiceType serviceType = findServiceType(serviceTypeCode, serviceTypeName);
         Range range = Range.between(from, to);
         rangeValidator.validate(range);
@@ -104,7 +109,7 @@ public class AgentV2Controller {
         if (serviceType.equals(ServiceType.UNDEFINED)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid serviceType. ServiceType is required for v2 table");
         }
-        return agentListV2Service.getActiveAgentList(serviceUid, applicationName, serviceType, range).stream()
+        return agentListV2Service.getActiveAgentList(service, applicationName, serviceType, range).stream()
                 .map(entry -> AgentIdView.of(entry, range.getTo()))
                 .toList();
     }
@@ -118,12 +123,12 @@ public class AgentV2Controller {
             @RequestParam(value = "serviceTypeName", required = false) String serviceTypeName,
             @RequestParam("from") Timestamp from,
             @RequestParam("to") Timestamp to) {
-        ServiceUid serviceUid = ServiceUid.DEFAULT;
+        final Service service = serviceModelResolver.getService(serviceName.getName());
         final ServiceType serviceType = findServiceType(serviceTypeCode, serviceTypeName);
         Range range = Range.between(from, to);
         rangeValidator.validate(range);
 
-        if (!ServiceUid.DEFAULT.equals(serviceUid)) {
+        if (!ServiceUid.DEFAULT.equals(service.getServiceUid())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "v1 table only supports 'default' service");
         }
         // Note: AgentsService internally uses v2 agentIds when 'pinpoint.web.application.index.read.v2' is true

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentIdDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentIdDao.java
@@ -116,7 +116,7 @@ public class HbaseAgentIdDao implements AgentIdDao {
     public void delete(List<AgentIdEntry> agentIdEntryList) {
         List<Delete> deletes = new ArrayList<>(agentIdEntryList.size());
         for (AgentIdEntry agentIdEntry : agentIdEntryList) {
-            byte[] rowKey = AgentIdRowKeyUtils.createRow(agentIdEntry.getService().getServiceUid(), agentIdEntry.getApplicationName(), agentIdEntry.getServiceTypeCode(), agentIdEntry.getAgentId(), agentIdEntry.getAgentStartTime());
+            byte[] rowKey = AgentIdRowKeyUtils.createRow(agentIdEntry.getService().getServiceUid().getUid(), agentIdEntry.getApplicationName(), agentIdEntry.getServiceTypeCode(), agentIdEntry.getAgentId(), agentIdEntry.getAgentStartTime());
             deletes.add(new Delete(rowKey));
         }
         TableName agentListTableName = tableNameProvider.getTableName(DESCRIPTOR.getTable());
@@ -188,7 +188,7 @@ public class HbaseAgentIdDao implements AgentIdDao {
         Scan scan = new Scan();
         if (lastAgentIdEntry != null) {
             byte[] startRow = AgentIdRowKeyUtils.createRow(
-                    lastAgentIdEntry.getService().getServiceUid(),
+                    lastAgentIdEntry.getService().getServiceUid().getUid(),
                     lastAgentIdEntry.getApplicationName(),
                     lastAgentIdEntry.getServiceTypeCode(),
                     lastAgentIdEntry.getAgentId(),

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentListV2Service.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentListV2Service.java
@@ -1,16 +1,16 @@
 package com.navercorp.pinpoint.web.service;
 
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentIdEntry;
 
 import java.util.List;
 
 public interface AgentListV2Service {
 
-    List<AgentIdEntry> getAllAgentList(ServiceUid serviceUid, String applicationName, ServiceType serviceType);
+    List<AgentIdEntry> getAllAgentList(Service service, String applicationName, ServiceType serviceType);
 
-    List<AgentIdEntry> getActiveAgentList(ServiceUid serviceUid, String applicationName, ServiceType serviceType, Range range);
+    List<AgentIdEntry> getActiveAgentList(Service service, String applicationName, ServiceType serviceType, Range range);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentListV2ServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentListV2ServiceImpl.java
@@ -17,24 +17,23 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.server.config.AgentProperties;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapAgentResponseDao;
 import com.navercorp.pinpoint.web.dao.AgentIdDao;
 import com.navercorp.pinpoint.web.vo.Application;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentIdEntry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-@Service
+@org.springframework.stereotype.Service
 public class AgentListV2ServiceImpl implements AgentListV2Service {
     private final Logger logger = LogManager.getLogger(this.getClass());
 
@@ -50,24 +49,24 @@ public class AgentListV2ServiceImpl implements AgentListV2Service {
     }
 
     @Override
-    public List<AgentIdEntry> getAllAgentList(ServiceUid serviceUid, String applicationName, ServiceType serviceType) {
-        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntry(serviceUid.getUid(), applicationName, serviceType.getCode());
+    public List<AgentIdEntry> getAllAgentList(Service service, String applicationName, ServiceType serviceType) {
+        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntry(service.getServiceUid().getUid(), applicationName, serviceType.getCode());
         return dedupeConsecutiveAgentId(agentIdEntryList);
     }
 
     @Override
-    public List<AgentIdEntry> getActiveAgentList(ServiceUid serviceUid, String applicationName, ServiceType serviceType, Range range) {
+    public List<AgentIdEntry> getActiveAgentList(Service service, String applicationName, ServiceType serviceType, Range range) {
         if (agentProperties.getStatisticsCheckServiceTypeCodes().contains((int) serviceType.getCode())) {
-            return getActiveAgentListByStatistics(serviceUid, applicationName, serviceType, range);
+            return getActiveAgentListByStatistics(service, applicationName, serviceType, range);
         }
-        return getActiveAgentListByStatus(serviceUid, applicationName, serviceType, range);
+        return getActiveAgentListByStatus(service, applicationName, serviceType, range);
     }
 
     /**
      * For service types that may not send steady pings — fetch all entries, then filter by span statistics.
      */
-    private List<AgentIdEntry> getActiveAgentListByStatistics(ServiceUid serviceUid, String applicationName, ServiceType serviceType, Range range) {
-        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntry(serviceUid.getUid(), applicationName, serviceType.getCode());
+    private List<AgentIdEntry> getActiveAgentListByStatistics(Service service, String applicationName, ServiceType serviceType, Range range) {
+        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntry(service.getServiceUid().getUid(), applicationName, serviceType.getCode());
         agentIdEntryList = filterByAgentStartTime(agentIdEntryList, range);
         agentIdEntryList = dedupeConsecutiveAgentId(agentIdEntryList);
 
@@ -82,8 +81,8 @@ public class AgentListV2ServiceImpl implements AgentListV2Service {
     /**
      * For service types that send pings — filter by status timestamp.
      */
-    private List<AgentIdEntry> getActiveAgentListByStatus(ServiceUid serviceUid, String applicationName, ServiceType serviceType, Range range) {
-        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntryByMinStateTimestamp(serviceUid.getUid(), applicationName, serviceType.getCode(), range.getFrom());
+    private List<AgentIdEntry> getActiveAgentListByStatus(Service service, String applicationName, ServiceType serviceType, Range range) {
+        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntryByMinStateTimestamp(service.getServiceUid().getUid(), applicationName, serviceType.getCode(), range.getFrom());
         agentIdEntryList = filterByAgentStartTime(agentIdEntryList, range);
         agentIdEntryList = dedupeConsecutiveAgentId(agentIdEntryList);
         return agentIdEntryList;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexServiceImpl.java
@@ -70,7 +70,7 @@ public class ApplicationIndexServiceImpl implements ApplicationIndexService {
     @Override
     public List<Application> selectAllApplications(Service service) {
         if (readV2) {
-            return this.applicationDao.getApplications(service.getServiceUid());
+            return this.applicationDao.getApplications(service.getServiceUid().getUid());
         }
         return this.applicationIndexDao.selectAllApplicationNames();
     }
@@ -159,7 +159,7 @@ public class ApplicationIndexServiceImpl implements ApplicationIndexService {
         if (v2TableEnabled) {
             List<Application> applicationList = this.applicationDao.getApplications(ServiceUid.DEFAULT_SERVICE_UID_CODE, applicationName);
             for (Application application : applicationList) {
-                batchDeleteAgentIdsV2(application.getService().getServiceUid(), application.getApplicationName(), application.getServiceTypeCode(), agentIds);
+                batchDeleteAgentIdsV2(application.getService().getServiceUid().getUid(), application.getApplicationName(), application.getServiceTypeCode(), agentIds);
             }
         }
         if (v1TableEnabled) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolver.java
@@ -108,7 +108,7 @@ public class CachingServiceModelResolver extends ServiceModelResolver implements
             for (ServiceEntity entity : serviceList) {
                 Service service = toService(entity);
                 serviceByNameCache.put(service.getServiceName(), service);
-                serviceByUidCache.put(service.getServiceUid(), service);
+                serviceByUidCache.put(service.getServiceUid().getUid(), service);
             }
             return serviceList.size();
         } catch (Exception e) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
@@ -15,10 +15,10 @@ public class ServiceModelResolver {
     }
 
     public Service getService(int serviceUid) {
-        if (Service.DEFAULT.getServiceUid() == serviceUid) {
+        if (Service.DEFAULT.getServiceUid().getUid() == serviceUid) {
             return Service.DEFAULT;
         }
-        if (Service.TEST_SERVICE.getServiceUid() == serviceUid) {
+        if (Service.TEST_SERVICE.getServiceUid().getUid() == serviceUid) {
             return Service.TEST_SERVICE;
         }
         Service service = resolveService(serviceUid);

--- a/web/src/main/java/com/navercorp/pinpoint/web/uid/service/ApplicationIndexV2CopyServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/uid/service/ApplicationIndexV2CopyServiceImpl.java
@@ -57,7 +57,7 @@ public class ApplicationIndexV2CopyServiceImpl implements ApplicationIndexV2Copy
             if (application.getServiceType().equals(ServiceType.UNDEFINED)) {
                 continue;
             }
-            applicationDao.insert(application.getService().getServiceUid(), application.getApplicationName(), application.getServiceTypeCode());
+            applicationDao.insert(application.getService().getServiceUid().getUid(), application.getApplicationName(), application.getServiceTypeCode());
         }
         stopWatch.stop();
         logger.info(stopWatch.prettyPrint());

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/Application.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/Application.java
@@ -89,7 +89,7 @@ public final class Application {
 
     @Override
     public String toString() {
-        return service.getServiceName() + "(" + service.getServiceUid() + ")/"
+        return service.getServiceName() + "(" + service.getServiceUid().getUid() + ")/"
                 + applicationName + "(" + serviceType.getDesc() + ":" + serviceType.getCode() + ")";
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/Service.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/Service.java
@@ -27,8 +27,8 @@ public class Service {
         return serviceName;
     }
 
-    public int getServiceUid() {
-        return serviceUid.getUid();
+    public ServiceUid getServiceUid() {
+        return serviceUid;
     }
 
     @Override

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap;
 
 import com.navercorp.pinpoint.common.server.bo.SimpleAgentKey;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
@@ -145,7 +145,7 @@ public class ApplicationMapBuilderTest {
             }
         }).when(agentInfoService).getAgentStatus(any());
 
-        when(agentListV2Service.getActiveAgentList(any(ServiceUid.class), anyString(), any(ServiceType.class), any(Range.class))).thenAnswer(invocation -> {
+        when(agentListV2Service.getActiveAgentList(any(Service.class), anyString(), any(ServiceType.class), any(Range.class))).thenAnswer(invocation -> {
             String applicationName = invocation.getArgument(1);
             ServiceType serviceType = invocation.getArgument(2);
             Range range = invocation.getArgument(3);

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/appender/server/ServerInfoAppenderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/appender/server/ServerInfoAppenderTest.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.web.applicationmap.appender.server;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.navercorp.pinpoint.common.server.bo.SimpleAgentKey;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
@@ -251,7 +251,7 @@ public class ServerInfoAppenderTest {
 
         Application app = wasNode.getApplication();
         AgentIdEntry agentIdEntry = new AgentIdEntry(app, "agent1", 1000L, "agent1", AgentLifeCycleState.RUNNING, 500L);
-        when(agentListV2ServiceMock.getActiveAgentList(any(ServiceUid.class), anyString(), any(ServiceType.class), any(Range.class)))
+        when(agentListV2ServiceMock.getActiveAgentList(any(Service.class), anyString(), any(ServiceType.class), any(Range.class)))
                 .thenReturn(List.of(agentIdEntry));
 
         when(agentInfoServiceMock.getAgentInfos(anyList())).thenAnswer(invocation -> {
@@ -291,7 +291,7 @@ public class ServerInfoAppenderTest {
 
         Application app = wasNode.getApplication();
         AgentIdEntry agentIdEntry = new AgentIdEntry(app, "agent1", 1000L, "agent1", AgentLifeCycleState.RUNNING, 500L);
-        when(agentListV2ServiceMock.getActiveAgentList(any(ServiceUid.class), anyString(), any(ServiceType.class), any(Range.class)))
+        when(agentListV2ServiceMock.getActiveAgentList(any(Service.class), anyString(), any(ServiceType.class), any(Range.class)))
                 .thenReturn(List.of(agentIdEntry));
 
         when(agentInfoServiceMock.getAgentInfos(anyList())).thenAnswer(invocation -> {
@@ -324,7 +324,7 @@ public class ServerInfoAppenderTest {
 
         AgentInfoService agentInfoServiceMock = mock(AgentInfoService.class);
         AgentListV2Service agentListV2ServiceMock = mock(AgentListV2Service.class);
-        when(agentListV2ServiceMock.getActiveAgentList(any(ServiceUid.class), anyString(), any(ServiceType.class), any(Range.class)))
+        when(agentListV2ServiceMock.getActiveAgentList(any(Service.class), anyString(), any(ServiceType.class), any(Range.class)))
                 .thenReturn(List.of());
 
         AgentInfoServerGroupListDataSource v2DataSource = new AgentInfoServerGroupListDataSource(agentInfoServiceMock, agentListV2ServiceMock, true);

--- a/web/src/test/java/com/navercorp/pinpoint/web/component/DefaultApplicationFactoryTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/component/DefaultApplicationFactoryTest.java
@@ -31,7 +31,7 @@ class DefaultApplicationFactoryTest {
     @BeforeEach
     void setUp() {
         lenient().when(mockRegistry.findServiceType(ServiceType.TEST.getCode())).thenReturn(ServiceType.TEST);
-        lenient().when(mockServiceModelResolver.getService(Service.DEFAULT.getServiceUid())).thenReturn(Service.DEFAULT);
+        lenient().when(mockServiceModelResolver.getService(Service.DEFAULT.getServiceUid().getUid())).thenReturn(Service.DEFAULT);
 
         defaultApplicationFactory = new DefaultApplicationFactory(mockRegistry, mockServiceModelResolver);
     }
@@ -63,7 +63,7 @@ class DefaultApplicationFactoryTest {
         int serviceType = ServiceType.TEST.getCode();
 
         // When
-        Application application = defaultApplicationFactory.createApplication(service.getServiceUid(), applicationName, serviceType);
+        Application application = defaultApplicationFactory.createApplication(service.getServiceUid().getUid(), applicationName, serviceType);
 
         // Then
         assertNotNull(application);

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/AgentListV2ServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/AgentListV2ServiceImplTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.server.config.AgentProperties;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapAgentResponseDao;
@@ -80,7 +80,7 @@ public class AgentListV2ServiceImplTest {
                 new AgentIdEntry(testApplication, agentId2, agentStartTime, null, RUNNING, currentTime)
         ));
 
-        List<AgentIdEntry> agentList = agentListV2Service.getActiveAgentList(ServiceUid.DEFAULT, testApplication.getApplicationName(), testApplication.getServiceType(), range);
+        List<AgentIdEntry> agentList = agentListV2Service.getActiveAgentList(Service.DEFAULT, testApplication.getApplicationName(), testApplication.getServiceType(), range);
 
         verify(agentIdDao, times(1)).getAgentIdEntryByMinStateTimestamp(anyInt(), any(), anyInt(), anyLong());
         Assertions.assertThat(agentList).hasSize(2);
@@ -103,7 +103,7 @@ public class AgentListV2ServiceImplTest {
                 new AgentIdEntry(testApplication, agentId2, newAgentStartTime, null, RUNNING, currentTime)
         ));
 
-        List<AgentIdEntry> agentList = agentListV2Service.getActiveAgentList(ServiceUid.DEFAULT, testApplication.getApplicationName(), testApplication.getServiceType(), range);
+        List<AgentIdEntry> agentList = agentListV2Service.getActiveAgentList(Service.DEFAULT, testApplication.getApplicationName(), testApplication.getServiceType(), range);
 
         Assertions.assertThat(agentList).hasSize(1);
         Assertions.assertThat(agentList.get(0).getAgentId()).isEqualTo(agentId);
@@ -125,7 +125,7 @@ public class AgentListV2ServiceImplTest {
                 new AgentIdEntry(testApplication, agentId, previousAgentStartTime, null, RUNNING, currentTime)
         ));
 
-        List<AgentIdEntry> agentList = agentListV2Service.getActiveAgentList(ServiceUid.DEFAULT, testApplication.getApplicationName(), testApplication.getServiceType(), range);
+        List<AgentIdEntry> agentList = agentListV2Service.getActiveAgentList(Service.DEFAULT, testApplication.getApplicationName(), testApplication.getServiceType(), range);
 
         Assertions.assertThat(agentList).hasSize(1);
         Assertions.assertThat(agentList.get(0).getAgentId()).isEqualTo(agentId);
@@ -149,7 +149,7 @@ public class AgentListV2ServiceImplTest {
                 new AgentIdEntry(testApplication, agentId2, agentStartTime, null, UNKNOWN, 0)
         ));
 
-        List<AgentIdEntry> agentList = agentListV2Service.getActiveAgentList(ServiceUid.DEFAULT, testApplication.getApplicationName(), testApplication.getServiceType(), range);
+        List<AgentIdEntry> agentList = agentListV2Service.getActiveAgentList(Service.DEFAULT, testApplication.getApplicationName(), testApplication.getServiceType(), range);
 
         Assertions.assertThat(agentList).hasSize(1);
         Assertions.assertThat(agentList.get(0).getAgentId()).isEqualTo(agentId);

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
@@ -64,9 +64,9 @@ class CachingServiceModelResolverTest {
         CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
 
         assertThat(resolver.getService(Service.DEFAULT.getServiceName())).isEqualTo(Service.DEFAULT);
-        assertThat(resolver.getService(Service.DEFAULT.getServiceUid())).isEqualTo(Service.DEFAULT);
+        assertThat(resolver.getService(Service.DEFAULT.getServiceUid().getUid())).isEqualTo(Service.DEFAULT);
         assertThat(resolver.getService(Service.TEST_SERVICE.getServiceName())).isEqualTo(Service.TEST_SERVICE);
-        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceUid())).isEqualTo(Service.TEST_SERVICE);
+        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceUid().getUid())).isEqualTo(Service.TEST_SERVICE);
 
         Mockito.verifyNoInteractions(serviceRegistryService);
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
@@ -31,9 +31,9 @@ class ServiceModelResolverTest {
         ServiceModelResolver resolver = new ServiceModelResolver(serviceRegistryService);
 
         assertThat(resolver.getService(Service.DEFAULT.getServiceName())).isEqualTo(Service.DEFAULT);
-        assertThat(resolver.getService(Service.DEFAULT.getServiceUid())).isEqualTo(Service.DEFAULT);
+        assertThat(resolver.getService(Service.DEFAULT.getServiceUid().getUid())).isEqualTo(Service.DEFAULT);
         assertThat(resolver.getService(Service.TEST_SERVICE.getServiceName())).isEqualTo(Service.TEST_SERVICE);
-        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceUid())).isEqualTo(Service.TEST_SERVICE);
+        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceUid().getUid())).isEqualTo(Service.TEST_SERVICE);
 
         Mockito.verifyNoInteractions(serviceRegistryService);
     }


### PR DESCRIPTION
resolves #13983

### Changes
- Resolve `@ServiceParam` serviceName and pass the resolved `Service` to agent list queries (v2 path). Previously the query was hardcoded to `ServiceUid.DEFAULT`, so the service concept was not reflected in the results.
- `/api/v1/agents` only supports the default service — non-default service requests are rejected with 400.
- Change `AgentListV2Service` signature from `ServiceUid` to `Service` so lower layers keep the service name context.
- `Service.getServiceUid()` now returns `ServiceUid` instead of `int`.
- Clean up `ServiceRegistryService` insert path: remove `useGeneratedKeys` from the insert mapper (uid is generated by `RandomServiceUidGenerator`), and distinguish duplicate name from uid collision on `DuplicateKeyException` so `@Retryable` only retries uid collisions.