### PR TITLE
[#noissue] Fix otlptrace mapper and sampler bugs

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpDbSystemTypeResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpDbSystemTypeResolver.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -106,7 +107,9 @@ public class OtlpDbSystemTypeResolver {
         if (dbSystem == null) {
             return DEFAULT_BASE;
         }
-        short[] codes = codeMap.get(dbSystem);
+        // Case-insensitive like the sibling resolvers (client/server/messaging); the semconv
+        // values are lowercase, but a non-conformant SDK sending "MySQL" must not fall to UNKNOWN_DB.
+        short[] codes = codeMap.get(dbSystem.toLowerCase(Locale.ROOT));
         return codes != null ? codes[0] : DEFAULT_BASE;
     }
 
@@ -114,7 +117,7 @@ public class OtlpDbSystemTypeResolver {
         if (dbSystem == null) {
             return DEFAULT_EXECUTE_QUERY;
         }
-        short[] codes = codeMap.get(dbSystem);
+        short[] codes = codeMap.get(dbSystem.toLowerCase(Locale.ROOT));
         return codes != null ? codes[1] : DEFAULT_EXECUTE_QUERY;
     }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/util/AttributeUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/util/AttributeUtils.java
@@ -12,8 +12,10 @@ public final class AttributeUtils {
 
     public static long getIntValue(Map<String, Object> attributes, String key, long defaultValue) {
         final Object value = attributes.get(key);
-        if (value instanceof Number) {
-            return (long) value;
+        // (long) value would be a Long unboxing cast and throw ClassCastException for any
+        // other Number subtype (e.g. a DOUBLE_VALUE attribute mapped to Double).
+        if (value instanceof Number number) {
+            return number.longValue();
         }
         return defaultValue;
     }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpDbSystemTypeResolverTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpDbSystemTypeResolverTest.java
@@ -142,6 +142,20 @@ class OtlpDbSystemTypeResolverTest {
     }
 
     // =======================================================================
+    // case-insensitivity (parity with the client/server/messaging resolvers)
+    // =======================================================================
+
+    @Test
+    void resolveCodes_caseInsensitive() {
+        // semconv values are lowercase, but a non-conformant SDK sending mixed case
+        // must not silently fall back to UNKNOWN_DB.
+        assertThat(resolver.resolveBaseCode("MySQL")).isEqualTo((short) 2100);
+        assertThat(resolver.resolveBaseCode("REDIS")).isEqualTo((short) 8200);
+        assertThat(resolver.resolveExecuteQueryCode("PostgreSQL")).isEqualTo((short) 2501);
+        assertThat(resolver.resolveExecuteQueryCode("Oracle.DB")).isEqualTo((short) 2301);
+    }
+
+    // =======================================================================
     // null / unknown → UNKNOWN_DB fallback
     // =======================================================================
 

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/util/AttributeUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/util/AttributeUtilsTest.java
@@ -72,4 +72,21 @@ class AttributeUtilsTest {
         assertThat(AttributeUtils.getIntValue(attrs, "port", 0L)).isEqualTo(8080L);
     }
 
+    @Test
+    void getIntValue_map_integerValue() {
+        // Regression: (long) value on an Object is a Long unboxing cast and threw
+        // ClassCastException for any other Number subtype.
+        Map<String, Object> attrs = Map.of("port", 8080);
+
+        assertThat(AttributeUtils.getIntValue(attrs, "port", 0L)).isEqualTo(8080L);
+    }
+
+    @Test
+    void getIntValue_map_doubleValue_truncatesToLong() {
+        // A DOUBLE_VALUE attribute reaches this path as a Double.
+        Map<String, Object> attrs = Map.of("port", 8080.0d);
+
+        assertThat(AttributeUtils.getIntValue(attrs, "port", 0L)).isEqualTo(8080L);
+    }
+
 }

--- a/otlptrace/otlptrace-otel-extension/src/main/java/com/navercorp/pinpoint/otlp/otel/extension/PinpointTraceStateSampler.java
+++ b/otlptrace/otlptrace-otel-extension/src/main/java/com/navercorp/pinpoint/otlp/otel/extension/PinpointTraceStateSampler.java
@@ -69,11 +69,15 @@ public final class PinpointTraceStateSampler implements Sampler {
         final SamplingResult delegateResult = delegate.shouldSample(
                 parentContext, traceId, name, spanKind, attributes, parentLinks);
         final TraceState parentTs = Span.fromContext(parentContext).getSpanContext().getTraceState();
-        final TraceState updated = withPinpointEntry(parentTs);
+        // Layer the pp entry on the delegate's updated trace state, not the parent's — a
+        // delegate that writes its own entries (e.g. a consistent-probability sampler's
+        // ot=th:... threshold) must not have them silently discarded here.
+        final TraceState delegateTs = delegateResult.getUpdatedTraceState(parentTs);
+        final TraceState updated = withPinpointEntry(delegateTs);
 
-        // If the trace state is unchanged (already had the same value), avoid allocating
-        // a wrapper SamplingResult.
-        if (updated.equals(parentTs) && updated.equals(delegateResult.getUpdatedTraceState(parentTs))) {
+        // If the delegate's trace state already carries the identical pp entry, avoid
+        // allocating a wrapper SamplingResult.
+        if (updated.equals(delegateTs)) {
             return delegateResult;
         }
 

--- a/otlptrace/otlptrace-otel-extension/src/test/java/com/navercorp/pinpoint/otlp/otel/extension/PinpointTraceStateSamplerTest.java
+++ b/otlptrace/otlptrace-otel-extension/src/test/java/com/navercorp/pinpoint/otlp/otel/extension/PinpointTraceStateSamplerTest.java
@@ -20,12 +20,14 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -85,6 +87,47 @@ class PinpointTraceStateSamplerTest {
 
         // pp= is added; dd / nr remain readable.
         assertThat(updated.get("pp")).isEqualTo("svc:my-svc;app:my-app;type:1010");
+    }
+
+    @Test
+    void shouldSample_preservesDelegateTraceStateUpdates() {
+        // Regression: the pp entry was layered on the *parent* trace state, silently
+        // discarding entries the delegate itself wrote (e.g. a consistent-probability
+        // sampler recording its ot=th:... threshold).
+        Sampler otWritingDelegate = new Sampler() {
+            @Override
+            public SamplingResult shouldSample(Context parentContext, String traceId, String name,
+                                               SpanKind spanKind, Attributes attributes,
+                                               List<LinkData> parentLinks) {
+                return new SamplingResult() {
+                    @Override
+                    public SamplingDecision getDecision() {
+                        return SamplingDecision.RECORD_AND_SAMPLE;
+                    }
+
+                    @Override
+                    public Attributes getAttributes() {
+                        return Attributes.empty();
+                    }
+
+                    @Override
+                    public TraceState getUpdatedTraceState(TraceState parentTraceState) {
+                        return parentTraceState.toBuilder().put("ot", "th:8").build();
+                    }
+                };
+            }
+
+            @Override
+            public String getDescription() {
+                return "OtWritingSampler";
+            }
+        };
+        Sampler sampler = new PinpointTraceStateSampler(otWritingDelegate, "my-svc", "my-app", null);
+
+        TraceState updated = invoke(sampler).getUpdatedTraceState(TraceState.getDefault());
+
+        assertThat(updated.get("ot")).isEqualTo("th:8");
+        assertThat(updated.get("pp")).isEqualTo("svc:my-svc;app:my-app");
     }
 
     @Test


### PR DESCRIPTION
- AttributeUtils.getIntValue: (long) value was a Long unboxing cast and threw ClassCastException for other Number subtypes (Integer/Double)
- OtlpDbSystemTypeResolver: lower-case the db.system(.name) lookup for parity with the client/server/messaging resolvers, so mixed-case values no longer fall back to UNKNOWN_DB
- PinpointTraceStateSampler: layer the pp entry on the delegate's updated trace state instead of the parent's, so entries written by the delegate (e.g. a consistent-probability sampler's ot=th:...) are no longer discarded