### PR TITLE
[#13596] Add OTel Link jump to Transaction List

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
@@ -19,6 +19,9 @@ import {
   FaPuzzlePiece,
 } from 'react-icons/fa';
 import { LuChevronRight, LuChevronDown } from 'react-icons/lu';
+import { PiStackDuotone } from 'react-icons/pi';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { Button } from '../..';
 import {
   addCommas,
@@ -29,10 +32,15 @@ import {
   getTransactionDetailQueryString,
   getTransactionListPath,
 } from '@pinpoint-fe/ui/src/utils';
-import { useTimezone, useTransactionSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import {
+  getTransactionTraceMetadataQueryOptions,
+  useTimezone,
+  useTransactionSearchParameters,
+} from '@pinpoint-fe/ui/src/hooks';
 import { transactionInfoCallTreeFocusId } from '@pinpoint-fe/ui/src/atoms';
 import { useSetAtom } from 'jotai';
 import React from 'react';
+import { useReactToastifyToast } from '../../Toast';
 import {
   computeParallelGroups,
   getRowEndOffsetNanos,
@@ -516,17 +524,21 @@ const MethodCell = (props: {
         </Button>
       );
     } else if (text === 'Link') {
-      const linkPath = buildOtelLinkPath(rowData.arguments, application, {
-        pathname,
-        searchParameters,
-      });
-      if (linkPath) {
+      const otelLink = parseOtelLinkArguments(rowData.arguments);
+      if (otelLink) {
+        const linkPath = buildOtelLinkPath(otelLink, application, {
+          pathname,
+          searchParameters,
+        });
         return (
-          <Button asChild className="text-xs h-[1rem] gap-0.5 p-1">
-            <Link to={linkPath} onClick={() => setCallTreeFocusId('')}>
-              <FaLink /> {text}
-            </Link>
-          </Button>
+          <>
+            <Button asChild className="text-xs h-[1rem] gap-0.5 p-1">
+              <Link to={linkPath} onClick={() => setCallTreeFocusId('')}>
+                <FaLink /> {text}
+              </Link>
+            </Button>
+            <OtelLinkTransactionListButton traceId={otelLink.traceId} spanId={otelLink.spanId} />
+          </>
         );
       }
       Icon = <FaLink />;
@@ -595,45 +607,138 @@ export const getExecPercentage = (
   return (elapsed / totalExecuteTime) * 100;
 };
 
-const buildOtelLinkPath = (
-  argumentsJson: string,
-  application: Parameters<typeof getTransactionDetailPath>[0],
-  context: {
-    pathname: string;
-    searchParameters: Record<string, string>;
-  },
-): string | null => {
+type OtelLinkArguments = {
+  traceId: string;
+  spanId: string;
+  linkTraceId: string;
+  linkSpanId: string;
+  focusTimestamp: number;
+};
+
+const parseOtelLinkArguments = (argumentsJson: string): OtelLinkArguments | null => {
   if (!argumentsJson) return null;
   try {
     const parsed = JSON.parse(argumentsJson);
     const { traceId, spanId, linkTraceId, linkSpanId, focusTimestamp } = parsed ?? {};
     if (!traceId || spanId == null || !linkTraceId || linkSpanId == null) return null;
-
-    const transactionInfoParams = {
-      agentId: '',
-      spanId: String(spanId),
+    return {
       traceId: String(traceId),
-      focusTimestamp: typeof focusTimestamp === 'number' ? focusTimestamp : 0,
+      spanId: String(spanId),
       linkTraceId: String(linkTraceId),
       linkSpanId: String(linkSpanId),
+      focusTimestamp: typeof focusTimestamp === 'number' ? focusTimestamp : 0,
     };
-
-    // Stay on /transactionList when the user opened the link from the list page,
-    // so the upper transaction-list panel (heatmap drag results) is preserved.
-    const onTransactionListPage =
-      context.pathname === APP_PATH.TRANSACTION_LIST ||
-      context.pathname.startsWith(`${APP_PATH.TRANSACTION_LIST}/`);
-    if (onTransactionListPage) {
-      return `${getTransactionListPath(application)}?${convertParamsToQueryString({
-        ...context.searchParameters,
-        transactionInfo: JSON.stringify(transactionInfoParams),
-      })}`;
-    }
-
-    return `${getTransactionDetailPath(application)}?${getTransactionDetailQueryString(
-      transactionInfoParams,
-    )}`;
   } catch {
     return null;
   }
+};
+
+const buildOtelLinkPath = (
+  otelLink: OtelLinkArguments,
+  application: Parameters<typeof getTransactionDetailPath>[0],
+  context: {
+    pathname: string;
+    searchParameters: Record<string, string>;
+  },
+): string => {
+  const transactionInfoParams = {
+    agentId: '',
+    spanId: otelLink.spanId,
+    traceId: otelLink.traceId,
+    focusTimestamp: otelLink.focusTimestamp,
+    linkTraceId: otelLink.linkTraceId,
+    linkSpanId: otelLink.linkSpanId,
+  };
+
+  // Stay on /transactionList when the user opened the link from the list page,
+  // so the upper transaction-list panel (heatmap drag results) is preserved.
+  const onTransactionListPage =
+    context.pathname === APP_PATH.TRANSACTION_LIST ||
+    context.pathname.startsWith(`${APP_PATH.TRANSACTION_LIST}/`);
+  if (onTransactionListPage) {
+    return `${getTransactionListPath(application)}?${convertParamsToQueryString({
+      ...context.searchParameters,
+      transactionInfo: JSON.stringify(transactionInfoParams),
+    })}`;
+  }
+
+  return `${getTransactionDetailPath(application)}?${getTransactionDetailQueryString(
+    transactionInfoParams,
+  )}`;
+};
+
+/**
+ * Opens the OTel Link target transaction standalone in the Transaction List screen
+ * (?traceInfo mode) in a new tab. Unlike the merged-view Link button, the target
+ * application/time are unknown until the traceId is resolved, so this fetches
+ * /api/transaction/metadata first and builds the application-scoped URL from the result.
+ */
+const OtelLinkTransactionListButton = ({
+  traceId,
+  spanId,
+}: {
+  traceId: string;
+  spanId: string;
+}) => {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const toast = useReactToastifyToast();
+  const [timezone] = useTimezone();
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    // fetch errors already surface via the global query error toast
+    const data = await queryClient
+      .fetchQuery(getTransactionTraceMetadataQueryOptions(traceId))
+      .catch(() => null);
+    if (data === null) {
+      return;
+    }
+    const rows = data?.metadata ?? [];
+
+    // A trace may contain multiple spans (multi-application); prefer the span the
+    // link points to, falling back to the first row (e.g. link target is a sub-span).
+    const preferred = rows.find((row) => String(row.spanId) === spanId) || rows[0];
+    if (!preferred?.applicationName || !preferred?.serviceType) {
+      toast.warn(t('TRANSACTION_LIST.LINKED_TRANSACTION_NOT_FOUND'));
+      return;
+    }
+
+    const baseTime = preferred.collectorAcceptTime;
+    const from = formatInTimeZone(baseTime - 150000, timezone, SEARCH_PARAMETER_DATE_FORMAT);
+    const to = formatInTimeZone(baseTime + 150000, timezone, SEARCH_PARAMETER_DATE_FORMAT);
+    const url = `${BASE_PATH}${getTransactionListPath({
+      applicationName: preferred.applicationName,
+      serviceType: preferred.serviceType,
+    })}?${convertParamsToQueryString({
+      from,
+      to,
+      traceInfo: traceId,
+      transactionInfo: JSON.stringify({
+        agentId: preferred.agentId,
+        spanId: preferred.spanId,
+        traceId: preferred.traceId,
+        focusTimestamp: preferred.collectorAcceptTime,
+        path: preferred.application,
+      }),
+    })}`;
+    // noopener/noreferrer prevents the opened tab from reaching back through
+    // window.opener (reverse tab-nabbing). With noopener, open() returns null;
+    // defensively null the opener too in case a browser ignores the feature.
+    const opened = window.open(url, '_blank', 'noopener,noreferrer');
+    if (opened) {
+      opened.opener = null;
+    }
+  };
+
+  return (
+    <Button
+      className="flex-none text-xs h-[1rem] gap-0.5 p-1 ml-1"
+      title={t('TRANSACTION_LIST.OPEN_IN_TRANSACTION_LIST')}
+      aria-label={t('TRANSACTION_LIST.OPEN_IN_TRANSACTION_LIST')}
+      onClick={handleClick}
+    >
+      <PiStackDuotone /> {t('TRANSACTION_LIST.JUMP')}
+    </Button>
+  );
 };

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListByTrace.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListByTrace.tsx
@@ -1,0 +1,50 @@
+import { useNavigate } from 'react-router-dom';
+import { useSetAtom } from 'jotai';
+import { TransactionListTable, TransactionListTableProps } from './TransactionListTable';
+import {
+  useGetTransactionTraceMetadata,
+  useTransactionSearchParameters,
+} from '@pinpoint-fe/ui/src/hooks';
+import { convertParamsToQueryString, getTransactionListPath } from '@pinpoint-fe/ui/src/utils';
+import { transactionInfoCallTreeFocusId } from '@pinpoint-fe/ui/src/atoms';
+
+export interface TransactionListByTraceProps extends TransactionListTableProps {}
+
+/**
+ * List panel source for traceId-lookup mode (?traceInfo=...), entered by following
+ * an OTel Link from the Call Tree. Rows come from a /api/transaction/metadata lookup
+ * instead of heatmap drag / filter map, so row clicks must preserve traceInfo
+ * (the default TransactionListTable handler only carries dragInfo).
+ */
+export const TransactionListByTrace = (props: TransactionListByTraceProps) => {
+  const navigate = useNavigate();
+  const { application, searchParameters, traceInfo } = useTransactionSearchParameters();
+  const setCallTreeFocusId = useSetAtom(transactionInfoCallTreeFocusId);
+  const { data } = useGetTransactionTraceMetadata({ traceId: traceInfo });
+
+  return (
+    <TransactionListTable
+      data={data?.metadata}
+      onClickRow={(row) => {
+        setCallTreeFocusId('');
+
+        const rowData = row.original;
+        navigate(
+          `${getTransactionListPath(application)}?${convertParamsToQueryString({
+            from: searchParameters.from,
+            to: searchParameters.to,
+            traceInfo,
+            transactionInfo: JSON.stringify({
+              agentId: rowData.agentId,
+              spanId: rowData.spanId,
+              traceId: rowData.traceId,
+              focusTimestamp: rowData.collectorAcceptTime,
+              path: rowData.application,
+            }),
+          })}`,
+        );
+      }}
+      {...props}
+    />
+  );
+};

--- a/web-frontend/src/main/v3/packages/ui/src/constants/EndPoints.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/EndPoints.ts
@@ -36,6 +36,7 @@ export const FILTERED_SERVER_MAP_DATA = `${LOCAL_API_PATH}/servermap/filterServe
 // export const = '/getAgentEvents';
 // export const = '/getAgentInfo';
 export const TRANSACTION_META_DATA = `${LOCAL_API_PATH}/transactionmetadata`;
+export const TRANSACTION_TRACE_METADATA = `${LOCAL_API_PATH}/transaction/metadata`;
 export const TRANSACTION_INFO = `${LOCAL_API_PATH}/transaction/trace`;
 export const TRANSACTION_INFO_LINK = `${LOCAL_API_PATH}/transaction/trace/link`;
 export const TRANSACTION_TRACE_SERVER_MAP = `${LOCAL_API_PATH}/transaction/traceServerMap`;

--- a/web-frontend/src/main/v3/packages/ui/src/constants/locales/en.json
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/locales/en.json
@@ -80,6 +80,9 @@
   },
   "TRANSACTION_LIST": {
     "CALL_TREE_TIMELINE": "Timeline",
+    "JUMP": "Jump",
+    "LINKED_TRANSACTION_NOT_FOUND": "Linked transaction not found.",
+    "OPEN_IN_TRANSACTION_LIST": "Open in Transaction List",
     "SELECT_TRANSACTION": "Select your transaction",
     "TRANSACTION_RETRIEVE_ERROR": "Transaction information is missing.",
     "TRANSACTION_RETRIEVE_ERROR_DESC": "Please start it over from the Servermap/Filtered page.  (If you close this dialog, you will be redirected to the Servermap page.)",

--- a/web-frontend/src/main/v3/packages/ui/src/constants/locales/ko.json
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/locales/ko.json
@@ -80,6 +80,9 @@
   },
   "TRANSACTION_LIST": {
     "CALL_TREE_TIMELINE": "타임라인",
+    "JUMP": "Jump",
+    "LINKED_TRANSACTION_NOT_FOUND": "링크된 Transaction을 찾을 수 없습니다.",
+    "OPEN_IN_TRANSACTION_LIST": "Transaction 목록에서 열기",
     "SELECT_TRANSACTION": "Transaction을 선택하세요.",
     "TRANSACTION_RETRIEVE_ERROR": "Transaction 정보가 없습니다.",
     "TRANSACTION_RETRIEVE_ERROR_DESC": "Servermap/Filtered 페이지에서 다시 시도해 주세요. (이 창을 닫으면 Servermap 페이지로 이동합니다)",

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/Transaction.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/Transaction.ts
@@ -10,4 +10,8 @@ export type Transaction = {
   remoteAddr: string;
   startTime: number;
   traceId: string;
+  // present on /api/transaction/metadata and /api/transactionmetadata responses;
+  // absent on /api/heatmap/drag rows
+  applicationName?: string;
+  serviceType?: string;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/TransactionTraceMetadata.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/TransactionTraceMetadata.ts
@@ -1,0 +1,13 @@
+import { Transaction } from './Transaction';
+
+export namespace TransactionTraceMetadata {
+  export interface Parameters {
+    traceId: string;
+  }
+
+  export interface Response {
+    metadata: Transaction[];
+    complete: boolean;
+    resultFrom: number;
+  }
+}

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/index.ts
@@ -50,6 +50,7 @@ export * from './Transaction';
 export * from './TransactionInfo';
 export * from './TransactionTraceServerMap';
 export * from './TransactionMetaData';
+export * from './TransactionTraceMetadata';
 export * from './UrlStatChart';
 export * from './UrlStatSummary';
 export * from './UserGroup';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/index.ts
@@ -50,6 +50,7 @@ export * from './useGetSystemMetricMetricInfoData';
 export * from './useGetSystemMetricTagsData';
 export * from './useGetTraceViewerData';
 export * from './useGetTransactionInfo';
+export * from './useGetTransactionTraceMetadata';
 export * from './useGetTransactionTraceServerMap';
 export * from './useGetUrlStatChartData';
 export * from './useGetUrlStatSummaryData';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetTransactionTraceMetadata.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetTransactionTraceMetadata.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
+
+// reactQueryHelper transitively imports the ECharts (ESM) stack via ErrorToast,
+// which babel-jest does not transform. Mock queryFn with an equivalent fetch impl.
+jest.mock('./reactQueryHelper', () => ({
+  queryFn: (url: string) => async () => {
+    const response = await fetch(url);
+    return response.json();
+  },
+}));
+
+import {
+  getTransactionTraceMetadataQueryOptions,
+  useGetTransactionTraceMetadata,
+} from './useGetTransactionTraceMetadata';
+
+const createWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};
+
+describe('useGetTransactionTraceMetadata', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('should fetch metadata by traceId when traceId is provided', async () => {
+    const response = {
+      metadata: [{ traceId: 't1', applicationName: 'app', serviceType: 'OPENTELEMETRY_SERVER' }],
+      complete: true,
+      resultFrom: 0,
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => response,
+    });
+
+    const { result } = renderHook(() => useGetTransactionTraceMetadata({ traceId: 't1' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(response);
+    const [url] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe(`${END_POINTS.TRANSACTION_TRACE_METADATA}?traceId=t1`);
+  });
+
+  test('should not fetch when traceId is missing', () => {
+    const { result } = renderHook(() => useGetTransactionTraceMetadata({}), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('should share the query key between the hook and click-time fetchQuery callers', () => {
+    const options = getTransactionTraceMetadataQueryOptions('t1');
+    expect(options.queryKey).toEqual([
+      END_POINTS.TRANSACTION_TRACE_METADATA,
+      '?traceId=t1',
+    ]);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetTransactionTraceMetadata.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetTransactionTraceMetadata.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { END_POINTS, TransactionTraceMetadata } from '@pinpoint-fe/ui/src/constants';
+import { convertParamsToQueryString } from '@pinpoint-fe/ui/src/utils';
+import { queryFn } from './reactQueryHelper';
+
+// Shared by the hook below and click-time queryClient.fetchQuery callers
+// (e.g. the OTel Link jump) so both hit the same cache entry.
+export const getTransactionTraceMetadataQueryOptions = (traceId?: string) => {
+  const queryString = traceId ? `?${convertParamsToQueryString({ traceId })}` : '';
+  return {
+    queryKey: [END_POINTS.TRANSACTION_TRACE_METADATA, queryString] as const,
+    queryFn: queryFn(
+      `${END_POINTS.TRANSACTION_TRACE_METADATA}${queryString}`,
+    ) as () => Promise<TransactionTraceMetadata.Response>,
+  };
+};
+
+export const useGetTransactionTraceMetadata = (
+  params: Partial<TransactionTraceMetadata.Parameters>,
+) => {
+  return useQuery<TransactionTraceMetadata.Response>({
+    ...getTransactionTraceMetadataQueryOptions(params.traceId),
+    enabled: !!params.traceId,
+    gcTime: 30000,
+  });
+};

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useTransactionSearchParameters.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useTransactionSearchParameters.ts
@@ -23,11 +23,15 @@ export const useTransactionSearchParameters = () => {
       return null;
     }
   })();
+  // plain traceId string; when present the list panel is populated by a
+  // /api/transaction/metadata lookup instead of heatmap drag / filter map
+  const traceInfo = props.searchParameters?.traceInfo;
   return {
     ...props,
     dateRange,
     withFilter,
     dragInfo: parseDragInfo,
     transactionInfo: parsedTransactionInfo,
+    traceInfo,
   };
 };

--- a/web-frontend/src/main/v3/packages/ui/src/pages/TransactionList.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/TransactionList.tsx
@@ -9,13 +9,14 @@ import { APP_SETTING_KEYS } from '@pinpoint-fe/ui/src/constants';
 import { PiStackDuotone } from 'react-icons/pi';
 import { TransactionListProgressBar } from '../components/Transaction/transaction-list/TransactionListProgressBar';
 import { TransactionListByFilterMap } from '../components/Transaction/transaction-list/TransactionListByFilterMap';
+import { TransactionListByTrace } from '../components/Transaction/transaction-list/TransactionListByTrace';
 
 export interface TransactionListPageProps {
   transactionInfoProps?: TransactionInfoProps;
 }
 
 export const TransactionListPage = ({ transactionInfoProps }: TransactionListPageProps) => {
-  const { application, withFilter } = useTransactionSearchParameters();
+  const { application, withFilter, traceInfo } = useTransactionSearchParameters();
   const [nextX2, setNextX2] = React.useState<number>();
   const [nextDataIndex, setNextDataIndex] = React.useState<number>(99);
   const transactionListData = useAtomValue(transactionListDatasAtom);
@@ -41,8 +42,22 @@ export const TransactionListPage = ({ transactionInfoProps }: TransactionListPag
         }
       >
         <ApplicationCombinedList selectedApplication={application} disabled />
+        {!traceInfo && (
+          <TransactionListProgressBar
+            className="hidden ml-10 xl:flex"
+            onClickResume={() => {
+              handleClickResume();
+            }}
+          >
+            {({ isComplete, completeRenderer, resumeRenderer }) =>
+              isComplete ? completeRenderer : resumeRenderer
+            }
+          </TransactionListProgressBar>
+        )}
+      </MainHeader>
+      {!traceInfo && (
         <TransactionListProgressBar
-          className="hidden ml-10 xl:flex"
+          className="flex mx-2 xl:hidden"
           onClickResume={() => {
             handleClickResume();
           }}
@@ -51,24 +66,16 @@ export const TransactionListPage = ({ transactionInfoProps }: TransactionListPag
             isComplete ? completeRenderer : resumeRenderer
           }
         </TransactionListProgressBar>
-      </MainHeader>
-      <TransactionListProgressBar
-        className="flex mx-2 xl:hidden"
-        onClickResume={() => {
-          handleClickResume();
-        }}
-      >
-        {({ isComplete, completeRenderer, resumeRenderer }) =>
-          isComplete ? completeRenderer : resumeRenderer
-        }
-      </TransactionListProgressBar>
+      )}
       <Separator />
       <ResizablePanelGroup
         direction="vertical"
         autoSaveId={APP_SETTING_KEYS.TRANSACTION_LIST_RESIZABLE}
       >
         <ResizablePanel minSize={10} maxSize={90}>
-          {withFilter ? (
+          {traceInfo ? (
+            <TransactionListByTrace />
+          ) : withFilter ? (
             <TransactionListByFilterMap nextDataIndex={nextDataIndex} />
           ) : (
             <TransactionList params={{ x2: nextX2 }} />

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ScatterChartController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ScatterChartController.java
@@ -93,7 +93,7 @@ public class ScatterChartController implements AccessDeniedExceptionHandler {
         }
 
         final List<SpanBo> metadata = scatterChartService.selectTransactionMetadata(selectTraceInfoList);
-        return new TransactionMetaDataViewModel(metadata);
+        return new TransactionMetaDataViewModel(metadata, this::findServiceTypeName);
     }
 
     /**
@@ -162,5 +162,13 @@ public class ScatterChartController implements AccessDeniedExceptionHandler {
             }
         }
         throw new IllegalArgumentException("application serviceType not found. code:" + serviceTypeCode + ", name:" + serviceTypeName);
+    }
+
+    private String findServiceTypeName(int serviceTypeCode) {
+        final ServiceType serviceType = serviceTypeRegistryService.findServiceType(serviceTypeCode);
+        if (serviceType == null) {
+            return null;
+        }
+        return serviceType.getName();
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/controller/TransactionController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/controller/TransactionController.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanId;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMap;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMapView;
 import com.navercorp.pinpoint.web.applicationmap.MapView;
@@ -30,6 +31,7 @@ import com.navercorp.pinpoint.web.applicationmap.service.FilteredMapServiceOptio
 import com.navercorp.pinpoint.web.applicationmap.view.LinkRender;
 import com.navercorp.pinpoint.web.applicationmap.view.NodeRender;
 import com.navercorp.pinpoint.web.applicationmap.view.TimeHistogramView;
+import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
 import com.navercorp.pinpoint.web.service.ScatterChartService;
 import com.navercorp.pinpoint.web.trace.callstacks.RecordSet;
@@ -83,6 +85,7 @@ public class TransactionController {
     private final HyperLinkFactory hyperLinkFactory;
     private final LogLinkBuilder logLinkBuilder;
     private final ScatterChartService scatterChartService;
+    private final ServiceTypeRegistryService serviceTypeRegistryService;
 
     @Value("${web.callstack.selectSpans.limit:-1}")
     private int callstackSelectSpansLimit;
@@ -94,7 +97,8 @@ public class TransactionController {
                                  FilteredMapService filteredMapService,
                                  HyperLinkFactory hyperLinkFactory,
                                  LogLinkBuilder logLinkBuilder,
-                                 ScatterChartService scatterChartService) {
+                                 ScatterChartService scatterChartService,
+                                 ServiceTypeRegistryService serviceTypeRegistryService) {
         this.mapProperties = Objects.requireNonNull(mapProperties, "mapProperties");
         this.spanService = Objects.requireNonNull(spanService, "spanService");
         this.transactionInfoService = Objects.requireNonNull(transactionInfoService, "transactionInfoService");
@@ -102,6 +106,7 @@ public class TransactionController {
         this.hyperLinkFactory = Objects.requireNonNull(hyperLinkFactory, "hyperLinkFactory");
         this.logLinkBuilder = Objects.requireNonNull(logLinkBuilder, "logLinkBuilder");
         this.scatterChartService = Objects.requireNonNull(scatterChartService, "scatterChartService");
+        this.serviceTypeRegistryService = Objects.requireNonNull(serviceTypeRegistryService, "serviceTypeRegistryService");
     }
 
     @GetMapping(value = "/trace")
@@ -320,7 +325,7 @@ public class TransactionController {
             spans = filterSpanId(spans, spanId);
         }
 
-        final TransactionMetaDataViewModel viewModel = new TransactionMetaDataViewModel(spans);
+        final TransactionMetaDataViewModel viewModel = new TransactionMetaDataViewModel(spans, this::findServiceTypeName);
         return new MetadataView(viewModel.getMetadata());
     }
 
@@ -338,6 +343,14 @@ public class TransactionController {
         public MetadataView(List<? extends DotMetaDataView> metadata) {
             this(metadata, true, 0);
         }
+    }
+
+    private String findServiceTypeName(int serviceTypeCode) {
+        final ServiceType serviceType = serviceTypeRegistryService.findServiceType(serviceTypeCode);
+        if (serviceType == null) {
+            return null;
+        }
+        return serviceType.getName();
     }
 
     private static long focusSpanId(long spanId, String linkTraceId, long linkSpanId) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/view/transactionlist/TransactionMetaDataViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/view/transactionlist/TransactionMetaDataViewModel.java
@@ -22,31 +22,49 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.IntFunction;
 
 /**
  * @author jaehong.kim
  */
 public class TransactionMetaDataViewModel {
     private final List<SpanBo> spanBoList;
+    private final IntFunction<String> serviceTypeNameResolver;
 
     public TransactionMetaDataViewModel() {
-        this(Collections.emptyList());
+        this(Collections.emptyList(), code -> null);
     }
 
-    public TransactionMetaDataViewModel(List<SpanBo> spanBoList) {
+    public TransactionMetaDataViewModel(List<SpanBo> spanBoList, IntFunction<String> serviceTypeNameResolver) {
         this.spanBoList = Objects.requireNonNull(spanBoList, "spanBoList");
+        this.serviceTypeNameResolver = Objects.requireNonNull(serviceTypeNameResolver, "serviceTypeNameResolver");
     }
 
     @JsonProperty("metadata")
     public List<MetaData> getMetadata() {
-        return Lists.transform(spanBoList, MetaData::new);
+        return Lists.transform(spanBoList, span -> new MetaData(span, serviceTypeNameResolver));
     }
 
     public static class MetaData implements DotMetaDataView {
         private final SpanBo span;
+        private final IntFunction<String> serviceTypeNameResolver;
 
-        public MetaData(SpanBo span) {
+        public MetaData(SpanBo span, IntFunction<String> serviceTypeNameResolver) {
             this.span = span;
+            this.serviceTypeNameResolver = serviceTypeNameResolver;
+        }
+
+        // applicationName/serviceType identify the application the span belongs to so a
+        // consumer can build application-scoped routes (e.g. /transactionList/{name}@{type})
+        // from a bare traceId lookup. The "application" field stays rpc for compatibility.
+        @JsonProperty("applicationName")
+        public String getApplicationName() {
+            return span.getApplicationName();
+        }
+
+        @JsonProperty("serviceType")
+        public String getServiceTypeName() {
+            return serviceTypeNameResolver.apply(span.getApplicationServiceType());
         }
 
         @Override

--- a/web/src/test/java/com/navercorp/pinpoint/web/view/transactionlist/TransactionMetaDataViewModelTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/view/transactionlist/TransactionMetaDataViewModelTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.view.transactionlist;
+
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TransactionMetaDataViewModelTest {
+
+    @Test
+    public void applicationNameAndServiceTypeName() {
+        SpanOwner owner = new SpanOwner();
+        owner.setApplicationName("test-app");
+        SpanBo span = new SpanBo(TraceSourceType.OPENTELEMETRY, owner);
+        span.setApplicationServiceType(ServiceType.OPENTELEMETRY_SERVER.getCode());
+        span.setRpc("/order/submit");
+
+        TransactionMetaDataViewModel viewModel = new TransactionMetaDataViewModel(List.of(span),
+                code -> code == ServiceType.OPENTELEMETRY_SERVER.getCode() ? ServiceType.OPENTELEMETRY_SERVER.getName() : null);
+
+        List<TransactionMetaDataViewModel.MetaData> metadata = viewModel.getMetadata();
+        assertThat(metadata).hasSize(1);
+        TransactionMetaDataViewModel.MetaData metaData = metadata.get(0);
+        assertThat(metaData.getApplicationName()).isEqualTo("test-app");
+        assertThat(metaData.getServiceTypeName()).isEqualTo(ServiceType.OPENTELEMETRY_SERVER.getName());
+        // "application" stays rpc for compatibility with existing consumers
+        assertThat(metaData.getApplication()).isEqualTo("/order/submit");
+    }
+
+    @Test
+    public void unknownServiceTypeCodeResolvesToNull() {
+        SpanOwner owner = new SpanOwner();
+        owner.setApplicationName("test-app");
+        SpanBo span = new SpanBo(TraceSourceType.OPENTELEMETRY, owner);
+        span.setApplicationServiceType(-1);
+
+        TransactionMetaDataViewModel viewModel = new TransactionMetaDataViewModel(List.of(span), code -> null);
+
+        assertThat(viewModel.getMetadata().get(0).getServiceTypeName()).isNull();
+    }
+
+    @Test
+    public void emptyViewModel() {
+        TransactionMetaDataViewModel viewModel = new TransactionMetaDataViewModel();
+        assertThat(viewModel.getMetadata()).isEmpty();
+    }
+}


### PR DESCRIPTION
Following an OTel Link previously offered only the merged call-tree view, which requires both traces to be present and a resolvable graft point. Add a second action on the Call Tree Link row that opens the link target transaction standalone in the Transaction List screen.

The Link annotation only carries the target traceId/spanId, so the jump resolves the target application, serviceType and accept time through GET /api/transaction/metadata first, then opens the application-scoped Transaction List URL (new ?traceInfo mode) in a new tab. The trace-lookup mode populates the upper list panel from the same metadata query and preserves traceInfo across row clicks; the detail pane reuses the existing /api/transaction/trace flow.

The metadata responses (GET /transaction/metadata and POST /transactionmetadata, which share TransactionMetaDataViewModel) now expose applicationName and the resolved serviceType name so consumers can build application-scoped routes from a bare traceId lookup; the existing "application" field stays rpc for compatibility.