### PR TITLE
[#noissue] Drop sensitive OTel Span attributes at storage

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapper.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.common.server.bo.AttributeBo;
 import com.navercorp.pinpoint.common.server.util.Utf8;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValueType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -43,12 +44,13 @@ public class OtlpAttributeBoMapper {
     }
 
     /**
-     * Converts attributes to an {@link AttributeBo} list, applying {@code excludeFilter} and
-     * truncating over-long string (UTF-8 byte length) and byte (raw byte length) values in the
-     * same pass, recursing into ARRAY / KVLIST. Numeric and boolean values are left untouched,
-     * matching the OTel spec (only string and byte values are length-limited). {@code onTruncated}
-     * is invoked once per truncated leaf so the caller can emit a single per-span
-     * {@code OPENTELEMETRY_TRUNCATED} summary.
+     * Converts attributes to an {@link AttributeBo} list, applying {@code excludeFilter}, the fixed
+     * security policy ({@link OtlpSensitiveAttributeFilter} — drops sensitive keys and strips
+     * query/fragment/userinfo from URL values) and truncating over-long string (UTF-8 byte length)
+     * and byte (raw byte length) values in the same pass, recursing into ARRAY / KVLIST. Numeric
+     * and boolean values are left untouched, matching the OTel spec (only string and byte values
+     * are length-limited). {@code onTruncated} is invoked once per truncated leaf so the caller can
+     * emit a single per-span {@code OPENTELEMETRY_TRUNCATED} summary.
      */
     public List<AttributeBo> toAttributeBoList(Map<String, AttributeValue> attributes, Predicate<String> excludeFilter, TruncationListener onTruncated) {
         Objects.requireNonNull(onTruncated, "onTruncated");
@@ -57,13 +59,29 @@ public class OtlpAttributeBoMapper {
         }
         List<AttributeBo> result = new ArrayList<>();
         for (Map.Entry<String, AttributeValue> entry : attributes.entrySet()) {
-            if (excludeFilter.test(entry.getKey())) {
+            final String key = entry.getKey();
+            // Caller exclusion (promoted / statically-filtered keys) + fixed security policy.
+            if (excludeFilter.test(key) || OtlpSensitiveAttributeFilter.isSensitive(key)) {
                 continue;
             }
-            final AttributeValue value = truncateValue(entry.getValue(), onTruncated);
-            result.add(new AttributeBo(entry.getKey(), value));
+            // Strip query/fragment/userinfo from URL values before truncation.
+            final AttributeValue sanitized = sanitizeValue(key, entry.getValue());
+            final AttributeValue value = truncateValue(sanitized, onTruncated);
+            result.add(new AttributeBo(key, value));
         }
         return result;
+    }
+
+    private AttributeValue sanitizeValue(String key, AttributeValue value) {
+        if (value.getType() != AttributeValueType.STRING) {
+            return value;
+        }
+        final String original = (String) value.getValue();
+        final String sanitized = OtlpSensitiveAttributeFilter.sanitizeUrl(key, original);
+        if (sanitized == null || sanitized.equals(original)) {
+            return value;
+        }
+        return AttributeValue.of(sanitized);
     }
 
     @SuppressWarnings("unchecked")

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpSensitiveAttributeFilter.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpSensitiveAttributeFilter.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Fixed (non-configurable) security policy for OTel Span / SpanEvent attributes at the point they
+ * are stored ({@link OtlpAttributeBoMapper#toAttributeBoList}). A collector exposes no per-attribute
+ * redaction settings, so the rules carry no toggle.
+ *
+ * <ul>
+ *   <li>{@link #isSensitive(String)} — attributes that must never be stored: HTTP headers, gRPC/RPC
+ *       metadata and messaging headers; request/response bodies; credentials; the DB connection
+ *       string and DB account (db.user); DB bind parameters; URL query/fragment/userinfo component
+ *       keys; and end-user/tenant identifiers (id/role/scope, user/tenant).</li>
+ *   <li>{@link #sanitizeUrl(String, String)} — URL-valued attributes ({@code url.full} /
+ *       {@code http.url} / {@code http.target}) are kept but reduced to {@code scheme://host[:port]/path}
+ *       (query, fragment and userinfo removed).</li>
+ * </ul>
+ *
+ * <p>Only Span and SpanEvent attributes pass through {@code toAttributeBoList}; Span Event and
+ * Span Link attributes use a separate JSON serializer and are intentionally out of scope.</p>
+ */
+final class OtlpSensitiveAttributeFilter {
+
+    // URL-valued keys: kept, but the value is reduced to scheme://host[:port]/path.
+    private static final Set<String> URL_KEYS = Set.of(
+            "url.full",
+            "http.url",
+            "http.target"
+    );
+
+    // Dedicated URL component attributes — dropped (the sanitized URL already omits them).
+    private static final Set<String> URL_COMPONENT_KEYS = Set.of(
+            "url.query",
+            "url.fragment",
+            "url.user_info"
+    );
+
+    private static final Set<String> BODY_KEYS = Set.of(
+            "http.request.body",
+            "http.response.body",
+            "messaging.message.body",
+            "rpc.request.body",
+            "rpc.response.body"
+    );
+
+    private static final Set<String> END_USER_KEYS = Set.of(
+            "enduser.id",
+            "enduser.role",
+            "enduser.scope",
+            "enduser.scopes",
+            "enduser.email",
+            "user.id",
+            "user.email",
+            "tenant.id",
+            "tenant.name"
+    );
+
+    private static final Set<String> CREDENTIAL_KEYS = Set.of(
+            "authorization",
+            "proxy_authorization",
+            "cookie",
+            "set_cookie",
+            "password",
+            "passwd",
+            "secret",
+            "token",
+            "access_token",
+            "refresh_token",
+            "auth_token",
+            "api_key",
+            "apikey",
+            "client_secret",
+            "credential",
+            "credentials",
+            "db.connection_string",
+            // DB account name — always emitted by the OTel SQL client extractor (password already
+            // stripped from the JDBC URL by the instrumentation). Dropped so the account is not stored.
+            "db.user"
+    );
+
+    // DB bind parameters (concrete query argument values). Not consumed/promoted anywhere.
+    private static final Set<String> DB_PARAMETER_KEYS = Set.of(
+            "db.bind.parameters",
+            "db.bind_parameters",
+            "db.parameters",
+            "db.query.parameters",
+            "db.statement.parameters"
+    );
+
+    // Every attribute under these prefixes is dropped — headers/metadata are never stored.
+    // gRPC metadata is captured under rpc.grpc.request/response.metadata.<name>
+    // (CapturedGrpcMetadataUtil); the generic rpc.request/response.metadata.* variants are kept for
+    // any other RPC system that follows the semconv naming.
+    private static final List<String> HEADER_PREFIXES = List.of(
+            "http.request.header.",
+            "http.response.header.",
+            "rpc.grpc.request.metadata.",
+            "rpc.grpc.response.metadata.",
+            "rpc.request.metadata.",
+            "rpc.response.metadata.",
+            "messaging.header."
+    );
+
+    private OtlpSensitiveAttributeFilter() {
+    }
+
+    /**
+     * True when the attribute must never be stored. Matched case-insensitively, with {@code '-'}
+     * treated as {@code '_'} (header/metadata name variants).
+     */
+    static boolean isSensitive(String key) {
+        final String normalized = normalize(key);
+        if (URL_COMPONENT_KEYS.contains(normalized)
+                || BODY_KEYS.contains(normalized)
+                || END_USER_KEYS.contains(normalized)) {
+            return true;
+        }
+        for (String prefix : HEADER_PREFIXES) {
+            if (normalized.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return isCredential(normalized) || isDbParameter(normalized);
+    }
+
+    private static boolean isCredential(String normalized) {
+        if (CREDENTIAL_KEYS.contains(normalized)) {
+            return true;
+        }
+        final int lastDot = normalized.lastIndexOf('.');
+        return lastDot >= 0 && CREDENTIAL_KEYS.contains(normalized.substring(lastDot + 1));
+    }
+
+    private static boolean isDbParameter(String normalized) {
+        return DB_PARAMETER_KEYS.contains(normalized)
+                || normalized.startsWith("db.query.parameter.")
+                || normalized.startsWith("db.statement.parameter.");
+    }
+
+    /**
+     * For URL-valued attributes, strips the query string, fragment and userinfo; every other key
+     * returns its value unchanged.
+     */
+    static String sanitizeUrl(String key, String value) {
+        if (value == null || value.isEmpty() || !URL_KEYS.contains(normalize(key))) {
+            return value;
+        }
+        return stripUrl(value);
+    }
+
+    /**
+     * Strips the query string, fragment and userinfo from a URL, keeping scheme://host[:port]/path.
+     * A value with no {@code ://} and no leading {@code //} only has its query/fragment removed.
+     */
+    static String stripUrl(String value) {
+        int fragmentIndex = value.indexOf('#');
+        int queryIndex = value.indexOf('?');
+        int end = value.length();
+        if (fragmentIndex >= 0) {
+            end = fragmentIndex;
+        }
+        if (queryIndex >= 0 && queryIndex < end) {
+            end = queryIndex;
+        }
+        String sanitized = end == value.length() ? value : value.substring(0, end);
+
+        int scheme = sanitized.indexOf("://");
+        int authorityStart;
+        if (scheme >= 0) {
+            authorityStart = scheme + 3;
+        } else if (sanitized.startsWith("//")) {
+            authorityStart = 2;
+        } else {
+            return sanitized;
+        }
+        int authorityEnd = sanitized.indexOf('/', authorityStart);
+        if (authorityEnd < 0) {
+            authorityEnd = sanitized.length();
+        }
+        int userInfoEnd = sanitized.lastIndexOf('@', authorityEnd - 1);
+        if (userInfoEnd < authorityStart) {
+            return sanitized;
+        }
+        return sanitized.substring(0, authorityStart) + sanitized.substring(userInfoEnd + 1);
+    }
+
+    private static String normalize(String key) {
+        return key.trim().toLowerCase(Locale.ROOT).replace('-', '_');
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -353,6 +353,9 @@ public class OtlpTraceSpanMapper {
         int schemeEnd = url.indexOf("://");
         if (schemeEnd >= 0) {
             start = schemeEnd + 3;
+        } else if (url.startsWith("//")) {
+            // scheme-relative URL: //host[:port]/path (consistent with OtlpSensitiveAttributeFilter.stripUrl)
+            start = 2;
         }
 
         int end = url.length();
@@ -362,6 +365,12 @@ public class OtlpTraceSpanMapper {
                 end = i;
                 break;
             }
+        }
+
+        // Strip userinfo ("user:pass@") so credentials never leak into the promoted endPoint.
+        int userInfoEnd = url.lastIndexOf('@', end - 1);
+        if (userInfoEnd >= start) {
+            start = userInfoEnd + 1;
         }
 
         return url.substring(start, end); // "host" or "host:port"

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpSensitiveAttributeFilterTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpSensitiveAttributeFilterTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpSensitiveAttributeFilterTest {
+
+    private static final List<String> SENSITIVE_KEYS = List.of(
+            // headers / metadata — whole prefix dropped, name-agnostic
+            "http.request.header.authorization",
+            "http.request.header.x-custom",
+            "http.response.header.set-cookie",
+            "rpc.request.metadata.authorization",
+            "rpc.response.metadata.x-trace",
+            "rpc.grpc.request.metadata.authorization",
+            "rpc.grpc.response.metadata.x-token",
+            "messaging.header.x-token",
+            // bodies
+            "http.request.body",
+            "http.response.body",
+            "messaging.message.body",
+            "rpc.request.body",
+            "rpc.response.body",
+            // credentials (exact and last-segment)
+            "authorization",
+            "cookie",
+            "set_cookie",
+            "password",
+            "access_token",
+            "api_key",
+            "db.connection_string",
+            "db.user",
+            "custom.password",
+            "myapp.api-key",
+            // DB bind parameters (exact and prefix)
+            "db.query.parameters",
+            "db.statement.parameters",
+            "db.query.parameter.customer_id",
+            "db.statement.parameter.1",
+            // URL components
+            "url.query",
+            "url.fragment",
+            "url.user_info",
+            // end-user / tenant identifiers
+            "enduser.id",
+            "enduser.role",
+            "enduser.scope",
+            "enduser.scopes",
+            "user.email",
+            "tenant.id",
+            // case / dash insensitivity
+            "URL.QUERY",
+            "Http.Request.Header.Cookie"
+    );
+
+    private static final List<String> KEPT_KEYS = List.of(
+            "url.full",
+            "http.url",
+            "http.target",
+            "url.path",
+            "http.request.method",
+            "db.system",
+            "db.statement",
+            "http.response.status_code",
+            "service.name",
+            "safe.custom"
+    );
+
+    @Test
+    void sensitiveKeys() {
+        for (String key : SENSITIVE_KEYS) {
+            assertThat(OtlpSensitiveAttributeFilter.isSensitive(key)).as("sensitive: %s", key).isTrue();
+        }
+    }
+
+    @Test
+    void nonSensitiveKeys() {
+        for (String key : KEPT_KEYS) {
+            assertThat(OtlpSensitiveAttributeFilter.isSensitive(key)).as("kept: %s", key).isFalse();
+        }
+    }
+
+    @Test
+    void sanitizeUrlStripsQueryOnUrlKeysOnly() {
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeUrl("url.full", "https://example.com/a?b=c#d"))
+                .isEqualTo("https://example.com/a");
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeUrl("http.target", "/orders?customer=42#x"))
+                .isEqualTo("/orders");
+        // non-URL keys keep their value verbatim
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeUrl("db.system", "mysql?x=1"))
+                .isEqualTo("mysql?x=1");
+    }
+
+    @Test
+    void sanitizeUrlHandlesNullAndEmpty() {
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeUrl("url.full", null)).isNull();
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeUrl("url.full", "")).isEmpty();
+    }
+
+    @Test
+    void stripUrlRemovesUserInfoQueryAndFragment() {
+        assertThat(OtlpSensitiveAttributeFilter.stripUrl(
+                "https://alice:password@example.com:8443/orders?token=secret#receipt"))
+                .isEqualTo("https://example.com:8443/orders");
+        assertThat(OtlpSensitiveAttributeFilter.stripUrl("/orders?email=user@example.com#details"))
+                .isEqualTo("/orders");
+        assertThat(OtlpSensitiveAttributeFilter.stripUrl("https://alice@[::1]:8443/path"))
+                .isEqualTo("https://[::1]:8443/path");
+        assertThat(OtlpSensitiveAttributeFilter.stripUrl("//alice:password@example.com/path?token=secret"))
+                .isEqualTo("//example.com/path");
+        assertThat(OtlpSensitiveAttributeFilter.stripUrl("https://example.com/path"))
+                .isEqualTo("https://example.com/path");
+        assertThat(OtlpSensitiveAttributeFilter.stripUrl("urn:orders:42?token=secret"))
+                .isEqualTo("urn:orders:42");
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -78,6 +78,20 @@ class OtlpTraceSpanMapperTest {
     }
 
     @Test
+    void extractHostAndPort_schemeRelative() {
+        assertThat(OtlpTraceSpanMapper.extractHostAndPort("//example.com:8080/path"))
+                .isEqualTo("example.com:8080");
+    }
+
+    @Test
+    void extractHostAndPort_stripsUserInfo() {
+        assertThat(OtlpTraceSpanMapper.extractHostAndPort("http://alice:pass@example.com:8080/path"))
+                .isEqualTo("example.com:8080");
+        assertThat(OtlpTraceSpanMapper.extractHostAndPort("//alice@example.com/path"))
+                .isEqualTo("example.com");
+    }
+
+    @Test
     void extractHostAndPort_null() {
         assertThat(OtlpTraceSpanMapper.extractHostAndPort(null)).isNull();
     }
@@ -241,6 +255,14 @@ class OtlpTraceSpanMapperTest {
         return bo.getAttributeBoList().stream()
                 .map(AttributeBo::getKey)
                 .toList();
+    }
+
+    private static Object attributeValue(SpanBo bo, String key) {
+        return bo.getAttributeBoList().stream()
+                .filter(attribute -> attribute.getKey().equals(key))
+                .map(attribute -> attribute.getValue().getValue())
+                .findFirst()
+                .orElse(null);
     }
 
     // =======================================================================
@@ -716,14 +738,16 @@ class OtlpTraceSpanMapperTest {
     }
 
     @Test
-    void map_server_httpUrl_partialConsumption_keptRaw() {
-        // http.url feeds both rpc (path) and endPoint (host:port) but retains query information —
-        // partial consumption keeps the raw attribute.
-        Span span = serverSpan(kv("http.url", strVal("http://shop:8080/api/cart?x=1")));
+    void map_server_httpUrl_partialConsumption_keptButSanitized() {
+        // http.url feeds both rpc (path) and endPoint (host:port); it is not "consumed", so the raw
+        // attribute is kept — but the security filter strips its query/fragment/userinfo, and the
+        // endPoint host extraction drops the userinfo.
+        Span span = serverSpan(kv("http.url", strVal("http://alice@shop:8080/api/cart?x=1#frag")));
         SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
         assertThat(bo.getRpc()).isEqualTo("/api/cart");
         assertThat(bo.getEndPoint()).isEqualTo("shop:8080");
         assertThat(attributeKeys(bo)).contains("http.url");
+        assertThat(attributeValue(bo, "http.url")).isEqualTo("http://shop:8080/api/cart");
     }
 
     @Test


### PR DESCRIPTION
Filter security-sensitive information out of OTel Span / SpanEvent attributes at the point they are stored, so it never reaches Pinpoint storage. A collector exposes no per-attribute redaction settings, so the policy is fixed.

- OtlpSensitiveAttributeFilter (new): isSensitive(key) drops HTTP headers, gRPC/RPC metadata and messaging headers, request/response bodies, credentials (incl. db.connection_string and db.user), DB bind parameters, URL query/fragment/userinfo component keys, and end-user/ tenant identifiers (enduser.id/role/scope, user, tenant); sanitizeUrl strips query/fragment/userinfo from url.full / http.url / http.target values.
- Applied in OtlpAttributeBoMapper.toAttributeBoList, the single Span / SpanEvent attribute serializer. Span Event and Span Link attributes use a separate JSON serializer and are intentionally out of scope.
- OtlpTraceSpanMapper.extractHostAndPort strips userinfo so credentials cannot leak into the promoted endPoint.

The gRPC metadata prefix (rpc.grpc.request/response.metadata.), enduser role/scope and db.user were identified by reviewing the opentelemetry-java-instrumentation attribute emitters. db.statement/SQL and exception message/stacktrace are out of scope (handled elsewhere).