### PR TITLE
[#14044] Keep coroutine resume trace blocks balanced

### DIFF
--- a/agent-module/plugins/kotlin-coroutines/src/main/java/com/navercorp/pinpoint/plugin/kotlinx/coroutines/interceptor/ResumeWithInterceptor.java
+++ b/agent-module/plugins/kotlin-coroutines/src/main/java/com/navercorp/pinpoint/plugin/kotlinx/coroutines/interceptor/ResumeWithInterceptor.java
@@ -22,7 +22,7 @@ import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.AsyncContextSpanEventSimpleAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.AsyncContextSpanEventBlockSimpleAroundInterceptor;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.plugin.kotlinx.coroutines.CoroutinesConfig;
 import com.navercorp.pinpoint.plugin.kotlinx.coroutines.CoroutinesConstants;
@@ -32,7 +32,7 @@ import kotlin.coroutines.CoroutineContext;
 /**
  * @author Taejin Koo
  */
-public class ResumeWithInterceptor extends AsyncContextSpanEventSimpleAroundInterceptor {
+public class ResumeWithInterceptor extends AsyncContextSpanEventBlockSimpleAroundInterceptor {
 
     private final ServiceType serviceType;
 

--- a/agent-module/plugins/kotlin-coroutines/src/test/java/com/navercorp/pinpoint/plugin/kotlinx/coroutines/interceptor/ResumeWithInterceptorTest.java
+++ b/agent-module/plugins/kotlin-coroutines/src/test/java/com/navercorp/pinpoint/plugin/kotlinx/coroutines/interceptor/ResumeWithInterceptorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.kotlinx.coroutines.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
+import com.navercorp.pinpoint.bootstrap.interceptor.BlockAroundInterceptor;
+import kotlin.coroutines.Continuation;
+import kotlin.coroutines.CoroutineContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeWithInterceptorTest {
+    @Mock
+    private TraceContext traceContext;
+    @Mock
+    private ProfilerConfig profilerConfig;
+    @Mock
+    private MethodDescriptor methodDescriptor;
+    @Mock
+    private Continuation<?> continuation;
+    @Mock
+    private AsyncContext asyncContext;
+    @Mock
+    private Trace trace;
+    @Mock
+    private TraceBlock traceBlock;
+    @Mock
+    private TraceScope traceScope;
+
+    private CoroutineContext coroutineContext;
+
+    @BeforeEach
+    void setUp() {
+        coroutineContext = mock(CoroutineContext.class, withSettings().extraInterfaces(AsyncContextAccessor.class));
+
+        when(traceContext.getProfilerConfig()).thenReturn(profilerConfig);
+        when(continuation.getContext()).thenReturn(coroutineContext);
+        when(((AsyncContextAccessor) coroutineContext)._$PINPOINT$_getAsyncContext()).thenReturn(asyncContext);
+        when(asyncContext.continueAsyncTraceObject(true)).thenReturn(trace);
+        when(trace.getScope(AsyncContext.ASYNC_TRACE_SCOPE)).thenReturn(traceScope);
+        when(trace.getTraceBlock()).thenReturn(traceBlock);
+        when(traceBlock.getTrace()).thenReturn(trace);
+        when(traceBlock.isBegin()).thenReturn(true);
+        when(traceScope.canLeave()).thenReturn(true);
+    }
+
+    @Test
+    void closesTraceBlockCreatedBeforeResumeWhenCurrentAsyncTraceIsUnavailable() {
+        BlockAroundInterceptor interceptor = assertInstanceOf(
+                BlockAroundInterceptor.class, new ResumeWithInterceptor(traceContext, methodDescriptor));
+
+        TraceBlock block = interceptor.before(continuation, null);
+        interceptor.after(block, continuation, null, null, null);
+
+        assertSame(traceBlock, block);
+        verify(asyncContext, never()).currentAsyncTraceObject();
+        verify(traceBlock).recordApi(methodDescriptor);
+
+        InOrder inOrder = inOrder(traceScope, traceBlock);
+        inOrder.verify(traceScope).tryEnter();
+        inOrder.verify(traceBlock).begin();
+        inOrder.verify(traceScope).leave();
+        inOrder.verify(traceBlock).close();
+    }
+}


### PR DESCRIPTION
## Why

`ResumeWithInterceptor` starts an async trace block from `continueAsyncTraceObject(...)`, but the simple around interceptor resolves the trace again through `currentAsyncTraceObject()` in `after()`. Nested async instrumentation can clear or replace that current trace, leaving the original block open and producing a corrupted `ChildTrace` call stack.

Fixes #14044

## What

- Use `AsyncContextSpanEventBlockSimpleAroundInterceptor` so `before()` passes the exact `TraceBlock` to `after()` and that same block is closed.
- Add a regression test that verifies no second current-trace lookup, exact block identity, and `scope enter -> block begin -> scope leave -> block close` ordering.

Follow-up #14047 strengthens the regression test so it executes the pre-fix callback contract and fails behaviorally against the old superclass.

## Verification

- `./mvnw -q -pl agent-module/plugins/kotlin-coroutines -am -DskipITs -Dtest=ResumeWithInterceptorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -q -pl agent-module/plugins/kotlin-coroutines -am -DskipITs test`
- `Coroutines_1_6_IT`: 38 tests across supported coroutine versions, 0 failures/errors/skips
- `git diff --check`