### PR TITLE
[#noissue] Implement OTLP/HTTP trace export response semantics

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceController.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceController.java
@@ -16,10 +16,16 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.controller;
 
+import com.google.rpc.Code;
+import com.google.rpc.Status;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportResult;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportService;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceResponseMapper;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,15 +43,31 @@ public class OtlpTraceController {
         this.exportService = Objects.requireNonNull(exportService, "exportService");
     }
 
-    @PostMapping(value = "/v1/traces", consumes = "application/x-protobuf")
-    public ResponseEntity<Void> saveOtlpMetric(@RequestBody ExportTraceServiceRequest request) {
+    // OTLP/HTTP response semantics (M-1), shared with the gRPC path via OtlpTraceResponseMapper:
+    // success / client-rejected -> 200 + ExportTraceServiceResponse body (empty or partial success),
+    // server error -> retryable 503 + google.rpc.Status body. Content-Type mirrors the protobuf request.
+    @PostMapping(value = "/v1/traces",
+            consumes = MediaType.APPLICATION_PROTOBUF_VALUE,
+            produces = MediaType.APPLICATION_PROTOBUF_VALUE)
+    public ResponseEntity<byte[]> export(@RequestBody ExportTraceServiceRequest request) {
         final List<ResourceSpans> resourceSpanList = request.getResourceSpansList();
         final OtlpTraceExportResult result = exportService.export(resourceSpanList);
 
-        // NOTE (M-1, out of scope for this change): the HTTP path currently returns 200 regardless of
-        // outcome and sends no ExportTraceServiceResponse body. result.serverErrorCount() /
-        // result.clientRejected() are now available here to implement proper OTLP/HTTP response
-        // semantics (5xx on server error, ExportTracePartialSuccess body on client rejects) later.
-        return ResponseEntity.ok().build();
+        if (OtlpTraceResponseMapper.isServerError(result)) {
+            // Mirror the gRPC UNAVAILABLE path with a retryable 503 carrying a google.rpc.Status body,
+            // so the exporter retries the whole batch instead of silently dropping recoverable data.
+            final Status status = Status.newBuilder()
+                    .setCode(Code.UNAVAILABLE_VALUE)
+                    .setMessage(result.serverMessage())
+                    .build();
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .contentType(MediaType.APPLICATION_PROTOBUF)
+                    .body(status.toByteArray());
+        }
+
+        final ExportTraceServiceResponse response = OtlpTraceResponseMapper.toResponse(result);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PROTOBUF)
+                .body(response.toByteArray());
     }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceService.java
@@ -16,11 +16,9 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.service;
 
-import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
 import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
-import io.opentelemetry.proto.collector.trace.v1.ExportTracePartialSuccess;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
@@ -108,7 +106,7 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
     private void handleExport(List<ResourceSpans> resourceSpanList, StreamObserver<ExportTraceServiceResponse> responseObserver) {
         final OtlpTraceExportResult result = exportService.export(resourceSpanList);
 
-        if (result.serverErrorCount() > 0) {
+        if (OtlpTraceResponseMapper.isServerError(result)) {
             // Server-side / transient failures (HBase insert, agentInfo): ask the client to retry
             // the whole batch via UNAVAILABLE (retryable) instead of dropping recoverable data.
             // INVALID_ARGUMENT here would be treated as non-retryable and silently lost.
@@ -116,19 +114,8 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
             return;
         }
 
-        final OtlpTraceCollectorRejectedSpan clientRejected = result.clientRejected();
-        if (clientRejected.count() > 0) {
-            // Client-side data faults (invalid/missing identifiers, unlinkable spans) are
-            // deterministic, so report them via OTLP partial success rather than a retryable error.
-            final ExportTracePartialSuccess partialSuccess = ExportTracePartialSuccess.newBuilder()
-                    .setErrorMessage(clientRejected.getMessage())
-                    .setRejectedSpans(clientRejected.count())
-                    .build();
-            safeComplete(responseObserver, ExportTraceServiceResponse.newBuilder().setPartialSuccess(partialSuccess).build());
-        } else {
-            // success
-            safeComplete(responseObserver, ExportTraceServiceResponse.getDefaultInstance());
-        }
+        // Client-side data faults surface as OTLP partial success; a clean run as the empty response.
+        safeComplete(responseObserver, OtlpTraceResponseMapper.toResponse(result));
     }
 
     // Guards response calls against IllegalStateException when the client already closed the call

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceResponseMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceResponseMapper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
+import io.opentelemetry.proto.collector.trace.v1.ExportTracePartialSuccess;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+
+/**
+ * Maps a transport-agnostic {@link OtlpTraceExportResult} to the OTLP response semantics shared by
+ * the gRPC ({@code GrpcOtlpTraceService}) and HTTP ({@code OtlpTraceController}) transports, so both
+ * paths classify an export outcome identically.
+ * <p>
+ * Only the two non-error outcomes have a common on-the-wire representation (an
+ * {@link ExportTraceServiceResponse}); the retryable server-error outcome is rendered per transport
+ * (gRPC {@code UNAVAILABLE} status vs HTTP 5xx + {@code google.rpc.Status} body), so callers branch
+ * on {@link #isServerError(OtlpTraceExportResult)} first and render the error themselves.
+ */
+public final class OtlpTraceResponseMapper {
+
+    private OtlpTraceResponseMapper() {
+    }
+
+    /**
+     * Whether the result carries retryable server-side / transient failures (HBase insert, agentInfo).
+     * Callers must render this as a retryable error (gRPC UNAVAILABLE / HTTP 5xx) before calling
+     * {@link #toResponse(OtlpTraceExportResult)}.
+     */
+    public static boolean isServerError(OtlpTraceExportResult result) {
+        return result.serverErrorCount() > 0;
+    }
+
+    /**
+     * Builds the OTLP response for a non-server-error result: an {@link ExportTracePartialSuccess}
+     * body when the client sent deterministically rejected spans, otherwise the empty success response.
+     */
+    public static ExportTraceServiceResponse toResponse(OtlpTraceExportResult result) {
+        final OtlpTraceCollectorRejectedSpan clientRejected = result.clientRejected();
+        if (clientRejected.count() > 0) {
+            // Client-side data faults (invalid/missing identifiers, unlinkable spans) are
+            // deterministic, so report them via OTLP partial success rather than a retryable error.
+            final ExportTracePartialSuccess partialSuccess = ExportTracePartialSuccess.newBuilder()
+                    .setErrorMessage(clientRejected.getMessage())
+                    .setRejectedSpans(clientRejected.count())
+                    .build();
+            return ExportTraceServiceResponse.newBuilder().setPartialSuccess(partialSuccess).build();
+        }
+        return ExportTraceServiceResponse.getDefaultInstance();
+    }
+}


### PR DESCRIPTION
The HTTP /v1/traces endpoint returned an empty 200 regardless of outcome, dropping data silently (an OTLP MUST-NOT violation) while the gRPC path already mapped the same OtlpTraceExportResult to proper OTLP semantics.

Extract the shared classification into OtlpTraceResponseMapper so both transports treat an export outcome identically:
- success            -> 200 + empty ExportTraceServiceResponse
- client-rejected    -> 200 + ExportTracePartialSuccess body
- server error       -> retryable (gRPC UNAVAILABLE / HTTP 503) so the
                        exporter retries the batch instead of losing it

Only the two non-error outcomes share an on-the-wire representation; the server-error outcome is rendered per transport (gRPC Status vs HTTP 5xx + google.rpc.Status body), so callers branch on isServerError() first.

The HTTP response now carries a protobuf body with a matching application/x-protobuf Content-Type.