### PR TITLE
[#noissue] Raise OTLP gRPC inbound limit to 4MB and align the admissi…

### DIFF
--- a/otlptrace/otlptrace-collector/README.md
+++ b/otlptrace/otlptrace-collector/README.md
@@ -51,14 +51,14 @@ OTLP exporter
 
 | Item | Value | Notes |
 |---|---|---|
-| inbound_message_size_max | 1MB | More conservative than the main collector's span receiver (4MB) |
+| inbound_message_size_max | 4MB | Matches the reference OTel Collector (4MiB) and the HTTP path; worst-case ~512MB/connection direct memory at 128 concurrent calls |
 | HTTP/2 flow-control window | 512KB | |
 | Concurrent calls per connection | 128 | Conservative vs the main collector's 1024 |
 | keepalive | time 30s / timeout 60s, permit 10s + without_calls | Handles OTLP exporter idle PINGs (avoids GOAWAY too_many_pings) |
 | max header | 8KB | Accounts for the JWT Authorization header |
 | server executor | 4 threads / queue 256 | Serves both the gRPC handler and HBase async callbacks |
 | worker executor | 16 threads / queue 128 | Runs mapping + insert, AbortPolicy |
-| in-flight byte admission | 256MB (Semaphore) | The code `@Value` default is 64MB — note the mismatch |
+| in-flight byte admission | 256MB (Semaphore) | Code `@Value` default aligned to 256MB (matches this properties value) |
 
 ### Request handling flow (`GrpcOtlpTraceService.java:86-153`)
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
@@ -89,7 +89,7 @@ public class OtlpTraceCollectorModule {
     @Bean
     public ServerServiceDefinition serverServiceDefinition(OtlpTraceExportService exportService,
                                                            @Qualifier("grpcOtlpTraceWorkerExecutor") Executor workerExecutor,
-                                                           @Value("${pinpoint.collector.otlptrace.admission.max-in-flight-bytes:67108864}") int maxInFlightBytes,
+                                                           @Value("${pinpoint.collector.otlptrace.admission.max-in-flight-bytes:268435456}") int maxInFlightBytes,
                                                            MeterRegistry meterRegistry) {
         BindableService spanService = new GrpcOtlpTraceService(exportService, workerExecutor, maxInFlightBytes);
         // gRPC server metrics (request count / latency / status code) for the OTLP trace endpoint,

--- a/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/pinpoint-otlptrace-grpc-root.properties
+++ b/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/pinpoint-otlptrace-grpc-root.properties
@@ -31,12 +31,19 @@ collector.receiver.grpc.otlp.trace.channel-type=AUTO
 
 # --- Flow control / message size (rate protection) ---
 # Bound concurrent calls per connection (ServerOption default is unlimited) and cap inbound
-# message size so a single OTLP exporter cannot overwhelm the receiver. Sized for a ~8GB server:
-# each in-flight call holds up to inbound_message_size_max of wire buffer, so 128 caps that to
-# ~128MB/connection of direct memory (the global ceiling is admission.max-in-flight-bytes below).
+# message size so a single OTLP exporter cannot overwhelm the receiver.
+# inbound is 4MB (was 1MB) to match the reference OTel Collector's 4MiB default and the HTTP path's
+# max-request-bytes: a batch over the limit is rejected with RESOURCE_EXHAUSTED, which OTLP treats as
+# terminal (no RetryInfo), so the exporter drops it permanently — 1MB was too small for typical batches.
+# Memory (~8GB server): each in-flight call buffers up to inbound_message_size_max of wire bytes (direct
+# memory), so 128 concurrent calls => up to ~512MB/connection worst case (was ~128MB at 1MB). This is the
+# adversarial ceiling (128 simultaneous max-size uploads on one connection); a normal exporter keeps only
+# a few streams in flight. It assumes a modest connection count — set -XX:MaxDirectMemorySize explicitly
+# rather than relying on it defaulting to -Xmx. The heap-side processing bound is unchanged
+# (admission.max-in-flight-bytes below).
 collector.receiver.grpc.otlp.trace.concurrent-calls_per-connection_max=128
 collector.receiver.grpc.otlp.trace.flow-control_window_size_init=512KB
-collector.receiver.grpc.otlp.trace.inbound_message_size_max=1MB
+collector.receiver.grpc.otlp.trace.inbound_message_size_max=4MB
 
 # --- Mapping truncation / memory protection (non-gRPC, prefix: pinpoint.collector.otlptrace.*) ---
 # Co-located here (not in the shared pinpoint-collector*.properties) so all otlptrace receiver


### PR DESCRIPTION
…on default

inbound_message_size_max was 1MB — smaller than the reference OTel Collector's 4MiB default and the HTTP path's max-request-bytes (4MB). A batch over the limit is rejected with RESOURCE_EXHAUSTED, which OTLP treats as terminal (no RetryInfo), so the exporter drops it permanently rather than retrying. Raise it to 4MB to match the ecosystem default and the HTTP transport.

Memory note (~8GB server): each in-flight call buffers up to inbound_message_size_max of wire bytes, so 128 concurrent calls now reach ~512MB/connection worst case (was ~128MB). That is the adversarial ceiling; a normal exporter keeps few streams in flight. The comment now flags this and recommends setting -XX:MaxDirectMemorySize explicitly. The heap-side processing bound (admission.max-in-flight-bytes) is unchanged.

Also align the admission.max-in-flight-bytes @Value fallback (64MB) with the shipped properties value (256MB), so a deployment missing the property no longer silently runs at a quarter of the intended 8GB-sized budget.