### PR TITLE
[#14011] Apply service concept to uristat

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/mapper/grpc/stat/GrpcAgentUriStatMapper.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/mapper/grpc/stat/GrpcAgentUriStatMapper.java
@@ -34,9 +34,8 @@ import java.util.List;
 @Component
 public class GrpcAgentUriStatMapper {
 
-    private static final String DEFAULT_SERVICE_NAME = "DEFAULT";
-
     public AgentUriStatBo map(ServerHeader header, final PAgentUriStat agentUriStat) {
+        final String serviceName = header.getServiceName();
         final String agentId = header.getAgentId();
         final String applicationName = header.getApplicationName();
 
@@ -51,7 +50,7 @@ public class GrpcAgentUriStatMapper {
 
         return new AgentUriStatBo(
                 (byte) bucketVersion,
-                DEFAULT_SERVICE_NAME,
+                serviceName,
                 applicationName,
                 agentId, list);
     }

--- a/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/controller/UriStatController.java
+++ b/uristat/uristat-web/src/main/java/com/navercorp/pinpoint/uristat/web/controller/UriStatController.java
@@ -104,6 +104,7 @@ public class UriStatController {
 
         UriStatSummaryQueryParameter query = new UriStatSummaryQueryParameter.Builder()
                 .setTenantId(tenantProvider.getTenantId())
+                .setServiceName(serviceName.getName())
                 .setApplicationName(applicationName)
                 .setAgentId(agentId)
                 .setRange(range)
@@ -139,6 +140,7 @@ public class UriStatController {
         TimeWindow timeWindow = new TimeWindow(range, DEFAULT_TIME_WINDOW_SAMPLER);
         UriStatChartQueryParameter query = new UriStatChartQueryParameter.Builder()
                 .setTenantId(tenantProvider.getTenantId())
+                .setServiceName(serviceName.getName())
                 .setApplicationName(applicationName)
                 .setAgentId(agentId)
                 .setUri(uri)

--- a/uristat/uristat-web/src/main/resources/mapper/uristat/UriStatChartMapper.xml
+++ b/uristat/uristat-web/src/main/resources/mapper/uristat/UriStatChartMapper.xml
@@ -30,6 +30,7 @@
         FROM uriStat
         WHERE
             tenantId = #{tenantId}
+            AND serviceName = #{serviceName}
             AND applicationName = #{applicationName}
             <if test="agentId != null">
                 AND agentId = #{agentId}
@@ -57,6 +58,7 @@
         FROM uriStat
         WHERE
             tenantId = #{tenantId}
+            AND serviceName = #{serviceName}
             AND applicationName = #{applicationName}
             <if test="agentId != null">
                 AND agentId = #{agentId}
@@ -78,6 +80,7 @@
         FROM uriStat
         WHERE
             tenantId = #{tenantId}
+            AND serviceName = #{serviceName}
             AND applicationName = #{applicationName}
             <if test="agentId != null">
                 AND agentId = #{agentId}
@@ -100,6 +103,7 @@
         FROM uriStat
         WHERE
             tenantId = #{tenantId}
+            AND serviceName = #{serviceName}
             AND applicationName = #{applicationName}
             <if test="agentId != null">
                 AND agentId = #{agentId}

--- a/uristat/uristat-web/src/main/resources/mapper/uristat/UriStatSummaryMapper.xml
+++ b/uristat/uristat-web/src/main/resources/mapper/uristat/UriStatSummaryMapper.xml
@@ -15,6 +15,7 @@
         version
         FROM uriStat
         WHERE tenantId = #{tenantId}
+        AND serviceName = #{serviceName}
         AND applicationName = #{applicationName}
         <if test="agentId != null">
             AND agentId = #{agentId}
@@ -61,6 +62,7 @@
         version
         FROM uriStat
         WHERE tenantId = #{tenantId}
+        AND serviceName = #{serviceName}
         AND applicationName = #{applicationName}
         <if test="agentId != null">
             AND agentId = #{agentId}


### PR DESCRIPTION
resolves #14011

### Changes
- Collector: store the agent's serviceName from the gRPC header (`ServerHeader.getServiceName()`) instead of the hardcoded `"DEFAULT"` literal in `GrpcAgentUriStatMapper`. Old agents (header v1) still resolve to "DEFAULT", so existing behavior is preserved.
- Web: pass the resolved `@ServiceParam` serviceName into the summary/chart query parameters in `UriStatController` (previously it was used only for the permission check).
- Web: add `AND serviceName = #{serviceName}` to every query in `UriStatSummaryMapper.xml` and `UriStatChartMapper.xml` — same pattern as the uristat-batch `UriStatMapper.xml`.

No Pinot schema change is required — the `uriStat` schema already has the `serviceName` dimension (bloom-filter indexed), and all existing rows were stored as "DEFAULT", so default-service queries return the same results as before.

### Verified
- E2E: agent(serviceName=X) → collector → Kafka → Pinot → `/api/uriStat/summary`, `/api/uriStat/chart` return the data under service X only; the same queries without serviceName (DEFAULT) return none of it.
- Existing tests pass (collector `GrpcAgentUriMetricHandlerV2Test`, uristat-web).