### PR TITLE
[#noissue] Add legacy and URL fallbacks for OTLP client span endPoint…

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -24,6 +24,16 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_CLIENT_ADDRESS = "client.address";
     public static final String ATTRIBUTE_KEY_PEER_ADDRESS = "peer.address";
     public static final String ATTRIBUTE_KEY_NET_PEER_IP = "net.peer.ip";
+    // Legacy (semconv 1.x) client peer: application-level logical name/port of the remote
+    // service. The new-semconv equivalent is server.address/server.port. Emitted by older SDK
+    // instrumentations (e.g. otel-js grpc/http) that predate the HTTP semconv stabilization —
+    // without this fallback such client spans lose their endPoint/destinationId entirely.
+    public static final String ATTRIBUTE_KEY_NET_PEER_NAME = "net.peer.name";
+    public static final String ATTRIBUTE_KEY_NET_PEER_PORT = "net.peer.port";
+    // Full request URL of an HTTP client span. New semconv: url.full; legacy: http.url
+    // (ATTRIBUTE_KEY_HTTP_URL). Host:port is extracted as an endPoint/destinationId fallback;
+    // the raw attribute is kept (path/query carry information beyond the extracted host).
+    public static final String ATTRIBUTE_KEY_URL_FULL = "url.full";
     public static final String ATTRIBUTE_KEY_NETWORK_PEER_IP = "network.peer.address";
     public static final String ATTRIBUTE_KEY_NETWORK_PEER_PORT = "network.peer.port";
     public static final String ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE = "http.response.status_code";
@@ -197,6 +207,11 @@ public class OtlpTraceConstants {
             ATTRIBUTE_KEY_MESSAGING_CLIENT_ID,
             ATTRIBUTE_KEY_SERVER_PORT,
             ATTRIBUTE_KEY_SERVER_ADDRESS,
+            // legacy equivalents of server.address/server.port — consumed the same way (client
+            // endPoint/destinationId), so filtered symmetrically. url.full / http.url are NOT
+            // filtered: only host:port is consumed and the raw URL retains path/query info.
+            ATTRIBUTE_KEY_NET_PEER_NAME,
+            ATTRIBUTE_KEY_NET_PEER_PORT,
             ATTRIBUTE_KEY_DB_NAME,
             ATTRIBUTE_KEY_DB_NAMESPACE,
             ATTRIBUTE_KEY_DB_STATEMENT,

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -37,6 +37,7 @@ import com.navercorp.pinpoint.otlp.trace.collector.mapper.message.RabbitMQAttrib
 import com.navercorp.pinpoint.otlp.trace.collector.mapper.message.RocketMQAttributeUtils;
 import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import io.opentelemetry.proto.trace.v1.Span;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -255,12 +256,26 @@ public class OtlpTraceSpanEventMapper {
     }
 
     String getClientSpanToEndPoint(Map<String, AttributeValue> attributes) {
+        // Logical names first (better ServerMap grouping than socket IPs), then URL-derived
+        // host:port, then the socket address, then the proxy tag.
         final String serverAddress = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS, null);
         if (serverAddress != null) {
             final long serverPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, 0L);
             return HostAndPort.toHostAndPortString(serverAddress, (int) serverPort, 0);
         }
-        // socket-level fallback when server.* attributes are not emitted by the SDK
+        // legacy (semconv 1.x) equivalent of server.address — otel-js gRPC/HTTP clients emit
+        // only net.peer.name/net.peer.port, which previously left endPoint/destinationId null.
+        final String netPeerName = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, null);
+        if (netPeerName != null) {
+            final long netPeerPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, 0L);
+            return HostAndPort.toHostAndPortString(netPeerName, (int) netPeerPort, 0);
+        }
+        // host:port extracted from the request URL — url.full (new semconv) / http.url (legacy)
+        final String urlHostAndPort = getUrlToHostAndPort(attributes);
+        if (urlHostAndPort != null) {
+            return urlHostAndPort;
+        }
+        // socket-level fallback when no application-level address is emitted by the SDK
         final String networkPeerIp = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, null);
         if (networkPeerIp != null) {
             final long networkPeerPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, 0L);
@@ -268,6 +283,23 @@ public class OtlpTraceSpanEventMapper {
         }
         // proxy
         return AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_ADDRESS, null);
+    }
+
+    /**
+     * Extracts {@code host[:port]} from the HTTP client request URL — {@code url.full}
+     * (new semconv) before {@code http.url} (legacy). Returns {@code null} when neither is
+     * present or the URL has no extractable host (e.g. a bare {@code "https://"}).
+     */
+    static @Nullable String getUrlToHostAndPort(Map<String, AttributeValue> attributes) {
+        String url = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_URL_FULL, null);
+        if (url == null) {
+            url = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, null);
+        }
+        final String hostAndPort = OtlpTraceSpanMapper.extractHostAndPort(url);
+        if (hostAndPort == null || hostAndPort.isEmpty()) {
+            return null;
+        }
+        return hostAndPort;
     }
 
     String getClientSpanToDestinationId(Map<String, AttributeValue> attributes) {
@@ -304,6 +336,17 @@ public class OtlpTraceSpanEventMapper {
         if (serverAddress != null) {
             final long serverPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, 0L);
             return HostAndPort.toHostAndPortString(serverAddress, (int) serverPort, 0);
+        }
+        // legacy (semconv 1.x) equivalent of server.address — see getClientSpanToEndPoint
+        final String netPeerName = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, null);
+        if (netPeerName != null) {
+            final long netPeerPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, 0L);
+            return HostAndPort.toHostAndPortString(netPeerName, (int) netPeerPort, 0);
+        }
+        // host:port from the request URL — url.full (new semconv) / http.url (legacy)
+        final String urlHostAndPort = getUrlToHostAndPort(attributes);
+        if (urlHostAndPort != null) {
+            return urlHostAndPort;
         }
         final String networkPeerIp = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, null);
         if (networkPeerIp != null) {

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -216,6 +216,76 @@ class OtlpTraceSpanEventMapperTest {
         assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("proxy:9000");
     }
 
+    @Test
+    void getClientSpanToEndPoint_fallsBackToNetPeerName() {
+        // Legacy semconv client (e.g. otel-js gRPC) emits only net.peer.name/net.peer.port —
+        // previously resolved to null, dropping the ServerMap node.
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, AttributeValue.of("cart"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, AttributeValue.of(7070L)
+        );
+        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("cart:7070");
+    }
+
+    @Test
+    void getClientSpanToEndPoint_netPeerNameWithoutPort() {
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, AttributeValue.of("cart")
+        );
+        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("cart");
+    }
+
+    @Test
+    void getClientSpanToEndPoint_serverAddressPreferredOverNetPeerName() {
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS, AttributeValue.of("cart.svc"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, AttributeValue.of(7070L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, AttributeValue.of("cart"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, AttributeValue.of(9999L)
+        );
+        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("cart.svc:7070");
+    }
+
+    @Test
+    void getClientSpanToEndPoint_fallsBackToHttpUrl() {
+        // Legacy HTTP client emitting only http.url (seen from python-requests instrumentations).
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, AttributeValue.of("http://frontend-proxy:8080/api/cart")
+        );
+        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("frontend-proxy:8080");
+    }
+
+    @Test
+    void getClientSpanToEndPoint_urlFullPreferredOverHttpUrl() {
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_URL_FULL, AttributeValue.of("https://api.example.com/users?id=1"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, AttributeValue.of("http://legacy.example.com/users")
+        );
+        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("api.example.com");
+    }
+
+    @Test
+    void getClientSpanToEndPoint_urlPreferredOverSocketAddress() {
+        // URL-derived logical host groups the ServerMap better than the socket IP.
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_URL_FULL, AttributeValue.of("http://api.example.com:8080/v1"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, AttributeValue.of("10.0.0.1"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, AttributeValue.of(8080L)
+        );
+        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("api.example.com:8080");
+    }
+
+    @Test
+    void getClientSpanToEndPoint_hostlessUrl_fallsThrough() {
+        // A malformed URL with no extractable host must not shadow later fallbacks.
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_URL_FULL, AttributeValue.of("https://"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, AttributeValue.of("10.0.0.1"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, AttributeValue.of(8080L)
+        );
+        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("10.0.0.1:8080");
+    }
+
     // =======================================================================
     // getClientSpanToDestinationId
     // =======================================================================
@@ -311,6 +381,35 @@ class OtlpTraceSpanEventMapperTest {
         assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("10.0.0.1:5432");
     }
 
+    @Test
+    void getClientSpanToDestinationId_fallsBackToNetPeerName() {
+        // Legacy semconv gRPC client — destinationId mirrors the endPoint fallback.
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, AttributeValue.of("cart"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, AttributeValue.of(7070L)
+        );
+        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("cart:7070");
+    }
+
+    @Test
+    void getClientSpanToDestinationId_fallsBackToUrl() {
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, AttributeValue.of("http://frontend-proxy:8080/api/cart")
+        );
+        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("frontend-proxy:8080");
+    }
+
+    @Test
+    void getClientSpanToDestinationId_dbSystemPreferredOverNetPeerName() {
+        // DB destination grouping (db.system) must not be shadowed by the new fallbacks.
+        Map<String, AttributeValue> attrs = Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_DB_SYSTEM, AttributeValue.of("redis"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, AttributeValue.of("cache-01"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, AttributeValue.of(6379L)
+        );
+        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("redis");
+    }
+
     // =======================================================================
     // map() — producer / internal endPoint & destinationId resolution
     // =======================================================================
@@ -352,6 +451,36 @@ class OtlpTraceSpanEventMapperTest {
 
     private static final int HTTP_STATUS_CODE =
             com.navercorp.pinpoint.common.trace.AnnotationKey.HTTP_STATUS_CODE.getCode();
+
+    @Test
+    void map_client_legacyGrpc_netPeerName_setsEndPointAndDestinationId_andFiltersRawKeys() {
+        // End-to-end: a legacy-semconv gRPC client span (net.peer.name/net.peer.port only, as
+        // emitted by otel-js) resolves endPoint/destinationId instead of dropping the node, and
+        // the consumed keys are filtered from the raw attribute list (mirroring server.address).
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.service", strVal("oteldemo.CartService")),
+                kv("net.peer.name", strVal("cart")),
+                kv("net.peer.port", intVal(7070)));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(event.getEndPoint()).isEqualTo("cart:7070");
+        assertThat(event.getDestinationId()).isEqualTo("cart:7070");
+        assertThat(attributeKeys(event)).doesNotContain("net.peer.name", "net.peer.port");
+    }
+
+    @Test
+    void map_client_httpUrlOnly_setsEndPoint_andKeepsRawUrl() {
+        // Legacy HTTP client emitting only http.url — endPoint is derived from the URL host,
+        // while the raw URL attribute is retained (path/query carry extra information).
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("http.url", strVal("http://frontend-proxy:8080/api/cart")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(event.getEndPoint()).isEqualTo("frontend-proxy:8080");
+        assertThat(event.getDestinationId()).isEqualTo("frontend-proxy:8080");
+        assertThat(attributeKeys(event)).contains("http.url");
+    }
 
     @Test
     void map_client_httpStatusCode_promotedToAnnotation_andConsumedKeyFiltered() {


### PR DESCRIPTION
… resolution

Client spans from legacy-semconv SDKs (e.g. otel-js gRPC/HTTP emitting only net.peer.name/net.peer.port, or python-requests emitting only http.url) resolved endPoint/destinationId to null, dropping the callee node from the ServerMap. Extend the fallback chain to server.address -> net.peer.name -> url.full/http.url (host:port extraction) -> network.peer.address -> upstream_address, preferring logical names over socket IPs for ServerMap grouping.

net.peer.name/net.peer.port are filtered from the raw attributes once consumed (mirroring server.address/server.port); url.full/http.url are kept raw since only host:port is consumed and the URL retains path/query information.