### PR TITLE
Keep list scroll position on non-navigation key press

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Application/ApplicationCombinedListForCommon.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Application/ApplicationCombinedListForCommon.tsx
@@ -252,7 +252,12 @@ export const ApplicationCombinedListForCommon = ({
       }
     }
 
-    setIsMouseMove(false);
+    // 실제로 포커스를 이동/선택하는 네비게이션 키에서만 마우스 이동 상태를 해제한다.
+    // 검색어 입력이나 Shift 등 그 외 키에서도 해제하면, 사용자가 마우스로 스크롤해 둔
+    // 리스트가 focusIndex(=포커스 위치, 보통 맨 위)로 강제 스크롤되어 튕겨 올라간다.
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter') {
+      setIsMouseMove(false);
+    }
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/web-frontend/src/main/v3/packages/ui/src/components/HostGroup/HostGroupList.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/HostGroup/HostGroupList.tsx
@@ -67,7 +67,12 @@ export const HostGroupList = ({
       }
     }
 
-    setIsMouseMove(false);
+    // 실제로 포커스를 이동/선택하는 네비게이션 키에서만 마우스 이동 상태를 해제한다.
+    // 검색어 입력이나 Shift 등 그 외 키에서도 해제하면, 사용자가 마우스로 스크롤해 둔
+    // 리스트가 focusIndex(=포커스 위치, 보통 맨 위)로 강제 스크롤되어 튕겨 올라간다.
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter') {
+      setIsMouseMove(false);
+    }
   };
 
   const handleMouseEnter = (idx: number) => {

--- a/web-frontend/src/main/v3/packages/ui/src/components/VirtualList/VirtualList.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/VirtualList/VirtualList.tsx
@@ -60,6 +60,12 @@ export const VirtualList = <T,>({
       return;
     }
 
+    // focusIndex가 음수(-1)이면 이 리스트는 키보드 포커스 대상이 아니라는 의미이므로
+    // 자동 스크롤하지 않는다. (다른 리스트가 포커스됐을 때 이 리스트가 맨 위로 튕기는 것을 방지)
+    if (focusIndex < 0) {
+      return;
+    }
+
     if (isFirst && focusIndex === 0) {
       // 최초 focusIndex가 0인 경우에만 스크롤을 생략
       return;


### PR DESCRIPTION
## Summary

- The application and host-group select popovers cleared the mouse-move state after handling **any** key, so typing a search keyword or pressing a modifier key (Shift, Ctrl, …) switched the list back to keyboard mode and force-scrolled it to the focused index — throwing away the scroll position the user had set with the mouse wheel. It is now cleared only for `ArrowUp` / `ArrowDown` / `Enter`, the keys that actually move or commit the focus.
- `VirtualList` passed a negative `focusIndex` straight to `scrollToIndex`. Since `-1` means "this list is not the keyboard focus target", the auto-scroll effect now returns early instead of yanking the unfocused list to the top.

Both changes only narrow an existing condition (early return), so keyboard navigation — moving between the Favorite List and the Application List with the arrow keys and selecting with Enter — is unchanged.

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (95 suites, 689 tests)
- [x] `yarn lint` passes (no new warnings)
- [x] `focusIndex` consumers audited: `HostGroupList` is the only other one and it passes `undefined` or a non-negative index, so no caller relies on `-1` to mean "scroll to top"
- [ ] Manual: open the application select popover, scroll the list with the mouse wheel, type a search keyword — the list keeps its position instead of jumping to the top
- [ ] Manual: same check on the host-group select popover
- [ ] Manual: arrow-key navigation still wraps between the Favorite List and the Application List, and Enter still selects the focused item
