### PR TITLE
[#noissue] Inject StringAllocatorFactory into the span row mapper

### DIFF
--- a/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/StringAllocatorFactory.java
+++ b/commons-buffer/src/main/java/com/navercorp/pinpoint/common/buffer/StringAllocatorFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.buffer;
+
+/**
+ * Creates a {@link StringAllocator} per decode scope. Callers must call
+ * {@link #create()} once per scope (e.g. per row) and not share the returned
+ * allocator across scopes: a caching allocator keys on buffers over the
+ * decoded data's backing array, so it must not outlive that array.
+ */
+public interface StringAllocatorFactory {
+
+    StringAllocator create();
+
+    /**
+     * No caching; returns the shared stateless allocator.
+     */
+    StringAllocatorFactory DEFAULT = new DefaultStringAllocatorFactory();
+
+    /**
+     * A fresh LRU-caching allocator per {@link #create()} call.
+     */
+    static StringAllocatorFactory cached(int cacheSize) {
+        return new CachedStringAllocatorFactory(cacheSize);
+    }
+
+
+    class DefaultStringAllocatorFactory implements StringAllocatorFactory {
+
+        @Override
+        public StringAllocator create() {
+            // stateless
+            return StringAllocator.DEFAULT_ALLOCATOR;
+        }
+
+        @Override
+        public String toString() {
+            return "DefaultStringAllocatorFactory";
+        }
+    }
+
+
+    class CachedStringAllocatorFactory implements StringAllocatorFactory {
+
+        private final int cacheSize;
+
+        public CachedStringAllocatorFactory(int cacheSize) {
+            this.cacheSize = cacheSize;
+        }
+
+        @Override
+        public StringAllocator create() {
+            return new CachedStringAllocator(cacheSize);
+        }
+
+        @Override
+        public String toString() {
+            return "CachedStringAllocatorFactory{cacheSize=" + cacheSize + '}';
+        }
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/TraceConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/TraceConfiguration.java
@@ -17,10 +17,12 @@
 package com.navercorp.pinpoint.web.trace;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.common.buffer.StringAllocatorFactory;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.config.SpanSerializeConfiguration;
 import com.navercorp.pinpoint.web.service.ProxyRequestTypeRegistryService;
 import com.navercorp.pinpoint.web.trace.callstacks.AnnotationRecordFormatter;
 import com.navercorp.pinpoint.web.trace.callstacks.AttributeBoWriter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -52,6 +54,17 @@ public class TraceConfiguration {
             }
     )
     public static class TraceServiceConfiguration {
+        /**
+         * Per-row string allocation strategy for the trace row mappers.
+         */
+        @Bean
+        public StringAllocatorFactory stringAllocatorFactory(@Value("${web.hbase.mapper.cache.string.size:-1}") int stringCacheSize) {
+            if (stringCacheSize > 0) {
+                return StringAllocatorFactory.cached(stringCacheSize);
+            }
+            return StringAllocatorFactory.DEFAULT;
+        }
+
         @Bean
         public AnnotationRecordFormatter annotationRecordFormatter(Optional<ProxyRequestTypeRegistryService> proxyRequestTypeRegistryService) {
             AnnotationRecordFormatter.Builder builder = AnnotationRecordFormatter.newBuilder();

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperFactory.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.web.trace.dao.mapper;
 
+import com.navercorp.pinpoint.common.buffer.StringAllocatorFactory;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
@@ -25,7 +26,6 @@ import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -38,18 +38,18 @@ public class SpanMapperFactory {
 
     private final RowKeyDecoder<ServerTraceId> rowKeyDecoder;
 
-    private final int stringCacheSize;
+    private final StringAllocatorFactory stringAllocatorFactory;
 
     private final RowMapper<List<SpanBo>> mapper;
 
     private final SpanDecoder spanDecoder = new SpanDecoderV0();
 
     public SpanMapperFactory(@Qualifier("traceRowKeyDecoderV2") RowKeyDecoder<ServerTraceId> rowKeyDecoder,
-                             @Value("${web.hbase.mapper.cache.string.size:-1}") int stringCacheSize) {
+                             StringAllocatorFactory stringAllocatorFactory) {
         this.rowKeyDecoder = Objects.requireNonNull(rowKeyDecoder, "rowKeyDecoder");
-        this.stringCacheSize = stringCacheSize;
+        this.stringAllocatorFactory = Objects.requireNonNull(stringAllocatorFactory, "stringAllocatorFactory");
 
-        this.mapper = wrap(new SpanMapperV2(rowKeyDecoder, stringCacheSize));
+        this.mapper = wrap(new SpanMapperV2(rowKeyDecoder, stringAllocatorFactory));
     }
 
     public RowMapper<List<SpanBo>> getSpanMapper() {
@@ -71,6 +71,6 @@ public class SpanMapperFactory {
         }
 
         final SpanDecoder targetSpanDecoder = new FilteringSpanDecoder(spanDecoder, spanFilter);
-        return new SpanMapperV2(rowKeyDecoder, targetSpanDecoder, stringCacheSize);
+        return new SpanMapperV2(rowKeyDecoder, targetSpanDecoder, stringAllocatorFactory);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2.java
@@ -19,8 +19,8 @@ package com.navercorp.pinpoint.web.trace.dao.mapper;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.navercorp.pinpoint.common.buffer.Buffer;
-import com.navercorp.pinpoint.common.buffer.CachedStringAllocator;
 import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
+import com.navercorp.pinpoint.common.buffer.StringAllocatorFactory;
 import com.navercorp.pinpoint.common.hbase.HbaseTables;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.server.bo.BasicSpan;
@@ -58,32 +58,30 @@ import java.util.Objects;
  */
 public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
 
-    private static final int DISABLED_CACHE = -1;
-
     private final Logger logger = LogManager.getLogger(this.getClass());
 
     private final SpanDecoder spanDecoder;
 
     private final RowKeyDecoder<ServerTraceId> rowKeyDecoder;
 
-    private final int cacheSize;
+    private final StringAllocatorFactory stringAllocatorFactory;
 
     public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder) {
-        this(rowKeyDecoder, new SpanDecoderV0(), DISABLED_CACHE);
+        this(rowKeyDecoder, new SpanDecoderV0(), StringAllocatorFactory.DEFAULT);
     }
 
-    public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder, int cacheSize) {
-        this(rowKeyDecoder, new SpanDecoderV0(), cacheSize);
+    public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder, StringAllocatorFactory stringAllocatorFactory) {
+        this(rowKeyDecoder, new SpanDecoderV0(), stringAllocatorFactory);
     }
 
     public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder, SpanDecoder spanDecoder) {
-        this(rowKeyDecoder, spanDecoder, DISABLED_CACHE);
+        this(rowKeyDecoder, spanDecoder, StringAllocatorFactory.DEFAULT);
     }
 
-    public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder, SpanDecoder spanDecoder, int cacheSize) {
+    public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder, SpanDecoder spanDecoder, StringAllocatorFactory stringAllocatorFactory) {
         this.rowKeyDecoder = Objects.requireNonNull(rowKeyDecoder, "rowKeyDecoder");
         this.spanDecoder = Objects.requireNonNull(spanDecoder, "spanDecoder");
-        this.cacheSize = cacheSize;
+        this.stringAllocatorFactory = Objects.requireNonNull(stringAllocatorFactory, "stringAllocatorFactory");
     }
 
     @Override
@@ -102,9 +100,8 @@ public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
         List<SpanChunkBo> spanChunkList = new ArrayList<>();
 
         final SpanDecodingContext decodingContext = new SpanDecodingContext(transactionId);
-        if (cacheSize > 0) {
-            decodingContext.setStringAllocator(new CachedStringAllocator(cacheSize));
-        }
+        // per-row allocator, see StringAllocatorFactory
+        decodingContext.setStringAllocator(stringAllocatorFactory.create());
 
         for (Cell cell : rawCells) {
             SpanDecoder spanDecoder = null;


### PR DESCRIPTION
SpanMapperV2 created CachedStringAllocator from a raw cacheSize int per
row. Introduce StringAllocatorFactory owning the per-scope allocation
strategy: the property binding moves to TraceConfiguration, and the
mapper just calls create() per row. The factory contract documents why
a caching allocator must not outlive a single row decode (its keys wrap
the row's backing array).
