### PR TITLE
[#noissue] Surface silent GET query failures via a global error toast

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Error/ErrorBoundary.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Error/ErrorBoundary.tsx
@@ -5,9 +5,7 @@ import {
   ErrorBoundaryProps as ErrorBoundaryPropsWithRender,
 } from 'react-error-boundary';
 import { ErrorDetailDialog } from './ErrorDetailDialog';
-import { useReactToastifyToast } from '../Toast';
 import { ErrorLike } from '@pinpoint-fe/ui/src/constants';
-import { ErrorToast } from './ErrorToast';
 import { useSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 
 export type ErrorBoundaryProps = Partial<ErrorBoundaryPropsWithRender> & {
@@ -22,18 +20,12 @@ export const ErrorBoundary = ({
 }: ErrorBoundaryProps) => {
   const { t } = useTranslation();
   const { search } = useSearchParameters();
-  const toast = useReactToastifyToast();
 
   return (
+    // 에러 토스트는 QueryCache/MutationCache의 글로벌 onError(reactQueryHelper)가
+    // 단일 출처로 담당한다. ErrorBoundary는 인라인 fallback UI만 렌더한다(토스트 중복 방지).
     <ErrorBoundaryComponent
       resetKeys={[search, ...(resetKeys || [])]}
-      onError={(props) => {
-        const error = props as unknown as ErrorLike;
-        toast.error(<ErrorToast error={error} />, {
-          bodyClassName: '!items-start',
-          autoClose: false,
-        });
-      }}
       fallbackRender={({ error, resetErrorBoundary }) => {
         if (fallbackRender) {
           return fallbackRender({ error, resetErrorBoundary });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.test.tsx
@@ -1,0 +1,48 @@
+import { toast } from 'react-toastify';
+import type { Query } from '@tanstack/react-query';
+import { handleGlobalQueryError, showGlobalErrorToast } from './reactQueryHelper';
+
+// ErrorToast transitively pulls the ECharts (ESM) stack that babel-jest does not
+// transform, so stub it out — we only assert on the toast options here.
+jest.mock('../../components/Error/ErrorToast', () => ({ ErrorToast: () => null }));
+jest.mock('react-toastify', () => ({ toast: { error: jest.fn() } }));
+jest.mock('@pinpoint-fe/ui/src/atoms', () => ({
+  toastCountAtom: { toString: () => 'toastCountAtom' },
+}));
+
+const makeQuery = (over: Partial<Query> = {}) =>
+  ({ queryHash: '["/api/test",""]', meta: undefined, ...over }) as unknown as Query;
+
+describe('reactQueryHelper global query error handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('shows a global error toast for a failed query', () => {
+    handleGlobalQueryError(new Error('boom'), makeQuery({ queryHash: 'hash-1' }));
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    const options = (toast.error as jest.Mock).mock.calls[0][1];
+    // toastId is keyed on the query hash so repeated polling failures dedupe instead of stacking.
+    expect(options.toastId).toBe('hash-1');
+    expect(options.autoClose).toBe(false);
+  });
+
+  test('does not toast when the query opts out via meta.ignoreGlobalError', () => {
+    handleGlobalQueryError(new Error('boom'), makeQuery({ meta: { ignoreGlobalError: true } }));
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  test('still toasts when meta is present without the ignore flag', () => {
+    handleGlobalQueryError(new Error('boom'), makeQuery({ meta: { ignoreGlobalError: false } }));
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  test('showGlobalErrorToast forwards the toastId option', () => {
+    showGlobalErrorToast(new Error('x'), { toastId: 'abc' });
+
+    expect((toast.error as jest.Mock).mock.calls[0][1].toastId).toBe('abc');
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.test.tsx
@@ -1,14 +1,16 @@
-import { toast } from 'react-toastify';
 import type { Query } from '@tanstack/react-query';
-import { handleGlobalQueryError, showGlobalErrorToast } from './reactQueryHelper';
 
 // ErrorToast transitively pulls the ECharts (ESM) stack that babel-jest does not
-// transform, so stub it out — we only assert on the toast options here.
+// transform, so stub it out. These mocks must run before reactQueryHelper (and the
+// mocked react-toastify) are imported, so those imports are placed after them.
 jest.mock('../../components/Error/ErrorToast', () => ({ ErrorToast: () => null }));
 jest.mock('react-toastify', () => ({ toast: { error: jest.fn() } }));
 jest.mock('@pinpoint-fe/ui/src/atoms', () => ({
   toastCountAtom: { toString: () => 'toastCountAtom' },
 }));
+
+import { toast } from 'react-toastify';
+import { handleGlobalQueryError, showGlobalErrorToast } from './reactQueryHelper';
 
 const makeQuery = (over: Partial<Query> = {}) =>
   ({ queryHash: '["/api/test",""]', meta: undefined, ...over }) as unknown as Query;

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.tsx
@@ -1,5 +1,5 @@
 import { ErrorResponse } from '@pinpoint-fe/ui/src/constants';
-import { MutationCache, QueryClient } from '@tanstack/react-query';
+import { MutationCache, QueryCache, QueryClient, type Query } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 import { getDefaultStore } from 'jotai';
 import { toastCountAtom } from '@pinpoint-fe/ui/src/atoms';
@@ -9,6 +9,10 @@ declare module '@tanstack/react-query' {
   interface Register {
     mutationMeta: {
       /** true로 설정하면 MutationCache의 글로벌 에러 토스트를 표시하지 않음. 컴포넌트에서 에러를 자체 처리할 때 사용. */
+      ignoreGlobalError?: boolean;
+    };
+    queryMeta: {
+      /** true로 설정하면 QueryCache의 글로벌 에러 토스트를 표시하지 않음. 컴포넌트에서 에러를 자체 처리할 때 사용. */
       ignoreGlobalError?: boolean;
     };
   }
@@ -62,24 +66,50 @@ export const queryFn = (url: string) => async () => {
   return response.json();
 };
 
+/**
+ * 글로벌 에러 토스트. 모듈 레벨이라 useReactToastifyToast 훅을 쓸 수 없으므로, 동일한
+ * default store를 통해 toastCountAtom을 직접 갱신해 "Clear All" 동작을 토스트와 일치시킨다.
+ * toastId를 지정하면 react-toastify가 동일 id의 중복 토스트를 억제한다(폴링 실패 누적 방지).
+ */
+export const showGlobalErrorToast = (error: unknown, options?: { toastId?: string }) => {
+  const store = getDefaultStore();
+  toast.error(<ErrorToast error={error as Error} />, {
+    toastId: options?.toastId,
+    className: 'pointer-events-auto',
+    bodyClassName: '!items-start',
+    autoClose: false,
+    onOpen: () => store.set(toastCountAtom, (prev) => prev + 1),
+    onClose: () => store.set(toastCountAtom, (prev) => (prev === 0 ? prev : prev - 1)),
+  });
+};
+
+/**
+ * 모든 쿼리(GET) 실패에 대한 글로벌 에러 토스트. 뮤테이션과 대칭 동작이며, React Query는
+ * 기본적으로 쿼리 에러를 throw하지 않으므로 이 핸들러가 없으면 실패가 조용히 삼켜진다.
+ * 컴포넌트가 에러를 자체 처리하는 경우 meta.ignoreGlobalError로 opt-out 할 수 있다.
+ * ErrorBoundary는 인라인 fallback UI만 담당하므로 토스트는 여기서만 발생한다(중복 방지).
+ */
+export const handleGlobalQueryError = (
+  error: unknown,
+  query: Query<unknown, unknown, unknown, readonly unknown[]>,
+) => {
+  if (query.meta?.ignoreGlobalError) return;
+  showGlobalErrorToast(error, { toastId: query.queryHash });
+};
+
 const mutationCache = new MutationCache({
   onError: (error, _variables, _context, mutation) => {
     if (mutation.meta?.ignoreGlobalError) return;
-
-    // 모듈 레벨이라 useReactToastifyToast 훅을 쓸 수 없으므로, 동일한 default store를
-    // 통해 toastCountAtom을 직접 갱신해 query 에러 토스트와 "Clear All" 동작을 일치시킨다.
-    const store = getDefaultStore();
-    toast.error(<ErrorToast error={error as Error} />, {
-      className: 'pointer-events-auto',
-      bodyClassName: '!items-start',
-      autoClose: false,
-      onOpen: () => store.set(toastCountAtom, (prev) => prev + 1),
-      onClose: () => store.set(toastCountAtom, (prev) => (prev === 0 ? prev : prev - 1)),
-    });
+    showGlobalErrorToast(error);
   },
 });
 
+const queryCache = new QueryCache({
+  onError: handleGlobalQueryError,
+});
+
 export const queryClient = new QueryClient({
+  queryCache,
   mutationCache,
   defaultOptions: { queries: { refetchOnWindowFocus: false, staleTime: 3000 } },
 });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfigAgentDuplicationCheck.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfigAgentDuplicationCheck.ts
@@ -21,5 +21,8 @@ export const useGetConfigAgentDuplicationCheck = ({ agentId }: { agentId: string
     queryFn: queryFn(`${END_POINTS.CONFIG_AGENT_DUPLICATION_CHECK}${queryString}`),
     enabled: !!queryString,
     retry: false,
+    // A failing response is an expected validation outcome (duplicate/invalid id) surfaced
+    // inline by the caller, not a system error — suppress the global error toast.
+    meta: { ignoreGlobalError: true },
   });
 };

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfigApplicationDuplicationCheck.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfigApplicationDuplicationCheck.ts
@@ -25,5 +25,8 @@ export const useGetConfigApplicationDuplicationCheck = ({
     queryFn: queryFn(`${END_POINTS.CONFIG_APPLICATION_DUPLICATION_CHECK}${queryString}`),
     enabled: !!queryString,
     retry: false,
+    // A failing response is an expected validation outcome (duplicate/invalid name) surfaced
+    // inline by the caller, not a system error — suppress the global error toast.
+    meta: { ignoreGlobalError: true },
   });
 };

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHeatmapAppData.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHeatmapAppData.ts
@@ -10,6 +10,9 @@ export const useGetHeatmapAppData = (parameters: GetHeatmapAppData.Parameters) =
     queryKey: [END_POINTS.HEATMAP_APP_DATA, parameters],
     queryFn: queryFn(`${END_POINTS.HEATMAP_APP_DATA}${queryString}`),
     enabled: !!queryString,
+    // HeatmapFetcher renders a full inline error overlay for this failure — suppress the
+    // redundant global error toast so the user sees a single error signal.
+    meta: { ignoreGlobalError: true },
   });
   return { data, isLoading, refetch, error };
 };


### PR DESCRIPTION
## Summary
- React Query v5 doesn't throw query errors by default and there was **no global `queryCache.onError`**, so most GET failures showed a blank/stuck UI with no feedback (silently swallowed). Only mutations had a global error toast.
- Add a `QueryCache.onError` (`handleGlobalQueryError`) wired into the `QueryClient`, symmetric with the existing `mutationCache.onError`. Every query failure now toasts, deduped by `query.queryHash` (react-toastify `toastId`) so repeated polling failures don't stack.
- Make toasting **single-sourced**: remove the query-error toast from `ErrorBoundary` (it now only renders the inline fallback UI). Boundary-backed query errors (useSuspenseQuery / throwOnError / ServerMap's `ThrowError`) previously would have toasted twice.
- Add `queryMeta.ignoreGlobalError` opt-out (mirrors `mutationMeta.ignoreGlobalError`). Opt out three hooks whose failure is already surfaced inline and is not a system error: `useGetConfigAgentDuplicationCheck`, `useGetConfigApplicationDuplicationCheck` (routine duplicate-id validation) and `useGetHeatmapAppData` (full inline overlay).

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (89 suites / 618 tests, incl. new `reactQueryHelper.test.tsx`)
- [x] `yarn lint` clean on changed files
- [ ] Manually verify a failing GET (non-boundary) now shows a toast
- [ ] Verify boundary-backed / ServerMap failures show exactly one toast + inline fallback (no double toast)
- [ ] Verify duplicate-id validation and heatmap errors do not pop a global toast

## Note
Trade-off: non-query render errors caught by `ErrorBoundary` (component crashes, lazy chunk-load failures) now show only the inline fallback and no toast. Acceptable — the fallback UI is prominent and this removes the double-toast for the common query path.