### PR TITLE
[#13958] Add service registry cache configuration properties

### DIFF
--- a/uristat/uristat-web/src/main/resources/mapper/uristat/UriStatSummaryMapper.xml
+++ b/uristat/uristat-web/src/main/resources/mapper/uristat/UriStatSummaryMapper.xml
@@ -7,10 +7,10 @@
     <select id="uriStatSummary" resultMap="uriStatSummaryEntity" parameterType="UriStatSummaryQueryParameter">
         SELECT
         uri,
-        sum(apdexRaw) as apdexRaw,
+        sum(apdexRaw) as totalApdexRaw,
         sum("count") as totalCount,
         max(maxLatencyMs) as maxTimeMs,
-        sum(totalTimeMs) as totalTimeMs,
+        sum(totalTimeMs) as sumOfTotalTimeMs,
         sum(failureCount) as failureCount,
         version
         FROM uriStat

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -106,6 +106,20 @@ pinpoint.web.application.index.read.v2=true
 # Trace Index
 pinpoint.web.trace.index.read.v2=true
 
+# Service registry cache
+web.service.registry.cache.initialCapacity=16
+web.service.registry.cache.maximumSize=2000
+web.service.registry.cache.recordStats=false
+# Expiration time for cached services
+web.service.registry.cache.expireAfterWrite=1d
+# Expiration time for missing(not found) services
+web.service.registry.cache.missingExpireAfterWrite=5m
+web.service.registry.cache.load.warmup.enabled=true
+web.service.registry.cache.load.refresh.enabled=true
+web.service.registry.cache.load.refresh.interval=300000
+# Unset or -1 means 90% of web.service.registry.cache.maximumSize value.
+#web.service.registry.cache.load.limit=-1
+
 ###########################################################
 # BANNER                                                  #
 ###########################################################


### PR DESCRIPTION
## Summary
- Add `web.service.registry.cache.*` properties to `pinpoint-web-root.properties`
- These properties configure the `CachingServiceModelResolver` cache (capacity, TTL, warmup/refresh settings) introduced in #13958 / PR #13959

issue: https://github.com/pinpoint-apm/pinpoint/issues/13958