### PR TITLE
[#noissue] Promote HTTP response status code to an annotation on Span…

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpHttpStatusResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpHttpStatusResolver.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * Resolves the HTTP response status code to promote to an {@code HTTP_STATUS_CODE} annotation,
+ * shared by the root-span ({@link OtlpTraceSpanMapper}) and SpanEvent ({@link OtlpTraceSpanEventMapper})
+ * paths. This mirrors the native agent convention where both server spans
+ * ({@code Span} via ServerResponseRecorder) and HTTP client SpanEvents (okhttp / httpclient /
+ * resttemplate / … plugins via {@code SpanEventRecorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, …)})
+ * record the status as a first-class annotation.
+ *
+ * <p>Exposing the source key alongside the value lets the caller exclude only the raw attribute
+ * key that was actually consumed, so a non-promoted status variant (or a non-numeric value that
+ * could not be promoted) is retained instead of blanket-dropped.</p>
+ */
+public final class OtlpHttpStatusResolver {
+
+    private OtlpHttpStatusResolver() {
+    }
+
+    /** Promoted HTTP status code together with the source attribute key it was read from. */
+    public record ResponseStatus(int code, String sourceKey) {
+    }
+
+    /**
+     * Returns the promoted HTTP status or {@code null} when no numeric status is present.
+     * Precedence follows {@link OtlpTraceConstants#RESPONSE_STATUS_CODE_KEYS}: new semconv
+     * ({@code http.response.status_code}) before legacy ({@code http.status_code}).
+     */
+    @Nullable
+    public static ResponseStatus resolve(Map<String, AttributeValue> attributes) {
+        for (String key : OtlpTraceConstants.RESPONSE_STATUS_CODE_KEYS) {
+            final long code = resolveStatusCode(attributes, key);
+            if (code != -1) {
+                return new ResponseStatus((int) code, key);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves an HTTP status code that may arrive typed as int or as string. The OTel HTTP
+     * instrumentation emits it as an int, but Envoy emits {@code http.status_code} as a string
+     * ("200"). Try the int form first, then a numeric-string fallback. Returns -1 when the key is
+     * absent or non-numeric.
+     */
+    static long resolveStatusCode(Map<String, AttributeValue> attributes, String key) {
+        final long intValue = AttributeUtils.getAttributeIntValue(attributes, key, -1L);
+        if (intValue != -1) {
+            return intValue;
+        }
+        final String stringValue = AttributeUtils.getAttributeStringValue(attributes, key, null);
+        if (stringValue != null) {
+            try {
+                return Long.parseLong(stringValue.trim());
+            } catch (NumberFormatException ignored) {
+                return -1L;
+            }
+        }
+        return -1L;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -167,7 +168,6 @@ public class OtlpTraceConstants {
 
     public static final Set<String> FILTERED_ATTRIBUTE_KEY_SET = Set.of(
             ATTRIBUTE_KEY_CLIENT_ADDRESS,
-            ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE,
             ATTRIBUTE_KEY_MESSAGING_KAFKA_MESSAGE_OFFSET,
             ATTRIBUTE_KEY_MESSAGING_KAFKA_OFFSET,
             ATTRIBUTE_KEY_MESSAGING_DESTINATION_PARTITION_ID,
@@ -200,4 +200,13 @@ public class OtlpTraceConstants {
     );
 
     public static final Predicate<String> FILTERED_ATTRIBUTE_KEY = FILTERED_ATTRIBUTE_KEY_SET::contains;
+
+    // HTTP status code keys are intentionally NOT in the base filter. On the root (SERVER/
+    // CONSUMER/INTERNAL) path OtlpTraceSpanMapper promotes one of them to the HTTP_STATUS_CODE
+    // annotation and then dynamically excludes only that consumed key from the raw attributes —
+    // so a non-promoted variant (or a non-numeric value that could not be promoted) is retained
+    // instead of blanket-dropped. On the SpanEvent path (client/producer/internal) they are never
+    // promoted, so they stay as raw attributes. Precedence order: new semconv before legacy.
+    public static final List<String> RESPONSE_STATUS_CODE_KEYS =
+            List.of(ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE, ATTRIBUTE_KEY_HTTP_STATUS_CODE);
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 @Component
 public class OtlpTraceSpanEventMapper {
@@ -162,10 +163,21 @@ public class OtlpTraceSpanEventMapper {
         spanEventBo.setApiId(0);
         spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_SPAN_ID.getCode(), OtlpTraceMapperUtils.getSpanId(span.getSpanId())));
         spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.OPENTELEMETRY_PARENT_SPAN_ID.getCode(), OtlpTraceMapperUtils.getParentSpanId(span.getParentSpanId())));
+        // HTTP response status → HTTP_STATUS_CODE annotation, mirroring the native HTTP client
+        // plugins (okhttp / httpclient / resttemplate / ...) which record it on the SpanEvent via
+        // SpanEventRecorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, ...). Only the consumed
+        // raw key is excluded below, so a non-promoted variant survives. Fires only when an HTTP
+        // status attribute is present (gRPC clients carry rpc.grpc.status_code instead → no-op).
+        final OtlpHttpStatusResolver.ResponseStatus responseStatus = OtlpHttpStatusResolver.resolve(attributes);
+        Predicate<String> attributeFilter = OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY;
+        if (responseStatus != null) {
+            spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatus.code()));
+            attributeFilter = attributeFilter.or(responseStatus.sourceKey()::equals);
+        }
         // attributes
         if (!attributes.isEmpty()) {
             List<AttributeBo> attributeBoList = attributeBoMapper.toAttributeBoList(
-                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, truncatedCounts::attribute);
+                    attributes, attributeFilter, truncatedCounts::attribute);
             spanEventBo.setAttributeBoList(attributeBoList);
         }
         // event

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 @Component
 public class OtlpTraceSpanMapper {
@@ -124,16 +125,20 @@ public class OtlpTraceSpanMapper {
             }
         }
         final boolean skipExceptionEvent = exceptionInfoResolver.isExceptionClassCaptured(exceptionInfo);
-        // response
-        final int responseStatusCode = (int) getServerSpanToResponseStatusCode(attributes);
-        if (responseStatusCode != -1) {
-            spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatusCode));
+        // response — promote the HTTP status code (int, or Envoy's numeric string) to an annotation.
+        // Only the raw attribute key actually consumed here is excluded from the attribute list below,
+        // so a non-promoted status variant (or a non-numeric value that could not be promoted) survives.
+        final OtlpHttpStatusResolver.ResponseStatus responseStatus = OtlpHttpStatusResolver.resolve(attributes);
+        Predicate<String> attributeFilter = OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY;
+        if (responseStatus != null) {
+            spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatus.code()));
+            attributeFilter = attributeFilter.or(responseStatus.sourceKey()::equals);
         }
         final TruncatedCounts truncatedCounts = new TruncatedCounts();
         // attributes
         if (!attributes.isEmpty()) {
             List<AttributeBo> attributeBoList = attributeBoMapper.toAttributeBoList(
-                    attributes, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY, truncatedCounts::attribute);
+                    attributes, attributeFilter, truncatedCounts::attribute);
             spanBo.setAttributeBoList(attributeBoList);
         }
 
@@ -409,11 +414,4 @@ public class OtlpTraceSpanMapper {
         return null;
     }
 
-    long getServerSpanToResponseStatusCode(Map<String, AttributeValue> attributes) {
-        long httpStatusCode = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE, -1L);
-        if (httpStatusCode != -1) {
-            return httpStatusCode;
-        }
-        return AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_STATUS_CODE, -1L);
-    }
 }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -85,13 +85,16 @@ class OtlpTraceMapperUtilsTest {
                 kv("http.method", strVal("POST")),
                 kv(OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH, strVal("/save")),
                 kv(OtlpTraceConstants.ATTRIBUTE_KEY_DB_STATEMENT, strVal("INSERT INTO t")),
+                // http.status_code / http.response.status_code are intentionally NOT in the base
+                // filter (only in SERVER_FILTERED) so client SpanEvents retain them as raw
+                // attributes; the base predicate must leave this one untouched.
                 kv(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE, strVal("201"))
         );
 
         Map<String, Object> result = OtlpTraceMapperUtils.getAttributeToMap(
                 attrs, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY);
 
-        assertThat(result).containsOnlyKeys("http.method");
+        assertThat(result).containsOnlyKeys("http.method", OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE);
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -2,6 +2,7 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
+import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
@@ -332,6 +333,73 @@ class OtlpTraceSpanEventMapperTest {
 
     private SpanEventBo mapSingle(Span span) {
         return mapper.map(0L, span).get(0);
+    }
+
+    private static List<String> attributeKeys(SpanEventBo event) {
+        return event.getAttributeBoList().stream()
+                .map(AttributeBo::getKey)
+                .toList();
+    }
+
+    private static Object findAnnotation(SpanEventBo event, int code) {
+        return event.getAnnotationBoList().stream()
+                .filter(a -> a.getKey() == code)
+                .map(com.navercorp.pinpoint.common.server.bo.AnnotationBo::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static final int HTTP_STATUS_CODE =
+            com.navercorp.pinpoint.common.trace.AnnotationKey.HTTP_STATUS_CODE.getCode();
+
+    @Test
+    void map_client_httpStatusCode_promotedToAnnotation_andConsumedKeyFiltered() {
+        // Mirrors native HTTP client plugins: the client SpanEvent promotes the status to the
+        // HTTP_STATUS_CODE annotation and the consumed raw key is removed (no duplicate).
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("http.status_code", intVal(200)));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, HTTP_STATUS_CODE)).isEqualTo(200);
+        assertThat(attributeKeys(event)).doesNotContain("http.status_code");
+    }
+
+    @Test
+    void map_client_bothStatusKeys_onlyConsumedKeyRemoved() {
+        // http.response.status_code wins (precedence) and is promoted + removed; the non-consumed
+        // legacy http.status_code is retained as a raw attribute.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("http.response.status_code", intVal(500)),
+                kv("http.status_code", intVal(500)));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, HTTP_STATUS_CODE)).isEqualTo(500);
+        assertThat(attributeKeys(event)).doesNotContain("http.response.status_code");
+        assertThat(attributeKeys(event)).contains("http.status_code");
+    }
+
+    @Test
+    void map_client_grpc_noHttpStatusAnnotation() {
+        // gRPC clients carry rpc.grpc.status_code, not an http.* status → no HTTP_STATUS_CODE
+        // annotation is promoted.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.grpc.status_code", intVal(0)));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, HTTP_STATUS_CODE)).isNull();
+    }
+
+    @Test
+    void map_internal_httpStatusCode_promotedToAnnotation() {
+        // A Next.js INTERNAL span (Node.runHandler) carries http.status_code; it is promoted to the
+        // HTTP_STATUS_CODE annotation just like the client path (uniform: status present → surfaced).
+        Span span = span(Span.SpanKind.SPAN_KIND_INTERNAL,
+                kv("http.status_code", intVal(200)));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, HTTP_STATUS_CODE)).isEqualTo(200);
+        assertThat(attributeKeys(event)).doesNotContain("http.status_code");
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -3,6 +3,7 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.bo.ParentApplication;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
@@ -226,6 +227,12 @@ class OtlpTraceSpanMapperTest {
                 .map(AnnotationBo::getValue)
                 .findFirst()
                 .orElse(null);
+    }
+
+    private static List<String> attributeKeys(SpanBo bo) {
+        return bo.getAttributeBoList().stream()
+                .map(AttributeBo::getKey)
+                .toList();
     }
 
     @Test
@@ -598,6 +605,63 @@ class OtlpTraceSpanMapperTest {
         Span span = serverSpan(kv("url.path", strVal("/api/users/123")));
         SpanBo bo = newMapper().map(id(), span);
         assertThat(bo.getRpc()).isEqualTo("/api/users/123");
+    }
+
+    // =======================================================================
+    // map() — HTTP status code promotion + root-only raw-attribute filtering
+    // =======================================================================
+
+    @Test
+    void map_server_httpStatusCode_int_promotedAndFilteredFromAttributes() {
+        // Legacy http.status_code (int) is promoted to the HTTP_STATUS_CODE annotation and removed
+        // from the raw attribute list on the root path so there is no duplicate.
+        Span span = serverSpan(kv("http.status_code", intVal(200)));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, AnnotationKey.HTTP_STATUS_CODE.getCode())).isEqualTo(200);
+        assertThat(attributeKeys(bo)).doesNotContain("http.status_code");
+    }
+
+    @Test
+    void map_server_httpResponseStatusCode_promotedAndFilteredFromAttributes() {
+        // New semconv http.response.status_code — same promotion + root-path filtering.
+        Span span = serverSpan(kv("http.response.status_code", intVal(404)));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, AnnotationKey.HTTP_STATUS_CODE.getCode())).isEqualTo(404);
+        assertThat(attributeKeys(bo)).doesNotContain("http.response.status_code");
+    }
+
+    @Test
+    void map_server_httpStatusCode_string_promoted() {
+        // Envoy emits http.status_code as a string ("200"); it must still be promoted to the
+        // HTTP_STATUS_CODE annotation (int-only extraction would have dropped it).
+        Span span = serverSpan(kv("http.status_code", strVal("200")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, AnnotationKey.HTTP_STATUS_CODE.getCode())).isEqualTo(200);
+    }
+
+    @Test
+    void map_server_httpStatusCode_nonNumericString_noAnnotationAndPreservedAsRawAttribute() {
+        // A non-numeric status string yields no HTTP_STATUS_CODE annotation rather than throwing.
+        // Because it was not promoted, the consumed-key filter leaves it untouched — the raw value
+        // survives instead of being blanket-dropped by a fixed status-key filter.
+        Span span = serverSpan(kv("http.status_code", strVal("OK")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, AnnotationKey.HTTP_STATUS_CODE.getCode())).isNull();
+        assertThat(attributeKeys(bo)).contains("http.status_code");
+    }
+
+    @Test
+    void map_server_bothStatusKeys_onlyConsumedKeyRemoved() {
+        // When both keys are present, http.response.status_code wins and is promoted + removed;
+        // the non-consumed legacy http.status_code is retained as a raw attribute (only the key
+        // actually read is filtered, not a fixed pair).
+        Span span = serverSpan(
+                kv("http.response.status_code", intVal(200)),
+                kv("http.status_code", intVal(200)));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, AnnotationKey.HTTP_STATUS_CODE.getCode())).isEqualTo(200);
+        assertThat(attributeKeys(bo)).doesNotContain("http.response.status_code");
+        assertThat(attributeKeys(bo)).contains("http.status_code");
     }
 
     // =======================================================================


### PR DESCRIPTION
Record the HTTP response status code as an HTTP_STATUS_CODE annotation on client/internal SpanEvents, mirroring the native HTTP client plugins (okhttp/httpclient/resttemplate/...) which record it via SpanEventRecorder. Extract the resolution into OtlpHttpStatusResolver, shared by the root-span and SpanEvent paths.

Also: accept an int- or numeric-string-typed status (Envoy emits http.status_code as a string), and filter only the consumed status key from the raw attributes so a non-promoted variant is retained. http.response.status_code is dropped from the base filter accordingly so client SpanEvents no longer lose it.