### PR TITLE
[#noissue] Filter only consumed attribute keys via a per-span consume…

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyTypeResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyTypeResolver.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -107,12 +108,19 @@ public class OtlpEnvoyTypeResolver {
 
     /**
      * Attaches the Envoy annotations (upstream.cluster + envoy.operation) to a Span/SpanEvent.
-     * upstream_cluster.name is preferred over the legacy upstream_cluster tag.
+     * upstream_cluster.name is preferred over the legacy upstream_cluster tag. The consumed
+     * cluster key is collected into {@code consumedKeys} so it is excluded from the raw
+     * attribute list; response_flags is only a detection gate (never promoted) and stays raw.
      */
-    public void recordAnnotations(Consumer<AnnotationBo> sink, Map<String, AttributeValue> attributes, boolean ingress) {
+    public void recordAnnotations(Consumer<AnnotationBo> sink, Map<String, AttributeValue> attributes, boolean ingress, Set<String> consumedKeys) {
         String cluster = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME, null);
-        if (cluster == null) {
+        if (cluster != null) {
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME);
+        } else {
             cluster = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER, null);
+            if (cluster != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER);
+            }
         }
         if (cluster != null) {
             sink.accept(AnnotationBo.of(OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER, cluster));

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -187,8 +187,26 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_PROCESS_RUNTIME_DESCRIPTION = "process.runtime.description";
     public static final String ATTRIBUTE_KEY_TELEMETRY_SDK_VERSION = "telemetry.sdk.version";
 
+    // Raw-attribute filtering follows one rule: "filter only what was promoted, on the path
+    // that promoted it, only when it actually was promoted". Most keys are therefore excluded
+    // DYNAMICALLY — the mapper collects the keys it actually consumed into a per-span
+    // consumedKeys set and composes the final filter as FILTERED_ATTRIBUTE_KEY.or(consumedKeys::
+    // contains). A key that was present but not consumed (wrong span kind, lost the precedence
+    // race, unparsable value) stays in the raw attribute list instead of being silently dropped.
+    //
+    // This STATIC base set is the documented exception: domain-gated key groups whose
+    // consumption is spread across many collaborators (messaging handlers/utils, the DB branch,
+    // the exception resolver), where threading the consumedKeys collector through every
+    // signature is not worth the churn. They are consumed whenever a span of their domain is
+    // mapped, so a blanket filter is a close approximation. Migrating them to the dynamic
+    // mechanism is a candidate follow-up.
+    //
+    // url.full / http.url are neither filtered nor collected: only host:port (or the path) is
+    // consumed, and the raw URL retains query/path information beyond the promoted field.
     public static final Set<String> FILTERED_ATTRIBUTE_KEY_SET = Set.of(
-            ATTRIBUTE_KEY_CLIENT_ADDRESS,
+            // messaging.* — consumed by OtlpMessagingConsumerResolver handlers (root CONSUMER
+            // spans) and recordMessagingProducerAnnotations / MessagingAttributeUtils (PRODUCER
+            // SpanEvents).
             ATTRIBUTE_KEY_MESSAGING_KAFKA_MESSAGE_OFFSET,
             ATTRIBUTE_KEY_MESSAGING_KAFKA_OFFSET,
             ATTRIBUTE_KEY_MESSAGING_DESTINATION_PARTITION_ID,
@@ -199,19 +217,16 @@ public class OtlpTraceConstants {
             ATTRIBUTE_KEY_MESSAGING_KAFKA_CONSUMER_GROUP,
             ATTRIBUTE_KEY_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
             ATTRIBUTE_KEY_MESSAGING_MESSAGE_ID,
-            ATTRIBUTE_KEY_HTTP_ROUTE,
-            ATTRIBUTE_KEY_NEXT_ROUTE,
-            ATTRIBUTE_KEY_URL_PATH,
-            ATTRIBUTE_KEY_HTTP_REQUEST_METHOD,
-            ATTRIBUTE_KEY_HTTP_METHOD,
             ATTRIBUTE_KEY_MESSAGING_CLIENT_ID,
-            ATTRIBUTE_KEY_SERVER_PORT,
+            // shared network endpoint keys — consumed by the root/SpanEvent endPoint chains AND
+            // by MessagingAttributeUtils.resolveEndPoint, so they stay in the static set until
+            // the messaging paths join the consumedKeys mechanism.
             ATTRIBUTE_KEY_SERVER_ADDRESS,
-            // legacy equivalents of server.address/server.port — consumed the same way (client
-            // endPoint/destinationId), so filtered symmetrically. url.full / http.url are NOT
-            // filtered: only host:port is consumed and the raw URL retains path/query info.
-            ATTRIBUTE_KEY_NET_PEER_NAME,
-            ATTRIBUTE_KEY_NET_PEER_PORT,
+            ATTRIBUTE_KEY_SERVER_PORT,
+            ATTRIBUTE_KEY_NETWORK_PEER_IP,
+            ATTRIBUTE_KEY_NETWORK_PEER_PORT,
+            // db.* — consumed by the DB branch of OtlpTraceSpanEventMapper (destinationId,
+            // ServiceType dispatch, SQL annotation).
             ATTRIBUTE_KEY_DB_NAME,
             ATTRIBUTE_KEY_DB_NAMESPACE,
             ATTRIBUTE_KEY_DB_STATEMENT,
@@ -223,23 +238,21 @@ public class OtlpTraceConstants {
             // filtering would drop them entirely. Keep them in the attribute list so the web
             // UI surfaces vendor error codes (ORA-02813, 08P01, WRONGTYPE), table/collection
             // names, and DB operation kind (INSERT/SELECT/findAndModify).
-            ATTRIBUTE_KEY_ERROR_TYPE,
-            ATTRIBUTE_KEY_NETWORK_PEER_IP,
-            ATTRIBUTE_KEY_RPC_SYSTEM
+            // error.type — consumed by OtlpExceptionInfoResolver on both paths.
+            ATTRIBUTE_KEY_ERROR_TYPE
     );
 
     public static final Predicate<String> FILTERED_ATTRIBUTE_KEY = FILTERED_ATTRIBUTE_KEY_SET::contains;
 
-    // HTTP status code keys are intentionally NOT in the base filter. On the root (SERVER/
-    // CONSUMER/INTERNAL) path OtlpTraceSpanMapper promotes one of them to the HTTP_STATUS_CODE
-    // annotation and then dynamically excludes only that consumed key from the raw attributes —
-    // so a non-promoted variant (or a non-numeric value that could not be promoted) is retained
-    // instead of blanket-dropped. On the SpanEvent path (client/producer/internal) they are never
-    // promoted, so they stay as raw attributes. Precedence order: new semconv before legacy.
+    // HTTP status code keys resolve via the consumedKeys mechanism: both paths promote one of
+    // them to the HTTP_STATUS_CODE annotation and only the consumed key is excluded from the raw
+    // attributes — a non-promoted variant (or a non-numeric value that could not be promoted) is
+    // retained instead of blanket-dropped. Precedence order: new semconv before legacy.
     public static final List<String> RESPONSE_STATUS_CODE_KEYS =
             List.of(ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE, ATTRIBUTE_KEY_HTTP_STATUS_CODE);
 
     // HTTP method resolution order: new semconv (http.request.method) before legacy (http.method).
+    // Same consumedKeys handling as the status keys: only the consumed variant is filtered.
     public static final List<String> HTTP_METHOD_KEYS =
             List.of(ATTRIBUTE_KEY_HTTP_REQUEST_METHOD, ATTRIBUTE_KEY_HTTP_METHOD);
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -42,9 +42,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -101,11 +103,15 @@ public class OtlpTraceSpanEventMapper {
 
         final Map<String, AttributeValue> attributes = OtlpTraceMapperUtils.getAttributeValueMap(span.getAttributesList());
         final TruncatedCounts truncatedCounts = new TruncatedCounts();
+        // Keys promoted to a 1st-class field/annotation are collected here and excluded from the
+        // raw attribute list below — "filter only what was actually consumed". Keys consumed by
+        // the messaging/db collaborators are covered by the static FILTERED_ATTRIBUTE_KEY_SET.
+        final Set<String> consumedKeys = new HashSet<>();
 
         // Keep the order
         if (isDatabase(attributes)) {
-            spanEventBo.setEndPoint(getClientSpanToEndPoint(attributes));
-            spanEventBo.setDestinationId(getClientSpanToDestinationId(attributes));
+            spanEventBo.setEndPoint(getClientSpanToEndPoint(attributes, consumedKeys));
+            spanEventBo.setDestinationId(getClientSpanToDestinationId(attributes, consumedKeys));
             final String dbSystem = getDbSystem(attributes);
             spanEventBo.setServiceType(dbSystemTypeResolver.resolveBaseCode(dbSystem));
             if (isDatabaseExecuteQuery(attributes)) {
@@ -120,16 +126,19 @@ public class OtlpTraceSpanEventMapper {
             }
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.API.getCode(), getSpanNameOrDefault(span, OtlpTraceMapper.CLIENT_METHOD_NAME)));
         } else if (isClient(span)) {
-            spanEventBo.setEndPoint(getClientSpanToEndPoint(attributes));
-            spanEventBo.setDestinationId(getClientSpanToDestinationId(attributes));
+            spanEventBo.setEndPoint(getClientSpanToEndPoint(attributes, consumedKeys));
+            spanEventBo.setDestinationId(getClientSpanToDestinationId(attributes, consumedKeys));
             // An Envoy egress span (detected via Envoy-specific tags) maps to ENVOY_EGRESS;
             // otherwise rpc.system dispatch: grpc → GRPC, apache_dubbo → APACHE_DUBBO_CONSUMER.
             // HTTP clients emit no rpc.system → OPENTELEMETRY_CLIENT fallback.
             if (envoyTypeResolver.isEnvoy(attributes)) {
                 spanEventBo.setServiceType(envoyTypeResolver.resolveEgressServiceType());
-                envoyTypeResolver.recordAnnotations(spanEventBo::addAnnotation, attributes, false);
+                envoyTypeResolver.recordAnnotations(spanEventBo::addAnnotation, attributes, false, consumedKeys);
             } else {
                 final String rpcSystem = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null);
+                if (rpcSystem != null) {
+                    consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM);
+                }
                 spanEventBo.setServiceType(clientTypeResolver.resolveClientServiceType(rpcSystem));
             }
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.API.getCode(), getSpanNameOrDefault(span, OtlpTraceMapper.CLIENT_METHOD_NAME)));
@@ -170,18 +179,18 @@ public class OtlpTraceSpanEventMapper {
         // raw key is excluded below, so a non-promoted variant survives. Fires only when an HTTP
         // status attribute is present (gRPC clients carry rpc.grpc.status_code instead → no-op).
         final OtlpHttpStatusResolver.ResponseStatus responseStatus = OtlpHttpStatusResolver.resolve(attributes);
-        Predicate<String> attributeFilter = OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY;
         if (responseStatus != null) {
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatus.code()));
-            attributeFilter = attributeFilter.or(responseStatus.sourceKey()::equals);
+            consumedKeys.add(responseStatus.sourceKey());
         }
         // http method → HTTP_METHOD annotation (e.g. an HTTP client SpanEvent's request method)
-        final String httpMethod = OtlpTraceSpanMapper.getHttpMethod(attributes);
+        final String httpMethod = OtlpTraceSpanMapper.getHttpMethod(attributes, consumedKeys);
         if (httpMethod != null) {
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_METHOD.getCode(), httpMethod));
         }
         // attributes
         if (!attributes.isEmpty()) {
+            final Predicate<String> attributeFilter = OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY.or(consumedKeys::contains);
             List<AttributeBo> attributeBoList = attributeBoMapper.toAttributeBoList(
                     attributes, attributeFilter, truncatedCounts::attribute);
             spanEventBo.setAttributeBoList(attributeBoList);
@@ -255,12 +264,14 @@ public class OtlpTraceSpanEventMapper {
         return statement;
     }
 
-    String getClientSpanToEndPoint(Map<String, AttributeValue> attributes) {
+    String getClientSpanToEndPoint(Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
         // Logical names first (better ServerMap grouping than socket IPs), then URL-derived
         // host:port, then the socket address, then the proxy tag.
         final String serverAddress = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS, null);
         if (serverAddress != null) {
             final long serverPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, 0L);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT);
             return HostAndPort.toHostAndPortString(serverAddress, (int) serverPort, 0);
         }
         // legacy (semconv 1.x) equivalent of server.address — otel-js gRPC/HTTP clients emit
@@ -268,9 +279,13 @@ public class OtlpTraceSpanEventMapper {
         final String netPeerName = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, null);
         if (netPeerName != null) {
             final long netPeerPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, 0L);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT);
             return HostAndPort.toHostAndPortString(netPeerName, (int) netPeerPort, 0);
         }
-        // host:port extracted from the request URL — url.full (new semconv) / http.url (legacy)
+        // host:port extracted from the request URL — url.full (new semconv) / http.url (legacy).
+        // The URL keys are deliberately NOT collected: only host:port is consumed and the raw
+        // URL retains path/query information beyond the promoted field.
         final String urlHostAndPort = getUrlToHostAndPort(attributes);
         if (urlHostAndPort != null) {
             return urlHostAndPort;
@@ -279,10 +294,16 @@ public class OtlpTraceSpanEventMapper {
         final String networkPeerIp = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, null);
         if (networkPeerIp != null) {
             final long networkPeerPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, 0L);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT);
             return HostAndPort.toHostAndPortString(networkPeerIp, (int) networkPeerPort, 0);
         }
         // proxy
-        return AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_ADDRESS, null);
+        final String upstreamAddress = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_ADDRESS, null);
+        if (upstreamAddress != null) {
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_ADDRESS);
+        }
+        return upstreamAddress;
     }
 
     /**
@@ -302,11 +323,12 @@ public class OtlpTraceSpanEventMapper {
         return hostAndPort;
     }
 
-    String getClientSpanToDestinationId(Map<String, AttributeValue> attributes) {
+    String getClientSpanToDestinationId(Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
         // Resolve db.system up front — OTel Redis spec defines db.namespace (and legacy
         // db.name) as the numeric DB index (0-15), not a logical namespace. For Redis we
         // skip those keys so destinationId falls through to db.system ("redis"), keeping
         // ServerMap grouped at the system level instead of fanning out per index.
+        // db.* keys are covered by the static FILTERED_ATTRIBUTE_KEY_SET, not collected here.
         final String dbSystem = getDbSystem(attributes);
         final boolean isRedis = OtlpTraceConstants.DB_SYSTEM_REDIS.equalsIgnoreCase(dbSystem);
         if (!isRedis) {
@@ -329,21 +351,27 @@ public class OtlpTraceSpanEventMapper {
 
         final String upstreamClusterName = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME, null);
         if (upstreamClusterName != null) {
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME);
             return upstreamClusterName;
         }
 
         final String serverAddress = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS, null);
         if (serverAddress != null) {
             final long serverPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, 0L);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT);
             return HostAndPort.toHostAndPortString(serverAddress, (int) serverPort, 0);
         }
         // legacy (semconv 1.x) equivalent of server.address — see getClientSpanToEndPoint
         final String netPeerName = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, null);
         if (netPeerName != null) {
             final long netPeerPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, 0L);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT);
             return HostAndPort.toHostAndPortString(netPeerName, (int) netPeerPort, 0);
         }
-        // host:port from the request URL — url.full (new semconv) / http.url (legacy)
+        // host:port from the request URL — url.full (new semconv) / http.url (legacy).
+        // URL keys are deliberately NOT collected (partial consumption, see getClientSpanToEndPoint).
         final String urlHostAndPort = getUrlToHostAndPort(attributes);
         if (urlHostAndPort != null) {
             return urlHostAndPort;
@@ -351,11 +379,17 @@ public class OtlpTraceSpanEventMapper {
         final String networkPeerIp = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, null);
         if (networkPeerIp != null) {
             final long networkPeerPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, 0L);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP);
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT);
             return HostAndPort.toHostAndPortString(networkPeerIp, (int) networkPeerPort, 0);
         }
 
         // proxy
-        return AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_ADDRESS, null);
+        final String upstreamAddress = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_ADDRESS, null);
+        if (upstreamAddress != null) {
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_ADDRESS);
+        }
+        return upstreamAddress;
     }
 
     String getSpanNameOrDefault(Span span, String defaultName) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -40,9 +40,11 @@ import io.opentelemetry.proto.trace.v1.Status;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
@@ -98,12 +100,16 @@ public class OtlpTraceSpanMapper {
         spanBo.setApiId(0);
 
         final Map<String, AttributeValue> attributes = OtlpTraceMapperUtils.getAttributeValueMap(span.getAttributesList());
+        // Keys promoted to a 1st-class field/annotation are collected here and excluded from the
+        // raw attribute list below — "filter only what was actually consumed". Keys consumed by
+        // the messaging/db collaborators are covered by the static FILTERED_ATTRIBUTE_KEY_SET.
+        final Set<String> consumedKeys = new HashSet<>();
         final String messagingSystem = isConsumer(span) ? MessagingAttributeUtils.getSystem(attributes) : null;
         final MessageConsumerRecorder messageConsumerRecorder = messagingConsumerResolver.resolve(messagingSystem);
         if (messageConsumerRecorder != null) {
             messageConsumerRecorder.recordMessagingConsumer(spanBo, attributes);
         } else {
-            recordServer(spanBo, span, attributes);
+            recordServer(spanBo, span, attributes, consumedKeys);
         }
 
         // Apply Pinpoint context propagated via tracestate from an upstream OTel-traced service.
@@ -129,16 +135,16 @@ public class OtlpTraceSpanMapper {
         // Only the raw attribute key actually consumed here is excluded from the attribute list below,
         // so a non-promoted status variant (or a non-numeric value that could not be promoted) survives.
         final OtlpHttpStatusResolver.ResponseStatus responseStatus = OtlpHttpStatusResolver.resolve(attributes);
-        Predicate<String> attributeFilter = OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY;
         if (responseStatus != null) {
             spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatus.code()));
-            attributeFilter = attributeFilter.or(responseStatus.sourceKey()::equals);
+            consumedKeys.add(responseStatus.sourceKey());
         }
         // http method → HTTP_METHOD annotation (surfaced as a 1st-class field in the web UI)
-        final String httpMethod = getHttpMethod(attributes);
+        final String httpMethod = getHttpMethod(attributes, consumedKeys);
         if (httpMethod != null) {
             spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_METHOD.getCode(), httpMethod));
         }
+        final Predicate<String> attributeFilter = OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY.or(consumedKeys::contains);
         final TruncatedCounts truncatedCounts = new TruncatedCounts();
         // attributes
         if (!attributes.isEmpty()) {
@@ -252,10 +258,10 @@ public class OtlpTraceSpanMapper {
      * to the server-style mapping). acceptorHost is only set when the span has a parent
      * (i.e. is not a trace root), since a root server span has no upstream caller.
      */
-    private void recordServer(SpanBo spanBo, Span span, Map<String, AttributeValue> attributes) {
-        spanBo.setRpc(getServerSpanToRpc(span, attributes));
-        spanBo.setEndPoint(getServerSpanToEndPoint(span, attributes));
-        spanBo.setRemoteAddr(getServerSpanToRemoteAddress(span, attributes));
+    private void recordServer(SpanBo spanBo, Span span, Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
+        spanBo.setRpc(getServerSpanToRpc(span, attributes, consumedKeys));
+        spanBo.setEndPoint(getServerSpanToEndPoint(span, attributes, consumedKeys));
+        spanBo.setRemoteAddr(getServerSpanToRemoteAddress(span, attributes, consumedKeys));
 
         if (spanBo.getParentSpanId() != -1) {
             spanBo.setAcceptorHost(spanBo.getEndPoint());
@@ -270,11 +276,14 @@ public class OtlpTraceSpanMapper {
         final boolean isServerKind = span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE;
         if (isServerKind && envoyTypeResolver.isEnvoy(attributes)) {
             spanBo.setServiceType(envoyTypeResolver.resolveNodeServiceType());
-            envoyTypeResolver.recordAnnotations(spanBo::addAnnotation, attributes, true);
+            envoyTypeResolver.recordAnnotations(spanBo::addAnnotation, attributes, true, consumedKeys);
         } else {
             final String rpcSystem = isServerKind
                     ? AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null)
                     : null;
+            if (rpcSystem != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM);
+            }
             spanBo.setServiceType(serverTypeResolver.resolveServerServiceType(rpcSystem));
         }
 
@@ -282,20 +291,25 @@ public class OtlpTraceSpanMapper {
         spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.API.getCode(), apiName));
     }
 
-    String getServerSpanToEndPoint(Span span, Map<String, AttributeValue> attributes) {
+    String getServerSpanToEndPoint(Span span, Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
         if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE || span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_INTERNAL_VALUE) {
             // HTTP Server
             final String serverAddress = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS, null);
             if (serverAddress != null) {
                 final long serverPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, 0L);
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS);
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT);
                 return HostAndPort.toHostAndPortString(serverAddress, (int) serverPort, 0);
             }
+            // http.url is deliberately NOT collected: only host:port is consumed and the raw URL
+            // retains path/query information beyond the promoted field.
             final String httpUrl = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, null);
             if (httpUrl != null) {
                 return extractHostAndPort(httpUrl);
             }
             final String rpcService = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SERVICE, null);
             if (rpcService != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SERVICE);
                 return rpcService;
             }
         } else if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_CONSUMER_VALUE) {
@@ -330,13 +344,22 @@ public class OtlpTraceSpanMapper {
         return url.substring(start, end); // "host" or "host:port"
     }
 
+    /**
+     * Consumption-free variant for callers that only need the value (e.g. the exception-trace
+     * uriTemplate in {@link OtlpTraceMapper}) — consumed keys are collected into a throwaway set.
+     */
     String getServerSpanToRpc(Span span, Map<String, AttributeValue> attributes) {
+        return getServerSpanToRpc(span, attributes, new HashSet<>());
+    }
+
+    String getServerSpanToRpc(Span span, Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
         if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE || span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_INTERNAL_VALUE) {
             // http.route is the matched route template ("/users/{id}") — prefer it over the raw
             // url.path ("/users/12345") so the rpc field stays low-cardinality, matching the agent's
             // recordUriTemplate behavior. Falls through to url.path when the request is unrouted.
             final String httpRoute = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_ROUTE, null);
             if (httpRoute != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_ROUTE);
                 return httpRoute;
             }
             // next.route is Next.js's route template (http.route's vendor equivalent). Next.js does
@@ -344,22 +367,28 @@ public class OtlpTraceSpanMapper {
             // to keep the rpc field low-cardinality (e.g. "/api/products/[productId]/index").
             final String nextRoute = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NEXT_ROUTE, null);
             if (nextRoute != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NEXT_ROUTE);
                 return nextRoute;
             }
             final String urlPath = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH, null);
             if (urlPath != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH);
                 return urlPath;
             }
+            // http.url is deliberately NOT collected — only the path is consumed here (and the
+            // host by getServerSpanToEndPoint); the raw URL retains the rest.
             final String httpUrl = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, null);
             if (httpUrl != null) {
                 return extractPath(httpUrl);
             }
             final String httpTarget = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_TARGET, null);
             if (httpTarget != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_TARGET);
                 return httpTarget;
             }
             final String rpcMethod = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_METHOD, null);
             if (rpcMethod != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_METHOD);
                 return rpcMethod;
             }
         }
@@ -400,23 +429,28 @@ public class OtlpTraceSpanMapper {
         return span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_CONSUMER_VALUE;
     }
 
-    String getServerSpanToRemoteAddress(Span span, Map<String, AttributeValue> attributes) {
+    String getServerSpanToRemoteAddress(Span span, Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
         if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE || span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_INTERNAL_VALUE) {
             String remoteAddress = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_CLIENT_ADDRESS, null);
             if (remoteAddress != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_CLIENT_ADDRESS);
                 return remoteAddress;
             }
             remoteAddress = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_PEER_ADDRESS, null);
             if (remoteAddress != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_PEER_ADDRESS);
                 return remoteAddress;
             }
             remoteAddress = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_IP, null);
             if (remoteAddress != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_IP);
                 return remoteAddress;
             }
             final String networkPeerIp = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, null);
             if (networkPeerIp != null) {
                 final long networkPeerPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, 0L);
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP);
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT);
                 return HostAndPort.toHostAndPortString(networkPeerIp, (int) networkPeerPort, 0);
             }
             return null;
@@ -429,12 +463,14 @@ public class OtlpTraceSpanMapper {
     /**
      * Resolves the HTTP request method (new semconv {@code http.request.method} before legacy
      * {@code http.method}) for promotion to the HTTP_METHOD annotation, or {@code null} when
-     * absent. Shared by the root-span and SpanEvent paths.
+     * absent. Shared by the root-span and SpanEvent paths. Only the consumed variant is
+     * collected, so a non-consumed legacy/new twin stays in the raw attribute list.
      */
-    static @Nullable String getHttpMethod(Map<String, AttributeValue> attributes) {
+    static @Nullable String getHttpMethod(Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
         for (String key : OtlpTraceConstants.HTTP_METHOD_KEYS) {
             final String method = AttributeUtils.getAttributeStringValue(attributes, key, null);
             if (method != null) {
+                consumedKeys.add(key);
                 return method;
             }
         }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyTypeResolverTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyTypeResolverTest.java
@@ -112,7 +112,7 @@ class OtlpEnvoyTypeResolverTest {
         attrs.put(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER, AttributeValue.of("legacy"));
 
         List<AnnotationBo> out = new ArrayList<>();
-        resolver.recordAnnotations(out::add, attrs, false);
+        resolver.recordAnnotations(out::add, attrs, false, new java.util.HashSet<>());
 
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isEqualTo("frontend");
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Egress");
@@ -124,7 +124,7 @@ class OtlpEnvoyTypeResolverTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER, AttributeValue.of("frontend"));
 
         List<AnnotationBo> out = new ArrayList<>();
-        resolver.recordAnnotations(out::add, attrs, true);
+        resolver.recordAnnotations(out::add, attrs, true, new java.util.HashSet<>());
 
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isEqualTo("frontend");
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Ingress");
@@ -134,7 +134,7 @@ class OtlpEnvoyTypeResolverTest {
     void recordAnnotations_noCluster_onlyOperationRecorded() {
         // response_flags-only Envoy span: no cluster annotation, but operation is still tagged.
         List<AnnotationBo> out = new ArrayList<>();
-        resolver.recordAnnotations(out::add, Map.of(), false);
+        resolver.recordAnnotations(out::add, Map.of(), false, new java.util.HashSet<>());
 
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isNull();
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Egress");

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -81,21 +81,29 @@ class OtlpTraceMapperUtilsTest {
 
     @Test
     void filteredAttributeKeySet_removesKnownKeys() {
+        // The static base filter covers only the domain-gated groups (messaging.*, db.*, shared
+        // network endpoint keys, error.type). Keys promoted per-span (rpc chain, HTTP method /
+        // status, remote address, ...) are excluded dynamically via the consumedKeys mechanism,
+        // so the base predicate must leave them untouched.
         List<KeyValue> attrs = List.of(
                 kv("custom.attr", strVal("keep-me")),
-                kv(OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH, strVal("/save")),
                 kv(OtlpTraceConstants.ATTRIBUTE_KEY_DB_STATEMENT, strVal("INSERT INTO t")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_MESSAGING_SYSTEM, strVal("kafka")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS, strVal("db.example.com")),
+                // dynamically-filtered keys — must survive the base predicate
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH, strVal("/save")),
                 kv(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_METHOD, strVal("POST")),
-                // http.status_code / http.response.status_code are intentionally NOT in the base
-                // filter (they are excluded dynamically, only when promoted) so client SpanEvents
-                // retain them as raw attributes; the base predicate must leave this one untouched.
                 kv(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE, strVal("201"))
         );
 
         Map<String, Object> result = OtlpTraceMapperUtils.getAttributeToMap(
                 attrs, OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY);
 
-        assertThat(result).containsOnlyKeys("custom.attr", OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE);
+        assertThat(result).containsOnlyKeys(
+                "custom.attr",
+                OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH,
+                OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_METHOD,
+                OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_RESPONSE_STATUS_CODE);
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -185,7 +186,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS, AttributeValue.of("db.example.com"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, AttributeValue.of(5432L)
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("db.example.com:5432");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("db.example.com:5432");
     }
 
     @Test
@@ -194,7 +195,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, AttributeValue.of("10.0.0.1"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, AttributeValue.of(5432L)
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("10.0.0.1:5432");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("10.0.0.1:5432");
     }
 
     @Test
@@ -205,7 +206,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, AttributeValue.of("10.0.0.1"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, AttributeValue.of(9999L)
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("db.example.com:5432");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("db.example.com:5432");
     }
 
     @Test
@@ -213,7 +214,7 @@ class OtlpTraceSpanEventMapperTest {
         Map<String, AttributeValue> attrs = Map.of(
                 OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_ADDRESS, AttributeValue.of("proxy:9000")
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("proxy:9000");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("proxy:9000");
     }
 
     @Test
@@ -224,7 +225,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, AttributeValue.of("cart"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, AttributeValue.of(7070L)
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("cart:7070");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("cart:7070");
     }
 
     @Test
@@ -232,7 +233,7 @@ class OtlpTraceSpanEventMapperTest {
         Map<String, AttributeValue> attrs = Map.of(
                 OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, AttributeValue.of("cart")
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("cart");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("cart");
     }
 
     @Test
@@ -243,7 +244,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, AttributeValue.of("cart"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, AttributeValue.of(9999L)
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("cart.svc:7070");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("cart.svc:7070");
     }
 
     @Test
@@ -252,7 +253,7 @@ class OtlpTraceSpanEventMapperTest {
         Map<String, AttributeValue> attrs = Map.of(
                 OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, AttributeValue.of("http://frontend-proxy:8080/api/cart")
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("frontend-proxy:8080");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("frontend-proxy:8080");
     }
 
     @Test
@@ -261,7 +262,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_URL_FULL, AttributeValue.of("https://api.example.com/users?id=1"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, AttributeValue.of("http://legacy.example.com/users")
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("api.example.com");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("api.example.com");
     }
 
     @Test
@@ -272,7 +273,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, AttributeValue.of("10.0.0.1"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, AttributeValue.of(8080L)
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("api.example.com:8080");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("api.example.com:8080");
     }
 
     @Test
@@ -283,7 +284,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, AttributeValue.of("10.0.0.1"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, AttributeValue.of(8080L)
         );
-        assertThat(mapper.getClientSpanToEndPoint(attrs)).isEqualTo("10.0.0.1:8080");
+        assertThat(mapper.getClientSpanToEndPoint(attrs, new HashSet<>())).isEqualTo("10.0.0.1:8080");
     }
 
     // =======================================================================
@@ -297,7 +298,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_DB_NAME, AttributeValue.of("legacy_db"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_DB_SYSTEM, AttributeValue.of("postgresql")
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("shop_db");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("shop_db");
     }
 
     @Test
@@ -306,7 +307,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_DB_NAME, AttributeValue.of("legacy_db"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_DB_SYSTEM, AttributeValue.of("mysql")
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("legacy_db");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("legacy_db");
     }
 
     @Test
@@ -317,7 +318,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS, AttributeValue.of("cache-01.example.com"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, AttributeValue.of(6379L)
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("redis");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("redis");
     }
 
     @Test
@@ -326,7 +327,7 @@ class OtlpTraceSpanEventMapperTest {
         Map<String, AttributeValue> attrs = Map.of(
                 OtlpTraceConstants.ATTRIBUTE_KEY_DB_SYSTEM, AttributeValue.of("elasticsearch")
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("elasticsearch");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("elasticsearch");
     }
 
     @Test
@@ -341,7 +342,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS, AttributeValue.of("cache-01.example.com"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, AttributeValue.of(6379L)
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("redis");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("redis");
     }
 
     @Test
@@ -351,7 +352,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_DB_SYSTEM, AttributeValue.of("redis"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_DB_NAME, AttributeValue.of("0")
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("redis");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("redis");
     }
 
     @Test
@@ -360,7 +361,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_DB_SYSTEM_NAME, AttributeValue.of("Redis"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_DB_NAMESPACE, AttributeValue.of("0")
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("Redis");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("Redis");
     }
 
     @Test
@@ -369,7 +370,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS, AttributeValue.of("svc.example.com"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, AttributeValue.of(8080L)
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("svc.example.com:8080");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("svc.example.com:8080");
     }
 
     @Test
@@ -378,7 +379,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP, AttributeValue.of("10.0.0.1"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT, AttributeValue.of(5432L)
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("10.0.0.1:5432");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("10.0.0.1:5432");
     }
 
     @Test
@@ -388,7 +389,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, AttributeValue.of("cart"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, AttributeValue.of(7070L)
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("cart:7070");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("cart:7070");
     }
 
     @Test
@@ -396,7 +397,7 @@ class OtlpTraceSpanEventMapperTest {
         Map<String, AttributeValue> attrs = Map.of(
                 OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, AttributeValue.of("http://frontend-proxy:8080/api/cart")
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("frontend-proxy:8080");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("frontend-proxy:8080");
     }
 
     @Test
@@ -407,7 +408,7 @@ class OtlpTraceSpanEventMapperTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_NAME, AttributeValue.of("cache-01"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_NET_PEER_PORT, AttributeValue.of(6379L)
         );
-        assertThat(mapper.getClientSpanToDestinationId(attrs)).isEqualTo("redis");
+        assertThat(mapper.getClientSpanToDestinationId(attrs, new HashSet<>())).isEqualTo("redis");
     }
 
     // =======================================================================
@@ -480,6 +481,35 @@ class OtlpTraceSpanEventMapperTest {
         assertThat(event.getEndPoint()).isEqualTo("frontend-proxy:8080");
         assertThat(event.getDestinationId()).isEqualTo("frontend-proxy:8080");
         assertThat(attributeKeys(event)).contains("http.url");
+    }
+
+    @Test
+    void map_client_envoyEgress_consumedKeysFiltered() {
+        // Envoy egress: upstream_cluster.name is promoted (destinationId + upstream.cluster
+        // annotation) and upstream_address resolves the endPoint — both consumed → filtered.
+        // response_flags is only the detection gate and stays raw.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("upstream_cluster.name", strVal("frontend")),
+                kv("upstream_address", strVal("172.18.0.27:8080")),
+                kv("response_flags", strVal("-")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(event.getDestinationId()).isEqualTo("frontend");
+        assertThat(event.getEndPoint()).isEqualTo("172.18.0.27:8080");
+        assertThat(attributeKeys(event)).doesNotContain("upstream_cluster.name", "upstream_address");
+        assertThat(attributeKeys(event)).contains("response_flags");
+    }
+
+    @Test
+    void map_internal_netPeerName_notConsumed_keptRaw() {
+        // INTERNAL spans resolve no endPoint/destinationId — net.peer.name is not consumed,
+        // so it stays in the raw attribute list instead of being silently dropped.
+        Span span = span(Span.SpanKind.SPAN_KIND_INTERNAL,
+                kv("net.peer.name", strVal("cart")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(event.getEndPoint()).isNull();
+        assertThat(attributeKeys(event)).contains("net.peer.name");
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -607,6 +607,99 @@ class OtlpTraceSpanMapperTest {
         assertThat(bo.getRpc()).isEqualTo("/api/users/123");
     }
 
+    // =======================================================================
+    // map() — consumedKeys: filter only what was actually promoted
+    // =======================================================================
+
+    @Test
+    void map_server_rpcRace_onlyWinningKeyFiltered() {
+        // http.route wins the rpc precedence race — only the consumed key is filtered;
+        // the losing url.path stays in the raw attribute list instead of being blanket-dropped.
+        Span span = serverSpan(
+                kv("http.route", strVal("/api/users/{id}")),
+                kv("url.path", strVal("/api/users/123")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(attributeKeys(bo)).doesNotContain("http.route");
+        assertThat(attributeKeys(bo)).contains("url.path");
+    }
+
+    @Test
+    void map_server_httpTarget_consumedAsRpc_filtered() {
+        Span span = serverSpan(kv("http.target", strVal("/api/cart?x=1")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(bo.getRpc()).isEqualTo("/api/cart?x=1");
+        assertThat(attributeKeys(bo)).doesNotContain("http.target");
+    }
+
+    @Test
+    void map_server_rpcServiceAndMethod_consumed_filtered() {
+        // rpc.service → endPoint, rpc.method → rpc; both consumed → both filtered.
+        Span span = serverSpan(
+                kv("rpc.service", strVal("oteldemo.CartService")),
+                kv("rpc.method", strVal("AddItem")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(bo.getRpc()).isEqualTo("AddItem");
+        assertThat(bo.getEndPoint()).isEqualTo("oteldemo.CartService");
+        assertThat(attributeKeys(bo)).doesNotContain("rpc.service", "rpc.method");
+    }
+
+    @Test
+    void map_server_peerAddress_consumedAsRemoteAddr_filtered() {
+        // peer.address (Envoy-style) resolves remoteAddr — previously it survived as a raw
+        // duplicate because it was missing from the static filter set.
+        Span span = serverSpan(kv("peer.address", strVal("172.18.0.25")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(bo.getRemoteAddr()).isEqualTo("172.18.0.25");
+        assertThat(attributeKeys(bo)).doesNotContain("peer.address");
+    }
+
+    @Test
+    void map_server_httpUrl_partialConsumption_keptRaw() {
+        // http.url feeds both rpc (path) and endPoint (host:port) but retains query information —
+        // partial consumption keeps the raw attribute.
+        Span span = serverSpan(kv("http.url", strVal("http://shop:8080/api/cart?x=1")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(bo.getRpc()).isEqualTo("/api/cart");
+        assertThat(bo.getEndPoint()).isEqualTo("shop:8080");
+        assertThat(attributeKeys(bo)).contains("http.url");
+    }
+
+    @Test
+    void map_server_rpcSystem_consumed_filtered() {
+        Span span = serverSpan(kv("rpc.system", strVal("grpc")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(attributeKeys(bo)).doesNotContain("rpc.system");
+    }
+
+    @Test
+    void map_internal_rpcSystem_notConsumed_keptRaw() {
+        // INTERNAL spans do not dispatch ServiceType via rpc.system — the key is not consumed,
+        // so it stays in the raw attribute list instead of being silently dropped.
+        Span span = Span.newBuilder()
+                .setName("op")
+                .setTraceId(ByteString.copyFrom(TRACE_ID))
+                .setSpanId(ByteString.copyFrom(SPAN_ID))
+                .setKindValue(Span.SpanKind.SPAN_KIND_INTERNAL_VALUE)
+                .addAttributes(kv("rpc.system", strVal("grpc")))
+                .build();
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(attributeKeys(bo)).contains("rpc.system");
+    }
+
+    @Test
+    void map_server_envoy_upstreamClusterName_consumed_filtered() {
+        // The Envoy ingress branch promotes upstream_cluster.name to the upstream.cluster
+        // annotation — the consumed key is filtered; response_flags is only a detection gate
+        // (never promoted) and stays raw.
+        Span span = serverSpan(
+                kv("upstream_cluster.name", strVal("frontend")),
+                kv("response_flags", strVal("-")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isEqualTo("frontend");
+        assertThat(attributeKeys(bo)).doesNotContain("upstream_cluster.name");
+        assertThat(attributeKeys(bo)).contains("response_flags");
+    }
+
     @Test
     void map_server_nextRoute_preferredOverRawPath() {
         // Next.js emits next.route (route template) but not http.route. It must win over the raw
@@ -710,13 +803,16 @@ class OtlpTraceSpanMapperTest {
 
     @Test
     void map_server_httpRequestMethod_newSemconv_preferredOverLegacy() {
-        // New semconv http.request.method wins over legacy http.method (both carry the method).
+        // New semconv http.request.method wins over legacy http.method. Only the consumed
+        // variant is filtered — the non-consumed legacy twin stays as a raw attribute
+        // (same consumedKeys rule as the status keys).
         Span span = serverSpan(
                 kv("http.request.method", strVal("POST")),
                 kv("http.method", strVal("POST")));
         SpanBo bo = newMapper().map(id(), span);
         assertThat(findAnnotation(bo, AnnotationKey.HTTP_METHOD.getCode())).isEqualTo("POST");
-        assertThat(attributeKeys(bo)).doesNotContain("http.request.method", "http.method");
+        assertThat(attributeKeys(bo)).doesNotContain("http.request.method");
+        assertThat(attributeKeys(bo)).contains("http.method");
     }
 
     // =======================================================================


### PR DESCRIPTION
…dKeys collector

The static FILTERED_ATTRIBUTE_KEY_SET had drifted from actual consumption: keys promoted to a 1st-class field kept leaking as raw duplicates (http.target, rpc.method, rpc.service, peer.address, net.peer.ip, network.peer.port, upstream_address, upstream_cluster/.name), while statically-filtered keys were dropped even on spans that never consumed them (rpc chain variants that lost the precedence race, rpc.system on INTERNAL spans, the non-consumed HTTP method twin).

Replace the per-promotion Predicate.or chains with a single per-span consumedKeys set: each resolution site registers the keys it actually consumed and the final filter is FILTERED_ATTRIBUTE_KEY.or(consumedKeys::contains). The static set shrinks to the domain-gated groups (messaging.*, db.*, shared network endpoint keys, error.type) whose consumption is spread across the messaging/db collaborators; migrating those to the collector is a follow-up. url.full/http.url remain raw by design (partial consumption).