### PR TITLE
Refetch application list on service change without a full reload

### DIFF
--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import {
+  useClearApplicationOnServiceChange,
   useExperimentals,
   useGetConfiguration,
   useInvalidateQueriesOnServiceChange,
@@ -26,6 +27,7 @@ export const InitialFetchOutlet = () => {
   useExperimentals(data);
   useServicesFetch(configuration);
   useInvalidateQueriesOnServiceChange(enableServiceMap);
+  useClearApplicationOnServiceChange(enableServiceMap);
 
   React.useEffect(() => {
     if (application && searchParameters) {

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.ts
@@ -10,6 +10,11 @@ export const isReservedServiceName = (name: string) =>
 // getOnInit: true → 첫 렌더부터 localStorage 값을 동기로 읽는다.
 // 이로써 fetch 인터셉터의 최초 요청도 저장된 service를 반영하고,
 // 새로고침 시 hydration으로 인한 불필요한 캐시 무효화를 방지한다.
-export const selectedServiceAtom = atomWithStorage<string>('selectedService', DEFAULT_SERVICE, undefined, {
-  getOnInit: true,
-});
+export const selectedServiceAtom = atomWithStorage<string>(
+  'selectedService',
+  DEFAULT_SERVICE,
+  undefined,
+  {
+    getOnInit: true,
+  },
+);

--- a/web-frontend/src/main/v3/packages/ui/src/components/Application/ApplicationCombinedListForCommon.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Application/ApplicationCombinedListForCommon.tsx
@@ -49,6 +49,8 @@ export const ApplicationCombinedListForCommon = ({
   // outside-dismiss(아래 onInteractOutside)를 무시해 "열리자마자 닫히는" 현상을 막는다.
   React.useEffect(() => {
     if (!open) {
+      // 억제 창이 열려 있는 동안 닫히면 ref가 true로 고착될 수 있으므로 반드시 되돌린다.
+      suppressDismissRef.current = false;
       setIsOpen(false);
       return;
     }
@@ -57,7 +59,11 @@ export const ApplicationCombinedListForCommon = ({
     const timer = setTimeout(() => {
       suppressDismissRef.current = false;
     }, 300);
-    return () => clearTimeout(timer);
+    // 타이머가 끝나기 전에 open이 바뀌어 정리될 때도 ref를 false로 되돌려 고착을 막는다.
+    return () => {
+      clearTimeout(timer);
+      suppressDismissRef.current = false;
+    };
   }, [open]);
 
   const [filterKeyword, setFilterKeyword] = React.useState('');

--- a/web-frontend/src/main/v3/packages/ui/src/components/Application/ApplicationCombinedListForCommon.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Application/ApplicationCombinedListForCommon.tsx
@@ -37,8 +37,28 @@ export const ApplicationCombinedListForCommon = ({
   selectedApplication,
   onClickApplication,
 }: ApplicationCombinedListForCommonProps) => {
-  const [isOpen, setIsOpen] = React.useState(open);
+  const [isOpen, setIsOpen] = React.useState(!!open);
   const popoverContentRef = React.useRef<HTMLDivElement>(null);
+  // 자동 열림 직후, 다른 Radix 레이어의 dismiss가 팝오버를 곧바로 닫지 못하게 막는 창(window).
+  const suppressDismissRef = React.useRef(false);
+
+  // `open`은 최초 마운트 시 초기값으로만 쓰이므로, 이후 prop 변화를 isOpen에 반영한다.
+  // (예: 서비스 변경으로 application이 비워져 open이 true가 될 때 자동으로 열려야 한다.)
+  // 이때 서비스 선택 DropdownMenu가 닫히며 포커스를 트리거로 되돌리는데(onCloseAutoFocus),
+  // 그 focus-outside가 방금 연 팝오버를 곧바로 닫아버린다. 팝오버는 즉시 열되, 짧은 시간 동안
+  // outside-dismiss(아래 onInteractOutside)를 무시해 "열리자마자 닫히는" 현상을 막는다.
+  React.useEffect(() => {
+    if (!open) {
+      setIsOpen(false);
+      return;
+    }
+    suppressDismissRef.current = true;
+    setIsOpen(true);
+    const timer = setTimeout(() => {
+      suppressDismissRef.current = false;
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [open]);
 
   const [filterKeyword, setFilterKeyword] = React.useState('');
   const prevFilterKeywordRef = React.useRef(filterKeyword);
@@ -272,6 +292,11 @@ export const ApplicationCombinedListForCommon = ({
         onKeyDown={handleKeyDown}
         onMouseMove={() => {
           setIsMouseMove(true);
+        }}
+        onInteractOutside={(e) => {
+          // 자동 열림 직후, 서비스 DropdownMenu가 닫히며 발생하는 focus/pointer outside가
+          // 팝오버를 곧바로 닫지 않도록 무시한다. 창이 지난 뒤엔 정상적으로 바깥 클릭 시 닫힌다.
+          if (suppressDismissRef.current) e.preventDefault();
         }}
         ref={popoverContentRef}
       >

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { getDefaultStore } from 'jotai';
 import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
+import { selectedServiceAtom, DEFAULT_SERVICE } from '@pinpoint-fe/ui/src/atoms/selectedService';
 
 // useGetApplicationList reads the module-level queryClient (from reactQueryHelper,
 // which transitively imports the ECharts ESM stack) only for the 304 cache lookup.
@@ -33,6 +35,7 @@ describe('useGetApplicationList', () => {
   beforeEach(() => {
     global.fetch = jest.fn();
     mockGetQueryData.mockReset();
+    getDefaultStore().set(selectedServiceAtom, DEFAULT_SERVICE);
   });
 
   afterEach(() => {
@@ -96,5 +99,22 @@ describe('useGetApplicationList', () => {
     });
 
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('refetches the list when the selected service changes', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(okResponse([{ applicationName: 'A' }], 'etag-a'))
+      .mockResolvedValueOnce(okResponse([{ applicationName: 'B' }], 'etag-b'));
+
+    const { result } = renderHook(() => useGetApplicationList(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ applicationName: 'A' }]);
+
+    act(() => {
+      getDefaultStore().set(selectedServiceAtom, 'service-b');
+    });
+
+    await waitFor(() => expect((global.fetch as jest.Mock).mock.calls.length).toBe(2));
+    await waitFor(() => expect(result.current.data).toEqual([{ applicationName: 'B' }]));
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.ts
@@ -31,7 +31,6 @@ const applicationListQueryFn = async (service: string, clearCache?: boolean) => 
 
   if (response.status === 304) {
     const cached = queryClient.getQueryData([END_POINTS.APPLICATION_LIST, service]);
-    console.log('304~~~~~~', cached);
     if (cached !== undefined) return cached;
     cachedETagByService.delete(service);
     return applicationListQueryFn(service, clearCache);

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.ts
@@ -1,19 +1,25 @@
 import { useQuery } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
 import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
+import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
 import React from 'react';
 import { queryClient } from './reactQueryHelper';
 
-let cachedETag: string | null = null;
+// ETag는 service별로 응답이 다를 수 있으므로 service마다 따로 보관한다.
+// 하나의 전역 값으로 두면 service 전환 시 이전 service의 ETag를 보내
+// 백엔드가 304를 돌려주며 옛 목록을 그대로 재사용하는 문제가 생긴다.
+const cachedETagByService = new Map<string, string>();
 
-const applicationListQueryFn = async (clearCache?: boolean) => {
+const applicationListQueryFn = async (service: string, clearCache?: boolean) => {
   const url = clearCache
     ? `${END_POINTS.APPLICATION_LIST}?clearCache=true`
     : END_POINTS.APPLICATION_LIST;
 
   const headers: HeadersInit = {};
   if (clearCache) {
-    cachedETag = null;
+    cachedETagByService.delete(service);
   }
+  const cachedETag = cachedETagByService.get(service);
   if (cachedETag) {
     headers['If-None-Match'] = cachedETag;
   }
@@ -24,10 +30,11 @@ const applicationListQueryFn = async (clearCache?: boolean) => {
   });
 
   if (response.status === 304) {
-    const cached = queryClient.getQueryData([END_POINTS.APPLICATION_LIST]);
+    const cached = queryClient.getQueryData([END_POINTS.APPLICATION_LIST, service]);
+    console.log('304~~~~~~', cached);
     if (cached !== undefined) return cached;
-    cachedETag = null;
-    return applicationListQueryFn(clearCache);
+    cachedETagByService.delete(service);
+    return applicationListQueryFn(service, clearCache);
   }
 
   if (!response.ok) {
@@ -38,21 +45,24 @@ const applicationListQueryFn = async (clearCache?: boolean) => {
 
   const etag = response.headers.get('ETag');
   if (etag) {
-    cachedETag = etag;
+    cachedETagByService.set(service, etag);
   }
 
   return response.json();
 };
 
 export const useGetApplicationList = (shouldFetch = true) => {
+  // selectedService가 바뀌면 queryKey가 달라져 새 service의 목록을 다시 불러온다.
+  // service마다 application 목록이 다르므로 캐시를 service별로 분리한다.
+  const selectedService = useAtomValue(selectedServiceAtom);
   const clearCacheRef = React.useRef(false);
 
   const query = useQuery({
-    queryKey: [END_POINTS.APPLICATION_LIST],
+    queryKey: [END_POINTS.APPLICATION_LIST, selectedService],
     queryFn: () => {
       const shouldClearCache = clearCacheRef.current;
       clearCacheRef.current = false;
-      return applicationListQueryFn(shouldClearCache);
+      return applicationListQueryFn(selectedService, shouldClearCache);
     },
     enabled: shouldFetch,
     refetchOnMount: false,

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
@@ -1,5 +1,6 @@
 export * from './useAgentListSortBy';
 export * from './useCaptureKeydown';
+export * from './useClearApplicationOnServiceChange';
 export * from './useDateFormat';
 export * from './useExperimentals';
 export * from './useHeightToBottom';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.test.tsx
@@ -1,0 +1,118 @@
+import { renderHook, act } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import {
+  DEFAULT_SERVICE,
+  searchParametersAtom,
+  selectedServiceAtom,
+} from '@pinpoint-fe/ui/src/atoms';
+import { ApplicationType } from '@pinpoint-fe/ui/src/constants';
+import {
+  resolveClearedApplicationPath,
+  useClearApplicationOnServiceChange,
+} from './useClearApplicationOnServiceChange';
+
+const mockNavigate = jest.fn();
+const mockLocation = { pathname: '/config/serviceSetting' };
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation,
+}));
+
+describe('resolveClearedApplicationPath', () => {
+  test('strips the application segment on the serverMap path', () => {
+    expect(resolveClearedApplicationPath('/serverMap/test-app@SPRING_BOOT')).toBe('/serverMap');
+  });
+
+  test('strips the application segment on any page path', () => {
+    expect(resolveClearedApplicationPath('/inspector/test-app@SPRING_BOOT')).toBe('/inspector');
+  });
+
+  test('handles the `^` separated application key form', () => {
+    expect(resolveClearedApplicationPath('/serverMap/test-app^SPRING_BOOT')).toBe('/serverMap');
+  });
+
+  test('keeps the basename prefix', () => {
+    expect(resolveClearedApplicationPath('/base/serverMap/test-app@SPRING_BOOT')).toBe(
+      '/base/serverMap',
+    );
+  });
+
+  test('returns null when there is no application segment', () => {
+    expect(resolveClearedApplicationPath('/serverMap')).toBeNull();
+    expect(resolveClearedApplicationPath('/config/general')).toBeNull();
+  });
+
+  test('falls back to root when stripping leaves an empty path', () => {
+    expect(resolveClearedApplicationPath('test-app@SPRING_BOOT')).toBe('/');
+  });
+});
+
+// 리다이렉트 경로 계산은 위 resolveClearedApplicationPath 테스트가 커버한다.
+// 여기서는 관측 가능한 부분(searchParametersAtom의 application 무효화, soft navigate 호출)과
+// 게이팅 동작을 검증한다.
+describe('useClearApplicationOnServiceChange', () => {
+  const store = getDefaultStore();
+
+  const APP: ApplicationType = { applicationName: 'old-app', serviceType: 'SPRING_BOOT' };
+
+  const renderClearHook = (enabled: boolean) =>
+    renderHook(({ enabled }) => useClearApplicationOnServiceChange(enabled), {
+      initialProps: { enabled },
+    });
+
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockLocation.pathname = '/config/serviceSetting';
+    act(() => {
+      store.set(selectedServiceAtom, DEFAULT_SERVICE);
+      store.set(searchParametersAtom, { application: APP, searchParameters: {} });
+    });
+  });
+
+  test('invalidates the stored application when the service changes', () => {
+    renderClearHook(true);
+    act(() => {
+      store.set(selectedServiceAtom, 'svc-a');
+    });
+    expect(store.get(searchParametersAtom).application).toEqual({});
+  });
+
+  test('does not invalidate the stored application on initial mount', () => {
+    renderClearHook(true);
+    expect(store.get(searchParametersAtom).application).toEqual(APP);
+  });
+
+  test('does not invalidate when disabled', () => {
+    renderClearHook(false);
+    act(() => {
+      store.set(selectedServiceAtom, 'svc-a');
+    });
+    expect(store.get(searchParametersAtom).application).toEqual(APP);
+  });
+
+  test('does not invalidate when the service value is set but unchanged', () => {
+    renderClearHook(true);
+    act(() => {
+      store.set(selectedServiceAtom, DEFAULT_SERVICE);
+    });
+    expect(store.get(searchParametersAtom).application).toEqual(APP);
+  });
+
+  test('soft-navigates to the cleared path when an application is in the URL', () => {
+    mockLocation.pathname = '/serverMap/old-app@SPRING_BOOT';
+    renderClearHook(true);
+    act(() => {
+      store.set(selectedServiceAtom, 'svc-a');
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/serverMap', { replace: true });
+  });
+
+  test('does not navigate when there is no application in the URL', () => {
+    renderClearHook(true);
+    act(() => {
+      store.set(selectedServiceAtom, 'svc-a');
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.ts
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { searchParametersAtom, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+import { ApplicationType } from '@pinpoint-fe/ui/src/constants';
+import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
+
+// URL 맨 끝의 application 세그먼트(`{appName}@{serviceType}` 또는 `^`)를 매칭한다.
+// getApplicationTypeAndName과 동일한 규칙으로 base 경로를 계산한다.
+const APPLICATION_PATH_SEGMENT = /\/?([^/]+)[@^]([^/]+)$/;
+
+/**
+ * 주어진 pathname에서 application 세그먼트를 떼어낸 base 경로를 반환한다.
+ * pathname에 application이 없으면 null을 반환한다(리다이렉트 불필요).
+ * 세그먼트만 제거하므로, 넘긴 pathname에 접두사(basename 등)가 있으면 그대로 유지된다.
+ */
+export const resolveClearedApplicationPath = (pathname: string): string | null => {
+  if (!getApplicationTypeAndName(pathname)) return null;
+  return pathname.replace(APPLICATION_PATH_SEGMENT, '') || '/';
+};
+
+/**
+ * selectedService(선택된 서비스)가 바뀌면 이전 서비스에서 고른 application 선택을 무효화한다.
+ * 서비스마다 application 목록이 다르므로 이전 선택을 유지하면 안 된다.
+ *
+ * 1) searchParametersAtom의 application을 비운다. 사이드바 네비게이션(useMenuItems)이
+ *    이 아톰의 application으로 각 페이지 링크를 만들기 때문에, 비우지 않으면 config 등
+ *    다른 페이지에서 servermap으로 돌아갈 때 이전 application이 그대로 복원된다.
+ * 2) 현재 URL에 application이 있으면 그 세그먼트를 떼어낸 base 경로로 soft navigate 한다.
+ *    react-router `navigate`는 basename을 자동으로 붙이므로, basename이 제거된
+ *    라우터 pathname(useLocation)을 기준으로 경로를 계산한다.
+ *    (하드 리다이렉트가 아니므로 React Query 캐시와 ETag 캐시가 유지된다.)
+ *
+ * enabled(enableServiceMap)가 아니면 아무 것도 하지 않는다.
+ */
+export const useClearApplicationOnServiceChange = (enabled: boolean) => {
+  const selectedService = useAtomValue(selectedServiceAtom);
+  const setSearchParameters = useSetAtom(searchParametersAtom);
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const prevSelectedServiceRef = React.useRef(selectedService);
+
+  React.useEffect(() => {
+    if (prevSelectedServiceRef.current === selectedService) return;
+    prevSelectedServiceRef.current = selectedService;
+    if (!enabled) return;
+
+    // 저장된 application 무효화 → 네비게이션 링크가 base 경로로 바뀐다.
+    setSearchParameters((prev) => ({ ...prev, application: {} as ApplicationType }));
+
+    // 현재 URL에 application이 있으면 base 경로로 soft navigate.
+    const target = resolveClearedApplicationPath(pathname);
+    if (target) navigate(target, { replace: true });
+  }, [selectedService, enabled, setSearchParameters, navigate, pathname]);
+};

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.ts
@@ -5,18 +5,18 @@ import { searchParametersAtom, selectedServiceAtom } from '@pinpoint-fe/ui/src/a
 import { ApplicationType } from '@pinpoint-fe/ui/src/constants';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
 
-// URL 맨 끝의 application 세그먼트(`{appName}@{serviceType}` 또는 `^`)를 매칭한다.
-// getApplicationTypeAndName과 동일한 규칙으로 base 경로를 계산한다.
-const APPLICATION_PATH_SEGMENT = /\/?([^/]+)[@^]([^/]+)$/;
-
 /**
  * 주어진 pathname에서 application 세그먼트를 떼어낸 base 경로를 반환한다.
  * pathname에 application이 없으면 null을 반환한다(리다이렉트 불필요).
- * 세그먼트만 제거하므로, 넘긴 pathname에 접두사(basename 등)가 있으면 그대로 유지된다.
+ *
+ * application 세그먼트는 항상 경로의 마지막 세그먼트다. getApplicationTypeAndName으로
+ * 존재를 확인한 뒤 마지막 세그먼트만 떼어내므로, 세그먼트 형식 정규식을 여기서
+ * 중복 정의하지 않는다(파싱 규칙이 바뀌어도 어긋날 일이 없다).
+ * 마지막 세그먼트만 제거하므로, 넘긴 pathname에 접두사(basename 등)가 있으면 그대로 유지된다.
  */
 export const resolveClearedApplicationPath = (pathname: string): string | null => {
   if (!getApplicationTypeAndName(pathname)) return null;
-  return pathname.replace(APPLICATION_PATH_SEGMENT, '') || '/';
+  return pathname.split('/').slice(0, -1).join('/') || '/';
 };
 
 /**
@@ -49,6 +49,9 @@ export const useClearApplicationOnServiceChange = (enabled: boolean) => {
     setSearchParameters((prev) => ({ ...prev, application: {} as ApplicationType }));
 
     // 현재 URL에 application이 있으면 base 경로로 soft navigate.
+    // query string(?from=...&to=...)은 굳이 유지하지 않는다. application이 비워진
+    // 중간 상태에서는 지도가 렌더링되지 않고, 사용자가 새 application을 고르는 순간
+    // from/to 없는 경로로 이동해 어차피 기본 시간 범위로 리셋되기 때문이다.
     const target = resolveClearedApplicationPath(pathname);
     if (target) navigate(target, { replace: true });
   }, [selectedService, enabled, setSearchParameters, navigate, pathname]);

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
@@ -86,13 +86,11 @@ export const ServerMapPage = ({
         serverMapCurrentTarget &&
         ((serverMapData.applicationMapData.nodeDataArray as GetServerMap.NodeData[]).some(
           (node) =>
-            node.key === serverMapCurrentTarget.id ||
-            node.nodeKey === serverMapCurrentTarget.id,
+            node.key === serverMapCurrentTarget.id || node.nodeKey === serverMapCurrentTarget.id,
         ) ||
           (serverMapData.applicationMapData.linkDataArray as GetServerMap.LinkData[]).some(
             (link) =>
-              link.key === serverMapCurrentTarget.id ||
-              link.linkKey === serverMapCurrentTarget.id,
+              link.key === serverMapCurrentTarget.id || link.linkKey === serverMapCurrentTarget.id,
           ));
 
       if (isTargetIncluded || serverMapCurrentTarget?.nodes || serverMapCurrentTarget?.edges) {


### PR DESCRIPTION
## Summary
- Scope the applications query key and ETag cache by the selected service, so switching services refetches the correct list instead of serving the previous service's cached one (304 handling now stays correct per service).
- Replace the hard page reload in `useClearApplicationOnServiceChange` with a React Router soft navigate, so React Query and the ETag cache survive a service change.
- Make `ApplicationCombinedListForCommon` react to the `open` prop after mount and briefly suppress the transient outside-dismiss, so the application selector still auto-opens after a soft navigate instead of flickering closed.

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (689 tests)
- [ ] With `experimental.enableServiceMap` on: switch service A → select an application → switch to service B, and confirm the URL changes without a full page reload and the application list reflects the new service.
- [ ] Returning to a previously visited service serves the cached/304 list (no unnecessary full refetch).
- [ ] The application selector popover auto-opens without flickering after a service change, and normal outside-click still closes it.