### PR TITLE
[#noissue] Send selected service in servicemap keepServiceNames param

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
@@ -5,6 +5,7 @@ import {
   serverMapDataAtom,
   currentServerAtom,
   serverMapCurrentTargetAtom,
+  selectedServiceAtom,
 } from '@pinpoint-fe/ui/src/atoms';
 import { EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
 import {
@@ -22,22 +23,32 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { ServerMapCore, ServerMapCoreProps } from '../ServerMap/ServerMapCore';
 
-export interface ServiceMapFetcherProps
-  extends Pick<ServerMapCoreProps, 'onClickMenuItem' | 'onApplyChangedOption' | 'queryOption'> {
+export interface ServiceMapFetcherProps extends Pick<
+  ServerMapCoreProps,
+  'onClickMenuItem' | 'onApplyChangedOption' | 'queryOption'
+> {
   shouldPoll?: boolean;
 }
 
-export const ServiceMapFetcher = ({ shouldPoll: _shouldPoll, ...props }: ServiceMapFetcherProps) => {
+export const ServiceMapFetcher = ({
+  shouldPoll: _shouldPoll,
+  ...props
+}: ServiceMapFetcherProps) => {
   const setDataAtom = useSetAtom(serverMapDataAtom);
   const setCurrentServer = useSetAtom(currentServerAtom);
   const setServerMapCurrentTarget = useSetAtom(serverMapCurrentTargetAtom);
   const serverMapCurrentTarget = useAtomValue(serverMapCurrentTargetAtom);
+  const selectedService = useAtomValue(selectedServiceAtom);
   const { application, dateRange, queryOption } = useServerMapSearchParameters();
   const experimentalOption = useExperimentals();
   const useStatisticsAgentState =
     experimentalOption[EXPERIMENTAL_CONFIG_KEYS.USE_STATISTICS_AGENT_STATE].value || true;
 
-  const { data: rawData, isLoading, error } = useGetServiceMap({
+  const {
+    data: rawData,
+    isLoading,
+    error,
+  } = useGetServiceMap({
     applicationName: application?.applicationName ?? '',
     serviceTypeName: application?.serviceType,
     from: toBasicISOString(dateRange.from),
@@ -47,6 +58,7 @@ export const ServiceMapFetcher = ({ shouldPoll: _shouldPoll, ...props }: Service
     bidirectional: !!queryOption.bidirectional,
     wasOnly: !!queryOption.wasOnly,
     useStatisticsAgentState,
+    keepServiceNames: [selectedService],
   });
 
   const data = React.useMemo(() => flattenServiceMapResponse(rawData), [rawData]);

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
@@ -58,7 +58,9 @@ export const ServiceMapFetcher = ({
     bidirectional: !!queryOption.bidirectional,
     wasOnly: !!queryOption.wasOnly,
     useStatisticsAgentState,
-    keepServiceNames: [selectedService],
+    // selectedService는 localStorage 기반이라 빈 값일 수 있다. 빈 값이면
+    // 넘기지 않고 useGetServiceMap이 'DEFAULT'로 폴백하도록 둔다.
+    keepServiceNames: selectedService ? [selectedService] : undefined,
   });
 
   const data = React.useMemo(() => flattenServiceMapResponse(rawData), [rawData]);


### PR DESCRIPTION
## Summary
- The servicemap API (`/api/servermap/serviceMap`) was always called with `keepServiceNames=DEFAULT`.
- `ServiceMapFetcher` now reads the currently selected service from `selectedServiceAtom` and passes it as `keepServiceNames`, so the request keeps the service the user is actually viewing.
- When no service is selected the atom defaults to `DEFAULT`, so the existing behavior is preserved.

## Test plan
- [ ] `yarn build` passes
- [ ] `yarn test` passes (660 tests)
- [ ] With a service selected, `/api/servermap/serviceMap` request includes `keepServiceNames=<serviceName>`
- [ ] With no service selected, request still sends `keepServiceNames=DEFAULT`