### PR TITLE
[#noissue] Promote the gRPC status code to the grpc.status annotation

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGrpcStatusResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGrpcStatusResolver.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * Resolves the gRPC result status to promote to the {@code grpc.status} (160) annotation,
+ * shared by the root-span ({@link OtlpTraceSpanMapper}) and SpanEvent
+ * ({@link OtlpTraceSpanEventMapper}) paths. The native gRPC client plugin records the status
+ * <em>name</em> ({@code io.grpc Status.getCode().name()}, e.g. "OK" / "UNAVAILABLE") on the
+ * client SpanEvent, so the OTel numeric code is translated to the same representation.
+ * The native agent has no gRPC <em>server</em> plugin — the root-span promotion is
+ * OTel-only added value.
+ *
+ * <p>Key precedence: standard RPC semconv {@code rpc.grpc.status_code} (int 0-16) before the
+ * nonstandard {@code grpc.status_code} (numeric string, emitted by e.g. the ASP.NET Core gRPC
+ * instrumentation). Exposing the source key lets the caller exclude only the consumed key from
+ * the raw attributes via the consumedKeys mechanism.</p>
+ */
+public final class OtlpGrpcStatusResolver {
+
+    // gRPC status code → canonical name, fixed by the gRPC spec (code 0-16). Hardcoded to
+    // avoid an io.grpc dependency; values match io.grpc Status.Code.name(), which is what the
+    // native gRPC client plugin records into the grpc.status annotation.
+    private static final String[] STATUS_NAMES = {
+            "OK",                   // 0
+            "CANCELLED",            // 1
+            "UNKNOWN",              // 2
+            "INVALID_ARGUMENT",     // 3
+            "DEADLINE_EXCEEDED",    // 4
+            "NOT_FOUND",            // 5
+            "ALREADY_EXISTS",       // 6
+            "PERMISSION_DENIED",    // 7
+            "RESOURCE_EXHAUSTED",   // 8
+            "FAILED_PRECONDITION",  // 9
+            "ABORTED",              // 10
+            "OUT_OF_RANGE",         // 11
+            "UNIMPLEMENTED",        // 12
+            "INTERNAL",             // 13
+            "UNAVAILABLE",          // 14
+            "DATA_LOSS",            // 15
+            "UNAUTHENTICATED",      // 16
+    };
+
+    private OtlpGrpcStatusResolver() {
+    }
+
+    /** Promoted gRPC status name together with the source attribute key it was read from. */
+    public record GrpcStatus(String name, String sourceKey) {
+    }
+
+    /**
+     * Returns the promoted gRPC status or {@code null} when no numeric status is present.
+     * The numeric value may arrive typed as int (standard semconv) or as a numeric string
+     * (nonstandard variant) — both forms are accepted per key.
+     */
+    @Nullable
+    public static GrpcStatus resolve(Map<String, AttributeValue> attributes) {
+        for (String key : OtlpTraceConstants.GRPC_STATUS_CODE_KEYS) {
+            final long code = OtlpHttpStatusResolver.resolveStatusCode(attributes, key);
+            if (code != -1) {
+                return new GrpcStatus(toStatusName(code), key);
+            }
+        }
+        return null;
+    }
+
+    /** Canonical gRPC status name for the code, or the raw number for out-of-range codes. */
+    static String toStatusName(long code) {
+        if (code >= 0 && code < STATUS_NAMES.length) {
+            return STATUS_NAMES[(int) code];
+        }
+        return String.valueOf(code);
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -116,6 +116,12 @@ public class OtlpTraceConstants {
     // resolves them. Attached by OtlpEnvoyTypeResolver when an Envoy span is detected.
     public static final int ANNOTATION_KEY_ENVOY_OPERATION = 9441;
     public static final int ANNOTATION_KEY_UPSTREAM_CLUSTER = 9442;
+
+    // AnnotationKey mirrored from agent-module/plugins/grpc type-provider.yml (code 160,
+    // name 'grpc.status', viewInRecordSet). The native gRPC client plugin records the status
+    // NAME (io.grpc Status.getCode().name()); the OTel numeric code is translated accordingly
+    // by OtlpGrpcStatusResolver.
+    public static final int ANNOTATION_KEY_GRPC_STATUS = 160;
     // OTel HTTP server semconv: the matched route template (low-cardinality, e.g. "/users/{id}").
     // Takes precedence over url.path/http.url/http.target so the rpc field groups by endpoint
     // pattern instead of the raw, high-cardinality request path. This is the OTel equivalent of
@@ -138,6 +144,11 @@ public class OtlpTraceConstants {
     // grpc-1.6 GrpcRpcAttributesGetter / apache-dubbo-2.7 DubboRpcAttributesGetter).
     public static final String RPC_SYSTEM_GRPC = "grpc";
     public static final String RPC_SYSTEM_APACHE_DUBBO = "apache_dubbo";
+    // gRPC result status code (0-16). Standard OTel RPC semconv: rpc.grpc.status_code (int);
+    // nonstandard variant grpc.status_code (numeric string) emitted by e.g. the ASP.NET Core
+    // gRPC instrumentation. Promoted to the grpc.status annotation via OtlpGrpcStatusResolver.
+    public static final String ATTRIBUTE_KEY_RPC_GRPC_STATUS_CODE = "rpc.grpc.status_code";
+    public static final String ATTRIBUTE_KEY_GRPC_STATUS_CODE = "grpc.status_code";
     public static final String ATTRIBUTE_KEY_MESSAGING_CLIENT_ID = "messaging.client_id";
     public static final String ATTRIBUTE_KEY_SERVER_PORT = "server.port";
     public static final String ATTRIBUTE_KEY_SERVER_ADDRESS = "server.address";
@@ -255,4 +266,9 @@ public class OtlpTraceConstants {
     // Same consumedKeys handling as the status keys: only the consumed variant is filtered.
     public static final List<String> HTTP_METHOD_KEYS =
             List.of(ATTRIBUTE_KEY_HTTP_REQUEST_METHOD, ATTRIBUTE_KEY_HTTP_METHOD);
+
+    // gRPC status resolution order: standard RPC semconv before the nonstandard variant.
+    // Same consumedKeys handling: only the consumed variant is filtered.
+    public static final List<String> GRPC_STATUS_CODE_KEYS =
+            List.of(ATTRIBUTE_KEY_RPC_GRPC_STATUS_CODE, ATTRIBUTE_KEY_GRPC_STATUS_CODE);
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -188,6 +188,13 @@ public class OtlpTraceSpanEventMapper {
         if (httpMethod != null) {
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_METHOD.getCode(), httpMethod));
         }
+        // gRPC status → grpc.status (160) annotation, mirroring the native gRPC client plugin
+        // (ListenerClosedInterceptor records Status.getCode().name() on the client SpanEvent).
+        final OtlpGrpcStatusResolver.GrpcStatus grpcStatus = OtlpGrpcStatusResolver.resolve(attributes);
+        if (grpcStatus != null) {
+            spanEventBo.addAnnotation(AnnotationBo.of(OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS, grpcStatus.name()));
+            consumedKeys.add(grpcStatus.sourceKey());
+        }
         // attributes
         if (!attributes.isEmpty()) {
             final Predicate<String> attributeFilter = OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY.or(consumedKeys::contains);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -144,6 +144,14 @@ public class OtlpTraceSpanMapper {
         if (httpMethod != null) {
             spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_METHOD.getCode(), httpMethod));
         }
+        // gRPC status → grpc.status (160) annotation. The native agent has no gRPC server
+        // plugin, so this root-span promotion is OTel-only added value (the value form mirrors
+        // the native client plugin's status-name representation).
+        final OtlpGrpcStatusResolver.GrpcStatus grpcStatus = OtlpGrpcStatusResolver.resolve(attributes);
+        if (grpcStatus != null) {
+            spanBo.addAnnotation(AnnotationBo.of(OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS, grpcStatus.name()));
+            consumedKeys.add(grpcStatus.sourceKey());
+        }
         final Predicate<String> attributeFilter = OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY.or(consumedKeys::contains);
         final TruncatedCounts truncatedCounts = new TruncatedCounts();
         // attributes

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -551,6 +551,43 @@ class OtlpTraceSpanEventMapperTest {
     }
 
     @Test
+    void map_client_grpcStatus_promotedToAnnotation_andConsumedKeyFiltered() {
+        // Mirrors the native gRPC client plugin: the numeric OTel code is translated to the
+        // status NAME (Status.getCode().name()) and recorded as the grpc.status (160) annotation;
+        // the consumed raw key is filtered.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.grpc.status_code", intVal(0)));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("OK");
+        assertThat(attributeKeys(event)).doesNotContain("rpc.grpc.status_code");
+    }
+
+    @Test
+    void map_client_grpcStatus_failureCode_translated() {
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.grpc.status_code", intVal(14)));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("UNAVAILABLE");
+    }
+
+    @Test
+    void map_client_grpcStatus_bothKeys_onlyConsumedKeyRemoved() {
+        // Standard rpc.grpc.status_code wins; the non-consumed nonstandard variant stays raw.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.grpc.status_code", intVal(0)),
+                kv("grpc.status_code", strVal("0")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("OK");
+        assertThat(attributeKeys(event)).doesNotContain("rpc.grpc.status_code");
+        assertThat(attributeKeys(event)).contains("grpc.status_code");
+    }
+
+    @Test
     void map_internal_httpStatusCode_promotedToAnnotation() {
         // A Next.js INTERNAL span (Node.runHandler) carries http.status_code; it is promoted to the
         // HTTP_STATUS_CODE annotation just like the client path (uniform: status present → surfaced).

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -686,6 +686,40 @@ class OtlpTraceSpanMapperTest {
         assertThat(attributeKeys(bo)).contains("rpc.system");
     }
 
+    // =======================================================================
+    // map() — gRPC status promotion (grpc.status, 160)
+    // =======================================================================
+
+    @Test
+    void map_server_grpcStatus_nonstandardStringVariant_promoted() {
+        // ASP.NET Core gRPC server emits the nonstandard grpc.status_code as a numeric string
+        // ("0"). The native agent has no gRPC server plugin, so this root-span promotion is
+        // OTel-only added value; the value mirrors the native name representation.
+        Span span = serverSpan(
+                kv("rpc.system", strVal("grpc")),
+                kv("grpc.status_code", strVal("0")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("OK");
+        assertThat(attributeKeys(bo)).doesNotContain("grpc.status_code");
+    }
+
+    @Test
+    void map_server_grpcStatus_outOfRangeCode_recordedAsNumber() {
+        // Codes outside the spec range (0-16) have no canonical name — record the raw number.
+        Span span = serverSpan(kv("rpc.grpc.status_code", intVal(99)));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("99");
+    }
+
+    @Test
+    void map_server_grpcStatus_nonNumeric_noAnnotationAndKeptRaw() {
+        // A non-numeric status is not promoted; the raw attribute survives (consumedKeys rule).
+        Span span = serverSpan(kv("grpc.status_code", strVal("OK")));
+        SpanBo bo = newMapper().map(id(), span);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isNull();
+        assertThat(attributeKeys(bo)).contains("grpc.status_code");
+    }
+
     @Test
     void map_server_envoy_upstreamClusterName_consumed_filtered() {
         // The Envoy ingress branch promotes upstream_cluster.name to the upstream.cluster


### PR DESCRIPTION
Record the gRPC result status as the grpc.status (160) annotation, mirroring the native gRPC client plugin which records Status.getCode().name() on the client SpanEvent. The OTel numeric code (standard rpc.grpc.status_code int, or the nonstandard grpc.status_code numeric string emitted by e.g. ASP.NET Core gRPC) is translated to the same canonical name (0 -> OK, 14 -> UNAVAILABLE, ...); out-of-range codes keep the raw number.

The native agent has no gRPC server plugin, so the root-span promotion is OTel-only added value. Only the consumed key is filtered from the raw attributes (consumedKeys mechanism); a non-numeric value is not promoted and stays raw.