### PR TITLE
[#noissue] Show OTel instrumentation scope in the Call Tree Class column

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/CallTree.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/CallTree.tsx
@@ -68,9 +68,8 @@ export const CallTree = ({ data, mapData, metaData }: CallTreeProps) => {
     bindedSql?: string;
     bindValue?: string;
   }>();
-  const [detailType, setDetailType] = React.useState<'sql' | 'attribute' | 'scope'>('sql');
+  const [detailType, setDetailType] = React.useState<'sql' | 'attribute'>('sql');
   const [jsonDetail, setJsonDetail] = React.useState<string>('');
-  const [scopeDetail, setScopeDetail] = React.useState<string>('');
   const { mutate } = usePostBind({
     onSuccess: (result) => {
       setSqlDetail((prev) => {
@@ -79,16 +78,7 @@ export const CallTree = ({ data, mapData, metaData }: CallTreeProps) => {
     },
   });
   const onClickDetailView = React.useCallback(
-    (callStackData: TransactionInfo.CallStackKeyValueMap, type?: 'scope') => {
-      // The Scope icon passes an explicit type: a row can carry both attributes and scope,
-      // so the scope click must not fall into the attribute branch below.
-      if (type === 'scope' && callStackData.scope) {
-        setScopeDetail(callStackData.scope);
-        setDetailType('scope');
-        setSheetOpen(true);
-        return;
-      }
-
+    (callStackData: TransactionInfo.CallStackKeyValueMap) => {
       if (callStackData.attributes) {
         setJsonDetail(prettyJson(callStackData.attributes));
         setDetailType('attribute');
@@ -302,11 +292,7 @@ export const CallTree = ({ data, mapData, metaData }: CallTreeProps) => {
         >
           <SheetHeader className="px-5 pb-4">
             <SheetTitle className="flex items-center">
-              {detailType === 'scope'
-                ? t('TRANSACTION_LIST.SCOPE_DETAIL')
-                : detailType === 'attribute'
-                  ? 'Attribute Detail'
-                  : 'SQL Detail'}
+              {detailType === 'attribute' ? 'Attribute Detail' : 'SQL Detail'}
               <Button
                 variant="outline"
                 size="icon"
@@ -319,9 +305,7 @@ export const CallTree = ({ data, mapData, metaData }: CallTreeProps) => {
           </SheetHeader>
           <Separator className="" />
           <div className="p-4 space-y-4 overflow-auto">
-            {detailType === 'scope' ? (
-              <ScopeDetail value={scopeDetail} />
-            ) : detailType === 'attribute' ? (
+            {detailType === 'attribute' ? (
               <div className="relative space-y-2">
                 <CollapsibleCodeViewer
                   title="Attribute"
@@ -370,38 +354,6 @@ export const CallTree = ({ data, mapData, metaData }: CallTreeProps) => {
           <HighLightCode className="p-2 text-xs min-h-20" code={content} />
         </DialogContent>
       </Dialog>
-    </div>
-  );
-};
-
-// OTel instrumentation-scope identity, serialized by the collector as "name@version"
-// (bare "name" when the SDK omitted the version). Split on the LAST '@' — scope names
-// may themselves contain '@' but versions never do.
-const parseScope = (value: string) => {
-  const at = value.lastIndexOf('@');
-  if (at <= 0) {
-    return { name: value, version: undefined };
-  }
-  return { name: value.slice(0, at), version: value.slice(at + 1) };
-};
-
-const ScopeDetail = ({ value }: { value: string }) => {
-  const { t } = useTranslation();
-  const { name, version } = parseScope(value);
-  return (
-    <div className="grid grid-cols-[6rem_1fr] gap-y-2 text-sm">
-      <span className="font-semibold text-muted-foreground">
-        {t('TRANSACTION_LIST.SCOPE_NAME')}
-      </span>
-      <span className="break-all">{name}</span>
-      {version && (
-        <>
-          <span className="font-semibold text-muted-foreground">
-            {t('TRANSACTION_LIST.SCOPE_VERSION')}
-          </span>
-          <span className="break-all">{version}</span>
-        </>
-      )}
     </div>
   );
 };

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
@@ -16,7 +16,6 @@ import {
   FaExclamationTriangle,
   FaLink,
   FaListUl,
-  FaPuzzlePiece,
 } from 'react-icons/fa';
 import { LuChevronRight, LuChevronDown } from 'react-icons/lu';
 import { PiStackDuotone } from 'react-icons/pi';
@@ -52,9 +51,8 @@ import {
 
 export interface CallTreeTableColumnsProps {
   metaData: TransactionInfo.Response;
-  // detailType distinguishes icons on the same row: the Scope icon passes 'scope';
-  // the Attribute/SQL icons omit it (the handler infers the type from the row data).
-  onClickDetailView?: (data: TransactionInfo.CallStackKeyValueMap, detailType?: 'scope') => void;
+  // The Attribute/SQL icons trigger the detail view; the handler infers the type from the row data.
+  onClickDetailView?: (data: TransactionInfo.CallStackKeyValueMap) => void;
   mapData?: TransactionInfo.CallStackKeyValueMap[];
 }
 
@@ -332,7 +330,16 @@ export const callTreeTableColumns = ({
     accessorKey: 'simpleClassName',
     header: 'Class',
     cell: (props) => {
-      return props.getValue();
+      const rowData = props.row.original;
+      // OTel spans carry no Java class (simpleClassName empty); surface the OTel
+      // instrumentation scope ("name@version") here instead — the analogous "origin
+      // component" identity. Full value shown on hover since it can exceed the column.
+      const value = rowData.scope || (props.getValue() as string);
+      return (
+        <span className="truncate" title={value}>
+          {value}
+        </span>
+      );
     },
     meta: {
       // cellClassName: 'max-w-[30px]',
@@ -573,19 +580,6 @@ const MethodCell = (props: {
           }}
         >
           <FaListUl />
-        </Button>
-      )}
-      {rowData.scope && (
-        <Button
-          className="flex-none w-4 h-4 p-0 ml-1.5 text-xs bg-indigo-500 text-white hover:bg-indigo-600"
-          title="Scope"
-          aria-label="Scope"
-          onClick={(e) => {
-            e.stopPropagation();
-            onClickDetailView?.(rowData, 'scope');
-          }}
-        >
-          <FaPuzzlePiece />
         </Button>
       )}
     </>

--- a/web-frontend/src/main/v3/packages/ui/src/constants/locales/en.json
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/locales/en.json
@@ -87,10 +87,7 @@
     "TRANSACTION_RETRIEVE_ERROR": "Transaction information is missing.",
     "TRANSACTION_RETRIEVE_ERROR_DESC": "Please start it over from the Servermap/Filtered page.  (If you close this dialog, you will be redirected to the Servermap page.)",
     "CALL_TREE_FILTER": "Filter",
-    "CALL_TREE_FILTER_PLACEHOLDER": "Filter call tree...",
-    "SCOPE_DETAIL": "Scope Detail",
-    "SCOPE_NAME": "Name",
-    "SCOPE_VERSION": "Version"
+    "CALL_TREE_FILTER_PLACEHOLDER": "Filter call tree..."
   },
   "METRIC": {
     "HOST_GROUP_LIST": "Host-Group List",

--- a/web-frontend/src/main/v3/packages/ui/src/constants/locales/ko.json
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/locales/ko.json
@@ -87,10 +87,7 @@
     "TRANSACTION_RETRIEVE_ERROR": "Transaction 정보가 없습니다.",
     "TRANSACTION_RETRIEVE_ERROR_DESC": "Servermap/Filtered 페이지에서 다시 시도해 주세요. (이 창을 닫으면 Servermap 페이지로 이동합니다)",
     "CALL_TREE_FILTER": "필터",
-    "CALL_TREE_FILTER_PLACEHOLDER": "콜 트리 필터...",
-    "SCOPE_DETAIL": "Scope 상세",
-    "SCOPE_NAME": "이름",
-    "SCOPE_VERSION": "버전"
+    "CALL_TREE_FILTER_PLACEHOLDER": "콜 트리 필터..."
   },
   "METRIC": {
     "HOST_GROUP_LIST": "호스트 그룹 목록",


### PR DESCRIPTION
The OTel instrumentation scope (name@version) was reachable only by clicking a per-row puzzle icon that opened a detail sheet, so the information stayed hidden and could not be scanned across rows. Show it inline in the Class column instead — the analogous "origin component" identity, and a column that is otherwise empty for OTel spans (they carry no Java class name). The full value is shown on hover since it can exceed the column width.

Removes the scope icon, the scope branch of the detail sheet (ScopeDetail / parseScope), and the now-unused SCOPE_* i18n keys. Backend, the OPENTELEMETRY_SCOPE annotation, and the frontend scope lifting are unchanged — only the display moves.