### PR TITLE
[#14072] Upgrade hbase client to 2.5.15-hadoop3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,10 +158,10 @@
         <build.frontend.skip>false</build.frontend.skip>
 
         <!-- hbase -->
-        <hbase.shaded.client.version>2.5.14-hadoop3</hbase.shaded.client.version>
+        <hbase.shaded.client.version>2.5.15-hadoop3</hbase.shaded.client.version>
         <!-- for shaded hbase client 1.5.0+ version -->
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-        <hbase2.client.version>2.5.14-hadoop3</hbase2.client.version>
+        <hbase2.client.version>2.5.15-hadoop3</hbase2.client.version>
 
         <pinot.client.version>1.3.0</pinot.client.version>
 


### PR DESCRIPTION
This pull request updates the HBase client dependencies to the latest patch version in the `pom.xml` file.

Dependency updates:

* Upgraded `hbase.shaded.client.version` from `2.5.14-hadoop3` to `2.5.15-hadoop3` to ensure the latest bug fixes and improvements are included.
* Upgraded `hbase2.client.version` from `2.5.14-hadoop3` to `2.5.15-hadoop3` for consistency and to leverage the latest HBase 2.x client updates.