### PR TITLE
[#noissue] Promote HTTP method to an HTTP_METHOD annotation

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -28,6 +28,11 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_NETWORK_PEER_PORT = "network.peer.port";
     public static final String ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE = "http.response.status_code";
     public static final String ATTRIBUTE_KEY_HTTP_STATUS_CODE = "http.status_code";
+    // HTTP request method. New semconv: http.request.method; legacy 1.x: http.method. Promoted to
+    // the HTTP_METHOD annotation on both the root span and SpanEvents; both keys are filtered from
+    // the raw attributes once promoted (the two are the same value in different semconv versions).
+    public static final String ATTRIBUTE_KEY_HTTP_REQUEST_METHOD = "http.request.method";
+    public static final String ATTRIBUTE_KEY_HTTP_METHOD = "http.method";
     // Kafka message offset
     public static final String ATTRIBUTE_KEY_MESSAGING_KAFKA_MESSAGE_OFFSET = "messaging.kafka.message.offset"; // legacy
     public static final String ATTRIBUTE_KEY_MESSAGING_KAFKA_OFFSET = "messaging.kafka.offset";                 // OTel semconv ≥ stable
@@ -187,6 +192,8 @@ public class OtlpTraceConstants {
             ATTRIBUTE_KEY_HTTP_ROUTE,
             ATTRIBUTE_KEY_NEXT_ROUTE,
             ATTRIBUTE_KEY_URL_PATH,
+            ATTRIBUTE_KEY_HTTP_REQUEST_METHOD,
+            ATTRIBUTE_KEY_HTTP_METHOD,
             ATTRIBUTE_KEY_MESSAGING_CLIENT_ID,
             ATTRIBUTE_KEY_SERVER_PORT,
             ATTRIBUTE_KEY_SERVER_ADDRESS,
@@ -216,4 +223,8 @@ public class OtlpTraceConstants {
     // promoted, so they stay as raw attributes. Precedence order: new semconv before legacy.
     public static final List<String> RESPONSE_STATUS_CODE_KEYS =
             List.of(ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE, ATTRIBUTE_KEY_HTTP_STATUS_CODE);
+
+    // HTTP method resolution order: new semconv (http.request.method) before legacy (http.method).
+    public static final List<String> HTTP_METHOD_KEYS =
+            List.of(ATTRIBUTE_KEY_HTTP_REQUEST_METHOD, ATTRIBUTE_KEY_HTTP_METHOD);
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -174,6 +174,11 @@ public class OtlpTraceSpanEventMapper {
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatus.code()));
             attributeFilter = attributeFilter.or(responseStatus.sourceKey()::equals);
         }
+        // http method → HTTP_METHOD annotation (e.g. an HTTP client SpanEvent's request method)
+        final String httpMethod = OtlpTraceSpanMapper.getHttpMethod(attributes);
+        if (httpMethod != null) {
+            spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_METHOD.getCode(), httpMethod));
+        }
         // attributes
         if (!attributes.isEmpty()) {
             List<AttributeBo> attributeBoList = attributeBoMapper.toAttributeBoList(

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -134,6 +134,11 @@ public class OtlpTraceSpanMapper {
             spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatus.code()));
             attributeFilter = attributeFilter.or(responseStatus.sourceKey()::equals);
         }
+        // http method → HTTP_METHOD annotation (surfaced as a 1st-class field in the web UI)
+        final String httpMethod = getHttpMethod(attributes);
+        if (httpMethod != null) {
+            spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_METHOD.getCode(), httpMethod));
+        }
         final TruncatedCounts truncatedCounts = new TruncatedCounts();
         // attributes
         if (!attributes.isEmpty()) {
@@ -421,4 +426,18 @@ public class OtlpTraceSpanMapper {
         return null;
     }
 
+    /**
+     * Resolves the HTTP request method (new semconv {@code http.request.method} before legacy
+     * {@code http.method}) for promotion to the HTTP_METHOD annotation, or {@code null} when
+     * absent. Shared by the root-span and SpanEvent paths.
+     */
+    static @Nullable String getHttpMethod(Map<String, AttributeValue> attributes) {
+        for (String key : OtlpTraceConstants.HTTP_METHOD_KEYS) {
+            final String method = AttributeUtils.getAttributeStringValue(attributes, key, null);
+            if (method != null) {
+                return method;
+            }
+        }
+        return null;
+    }
 }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -82,19 +82,20 @@ class OtlpTraceMapperUtilsTest {
     @Test
     void filteredAttributeKeySet_removesKnownKeys() {
         List<KeyValue> attrs = List.of(
-                kv("http.method", strVal("POST")),
+                kv("custom.attr", strVal("keep-me")),
                 kv(OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH, strVal("/save")),
                 kv(OtlpTraceConstants.ATTRIBUTE_KEY_DB_STATEMENT, strVal("INSERT INTO t")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_METHOD, strVal("POST")),
                 // http.status_code / http.response.status_code are intentionally NOT in the base
-                // filter (only in SERVER_FILTERED) so client SpanEvents retain them as raw
-                // attributes; the base predicate must leave this one untouched.
+                // filter (they are excluded dynamically, only when promoted) so client SpanEvents
+                // retain them as raw attributes; the base predicate must leave this one untouched.
                 kv(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE, strVal("201"))
         );
 
         Map<String, Object> result = OtlpTraceMapperUtils.getAttributeToMap(
                 attrs, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY);
 
-        assertThat(result).containsOnlyKeys("http.method", OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE);
+        assertThat(result).containsOnlyKeys("custom.attr", OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE);
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
@@ -400,6 +401,18 @@ class OtlpTraceSpanEventMapperTest {
         SpanEventBo event = mapSingle(span);
         assertThat(findAnnotation(event, HTTP_STATUS_CODE)).isEqualTo(200);
         assertThat(attributeKeys(event)).doesNotContain("http.status_code");
+    }
+
+    @Test
+    void map_client_httpMethod_promotedToAnnotation_andFiltered() {
+        // HTTP client SpanEvent: the request method is promoted to the HTTP_METHOD annotation and
+        // removed from the raw attributes.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("http.request.method", strVal("GET")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, AnnotationKey.HTTP_METHOD.getCode())).isEqualTo("GET");
+        assertThat(attributeKeys(event)).doesNotContain("http.request.method");
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -695,6 +695,31 @@ class OtlpTraceSpanMapperTest {
     }
 
     // =======================================================================
+    // map() — HTTP method promotion
+    // =======================================================================
+
+    @Test
+    void map_server_httpMethod_legacy_promotedAndFiltered() {
+        // Legacy http.method is promoted to the HTTP_METHOD annotation and removed from the raw
+        // attribute list (no duplicate).
+        Span span = serverSpan(kv("http.method", strVal("GET")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, AnnotationKey.HTTP_METHOD.getCode())).isEqualTo("GET");
+        assertThat(attributeKeys(bo)).doesNotContain("http.method");
+    }
+
+    @Test
+    void map_server_httpRequestMethod_newSemconv_preferredOverLegacy() {
+        // New semconv http.request.method wins over legacy http.method (both carry the method).
+        Span span = serverSpan(
+                kv("http.request.method", strVal("POST")),
+                kv("http.method", strVal("POST")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, AnnotationKey.HTTP_METHOD.getCode())).isEqualTo("POST");
+        assertThat(attributeKeys(bo)).doesNotContain("http.request.method", "http.method");
+    }
+
+    // =======================================================================
     // map() — SDK-side dropped count annotations
     // =======================================================================
 


### PR DESCRIPTION
Record the HTTP request method as an HTTP_METHOD annotation on the root span and on SpanEvents, so GET/POST is surfaced as a first-class field in the web UI instead of only living in the raw attribute list. Resolves the new semconv http.request.method before the legacy http.method, and filters both keys from the raw attributes once promoted.