### PR TITLE
[#noissue] Support Release Candidate rpc semconv keys in the OTLP tra…

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpClientTypeResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpClientTypeResolver.java
@@ -49,9 +49,11 @@ public class OtlpClientTypeResolver {
     // rpc.system value → registered ServiceType name. Names mirror the agent plugin
     // constants (GrpcConstants GRPC, ApacheDubboConstants APACHE_DUBBO_CONSUMER) and are
     // registered on the collector via SPI TraceMetadataProvider / type-provider.yml.
+    // "dubbo" is the RC rpc.system.name spelling of the deprecated "apache_dubbo".
     private static final Map<String, String> NAME_MAP = Map.of(
             OtlpTraceConstants.RPC_SYSTEM_GRPC,         "GRPC",
-            OtlpTraceConstants.RPC_SYSTEM_APACHE_DUBBO, "APACHE_DUBBO_CONSUMER");
+            OtlpTraceConstants.RPC_SYSTEM_APACHE_DUBBO, "APACHE_DUBBO_CONSUMER",
+            OtlpTraceConstants.RPC_SYSTEM_DUBBO,        "APACHE_DUBBO_CONSUMER");
 
     private static final int DEFAULT_CLIENT = ServiceType.OPENTELEMETRY_CLIENT.getCode();
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGrpcStatusResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGrpcStatusResolver.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
@@ -30,7 +31,10 @@ import java.util.Map;
  * The native agent has no gRPC <em>server</em> plugin — the root-span promotion is
  * OTel-only added value.
  *
- * <p>Key precedence: standard RPC semconv {@code rpc.grpc.status_code} (int 0-16) before the
+ * <p>Key precedence: RC semconv {@code rpc.response.status_code} (string status NAME, e.g.
+ * "OK"; shared by all rpc systems, so it is only interpreted here when {@code rpc.system(.name)}
+ * is {@code grpc} — a jsonrpc error code like "-32602" must not be promoted as a gRPC status),
+ * then the deprecated gRPC-specific {@code rpc.grpc.status_code} (int 0-16), then the
  * nonstandard {@code grpc.status_code} (numeric string, emitted by e.g. the ASP.NET Core gRPC
  * instrumentation). Exposing the source key lets the caller exclude only the consumed key from
  * the raw attributes via the consumedKeys mechanism.</p>
@@ -68,12 +72,23 @@ public final class OtlpGrpcStatusResolver {
     }
 
     /**
-     * Returns the promoted gRPC status or {@code null} when no numeric status is present.
-     * The numeric value may arrive typed as int (standard semconv) or as a numeric string
-     * (nonstandard variant) — both forms are accepted per key.
+     * Returns the promoted gRPC status or {@code null} when none is present. The RC
+     * {@code rpc.response.status_code} carries the status NAME directly (numeric strings are
+     * translated defensively); the legacy keys carry the numeric code, typed as int (standard
+     * semconv) or as a numeric string (nonstandard variant) — both forms are accepted per key.
      */
     @Nullable
     public static GrpcStatus resolve(Map<String, AttributeValue> attributes) {
+        // RC generic key first — gated on the rpc system actually being grpc (peek only; the
+        // status key itself is what the caller consumes via sourceKey()).
+        if (isGrpcSystem(attributes)) {
+            final String status = AttributeUtils.getAttributeStringValue(
+                    attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_RESPONSE_STATUS_CODE, null);
+            if (status != null && !status.isEmpty()) {
+                return new GrpcStatus(normalizeStatus(status),
+                        OtlpTraceConstants.ATTRIBUTE_KEY_RPC_RESPONSE_STATUS_CODE);
+            }
+        }
         for (String key : OtlpTraceConstants.GRPC_STATUS_CODE_KEYS) {
             final long code = OtlpHttpStatusResolver.resolveStatusCode(attributes, key);
             if (code != -1) {
@@ -81,6 +96,29 @@ public final class OtlpGrpcStatusResolver {
             }
         }
         return null;
+    }
+
+    private static boolean isGrpcSystem(Map<String, AttributeValue> attributes) {
+        for (String key : OtlpTraceConstants.RPC_SYSTEM_KEYS) {
+            final String system = AttributeUtils.getAttributeStringValue(attributes, key, null);
+            if (system != null) {
+                return OtlpTraceConstants.RPC_SYSTEM_GRPC.equalsIgnoreCase(system);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * RC values are status NAMES ("OK", "DEADLINE_EXCEEDED") per the gRPC semconv; a numeric
+     * string (a sender still emitting the legacy code shape under the new key) is translated
+     * to the same name representation.
+     */
+    private static String normalizeStatus(String status) {
+        try {
+            return toStatusName(Long.parseLong(status.trim()));
+        } catch (NumberFormatException e) {
+            return status;
+        }
     }
 
     /** Canonical gRPC status name for the code, or the raw number for out-of-range codes. */

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpServerTypeResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpServerTypeResolver.java
@@ -50,9 +50,11 @@ public class OtlpServerTypeResolver {
     // rpc.system value → registered ServiceType name. Names mirror the agent plugin
     // constants (GrpcConstants GRPC_SERVER, ApacheDubboConstants APACHE_DUBBO_PROVIDER)
     // and are registered on the collector via SPI TraceMetadataProvider / type-provider.yml.
+    // "dubbo" is the RC rpc.system.name spelling of the deprecated "apache_dubbo".
     private static final Map<String, String> NAME_MAP = Map.of(
             OtlpTraceConstants.RPC_SYSTEM_GRPC,         "GRPC_SERVER",
-            OtlpTraceConstants.RPC_SYSTEM_APACHE_DUBBO, "APACHE_DUBBO_PROVIDER");
+            OtlpTraceConstants.RPC_SYSTEM_APACHE_DUBBO, "APACHE_DUBBO_PROVIDER",
+            OtlpTraceConstants.RPC_SYSTEM_DUBBO,        "APACHE_DUBBO_PROVIDER");
 
     private static final int DEFAULT_SERVER = ServiceType.OPENTELEMETRY_SERVER.getCode();
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -137,16 +137,28 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_URL_PATH = "url.path";
     public static final String ATTRIBUTE_KEY_HTTP_URL = "http.url";
     public static final String ATTRIBUTE_KEY_HTTP_TARGET = "http.target";
+    // rpc.service is deprecated in the RC semconv (folded into the fully-qualified rpc.method,
+    // e.g. "com.example.ExampleService/exampleMethod") but is kept as an endPoint fallback for
+    // 1.x SDKs that still emit it.
     public static final String ATTRIBUTE_KEY_RPC_SERVICE = "rpc.service";
     public static final String ATTRIBUTE_KEY_RPC_METHOD = "rpc.method";
+    // RPC system identifier. RC semconv (Release Candidate): rpc.system.name; deprecated 1.x:
+    // rpc.system. Same consumedKeys handling as the HTTP keys: only the consumed variant is
+    // filtered from the raw attributes.
+    public static final String ATTRIBUTE_KEY_RPC_SYSTEM_NAME = "rpc.system.name";
     public static final String ATTRIBUTE_KEY_RPC_SYSTEM = "rpc.system";
-    // OTel RPC semconv enum values emitted by the OTel Java agent (verified against
-    // grpc-1.6 GrpcRpcAttributesGetter / apache-dubbo-2.7 DubboRpcAttributesGetter).
+    // OTel RPC semconv enum values. grpc is unchanged across versions; Dubbo was renamed —
+    // deprecated rpc.system used "apache_dubbo" (emitted by the OTel Java agent
+    // apache-dubbo-2.7 DubboRpcAttributesGetter), RC rpc.system.name uses "dubbo".
     public static final String RPC_SYSTEM_GRPC = "grpc";
     public static final String RPC_SYSTEM_APACHE_DUBBO = "apache_dubbo";
-    // gRPC result status code (0-16). Standard OTel RPC semconv: rpc.grpc.status_code (int);
+    public static final String RPC_SYSTEM_DUBBO = "dubbo";
+    // gRPC result status. RC semconv: rpc.response.status_code (string status NAME, e.g. "OK" /
+    // "DEADLINE_EXCEEDED"; shared by all rpc systems, so it is only interpreted as a gRPC status
+    // when rpc.system(.name) == grpc). Deprecated 1.x: rpc.grpc.status_code (int 0-16);
     // nonstandard variant grpc.status_code (numeric string) emitted by e.g. the ASP.NET Core
     // gRPC instrumentation. Promoted to the grpc.status annotation via OtlpGrpcStatusResolver.
+    public static final String ATTRIBUTE_KEY_RPC_RESPONSE_STATUS_CODE = "rpc.response.status_code";
     public static final String ATTRIBUTE_KEY_RPC_GRPC_STATUS_CODE = "rpc.grpc.status_code";
     public static final String ATTRIBUTE_KEY_GRPC_STATUS_CODE = "grpc.status_code";
     public static final String ATTRIBUTE_KEY_MESSAGING_CLIENT_ID = "messaging.client_id";
@@ -268,7 +280,14 @@ public class OtlpTraceConstants {
             List.of(ATTRIBUTE_KEY_HTTP_REQUEST_METHOD, ATTRIBUTE_KEY_HTTP_METHOD);
 
     // gRPC status resolution order: standard RPC semconv before the nonstandard variant.
+    // (The RC rpc.response.status_code is handled separately in OtlpGrpcStatusResolver — it
+    // needs the rpc-system gate, unlike these gRPC-specific keys.)
     // Same consumedKeys handling: only the consumed variant is filtered.
     public static final List<String> GRPC_STATUS_CODE_KEYS =
             List.of(ATTRIBUTE_KEY_RPC_GRPC_STATUS_CODE, ATTRIBUTE_KEY_GRPC_STATUS_CODE);
+
+    // RPC system resolution order: RC semconv (rpc.system.name) before deprecated (rpc.system).
+    // Same consumedKeys handling: only the consumed variant is filtered.
+    public static final List<String> RPC_SYSTEM_KEYS =
+            List.of(ATTRIBUTE_KEY_RPC_SYSTEM_NAME, ATTRIBUTE_KEY_RPC_SYSTEM);
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -129,12 +129,9 @@ public class OtlpTraceSpanEventMapper {
         } else if (isClient(span)) {
             spanEventBo.setEndPoint(getClientSpanToEndPoint(attributes, consumedKeys));
             spanEventBo.setDestinationId(getClientSpanToDestinationId(attributes, consumedKeys));
-            // rpc.system dispatch: grpc → GRPC, apache_dubbo → APACHE_DUBBO_CONSUMER.
-            // HTTP clients emit no rpc.system → OPENTELEMETRY_CLIENT fallback.
-            final String rpcSystem = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null);
-            if (rpcSystem != null) {
-                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM);
-            }
+            // rpc.system(.name) dispatch: grpc → GRPC, dubbo/apache_dubbo → APACHE_DUBBO_CONSUMER.
+            // HTTP clients emit no rpc system → OPENTELEMETRY_CLIENT fallback.
+            final String rpcSystem = OtlpTraceSpanMapper.getRpcSystem(attributes, consumedKeys);
             spanEventBo.setServiceType(clientTypeResolver.resolveClientServiceType(rpcSystem));
             // Envoy egress detection → identification annotations only. The ServiceType is NOT
             // overridden to ENVOY_EGRESS (see OtlpEnvoyRecorder Javadoc).

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -287,17 +287,12 @@ public class OtlpTraceSpanMapper {
             spanBo.setAcceptorHost(spanBo.getEndPoint());
         }
 
-        // SERVER kind only: dispatch ServiceType via rpc.system (grpc → GRPC_SERVER,
-        // apache_dubbo → APACHE_DUBBO_PROVIDER). INTERNAL and unsupported-messaging consumer
-        // fallthrough stay on OPENTELEMETRY_SERVER. HTTP server framework cannot be derived
-        // from OTel attributes.
+        // SERVER kind only: dispatch ServiceType via rpc.system(.name) (grpc → GRPC_SERVER,
+        // dubbo / apache_dubbo → APACHE_DUBBO_PROVIDER). INTERNAL and unsupported-messaging
+        // consumer fallthrough stay on OPENTELEMETRY_SERVER. HTTP server framework cannot be
+        // derived from OTel attributes.
         final boolean isServerKind = span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE;
-        final String rpcSystem = isServerKind
-                ? AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM, null)
-                : null;
-        if (rpcSystem != null) {
-            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SYSTEM);
-        }
+        final String rpcSystem = isServerKind ? getRpcSystem(attributes, consumedKeys) : null;
         spanBo.setServiceType(serverTypeResolver.resolveServerServiceType(rpcSystem));
         // Envoy ingress detection → identification annotations only. The ServiceType is NOT
         // overridden (see OtlpEnvoyRecorder Javadoc: mixing ENVOY(1550) with
@@ -491,6 +486,23 @@ public class OtlpTraceSpanMapper {
             if (method != null) {
                 consumedKeys.add(key);
                 return method;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the RPC system (RC semconv {@code rpc.system.name} before the deprecated
+     * {@code rpc.system}) for ServiceType dispatch, or {@code null} when absent. Shared by the
+     * root-span and SpanEvent paths. Only the consumed variant is collected, so a non-consumed
+     * new/deprecated twin stays in the raw attribute list.
+     */
+    static @Nullable String getRpcSystem(Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
+        for (String key : OtlpTraceConstants.RPC_SYSTEM_KEYS) {
+            final String system = AttributeUtils.getAttributeStringValue(attributes, key, null);
+            if (system != null) {
+                consumedKeys.add(key);
+                return system;
             }
         }
         return null;

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpClientTypeResolverTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpClientTypeResolverTest.java
@@ -30,6 +30,12 @@ class OtlpClientTypeResolverTest {
     }
 
     @Test
+    void resolve_dubbo_rcSpelling() {
+        // RC rpc.system.name renamed the value apache_dubbo → dubbo; both spellings resolve.
+        assertThat(resolver.resolveClientServiceType("dubbo")).isEqualTo(9997);
+    }
+
+    @Test
     void resolve_caseInsensitive() {
         assertThat(resolver.resolveClientServiceType("GRPC")).isEqualTo(9160);
         assertThat(resolver.resolveClientServiceType("Apache_Dubbo")).isEqualTo(9997);

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpServerTypeResolverTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpServerTypeResolverTest.java
@@ -30,6 +30,12 @@ class OtlpServerTypeResolverTest {
     }
 
     @Test
+    void resolve_dubbo_rcSpelling() {
+        // RC rpc.system.name renamed the value apache_dubbo → dubbo; both spellings resolve.
+        assertThat(resolver.resolveServerServiceType("dubbo")).isEqualTo(1999);
+    }
+
+    @Test
     void resolve_caseInsensitive() {
         assertThat(resolver.resolveServerServiceType("GRPC")).isEqualTo(1130);
         assertThat(resolver.resolveServerServiceType("Apache_Dubbo")).isEqualTo(1999);

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -749,6 +749,31 @@ class OtlpTraceSpanEventMapperTest {
     }
 
     @Test
+    void map_client_rpcSystemName_rcKey_dispatchesServiceType() {
+        // RC semconv: rpc.system.name replaces rpc.system, and the Dubbo value was renamed
+        // apache_dubbo → dubbo. The consumed RC key is filtered from the raw attributes.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.system.name", strVal("dubbo")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(event.getServiceType()).isEqualTo((short) 9997); // APACHE_DUBBO_CONSUMER
+        assertThat(attributeKeys(event)).doesNotContain("rpc.system.name");
+    }
+
+    @Test
+    void map_client_grpcStatus_rcResponseStatusCode_promoted() {
+        // RC rpc.response.status_code carries the status NAME; promoted only because the rpc
+        // system is grpc.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.response.status_code", strVal("UNAVAILABLE")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("UNAVAILABLE");
+        assertThat(attributeKeys(event)).doesNotContain("rpc.response.status_code");
+    }
+
+    @Test
     void map_client_http_keepsOpenTelemetryClient() {
         // Generic HTTP client (Apache HttpClient / OkHttp / java-http-client / async-http-client)
         // emits no rpc.system and no framework identifier — stays on OPENTELEMETRY_CLIENT.

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -782,6 +782,68 @@ class OtlpTraceSpanMapperTest {
         assertThat(attributeKeys(bo)).contains("grpc.status_code");
     }
 
+    // =======================================================================
+    // map() — RC semconv rpc keys (rpc.system.name / rpc.response.status_code)
+    // =======================================================================
+
+    @Test
+    void map_server_rpcSystemName_rcKey_dispatchesServiceType() {
+        // RC semconv renamed rpc.system → rpc.system.name.
+        Span span = serverSpan(kv("rpc.system.name", strVal("grpc")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getServiceType()).isEqualTo((short) 1130); // GRPC_SERVER
+        assertThat(attributeKeys(bo)).doesNotContain("rpc.system.name");
+    }
+
+    @Test
+    void map_server_rpcSystemName_precedesDeprecatedKey() {
+        // A dual-emitting migration SDK: the RC key wins; the non-consumed deprecated twin
+        // stays in the raw attribute list (consumedKeys rule).
+        Span span = serverSpan(
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.system", strVal("grpc")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getServiceType()).isEqualTo((short) 1130); // GRPC_SERVER
+        assertThat(attributeKeys(bo)).doesNotContain("rpc.system.name").contains("rpc.system");
+    }
+
+    @Test
+    void map_server_grpcStatus_rcResponseStatusCode_statusName_promoted() {
+        // RC rpc.response.status_code carries the gRPC status NAME directly.
+        Span span = serverSpan(
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.response.status_code", strVal("DEADLINE_EXCEEDED")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS))
+                .isEqualTo("DEADLINE_EXCEEDED");
+        assertThat(attributeKeys(bo)).doesNotContain("rpc.response.status_code");
+    }
+
+    @Test
+    void map_server_grpcStatus_rcResponseStatusCode_numericString_translated() {
+        // Defensive: a sender still emitting the legacy numeric shape under the RC key is
+        // translated to the name representation. The gate also accepts the deprecated
+        // rpc.system spelling.
+        Span span = serverSpan(
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.response.status_code", strVal("14")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS))
+                .isEqualTo("UNAVAILABLE");
+    }
+
+    @Test
+    void map_server_rpcResponseStatusCode_nonGrpcSystem_notPromoted() {
+        // rpc.response.status_code is shared by all rpc systems — a jsonrpc error code must
+        // not render as a gRPC status; the raw attribute is retained.
+        Span span = serverSpan(
+                kv("rpc.system.name", strVal("jsonrpc")),
+                kv("rpc.response.status_code", strVal("-32602")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isNull();
+        assertThat(attributeKeys(bo)).contains("rpc.response.status_code");
+    }
+
     @Test
     void map_server_envoy_upstreamClusterName_consumed_filtered() {
         // The Envoy ingress branch promotes upstream_cluster.name to the upstream.cluster


### PR DESCRIPTION
…ce collector

The RPC semantic conventions reached Release Candidate with renames the collector only knew by their deprecated 1.x spellings:

- rpc.system -> rpc.system.name: resolved via a shared key-precedence helper (RC key before deprecated), consistent with the existing http.request.method/http.method handling. Only the consumed variant is filtered from the raw attributes.
- rpc.system value "apache_dubbo" -> "dubbo": both spellings resolve to APACHE_DUBBO_PROVIDER/CONSUMER in the server/client type resolvers.
- rpc.grpc.status_code (int 0-16) -> rpc.response.status_code (string status NAME, e.g. "OK"): promoted to the grpc.status annotation. The RC key is shared by all rpc systems, so it is only interpreted when rpc.system(.name) is grpc — a jsonrpc error code like "-32602" must not render as a gRPC status. Numeric strings under the RC key are defensively translated to the name representation.

rpc.service (deprecated, folded into the fully-qualified rpc.method) is kept as an endPoint fallback for 1.x SDKs; no behavior change there.