### PR TITLE
[#noissue] Fix bug:Server Map and Service Map read the `useStatisticsAgentState` experimental option with`value || true`.

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapFetcher.tsx
@@ -12,7 +12,12 @@ import {
   useServerMapSearchParameters,
 } from '@pinpoint-fe/ui/src/hooks';
 import { useTranslation } from 'react-i18next';
-import { getBaseNodeId, getServerImagePath, parseBaseNodeId } from '@pinpoint-fe/ui/src/utils';
+import {
+  getBaseNodeId,
+  getServerImagePath,
+  parseBaseNodeId,
+  resolveUseStatisticsAgentState,
+} from '@pinpoint-fe/ui/src/utils';
 import { ServerMapCore, ServerMapCoreProps } from './ServerMapCore';
 
 export interface ServerMapFetcherProps extends Pick<
@@ -28,7 +33,9 @@ export const ServerMapFetcher = ({ shouldPoll, ...props }: ServerMapFetcherProps
   const setServerMapCurrentTarget = useSetAtom(serverMapCurrentTargetAtom);
   const { application } = useServerMapSearchParameters();
   const experimentalOption = useExperimentals();
-  const useStatisticsAgentState = experimentalOption.statisticsAgentState.value || true;
+  const useStatisticsAgentState = resolveUseStatisticsAgentState(
+    experimentalOption.statisticsAgentState.value,
+  );
 
   const { data, isLoading, error } = useGetServerMapDataV2({
     shouldPoll: !!shouldPoll,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
@@ -18,26 +18,37 @@ import {
   getBaseNodeId,
   getServerImagePath,
   parseBaseNodeId,
+  resolveUseStatisticsAgentState,
   toBasicISOString,
 } from '@pinpoint-fe/ui/src/utils';
 import { ServerMapCore, ServerMapCoreProps } from '../ServerMap/ServerMapCore';
 
-export interface ServiceMapFetcherProps
-  extends Pick<ServerMapCoreProps, 'onClickMenuItem' | 'onApplyChangedOption' | 'queryOption'> {
+export interface ServiceMapFetcherProps extends Pick<
+  ServerMapCoreProps,
+  'onClickMenuItem' | 'onApplyChangedOption' | 'queryOption'
+> {
   shouldPoll?: boolean;
 }
 
-export const ServiceMapFetcher = ({ shouldPoll: _shouldPoll, ...props }: ServiceMapFetcherProps) => {
+export const ServiceMapFetcher = ({
+  shouldPoll: _shouldPoll,
+  ...props
+}: ServiceMapFetcherProps) => {
   const setDataAtom = useSetAtom(serverMapDataAtom);
   const setCurrentServer = useSetAtom(currentServerAtom);
   const setServerMapCurrentTarget = useSetAtom(serverMapCurrentTargetAtom);
   const serverMapCurrentTarget = useAtomValue(serverMapCurrentTargetAtom);
   const { application, dateRange } = useServerMapSearchParameters();
   const experimentalOption = useExperimentals();
-  const useStatisticsAgentState =
-    experimentalOption[EXPERIMENTAL_CONFIG_KEYS.USE_STATISTICS_AGENT_STATE].value || true;
+  const useStatisticsAgentState = resolveUseStatisticsAgentState(
+    experimentalOption[EXPERIMENTAL_CONFIG_KEYS.USE_STATISTICS_AGENT_STATE].value,
+  );
 
-  const { data: rawData, isLoading, error } = useGetServiceMap({
+  const {
+    data: rawData,
+    isLoading,
+    error,
+  } = useGetServiceMap({
     applicationName: application?.applicationName ?? '',
     serviceTypeName: application?.serviceType,
     from: toBasicISOString(dateRange.from),

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.test.ts
@@ -1,4 +1,4 @@
-import { getBaseNodeId, getTimeSeriesApdexInfo } from './serverMap';
+import { getBaseNodeId, getTimeSeriesApdexInfo, resolveUseStatisticsAgentState } from './serverMap';
 import {
   ApplicationType,
   GetServerMap,
@@ -6,10 +6,22 @@ import {
 } from '@pinpoint-fe/ui/src/constants';
 
 describe('Test serverMap helper utils', () => {
+  describe('Test "resolveUseStatisticsAgentState"', () => {
+    test('Preserve an explicitly disabled option', () => {
+      expect(resolveUseStatisticsAgentState(false)).toBe(false);
+    });
+
+    test('Preserve an explicitly enabled option', () => {
+      expect(resolveUseStatisticsAgentState(true)).toBe(true);
+    });
+
+    test.each([null, undefined])('Use the fallback when the option is %s', (value) => {
+      expect(resolveUseStatisticsAgentState(value)).toBe(true);
+    });
+  });
+
   describe('Test "getTimeSeriesApdexInfo"', () => {
-    const makeNode = (
-      overrides: Partial<GetServerMap.NodeData> = {},
-    ): GetServerMap.NodeData =>
+    const makeNode = (overrides: Partial<GetServerMap.NodeData> = {}): GetServerMap.NodeData =>
       ({
         isAuthorized: true,
         apdexSlot: [],
@@ -55,7 +67,6 @@ describe('Test serverMap helper utils', () => {
       expect(getTimeSeriesApdexInfo(node)).toEqual([1, 0.6, 1, 0.95]);
     });
   });
-
 
   describe('Test "getBaseNodeId"', () => {
     test('Return base node ID when node list is empty', () => {

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
@@ -8,6 +8,9 @@ import { Edge as ServerMapEdge, Node as ServerMapNode } from '@pinpoint-fe/serve
 export type Edge = ServerMapEdge;
 export type Node = ServerMapNode;
 
+export const resolveUseStatisticsAgentState = (value: boolean | null | undefined): boolean =>
+  value ?? true;
+
 // node/link key는 2-part(applicationName^serviceType) 또는 3-part(serviceName^applicationName^serviceType)로 들어올 수 있다.
 // 마지막 두 토큰이 항상 [applicationName, serviceType]이므로 뒤에서 잘라낸다.
 export const parseBaseNodeId = (


### PR DESCRIPTION
## Problem

Server Map and Service Map read the `useStatisticsAgentState` experimental option with
`value || true`. JavaScript treats an explicit `false` as falsy, so the expression always evaluates
to `true`. Users and server-side configuration therefore cannot disable the feature.

## Fix

A shared `resolveUseStatisticsAgentState` function now uses the nullish coalescing expression
`value ?? true`:

- `false` remains `false`;
- `true` remains `true`;
- only `null` or `undefined` falls back to `true`.

This preserves the existing design of enabling the option when the value is absent while respecting
an explicit `false` from the user or server configuration.

Server Map and Service Map use the same function so their option handling cannot diverge.