### PR TITLE
[#noissue] Migrate AgentActiveChart from Recharts to ECharts

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveChart.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveChart.test.tsx
@@ -1,0 +1,216 @@
+import { render } from '@testing-library/react';
+import { AgentActiveData } from './AgentActiveTable';
+
+// echarts 자체와 인스턴스 라이프사이클 훅은 모킹해, AgentActiveChart 가 chart.setOption 에 넘기는
+// 옵션(순수 변환 로직)과 클릭 핸들러만 검증한다. (실제 렌더/canvas 는 이 테스트의 관심사가 아니다)
+const mockSetOption = jest.fn();
+const mockZrOn = jest.fn();
+const mockZrOff = jest.fn();
+const mockZr = { on: mockZrOn, off: mockZrOff };
+const mockContainPixel = jest.fn(() => true);
+const mockConvertFromPixel = jest.fn(() => 0);
+const mockChartRef = { current: null as HTMLDivElement | null };
+const mockChartInstanceRef = {
+  current: {
+    setOption: mockSetOption,
+    getZr: () => mockZr,
+    containPixel: mockContainPixel,
+    convertFromPixel: mockConvertFromPixel,
+  },
+};
+
+jest.mock('echarts/core', () => ({ use: jest.fn() }));
+jest.mock('echarts/charts', () => ({ BarChart: {} }));
+jest.mock('echarts/components', () => ({
+  GridComponent: {},
+  TooltipComponent: {},
+  LegendComponent: {},
+}));
+jest.mock('echarts/renderers', () => ({ CanvasRenderer: {} }));
+jest.mock('../../lib/charts/useEChartsInstance', () => ({
+  useEChartsInstance: () => ({
+    chartRef: mockChartRef,
+    chartInstanceRef: mockChartInstanceRef,
+    renderRef: { current: null },
+  }),
+}));
+
+// eslint-disable-next-line import/first
+import { AgentActiveChart, AgentActiveChartProps } from './AgentActiveChart';
+
+const makeRow = (server: string, values: [number, number, number, number]): AgentActiveData => ({
+  server,
+  '1s': values[0],
+  '3s': values[1],
+  '5s': values[2],
+  slow: values[3],
+  agentName: `${server}-name`,
+  message: '',
+});
+
+const renderChart = (props: Partial<AgentActiveChartProps> = {}) => {
+  render(<AgentActiveChart {...props} />);
+  const [option, mergeArg] = mockSetOption.mock.calls[0];
+  return { option, mergeArg };
+};
+
+describe('AgentActiveChart', () => {
+  beforeEach(() => {
+    mockSetOption.mockClear();
+    mockZrOn.mockClear();
+    mockZrOff.mockClear();
+    mockContainPixel.mockClear();
+    mockContainPixel.mockReturnValue(true);
+    mockConvertFromPixel.mockClear();
+    mockConvertFromPixel.mockReturnValue(0);
+  });
+
+  it('enables growth animation and merges updates so bars transition smoothly', () => {
+    const { option, mergeArg } = renderChart({ data: [makeRow('a', [1, 2, 3, 4])] });
+    expect(option.animation).toBe(true);
+    // 기본 병합(replaceMerge 미사용)이라 실시간 값 변화가 애니메이션으로 이어진다.
+    expect(mergeArg).toBeUndefined();
+  });
+
+  it('stacks four bar series from slow (bottom) to 1s (top) with fixed colors', () => {
+    const { option } = renderChart({ data: [makeRow('a', [1, 2, 3, 4])] });
+    const dataSeries = option.series.filter((s: { stack?: string }) => s.stack === 'agentActiveThread');
+    expect(dataSeries.map((s: { name: string }) => s.name)).toEqual(['slow', '5s', '3s', '1s']);
+    expect(dataSeries.every((s: { type: string }) => s.type === 'bar')).toBe(true);
+    expect(dataSeries[0].itemStyle.color).toBe('#e67f22'); // slow
+    expect(dataSeries[3].itemStyle.color).toBe('#34b994'); // 1s
+  });
+
+  it('maps each series value from the matching data key', () => {
+    const { option } = renderChart({ data: [makeRow('a', [10, 20, 30, 40])] });
+    // series order: slow, 5s, 3s, 1s
+    expect(option.series[0].data[0].value).toBe(40); // slow
+    expect(option.series[1].data[0].value).toBe(30); // 5s
+    expect(option.series[2].data[0].value).toBe(20); // 3s
+    expect(option.series[3].data[0].value).toBe(10); // 1s
+  });
+
+  it('dims non-selected servers to 0.3 and keeps the selected one at 1', () => {
+    const { option } = renderChart({
+      data: [makeRow('a', [1, 1, 1, 1]), makeRow('b', [1, 1, 1, 1])],
+      clickedActiveThread: 'b',
+    });
+    expect(option.series[0].data[0].itemStyle.opacity).toBe(0.3); // server a (not selected)
+    expect(option.series[0].data[1].itemStyle.opacity).toBe(1); // server b (selected)
+  });
+
+  it('keeps every server at full opacity when nothing is selected', () => {
+    const { option } = renderChart({ data: [makeRow('a', [1, 1, 1, 1]), makeRow('b', [1, 1, 1, 1])] });
+    expect(option.series[0].data[0].itemStyle.opacity).toBe(1);
+    expect(option.series[0].data[1].itemStyle.opacity).toBe(1);
+  });
+
+  it('hides the bars while loading (empty series data)', () => {
+    const { option } = renderChart({ data: [makeRow('a', [1, 2, 3, 4])], loading: true });
+    expect(option.series.every((s: { data: unknown[] }) => s.data.length === 0)).toBe(true);
+  });
+
+  it('applies the segment decal to the bars but not the legend swatch', () => {
+    const { option } = renderChart({ data: [makeRow('a', [1, 2, 3, 4])] });
+    // 막대(데이터 아이템)에는 흰 가로줄 decal 이 있어 칸칸(볼륨미터)으로 보인다.
+    expect(option.series[0].data[0].itemStyle.decal).toBeDefined();
+    expect(option.series[0].data[0].itemStyle.decal.color).toContain('255');
+    // 시리즈 레벨(범례 아이콘이 참조)에는 decal 이 없어야 스와치가 갈라지지 않는다.
+    expect(option.series[0].itemStyle.decal).toBeUndefined();
+  });
+
+  it('applies the configured yMax to the value axis', () => {
+    const { option } = renderChart({
+      data: [makeRow('a', [1, 2, 3, 4])],
+      setting: { yMax: 10, isSplit: false, inactivityThreshold: 5 },
+    });
+    expect(option.yAxis.max).toBe(10);
+  });
+
+  it('renders the legend in reverse (1s, 3s, 5s, slow) with rounded swatches', () => {
+    const { option } = renderChart({ data: [makeRow('a', [1, 2, 3, 4])] });
+    expect(option.legend.data).toEqual(['1s', '3s', '5s', 'slow']);
+    // 1:1 비율 rounded-square path (정사각형 둥근 스와치)
+    expect(option.legend.icon).toContain('path://');
+    expect(option.legend.itemWidth).toBe(option.legend.itemHeight);
+  });
+
+  it('hides the x-axis server labels', () => {
+    const { option } = renderChart({ data: [makeRow('srv', [1, 2, 3, 4])] });
+    expect(option.xAxis.axisLabel.show).toBe(false);
+    expect(option.xAxis.data).toEqual(['srv']);
+  });
+
+  it('marks the selected column with an overlapping full-height highlight bar (bar width, not slot)', () => {
+    const { option } = renderChart({
+      data: [makeRow('srv-a', [1, 2, 3, 4]), makeRow('srv-b', [1, 2, 3, 4])],
+      clickedActiveThread: 'srv-b',
+      setting: { yMax: 100, isSplit: false, inactivityThreshold: 5 },
+    });
+    const highlight = option.series.find((s: { name: string }) => s.name === '__selected_column__');
+    expect(highlight).toBeDefined();
+    // 막대와 같은 폭으로 겹쳐(barGap -100%) 옆 칸을 침범하지 않는다.
+    expect(highlight.barGap).toBe('-100%');
+    expect(highlight.barWidth).toBe(option.series[0].barWidth);
+    // 선택된 서버만 전체 높이(yMax), 나머지는 null.
+    expect(highlight.data).toEqual([null, 100]);
+  });
+
+  it('clears the highlight bar when nothing is selected', () => {
+    const { option } = renderChart({ data: [makeRow('srv-a', [1, 2, 3, 4])] });
+    const highlight = option.series.find((s: { name: string }) => s.name === '__selected_column__');
+    expect(highlight.data).toEqual([]);
+  });
+
+  describe('tooltip formatter', () => {
+    it('shows the server as header and rows in reverse order, mapping negatives to "-"', () => {
+      const { option } = renderChart({ data: [makeRow('srv1', [1, 2, 3, 4])] });
+      // params come in series order (slow, 5s, 3s, 1s); -1 means uncollected
+      const html = option.tooltip.formatter([
+        { axisValue: 'srv1', seriesName: 'slow', value: -1, color: '#e67f22' },
+        { axisValue: 'srv1', seriesName: '5s', value: 3, color: '#ffba00' },
+        { axisValue: 'srv1', seriesName: '3s', value: 2, color: '#51afdf' },
+        { axisValue: 'srv1', seriesName: '1s', value: 1, color: '#34b994' },
+      ]);
+      expect(html).toContain('srv1');
+      // reversed display order: 1s appears before slow
+      expect(html.indexOf('1s')).toBeLessThan(html.indexOf('slow'));
+      // negative value rendered as '-'
+      expect(html).toContain('>-<');
+    });
+  });
+
+  describe('click toggle (column background, not just the bar)', () => {
+    it('toggles the server at the clicked column via a zrender click on the grid', () => {
+      const setClicked = jest.fn();
+      mockConvertFromPixel.mockReturnValue(1); // clicked column index → server 'b'
+      render(
+        <AgentActiveChart
+          data={[makeRow('a', [1, 2, 3, 4]), makeRow('b', [1, 2, 3, 4])]}
+          setClickedActiveThread={setClicked}
+        />,
+      );
+      const [eventName, handler] = mockZrOn.mock.calls[0];
+      expect(eventName).toBe('click');
+
+      handler({ offsetX: 20, offsetY: 20 });
+      const updater = setClicked.mock.calls[0][0];
+      expect(updater('')).toBe('b'); // select when none selected
+      expect(updater('b')).toBe(''); // deselect when already selected
+    });
+
+    it('ignores clicks outside the grid (e.g. legend/blank area)', () => {
+      const setClicked = jest.fn();
+      mockContainPixel.mockReturnValue(false);
+      render(<AgentActiveChart data={[makeRow('a', [1, 2, 3, 4])]} setClickedActiveThread={setClicked} />);
+      const handler = mockZrOn.mock.calls[0][1];
+      handler({ offsetX: 0, offsetY: 0 });
+      expect(setClicked).not.toHaveBeenCalled();
+    });
+  });
+
+  it('disables legend toggling so it stays on one line', () => {
+    const { option } = renderChart({ data: [makeRow('a', [1, 2, 3, 4])] });
+    expect(option.legend.selectedMode).toBe(false);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveChart.tsx
@@ -1,24 +1,14 @@
 import React from 'react';
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-  ChartTooltip,
-  ChartTooltipContent,
-} from '../ui';
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Cell,
-  ReferenceLine,
-  ResponsiveContainer,
-  XAxis,
-  YAxis,
-} from 'recharts';
+import * as echarts from 'echarts/core';
+import { BarChart } from 'echarts/charts';
+import { GridComponent, TooltipComponent, LegendComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+import { escapeHTMLEntities } from '@pinpoint-fe/ui/src/utils';
+import { useEChartsInstance } from '../../lib/charts/useEChartsInstance';
 import { AgentActiveSettingType } from './AgentActiveSetting';
 import { AgentActiveData } from './AgentActiveTable';
+
+echarts.use([BarChart, GridComponent, TooltipComponent, LegendComponent, CanvasRenderer]);
 
 export const DefaultValue = { yMax: 100 };
 
@@ -31,25 +21,31 @@ export interface AgentActiveChartProps {
 }
 
 const TICK_COUNT = 4;
-const DefaultReferenceLineLength = 50;
-const chartConfig = {
-  '1s': {
-    label: '1s',
-    color: '#34b994',
-  },
-  '3s': {
-    label: '3s',
-    color: '#51afdf',
-  },
-  '5s': {
-    label: '5s',
-    color: '#ffba00',
-  },
-  slow: {
-    label: 'slow',
-    color: '#e67f22',
-  },
-} satisfies ChartConfig;
+
+// 스택(쌓이는) 순서 = recharts 의 Object.keys(chartConfig).reverse() 와 동일: slow(맨 아래) → 1s(맨 위).
+// legend/tooltip 은 이 순서를 뒤집어 1s, 3s, 5s, slow 로 표시한다.
+const SERIES = [
+  { key: 'slow', label: 'slow', color: '#e67f22' },
+  { key: '5s', label: '5s', color: '#ffba00' },
+  { key: '3s', label: '3s', color: '#51afdf' },
+  { key: '1s', label: '1s', color: '#34b994' },
+] as const;
+const STACK_ID = 'agentActiveThread';
+const BAR_WIDTH = '60%';
+// x/y 축 선 색 (은은한 회색 테두리).
+const AXIS_LINE_COLOR = '#e5e7eb';
+// 선택 컬럼 하이라이트용 내부 시리즈 이름. legend/tooltip 에는 노출하지 않는다.
+const HIGHLIGHT_SERIES = '__selected_column__';
+
+// 막대 위에 흰색 가로줄 패턴(decal)을 얹어, 값이 쌓일수록 칸칸(볼륨미터)으로 보이게 한다.
+// decal 은 캔버스 패턴이라 요소 수가 고정이라, 실시간 갱신에도 메모리 부담이 없다.
+// (recharts 의 흰색 ReferenceLine 게이지 대체)
+const SEGMENT_DECAL = {
+  color: 'rgba(255, 255, 255, 1)',
+  dashArrayX: [1, 0], // 가로로는 끊김 없이 막대 폭 전체
+  dashArrayY: [2, 4], // 세로로 흰 줄 2px + 색 칸 4px 반복 → 칸칸이 나뉘어 보임
+  rotation: 0,
+} as const;
 
 export const AgentActiveChart = ({
   loading,
@@ -58,106 +54,160 @@ export const AgentActiveChart = ({
   clickedActiveThread,
   setClickedActiveThread,
 }: AgentActiveChartProps) => {
-  const chartContainerRef = React.useRef<HTMLDivElement>(null);
-  const height = chartContainerRef?.current?.clientHeight || 0;
+  const { chartRef, chartInstanceRef, renderRef } = useEChartsInstance();
   const yMax = setting?.yMax || DefaultValue.yMax;
-  const ReferenceLineLength = yMax < DefaultReferenceLineLength ? yMax : DefaultReferenceLineLength;
 
-  return (
-    <ResponsiveContainer>
-      <ChartContainer
-        config={chartConfig}
-        className="p-1.5 z-0 min-w-[50%]"
-        ref={chartContainerRef}
-      >
-        <BarChart
-          accessibilityLayer
-          data={data || []}
-          onClick={(props) =>
-            setClickedActiveThread?.((prev) => {
-              const activeLabel = props?.activeLabel || '';
-              return prev === activeLabel ? '' : activeLabel;
-            })
-          }
-        >
-          <CartesianGrid vertical={false} />
-          <XAxis
-            dataKey="server"
-            hide={true}
-            tickLine={false}
-            axisLine={false}
-            type="category"
-            interval={0}
-            tick={(props) => <CustomTick {...props} />}
-          />
-          <YAxis
-            tickLine={false}
-            axisLine={false}
-            tickMargin={10}
-            ticks={Array.from({ length: TICK_COUNT + 1 }, (_, index) =>
-              Math.ceil((yMax / TICK_COUNT) * index),
-            )}
-            allowDecimals={false}
-            domain={() => [0, yMax]}
-          />
-          <ChartTooltip
-            content={
-              <ChartTooltipContent
-                isReverse={true}
-                valueFormatter={(value) => ((value as number) < 0 ? '-' : value)}
-              />
-            }
-          />
-          <ChartLegend content={<ChartLegendContent isReverse={true} />} />
-          {Object.keys(chartConfig)
-            .reverse()
-            .map((key) => (
-              <Bar
-                key={key}
-                dataKey={key}
-                stackId="agentActiveThread"
-                fill={chartConfig[key as keyof typeof chartConfig].color}
-                hide={loading}
-              >
-                {data?.map((entry, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    opacity={
-                      clickedActiveThread ? (entry.server === clickedActiveThread ? 1 : 0.3) : 1
-                    }
-                  />
-                ))}
-              </Bar>
-            ))}
-          {Array.from({ length: ReferenceLineLength }, (_, index) => {
-            return (
-              <ReferenceLine
-                key={index}
-                y={Math.floor(yMax / ReferenceLineLength) * (index + 1)}
-                stroke="white"
-                strokeWidth={height >= 650 ? 4 : height >= 450 ? 3 : height >= 300 ? 2 : 1}
-                isFront={true}
-              />
-            );
-          })}
-        </BarChart>
-      </ChartContainer>
-    </ResponsiveContainer>
-  );
-};
+  // 클릭 핸들러는 인스턴스 생성 시 한 번만 등록하고, 최신 값(setter/서버목록)은 ref 로 참조한다.
+  const setClickedRef = React.useRef(setClickedActiveThread);
+  setClickedRef.current = setClickedActiveThread;
+  const serversRef = React.useRef<string[]>([]);
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const CustomTick = (props: any) => {
-  const { payload, x, y } = props;
-  const maxLength = Math.ceil(payload?.offset / 10);
-  const value = payload?.value;
-  const displayValue = value?.length <= maxLength ? value : value?.slice(0, maxLength) + '...';
+  React.useEffect(() => {
+    const chart = chartInstanceRef.current;
+    if (!chart) return;
 
-  return (
-    <g transform={`translate(${x},${y})`}>
-      <text x={0} y={0} dy={16} textAnchor="middle" fill="#666">
-        {displayValue}
-      </text>
-    </g>
-  );
+    // 막대뿐 아니라 컬럼 배경 아무 곳이나 클릭해도 그 서버를 선택/해제한다.
+    // (recharts onClick 의 activeLabel 처럼 클릭 위치의 x 카테고리를 찾아 토글)
+    const zr = chart.getZr();
+    const handleZrClick = (event: { offsetX: number; offsetY: number }) => {
+      const point = [event.offsetX, event.offsetY];
+      if (!chart.containPixel('grid', point)) return; // 그리드(막대 영역) 밖 클릭은 무시
+      const index = Math.round(chart.convertFromPixel({ xAxisIndex: 0 }, point[0]) as number);
+      const server = serversRef.current[index];
+      if (server == null) return;
+      setClickedRef.current?.((prev) => (prev === server ? '' : server));
+    };
+    zr.on('click', handleZrClick);
+    return () => {
+      zr.off('click', handleZrClick);
+    };
+  }, [chartInstanceRef]);
+
+  React.useEffect(() => {
+    if (!chartInstanceRef.current) return;
+
+    const servers = (data ?? []).map((d) => d.server);
+    // 배경 클릭 시 클릭 위치의 x 인덱스로 서버를 찾기 위해 최신 목록을 ref 에 보관한다.
+    serversRef.current = servers;
+
+    // trigger:'axis' 툴팁. 헤더는 서버명, 행은 1s→slow 순(스택의 역순)으로, 음수(미수집)는 '-' 로 표시.
+    const tooltipFormatter = (
+      // echarts 툴팁 params 는 라이브러리 타입이 느슨해 any 로 받는다.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      params: any,
+    ) => {
+      if (!Array.isArray(params) || params.length === 0) return '';
+      const header = String(params[0].axisValue ?? '');
+      // 선택 하이라이트용 내부 시리즈는 tooltip 에서 제외한다.
+      const rows = [...params]
+        .filter((p: { seriesName?: string }) => p.seriesName !== HIGHLIGHT_SERIES)
+        .reverse()
+        .map((p: { value?: number; seriesName?: string; color?: string }) => {
+          const raw = typeof p.value === 'number' ? p.value : Number(p.value);
+          const display = raw < 0 ? '-' : String(raw);
+          return `<div style="display: flex; justify-content: space-between; gap: 12px; align-items: center;">
+                    <div style="display: flex; gap: 5px; align-items: center;">
+                      <span style="display: inline-block; width: 10px; height: 10px; background: ${p.color};"></span>${escapeHTMLEntities(String(p.seriesName ?? ''))}
+                    </div>
+                    <div>${escapeHTMLEntities(display)}</div>
+                  </div>`;
+        })
+        .join('');
+      return `<div><div style="margin-bottom: 5px;"><strong>${escapeHTMLEntities(header)}</strong></div>${rows}</div>`;
+    };
+
+    const dataSeries = SERIES.map((s) => ({
+      name: s.label,
+      type: 'bar' as const,
+      stack: STACK_ID,
+      barWidth: BAR_WIDTH,
+      // 시리즈 레벨엔 색만 둔다. (범례 아이콘은 이 스타일을 쓰므로 decal 을 넣으면 칸칸이 갈라져 보인다)
+      itemStyle: { color: s.color },
+      // 칸칸(volume) 패턴 decal 과 선택 dimming(opacity) 은 막대 데이터에만 적용한다.
+      data: loading
+        ? []
+        : (data ?? []).map((d) => ({
+            value: d[s.key],
+            itemStyle: {
+              decal: SEGMENT_DECAL,
+              opacity: clickedActiveThread ? (d.server === clickedActiveThread ? 1 : 0.3) : 1,
+            },
+          })),
+    }));
+
+    // 선택된 서버 컬럼 뒤에, 막대와 같은 폭(BAR_WIDTH)의 전체 높이 하이라이트 막대를 겹쳐 그린다.
+    // barGap:'-100%' 로 스택 막대와 정확히 겹치고, z:0 으로 뒤에 깔린다. (markArea 는 슬롯 전체를
+    // 칠해 옆 칸까지 닿으므로 대신 이 방식을 쓴다) 선택이 없으면 빈 데이터로 둔다.
+    const highlightSeries = {
+      name: HIGHLIGHT_SERIES,
+      type: 'bar' as const,
+      silent: true,
+      z: 0,
+      barWidth: BAR_WIDTH,
+      barGap: '-100%',
+      itemStyle: { color: 'rgba(59, 130, 246, 0.12)' },
+      data:
+        loading || !clickedActiveThread
+          ? []
+          : servers.map((server) => (server === clickedActiveThread ? yMax : null)),
+    };
+
+    const series = [...dataSeries, highlightSeries];
+
+    const render = () => {
+      const chart = chartInstanceRef.current;
+      if (!chart) return;
+
+      chart.setOption({
+        // 막대가 바닥에서 위로 자라고, 실시간 값 변화도 부드럽게 전환(파도)되도록 애니메이션을 켠다.
+        animation: true,
+        animationDuration: 500,
+        animationDurationUpdate: 300,
+        animationEasing: 'cubicOut' as const,
+        animationEasingUpdate: 'cubicOut' as const,
+        legend: {
+          bottom: 0,
+          // 기존 UI(rounded-[2px] 정사각형)처럼 모서리가 둥근 '정사각형' 스와치.
+          // roundRect 는 이 크기에서 납작해 보여, 1:1 비율의 rounded-square path 를 직접 쓴다.
+          icon: 'path://M2,0 L10,0 Q12,0 12,2 L12,10 Q12,12 10,12 L2,12 Q0,12 0,10 L0,2 Q0,0 2,0 Z',
+          itemWidth: 12,
+          itemHeight: 12,
+          itemGap: 12,
+          // 클릭해도 시리즈가 토글(회색)되지 않도록 해 한 줄로 온전히 유지한다. (기존 UI 동작)
+          selectedMode: false,
+          // 스택 역순(1s, 3s, 5s, slow)으로 표시.
+          data: [...SERIES].reverse().map((s) => s.label),
+        },
+        grid: { top: 10, right: 12, bottom: 32, left: 8, containLabel: true },
+        xAxis: {
+          type: 'category',
+          data: servers,
+          // 서버명 x축 라벨은 숨긴다(서버 식별은 tooltip/테이블/선택 하이라이트로).
+          axisLabel: { show: false },
+          axisTick: { show: false },
+          // x축(바닥) 선 하나를 표시한다.
+          axisLine: { show: true, lineStyle: { color: AXIS_LINE_COLOR } },
+        },
+        yAxis: {
+          type: 'value',
+          min: 0,
+          max: yMax,
+          splitNumber: TICK_COUNT,
+          splitLine: { show: false },
+          // y축(왼쪽) 선 하나를 표시한다.
+          axisLine: { show: true, lineStyle: { color: AXIS_LINE_COLOR } },
+          // 각 값(눈금)마다 tick 을 표시한다.
+          axisTick: { show: true, lineStyle: { color: AXIS_LINE_COLOR } },
+          axisLabel: { margin: 10, formatter: (value: number) => `${Math.round(value)}` },
+        },
+        tooltip: { trigger: 'axis', confine: true, formatter: tooltipFormatter },
+        series,
+      });
+    };
+
+    renderRef.current = render;
+    render();
+  }, [data, loading, clickedActiveThread, yMax, chartInstanceRef, chartRef, renderRef]);
+
+  return <div ref={chartRef} className="flex-1 min-w-[50%] min-h-0 overflow-hidden p-1.5" />;
 };


### PR DESCRIPTION
## Summary
- Migrate the realtime agent active-thread chart from Recharts to ECharts, keeping the props and `DefaultValue` export so `AgentActiveThreadView` needs no change.
- Stacked bars (slow..1s) with a white horizontal decal for the segmented volume-meter look; column-wide click toggles server selection with a full-height highlight bar and dimming of non-selected servers; reverse-order tooltip and one-line legend.
- Show a single x-axis (bottom) and y-axis (left) line plus per-value y-axis ticks for clearer reading.

## Test plan
- [ ] `yarn build` passes
- [ ] `yarn workspace @pinpoint-fe/ui jest AgentActiveChart` passes (16 tests)
- [ ] Realtime page: bars render, grow/update smoothly, and the x/y axis lines + y-axis ticks are visible
- [ ] Clicking a column toggles selection (highlight + dimming); tooltip shows reverse-order rows with `-` for uncollected
