### PR TITLE
[#noissue] Resolve OTel agentStartTime from process.creation.time

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentStartTimeResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentStartTimeResolver.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.profiler.logging.ThrottledLogger;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Resolves the agentStartTime session field from the {@code process.creation.time} resource
+ * attribute — the OTel counterpart of the native agent's {@code RuntimeMXBean.getStartTime()}.
+ *
+ * <p>Stateless by design: the value is derived from the resource attributes alone (no cache,
+ * storage, or collector-local clock), so any collector instance resolves the same value at any
+ * time. When the attribute is absent or unusable, {@link #UNSET} is returned and the caller keeps
+ * the pre-existing per-span approximation (span start time), so deployments that do not set the
+ * attribute see no behavior change.</p>
+ */
+@Component
+public class OtlpAgentStartTimeResolver {
+
+    // "not provided" sentinel (same convention as the parentSpanId -1). Cannot collide with a
+    // resolved value: the range validation below only admits large positive epoch millis.
+    public static final long UNSET = -1;
+
+    private static final String RESOLVED_METRIC = "collector.otlptrace.agent-start-time.resolved";
+
+    // process.creation.time is semconv Development stage — validate before trusting. Values
+    // outside [2000-01-01, now + 5min] (epoch 0, exporter clock far in the future) would corrupt
+    // the AGENTINFO session rowkey, so they are discarded rather than clamped.
+    private static final long MIN_VALID_EPOCH_MILLIS = 946684800000L; // 2000-01-01T00:00:00Z
+    private static final long MAX_FUTURE_SKEW_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
+    private final Logger logger = LogManager.getLogger(this.getClass());
+    // Throttled so a fleet-wide misconfigured exporter (every batch failing to parse) does not
+    // flood the log; the true failure rate stays observable via the parse-error counter.
+    private final ThrottledLogger throttledLogger = ThrottledLogger.getLogger(logger, 100);
+
+    private final Counter creationTimeCounter;
+    private final Counter spanTimeCounter;
+    private final Counter parseErrorCounter;
+
+    public OtlpAgentStartTimeResolver(MeterRegistry meterRegistry) {
+        Objects.requireNonNull(meterRegistry, "meterRegistry");
+        // A high span-time ratio signals fleets that should be guided to set
+        // process.creation.time (session semantics are approximated without it).
+        this.creationTimeCounter = resolvedCounter(meterRegistry, "creation-time");
+        this.spanTimeCounter = resolvedCounter(meterRegistry, "span-time");
+        this.parseErrorCounter = Counter.builder("collector.otlptrace.agent-start-time.parse-error")
+                .description("OTLP trace process.creation.time values discarded (unparsable or out of range)")
+                .register(meterRegistry);
+    }
+
+    private static Counter resolvedCounter(MeterRegistry meterRegistry, String source) {
+        return Counter.builder(RESOLVED_METRIC)
+                .description("OTLP trace agentStartTime resolutions by source")
+                .tag("source", source)
+                .register(meterRegistry);
+    }
+
+    /**
+     * @return the process start time in epoch millis, or {@link #UNSET} when the attribute is
+     * absent or unusable (caller falls back to the span start time)
+     */
+    public long resolve(Map<String, AttributeValue> resourceAttributeMap) {
+        final String creationTime = AttributeUtils.getAttributeStringValue(
+                resourceAttributeMap, OtlpTraceConstants.ATTRIBUTE_KEY_PROCESS_CREATION_TIME, null);
+        if (creationTime == null) {
+            spanTimeCounter.increment();
+            return UNSET;
+        }
+        final long epochMillis;
+        try {
+            epochMillis = OffsetDateTime.parse(creationTime).toInstant().toEpochMilli();
+        } catch (DateTimeParseException e) {
+            discard(creationTime);
+            return UNSET;
+        }
+        if (epochMillis < MIN_VALID_EPOCH_MILLIS
+                || epochMillis > System.currentTimeMillis() + MAX_FUTURE_SKEW_MILLIS) {
+            discard(creationTime);
+            return UNSET;
+        }
+        creationTimeCounter.increment();
+        return epochMillis;
+    }
+
+    private void discard(String creationTime) {
+        parseErrorCounter.increment();
+        spanTimeCounter.increment();
+        throttledLogger.warn("Discarded invalid process.creation.time={}", creationTime);
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -195,6 +195,11 @@ public class OtlpTraceConstants {
 
     public static final String ATTRIBUTE_KEY_HOST_NAME = "host.name";
     public static final String ATTRIBUTE_KEY_PROCESS_PID = "process.pid";
+    // Process start timestamp (ISO 8601 string, semconv Development stage). When present, promoted
+    // to the agentStartTime session field — the OTel counterpart of the native agent's
+    // RuntimeMXBean.getStartTime(). Absent by default in SDK resource detectors; set via
+    // OTEL_RESOURCE_ATTRIBUTES when session semantics are needed.
+    public static final String ATTRIBUTE_KEY_PROCESS_CREATION_TIME = "process.creation.time";
     public static final String ATTRIBUTE_KEY_PROCESS_RUNTIME_DESCRIPTION = "process.runtime.description";
     public static final String ATTRIBUTE_KEY_TELEMETRY_SDK_VERSION = "telemetry.sdk.version";
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
@@ -65,10 +65,12 @@ public class OtlpTraceMapper {
     private final OtlpAgentInfoMapper agentInfoMapper;
     private final OtlpExceptionMapper exceptionMapper;
     private final OtlpExceptionInfoResolver exceptionInfoResolver;
+    private final OtlpAgentStartTimeResolver agentStartTimeResolver;
     private final boolean allowApplicationNameFallback;
 
     public OtlpTraceMapper(OtlpTraceSpanMapper spanMapper, OtlpTraceSpanEventMapper spanEventMapper, OtlpTraceSpanChunkMapper spanChunkMapper, OtlpAgentInfoMapper agentInfoMapper, OtlpExceptionMapper exceptionMapper,
                            OtlpExceptionInfoResolver exceptionInfoResolver,
+                           OtlpAgentStartTimeResolver agentStartTimeResolver,
                            @Value("${pinpoint.collector.otlptrace.application-name-fallback.enabled:false}") boolean allowApplicationNameFallback) {
         this.spanMapper = spanMapper;
         this.spanEventMapper = spanEventMapper;
@@ -76,6 +78,7 @@ public class OtlpTraceMapper {
         this.agentInfoMapper = agentInfoMapper;
         this.exceptionMapper = exceptionMapper;
         this.exceptionInfoResolver = Objects.requireNonNull(exceptionInfoResolver, "exceptionInfoResolver");
+        this.agentStartTimeResolver = Objects.requireNonNull(agentStartTimeResolver, "agentStartTimeResolver");
         this.allowApplicationNameFallback = allowApplicationNameFallback;
     }
 
@@ -92,6 +95,9 @@ public class OtlpTraceMapper {
                 // skip
                 continue;
             }
+            // Stateless, per-ResourceSpans: UNSET(-1) when process.creation.time is absent/unusable,
+            // in which case the span mapper keeps the span-start-time approximation.
+            final long agentStartTime = agentStartTimeResolver.resolve(resourceAttributeMap);
 
             final List<ScopeSpans> scopeSpanList = resourceSpan.getScopeSpansList();
             final Map<ByteString, List<ScopedSpan>> spanMap = getSpanMap(scopeSpanList, mapperData.getRejectedSpan());
@@ -113,7 +119,7 @@ public class OtlpTraceMapper {
                         final String rootUriTemplate = spanMapper.getServerSpanToRpc(rootSpan, rootAttributes);
                         final long rootSpanId = OtlpTraceMapperUtils.getSpanId(rootSpan.getSpanId());
 
-                        final SpanBo spanBo = spanMapper.map(idAndName, rootSpan, rootScopedSpan.scope());
+                        final SpanBo spanBo = spanMapper.map(idAndName, rootSpan, rootScopedSpan.scope(), agentStartTime);
 
                         // root span's own exception
                         recordException(mapperData, idAndName, rootSpan, rootSpanId, rootUriTemplate);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -76,6 +76,10 @@ public class OtlpTraceSpanMapper {
     }
 
     SpanBo map(IdAndName idAndName, Span span, InstrumentationScope scope) {
+        return map(idAndName, span, scope, OtlpAgentStartTimeResolver.UNSET);
+    }
+
+    SpanBo map(IdAndName idAndName, Span span, InstrumentationScope scope, long agentStartTimeMillis) {
         final long startTimeNanos = span.getStartTimeUnixNano();
 
         final SpanOwner owner = new SpanOwner();
@@ -85,7 +89,12 @@ public class OtlpTraceSpanMapper {
         }
         owner.setApplicationName(idAndName.applicationName());
         owner.setServiceName(idAndName.serviceName());
-        owner.setAgentStartTime(TimeUnit.NANOSECONDS.toMillis(startTimeNanos));
+        // process.creation.time (resource) when provided — the actual process session start,
+        // matching the native agent's RuntimeMXBean.getStartTime(). Otherwise the span start
+        // time remains the per-span approximation for exporters that don't report it.
+        owner.setAgentStartTime(agentStartTimeMillis != OtlpAgentStartTimeResolver.UNSET
+                ? agentStartTimeMillis
+                : TimeUnit.NANOSECONDS.toMillis(startTimeNanos));
 
         SpanBo spanBo = new SpanBo(TraceSourceType.OPENTELEMETRY, owner);
         // Application-level type is always the generic OTel server type. The span-level

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentStartTimeResolverTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentStartTimeResolverTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.intVal;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.kv;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.strVal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpAgentStartTimeResolverTest {
+
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final OtlpAgentStartTimeResolver resolver = new OtlpAgentStartTimeResolver(meterRegistry);
+
+    private static Map<String, AttributeValue> attributes(io.opentelemetry.proto.common.v1.KeyValue... kvs) {
+        return OtlpTraceMapperUtils.getAttributeValueMap(List.of(kvs));
+    }
+
+    private double count(String name, String... tags) {
+        return meterRegistry.counter(name, tags).count();
+    }
+
+    @Test
+    void resolve_utc() {
+        long resolved = resolver.resolve(attributes(
+                kv("process.creation.time", strVal("2026-07-01T00:00:00Z"))));
+
+        assertThat(resolved).isEqualTo(1782864000000L);
+        assertThat(count("collector.otlptrace.agent-start-time.resolved", "source", "creation-time")).isEqualTo(1);
+    }
+
+    @Test
+    void resolve_zoneOffset() {
+        // 2026-07-01T09:00:00+09:00 == 2026-07-01T00:00:00Z
+        long resolved = resolver.resolve(attributes(
+                kv("process.creation.time", strVal("2026-07-01T09:00:00+09:00"))));
+
+        assertThat(resolved).isEqualTo(1782864000000L);
+    }
+
+    @Test
+    void resolve_fractionalSeconds() {
+        long resolved = resolver.resolve(attributes(
+                kv("process.creation.time", strVal("2026-07-01T00:00:00.588Z"))));
+
+        assertThat(resolved).isEqualTo(1782864000588L);
+    }
+
+    @Test
+    void resolve_absent_returnsUnset() {
+        long resolved = resolver.resolve(attributes(kv("host.name", strVal("host-1"))));
+
+        assertThat(resolved).isEqualTo(OtlpAgentStartTimeResolver.UNSET);
+        assertThat(count("collector.otlptrace.agent-start-time.resolved", "source", "span-time")).isEqualTo(1);
+        assertThat(count("collector.otlptrace.agent-start-time.parse-error")).isZero();
+    }
+
+    @Test
+    void resolve_nonStringValue_returnsUnset() {
+        // an int-typed attribute is not the semconv shape (string ISO 8601) — treated as absent
+        long resolved = resolver.resolve(attributes(
+                kv("process.creation.time", intVal(1782864000000L))));
+
+        assertThat(resolved).isEqualTo(OtlpAgentStartTimeResolver.UNSET);
+    }
+
+    @Test
+    void resolve_unparsable_returnsUnset_andCountsParseError() {
+        long resolved = resolver.resolve(attributes(
+                kv("process.creation.time", strVal("not-a-timestamp"))));
+
+        assertThat(resolved).isEqualTo(OtlpAgentStartTimeResolver.UNSET);
+        assertThat(count("collector.otlptrace.agent-start-time.parse-error")).isEqualTo(1);
+        // discarded values fall back to the span-time source
+        assertThat(count("collector.otlptrace.agent-start-time.resolved", "source", "span-time")).isEqualTo(1);
+    }
+
+    @Test
+    void resolve_beforeYear2000_discarded() {
+        long resolved = resolver.resolve(attributes(
+                kv("process.creation.time", strVal("1999-12-31T23:59:59Z"))));
+
+        assertThat(resolved).isEqualTo(OtlpAgentStartTimeResolver.UNSET);
+        assertThat(count("collector.otlptrace.agent-start-time.parse-error")).isEqualTo(1);
+    }
+
+    @Test
+    void resolve_farFuture_discarded() {
+        String tenMinutesAhead = OffsetDateTime.ofInstant(
+                Instant.now().plusSeconds(600), ZoneOffset.UTC).toString();
+
+        long resolved = resolver.resolve(attributes(
+                kv("process.creation.time", strVal(tenMinutesAhead))));
+
+        assertThat(resolved).isEqualTo(OtlpAgentStartTimeResolver.UNSET);
+        assertThat(count("collector.otlptrace.agent-start-time.parse-error")).isEqualTo(1);
+    }
+
+    @Test
+    void resolve_recentPast_accepted() {
+        String oneMinuteAgo = OffsetDateTime.ofInstant(
+                Instant.now().minusSeconds(60), ZoneOffset.UTC).toString();
+
+        long resolved = resolver.resolve(attributes(
+                kv("process.creation.time", strVal(oneMinuteAgo))));
+
+        assertThat(resolved).isNotEqualTo(OtlpAgentStartTimeResolver.UNSET);
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -112,7 +112,7 @@ class OtlpTraceMapperTest {
         OtlpTraceSpanChunkMapper spanChunkMapper = new OtlpTraceSpanChunkMapper(spanEventMapper);
         return new OtlpTraceMapper(spanMapper, spanEventMapper, spanChunkMapper,
                 new OtlpAgentInfoMapper(), new OtlpExceptionMapper(8192, 256, 2048, new SimpleMeterRegistry()),
-                exceptionInfoResolver, false);
+                exceptionInfoResolver, new OtlpAgentStartTimeResolver(new SimpleMeterRegistry()), false);
     }
 
     private static Span.Event exceptionEvent(String type) {
@@ -489,5 +489,67 @@ class OtlpTraceMapperTest {
         assertThat(data.getSpanBoList()).hasSize(1);
         assertThat(data.getSpanBoList().get(0).getSpanEventBoList()).isEmpty();
         assertThat(data.getRejectedSpan().count()).isEqualTo(1);
+    }
+
+    // =======================================================================
+    // agentStartTime — process.creation.time resource attribute
+    // =======================================================================
+
+    private static List<ResourceSpans> resourceSpansWithCreationTime(String creationTime, Span... spans) {
+        Resource resource = Resource.newBuilder()
+                .addAttributes(kv("pinpoint.applicationName", strVal("app-1")))
+                .addAttributes(kv("pinpoint.agentId", strVal("agent-1")))
+                .addAttributes(kv("process.creation.time", strVal(creationTime)))
+                .build();
+        ScopeSpans.Builder scope = ScopeSpans.newBuilder();
+        for (Span span : spans) {
+            scope.addSpans(span);
+        }
+        return List.of(ResourceSpans.newBuilder()
+                .setResource(resource)
+                .addScopeSpans(scope)
+                .build());
+    }
+
+    @Test
+    void agentStartTime_fromProcessCreationTime() {
+        // 2026-07-01T00:00:00Z = 1782864000000 epoch millis
+        Span rootA = serverRoot(ROOT_A, "/api/orders", false);
+        Span rootB = serverRoot(ROOT_B, "/api/items", false);
+
+        OtlpTraceMapperData data = newMapper().map(
+                resourceSpansWithCreationTime("2026-07-01T00:00:00Z", rootA, rootB));
+
+        assertThat(data.getSpanBoList()).hasSize(2);
+        // every root span of the ResourceSpans carries the same process session time
+        for (SpanBo spanBo : data.getSpanBoList()) {
+            assertThat(spanBo.getSpanOwner().getAgentStartTime()).isEqualTo(1782864000000L);
+        }
+        // AgentInfoBo (AGENTINFO rowkey) uses the same value
+        assertThat(data.getAgentInfoBoList()).isNotEmpty();
+        assertThat(data.getAgentInfoBoList().get(0).getStartTime()).isEqualTo(1782864000000L);
+    }
+
+    @Test
+    void agentStartTime_absentCreationTime_keepsSpanStartTime() {
+        // regression: without process.creation.time the pre-existing approximation
+        // (span start time) must remain unchanged. serverRoot starts at 1_000_000_000ns = 1000ms.
+        Span root = serverRoot(ROOT_A, "/api/orders", false);
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(root));
+
+        assertThat(data.getSpanBoList()).hasSize(1);
+        assertThat(data.getSpanBoList().get(0).getSpanOwner().getAgentStartTime()).isEqualTo(1000L);
+    }
+
+    @Test
+    void agentStartTime_invalidCreationTime_fallsBackToSpanStartTime() {
+        Span root = serverRoot(ROOT_A, "/api/orders", false);
+
+        OtlpTraceMapperData data = newMapper().map(
+                resourceSpansWithCreationTime("not-a-timestamp", root));
+
+        assertThat(data.getSpanBoList()).hasSize(1);
+        assertThat(data.getSpanBoList().get(0).getSpanOwner().getAgentStartTime()).isEqualTo(1000L);
     }
 }


### PR DESCRIPTION
The agentStartTime session field was approximated with the span start time because OTLP has no direct counterpart of the native agent's RuntimeMXBean.getStartTime().

Introduce OtlpAgentStartTimeResolver: when the process.creation.time resource attribute (semconv, ISO 8601) is present and valid, promote it to agentStartTime on the root SpanBo owner and AgentInfoBo — stateless, so any collector instance resolves the same session value. When absent or unusable (unparsable / outside [2000-01-01, now+5min]), the resolver returns the UNSET(-1) sentinel and the pre-existing span-start-time approximation is kept unchanged.

Resolution sources and discarded values are observable via the collector.otlptrace.agent-start-time.resolved{source} and .parse-error meters.