### PR TITLE
[#noissue] Only treat OTel spans as unsampled from the trace-flags byte

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
@@ -239,17 +239,23 @@ public class OtlpTraceMapper {
         return spanMap;
     }
 
-    // Span.flags == 0 is ambiguous: exporters predating the flags field (opentelemetry-proto
-    // < 1.1) leave it unset, which is indistinguishable from an explicit all-clear — and unlike
-    // the is_remote bits there is no "has trace flags" validity bit. Treat 0 as "not populated"
-    // and keep the span; only a non-zero flags value with the W3C sampled bit clear identifies
-    // a definitively unsampled span.
+    // Only the low trace-flags byte (bits 0-7, W3C sampled = bit 0) carries the sampling
+    // decision. The is_remote metadata bits (bits 8-9) are set by modern SDKs on *every* span,
+    // so the whole flags int being non-zero does NOT mean the trace-flags byte was populated —
+    // reading it that way dropped spans that only carried is_remote metadata (e.g. a locust
+    // load-generator's root spans, exported with is_remote set but the sampled bit clear).
+    //
+    // A trace-flags byte of 0 is ambiguous: an exporter predating the flags field
+    // (opentelemetry-proto < 1.1), or one that populated only is_remote metadata, is
+    // indistinguishable from an explicit all-clear, and there is no "has trace flags" validity
+    // bit. Be conservative and keep the span. Only a trace-flags byte that is itself populated
+    // (non-zero) yet has the sampled bit clear identifies a definitively unsampled span.
     static boolean isUnsampled(Span span) {
-        final int flags = span.getFlags();
-        if (flags == 0) {
+        final int traceFlags = span.getFlags() & SpanFlags.SPAN_FLAGS_TRACE_FLAGS_MASK_VALUE;
+        if (traceFlags == 0) {
             return false;
         }
-        return (flags & SpanFlags.SPAN_FLAGS_TRACE_FLAGS_MASK_VALUE & W3C_SAMPLED_FLAG) == 0;
+        return (traceFlags & W3C_SAMPLED_FLAG) == 0;
     }
 
     void initRootAndChild(List<ScopedSpan> spanList, List<ScopedSpan> rootSpanList, List<ScopedSpan> childSpanList) {

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -407,6 +407,12 @@ class OtlpTraceMapperTest {
         return span.toBuilder().setFlags(flags).build();
     }
 
+    // A definitively-unsampled wire shape: the trace-flags byte is populated (W3C "random" bit,
+    // 0x02) so we know the sampling decision is real, while the sampled bit (0x01) stays clear.
+    // is_remote metadata is included to mirror a modern SDK.
+    private static final int UNSAMPLED_FLAGS =
+            SpanFlags.SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK_VALUE | 0x02;
+
     @Test
     void isUnsampled_flagRules() {
         Span base = serverRoot(ROOT_A, "/api/orders", false);
@@ -414,18 +420,20 @@ class OtlpTraceMapperTest {
         assertThat(OtlpTraceMapper.isUnsampled(withFlags(base, 0))).isFalse();
         // sampled bit set, remote bits unset
         assertThat(OtlpTraceMapper.isUnsampled(withFlags(base, 0x01))).isFalse();
-        // populated flags (has_is_remote bit) with the sampled bit clear: definitively unsampled
+        // is_remote metadata only: the trace-flags byte is unpopulated — NOT a sampling signal,
+        // so keep (e.g. a locust load-generator root span exported with is_remote but no sampled bit).
         assertThat(OtlpTraceMapper.isUnsampled(
-                withFlags(base, SpanFlags.SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK_VALUE))).isTrue();
-        // populated flags with the sampled bit set
+                withFlags(base, SpanFlags.SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK_VALUE))).isFalse();
+        // is_remote metadata + sampled bit set
         assertThat(OtlpTraceMapper.isUnsampled(
                 withFlags(base, SpanFlags.SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK_VALUE | 0x01))).isFalse();
+        // trace-flags byte populated (random bit) with the sampled bit clear: definitively unsampled
+        assertThat(OtlpTraceMapper.isUnsampled(withFlags(base, UNSAMPLED_FLAGS))).isTrue();
     }
 
     @Test
     void unsampledSpan_droppedAndCountedAsRejected() {
-        Span unsampledRoot = withFlags(serverRoot(ROOT_A, "/api/orders", false),
-                SpanFlags.SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK_VALUE);
+        Span unsampledRoot = withFlags(serverRoot(ROOT_A, "/api/orders", false), UNSAMPLED_FLAGS);
 
         OtlpTraceMapperData data = newMapper().map(resourceSpans(unsampledRoot));
 
@@ -446,6 +454,20 @@ class OtlpTraceMapperTest {
     }
 
     @Test
+    void isRemoteMetadataOnly_keptConservatively() {
+        // Regression: a span carrying only is_remote metadata (trace-flags byte all-clear) must be
+        // kept. Reading the non-zero flags int as "populated" previously dropped these — which
+        // silently lost a whole service's traces (locust load-generator root spans).
+        Span isRemoteOnlyRoot = withFlags(serverRoot(ROOT_A, "/api/orders", false),
+                SpanFlags.SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK_VALUE);
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(isRemoteOnlyRoot));
+
+        assertThat(data.getSpanBoList()).hasSize(1);
+        assertThat(data.getRejectedSpan().count()).isZero();
+    }
+
+    @Test
     void zeroFlags_treatedAsLegacyAndKept() {
         // serverRoot() never sets flags — the pre-flags wire shape must keep flowing unchanged
         Span legacyRoot = serverRoot(ROOT_A, "/api/orders", false);
@@ -460,8 +482,7 @@ class OtlpTraceMapperTest {
     void unsampledChild_droppedButSampledRootKept() {
         // per-span drop: the sampled root survives; the explicitly unsampled child is rejected
         Span root = serverRoot(ROOT_A, "/api/orders", false);
-        Span unsampledChild = withFlags(clientChild(CHILD, ROOT_A, false),
-                SpanFlags.SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK_VALUE);
+        Span unsampledChild = withFlags(clientChild(CHILD, ROOT_A, false), UNSAMPLED_FLAGS);
 
         OtlpTraceMapperData data = newMapper().map(resourceSpans(root, unsampledChild));
 


### PR DESCRIPTION
isUnsampled() read the whole Span.flags int for its "populated?" guard, but modern SDKs set the is_remote metadata bits (8-9) on every span. A span that carried only is_remote metadata (trace-flags byte all-clear, sampled bit absent) was therefore judged definitively unsampled and dropped — silently losing an entire service's traces (a locust load-generator's root spans are exported this way).

Mask to the W3C trace-flags byte (bits 0-7) before the guard: a zero trace-flags byte is ambiguous (pre-1.1 exporter, or is_remote-only metadata) and is kept; only a populated trace-flags byte with the sampled bit clear is treated as unsampled. Follow-up to the unsampled-drop change.