### PR TITLE
[#noissue] Force DEFAULT serviceName for OTLP spans

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -201,17 +201,28 @@ public class OtlpTraceMapperUtils {
     }
 
     public static String getServiceName(Map<String, AttributeValue> attributes) {
-        String serviceName = AttributeUtils.getAttributeStringValue(attributes, KEY_PINPOINT_SERVICE_NAME, null);
-        if (serviceName == null) {
-            serviceName = AttributeUtils.getAttributeStringValue(attributes, KEY_SERVICE_NAMESPACE, null);
-        }
-        if (serviceName == null) {
-            return ServiceUid.DEFAULT_SERVICE_UID_NAME;
-        }
-        if (!IdValidateUtils.validateId(serviceName, PinpointConstants.SERVICE_NAME_MAX_LEN)) {
-            throw new IllegalArgumentException("invalid serviceName=" + serviceName);
-        }
-        return serviceName;
+        // TEMPORARY: OTLP spans are always assigned the DEFAULT serviceName, matching the native
+        // agent's effective default (SpanOwner.serviceName = ServiceUid.DEFAULT_SERVICE_UID_NAME).
+        // Rationale: OTLP applications are registered under DEFAULT_SERVICE_UID (see
+        // OtlpTraceExportService), and the web queries service-keyed stores (e.g. the Pinot heatmap
+        // sortKey = serviceName#applicationName) with DEFAULT. Deriving serviceName from
+        // pinpoint.serviceName / service.namespace here produced a key that never matched the web
+        // query, so OTLP transactions were missing from those views.
+        // Revisit once the serviceUid policy for OTLP is decided; the attribute-based resolution
+        // below should be restored (and validated against DEFAULT_SERVICE_UID registration) then.
+        //
+        //   String serviceName = AttributeUtils.getAttributeStringValue(attributes, KEY_PINPOINT_SERVICE_NAME, null);
+        //   if (serviceName == null) {
+        //       serviceName = AttributeUtils.getAttributeStringValue(attributes, KEY_SERVICE_NAMESPACE, null);
+        //   }
+        //   if (serviceName == null) {
+        //       return ServiceUid.DEFAULT_SERVICE_UID_NAME;
+        //   }
+        //   if (!IdValidateUtils.validateId(serviceName, PinpointConstants.SERVICE_NAME_MAX_LEN)) {
+        //       throw new IllegalArgumentException("invalid serviceName=" + serviceName);
+        //   }
+        //   return serviceName;
+        return ServiceUid.DEFAULT_SERVICE_UID_NAME;
     }
 
     public static long getSpanId(ByteString bytes) {

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -548,8 +548,12 @@ class OtlpTraceMapperUtilsTest {
         assertThat(result.serviceName()).isEqualTo(ServiceUid.DEFAULT_SERVICE_UID_NAME);
     }
 
+    // TEMPORARY: serviceName is forced to DEFAULT for OTLP spans (see OtlpTraceMapperUtils.getServiceName).
+    // The pinpoint.serviceName / service.namespace attributes are currently ignored. Restore the
+    // attribute-derived assertions (my-service / otel-ns / pinpoint-over-namespace priority) once the
+    // OTLP serviceUid policy is decided and getServiceName's attribute resolution is re-enabled.
     @Test
-    void getId_serviceName_fromPinpointServiceName() {
+    void getId_serviceName_pinpointServiceName_ignored_returnsDefault() {
         Map<String, AttributeValue> attrs = Map.of(
                 "pinpoint.agentId", AttributeValue.of("agent1"),
                 "pinpoint.applicationName", AttributeValue.of("app"),
@@ -558,11 +562,11 @@ class OtlpTraceMapperUtilsTest {
 
         IdAndName result = OtlpTraceMapperUtils.getId(attrs);
 
-        assertThat(result.serviceName()).isEqualTo("my-service");
+        assertThat(result.serviceName()).isEqualTo(ServiceUid.DEFAULT_SERVICE_UID_NAME);
     }
 
     @Test
-    void getId_serviceName_fromServiceNamespace() {
+    void getId_serviceName_serviceNamespace_ignored_returnsDefault() {
         Map<String, AttributeValue> attrs = Map.of(
                 "pinpoint.agentId", AttributeValue.of("agent1"),
                 "pinpoint.applicationName", AttributeValue.of("app"),
@@ -571,11 +575,11 @@ class OtlpTraceMapperUtilsTest {
 
         IdAndName result = OtlpTraceMapperUtils.getId(attrs);
 
-        assertThat(result.serviceName()).isEqualTo("otel-ns");
+        assertThat(result.serviceName()).isEqualTo(ServiceUid.DEFAULT_SERVICE_UID_NAME);
     }
 
     @Test
-    void getId_serviceName_pinpointHasPriorityOverNamespace() {
+    void getId_serviceName_attributes_ignored_returnsDefault() {
         Map<String, AttributeValue> attrs = Map.of(
                 "pinpoint.agentId", AttributeValue.of("agent1"),
                 "pinpoint.applicationName", AttributeValue.of("app"),
@@ -585,7 +589,7 @@ class OtlpTraceMapperUtilsTest {
 
         IdAndName result = OtlpTraceMapperUtils.getId(attrs);
 
-        assertThat(result.serviceName()).isEqualTo("pinpoint-service");
+        assertThat(result.serviceName()).isEqualTo(ServiceUid.DEFAULT_SERVICE_UID_NAME);
     }
 
     @Test


### PR DESCRIPTION
OTLP spans were assigned serviceName from pinpoint.serviceName / service.namespace attributes, but OTLP applications are registered under DEFAULT_SERVICE_UID and the web queries service-keyed stores (e.g. the Pinot heatmap sortKey serviceName#applicationName) with DEFAULT. The mismatch hid OTLP transactions from the heatmap while the scatter view (application-keyed) still showed them.

Temporarily force getServiceName to always return DEFAULT_SERVICE_UID_NAME, matching the native agent's effective default. The attribute-based resolution is preserved in a comment and should be restored once the OTLP serviceUid policy is decided.