### PR TITLE
[#14017] Keep StringUtils.abbreviate from splitting surrogate pairs

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/StringUtils.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/StringUtils.java
@@ -154,13 +154,26 @@ public final class StringUtils {
             throw new IllegalArgumentException("negative maxWidth:" + maxWidth);
         }
         if (str.length() > maxWidth) {
-            StringBuilder buffer = new StringBuilder(abbreviateBufferSize(maxWidth, str.length()));
-            buffer.append(str, 0, maxWidth);
+            final int endIndex = abbreviateEndIndex(str, maxWidth);
+            StringBuilder buffer = new StringBuilder(abbreviateBufferSize(endIndex, str.length()));
+            buffer.append(str, 0, endIndex);
             appendAbbreviateMessage(buffer, str.length());
             return buffer.toString();
         } else {
             return str;
         }
+    }
+
+    /**
+     * An unpaired high surrogate left by cutting a surrogate pair in half
+     * is not encodable to UTF-8 (e.g. protobuf throws UnpairedSurrogateException),
+     * so drop the high surrogate instead of splitting the pair.
+     */
+    static int abbreviateEndIndex(final String str, final int maxWidth) {
+        if (maxWidth > 0 && Character.isHighSurrogate(str.charAt(maxWidth - 1))) {
+            return maxWidth - 1;
+        }
+        return maxWidth;
     }
 
     static int abbreviateBufferSize(int maxWidth, int strLength) {
@@ -175,7 +188,7 @@ public final class StringUtils {
             return;
         }
         if (str.length() > maxWidth) {
-            builder.append(str, 0, maxWidth);
+            builder.append(str, 0, abbreviateEndIndex(str, maxWidth));
             appendAbbreviateMessage(builder, str.length());
         } else {
             builder.append(str);

--- a/commons/src/test/java/com/navercorp/pinpoint/common/util/StringUtilsTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/util/StringUtilsTest.java
@@ -112,6 +112,34 @@ public class StringUtilsTest {
 
 
     @Test
+    public void abbreviate_surrogatePair() {
+        // "ab" + emoji(high surrogate + low surrogate) + "cd"
+        String string = "ab😀cd";
+
+        // cutting at maxWidth=3 would split the surrogate pair - drop the high surrogate
+        Assertions.assertEquals("ab...(6)", StringUtils.abbreviate(string, 3));
+        // maxWidth=4 keeps the pair intact
+        Assertions.assertEquals("ab😀...(6)", StringUtils.abbreviate(string, 4));
+
+        String highSurrogateFirst = "😀abc";
+        Assertions.assertEquals("...(5)", StringUtils.abbreviate(highSurrogateFirst, 1));
+        Assertions.assertEquals("😀...(5)", StringUtils.abbreviate(highSurrogateFirst, 2));
+    }
+
+    @Test
+    public void appendAbbreviate_surrogatePair() {
+        String string = "ab😀cd";
+
+        StringBuilder buffer = new StringBuilder();
+        StringUtils.appendAbbreviate(buffer, string, 3);
+        Assertions.assertEquals("ab...(6)", buffer.toString());
+
+        buffer.setLength(0);
+        StringUtils.appendAbbreviate(buffer, string, 4);
+        Assertions.assertEquals("ab😀...(6)", buffer.toString());
+    }
+
+    @Test
     public void testAbbreviate1() {
         String string = "abc";
         String drop = StringUtils.abbreviate(string, 1);


### PR DESCRIPTION
#14017 