### PR TITLE
[#14039] Query serviceMap by service unit

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapControllerConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapControllerConfiguration.java
@@ -26,6 +26,8 @@ import com.navercorp.pinpoint.web.applicationmap.service.FilteredMapService;
 import com.navercorp.pinpoint.web.applicationmap.service.HistogramService;
 import com.navercorp.pinpoint.web.applicationmap.service.MapService;
 import com.navercorp.pinpoint.web.applicationmap.service.ResponseTimeHistogramService;
+import com.navercorp.pinpoint.web.service.CommonService;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.applicationmap.service.TraceIndexService;
 import com.navercorp.pinpoint.web.applicationmap.servicemap.ServiceMappingProperties;
 import com.navercorp.pinpoint.web.applicationmap.servicemap.ServiceResolver;
@@ -58,9 +60,11 @@ public class MapControllerConfiguration {
     public MapController mapController(MapProperties mapProperties,
                                        MapService mapService,
                                        ApplicationValidator applicationValidator,
+                                       ServiceModelResolver serviceModelResolver,
+                                       CommonService commonService,
                                        ConfigProperties configProperties) {
         Duration maxPeriod = Duration.ofDays(configProperties.getServerMapPeriodMax());
-        return new MapController(mapProperties, mapService, applicationValidator, maxPeriod);
+        return new MapController(mapProperties, mapService, applicationValidator, serviceModelResolver, commonService, maxPeriod);
     }
 
     @Bean

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.web.applicationmap.controller;
 
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.time.ForwardRangeValidator;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.time.RangeValidator;
@@ -25,23 +24,30 @@ import com.navercorp.pinpoint.web.applicationmap.ApplicationMap;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMapView;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMapViewV3;
 import com.navercorp.pinpoint.web.applicationmap.MapWrap;
+import com.navercorp.pinpoint.web.applicationmap.SimpleApplicationMap;
 import com.navercorp.pinpoint.web.applicationmap.config.MapProperties;
 import com.navercorp.pinpoint.web.applicationmap.controller.form.ApplicationForm;
 import com.navercorp.pinpoint.web.applicationmap.controller.form.RangeForm;
 import com.navercorp.pinpoint.web.applicationmap.controller.form.SearchOptionForm;
+import com.navercorp.pinpoint.web.applicationmap.link.LinkList;
+import com.navercorp.pinpoint.web.applicationmap.nodes.NodeList;
 import com.navercorp.pinpoint.web.applicationmap.service.MapService;
 import com.navercorp.pinpoint.web.applicationmap.service.MapServiceOption;
 import com.navercorp.pinpoint.web.applicationmap.servicemap.ServiceMapView;
 import com.navercorp.pinpoint.web.applicationmap.servicemap.ServiceMapViewBuilder;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.applicationmap.view.LinkRender;
 import com.navercorp.pinpoint.web.applicationmap.view.NodeRender;
+import com.navercorp.pinpoint.web.service.CommonService;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.util.ApplicationValidator;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.SearchOption;
+import com.navercorp.pinpoint.web.vo.Service;
 import jakarta.validation.Valid;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jspecify.annotations.NonNull;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -50,7 +56,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -71,6 +76,8 @@ public class MapController {
     private final MapService mapService;
     private final RangeValidator rangeValidator;
     private final ApplicationValidator applicationValidator;
+    private final ServiceModelResolver serviceModelResolver;
+    private final CommonService commonService;
 
     private static final int DEFAULT_MAX_SEARCH_DEPTH = 4;
 
@@ -78,10 +85,14 @@ public class MapController {
             MapProperties mapProperties,
             MapService mapService,
             ApplicationValidator applicationValidator,
+            ServiceModelResolver serviceModelResolver,
+            CommonService commonService,
             Duration limitDay) {
         this.mapProperties = Objects.requireNonNull(mapProperties, "mapProperties");
         this.mapService = Objects.requireNonNull(mapService, "mapService");
         this.applicationValidator = Objects.requireNonNull(applicationValidator, "applicationValidator");
+        this.serviceModelResolver = Objects.requireNonNull(serviceModelResolver, "serviceModelResolver");
+        this.commonService = Objects.requireNonNull(commonService, "commonService");
         this.rangeValidator = new ForwardRangeValidator(Objects.requireNonNull(limitDay, "limitDay"));
     }
 
@@ -131,51 +142,48 @@ public class MapController {
 
     @GetMapping(value = "/serviceMap")
     public MapWrap<ServiceMapView> getServiceMapData(
-            @Valid @ModelAttribute
+            @ServiceParam ServiceName serviceName,
+            @ModelAttribute
             ApplicationForm appForm,
             @Valid @ModelAttribute
             RangeForm rangeForm,
-            @Valid @ModelAttribute
-            SearchOptionForm searchForm,
             @RequestParam(value = "useStatisticsAgentState", defaultValue = "false", required = false)
-            boolean useStatisticsAgentState,
-            @RequestParam(value = "keepServiceNames", required = false)
-            List<String> keepServiceNames
+            boolean useStatisticsAgentState
     ) {
         if (!mapProperties.isEnableServiceMap()) {
             logger.warn("Service map is not enabled");
             throw new UnsupportedOperationException("Service map is not enabled");
         }
         final TimeWindow timeWindow = newTimeWindow(rangeForm);
-
-        final SearchOption searchOption = searchOptionBuilder()
-                .build(searchForm.getCallerRange(), searchForm.getCalleeRange(), searchForm.isBidirectional(), searchForm.isWasOnly());
-
-        final Set<String> keepServices = getKeepServices(keepServiceNames);
-
-        final Application application = getApplication(appForm);
-
-        final MapServiceOption option = new MapServiceOption
-                .Builder(application, timeWindow, searchOption)
-                .setUseStatisticsAgentState(useStatisticsAgentState)
-                .build();
-
-        logger.info("Select serviceMap. option={}", option);
-        final ApplicationMap map = this.mapService.selectApplicationMap(option);
+        final SearchOption searchOption = searchOptionBuilder().build(SearchOptionForm.DEFAULT_SEARCH_DEPTH, SearchOptionForm.DEFAULT_SEARCH_DEPTH, false, false);
+        final Service service = serviceModelResolver.getService(serviceName.getName());
+        final List<Application> sourceApplications = getSourceApplications(service, appForm);
+        final ApplicationMap map = selectServiceMap(service, sourceApplications, timeWindow, searchOption, useStatisticsAgentState);
 
         NodeRender nodeRender = NodeRender.forServiceMap();
         LinkRender linkRender = LinkRender.forServiceMap();
-        ServiceMapViewBuilder builder = new ServiceMapViewBuilder(map, timeWindow, nodeRender, linkRender, keepServices);
-
-        ServiceMapView build = builder.build();
-        return new MapWrap<>(build);
+        final Set<String> expandedServiceNames = Set.of(serviceName.getName());
+        ServiceMapViewBuilder builder = new ServiceMapViewBuilder(map, timeWindow, nodeRender, linkRender, expandedServiceNames);
+        return new MapWrap<>(builder.build());
     }
 
-    private @NonNull Set<String> getKeepServices(List<String> keepServiceNames) {
-        if (keepServiceNames == null) {
-            return Set.of(ServiceUid.DEFAULT_SERVICE_UID_NAME);
+    private ApplicationMap selectServiceMap(Service service, List<Application> sourceApplications, TimeWindow timeWindow, SearchOption searchOption, boolean useStatisticsAgentState) {
+        if (sourceApplications.isEmpty()) {
+            logger.info("Select serviceMap. no applications found. service={}", service);
+            return new SimpleApplicationMap(NodeList.EMPTY, LinkList.EMPTY, timeWindow.getWindowRange());
         }
-        return new HashSet<>(keepServiceNames);
+
+        final MapServiceOption option = new MapServiceOption.Builder(sourceApplications, timeWindow, searchOption).setUseStatisticsAgentState(useStatisticsAgentState).build();
+        logger.info("Select serviceMap. option={}", option);
+        return this.mapService.selectApplicationMap(option);
+    }
+
+    private List<Application> getSourceApplications(Service service, ApplicationForm appForm) {
+        if (Service.DEFAULT.equals(service)) {
+            Application application = applicationValidator.newApplication(service, appForm.getApplicationName(), appForm.getServiceTypeCode(), appForm.getServiceTypeName());
+            return List.of(application);
+        }
+        return commonService.selectAllApplicationNames(service);
     }
 
     private Application getApplication(ApplicationForm appForm) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/util/ApplicationValidator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/util/ApplicationValidator.java
@@ -5,6 +5,7 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.vo.Application;
+import com.navercorp.pinpoint.web.vo.Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
@@ -49,6 +50,11 @@ public class ApplicationValidator {
     }
 
     public Application newApplication(String applicationName, int serviceTypeCode, String serviceTypeName) {
+        return newApplication(Service.DEFAULT, applicationName, serviceTypeCode, serviceTypeName);
+    }
+
+    public Application newApplication(Service service, String applicationName, int serviceTypeCode, String serviceTypeName) {
+        Objects.requireNonNull(service, "service");
         validateName(applicationName);
 
         ServiceType serviceType = null;
@@ -59,7 +65,7 @@ public class ApplicationValidator {
             serviceType = registry.findServiceTypeByName(serviceTypeName);
         }
         if (serviceType != null && serviceType.getCode() != undefined) {
-            return new Application(applicationName, serviceType);
+            return new Application(service, applicationName, serviceType);
         }
 
         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid serviceTypeCode or serviceTypeName");

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/controller/MapControllerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/controller/MapControllerTest.java
@@ -20,6 +20,8 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.ApplicationMap;
 import com.navercorp.pinpoint.web.applicationmap.config.MapProperties;
 import com.navercorp.pinpoint.web.applicationmap.service.MapService;
+import com.navercorp.pinpoint.web.service.CommonService;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.util.ApplicationValidator;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.logging.log4j.LogManager;
@@ -50,6 +52,10 @@ class MapControllerTest {
     MapService mapService;
     @Mock
     ApplicationValidator applicationValidator;
+    @Mock
+    ServiceModelResolver serviceModelResolver;
+    @Mock
+    CommonService commonService;
 
     private MockMvc mockMvc;
 
@@ -60,7 +66,7 @@ class MapControllerTest {
 
         MapProperties mapProperties = new MapProperties();
         Duration duration = Duration.ofMinutes(1);
-        MapController controller = new MapController(mapProperties, mapService, applicationValidator, duration);
+        MapController controller = new MapController(mapProperties, mapService, applicationValidator, serviceModelResolver, commonService, duration);
         when(applicationValidator.newApplication(any(), anyInt(), any()))
                 .thenReturn(new Application("test", ServiceType.STAND_ALONE));
 


### PR DESCRIPTION
## Summary
- Resolve `serviceName` via `@ServiceParam` and pass the resolved service uid to the serviceMap query
- Non-DEFAULT service: ignore `applicationName` and build the map from all applications belonging to the service (multi-seed `MapServiceOption`)
- DEFAULT service: keep the existing single-application behavior
- The requested service is always rendered expanded; `keepServiceNames` parameter removed
- Search options fixed to defaults (depth 1/1, unidirectional); `SearchOptionForm` parameters removed from this API
- A service with no applications returns an empty map instead of an error

Closes #14039