### PR TITLE
[#13997] Bump reactor-bom from 2023.0.9 to 2024.0.18

### DIFF
--- a/agent-module/agent-testweb/spring-restclient-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-restclient-plugin-testweb/pom.xml
@@ -84,8 +84,11 @@
 
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
-            <artifactId>reactor-netty-http-brave</artifactId>
-            <version>1.1.23</version>
+            <artifactId>reactor-netty-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-core</artifactId>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <httpcomponents5.version>5.4.4</httpcomponents5.version>
         <httpcomponents5.core.version>5.3.4</httpcomponents5.core.version>
 
-        <reactor-core.version>3.6.9</reactor-core.version>
+        <reactor-core.version>3.7.19</reactor-core.version>
 
         <spring5.version>5.3.39</spring5.version>
         <spring-batch.version>5.2.5</spring-batch.version>
@@ -978,7 +978,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2023.0.9</version>
+                <version>2024.0.18</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Bump the managed `reactor-bom` in the root pom from 2023.0.9 to 2024.0.18.

- Managed reactor versions move to reactor-core 3.7.19 and reactor-netty 1.2.17 project-wide
- Add bom-managed reactor-netty-http/core dependencies to spring-restclient-plugin-testweb

resolve #13997