### PR TITLE
[#noissue] Keep OTLP Envoy spans on the generic OpenTelemetry Service…

### DIFF
--- a/agent-module/plugins/external/src/main/resources/META-INF/pinpoint/type-providers/envoy-type-provider.yml
+++ b/agent-module/plugins/external/src/main/resources/META-INF/pinpoint/type-providers/envoy-type-provider.yml
@@ -1,5 +1,7 @@
 serviceTypes:
-    # Envoy
+    # Envoy ServiceTypes are emitted by the native pinpoint-cpp Envoy tracer.
+    # The OTLP trace mapping does NOT re-type Envoy spans (they keep OPENTELEMETRY_SERVER /
+    # OPENTELEMETRY_CLIENT) and uses only the annotation keys below for identification.
     - code: 1550
       name: 'ENVOY'
       property:

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyRecorder.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyRecorder.java
@@ -17,23 +17,26 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
-import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
-import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
 /**
- * Detects Envoy proxy spans that arrive via OTLP and maps them to the dedicated Envoy
- * ServiceTypes — {@code ENVOY} (1550) for the SERVER-kind ingress node and
- * {@code ENVOY_EGRESS} (9302) for the CLIENT-kind egress call. This complements the native
- * pinpoint-cpp Envoy tracer (which sets SVC_TYPE_ENVOY 1550 on the span and
- * SVC_TYPE_ENVOY_INGRESS 9301 / SVC_TYPE_ENVOY_EGRESS 9302 on its child SpanEvents).
+ * Detects Envoy proxy spans that arrive via OTLP and records the Envoy identification
+ * annotations ({@code envoy.operation} + {@code upstream.cluster}) on the Span/SpanEvent.
+ *
+ * <p><b>No ServiceType override.</b> Envoy spans keep the regular OTLP types
+ * (OPENTELEMETRY_SERVER / OPENTELEMETRY_CLIENT): re-typing them to ENVOY (1550) /
+ * ENVOY_EGRESS (9302) mixed two node types under a single applicationName whenever the
+ * tag-based detection missed a span (the gate depends on Envoy's deployment-specific tag
+ * configuration), causing ApplicationIndex/ServerMap type conflicts. The dedicated Envoy
+ * ServiceType codes remain registered in envoy-type-provider.yml for the native pinpoint-cpp
+ * Envoy tracer, which emits them directly. Envoy identification on the OTLP path is carried
+ * by the annotations only.</p>
  *
  * <p><b>Detection gate.</b> Envoy is identified by the presence of Envoy-specific span tags
  * ({@code upstream_cluster} / {@code upstream_cluster.name} / {@code response_flags}). These
@@ -44,45 +47,13 @@ import java.util.function.Consumer;
  * <p><b>Direction.</b> The caller decides ingress vs egress from {@code span.kind}
  * (SERVER → ingress, CLIENT → egress), matching how Envoy's OTLP exporter derives span kind
  * from the listener operation name.</p>
- *
- * <p><b>ServiceType category matters.</b> A SERVER-kind Envoy span becomes a root SpanBo — a
- * ServerMap <em>node</em> — so it must carry a SERVER-category type: {@code ENVOY} (1550),
- * NOT {@code ENVOY_INGRESS} (9301, an RPC-category <em>call</em> type used by the native tracer
- * on a child SpanEvent). A CLIENT-kind Envoy span becomes a SpanEvent — an outbound
- * <em>call</em> — so it carries the RPC-category {@code ENVOY_EGRESS} (9302). The ingress
- * direction is otherwise preserved via the {@code envoy.operation} annotation. This mirrors how
- * OTLP server nodes use {@code OPENTELEMETRY_SERVER} (1220) while client events use
- * {@code OPENTELEMETRY_CLIENT} (9310).</p>
- *
- * <p><b>Graceful fallback.</b> ServiceType codes are resolved from
- * {@link ServiceTypeRegistryService} by <em>name</em>. When the {@code envoy-type-provider}
- * is not deployed on the collector classpath the resolver falls back to
- * {@link ServiceType#OPENTELEMETRY_SERVER} / {@link ServiceType#OPENTELEMETRY_CLIENT}, so the
- * mapping degrades to today's behavior instead of failing.</p>
  */
 @Component
-public class OtlpEnvoyTypeResolver {
-
-    private static final String SERVICE_TYPE_NAME_ENVOY = "ENVOY";
-    private static final String SERVICE_TYPE_NAME_ENVOY_EGRESS = "ENVOY_EGRESS";
+public class OtlpEnvoyRecorder {
 
     // envoy.operation annotation values, mirroring the native tracer's AppendString(...).
     private static final String OPERATION_INGRESS = "Ingress";
     private static final String OPERATION_EGRESS = "Egress";
-
-    private final int nodeCode;
-    private final int egressCode;
-
-    public OtlpEnvoyTypeResolver(ServiceTypeRegistryService registry) {
-        Objects.requireNonNull(registry, "registry");
-        this.nodeCode = resolve(registry, SERVICE_TYPE_NAME_ENVOY, ServiceType.OPENTELEMETRY_SERVER.getCode());
-        this.egressCode = resolve(registry, SERVICE_TYPE_NAME_ENVOY_EGRESS, ServiceType.OPENTELEMETRY_CLIENT.getCode());
-    }
-
-    private static int resolve(ServiceTypeRegistryService registry, String typeName, int fallback) {
-        ServiceType type = registry.findServiceTypeByName(typeName);
-        return (type == null || type == ServiceType.UNDEFINED) ? fallback : type.getCode();
-    }
 
     /**
      * Envoy detection gate. Keyed on Envoy-specific tags only (see class Javadoc).
@@ -91,19 +62,6 @@ public class OtlpEnvoyTypeResolver {
         return attributes.containsKey(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER)
                 || attributes.containsKey(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME)
                 || attributes.containsKey(OtlpTraceConstants.ATTRIBUTE_KEY_RESPONSE_FLAGS);
-    }
-
-    /**
-     * Envoy node (SERVER-category) code for a SERVER-kind ingress span, or OPENTELEMETRY_SERVER
-     * when the Envoy plugin is not deployed.
-     */
-    public int resolveNodeServiceType() {
-        return nodeCode;
-    }
-
-    /** ENVOY_EGRESS code, or OPENTELEMETRY_CLIENT when the Envoy plugin is not deployed. */
-    public int resolveEgressServiceType() {
-        return egressCode;
     }
 
     /**

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -113,7 +113,7 @@ public class OtlpTraceConstants {
 
     // AnnotationKey codes mirrored from agent-module/plugins/external envoy-type-provider.yml.
     // Display names ("envoy.operation", "upstream.cluster") are registered there so the web UI
-    // resolves them. Attached by OtlpEnvoyTypeResolver when an Envoy span is detected.
+    // resolves them. Attached by OtlpEnvoyRecorder when an Envoy span is detected.
     public static final int ANNOTATION_KEY_ENVOY_OPERATION = 9441;
     public static final int ANNOTATION_KEY_UPSTREAM_CLUSTER = 9442;
     // OTel HTTP server semconv: the matched route template (low-cardinality, e.g. "/users/{id}").
@@ -147,7 +147,7 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME = "upstream_cluster.name";
     // Envoy-specific span tags. upstream_cluster (no ".name" suffix) is the legacy Zipkin-style
     // tag; response_flags is Envoy's connection/response flag string ("-" when none). Both are
-    // emitted only by Envoy, so they serve as the Envoy detection gate in OtlpEnvoyTypeResolver.
+    // emitted only by Envoy, so they serve as the Envoy detection gate in OtlpEnvoyRecorder.
     // component=proxy is intentionally NOT used — it is deprecated in OTel semconv and set by
     // other proxies too, so it has no reliable discriminating power on its own.
     public static final String ATTRIBUTE_KEY_UPSTREAM_CLUSTER = "upstream_cluster";

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -58,7 +58,7 @@ public class OtlpTraceSpanEventMapper {
     private final OtlpDbSystemTypeResolver dbSystemTypeResolver;
     private final OtlpMessagingTypeResolver messagingTypeResolver;
     private final OtlpClientTypeResolver clientTypeResolver;
-    private final OtlpEnvoyTypeResolver envoyTypeResolver;
+    private final OtlpEnvoyRecorder envoyRecorder;
     private final OtlpExceptionInfoResolver exceptionInfoResolver;
     private final OtlpAttributeBoMapper attributeBoMapper;
     private final int sqlMaxBytes;
@@ -67,7 +67,7 @@ public class OtlpTraceSpanEventMapper {
                                     ServiceTypeRegistryService serviceTypeRegistryService,
                                     OtlpMessagingTypeResolver messagingTypeResolver,
                                     OtlpClientTypeResolver clientTypeResolver,
-                                    OtlpEnvoyTypeResolver envoyTypeResolver,
+                                    OtlpEnvoyRecorder envoyRecorder,
                                     OtlpExceptionInfoResolver exceptionInfoResolver,
                                     OtlpAttributeBoMapper attributeBoMapper,
                                     @Value("${pinpoint.collector.otlptrace.sql.max-bytes:8192}") int sqlMaxBytes) {
@@ -76,7 +76,7 @@ public class OtlpTraceSpanEventMapper {
                 Objects.requireNonNull(serviceTypeRegistryService, "serviceTypeRegistryService"));
         this.messagingTypeResolver = Objects.requireNonNull(messagingTypeResolver, "messagingTypeResolver");
         this.clientTypeResolver = Objects.requireNonNull(clientTypeResolver, "clientTypeResolver");
-        this.envoyTypeResolver = Objects.requireNonNull(envoyTypeResolver, "envoyTypeResolver");
+        this.envoyRecorder = Objects.requireNonNull(envoyRecorder, "envoyRecorder");
         this.exceptionInfoResolver = Objects.requireNonNull(exceptionInfoResolver, "exceptionInfoResolver");
         this.attributeBoMapper = Objects.requireNonNull(attributeBoMapper, "attributeBoMapper");
         if (sqlMaxBytes < 0) {
@@ -128,18 +128,17 @@ public class OtlpTraceSpanEventMapper {
         } else if (isClient(span)) {
             spanEventBo.setEndPoint(getClientSpanToEndPoint(attributes, consumedKeys));
             spanEventBo.setDestinationId(getClientSpanToDestinationId(attributes, consumedKeys));
-            // An Envoy egress span (detected via Envoy-specific tags) maps to ENVOY_EGRESS;
-            // otherwise rpc.system dispatch: grpc → GRPC, apache_dubbo → APACHE_DUBBO_CONSUMER.
+            // rpc.system dispatch: grpc → GRPC, apache_dubbo → APACHE_DUBBO_CONSUMER.
             // HTTP clients emit no rpc.system → OPENTELEMETRY_CLIENT fallback.
-            if (envoyTypeResolver.isEnvoy(attributes)) {
-                spanEventBo.setServiceType(envoyTypeResolver.resolveEgressServiceType());
-                envoyTypeResolver.recordAnnotations(spanEventBo::addAnnotation, attributes, false, consumedKeys);
-            } else {
-                final String rpcSystem = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null);
-                if (rpcSystem != null) {
-                    consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM);
-                }
-                spanEventBo.setServiceType(clientTypeResolver.resolveClientServiceType(rpcSystem));
+            final String rpcSystem = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null);
+            if (rpcSystem != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM);
+            }
+            spanEventBo.setServiceType(clientTypeResolver.resolveClientServiceType(rpcSystem));
+            // Envoy egress detection → identification annotations only. The ServiceType is NOT
+            // overridden to ENVOY_EGRESS (see OtlpEnvoyRecorder Javadoc).
+            if (envoyRecorder.isEnvoy(attributes)) {
+                envoyRecorder.recordAnnotations(spanEventBo::addAnnotation, attributes, false, consumedKeys);
             }
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.API.getCode(), getSpanNameOrDefault(span, OtlpTraceMapper.CLIENT_METHOD_NAME)));
         } else if (isProducer(span)) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -53,7 +53,7 @@ public class OtlpTraceSpanMapper {
     private final OtlpTraceEventMapper eventMapper;
     private final OtlpTraceLinkMapper linkMapper;
     private final OtlpServerTypeResolver serverTypeResolver;
-    private final OtlpEnvoyTypeResolver envoyTypeResolver;
+    private final OtlpEnvoyRecorder envoyRecorder;
     private final OtlpExceptionInfoResolver exceptionInfoResolver;
     private final OtlpMessagingConsumerResolver messagingConsumerResolver;
     private final OtlpAttributeBoMapper attributeBoMapper;
@@ -61,14 +61,14 @@ public class OtlpTraceSpanMapper {
     public OtlpTraceSpanMapper(OtlpTraceEventMapper eventMapper,
                                OtlpTraceLinkMapper linkMapper,
                                OtlpServerTypeResolver serverTypeResolver,
-                               OtlpEnvoyTypeResolver envoyTypeResolver,
+                               OtlpEnvoyRecorder envoyRecorder,
                                OtlpExceptionInfoResolver exceptionInfoResolver,
                                OtlpMessagingConsumerResolver messagingConsumerResolver,
                                OtlpAttributeBoMapper attributeBoMapper) {
         this.eventMapper = Objects.requireNonNull(eventMapper, "eventMapper");
         this.linkMapper = Objects.requireNonNull(linkMapper, "linkMapper");
         this.serverTypeResolver = Objects.requireNonNull(serverTypeResolver, "serverTypeResolver");
-        this.envoyTypeResolver = Objects.requireNonNull(envoyTypeResolver, "envoyTypeResolver");
+        this.envoyRecorder = Objects.requireNonNull(envoyRecorder, "envoyRecorder");
         this.exceptionInfoResolver = Objects.requireNonNull(exceptionInfoResolver, "exceptionInfoResolver");
         this.messagingConsumerResolver = Objects.requireNonNull(messagingConsumerResolver, "messagingConsumerResolver");
         this.attributeBoMapper = Objects.requireNonNull(attributeBoMapper, "attributeBoMapper");
@@ -267,24 +267,23 @@ public class OtlpTraceSpanMapper {
             spanBo.setAcceptorHost(spanBo.getEndPoint());
         }
 
-        // SERVER kind only: an Envoy ingress span (detected via Envoy-specific tags) becomes a
-        // ServerMap node, so it maps to the SERVER-category ENVOY (1550) node type — NOT the
-        // RPC-category ENVOY_INGRESS (9301), which the native tracer uses on a child SpanEvent.
-        // Otherwise dispatch ServiceType via rpc.system (grpc → GRPC_SERVER, apache_dubbo →
-        // APACHE_DUBBO_PROVIDER). INTERNAL and unsupported-messaging consumer fallthrough stay on
-        // OPENTELEMETRY_SERVER. HTTP server framework cannot be derived from OTel attributes.
+        // SERVER kind only: dispatch ServiceType via rpc.system (grpc → GRPC_SERVER,
+        // apache_dubbo → APACHE_DUBBO_PROVIDER). INTERNAL and unsupported-messaging consumer
+        // fallthrough stay on OPENTELEMETRY_SERVER. HTTP server framework cannot be derived
+        // from OTel attributes.
         final boolean isServerKind = span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE;
-        if (isServerKind && envoyTypeResolver.isEnvoy(attributes)) {
-            spanBo.setServiceType(envoyTypeResolver.resolveNodeServiceType());
-            envoyTypeResolver.recordAnnotations(spanBo::addAnnotation, attributes, true, consumedKeys);
-        } else {
-            final String rpcSystem = isServerKind
-                    ? AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null)
-                    : null;
-            if (rpcSystem != null) {
-                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM);
-            }
-            spanBo.setServiceType(serverTypeResolver.resolveServerServiceType(rpcSystem));
+        final String rpcSystem = isServerKind
+                ? AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null)
+                : null;
+        if (rpcSystem != null) {
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM);
+        }
+        spanBo.setServiceType(serverTypeResolver.resolveServerServiceType(rpcSystem));
+        // Envoy ingress detection → identification annotations only. The ServiceType is NOT
+        // overridden (see OtlpEnvoyRecorder Javadoc: mixing ENVOY(1550) with
+        // OPENTELEMETRY_SERVER under one applicationName caused node-type conflicts).
+        if (isServerKind && envoyRecorder.isEnvoy(attributes)) {
+            envoyRecorder.recordAnnotations(spanBo::addAnnotation, attributes, true, consumedKeys);
         }
 
         final String apiName = isConsumer(span) ? OtlpTraceMapper.CONSUMER_METHOD_NAME : OtlpTraceMapper.SERVER_METHOD_NAME;

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyRecorderTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpEnvoyRecorderTest.java
@@ -17,29 +17,21 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
-import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
-import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class OtlpEnvoyTypeResolverTest {
+class OtlpEnvoyRecorderTest {
 
-    private static final short ENVOY_NODE_CODE = 1550;
-    private static final short ENVOY_EGRESS_CODE = 9302;
-
-    private static final ServiceTypeRegistryService FULL_REGISTRY = buildRegistry(Map.of(
-            "ENVOY", ENVOY_NODE_CODE,
-            "ENVOY_EGRESS", ENVOY_EGRESS_CODE));
-
-    private final OtlpEnvoyTypeResolver resolver = new OtlpEnvoyTypeResolver(FULL_REGISTRY);
+    private final OtlpEnvoyRecorder recorder = new OtlpEnvoyRecorder();
 
     // =======================================================================
     // isEnvoy — detection gate
@@ -47,19 +39,19 @@ class OtlpEnvoyTypeResolverTest {
 
     @Test
     void isEnvoy_true_whenUpstreamCluster() {
-        assertThat(resolver.isEnvoy(Map.of(
+        assertThat(recorder.isEnvoy(Map.of(
                 OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER, AttributeValue.of("frontend")))).isTrue();
     }
 
     @Test
     void isEnvoy_true_whenUpstreamClusterName() {
-        assertThat(resolver.isEnvoy(Map.of(
+        assertThat(recorder.isEnvoy(Map.of(
                 OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME, AttributeValue.of("frontend")))).isTrue();
     }
 
     @Test
     void isEnvoy_true_whenResponseFlags() {
-        assertThat(resolver.isEnvoy(Map.of(
+        assertThat(recorder.isEnvoy(Map.of(
                 OtlpTraceConstants.ATTRIBUTE_KEY_RESPONSE_FLAGS, AttributeValue.of("-")))).isTrue();
     }
 
@@ -69,36 +61,12 @@ class OtlpEnvoyTypeResolverTest {
         Map<String, AttributeValue> attrs = new HashMap<>();
         attrs.put("component", AttributeValue.of("proxy"));
         attrs.put(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_URL, AttributeValue.of("http://x/y"));
-        assertThat(resolver.isEnvoy(attrs)).isFalse();
+        assertThat(recorder.isEnvoy(attrs)).isFalse();
     }
 
     @Test
     void isEnvoy_false_whenEmpty() {
-        assertThat(resolver.isEnvoy(Map.of())).isFalse();
-    }
-
-    // =======================================================================
-    // resolve — ServiceType codes
-    // =======================================================================
-
-    @Test
-    void resolveNode_returnsEnvoy() {
-        // SERVER-kind ingress span → SERVER-category ENVOY (1550) node type, not ENVOY_INGRESS.
-        assertThat(resolver.resolveNodeServiceType()).isEqualTo(ENVOY_NODE_CODE);
-    }
-
-    @Test
-    void resolveEgress_returnsEnvoyEgress() {
-        assertThat(resolver.resolveEgressServiceType()).isEqualTo(ENVOY_EGRESS_CODE);
-    }
-
-    @Test
-    void resolve_pluginMissingFromRegistry_fallsBackToOtel() {
-        // Collector without the envoy-type-provider on its classpath: degrade to the generic
-        // OpenTelemetry server/client types instead of failing.
-        OtlpEnvoyTypeResolver r = new OtlpEnvoyTypeResolver(buildRegistry(Map.of()));
-        assertThat(r.resolveNodeServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getCode());
-        assertThat(r.resolveEgressServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_CLIENT.getCode());
+        assertThat(recorder.isEnvoy(Map.of())).isFalse();
     }
 
     // =======================================================================
@@ -112,10 +80,13 @@ class OtlpEnvoyTypeResolverTest {
         attrs.put(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER, AttributeValue.of("legacy"));
 
         List<AnnotationBo> out = new ArrayList<>();
-        resolver.recordAnnotations(out::add, attrs, false, new java.util.HashSet<>());
+        Set<String> consumedKeys = new HashSet<>();
+        recorder.recordAnnotations(out::add, attrs, false, consumedKeys);
 
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isEqualTo("frontend");
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Egress");
+        // only the consumed cluster key is collected
+        assertThat(consumedKeys).containsExactly(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER_NAME);
     }
 
     @Test
@@ -124,17 +95,19 @@ class OtlpEnvoyTypeResolverTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER, AttributeValue.of("frontend"));
 
         List<AnnotationBo> out = new ArrayList<>();
-        resolver.recordAnnotations(out::add, attrs, true, new java.util.HashSet<>());
+        Set<String> consumedKeys = new HashSet<>();
+        recorder.recordAnnotations(out::add, attrs, true, consumedKeys);
 
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isEqualTo("frontend");
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Ingress");
+        assertThat(consumedKeys).containsExactly(OtlpTraceConstants.ATTRIBUTE_KEY_UPSTREAM_CLUSTER);
     }
 
     @Test
     void recordAnnotations_noCluster_onlyOperationRecorded() {
         // response_flags-only Envoy span: no cluster annotation, but operation is still tagged.
         List<AnnotationBo> out = new ArrayList<>();
-        resolver.recordAnnotations(out::add, Map.of(), false, new java.util.HashSet<>());
+        recorder.recordAnnotations(out::add, Map.of(), false, new HashSet<>());
 
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isNull();
         assertThat(annotationValue(out, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Egress");
@@ -146,29 +119,5 @@ class OtlpEnvoyTypeResolverTest {
                 .map(AnnotationBo::getValue)
                 .findFirst()
                 .orElse(null);
-    }
-
-    private static ServiceTypeRegistryService buildRegistry(Map<String, Short> entries) {
-        Map<String, ServiceType> byName = new HashMap<>();
-        entries.forEach((name, code) -> byName.put(name, ServiceTypeFactory.of(code, name, name)));
-        return new ServiceTypeRegistryService() {
-            @Override
-            public ServiceType findServiceType(int code) {
-                return byName.values().stream()
-                        .filter(t -> t.getCode() == code)
-                        .findFirst()
-                        .orElse(ServiceType.UNDEFINED);
-            }
-
-            @Override
-            public ServiceType findServiceTypeByName(String typeName) {
-                return byName.getOrDefault(typeName, ServiceType.UNDEFINED);
-            }
-
-            @Override
-            public List<ServiceType> findDesc(String desc) {
-                return List.of();
-            }
-        };
     }
 }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -87,7 +87,7 @@ class OtlpTraceMapperTest {
                 eventMapper,
                 new OtlpTraceLinkMapper(json, 8192),
                 new OtlpServerTypeResolver(REGISTRY),
-                new OtlpEnvoyTypeResolver(REGISTRY),
+                new OtlpEnvoyRecorder(),
                 exceptionInfoResolver,
                 new OtlpMessagingConsumerResolver(List.of(
                         new KafkaMessagingConsumerHandler(),
@@ -101,7 +101,7 @@ class OtlpTraceMapperTest {
                 REGISTRY,
                 new OtlpMessagingTypeResolver(REGISTRY),
                 new OtlpClientTypeResolver(REGISTRY),
-                new OtlpEnvoyTypeResolver(REGISTRY),
+                new OtlpEnvoyRecorder(),
                 exceptionInfoResolver,
                 new OtlpAttributeBoMapper(8192),
                 8192);

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -37,7 +37,6 @@ class OtlpTraceSpanEventMapperTest {
         Map<String, ServiceType> byName = new HashMap<>();
         byName.put("GRPC",                   ServiceTypeFactory.of(9160, "GRPC",                   "GRPC"));
         byName.put("APACHE_DUBBO_CONSUMER",  ServiceTypeFactory.of(9997, "APACHE_DUBBO_CONSUMER",  "APACHE_DUBBO_CONSUMER"));
-        byName.put("ENVOY_EGRESS",           ServiceTypeFactory.of(9302, "ENVOY_EGRESS",           "ENVOY_EGRESS"));
         return new ServiceTypeRegistryService() {
             @Override
             public ServiceType findServiceType(int serviceType) {
@@ -68,7 +67,7 @@ class OtlpTraceSpanEventMapperTest {
                 TEST_REGISTRY,
                 new OtlpMessagingTypeResolver(TEST_REGISTRY),
                 new OtlpClientTypeResolver(TEST_REGISTRY),
-                new OtlpEnvoyTypeResolver(TEST_REGISTRY),
+                new OtlpEnvoyRecorder(),
                 new OtlpExceptionInfoResolver(),
                 new OtlpAttributeBoMapper(8192),
                 8192);
@@ -708,10 +707,10 @@ class OtlpTraceSpanEventMapperTest {
     }
 
     @Test
-    void map_client_envoy_setsEnvoyEgressAndUpstreamClusterAnnotation() {
-        // Envoy egress leg over OTLP: upstream_cluster tags trigger the Envoy branch, which
-        // overrides the generic OPENTELEMETRY_CLIENT with ENVOY_EGRESS and records the
-        // upstream.cluster / envoy.operation annotations.
+    void map_client_envoy_keepsOpenTelemetryClient_andRecordsAnnotations() {
+        // Envoy egress leg keeps the regular OPENTELEMETRY_CLIENT type — no ServiceType
+        // override (see OtlpEnvoyRecorder Javadoc). Envoy identification is carried by the
+        // upstream.cluster / envoy.operation annotations only.
         Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
                 kv("response_flags", strVal("-")),
                 kv("http.status_code", strVal("200")),
@@ -720,7 +719,7 @@ class OtlpTraceSpanEventMapperTest {
                 kv("upstream_address", strVal("172.18.0.27:8080")));
 
         SpanEventBo event = mapSingle(span);
-        assertThat(event.getServiceType()).isEqualTo((short) 9302); // ENVOY_EGRESS
+        assertThat(event.getServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_CLIENT.getCode());
         assertThat(event.getEndPoint()).isEqualTo("172.18.0.27:8080");
         assertThat(event.getDestinationId()).isEqualTo("frontend");
         assertThat(annotationValue(event.getAnnotationBoList(), OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER))
@@ -729,57 +728,12 @@ class OtlpTraceSpanEventMapperTest {
                 .isEqualTo("Egress");
     }
 
-    @Test
-    void map_client_envoy_absentEnvoyType_fallsBackToOpenTelemetryClient() {
-        // A collector without the envoy-type-provider still ingests the span; it just keeps the
-        // generic OPENTELEMETRY_CLIENT type (resolver fallback), never failing.
-        OtlpTraceSpanEventMapper noEnvoy = new OtlpTraceSpanEventMapper(
-                new OtlpTraceEventMapper(new ObjectMapper(), 8192),
-                TEST_REGISTRY,
-                new OtlpMessagingTypeResolver(TEST_REGISTRY),
-                new OtlpClientTypeResolver(TEST_REGISTRY),
-                new OtlpEnvoyTypeResolver(buildRegistryWithout("ENVOY_EGRESS")),
-                new OtlpExceptionInfoResolver(),
-                new OtlpAttributeBoMapper(8192),
-                8192);
-        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
-                kv("upstream_cluster.name", strVal("frontend")));
-
-        SpanEventBo event = noEnvoy.map(0L, span).get(0);
-        assertThat(event.getServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_CLIENT.getCode());
-    }
-
     private static Object annotationValue(List<com.navercorp.pinpoint.common.server.bo.AnnotationBo> annotations, int key) {
         return annotations.stream()
                 .filter(a -> a.getKey() == key)
                 .map(com.navercorp.pinpoint.common.server.bo.AnnotationBo::getValue)
                 .findFirst()
                 .orElse(null);
-    }
-
-    private static ServiceTypeRegistryService buildRegistryWithout(String excludedName) {
-        Map<String, ServiceType> byName = new HashMap<>();
-        byName.put("GRPC", ServiceTypeFactory.of(9160, "GRPC", "GRPC"));
-        byName.remove(excludedName);
-        return new ServiceTypeRegistryService() {
-            @Override
-            public ServiceType findServiceType(int serviceType) {
-                return byName.values().stream()
-                        .filter(t -> t.getCode() == serviceType)
-                        .findFirst()
-                        .orElse(ServiceType.UNDEFINED);
-            }
-
-            @Override
-            public ServiceType findServiceTypeByName(String typeName) {
-                return byName.getOrDefault(typeName, ServiceType.UNDEFINED);
-            }
-
-            @Override
-            public List<ServiceType> findDesc(String desc) {
-                return List.of();
-            }
-        };
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -164,7 +164,6 @@ class OtlpTraceSpanMapperTest {
         byName.put("ACTIVEMQ_CLIENT",       ServiceTypeFactory.of(8310, "ACTIVEMQ_CLIENT",       "ACTIVEMQ_CLIENT"));
         byName.put("GRPC_SERVER",           ServiceTypeFactory.of(1130, "GRPC_SERVER",           "GRPC_SERVER"));
         byName.put("APACHE_DUBBO_PROVIDER", ServiceTypeFactory.of(1999, "APACHE_DUBBO_PROVIDER", "APACHE_DUBBO_PROVIDER"));
-        byName.put("ENVOY",                 ServiceTypeFactory.of(1550, "ENVOY",                 "ENVOY"));
         return new ServiceTypeRegistryService() {
             @Override
             public ServiceType findServiceType(int code) {
@@ -192,7 +191,7 @@ class OtlpTraceSpanMapperTest {
                 new OtlpTraceEventMapper(json, 8192),
                 new OtlpTraceLinkMapper(json, 8192),
                 new OtlpServerTypeResolver(MESSAGING_REGISTRY),
-                new OtlpEnvoyTypeResolver(MESSAGING_REGISTRY),
+                new OtlpEnvoyRecorder(),
                 new OtlpExceptionInfoResolver(),
                 new OtlpMessagingConsumerResolver(List.of(
                         new KafkaMessagingConsumerHandler(),
@@ -547,16 +546,17 @@ class OtlpTraceSpanMapperTest {
     }
 
     @Test
-    void map_server_envoy_setsEnvoyNodeAndUpstreamClusterAnnotation() {
-        // Envoy ingress span over OTLP becomes a ServerMap node, so it maps to the SERVER-category
-        // ENVOY (1550) node type — not the RPC-category ENVOY_INGRESS (9301) — overriding the
-        // generic OPENTELEMETRY_SERVER and recording the upstream.cluster / envoy.operation annotations.
+    void map_server_envoy_keepsOpenTelemetryServer_andRecordsAnnotations() {
+        // Envoy ingress span keeps the regular OPENTELEMETRY_SERVER type — no ServiceType
+        // override (mixing ENVOY(1550) with OPENTELEMETRY_SERVER under one applicationName
+        // caused node-type conflicts). Envoy identification is carried by the
+        // upstream.cluster / envoy.operation annotations only.
         Span span = serverSpan(
                 kv("response_flags", strVal("-")),
                 kv("upstream_cluster", strVal("frontend")),
                 kv("upstream_cluster.name", strVal("frontend")));
         SpanBo bo = newMapper().map(id(), span);
-        assertThat(bo.getServiceType()).isEqualTo((short) 1550); // ENVOY (SERVER-category node)
+        assertThat(bo.getServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getCode());
         assertThat(annotationValue(bo, OtlpTraceConstants.ANNOTATION_KEY_UPSTREAM_CLUSTER)).isEqualTo("frontend");
         assertThat(annotationValue(bo, OtlpTraceConstants.ANNOTATION_KEY_ENVOY_OPERATION)).isEqualTo("Ingress");
     }


### PR DESCRIPTION
…Types

Stop re-typing detected Envoy spans to ENVOY (1550) / ENVOY_EGRESS (9302): whenever the tag-based detection missed a span (the gate depends on Envoy's deployment-specific tag configuration), the same applicationName ended up with two node types (ENVOY and OPENTELEMETRY_SERVER), causing ApplicationIndex/ServerMap type conflicts. Envoy spans now keep OPENTELEMETRY_SERVER / OPENTELEMETRY_CLIENT and are identified by the envoy.operation / upstream.cluster annotations only.

OtlpEnvoyTypeResolver is renamed to OtlpEnvoyRecorder and slimmed to the detection gate plus annotation recording (the ServiceTypeRegistryService dependency is gone). The Envoy ServiceType codes stay registered in envoy-type-provider.yml for the native pinpoint-cpp Envoy tracer, which emits them directly.