### PR TITLE
[#noissue] Apply the service concept to the agent management page

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/agentManagement/AgentManagementFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/agentManagement/AgentManagementFetcher.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Configuration, ApplicationType, AgentOverview } from '@pinpoint-fe/ui/src/constants';
+import { Configuration, ApplicationType, AgentManagementList } from '@pinpoint-fe/ui/src/constants';
 import { ApplicationCombinedList } from '../../../components/Application';
 import { Button, ScrollArea, Separator, useReactToastifyToast } from '../../../components';
 import { AgentManagementTable } from './AgentManagementTable';
 import {
   useDeleteAgent,
   useDeleteApplication,
-  useGetAgentOverview,
+  useGetAgentManagementList,
 } from '@pinpoint-fe/ui/src/hooks';
 import { FaRegTrashCan } from 'react-icons/fa6';
 import { AgentManagementRemovePopup } from './AgentManagementRemovePopup';
@@ -23,8 +23,8 @@ export const AgentManagementFetcher = ({ configuration }: AgentManagementFetcher
   const { t } = useTranslation();
   const [application, setApplication] = React.useState<ApplicationType>();
 
-  const { data, refetch } = useGetAgentOverview({
-    application: application?.applicationName || '',
+  const { data, refetch } = useGetAgentManagementList({
+    applicationName: application?.applicationName || '',
     serviceTypeName: application?.serviceType,
   });
 
@@ -59,13 +59,15 @@ export const AgentManagementFetcher = ({ configuration }: AgentManagementFetcher
   function handleRemoveApplication(removeApplication?: ApplicationType, password: string = '') {
     deleteApplication({
       applicationName: removeApplication?.applicationName || '',
+      serviceTypeName: removeApplication?.serviceType,
       password,
     });
   }
 
-  function handleRemoveAgent(removeAgent?: AgentOverview.Instance, password: string = '') {
+  function handleRemoveAgent(removeAgent?: AgentManagementList.Instance, password: string = '') {
     deleteAgent({
       applicationName: removeAgent?.applicationName || '',
+      serviceTypeName: removeAgent?.serviceTypeName,
       agentId: removeAgent?.agentId || '',
       password,
     });

--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/agentManagement/AgentManagementRemovePopup.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/agentManagement/AgentManagementRemovePopup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { RemovePopup } from '../../Popup';
-import { AgentOverview, ApplicationType } from '@pinpoint-fe/ui/src/constants';
+import { AgentManagementList, ApplicationType } from '@pinpoint-fe/ui/src/constants';
 import {
   Form,
   FormControl,
@@ -24,9 +24,9 @@ export interface AgentManagementRemovePopupProps {
   isApplication?: boolean;
   popupTrigger: React.ReactNode;
   application?: ApplicationType;
-  agent?: AgentOverview.Instance;
+  agent?: AgentManagementList.Instance;
   onClickRemove?: (
-    removeTarget?: AgentOverview.Instance | ApplicationType,
+    removeTarget?: AgentManagementList.Instance | ApplicationType,
     password?: string,
   ) => void;
 }
@@ -71,7 +71,7 @@ export const AgentManagementRemovePopup = ({
       popupContents={
         <div className="flex flex-col gap-2 text-sm font-semibold">
           <div>
-            {isApplication ? application?.applicationName : agent?.hostName}{' '}
+            {isApplication ? application?.applicationName : agent?.agentName}{' '}
             {!isApplication && <span className="text-muted-foreground">({agent?.agentId})</span>}
           </div>
           <div>

--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/agentManagement/AgentManagementTable.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/agentManagement/AgentManagementTable.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { AgentOverview } from '@pinpoint-fe/ui/src/constants';
+import { useTranslation } from 'react-i18next';
+import { AgentManagementList } from '@pinpoint-fe/ui/src/constants';
+import { format } from '@pinpoint-fe/ui/src/utils';
 import { ColumnDef } from '@tanstack/react-table';
 import { Button, DataTable } from '../../../components';
 import { cn } from '../../../lib';
@@ -7,33 +9,46 @@ import { FaRegTrashCan } from 'react-icons/fa6';
 import { AgentManagementRemovePopup } from './AgentManagementRemovePopup';
 
 export interface AgentManagementTableProps {
-  data?: AgentOverview.Instance[];
-  onRemove?: (instance: AgentOverview.Instance, password?: string) => void;
+  data?: AgentManagementList.Instance[];
+  onRemove?: (instance: AgentManagementList.Instance, password?: string) => void;
 }
 
 export const AgentManagementTable = ({ data, onRemove }: AgentManagementTableProps) => {
+  const { t } = useTranslation();
+
   // https://github.com/shadcn-ui/ui/issues/4261#issuecomment-2295547143
-  const columns: ColumnDef<AgentOverview.Instance>[] = React.useMemo(
+  const columns: ColumnDef<AgentManagementList.Instance>[] = React.useMemo(
     () => [
-      {
-        accessorKey: 'hostName',
-        header: 'Host Name',
-      },
       {
         accessorKey: 'agentId',
         header: 'Agent Id',
+      },
+      {
+        accessorKey: 'agentStartTime',
+        header: 'Agent Start Time',
+        cell: ({ row }) => format(row?.original?.agentStartTime),
       },
       {
         accessorKey: 'agentName',
         header: 'Agent Name',
       },
       {
-        accessorKey: 'agentVersion',
-        header: 'Agent Version',
-      },
-      {
-        accessorKey: 'ip',
-        header: 'IP',
+        accessorKey: 'state',
+        header: 'State',
+        cell: ({ row }) => {
+          const { state, lastStateUpdateTimestamp } = row?.original || {};
+
+          return (
+            <div className="flex flex-col">
+              <span>{state?.desc}</span>
+              <span className="text-xs text-muted-foreground">
+                {t('CONFIGURATION.AGENT_MANAGEMENT.LABEL.LAST_UPDATED', {
+                  time: format(lastStateUpdateTimestamp),
+                })}
+              </span>
+            </div>
+          );
+        },
       },
       {
         header: 'Action',
@@ -65,7 +80,7 @@ export const AgentManagementTable = ({ data, onRemove }: AgentManagementTablePro
         },
       },
     ],
-    [],
+    [t],
   );
 
   return (

--- a/web-frontend/src/main/v3/packages/ui/src/constants/EndPoints.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/EndPoints.ts
@@ -63,8 +63,8 @@ export const ALARM_RULE = `${LOCAL_API_PATH}/application/alarmRule`;
 // export const = '/getApplicationStat/directBuffer/chart';
 // export const = '/admin/removeAgentId';
 // export const = '/admin/removeInactiveAgents';
-export const ADMIN_REMOVE_APPLICATION = `${LOCAL_API_PATH}/admin/removeApplicationName`;
-export const ADMIN_REMOVE_AGENT = `${LOCAL_API_PATH}/admin/removeAgentId`;
+export const ADMIN_APPLICATIONS = `${LOCAL_API_PATH}/admin/applications`;
+export const ADMIN_AGENTS = `${LOCAL_API_PATH}/admin/agents`;
 
 export const BIND = `${LOCAL_API_PATH}/bind`;
 // export const = '/getAgentStat/uriStat/chartList';

--- a/web-frontend/src/main/v3/packages/ui/src/constants/locales/en.json
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/locales/en.json
@@ -140,7 +140,8 @@
       "REMOVE_AGENT_TITLE": "Remove agent",
       "REMOVE_AGENT_DESC": "Remove the following agent.",
       "LABEL": {
-        "REMOVE_APPLICATION": "Remove application"
+        "REMOVE_APPLICATION": "Remove application",
+        "LAST_UPDATED": "last updated: {{time}}"
       },
       "REMOVE_PASSWORD_DESCRIPTION": "If you have set a password, please enter it."
     },

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/AgentManagementList.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/AgentManagementList.ts
@@ -1,0 +1,28 @@
+export namespace AgentManagementList {
+  export type Response = Instance[];
+
+  export interface Parameters {
+    applicationName: string;
+    serviceTypeName?: string;
+    serviceTypeCode?: number;
+  }
+
+  export interface State {
+    code: number;
+    desc: string;
+  }
+
+  export interface Instance {
+    agentId: string;
+    agentStartTime: number;
+    agentName: string;
+    // state within the query range
+    state: State;
+    // most recently persisted state of the agent
+    lastState: State;
+    lastStateUpdateTimestamp: number;
+    applicationName: string;
+    serviceTypeCode: number;
+    serviceTypeName: string;
+  }
+}

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/index.ts
@@ -2,6 +2,7 @@ export * from './common';
 export * from './ActiveThreadDump';
 export * from './ActiveThreadLightDump';
 export * from './AgentActiveThread';
+export * from './AgentManagementList';
 export * from './AgentOverview';
 export * from './AlarmRule';
 export * from './Application';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/index.ts
@@ -8,6 +8,7 @@ export * from './useConfigUsers';
 export * from './useGetActiveThreadLightDump';
 export * from './useGetActiveThreadDump';
 export * from './useGetAgentList';
+export * from './useGetAgentManagementList';
 export * from './useGetAgentOverview';
 export * from './useGetAlarmRuleChecker';
 export * from './useGetApdexScore';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useAdmin.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useAdmin.test.tsx
@@ -29,28 +29,41 @@ describe('useAdmin', () => {
     jest.clearAllMocks();
   });
 
-  test('useDeleteApplication calls the remove-application endpoint with name and password', async () => {
+  test('useDeleteApplication DELETEs the applications endpoint with name, serviceType and password', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: true });
 
     const { result } = renderHook(() => useDeleteApplication(), { wrapper: createWrapper() });
-    const data = await result.current.mutateAsync({ applicationName: 'App', password: 'pw' });
+    const data = await result.current.mutateAsync({
+      applicationName: 'App',
+      serviceTypeName: 'SPRING_BOOT',
+      password: 'pw',
+    });
 
     expect(data).toBeNull();
-    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
-    expect(calledUrl).toContain(END_POINTS.ADMIN_REMOVE_APPLICATION);
-    expect(calledUrl).toContain('applicationName=App');
-    expect(calledUrl).toContain('password=pw');
+    const [calledUrl, calledInit] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(calledUrl as string).toContain(END_POINTS.ADMIN_APPLICATIONS);
+    expect(calledUrl as string).toContain('applicationName=App');
+    expect(calledUrl as string).toContain('serviceTypeName=SPRING_BOOT');
+    expect(calledUrl as string).toContain('password=pw');
+    expect((calledInit as RequestInit).method).toBe('DELETE');
   });
 
-  test('useDeleteAgent calls the remove-agent endpoint with agentId', async () => {
+  test('useDeleteAgent DELETEs the agents endpoint with agentId and serviceType', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: true });
 
     const { result } = renderHook(() => useDeleteAgent(), { wrapper: createWrapper() });
-    await result.current.mutateAsync({ applicationName: 'App', agentId: 'a1', password: 'pw' });
+    await result.current.mutateAsync({
+      applicationName: 'App',
+      serviceTypeName: 'SPRING_BOOT',
+      agentId: 'a1',
+      password: 'pw',
+    });
 
-    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
-    expect(calledUrl).toContain(END_POINTS.ADMIN_REMOVE_AGENT);
-    expect(calledUrl).toContain('agentId=a1');
+    const [calledUrl, calledInit] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(calledUrl as string).toContain(END_POINTS.ADMIN_AGENTS);
+    expect(calledUrl as string).toContain('agentId=a1');
+    expect(calledUrl as string).toContain('serviceTypeName=SPRING_BOOT');
+    expect((calledInit as RequestInit).method).toBe('DELETE');
   });
 
   test('rejects through parseResponseError when the response is not ok', async () => {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useAdmin.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useAdmin.ts
@@ -1,9 +1,12 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
+import { convertParamsToQueryString } from '@pinpoint-fe/ui/src/utils';
 import { parseResponseError } from './reactQueryHelper';
 
 type deleteApplicationParams = {
   applicationName: string;
+  serviceTypeName?: string;
+  serviceTypeCode?: number;
   password: string;
 };
 
@@ -11,15 +14,13 @@ export const useDeleteApplication = (
   options?: UseMutationOptions<null, unknown, deleteApplicationParams, unknown>,
 ) => {
   const deleteApplication = async (params: deleteApplicationParams) => {
-    const response = await fetch(
-      `${END_POINTS.ADMIN_REMOVE_APPLICATION}?applicationName=${params?.applicationName}&password=${params?.password}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+    const queryString = convertParamsToQueryString(params);
+    const response = await fetch(`${END_POINTS.ADMIN_APPLICATIONS}?${queryString}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
       },
-    );
+    });
     if (!response.ok) {
       await parseResponseError(response);
     }
@@ -34,6 +35,8 @@ export const useDeleteApplication = (
 
 type deleteAgentParams = {
   applicationName: string;
+  serviceTypeName?: string;
+  serviceTypeCode?: number;
   agentId: string;
   password: string;
 };
@@ -42,15 +45,13 @@ export const useDeleteAgent = (
   options?: UseMutationOptions<null, unknown, deleteAgentParams, unknown>,
 ) => {
   const deleteAgent = async (params: deleteAgentParams) => {
-    const response = await fetch(
-      `${END_POINTS.ADMIN_REMOVE_AGENT}?applicationName=${params?.applicationName}&agentId=${params?.agentId}&password=${params?.password}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+    const queryString = convertParamsToQueryString(params);
+    const response = await fetch(`${END_POINTS.ADMIN_AGENTS}?${queryString}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
       },
-    );
+    });
     if (!response.ok) {
       await parseResponseError(response);
     }

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetAgentManagementList.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetAgentManagementList.ts
@@ -1,0 +1,32 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { END_POINTS, AgentManagementList } from '@pinpoint-fe/ui/src/constants';
+import { convertParamsToQueryString } from '@pinpoint-fe/ui/src/utils';
+import { queryFn } from './reactQueryHelper';
+
+const getQueryString = (queryParams: AgentManagementList.Parameters) => {
+  if (queryParams.applicationName && (queryParams.serviceTypeName || queryParams.serviceTypeCode)) {
+    // from/to 없이 호출하면 백엔드가 전체 agent 목록(현시점 상태)을 반환한다.
+    return '?' + convertParamsToQueryString(queryParams);
+  }
+
+  return '';
+};
+
+export const useGetAgentManagementList = ({
+  applicationName,
+  serviceTypeName,
+  serviceTypeCode,
+}: AgentManagementList.Parameters) => {
+  const queryString = getQueryString({ applicationName, serviceTypeName, serviceTypeCode });
+
+  const { data, isLoading, refetch } = useSuspenseQuery<AgentManagementList.Response | null>({
+    queryKey: [END_POINTS.AGENT_LIST, queryString],
+    queryFn: queryString ? queryFn(`${END_POINTS.AGENT_LIST}${queryString}`) : () => null,
+  });
+
+  return {
+    data: [...(data || [])].sort((a, b) => a.agentId.localeCompare(b.agentId)),
+    isLoading,
+    refetch,
+  };
+};


### PR DESCRIPTION
## Summary
- Delete applications and agents through the service-aware admin API (`DELETE /api/admin/applications`, `DELETE /api/admin/agents`), scoped by the service unit and serviceType.
- Fetch the agent list from `GET /api/agents` (without a time range), since the list endpoint was moved out of the admin API.
- Rework the agent management table to show agentId, agentStartTime, agentName and the agent state together with its last update time.

## Test plan
- [ ] Select an application on the agent management page and confirm the agent list loads without a password prompt.
- [ ] Confirm the table shows agentId, agentStartTime, agentName and state (with the last updated time).
- [ ] Delete an agent and an application, and confirm the request succeeds and the list refreshes.

> Tracked by an internal issue (`pinpoint/pinpoint-naver#10262`). Since the issue and repository live on different platforms, the commit uses `[#noissue]` per the commit convention.
