### PR TITLE
[#noissue] Drop the java.nio --add-opens to reproduce HBASE-30256 in CI

### DIFF
--- a/commons-server/pom.xml
+++ b/commons-server/pom.xml
@@ -217,14 +217,7 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Add  @{argLine} for jacoco -->
-                    <argLine>@{argLine} --add-opens java.base/java.nio=ALL-UNNAMED</argLine>
-                </configuration>
-            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,10 +158,10 @@
         <build.frontend.skip>false</build.frontend.skip>
 
         <!-- hbase -->
-        <hbase.shaded.client.version>2.5.14-hadoop3</hbase.shaded.client.version>
+        <hbase.shaded.client.version>2.5.15-hadoop3</hbase.shaded.client.version>
         <!-- for shaded hbase client 1.5.0+ version -->
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-        <hbase2.client.version>2.5.14-hadoop3</hbase2.client.version>
+        <hbase2.client.version>2.5.15-hadoop3</hbase2.client.version>
 
         <pinot.client.version>1.3.0</pinot.client.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,10 +158,10 @@
         <build.frontend.skip>false</build.frontend.skip>
 
         <!-- hbase -->
-        <hbase.shaded.client.version>2.5.15-hadoop3</hbase.shaded.client.version>
+        <hbase.shaded.client.version>2.6.6-hadoop3</hbase.shaded.client.version>
         <!-- for shaded hbase client 1.5.0+ version -->
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-        <hbase2.client.version>2.5.15-hadoop3</hbase2.client.version>
+        <hbase2.client.version>2.6.6-hadoop3</hbase2.client.version>
 
         <pinot.client.version>1.3.0</pinot.client.version>
 


### PR DESCRIPTION
commons-server grants --add-opens java.base/java.nio=ALL-UNNAMED to the
surefire runner, which forces HBase's FuzzyRowFilter onto the sun.misc.Unsafe
path and thereby hides HBASE-30256 (on the no-unsafe path the fuzzy mask is
mishandled and matching rows are dropped). Removing the option makes the tests
run on the no-unsafe path, so FuzzyRowFilterTest should reproduce the bug on
the current hbase 2.5.14 (the fix ships in 2.5.16).

Verification-only commit for GitHub Actions; not intended to be merged.

https://issues.apache.org/jira/browse/HBASE-30256
Fix Version/s:
[3.0.0](https://issues.apache.org/jira/issues/?jql=project+%3D+HBASE+AND+fixVersion+%3D+3.0.0), [2.7.0](https://issues.apache.org/jira/issues/?jql=project+%3D+HBASE+AND+fixVersion+%3D+2.7.0), [3.0.0-beta-2](https://issues.apache.org/jira/issues/?jql=project+%3D+HBASE+AND+fixVersion+%3D+3.0.0-beta-2), [2.5.16](https://issues.apache.org/jira/issues/?jql=project+%3D+HBASE+AND+fixVersion+%3D+2.5.16), [2.6.7](https://issues.apache.org/jira/issues/?jql=project+%3D+HBASE+AND+fixVersion+%3D+2.6.7)