### PR TITLE
[#noissue] Pin OTel span applicationServiceType to OPENTELEMETRY_SERVER

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentInfoMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentInfoMapper.java
@@ -36,7 +36,10 @@ public class OtlpAgentInfoMapper {
             builder.setAgentName(owner.getAgentName());
         }
         builder.setApplicationName(owner.getApplicationName());
-        builder.setServiceTypeCode(spanBo.getServiceType());
+        // Register the agent/application under the application-level type, not the span-level
+        // serviceType — a specialized root (e.g. a kafka CONSUMER as the first-seen span) must
+        // not decide the application's registered type.
+        builder.setServiceTypeCode(spanBo.getApplicationServiceType());
         builder.setStartTime(owner.getAgentStartTime());
 
         final String hostName = AttributeUtils.getAttributeStringValue(resourceAttributeMap, OtlpTraceConstants.ATTRIBUTE_KEY_HOST_NAME, null);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -88,6 +88,11 @@ public class OtlpTraceSpanMapper {
         owner.setAgentStartTime(TimeUnit.NANOSECONDS.toMillis(startTimeNanos));
 
         SpanBo spanBo = new SpanBo(TraceSourceType.OPENTELEMETRY, owner);
+        // Application-level type is always the generic OTel server type. The span-level
+        // serviceType assigned below may specialize (GRPC_SERVER, KAFKA_CLIENT, ...) without
+        // leaking into application-keyed storage via the applicationServiceType fallback
+        // (trace index v2 row key, server-map self vertex, application registration).
+        spanBo.setApplicationServiceType(ServiceType.OPENTELEMETRY_SERVER.getCode());
         spanBo.setTransactionId(new OtelServerTraceId(span.getTraceId().toByteArray()));
         spanBo.setSpanId(OtlpTraceMapperUtils.getSpanId(span.getSpanId()));
         spanBo.setParentSpanId(OtlpTraceMapperUtils.getParentSpanId(span.getParentSpanId()));

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentInfoMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentInfoMapperTest.java
@@ -1,0 +1,49 @@
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpAgentInfoMapperTest {
+
+    @Test
+    void map_registersApplicationLevelType_notSpanLevelSpecialization() {
+        // A specialized root (e.g. a kafka CONSUMER as the first-seen span of an
+        // application) must not decide the application's registered type.
+        SpanBo spanBo = spanBo();
+        spanBo.setServiceType(8660); // KAFKA_CLIENT — span-level specialization
+
+        AgentInfoBo agentInfo = new OtlpAgentInfoMapper().map(spanBo, Map.of());
+
+        assertThat(agentInfo.getServiceTypeCode()).isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getCode());
+    }
+
+    @Test
+    void map_basicIdentityFields() {
+        SpanBo spanBo = spanBo();
+
+        AgentInfoBo agentInfo = new OtlpAgentInfoMapper().map(spanBo, Map.of());
+
+        assertThat(agentInfo.getAgentId()).isEqualTo("agent-1");
+        assertThat(agentInfo.getApplicationName()).isEqualTo("app-1");
+        assertThat(agentInfo.getServiceTypeCode()).isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getCode());
+    }
+
+    private static SpanBo spanBo() {
+        SpanOwner owner = new SpanOwner();
+        owner.setAgentId("agent-1");
+        owner.setApplicationName("app-1");
+        owner.setAgentStartTime(1000L);
+        SpanBo spanBo = new SpanBo(TraceSourceType.OPENTELEMETRY, owner);
+        // mirrors OtlpTraceSpanMapper.map(): application-level type is always pinned
+        spanBo.setApplicationServiceType(ServiceType.OPENTELEMETRY_SERVER.getCode());
+        return spanBo;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -278,6 +278,16 @@ class OtlpTraceSpanMapperTest {
     }
 
     @Test
+    void map_consumer_kafka_applicationServiceTypeStaysOtelServer() {
+        // The span-level KAFKA_CLIENT specialization must not leak into the
+        // application-level type used by application-keyed storage (trace index v2
+        // row key, server-map self vertex, application registration).
+        Span span = consumerKafkaSpan();
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getApplicationServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getCode());
+    }
+
+    @Test
     void map_consumer_kafka_rpcFormat() {
         Span span = consumerKafkaSpan(
                 kv("messaging.kafka.destination.partition", intVal(0)),
@@ -557,6 +567,22 @@ class OtlpTraceSpanMapperTest {
                 kv("rpc.method", strVal("PlaceOrder")));
         SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
         assertThat(bo.getServiceType()).isEqualTo((short) 1130); // GRPC_SERVER
+    }
+
+    @Test
+    void map_server_grpc_applicationServiceTypeStaysOtelServer() {
+        // The span-level GRPC_SERVER specialization must not leak into the
+        // application-level type used by application-keyed storage.
+        Span span = serverSpan(kv("rpc.system", strVal("grpc")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getApplicationServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getCode());
+    }
+
+    @Test
+    void map_server_http_applicationServiceTypeIsOtelServer() {
+        Span span = serverSpan(kv("url.path", strVal("/api/users/123")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getApplicationServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getCode());
     }
 
     @Test


### PR DESCRIPTION
Root-span ServiceType specialization (GRPC_SERVER, KAFKA_CLIENT via the messaging consumer path, ...) leaked into application-keyed storage through the SpanBo.getApplicationServiceType() fallback: trace index v2 rows, server-map self vertices, and agent/application registration were keyed by the specialized type while the web reads scan by the application's canonical type, leaving scatter/heatmap empty for consumer-rooted applications.

Pin applicationServiceType explicitly at SpanBo construction (mirroring OtlpTraceSpanChunkMapper) and register agents/applications under the application-level type instead of the first-seen span's serviceType. Span-level serviceType specialization is kept for Call Tree semantics, matching the agent model where consumer entry spans carry KAFKA_CLIENT while applicationServiceType stays the application's own type.