### PR TITLE
[#noissue] Introduce SpanHeader enum for the trace qualifier type byte

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
@@ -60,18 +60,15 @@ public class SpanDecoderV0 implements SpanDecoder {
     public BasicSpan decode(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext) {
         final byte type = qualifier.readByte();
 
-        if (SpanEncoder.TYPE_SPAN == type) {
-            return readSpan(qualifier, columnValue, decodingContext, TraceSourceType.PINPOINT);
-        } else if (SpanEncoder.TYPE_OTEL_SPAN == type) {
-            return readSpan(qualifier, columnValue, decodingContext, TraceSourceType.OPENTELEMETRY);
-        } else if (SpanEncoder.TYPE_SPAN_CHUNK == type) {
-            return readSpanChunk(qualifier, columnValue, decodingContext, TraceSourceType.PINPOINT);
-        } else if (SpanEncoder.TYPE_OTEL_SPAN_CHUNK == type) {
-            return readSpanChunk(qualifier, columnValue, decodingContext, TraceSourceType.OPENTELEMETRY);
-        } else {
+        final SpanHeader header = SpanHeader.of(type);
+        if (header == null) {
             logger.warn("Unknown span type {}", type);
             return null;
         }
+        if (header.isSpanChunk()) {
+            return readSpanChunk(qualifier, columnValue, decodingContext, header.getTraceSourceType());
+        }
+        return readSpan(qualifier, columnValue, decodingContext, header.getTraceSourceType());
     }
 
     private SpanChunkBo readSpanChunk(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext,

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderV0.java
@@ -13,7 +13,6 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.SpanOwner;
-import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.SpanBitField;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.SpanEventBitField;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.SpanEventQualifierBitField;
@@ -42,9 +41,8 @@ public class SpanEncoderV0 implements SpanEncoder {
         final List<SpanEventBo> spanEventBoList = spanBo.getSpanEventBoList();
         final SpanEventBo firstEvent = getFirstSpanEvent(spanEventBoList);
 
-        final byte type = (spanBo.getTraceSourceType() == TraceSourceType.OPENTELEMETRY)
-                ? TYPE_OTEL_SPAN : TYPE_SPAN;
-        return encodeQualifier(type, spanBo, firstEvent, null);
+        final SpanHeader header = SpanHeader.span(spanBo.getTraceSourceType());
+        return encodeQualifier(header, spanBo, firstEvent, null);
     }
 
     @Override
@@ -55,15 +53,14 @@ public class SpanEncoderV0 implements SpanEncoder {
         final SpanEventBo firstEvent = getFirstSpanEvent(spanEventBoList);
 
         LocalAsyncIdBo localAsyncId = spanChunkBo.getLocalAsyncId();
-        final byte type = (spanChunkBo.getTraceSourceType() == TraceSourceType.OPENTELEMETRY)
-                ? TYPE_OTEL_SPAN_CHUNK : TYPE_SPAN_CHUNK;
-        return encodeQualifier(type, spanChunkBo, firstEvent, localAsyncId);
+        final SpanHeader header = SpanHeader.spanChunk(spanChunkBo.getTraceSourceType());
+        return encodeQualifier(header, spanChunkBo, firstEvent, localAsyncId);
     }
 
-    private ByteBuffer encodeQualifier(byte type, BasicSpan basicSpan, SpanEventBo firstEvent, LocalAsyncIdBo localAsyncId) {
+    private ByteBuffer encodeQualifier(SpanHeader header, BasicSpan basicSpan, SpanEventBo firstEvent, LocalAsyncIdBo localAsyncId) {
         final SpanOwner owner = basicSpan.getSpanOwner();
         final Buffer buffer = new AutomaticBuffer(128);
-        buffer.putByte(type);
+        buffer.putByte(header.getCode());
         buffer.putPrefixedString(owner.getApplicationName());
         buffer.putPrefixedString(owner.getAgentId());
         buffer.putVLong(owner.getAgentStartTime());

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeader.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeader.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
+
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
+
+/**
+ * First byte of the trace qualifier. The code doubles as both the span/chunk
+ * discriminator and the source-type discriminator (Pinpoint vs OTel) — this
+ * enum is the single owner of that mapping for the encoder, the decoder and
+ * the HBase qualifier filters.
+ */
+public enum SpanHeader {
+    SPAN(SpanEncoder.TYPE_SPAN, TraceSourceType.PINPOINT, false),
+    SPAN_CHUNK(SpanEncoder.TYPE_SPAN_CHUNK, TraceSourceType.PINPOINT, true),
+    OTEL_SPAN(SpanEncoder.TYPE_OTEL_SPAN, TraceSourceType.OPENTELEMETRY, false),
+    OTEL_SPAN_CHUNK(SpanEncoder.TYPE_OTEL_SPAN_CHUNK, TraceSourceType.OPENTELEMETRY, true);
+
+    private final byte code;
+    private final TraceSourceType traceSourceType;
+    private final boolean spanChunk;
+
+    SpanHeader(byte code, TraceSourceType traceSourceType, boolean spanChunk) {
+        this.code = code;
+        this.traceSourceType = traceSourceType;
+        this.spanChunk = spanChunk;
+    }
+
+    public byte getCode() {
+        return code;
+    }
+
+    public TraceSourceType getTraceSourceType() {
+        return traceSourceType;
+    }
+
+    public boolean isSpanChunk() {
+        return spanChunk;
+    }
+
+    public static SpanHeader span(TraceSourceType traceSourceType) {
+        if (traceSourceType == TraceSourceType.OPENTELEMETRY) {
+            return OTEL_SPAN;
+        }
+        return SPAN;
+    }
+
+    public static SpanHeader spanChunk(TraceSourceType traceSourceType) {
+        if (traceSourceType == TraceSourceType.OPENTELEMETRY) {
+            return OTEL_SPAN_CHUNK;
+        }
+        return SPAN_CHUNK;
+    }
+
+    /**
+     * Resolves the header for the qualifier's first byte; {@code null} for
+     * unknown or reserved codes ({@code TYPE_PASSIVE_SPAN}, {@code TYPE_INDEX})
+     * so decoders can skip them leniently.
+     */
+    public static SpanHeader of(byte code) {
+        return switch (code) {
+            case SpanEncoder.TYPE_SPAN -> SPAN;
+            case SpanEncoder.TYPE_SPAN_CHUNK -> SPAN_CHUNK;
+            case SpanEncoder.TYPE_OTEL_SPAN -> OTEL_SPAN;
+            case SpanEncoder.TYPE_OTEL_SPAN_CHUNK -> OTEL_SPAN_CHUNK;
+            default -> null;
+        };
+    }
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeaderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeaderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
+
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpanHeaderTest {
+
+    @Test
+    void of_roundTrip() {
+        // guards the of() switch against a missing case when a constant is added
+        for (SpanHeader header : SpanHeader.values()) {
+            assertThat(SpanHeader.of(header.getCode()))
+                    .as("of(%s.getCode())", header)
+                    .isSameAs(header);
+        }
+    }
+
+    @Test
+    void of_unknownCode() {
+        assertThat(SpanHeader.of(SpanEncoder.TYPE_PASSIVE_SPAN)).isNull();
+        assertThat(SpanHeader.of(SpanEncoder.TYPE_INDEX)).isNull();
+        assertThat(SpanHeader.of((byte) -1)).isNull();
+    }
+
+    @Test
+    void span_factory() {
+        assertThat(SpanHeader.span(TraceSourceType.PINPOINT)).isSameAs(SpanHeader.SPAN);
+        assertThat(SpanHeader.span(TraceSourceType.OPENTELEMETRY)).isSameAs(SpanHeader.OTEL_SPAN);
+        assertThat(SpanHeader.spanChunk(TraceSourceType.PINPOINT)).isSameAs(SpanHeader.SPAN_CHUNK);
+        assertThat(SpanHeader.spanChunk(TraceSourceType.OPENTELEMETRY)).isSameAs(SpanHeader.OTEL_SPAN_CHUNK);
+    }
+
+    @Test
+    void spanChunk_discriminator() {
+        assertThat(SpanHeader.SPAN.isSpanChunk()).isFalse();
+        assertThat(SpanHeader.OTEL_SPAN.isSpanChunk()).isFalse();
+        assertThat(SpanHeader.SPAN_CHUNK.isSpanChunk()).isTrue();
+        assertThat(SpanHeader.OTEL_SPAN_CHUNK.isSpanChunk()).isTrue();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/hbase/HbaseTraceDaoV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/hbase/HbaseTraceDaoV2.java
@@ -29,7 +29,7 @@ import com.navercorp.pinpoint.common.hbase.rowmapper.ResultSizeMapper;
 import com.navercorp.pinpoint.common.hbase.rowmapper.RowMapperResultAdaptor;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
-import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoder;
+import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanHeader;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.web.dao.hbase.HBaseUtils;
 import com.navercorp.pinpoint.web.service.FetchResult;
@@ -250,9 +250,9 @@ public class HbaseTraceDaoV2 implements TraceDao {
         // Keep span cells only (drop span-chunk cells). TYPE_SPAN marks Pinpoint-origin spans,
         // TYPE_OTEL_SPAN marks OpenTelemetry-origin spans — both are full Span rows.
         Filter pinpointSpan = new QualifierFilter(CompareOperator.EQUAL,
-                new BinaryPrefixComparator(new byte[]{SpanEncoder.TYPE_SPAN}));
+                new BinaryPrefixComparator(new byte[]{SpanHeader.SPAN.getCode()}));
         Filter otelSpan = new QualifierFilter(CompareOperator.EQUAL,
-                new BinaryPrefixComparator(new byte[]{SpanEncoder.TYPE_OTEL_SPAN}));
+                new BinaryPrefixComparator(new byte[]{SpanHeader.OTEL_SPAN.getCode()}));
         return new FilterList(FilterList.Operator.MUST_PASS_ONE, pinpointSpan, otelSpan);
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/FilteringSpanDecoder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/FilteringSpanDecoder.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.common.server.bo.BasicSpan;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecodingContext;
-import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoder;
+import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanHeader;
 
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -46,14 +46,17 @@ public class FilteringSpanDecoder implements SpanDecoder {
             return null;
         }
         final byte type = qualifier.getByte(0);
-        if (SpanEncoder.TYPE_SPAN == type || SpanEncoder.TYPE_OTEL_SPAN == type) {
-            BasicSpan spanBo = delegate.decode(qualifier, columnValue, decodingContext);
-            if (spanBo != null ) {
-                if (spanFilter.test((SpanBo) spanBo)) {
-                    return spanBo;
-                }
-            }
+        final SpanHeader header = SpanHeader.of(type);
+        if (header == null || header.isSpanChunk()) {
             return null;
+        }
+        // span
+        BasicSpan spanBo = delegate.decode(qualifier, columnValue, decodingContext);
+        if (spanBo == null) {
+            return null;
+        }
+        if (spanFilter.test((SpanBo) spanBo)) {
+            return spanBo;
         }
         return null;
     }


### PR DESCRIPTION
The qualifier's first byte doubles as the span/chunk and Pinpoint/OTel
discriminator, but the byte-to-meaning mapping was duplicated across the
encoder, the decoder, FilteringSpanDecoder and the HBase qualifier
filter. Centralize it in the SpanHeader enum so an upcoming optional
qualifier field (serviceUid) can extend the header in one place.
