### PR TITLE
[#noissue] Validate OTLP trace and span IDs at ingestion

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpIdValidator.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpIdValidator.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.google.protobuf.ByteString;
+import com.navercorp.pinpoint.common.PinpointConstants;
+import com.navercorp.pinpoint.common.server.util.ByteStringUtils;
+import com.navercorp.pinpoint.common.util.BytesUtils;
+
+/**
+ * Validates OTLP trace/span identifiers at the ingestion boundary, per the OTel Trace API: a trace ID
+ * is exactly 16 bytes and a span ID exactly 8 bytes, and neither may be all-zero.
+ *
+ * <p>Without this, the previous conversion accepted invalid IDs: an over-8-byte span ID was silently
+ * truncated to its first 8 bytes (distinct IDs could collide) and an all-zero trace/span ID passed
+ * through. Validating here rejects those as client-data faults.
+ *
+ * <p>The throwing {@code validate*} forms raise {@link IllegalArgumentException} so the caller counts
+ * the span as a client-side reject (reflected in {@code rejected_spans}), never as a server error.
+ * The boolean {@code isValid*} forms are for callers that filter/skip without throwing (span map
+ * gate, link drop).
+ *
+ * <p>Kept separate from {@link com.navercorp.pinpoint.common.server.trace.OtelServerTraceId}, which is
+ * a storage/read-back type that must stay permissive; validation belongs only on the ingestion path.
+ */
+public final class OtlpIdValidator {
+
+    private static final int TRACE_ID_LEN = PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN; // 16
+    private static final int SPAN_ID_LEN = BytesUtils.LONG_BYTE_LENGTH; // 8
+
+    private OtlpIdValidator() {
+    }
+
+    public static boolean isValidTraceId(ByteString traceId) {
+        return traceIdError(traceId) == null;
+    }
+
+    public static boolean isValidSpanId(ByteString spanId) {
+        return spanIdError(spanId) == null;
+    }
+
+    /**
+     * A parent span reference is valid when it is either absent (a root span) or itself a valid span ID.
+     * A present-but-malformed parent is treated as invalid so the owning span can be rejected.
+     */
+    public static boolean isValidParentSpanId(ByteString parentSpanId) {
+        return ByteStringUtils.isEmpty(parentSpanId) || isValidSpanId(parentSpanId);
+    }
+
+    /**
+     * @return the 16-byte trace ID
+     * @throws IllegalArgumentException if empty, not 16 bytes, or all-zero
+     */
+    public static byte[] validateTraceId(ByteString traceId) {
+        final String error = traceIdError(traceId);
+        if (error != null) {
+            throw new IllegalArgumentException("invalid traceId: " + error);
+        }
+        return traceId.toByteArray();
+    }
+
+    /**
+     * @return the span ID as a big-endian long
+     * @throws IllegalArgumentException if empty, not 8 bytes, or all-zero
+     */
+    public static long validateSpanId(ByteString spanId) {
+        final String error = spanIdError(spanId);
+        if (error != null) {
+            throw new IllegalArgumentException("invalid spanId: " + error);
+        }
+        return ByteStringUtils.parseLong(spanId);
+    }
+
+    private static String traceIdError(ByteString traceId) {
+        return idError(traceId, TRACE_ID_LEN);
+    }
+
+    private static String spanIdError(ByteString spanId) {
+        return idError(spanId, SPAN_ID_LEN);
+    }
+
+    private static String idError(ByteString id, int expectedLen) {
+        if (ByteStringUtils.isEmpty(id)) {
+            return "empty";
+        }
+        if (id.size() != expectedLen) {
+            return "length " + id.size() + " (expected " + expectedLen + ")";
+        }
+        if (isAllZero(id)) {
+            return "all-zero";
+        }
+        return null;
+    }
+
+    private static boolean isAllZero(ByteString bytes) {
+        for (int i = 0; i < bytes.size(); i++) {
+            if (bytes.byteAt(i) != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapper.java
@@ -44,13 +44,14 @@ public class OtlpTraceLinkMapper {
      * Serializes an OTel {@link Span.Link} as {@link OtelLink} JSON into an
      * {@link AnnotationKey#OPENTELEMETRY_LINK} annotation.
      *
-     * <p>Returns {@code null} when both traceId and spanId are empty — OTel spec requires links
-     * to carry a non-empty SpanContext, so a fully-empty link is invalid input we drop silently.</p>
+     * <p>Returns {@code null} when the link does not carry a valid SpanContext (16-byte non-zero
+     * traceId + 8-byte non-zero spanId). OTel requires a link to reference a valid span, so an
+     * invalid/empty link is unusable input; only the link is dropped, not the owning span.</p>
      *
      * <p>{@code onTruncated} is invoked once per truncated value (traceState or attribute leaf).</p>
      */
     public @Nullable AnnotationBo toAnnotation(Span.Link link, TruncationListener onTruncated) {
-        if (link.getTraceId().isEmpty() && link.getSpanId().isEmpty()) {
+        if (!OtlpIdValidator.isValidTraceId(link.getTraceId()) || !OtlpIdValidator.isValidSpanId(link.getSpanId())) {
             return null;
         }
         try {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
@@ -220,6 +220,7 @@ public class OtlpTraceMapper {
     Map<ByteString, List<ScopedSpan>> getSpanMap(List<ScopeSpans> scopeSpanList, OtlpTraceCollectorRejectedSpan rejectedSpan) {
         Map<ByteString, List<ScopedSpan>> spanMap = new HashMap<>();
         int unsampledCount = 0;
+        int invalidIdCount = 0;
         for (ScopeSpans scopeSpan : scopeSpanList) {
             // The scope→span association only exists on this container — capture it here
             // (see ScopedSpan) so the mappers can emit the OPENTELEMETRY_SCOPE annotation.
@@ -228,6 +229,16 @@ public class OtlpTraceMapper {
             for (Span span : spansList) {
                 if (isUnsampled(span)) {
                     unsampledCount++;
+                    continue;
+                }
+                // Reject malformed identifiers up front (OTel: trace ID = 16 bytes, span ID = 8 bytes,
+                // neither all-zero). A present-but-invalid parentSpanId also rejects the span, so it is
+                // never mis-classified as a root. Skipped here so the invalid ID never becomes a
+                // storage key (transactionId/spanId) or a truncated-collision.
+                if (!OtlpIdValidator.isValidTraceId(span.getTraceId())
+                        || !OtlpIdValidator.isValidSpanId(span.getSpanId())
+                        || !OtlpIdValidator.isValidParentSpanId(span.getParentSpanId())) {
+                    invalidIdCount++;
                     continue;
                 }
                 spanMap.computeIfAbsent(span.getTraceId(), k -> new ArrayList<>()).add(new ScopedSpan(span, scope));
@@ -241,6 +252,12 @@ public class OtlpTraceMapper {
             rejectedSpan.putMessage("unsampled span (" + unsampledCount + ")");
             rejectedSpan.addCount(unsampledCount);
             logger.debug("Dropped unsampled spans count={}", unsampledCount);
+        }
+        if (invalidIdCount > 0) {
+            // Same client-data reject policy as above: count into rejected_spans, debug log only.
+            rejectedSpan.putMessage("invalid id (" + invalidIdCount + ")");
+            rejectedSpan.addCount(invalidIdCount);
+            logger.debug("Dropped spans with invalid trace/span id count={}", invalidIdCount);
         }
         return spanMap;
     }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -215,18 +215,16 @@ public class OtlpTraceMapperUtils {
     }
 
     public static long getSpanId(ByteString bytes) {
-        if (ByteStringUtils.isEmpty(bytes)) {
-            throw new IllegalArgumentException("not found spanId");
-        }
-
-        return ByteStringUtils.parseLong(bytes);
+        // Validates length (exactly 8 bytes — no silent truncation of longer IDs) and rejects all-zero.
+        return OtlpIdValidator.validateSpanId(bytes);
     }
 
     public static long getParentSpanId(ByteString bytes) {
+        // An absent parent (root span) is represented as -1; a present parent must be a valid span ID.
         if (ByteStringUtils.isEmpty(bytes)) {
             return -1;
         }
-        return ByteStringUtils.parseLong(bytes);
+        return OtlpIdValidator.validateSpanId(bytes);
     }
 
     public static Map<String, AttributeValue> getAttributeValueMap(List<KeyValue> keyValueList) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -102,7 +102,7 @@ public class OtlpTraceSpanMapper {
         // leaking into application-keyed storage via the applicationServiceType fallback
         // (trace index v2 row key, server-map self vertex, application registration).
         spanBo.setApplicationServiceType(ServiceType.OPENTELEMETRY_SERVER.getCode());
-        spanBo.setTransactionId(new OtelServerTraceId(span.getTraceId().toByteArray()));
+        spanBo.setTransactionId(new OtelServerTraceId(OtlpIdValidator.validateTraceId(span.getTraceId())));
         spanBo.setSpanId(OtlpTraceMapperUtils.getSpanId(span.getSpanId()));
         spanBo.setParentSpanId(OtlpTraceMapperUtils.getParentSpanId(span.getParentSpanId()));
         final long endTimeNanos = Math.max(span.getEndTimeUnixNano(), startTimeNanos);

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpIdValidatorTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpIdValidatorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OtlpIdValidatorTest {
+
+    private static ByteString bytes(int len, int fill) {
+        final byte[] b = new byte[len];
+        for (int i = 0; i < len; i++) {
+            b[i] = (byte) fill;
+        }
+        return ByteString.copyFrom(b);
+    }
+
+    private static ByteString of(int... values) {
+        final byte[] b = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            b[i] = (byte) values[i];
+        }
+        return ByteString.copyFrom(b);
+    }
+
+    // --- trace id ---
+
+    @Test
+    void validTraceId_16BytesNonZero() {
+        final ByteString id = bytes(16, 1);
+        assertThat(OtlpIdValidator.isValidTraceId(id)).isTrue();
+        assertThat(OtlpIdValidator.validateTraceId(id)).hasSize(16);
+    }
+
+    @Test
+    void traceId_wrongLength_rejected() {
+        assertThat(OtlpIdValidator.isValidTraceId(bytes(8, 1))).isFalse();
+        assertThat(OtlpIdValidator.isValidTraceId(bytes(17, 1))).isFalse();
+        assertThatThrownBy(() -> OtlpIdValidator.validateTraceId(bytes(8, 1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("length");
+    }
+
+    @Test
+    void traceId_empty_rejected() {
+        assertThat(OtlpIdValidator.isValidTraceId(ByteString.EMPTY)).isFalse();
+        assertThatThrownBy(() -> OtlpIdValidator.validateTraceId(ByteString.EMPTY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty");
+    }
+
+    @Test
+    void traceId_allZero_rejected() {
+        assertThat(OtlpIdValidator.isValidTraceId(bytes(16, 0))).isFalse();
+        assertThatThrownBy(() -> OtlpIdValidator.validateTraceId(bytes(16, 0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("all-zero");
+    }
+
+    // --- span id ---
+
+    @Test
+    void validSpanId_8BytesNonZero_parsedBigEndian() {
+        final ByteString id = of(0, 0, 0, 0, 0, 0, 0, 1);
+        assertThat(OtlpIdValidator.isValidSpanId(id)).isTrue();
+        assertThat(OtlpIdValidator.validateSpanId(id)).isEqualTo(1L);
+    }
+
+    @Test
+    void spanId_longerThan8_rejectedNotTruncated() {
+        // Regression: a >8-byte span ID used to be silently truncated to its first 8 bytes.
+        assertThat(OtlpIdValidator.isValidSpanId(bytes(9, 1))).isFalse();
+        assertThatThrownBy(() -> OtlpIdValidator.validateSpanId(bytes(9, 1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("length");
+    }
+
+    @Test
+    void spanId_shorterThan8_rejected() {
+        assertThat(OtlpIdValidator.isValidSpanId(bytes(4, 1))).isFalse();
+        assertThatThrownBy(() -> OtlpIdValidator.validateSpanId(bytes(4, 1)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void spanId_allZero_rejected() {
+        assertThat(OtlpIdValidator.isValidSpanId(bytes(8, 0))).isFalse();
+        assertThatThrownBy(() -> OtlpIdValidator.validateSpanId(bytes(8, 0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("all-zero");
+    }
+
+    // --- parent span id ---
+
+    @Test
+    void parentSpanId_absent_isValid() {
+        assertThat(OtlpIdValidator.isValidParentSpanId(ByteString.EMPTY)).isTrue();
+    }
+
+    @Test
+    void parentSpanId_presentValid_isValid() {
+        assertThat(OtlpIdValidator.isValidParentSpanId(bytes(8, 9))).isTrue();
+    }
+
+    @Test
+    void parentSpanId_presentInvalid_isInvalid() {
+        assertThat(OtlpIdValidator.isValidParentSpanId(bytes(8, 0))).isFalse();
+        assertThat(OtlpIdValidator.isValidParentSpanId(bytes(9, 1))).isFalse();
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceLinkMapperTest.java
@@ -166,6 +166,32 @@ class OtlpTraceLinkMapperTest {
     }
 
     @Test
+    void invalidSpanId_link_isDropped() {
+        // Valid traceId but a malformed spanId (wrong length) — the link cannot reference a real
+        // span, so drop just the link (the owning span is unaffected).
+        Span.Link link = Span.Link.newBuilder()
+                .setTraceId(ByteString.copyFrom(TRACE_ID))
+                .setSpanId(ByteString.copyFrom(new byte[]{1, 2, 3, 4}))
+                .build();
+
+        addLink(link);
+
+        assertThat(annotations).isEmpty();
+    }
+
+    @Test
+    void allZeroIds_link_isDropped() {
+        Span.Link link = Span.Link.newBuilder()
+                .setTraceId(ByteString.copyFrom(new byte[16]))
+                .setSpanId(ByteString.copyFrom(new byte[8]))
+                .build();
+
+        addLink(link);
+
+        assertThat(annotations).isEmpty();
+    }
+
+    @Test
     void allFields_combined() throws Exception {
         Span.Link link = Span.Link.newBuilder()
                 .setTraceId(ByteString.copyFrom(TRACE_ID))

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -169,6 +169,34 @@ class OtlpTraceMapperTest {
                 .build());
     }
 
+    @Test
+    void invalidId_span_isRejectedAndCounted() {
+        OtlpTraceMapper mapper = newMapper();
+        Span validRoot = serverRoot(ROOT_A, "/ok", false);
+        // all-zero span id -> invalid; dropped at the span-map gate before it can become a storage key
+        Span invalidRoot = serverRoot(new byte[8], "/bad", false);
+
+        OtlpTraceMapperData data = mapper.map(resourceSpans(validRoot, invalidRoot));
+
+        assertThat(data.getSpanBoList()).hasSize(1);
+        assertThat(data.getRejectedSpan().count()).isEqualTo(1);
+        assertThat(data.getRejectedSpan().getMessage()).contains("invalid id");
+    }
+
+    @Test
+    void invalidParentSpanId_child_isRejected() {
+        OtlpTraceMapper mapper = newMapper();
+        Span root = serverRoot(ROOT_A, "/ok", false);
+        // present-but-all-zero parentSpanId -> invalid; the child span is rejected (decision A)
+        Span badChild = clientChild(CHILD, new byte[8], false);
+
+        OtlpTraceMapperData data = mapper.map(resourceSpans(root, badChild));
+
+        assertThat(data.getSpanBoList()).hasSize(1);
+        assertThat(data.getRejectedSpan().count()).isEqualTo(1);
+        assertThat(data.getRejectedSpan().getMessage()).contains("invalid id");
+    }
+
     private static ExceptionMetaDataBo findBySpanId(OtlpTraceMapperData data, long rootSpanId) {
         return data.getExceptionMetaDataBoList().stream()
                 .filter(bo -> bo.getSpanId() == rootSpanId)

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -725,14 +725,14 @@ class OtlpTraceMapperUtilsTest {
     void getSpanId_empty_throws() {
         assertThatThrownBy(() -> OtlpTraceMapperUtils.getSpanId(ByteString.EMPTY))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("not found spanId");
+                .hasMessageContaining("invalid spanId");
     }
 
     @Test
     void getSpanId_null_throws() {
         assertThatThrownBy(() -> OtlpTraceMapperUtils.getSpanId(null))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("not found spanId");
+                .hasMessageContaining("invalid spanId");
     }
 
     // =======================================================================


### PR DESCRIPTION
Trace/span identifiers were only checked for emptiness: a span ID longer than 8 bytes was silently truncated to its first 8 bytes (distinct IDs could collide) and an all-zero trace/span ID passed through. An all-zero trace ID is the OTel spec's INVALID_TRACE_ID sentinel and would merge unrelated transactions onto one storage key.

Add OtlpIdValidator enforcing the OTel Trace API: trace ID exactly 16 bytes, span ID exactly 8 bytes, each with at least one non-zero byte. Applied at the span-map gate (per-span traceId/spanId, and a present parentSpanId), so an invalid ID never becomes a storage key and is counted into rejected_spans (client-data fault) rather than truncated or accepted:
- getSpanId/getParentSpanId now reject wrong-length/all-zero instead of truncating
- the trace ID is validated before OtelServerTraceId construction
- a link with an invalid SpanContext is dropped (only the link, not the span)

OtelServerTraceId is left permissive on purpose (a storage/read-back type); validation belongs only on the ingestion path.