### PR TITLE
[#14051] Fix FixedBuffer.getByte ignoring the index argument

### DIFF
--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/Buffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/Buffer.java
@@ -149,6 +149,12 @@ public interface Buffer {
 
     void putBytes(byte[] v);
 
+    /**
+     * Returns the byte at the given index without moving the read position.
+     * The index is relative to the buffer's start offset: index 0 is this
+     * buffer's first byte even when it is a window over a shared array.
+     * Symmetric with {@link #setByte(int, byte)}.
+     */
     byte getByte(int index);
 
     byte readByte();
@@ -201,6 +207,10 @@ public interface Buffer {
 
     String readNullTerminatedString();
 
+    /**
+     * Writes the byte at the given index without moving the write position.
+     * The index is relative to the buffer's start offset, see {@link #getByte(int)}.
+     */
     void setByte(int offset, byte value);
 
     byte[] getBuffer();

--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/FixedBuffer.java
@@ -304,7 +304,15 @@ public class FixedBuffer implements Buffer {
 
     @Override
     public byte getByte(int index) {
-        return this.buffer[offset];
+        return this.buffer[absoluteIndex(index)];
+    }
+
+    /**
+     * Translates an index relative to the buffer's start offset into an
+     * absolute index of the backing array.
+     */
+    private int absoluteIndex(final int index) {
+        return getStartOffset() + index;
     }
 
     @Override
@@ -622,7 +630,7 @@ public class FixedBuffer implements Buffer {
 
     @Override
     public void setByte(int offset, byte value) {
-        this.buffer[offset] = value;
+        this.buffer[absoluteIndex(offset)] = value;
     }
 
     /**

--- a/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/FixedBufferTest.java
+++ b/commons-buffer/src/test/java/com/navercorp/pinpoint/common/buffer/FixedBufferTest.java
@@ -41,6 +41,38 @@ public class FixedBufferTest {
     private final Random random = new Random();
 
     @Test
+    public void testGetByte() {
+        Buffer buffer = new FixedBuffer(8);
+        buffer.putByte((byte) 10);
+        buffer.putByte((byte) 20);
+
+        // does not depend on, nor move, the current position
+        assertThat(buffer.getByte(0)).isEqualTo((byte) 10);
+        assertThat(buffer.getByte(1)).isEqualTo((byte) 20);
+        assertThat(buffer.getOffset()).isEqualTo(2);
+
+        // symmetric with setByte
+        buffer.setByte(0, (byte) 30);
+        assertThat(buffer.getByte(0)).isEqualTo((byte) 30);
+    }
+
+    @Test
+    public void testGetByte_offsetBuffer() {
+        // index 0 is the window's first byte, not the backing array's
+        byte[] backing = {99, 99, 42, 1, 2};
+        Buffer buffer = new OffsetFixedBuffer(backing, 2, 3);
+
+        assertThat(buffer.getByte(0)).isEqualTo((byte) 42);
+        assertThat(buffer.getByte(1)).isEqualTo((byte) 1);
+        // stays stable after reads
+        buffer.readByte();
+        assertThat(buffer.getByte(0)).isEqualTo((byte) 42);
+
+        buffer.setByte(0, (byte) 7);
+        assertThat(backing[2]).isEqualTo((byte) 7);
+    }
+
+    @Test
     public void testPutPrefixedBytes() {
         String test = "test";
         int endExpected = 3333;


### PR DESCRIPTION
Resolves #14051

`FixedBuffer.getByte(int index)` returned the byte at the current read position regardless of the given index, and was asymmetric with `setByte(int offset, byte value)`.

### Changes
- Define the `getByte`/`setByte` index as **relative to the buffer's start offset**: index 0 is the buffer's first byte even when the buffer is a window over a shared array (e.g. an HBase cell backing array). Documented the contract on the `Buffer` interface.
- Extract the index translation into a private `absoluteIndex(int)` helper shared by both methods.
- Existing callers (`FilteringSpanDecoder`, `SpanMapperV2` — `getByte(0)` on a fresh `OffsetFixedBuffer`) now work by contract instead of by accident; no caller changes required.
- Add tests covering position independence, `getByte`/`setByte` symmetry, and the offset-window case.