### PR TITLE
[#noissue] Support gzip request decompression on the OTLP/HTTP trace …

### DIFF
--- a/otlptrace/otlptrace-collector/README.md
+++ b/otlptrace/otlptrace-collector/README.md
@@ -79,9 +79,9 @@ OTLP exporter
 
 ## 3. HTTP Layer
 
-- Endpoint: a single mapping `POST /v1/traces`, `consumes = application/x-protobuf`
-  (`OtlpTraceController.java:67-68`). **OTLP/HTTP JSON encoding is not supported** (415),
-  **Content-Encoding: gzip is not supported** (parse failure 400 — beware exporters that default to gzip).
+- Endpoint: a single mapping `POST /v1/traces`, `consumes = application/x-protobuf`.
+  **OTLP/HTTP JSON encoding is not supported** (415). **`Content-Encoding: gzip` is supported**
+  (decompressed by `OtlpTraceDecompressionFilter`); any other encoding → **415**.
 - Body parsing: `ProtobufHttpMessageConverter` (`OtlpTraceCollectorHttpModule.java:36-40`)
 - Executed synchronously on the Tomcat request thread (no worker offload)
 
@@ -97,6 +97,15 @@ deserialization. A 3-stage gate:
 
 Permits are released in a finally block after the entire request (parse + insert) completes.
 Config keys: `pinpoint.collector.otlptrace.http.*`
+
+### Decompression Filter (`OtlpTraceDecompressionFilter`)
+
+Registered for `/v1/traces` just after the admission filter (`HIGHEST_PRECEDENCE + 1`), so the
+compressed-size gates apply to the raw request first. `Content-Encoding: gzip` bodies are inflated
+before protobuf deserialization; `identity`/absent pass through; any other encoding → **415**.
+Since Content-Length bounds only the compressed size, the inflated stream is capped at
+`http.max-decompressed-request-bytes` (16MB) to guard against decompression bombs — overflow → **400**.
+The gRPC path needs no counterpart (grpc-java decompresses `grpc-encoding: gzip` natively).
 
 ### gRPC vs HTTP comparison
 

--- a/otlptrace/otlptrace-collector/pom.xml
+++ b/otlptrace/otlptrace-collector/pom.xml
@@ -92,5 +92,10 @@
             <artifactId>spring-kafka</artifactId>
             <version>${spring.kafka.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorHttpModule.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorHttpModule.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector;
 
+import com.navercorp.pinpoint.otlp.trace.collector.controller.OtlpTraceDecompressionFilter;
 import com.navercorp.pinpoint.otlp.trace.collector.controller.OtlpTraceHttpAdmissionFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -56,6 +57,22 @@ public class OtlpTraceCollectorHttpModule implements WebMvcConfigurer {
         FilterRegistrationBean<OtlpTraceHttpAdmissionFilter> registration = new FilterRegistrationBean<>(filter);
         registration.addUrlPatterns(OTLP_HTTP_TRACES_PATH);
         registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+
+    /**
+     * Decompresses {@code Content-Encoding: gzip} bodies for {@value #OTLP_HTTP_TRACES_PATH} (the
+     * OTel {@code otlphttp} exporter's default). Ordered just after the admission filter so the
+     * compressed-size gates apply to the raw request first, then the inflated size is capped to guard
+     * against decompression bombs.
+     */
+    @Bean
+    public FilterRegistrationBean<OtlpTraceDecompressionFilter> otlpTraceDecompressionFilter(
+            @Value("${pinpoint.collector.otlptrace.http.max-decompressed-request-bytes:16777216}") int maxDecompressedBytes) {
+        OtlpTraceDecompressionFilter filter = new OtlpTraceDecompressionFilter(maxDecompressedBytes);
+        FilterRegistrationBean<OtlpTraceDecompressionFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.addUrlPatterns(OTLP_HTTP_TRACES_PATH);
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 1);
         return registration;
     }
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceDecompressionFilter.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceDecompressionFilter.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.controller;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Content-Encoding decompression for the OTLP/HTTP trace endpoint (POST /v1/traces).
+ *
+ * <p>The OTel Collector's {@code otlphttp} exporter compresses with gzip by default, so without
+ * this filter the raw gzip bytes reach {@code ProtobufHttpMessageConverter} and fail to parse
+ * (HTTP 400) — an OTLP/HTTP interop break. This filter transparently inflates a
+ * {@code Content-Encoding: gzip} body so the converter sees plain protobuf.
+ *
+ * <ul>
+ *   <li>no / empty Content-Encoding, or {@code identity} &rarr; passed through unchanged</li>
+ *   <li>{@code gzip} &rarr; body inflated through a size-limited stream</li>
+ *   <li>any other encoding &rarr; 415 Unsupported Media Type (only gzip is defined by OTLP/HTTP)</li>
+ * </ul>
+ *
+ * <p><b>Decompression-bomb guard.</b> The admission filter's per-request cap bounds only the
+ * <i>compressed</i> size (Content-Length); a small gzip body can inflate by orders of magnitude.
+ * The inflated stream is therefore capped at {@code maxDecompressedBytes}: exceeding it aborts the
+ * read with an {@link IOException}, which surfaces to the converter as a 400 (same as the admission
+ * filter's chunked-body guard). Worst-case heap is {@code maxConcurrentRequests * maxDecompressedBytes},
+ * since the converter materializes the whole decompressed message.
+ *
+ * <p>Runs just after {@link OtlpTraceHttpAdmissionFilter} so the compressed-size gates (413 /
+ * in-flight byte budget) apply to the raw request first. The gRPC path needs no counterpart: grpc-java
+ * decompresses {@code grpc-encoding: gzip} via its default decompressor registry.
+ */
+public class OtlpTraceDecompressionFilter extends OncePerRequestFilter {
+
+    private static final String GZIP = "gzip";
+    private static final String IDENTITY = "identity";
+
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    private final int maxDecompressedBytes;
+
+    public OtlpTraceDecompressionFilter(int maxDecompressedBytes) {
+        this.maxDecompressedBytes = maxDecompressedBytes;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        final String encoding = request.getHeader(HttpHeaders.CONTENT_ENCODING);
+        if (encoding == null || encoding.isBlank() || IDENTITY.equalsIgnoreCase(encoding.trim())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        if (!GZIP.equalsIgnoreCase(encoding.trim())) {
+            // Only gzip is defined for OTLP/HTTP; reject anything else (incl. multi-encoding) explicitly
+            // rather than letting an undecoded body fail later as an opaque 400.
+            logger.warn("OTLP/HTTP trace request rejected. Unsupported Content-Encoding={}", encoding);
+            response.setStatus(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
+            return;
+        }
+
+        filterChain.doFilter(new GzipRequestWrapper(request, maxDecompressedBytes), response);
+    }
+
+    /**
+     * Presents a gzip-encoded request as its decompressed body. Content-Length now describes the
+     * compressed size, so it is cleared (reported as unknown) to stop a downstream reader from
+     * truncating the inflated stream at the compressed length.
+     */
+    private static final class GzipRequestWrapper extends HttpServletRequestWrapper {
+        private final int limit;
+        // Created lazily and cached so repeated getInputStream() calls return the same instance
+        // (servlet wrapper contract). A second GZIPInputStream over the already-consumed underlying
+        // stream would otherwise fail to re-read the gzip header. Single-threaded per request.
+        private ServletInputStream inputStream;
+
+        private GzipRequestWrapper(HttpServletRequest request, int limit) {
+            super(request);
+            this.limit = limit;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            if (this.inputStream == null) {
+                this.inputStream = new GzipLimitedServletInputStream(super.getInputStream(), limit);
+            }
+            return this.inputStream;
+        }
+
+        @Override
+        public int getContentLength() {
+            return -1;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return -1;
+        }
+
+        // Hide the now-inaccurate framing headers across every accessor: Content-Length describes the
+        // compressed size and Content-Encoding has already been applied, so a caller reading either
+        // (directly, by enumeration, or as an int) must not see the original values.
+        private static boolean isHiddenHeader(String name) {
+            return HttpHeaders.CONTENT_LENGTH.equalsIgnoreCase(name)
+                    || HttpHeaders.CONTENT_ENCODING.equalsIgnoreCase(name);
+        }
+
+        @Override
+        public String getHeader(String name) {
+            return isHiddenHeader(name) ? null : super.getHeader(name);
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(String name) {
+            return isHiddenHeader(name) ? Collections.emptyEnumeration() : super.getHeaders(name);
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            final List<String> names = new ArrayList<>();
+            final Enumeration<String> original = super.getHeaderNames();
+            if (original != null) {
+                while (original.hasMoreElements()) {
+                    final String name = original.nextElement();
+                    if (!isHiddenHeader(name)) {
+                        names.add(name);
+                    }
+                }
+            }
+            return Collections.enumeration(names);
+        }
+
+        @Override
+        public int getIntHeader(String name) {
+            // Contract: -1 when the header is absent, which is what hiding it should look like.
+            return isHiddenHeader(name) ? -1 : super.getIntHeader(name);
+        }
+    }
+
+    /**
+     * Inflates a gzip stream while counting decompressed bytes, aborting once {@code limit} is exceeded.
+     * The {@link GZIPInputStream} is constructed eagerly, so a body that is not valid gzip fails here
+     * (surfaces to the protobuf converter as a 400). Async reads are not supported (OTLP ingestion is
+     * a blocking read through the message converter).
+     */
+    private static final class GzipLimitedServletInputStream extends ServletInputStream {
+        private final GZIPInputStream gzip;
+        private final long limit;
+        private long count;
+        private boolean finished;
+
+        private GzipLimitedServletInputStream(InputStream compressed, long limit) throws IOException {
+            this.gzip = new GZIPInputStream(compressed);
+            this.limit = limit;
+        }
+
+        private void add(int read) throws IOException {
+            count += read;
+            if (count > limit) {
+                throw new IOException("OTLP/HTTP decompressed request body exceeded max size: limit=" + limit);
+            }
+        }
+
+        @Override
+        public int read() throws IOException {
+            final int b = gzip.read();
+            if (b < 0) {
+                finished = true;
+                return -1;
+            }
+            add(1);
+            return b;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            final int n = gzip.read(b, off, len);
+            if (n < 0) {
+                finished = true;
+                return -1;
+            }
+            add(n);
+            return n;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return finished;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new UnsupportedOperationException("async read not supported");
+        }
+
+        @Override
+        public void close() throws IOException {
+            gzip.close();
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/pinpoint-otlptrace-grpc-root.properties
+++ b/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/pinpoint-otlptrace-grpc-root.properties
@@ -73,6 +73,11 @@ pinpoint.collector.otlptrace.http.admission.max-in-flight-bytes=268435456
 pinpoint.collector.otlptrace.http.max-concurrent-requests=64
 # Retry-After (seconds) returned on 503 backpressure.
 pinpoint.collector.otlptrace.http.rejected.retry-after-seconds=1
+# gzip decompression cap (OtlpTraceDecompressionFilter). Content-Length bounds only the compressed
+# size, so the inflated body is capped here to guard against decompression bombs; exceeding it -> 400.
+# 16MB = ~4x max-request-bytes headroom for gzip'd protobuf. Worst-case inflated heap is
+# max-concurrent-requests * this value, so raise both together. Unsupported encodings -> 415.
+pinpoint.collector.otlptrace.http.max-decompressed-request-bytes=16777216
 
 # --- TLS (in-app) ---
 # Activated by pinpoint.modules.collector.grpc.otlptrace.ssl.enabled=true (default off).

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceDecompressionFilterTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceDecompressionFilterTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.controller;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.util.StreamUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OtlpTraceDecompressionFilterTest {
+
+    private static final int MAX_DECOMPRESSED = 1024 * 1024; // 1MB
+
+    private static byte[] gzip(byte[] plain) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gos = new GZIPOutputStream(bos)) {
+            gos.write(plain);
+        }
+        return bos.toByteArray();
+    }
+
+    private static MockHttpServletRequest request(String contentEncoding, byte[] body) {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/v1/traces");
+        if (contentEncoding != null) {
+            request.addHeader(HttpHeaders.CONTENT_ENCODING, contentEncoding);
+        }
+        request.setContent(body);
+        return request;
+    }
+
+    @Test
+    void gzipBody_isDecompressedForDownstream() throws ServletException, IOException {
+        byte[] plain = "hello-otlp-protobuf-payload".getBytes(StandardCharsets.UTF_8);
+        MockHttpServletRequest request = request("gzip", gzip(plain));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).as("chain invoked with wrapped request").isNotNull();
+        byte[] decoded = StreamUtils.copyToByteArray(chain.getRequest().getInputStream());
+        assertThat(decoded).isEqualTo(plain);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        // Content-Length now describes the compressed size, so it is hidden (unknown) to stop a
+        // downstream reader from truncating the inflated stream at the compressed length.
+        assertThat(chain.getRequest().getContentLength()).isEqualTo(-1);
+        assertThat(((jakarta.servlet.http.HttpServletRequest) chain.getRequest())
+                .getHeader(HttpHeaders.CONTENT_ENCODING)).isNull();
+    }
+
+    @Test
+    void wrappedRequest_returnsSameInputStreamInstanceOnRepeatedCalls() throws ServletException, IOException {
+        MockHttpServletRequest request = request("gzip", gzip("repeatable".getBytes(StandardCharsets.UTF_8)));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+
+        jakarta.servlet.ServletRequest wrapped = chain.getRequest();
+        // Servlet wrapper contract: repeated getInputStream() must return the same instance, otherwise
+        // a second GZIPInputStream over the already-consumed underlying stream would corrupt the read.
+        assertThat(wrapped.getInputStream()).isSameAs(wrapped.getInputStream());
+    }
+
+    @Test
+    void wrappedRequest_hidesFramingHeadersAcrossAllAccessors() throws ServletException, IOException {
+        byte[] body = gzip("payload".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletRequest request = request("gzip", body);
+        request.addHeader("Content-Length", String.valueOf(body.length));
+        request.addHeader("X-Custom", "keep");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+
+        jakarta.servlet.http.HttpServletRequest wrapped =
+                (jakarta.servlet.http.HttpServletRequest) chain.getRequest();
+        // Content-Length (compressed) and Content-Encoding (already applied) must be hidden everywhere.
+        assertThat(wrapped.getHeader(HttpHeaders.CONTENT_ENCODING)).isNull();
+        assertThat(wrapped.getHeader(HttpHeaders.CONTENT_LENGTH)).isNull();
+        assertThat(java.util.Collections.list(wrapped.getHeaders(HttpHeaders.CONTENT_ENCODING))).isEmpty();
+        assertThat(java.util.Collections.list(wrapped.getHeaders(HttpHeaders.CONTENT_LENGTH))).isEmpty();
+        assertThat(wrapped.getIntHeader(HttpHeaders.CONTENT_LENGTH)).isEqualTo(-1);
+
+        List<String> names = java.util.Collections.list(wrapped.getHeaderNames());
+        assertThat(names).noneMatch(n -> n.equalsIgnoreCase(HttpHeaders.CONTENT_LENGTH)
+                || n.equalsIgnoreCase(HttpHeaders.CONTENT_ENCODING));
+        // Non-framing headers must still pass through.
+        assertThat(wrapped.getHeader("X-Custom")).isEqualTo("keep");
+        assertThat(names).contains("X-Custom");
+    }
+
+    @Test
+    void gzipCaseInsensitive_isDecompressed() throws ServletException, IOException {
+        byte[] plain = "case-insensitive".getBytes(StandardCharsets.UTF_8);
+        MockHttpServletRequest request = request("GZIP", gzip(plain));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).isNotNull();
+        assertThat(StreamUtils.copyToByteArray(chain.getRequest().getInputStream())).isEqualTo(plain);
+    }
+
+    @Test
+    void noEncoding_passesThroughUnchanged() throws ServletException, IOException {
+        MockHttpServletRequest request = request(null, "plain".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).as("same request instance passed through").isSameAs(request);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+    }
+
+    @Test
+    void identityEncoding_passesThroughUnchanged() throws ServletException, IOException {
+        MockHttpServletRequest request = request("identity", "plain".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).isSameAs(request);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+    }
+
+    @Test
+    void unsupportedEncoding_returns415AndShortCircuits() throws ServletException, IOException {
+        MockHttpServletRequest request = request("br", "whatever".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
+        assertThat(chain.getRequest()).as("chain must not be invoked").isNull();
+    }
+
+    @Test
+    void decompressionBomb_abortsReadOnceLimitExceeded() throws ServletException, IOException {
+        // 64KB inflates to a tiny gzip body; a 1KB cap must abort the read before full inflation.
+        byte[] plain = new byte[64 * 1024];
+        MockHttpServletRequest request = request("gzip", gzip(plain));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        final int tinyLimit = 1024;
+        new OtlpTraceDecompressionFilter(tinyLimit).doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).isNotNull();
+        assertThatThrownBy(() -> StreamUtils.copyToByteArray(chain.getRequest().getInputStream()))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("exceeded max size");
+    }
+
+    @Test
+    void invalidGzip_failsOnStreamOpen() throws ServletException, IOException {
+        MockHttpServletRequest request = request("gzip", "this-is-not-gzip".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).isNotNull();
+        // GZIPInputStream validates the header eagerly, so opening the body fails (surfaces as a 400).
+        assertThatThrownBy(() -> chain.getRequest().getInputStream())
+                .isInstanceOf(IOException.class);
+    }
+}


### PR DESCRIPTION
…endpoint

The OTel Collector's otlphttp exporter compresses with gzip by default, so POST /v1/traces rejected those bodies with a parse-failure 400 (the raw gzip bytes reached ProtobufHttpMessageConverter) — an OTLP/HTTP interop break. The gRPC path already decompresses grpc-encoding: gzip via grpc-java's default decompressor registry, so this was HTTP-only.

Add OtlpTraceDecompressionFilter, scoped to /v1/traces and ordered just after the admission filter so the compressed-size gates apply to the raw request first:
- Content-Encoding gzip -> body inflated for the converter
- absent / identity     -> passed through unchanged
- any other encoding    -> 415 Unsupported Media Type (only gzip is defined)

Decompression-bomb guard: Content-Length bounds only the compressed size, so the inflated stream is capped at http.max-decompressed-request-bytes (16MB default); overflow aborts the read -> 400. Content-Length/Content-Encoding are hidden on the wrapped request so a downstream reader cannot truncate the inflated stream at the compressed length. Worst-case heap is max-concurrent-requests * the cap, documented alongside the new property.

README updated to reflect gzip support; adds spring-test (test scope) for the MockHttpServletRequest-based filter tests.