### PR TITLE
[#13995] Bump jakarta.validation-api from 3.0.2 to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <jakarta.servlet5.version>5.0.0</jakarta.servlet5.version>
         <jakarta.servlet6.version>6.0.0</jakarta.servlet6.version>
         <jaxb4.version>4.0.0</jaxb4.version>
-        <jakarta.validation-api3.version>3.0.2</jakarta.validation-api3.version>
+        <jakarta.validation-api3.version>3.1.1</jakarta.validation-api3.version>
 
 <!--        <slf4j.version>1.7.30</slf4j.version>-->
         <slf4j.version>2.0.16</slf4j.version>


### PR DESCRIPTION
Bump the managed `jakarta.validation-api3.version` in the root pom from 3.0.2 to 3.1.1.

resolve #13995