### PR TITLE
[#noissue] Migrate AgentStatisticChart from Recharts to ECharts

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/agentStatistic/AgentStatisticChart.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/agentStatistic/AgentStatisticChart.test.tsx
@@ -1,0 +1,101 @@
+import { render } from '@testing-library/react';
+import { colors } from '@pinpoint-fe/ui/src/constants';
+
+// echarts 자체와 인스턴스 라이프사이클 훅은 모킹해, AgentStatisticChart 가 chart.setOption 에
+// 넘기는 옵션(순수 변환 로직)만 검증한다. (실제 렌더/canvas 는 이 테스트의 관심사가 아니다)
+const mockSetOption = jest.fn();
+const mockChartRef = { current: null as HTMLDivElement | null };
+const mockChartInstanceRef = { current: { setOption: mockSetOption } };
+
+jest.mock('echarts/core', () => ({ use: jest.fn() }));
+jest.mock('echarts/charts', () => ({ BarChart: {} }));
+jest.mock('echarts/components', () => ({ GridComponent: {}, LegendComponent: {} }));
+jest.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+jest.mock('../../../lib/charts/useEChartsInstance', () => ({
+  useEChartsInstance: () => ({
+    chartRef: mockChartRef,
+    chartInstanceRef: mockChartInstanceRef,
+    renderRef: { current: null },
+  }),
+}));
+
+// eslint-disable-next-line import/first
+import { AgentStatisticChart, ChartData } from './AgentStatisticChart';
+
+const renderChart = (type: 'vmVersion' | 'agentVersion', chartData?: ChartData[]) => {
+  render(<AgentStatisticChart type={type} chartData={chartData} />);
+  const [option, mergeArg] = mockSetOption.mock.calls[0];
+  return { option, mergeArg };
+};
+
+describe('AgentStatisticChart', () => {
+  beforeEach(() => {
+    mockSetOption.mockClear();
+  });
+
+  it('calls setOption with replaceMerge so stale series/axes do not linger', () => {
+    const { mergeArg } = renderChart('vmVersion', [{ vmVersion: '1.8', value: 3 }]);
+    expect(mergeArg).toEqual({ replaceMerge: ['series', 'yAxis'] });
+  });
+
+  it('disables animation to match the other echarts charts', () => {
+    const { option } = renderChart('vmVersion', [{ vmVersion: '1.8', value: 3 }]);
+    expect(option.animation).toBe(false);
+  });
+
+  it('renders a horizontal bar: value on the x axis and version categories on the y axis', () => {
+    const { option } = renderChart('vmVersion', [
+      { vmVersion: '1.8', value: 3 },
+      { vmVersion: '11', value: 5 },
+    ]);
+    expect(option.xAxis.type).toBe('value');
+    expect(option.yAxis.type).toBe('category');
+    expect(option.yAxis.data).toEqual(['1.8', '11']);
+    expect(option.series[0].data).toEqual([3, 5]);
+    expect(option.series[0].type).toBe('bar');
+  });
+
+  it('inverts the y axis so the first category renders at the top (recharts parity)', () => {
+    const { option } = renderChart('vmVersion', [{ vmVersion: '1.8', value: 3 }]);
+    expect(option.yAxis.inverse).toBe(true);
+  });
+
+  it('reads the category from the field matching the chart type', () => {
+    const { option } = renderChart('agentVersion', [
+      { agentVersion: '2.5.0', value: 7 },
+      { agentVersion: '2.5.1', value: 2 },
+    ]);
+    expect(option.yAxis.data).toEqual(['2.5.0', '2.5.1']);
+  });
+
+  it('names the series JVM and colors it blue for vmVersion', () => {
+    const { option } = renderChart('vmVersion', [{ vmVersion: '1.8', value: 3 }]);
+    expect(option.series[0].name).toBe('JVM');
+    expect(option.series[0].itemStyle.color).toBe(colors.blue[600]);
+    expect(option.legend.data).toEqual(['JVM']);
+  });
+
+  it('names the series Agent and colors it orange for agentVersion', () => {
+    const { option } = renderChart('agentVersion', [{ agentVersion: '2.5.0', value: 7 }]);
+    expect(option.series[0].name).toBe('Agent');
+    expect(option.series[0].itemStyle.color).toBe(colors.orange[500]);
+    expect(option.legend.data).toEqual(['Agent']);
+  });
+
+  it('shows the value label at the right end of each bar', () => {
+    const { option } = renderChart('vmVersion', [{ vmVersion: '1.8', value: 3 }]);
+    expect(option.series[0].label).toEqual({ show: true, position: 'right', fontSize: 12 });
+  });
+
+  it('renders empty category/data lists without crashing when there is no data', () => {
+    const { option } = renderChart('vmVersion', []);
+    expect(option.yAxis.data).toEqual([]);
+    expect(option.series[0].data).toEqual([]);
+  });
+
+  it('renders without crashing when chartData is undefined', () => {
+    const { option } = renderChart('vmVersion', undefined);
+    expect(option.yAxis.data).toEqual([]);
+    expect(option.series[0].data).toEqual([]);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/agentStatistic/AgentStatisticChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/agentStatistic/AgentStatisticChart.tsx
@@ -1,11 +1,13 @@
+import React from 'react';
+import * as echarts from 'echarts/core';
+import { BarChart } from 'echarts/charts';
+import { GridComponent, LegendComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
 import { colors } from '@pinpoint-fe/ui/src/constants';
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-} from '../../../components/ui';
-import { XAxis, YAxis, LabelList, Bar, BarChart } from 'recharts';
+import { useEChartsInstance } from '../../../lib/charts/useEChartsInstance';
+import { buildBottomLegend } from '../../../lib/charts/echartsLegendLayout';
+
+echarts.use([BarChart, GridComponent, LegendComponent, CanvasRenderer]);
 
 export type ChartData = {
   vmVersion?: string;
@@ -20,42 +22,60 @@ export function AgentStatisticChart({
   type: 'vmVersion' | 'agentVersion';
   chartData?: ChartData[];
 }) {
-  const chartConfig = {
-    value: {
-      label: type === 'vmVersion' ? 'JVM' : 'Agent',
-      color: type === 'vmVersion' ? colors.blue[600] : colors.orange[500],
-    },
-  } satisfies ChartConfig;
+  const { chartRef, chartInstanceRef, renderRef } = useEChartsInstance();
+  const seriesName = type === 'vmVersion' ? 'JVM' : 'Agent';
+  const color = type === 'vmVersion' ? colors.blue[600] : colors.orange[500];
 
-  return (
-    <ChartContainer config={chartConfig} className="w-full h-full">
-      <BarChart
-        accessibilityLayer
-        data={chartData}
-        layout="vertical"
-        margin={{
-          right: 50,
-          left: 15,
-        }}
-      >
-        <XAxis type="number" dataKey={'value'} />
-        <YAxis
-          dataKey={type}
-          type="category"
-          width={type === 'vmVersion' ? 60 : 120}
-          tickLine={false}
-        />
-        <ChartLegend content={<ChartLegendContent />} />
-        <Bar dataKey="value" fill="var(--color-value)">
-          <LabelList
-            dataKey="value"
-            position="right"
-            offset={8}
-            className="fill-foreground"
-            fontSize={12}
-          />
-        </Bar>
-      </BarChart>
-    </ChartContainer>
-  );
+  React.useEffect(() => {
+    if (!chartInstanceRef.current) return;
+
+    // 카테고리(버전) 하나가 막대 하나. recharts YAxis(type=category) 렌더 순서와 맞추기 위해
+    // 첫 항목을 위에 두도록 yAxis.inverse 를 켠다.
+    const categories = (chartData ?? []).map((d) => d[type] ?? '');
+    const values = (chartData ?? []).map((d) => d.value);
+
+    const render = () => {
+      const chart = chartInstanceRef.current;
+      if (!chart) return;
+
+      chart.setOption(
+        {
+          animation: false,
+          legend: buildBottomLegend([seriesName]),
+          // 버전 문자열 길이가 type 별로 다르므로 containLabel 로 좌측 라벨 폭을 자동 확보한다.
+          // (recharts 의 YAxis width 60/120 를 대체)
+          grid: { top: 10, right: 50, bottom: 28, left: 5, containLabel: true },
+          xAxis: {
+            type: 'value',
+            minInterval: 1,
+          },
+          yAxis: {
+            type: 'category',
+            inverse: true,
+            data: categories,
+            axisTick: { show: false },
+          },
+          series: [
+            {
+              name: seriesName,
+              type: 'bar' as const,
+              data: values,
+              itemStyle: { color },
+              // 막대 끝에 값 라벨 표시 (recharts LabelList position="right" 대체)
+              label: { show: true, position: 'right' as const, fontSize: 12 },
+            },
+          ],
+        },
+        { replaceMerge: ['series', 'yAxis'] },
+      );
+    };
+
+    renderRef.current = render;
+    render();
+  }, [chartData, type, seriesName, color, chartInstanceRef, renderRef]);
+
+  // echarts 는 div 안에 고정 크기 canvas 를 그린다. flex 항목에서 canvas 가 min-content 로 작용해
+  // 컨테이너가 축소되지 못하는 것을 막기 위해 min-w-0/min-h-0 + overflow-hidden 을 준다.
+  // (ChartCore 와 동일한 처리) 이래야 축소 시 ResizeObserver 가 동작해 chart.resize 가 호출된다.
+  return <div ref={chartRef} className="w-full h-full min-w-0 min-h-0 overflow-hidden" />;
 }

--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/agentStatistic/AgentStatisticChartContainer.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/agentStatistic/AgentStatisticChartContainer.tsx
@@ -26,7 +26,7 @@ export function AgentStatisticContainer({ data }: { data?: AgentOverview.Respons
   const agentVersionChartData = useVersionChartData(data, 'agentVersion');
 
   return (
-    <div className="flex min-w-full gap-5 max-h-[40%]">
+    <div className="flex min-w-full gap-5 h-[40%] min-h-0">
       <AgentStatisticChart type="vmVersion" chartData={vmVersionChartData as ChartData[]} />
       <AgentStatisticChart type="agentVersion" chartData={agentVersionChartData as ChartData[]} />
     </div>


### PR DESCRIPTION
## Summary
- Migrate `AgentStatisticChart` (Config → Agent statistic) from Recharts to ECharts, continuing the effort to unify the chart library on ECharts.
- Reuse the shared `useEChartsInstance` / `buildBottomLegend` helpers so it behaves consistently with the already-migrated charts; the public API (props and `ChartData` type) is preserved, so `AgentStatisticChartContainer` needs no change.
- Fix layout so the chart has a real height and stays responsive on resize (the fixed-size ECharts canvas otherwise blocks flex shrinking).

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (added unit tests for the ECharts option mapping)
- [ ] Config → Agent statistic: JVM (blue) / Agent (orange) horizontal bar charts render with value labels and a bottom legend
- [ ] Charts update when data is reloaded via the refresh button
- [ ] Charts resize when the window/container size changes
