### PR TITLE
[#noissue] Render MiniChart with ECharts and skip redundant resize re-render

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/OpenTelemetry/charts/constant.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/OpenTelemetry/charts/constant.ts
@@ -1,24 +1,3 @@
-import { colors } from '@pinpoint-fe/ui/src/constants';
+import { CHART_SERIES_COLORS } from '@pinpoint-fe/ui/src/lib/colors';
 
-export const COLORS = [
-  colors.blue[600],
-  colors.blue[200],
-  colors.orange[500],
-  colors.orange[200],
-  colors.green[600],
-  colors.green[300],
-  colors.red[600],
-  colors.red[300],
-  colors.purple[500],
-  colors.purple[300],
-  colors.stone[700],
-  colors.stone[400],
-  colors.pink[400],
-  colors.pink[200],
-  colors.gray[500],
-  colors.gray[300],
-  colors.lime[500],
-  colors.yellow[200],
-  colors.cyan[500],
-  colors.cyan[200],
-];
+export const COLORS = CHART_SERIES_COLORS;

--- a/web-frontend/src/main/v3/packages/ui/src/components/ReChart/useRechart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ReChart/useRechart.tsx
@@ -9,34 +9,13 @@ import {
   BarProps,
   AreaProps,
 } from 'recharts';
-import { Chart, colors } from '@pinpoint-fe/ui/src/constants';
+import { Chart } from '@pinpoint-fe/ui/src/constants';
 import { isNil } from 'lodash';
 import { useState, useEffect } from 'react';
 import { ChartConfig } from '../../components/ui';
-import { getRandomColorInHSL } from '../../lib/colors';
+import { CHART_SERIES_COLORS, getRandomColorInHSL } from '../../lib/colors';
 
-export const COLORS = [
-  colors.blue[600],
-  colors.blue[200],
-  colors.orange[500],
-  colors.orange[200],
-  colors.green[600],
-  colors.green[300],
-  colors.red[600],
-  colors.red[300],
-  colors.purple[500],
-  colors.purple[300],
-  colors.stone[700],
-  colors.stone[400],
-  colors.pink[400],
-  colors.pink[200],
-  colors.gray[500],
-  colors.gray[300],
-  colors.lime[500],
-  colors.yellow[200],
-  colors.cyan[500],
-  colors.cyan[200],
-];
+export const COLORS = CHART_SERIES_COLORS;
 
 const CHART_DEFINITION = {
   line: {

--- a/web-frontend/src/main/v3/packages/ui/src/components/common/MiniChart.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/common/MiniChart.test.tsx
@@ -1,0 +1,137 @@
+import { render } from '@testing-library/react';
+import { Chart, MetricValue, MetricValueGroup } from '@pinpoint-fe/ui/src/constants';
+import { CHART_SERIES_COLORS } from '../../lib/colors';
+
+// echarts 자체와 인스턴스 라이프사이클 훅은 모킹해, MiniChart 가 chart.setOption 에 넘기는
+// 옵션(순수 변환 로직)만 검증한다. (실제 렌더/canvas 는 이 테스트의 관심사가 아니다)
+const mockSetOption = jest.fn();
+const mockChartRef = { current: null as HTMLDivElement | null };
+const mockChartInstanceRef = { current: { setOption: mockSetOption } };
+
+jest.mock('echarts/core', () => ({ use: jest.fn() }));
+jest.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {} }));
+jest.mock('echarts/components', () => ({ GridComponent: {}, MarkLineComponent: {} }));
+jest.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+jest.mock('../../lib/charts/useEChartsInstance', () => ({
+  useEChartsInstance: () => ({
+    chartRef: mockChartRef,
+    chartInstanceRef: mockChartInstanceRef,
+    renderRef: { current: null },
+  }),
+}));
+
+// eslint-disable-next-line import/first
+import { MiniChart } from './MiniChart';
+
+const makeMetricValue = (fieldName: string, values: number[]): MetricValue => ({
+  fieldName,
+  values,
+});
+
+const makeGroup = (chartType: string, metricValues: MetricValue[]): MetricValueGroup => ({
+  groupName: 'group',
+  chartType,
+  unit: '',
+  metricValues,
+});
+
+const makeChart = (
+  metricValueGroups: MetricValueGroup[],
+  timestamp: number[] = [1000, 2000, 3000],
+): Chart => ({ title: 'Test', timestamp, metricValueGroups });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const renderChart = (chart: Chart) => {
+  render(<MiniChart chart={chart} />);
+  const [option, mergeArg] = mockSetOption.mock.calls[0];
+  return { option, mergeArg };
+};
+
+describe('MiniChart', () => {
+  beforeEach(() => {
+    mockSetOption.mockClear();
+  });
+
+  it('calls setOption with notMerge so stale series do not linger', () => {
+    const { mergeArg } = renderChart(
+      makeChart([makeGroup('line', [makeMetricValue('cpu', [1, 2, 3])])]),
+    );
+    expect(mergeArg).toEqual({ notMerge: true });
+  });
+
+  it('disables animation to match the other echarts charts (per-row render cost)', () => {
+    const { option } = renderChart(
+      makeChart([makeGroup('line', [makeMetricValue('cpu', [1, 2, 3])])]),
+    );
+    expect(option.animation).toBe(false);
+  });
+
+  it('builds [timestamp, value] points and converts -1/null to null (keeping 0/positive)', () => {
+    const { option } = renderChart(
+      makeChart([makeGroup('line', [makeMetricValue('cpu', [-1, 0, 5])])]),
+    );
+    expect(option.series[0].data).toEqual([
+      [1000, null],
+      [2000, 0],
+      [3000, 5],
+    ]);
+  });
+
+  it('attaches the max-value markLine only to the first series', () => {
+    const { option } = renderChart(
+      makeChart([
+        makeGroup('line', [makeMetricValue('cpu', [1, 2, 3]), makeMetricValue('mem', [4, 5, 6])]),
+      ]),
+    );
+    expect(option.series[0].markLine).toBeDefined();
+    expect(option.series[1].markLine).toBeUndefined();
+  });
+
+  it('uses the overall max for the markLine and rounds its label to 2 decimals', () => {
+    const { option } = renderChart(
+      makeChart([makeGroup('line', [makeMetricValue('cpu', [0.1, 1.23456, 0.2])])]),
+    );
+    expect(option.series[0].markLine.data).toEqual([{ yAxis: 1.23456 }]);
+    expect(option.series[0].markLine.label.formatter()).toBe('1.23');
+  });
+
+  it('omits the markLine when every value is uncollected (-1)', () => {
+    const { option } = renderChart(
+      makeChart([makeGroup('line', [makeMetricValue('cpu', [-1, -1, -1])])]),
+    );
+    expect(option.series[0].markLine).toBeUndefined();
+  });
+
+  it('maps a bar chartType to a bar series without smoothing or area fill', () => {
+    const { option } = renderChart(
+      makeChart([makeGroup('bar', [makeMetricValue('cpu', [1, 2, 3])])]),
+    );
+    expect(option.series[0].type).toBe('bar');
+    expect(option.series[0].smooth).toBe(false);
+    expect(option.series[0].areaStyle).toBeUndefined();
+  });
+
+  it('maps an area chartType to a smoothed line series with an area fill', () => {
+    const { option } = renderChart(
+      makeChart([makeGroup('area', [makeMetricValue('cpu', [1, 2, 3])])]),
+    );
+    expect(option.series[0].type).toBe('line');
+    expect(option.series[0].smooth).toBe(true);
+    expect(option.series[0].areaStyle).toEqual({ opacity: 0.4 });
+  });
+
+  it('assigns palette colors by the metricValue index within its group', () => {
+    const { option } = renderChart(
+      makeChart([
+        makeGroup('line', [makeMetricValue('cpu', [1, 2, 3]), makeMetricValue('mem', [4, 5, 6])]),
+      ]),
+    );
+    expect(option.series[0].itemStyle.color).toBe(CHART_SERIES_COLORS[0]);
+    expect(option.series[1].itemStyle.color).toBe(CHART_SERIES_COLORS[1]);
+  });
+
+  it('renders an empty series list without crashing when there is no data', () => {
+    const { option } = renderChart(makeChart([], []));
+    expect(option.series).toEqual([]);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/components/common/MiniChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/common/MiniChart.tsx
@@ -80,6 +80,8 @@ export const MiniChart = ({ chart }: MiniChartProps) => {
 
       chartInstance.setOption(
         {
+          // 행마다 그려지는 미니 차트라 다른 echarts 차트들과 동일하게 애니메이션을 끈다.
+          animation: false,
           grid: { top: 6, right: 60, bottom: 6, left: 2 },
           xAxis: {
             type: 'time',

--- a/web-frontend/src/main/v3/packages/ui/src/components/common/MiniChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/common/MiniChart.tsx
@@ -1,38 +1,107 @@
+import React from 'react';
+import * as echarts from 'echarts/core';
+import { BarChart, LineChart } from 'echarts/charts';
+import { GridComponent, MarkLineComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
 import { Chart } from '@pinpoint-fe/ui/src/constants';
-import { ComposedChart, ReferenceLine } from 'recharts';
-import { useRechart } from '../ReChart/useRechart';
-import { ChartContainer } from '../ui';
+import { CHART_SERIES_COLORS, getRandomColorInHSL } from '../../lib/colors';
+import { useEChartsInstance } from '../../lib/charts/useEChartsInstance';
+
+echarts.use([BarChart, LineChart, GridComponent, MarkLineComponent, CanvasRenderer]);
 
 export interface MiniChartProps {
   chart: Chart;
 }
 
 export const MiniChart = ({ chart }: MiniChartProps) => {
-  const { data, chartConfig, maxValue, renderChartChildComponents } = useRechart(chart);
+  const { chartRef, chartInstanceRef } = useEChartsInstance();
 
-  return (
-    <ChartContainer config={chartConfig} className="w-full h-[40px]">
-      <ComposedChart
-        data={data}
-        margin={{
-          top: 6,
-          right: 60,
-          bottom: 6,
-          left: 2,
-        }}
-      >
-        {data?.length && maxValue > -1 && (
-          <ReferenceLine
-            y={maxValue}
-            stroke="black"
-            strokeDasharray="3 3"
-            position="middle"
-            label={{ position: 'right', value: Math.round(maxValue * 100) / 100 }}
-            ifOverflow="extendDomain"
-          />
-        )}
-        {renderChartChildComponents()}
-      </ComposedChart>
-    </ChartContainer>
-  );
+  React.useEffect(() => {
+    if (!chartInstanceRef.current) return;
+
+    const timestamps = chart?.timestamp ?? [];
+
+    // metricValueGroup 안의 metricValue 하나가 시리즈 하나가 된다. (색상은 그룹 내 index 기준)
+    const entries = (chart?.metricValueGroups ?? []).flatMap((mvg) =>
+      (mvg?.metricValues ?? []).map((mv, mvi) => ({ mv, mvi, chartType: mvg?.chartType })),
+    );
+
+    // -1 은 "값 없음"이므로 null 로 치환하고, 최대값은 기준선(markLine)에 쓴다.
+    let maxValue = -1;
+    entries.forEach(({ mv }) => {
+      mv?.values?.forEach((raw) => {
+        if (raw !== -1 && raw != null && raw > maxValue) {
+          maxValue = raw;
+        }
+      });
+    });
+
+    const hasData = timestamps.length > 0 && entries.length > 0;
+    const showMarkLine = hasData && maxValue > -1;
+
+    const series = entries.map(({ mv, mvi, chartType }, index) => {
+      const data = timestamps.map((t, i) => {
+        const raw = mv?.values?.[i];
+        return [t, raw === -1 || raw == null ? null : raw];
+      });
+      const color = CHART_SERIES_COLORS[mvi] ?? getRandomColorInHSL();
+
+      return {
+        name: mv?.fieldName || '',
+        type: chartType === 'bar' ? ('bar' as const) : ('line' as const),
+        data,
+        showSymbol: false,
+        smooth: chartType !== 'bar',
+        lineStyle: { width: 1 },
+        areaStyle: chartType === 'area' ? { opacity: 0.4 } : undefined,
+        itemStyle: { color },
+        // 기준선(최대값)은 첫 시리즈에만 붙여 라벨 중복을 막는다.
+        ...(index === 0 && showMarkLine
+          ? {
+              markLine: {
+                silent: true,
+                symbol: 'none',
+                lineStyle: { color: 'black', type: 'dashed' as const, width: 1 },
+                label: {
+                  position: 'end' as const,
+                  fontSize: 10,
+                  formatter: () => String(Math.round(maxValue * 100) / 100),
+                },
+                data: [{ yAxis: maxValue }],
+              },
+            }
+          : {}),
+      };
+    });
+
+    const render = () => {
+      const chartInstance = chartInstanceRef.current;
+      if (!chartInstance) return;
+
+      chartInstance.setOption(
+        {
+          grid: { top: 6, right: 60, bottom: 6, left: 2 },
+          xAxis: {
+            type: 'time',
+            show: false,
+            boundaryGap: false,
+          },
+          yAxis: {
+            type: 'value',
+            show: false,
+            scale: true,
+          },
+          series,
+        },
+        { notMerge: true },
+      );
+    };
+
+    // MiniChart는 legend가 없고 grid가 고정이라 폭 변화 시 재계산할 게 없다.
+    // 따라서 renderRef에 등록하지 않아 resize 때는 chart.resize()만 돌고,
+    // setOption 전체 재호출(불필요한 작업)은 건너뛴다.
+    render();
+  }, [chart, chartInstanceRef]);
+
+  return <div ref={chartRef} className="w-full h-[40px]" />;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/lib/colors.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/lib/colors.ts
@@ -1,5 +1,30 @@
 import { colors } from '@pinpoint-fe/ui/src/constants';
 
+// 다중 시리즈 차트에서 시리즈 색상을 순서대로 배정할 때 쓰는 공용 팔레트.
+// (recharts/echarts 등 렌더러와 무관하게 재사용하기 위해 여기에 둔다.)
+export const CHART_SERIES_COLORS = [
+  colors.blue[600],
+  colors.blue[200],
+  colors.orange[500],
+  colors.orange[200],
+  colors.green[600],
+  colors.green[300],
+  colors.red[600],
+  colors.red[300],
+  colors.purple[500],
+  colors.purple[300],
+  colors.stone[700],
+  colors.stone[400],
+  colors.pink[400],
+  colors.pink[200],
+  colors.gray[500],
+  colors.gray[300],
+  colors.lime[500],
+  colors.yellow[200],
+  colors.cyan[500],
+  colors.cyan[200],
+];
+
 export const getRandomColor = () => {
   const random = (Math.random() * 0xfffff * 1000000).toString(16);
   return `#${random.slice(0, 6)}`;


### PR DESCRIPTION
## Summary
- Render `MiniChart` with ECharts (BarChart/LineChart) instead of recharts, aligning it with the other ECharts-based charts in the app.
- Since `MiniChart` has no legend and uses a fixed-pixel grid, it no longer registers a render callback with the shared instance hook: on window resize only `chart.resize()` runs, skipping a redundant full `setOption` re-render (matters because `MiniChart` is rendered per table row).
- Extract the shared series color palette into `CHART_SERIES_COLORS` (`lib/colors.ts`) so both renderers can reuse the same order/values; `useRechart` now re-exports it as `COLORS`.

## Test plan
- [ ] `yarn build` passes
- [ ] `yarn test` passes (618 tests)
- [ ] Error Analysis grouped table (`/errorAnalysis`): mini charts render with correct series colors and the max-value markLine label is not clipped on the right.
- [ ] URL statistic summary (`/urlStatistic`): mini charts render correctly.
- [ ] Resize the window with many rows visible: mini charts still resize correctly and no longer trigger a full re-render.
