### PR TITLE
[#14016] Fix apdex and avgTimeMs returning 0 in uriStat summary

### DIFF
--- a/uristat/uristat-web/src/main/resources/mapper/uristat/UriStatSummaryMapper.xml
+++ b/uristat/uristat-web/src/main/resources/mapper/uristat/UriStatSummaryMapper.xml
@@ -7,10 +7,10 @@
     <select id="uriStatSummary" resultMap="uriStatSummaryEntity" parameterType="UriStatSummaryQueryParameter">
         SELECT
         uri,
-        sum(apdexRaw) as apdexRaw,
+        sum(apdexRaw) as totalApdexRaw,
         sum("count") as totalCount,
         max(maxLatencyMs) as maxTimeMs,
-        sum(totalTimeMs) as totalTimeMs,
+        sum(totalTimeMs) as sumOfTotalTimeMs,
         sum(failureCount) as failureCount,
         version
         FROM uriStat


### PR DESCRIPTION
resolves #14016

### Cause
#11944 renamed `UriStatSummaryEntity` fields `apdexRaw` → `totalApdexRaw` and `totalTimeMs` → `sumOfTotalTimeMs` and updated the aliases in the shared `selectStatSummary` SQL, but the plain `uriStatSummary` query kept the old aliases. Since the result map relies on column-name auto-mapping, those two columns silently stopped matching any entity field, so `GET /api/uriStat/summary` (without `type`) always returned `apdex: 0.0` and `avgTimeMs: 0.0`.

### Change
Rename the two aliases in the `uriStatSummary` query to match the entity fields. 2-line mapper XML change, no Java change.