### PR TITLE
[#14039] Remove obsolete query parameters from serviceMap request

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
@@ -32,7 +32,7 @@ export const ServiceMapFetcher = ({ shouldPoll: _shouldPoll, ...props }: Service
   const setCurrentServer = useSetAtom(currentServerAtom);
   const setServerMapCurrentTarget = useSetAtom(serverMapCurrentTargetAtom);
   const serverMapCurrentTarget = useAtomValue(serverMapCurrentTargetAtom);
-  const { application, dateRange, queryOption } = useServerMapSearchParameters();
+  const { application, dateRange } = useServerMapSearchParameters();
   const experimentalOption = useExperimentals();
   const useStatisticsAgentState =
     experimentalOption[EXPERIMENTAL_CONFIG_KEYS.USE_STATISTICS_AGENT_STATE].value || true;
@@ -42,10 +42,6 @@ export const ServiceMapFetcher = ({ shouldPoll: _shouldPoll, ...props }: Service
     serviceTypeName: application?.serviceType,
     from: toBasicISOString(dateRange.from),
     to: toBasicISOString(dateRange.to),
-    callerRange: queryOption.outbound,
-    calleeRange: queryOption.inbound,
-    bidirectional: !!queryOption.bidirectional,
-    wasOnly: !!queryOption.wasOnly,
     useStatisticsAgentState,
   });
 

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/GetServiceMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/GetServiceMap.ts
@@ -8,12 +8,7 @@ export namespace GetServiceMap {
     serviceTypeCode?: number;
     from: number | string;
     to: number | string;
-    calleeRange?: number;
-    callerRange?: number;
-    wasOnly?: boolean;
-    bidirectional?: boolean;
     useStatisticsAgentState?: boolean;
-    keepServiceNames?: string[];
   }
 
   export interface Response {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetServiceMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetServiceMap.ts
@@ -4,11 +4,7 @@ import { convertParamsToQueryString } from '@pinpoint-fe/ui/src/utils';
 import { queryFn } from './reactQueryHelper';
 
 export const useGetServiceMap = (params: GetServiceMap.Parameters) => {
-  const { keepServiceNames, ...rest } = params;
-  const queryString = convertParamsToQueryString({
-    ...rest,
-    keepServiceNames: keepServiceNames?.length ? keepServiceNames.join(',') : 'DEFAULT',
-  });
+  const queryString = convertParamsToQueryString(params);
 
   return useQuery<GetServiceMap.Response>({
     queryKey: [END_POINTS.SERVICE_MAP_DATA, queryString],


### PR DESCRIPTION
## Summary
- #14040 dropped SearchOption (callerRange/calleeRange/bidirectional/wasOnly) and keepServiceNames from `GET /serviceMap`; the service map is now queried per service unit with a fixed search depth.
- Stop sending these now-ignored parameters from the FE (`GetServiceMap.Parameters`, `useGetServiceMap`, `ServiceMapFetcher`).

## Test plan
- [ ] `/serviceMap` request URL no longer includes callerRange/calleeRange/bidirectional/wasOnly/keepServiceNames
- [ ] Service map renders correctly with the remaining parameters (no regression)