### PR TITLE
[#noissue] Map Next.js next.route to the rpc uriTemplate

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -100,6 +100,12 @@ public class OtlpTraceConstants {
     // the Pinpoint agent's SpanRecorder.recordUriTemplate. Emitted by framework instrumentations
     // (Spring WebMVC/WebFlux, JAX-RS, etc.); absent for unrouted requests, where url.path is the fallback.
     public static final String ATTRIBUTE_KEY_HTTP_ROUTE = "http.route";
+    // Next.js built-in OTel instrumentation emits next.route as the low-cardinality route template
+    // (e.g. "/api/products/[productId]/index") on its SERVER span (next.span_type=BaseServer.handleRequest).
+    // It is http.route's vendor equivalent — Next.js does NOT emit http.route, so this is the only
+    // route-template source for Next.js. Promoted to the rpc field just below http.route in
+    // getServerSpanToRpc so the endpoint groups by pattern instead of the raw http.target path.
+    public static final String ATTRIBUTE_KEY_NEXT_ROUTE = "next.route";
     public static final String ATTRIBUTE_KEY_URL_PATH = "url.path";
     public static final String ATTRIBUTE_KEY_HTTP_URL = "http.url";
     public static final String ATTRIBUTE_KEY_HTTP_TARGET = "http.target";
@@ -166,6 +172,7 @@ public class OtlpTraceConstants {
             ATTRIBUTE_KEY_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
             ATTRIBUTE_KEY_MESSAGING_MESSAGE_ID,
             ATTRIBUTE_KEY_HTTP_ROUTE,
+            ATTRIBUTE_KEY_NEXT_ROUTE,
             ATTRIBUTE_KEY_URL_PATH,
             ATTRIBUTE_KEY_MESSAGING_CLIENT_ID,
             ATTRIBUTE_KEY_SERVER_PORT,

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -315,6 +315,13 @@ public class OtlpTraceSpanMapper {
             if (httpRoute != null) {
                 return httpRoute;
             }
+            // next.route is Next.js's route template (http.route's vendor equivalent). Next.js does
+            // not emit http.route, so prefer next.route over the raw url.path/http.url/http.target
+            // to keep the rpc field low-cardinality (e.g. "/api/products/[productId]/index").
+            final String nextRoute = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NEXT_ROUTE, null);
+            if (nextRoute != null) {
+                return nextRoute;
+            }
             final String urlPath = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH, null);
             if (urlPath != null) {
                 return urlPath;

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -3,6 +3,7 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.bo.ParentApplication;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
@@ -224,6 +225,12 @@ class OtlpTraceSpanMapperTest {
                 .map(AnnotationBo::getValue)
                 .findFirst()
                 .orElse(null);
+    }
+
+    private static List<String> attributeKeys(SpanBo bo) {
+        return bo.getAttributeBoList().stream()
+                .map(AttributeBo::getKey)
+                .toList();
     }
 
     @Test
@@ -573,6 +580,36 @@ class OtlpTraceSpanMapperTest {
         Span span = serverSpan(kv("url.path", strVal("/api/users/123")));
         SpanBo bo = newMapper().map(id(), span);
         assertThat(bo.getRpc()).isEqualTo("/api/users/123");
+    }
+
+    @Test
+    void map_server_nextRoute_preferredOverRawPath() {
+        // Next.js emits next.route (route template) but not http.route. It must win over the raw
+        // http.target so the rpc field groups by endpoint pattern instead of the concrete path.
+        Span span = serverSpan(
+                kv("next.route", strVal("/api/products/[productId]/index")),
+                kv("http.target", strVal("/api/products/66VCHSJNUP")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(bo.getRpc()).isEqualTo("/api/products/[productId]/index");
+    }
+
+    @Test
+    void map_server_httpRoute_preferredOverNextRoute() {
+        // Standard http.route (when present) still wins over the vendor next.route.
+        Span span = serverSpan(
+                kv("http.route", strVal("/api/users/{id}")),
+                kv("next.route", strVal("/api/users/[id]")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(bo.getRpc()).isEqualTo("/api/users/{id}");
+    }
+
+    @Test
+    void map_server_nextRoute_notStoredAsRawAttribute() {
+        // Promoted to the rpc field on the root path, so it must not also leak as a raw
+        // attribute (mirrors http.route / url.path).
+        Span span = serverSpan(kv("next.route", strVal("/api/cart")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(attributeKeys(bo)).doesNotContain("next.route");
     }
 
     // =======================================================================


### PR DESCRIPTION
Next.js built-in OTel instrumentation emits next.route (the low-cardinality route template, e.g. "/api/products/[productId]/index") on its SERVER span but does not emit http.route. Add next.route to getServerSpanToRpc just below http.route so the rpc field groups by endpoint pattern instead of the raw http.target path, and filter it from the raw attributes once promoted.