### PR TITLE
[#14024] Add serviceName to heatmap data path

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/heatmap/service/HeatmapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/heatmap/service/HeatmapService.java
@@ -43,7 +43,7 @@ public class HeatmapService implements TraceService {
 
     @Override
     public void insertSpan(SpanBo spanBo) {
-        HeatmapStat heatmapStat = new HeatmapStat(spanBo.getApplicationName(), spanBo.getAgentId(), spanBo.getCollectorAcceptTime(), spanBo.getElapsed(), spanBo.getErrCode());
+        HeatmapStat heatmapStat = new HeatmapStat(spanBo.getServiceName(), spanBo.getApplicationName(), spanBo.getAgentId(), spanBo.getCollectorAcceptTime(), spanBo.getElapsed(), spanBo.getErrCode());
         heatmapDao.insert(heatmapStat);
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/heatmap/vo/HeatmapStat.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/heatmap/vo/HeatmapStat.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  */
 public class HeatmapStat {
 
-    private static final String DEFAULT_SERVICE_NAME = "DEFAULT";
+    private final String serviceName;
     private final String applicationName;
     private final String agentId;
     private final String sortKey;
@@ -34,14 +34,19 @@ public class HeatmapStat {
     private final int elapsedTime;
     private final Boolean isSuccess;
 
-    public HeatmapStat(String applicationName, String agentId, long eventTime, int elapsedTime, int errCode) {
+    public HeatmapStat(String serviceName, String applicationName, String agentId, long eventTime, int elapsedTime, int errCode) {
+        this.serviceName = Objects.requireNonNull(serviceName, "serviceName");
         this.applicationName = Objects.requireNonNull(applicationName, "applicationName");
         this.agentId = Objects.requireNonNull(agentId, "agentId");
         this.eventTime = eventTime;
         this.elapsedTime = (((elapsedTime - 1) / 200) + 1) * 200;
         this.isSuccess = errCode == 0;
-        String sortKeyPrefix = DEFAULT_SERVICE_NAME + "#" + applicationName;
+        String sortKeyPrefix = serviceName + "#" + applicationName;
         this.sortKey = HashmapSortKeyUtils.generateKey(sortKeyPrefix, isSuccess);
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 
     public String getApplicationName() {
@@ -71,7 +76,8 @@ public class HeatmapStat {
     @Override
     public String toString() {
         return "HeatmapStat{" +
-                "applicationName='" + applicationName + '\'' +
+                "serviceName='" + serviceName + '\'' +
+                ", applicationName='" + applicationName + '\'' +
                 ", agentId='" + agentId + '\'' +
                 ", sortKey='" + sortKey + '\'' +
                 ", eventTime=" + eventTime +

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/heatmap/vo/HeatmapStatTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/heatmap/vo/HeatmapStatTest.java
@@ -28,32 +28,42 @@ class HeatmapStatTest {
 
     @Test
     public void elapsedTimeTest() {
-        HeatmapStat heatmapStat = new HeatmapStat("applicationName", "agentId", 1000, 1000, 0);
+        HeatmapStat heatmapStat = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 1000, 0);
         assertEquals(1000, heatmapStat.getElapsedTime());
 
-        HeatmapStat heatmapStat2 = new HeatmapStat("applicationName", "agentId", 1000, 200, 0);
+        HeatmapStat heatmapStat2 = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 200, 0);
         assertEquals(200, heatmapStat2.getElapsedTime());
 
-        HeatmapStat heatmapStat3 = new HeatmapStat("applicationName", "agentId", 1000, 201, 0);
+        HeatmapStat heatmapStat3 = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 201, 0);
         assertEquals(400, heatmapStat3.getElapsedTime());
 
-        HeatmapStat heatmapStat4 = new HeatmapStat("applicationName", "agentId", 1000, 199, 0);
+        HeatmapStat heatmapStat4 = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 199, 0);
         assertEquals(200, heatmapStat4.getElapsedTime());
 
-        HeatmapStat heatmapStat5 = new HeatmapStat("applicationName", "agentId", 1000, 100, 0);
+        HeatmapStat heatmapStat5 = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 100, 0);
         assertEquals(200, heatmapStat5.getElapsedTime());
 
-        HeatmapStat heatmapStat6 = new HeatmapStat("applicationName", "agentId", 1000, 300, 0);
+        HeatmapStat heatmapStat6 = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 300, 0);
         assertEquals(400, heatmapStat6.getElapsedTime());
 
-        HeatmapStat heatmapStat7 = new HeatmapStat("applicationName", "agentId", 1000, 399, 0);
+        HeatmapStat heatmapStat7 = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 399, 0);
         assertEquals(400, heatmapStat7.getElapsedTime());
 
-        HeatmapStat heatmapStat8 = new HeatmapStat("applicationName", "agentId", 1000, 400, 0);
+        HeatmapStat heatmapStat8 = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 400, 0);
         assertEquals(400, heatmapStat8.getElapsedTime());
 
-        HeatmapStat heatmapStat9 = new HeatmapStat("applicationName", "agentId", 1000, 401, 0);
+        HeatmapStat heatmapStat9 = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 401, 0);
         assertEquals(600, heatmapStat9.getElapsedTime());
+    }
+
+    @Test
+    public void sortKeyTest() {
+        HeatmapStat successStat = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 100, 0);
+        assertEquals("serviceName", successStat.getServiceName());
+        assertEquals("serviceName#applicationName#suc", successStat.getSortKey());
+
+        HeatmapStat failureStat = new HeatmapStat("serviceName", "applicationName", "agentId", 1000, 100, 1);
+        assertEquals("serviceName#applicationName#fal", failureStat.getSortKey());
     }
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatmapChartController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatmapChartController.java
@@ -49,7 +49,6 @@ import java.util.Optional;
 public class HeatmapChartController {
 
     private static final int MAX_TIMESLOT_COUNT = 60;
-    private static final String DEFAULT_SERVICE_NAME = "DEFAULT";
 
     private final TimeWindowSampler DEFAULT_TIME_WINDOW_SAMPLER = new TimeWindowSlotCentricSampler(10000L, MAX_TIMESLOT_COUNT);
     private final HeatmapChartService heatmapChartService;
@@ -69,7 +68,7 @@ public class HeatmapChartController {
                                   @RequestParam("maxElapsedTime") @Positive int maxElapsedTime) {
         Range range = Range.between(from, to);
         TimeWindow timeWindow = getTimeWindow(range);
-        HeatMapData heatMapData = heatmapChartService.getHeatmapAppData(DEFAULT_SERVICE_NAME, applicationName, timeWindow, minElapsedTime, maxElapsedTime);
+        HeatMapData heatMapData = heatmapChartService.getHeatmapAppData(serviceName.getName(), applicationName, timeWindow, minElapsedTime, maxElapsedTime);
         return new HeatMapDataView(heatMapData);
     }
 


### PR DESCRIPTION
## Summary
- Pass `spanBo.getServiceName()` to `HeatmapStat` sortKey instead of hardcoded `"DEFAULT"`
- Forward `@ServiceParam serviceName` in `HeatmapChartController` to the query layer
- Existing data (`DEFAULT#...` sortKey) continues to work — no migration needed

Closes #14024