### PR TITLE
[#noissue] Introduce SpanHeader enum and a QualifierFilter-friendly serviceUid layout

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/io/request/GrpcHeaderFactory.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/io/request/GrpcHeaderFactory.java
@@ -2,16 +2,15 @@ package com.navercorp.pinpoint.io.request;
 
 import com.navercorp.pinpoint.common.server.io.DefaultServerHeader;
 import com.navercorp.pinpoint.common.server.io.ServerHeader;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.uid.ServiceUidSupplier;
 import com.navercorp.pinpoint.grpc.Header;
 
-import java.util.function.Supplier;
 
 public class GrpcHeaderFactory {
     public GrpcHeaderFactory() {
     }
 
-    public ServerHeader serverHeader(Header header, Supplier<ServiceUid> uidSupplier) {
+    public ServerHeader serverHeader(Header header, ServiceUidSupplier uidSupplier) {
         return new DefaultServerHeader(
                 header.getAgentId(),
                 header.getAgentName(),

--- a/collector/src/main/java/com/navercorp/pinpoint/io/request/GrpcServerHeaderV1.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/io/request/GrpcServerHeaderV1.java
@@ -1,20 +1,19 @@
 package com.navercorp.pinpoint.io.request;
 
 import com.navercorp.pinpoint.common.server.io.ServerHeader;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.uid.ServiceUidSupplier;
 import com.navercorp.pinpoint.grpc.Header;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Supplier;
 
 
 public class GrpcServerHeaderV1 implements ServerHeader {
 
     private final Header header;
 
-    private final Supplier<ServiceUid> serviceUidSupplier;
+    private final ServiceUidSupplier serviceUidSupplier;
 
     public GrpcServerHeaderV1(Header header) {
         this(header, UidFetchers.defaultUidFetcher());
@@ -49,7 +48,7 @@ public class GrpcServerHeaderV1 implements ServerHeader {
     }
 
     @Override
-    public Supplier<ServiceUid> getServiceUid() {
+    public ServiceUidSupplier getServiceUid() {
         return serviceUidSupplier;
     }
 

--- a/collector/src/main/java/com/navercorp/pinpoint/io/request/ServiceUidSuppliers.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/io/request/ServiceUidSuppliers.java
@@ -1,13 +1,13 @@
 package com.navercorp.pinpoint.io.request;
 
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.uid.ServiceUidSupplier;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
 
 public final class ServiceUidSuppliers {
 
@@ -16,11 +16,11 @@ public final class ServiceUidSuppliers {
     private ServiceUidSuppliers() {
     }
 
-    public static Supplier<ServiceUid> newSupplier(String serviceName, UidFetcher uidFetcher) {
+    public static ServiceUidSupplier newSupplier(String serviceName, UidFetcher uidFetcher) {
         return newSupplier(serviceName, uidFetcher, DEFAULT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     }
 
-    public static Supplier<ServiceUid> newSupplier(String serviceName, UidFetcher uidFetcher, long timeout, TimeUnit unit) {
+    public static ServiceUidSupplier newSupplier(String serviceName, UidFetcher uidFetcher, long timeout, TimeUnit unit) {
         Objects.requireNonNull(uidFetcher, "uidFetcher");
         Objects.requireNonNull(unit, "unit");
 

--- a/collector/src/test/java/com/navercorp/pinpoint/io/request/ServiceUidSuppliersTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/io/request/ServiceUidSuppliersTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
+import com.navercorp.pinpoint.common.server.uid.ServiceUidSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -21,7 +21,7 @@ class ServiceUidSuppliersTest {
             return CompletableFuture.completedFuture(ServiceUid.of(100001));
         };
 
-        Supplier<ServiceUid> supplier = ServiceUidSuppliers.newSupplier("serviceName", uidFetcher);
+        ServiceUidSupplier supplier = ServiceUidSuppliers.newSupplier("serviceName", uidFetcher);
 
         assertThat(requestedServiceName).hasValue("serviceName");
         assertThat(supplier.get()).isEqualTo(ServiceUid.of(100001));
@@ -31,7 +31,7 @@ class ServiceUidSuppliersTest {
     void throwExceptionOnTimeout() {
         UidFetcher uidFetcher = serviceName -> new CompletableFuture<>();
 
-        Supplier<ServiceUid> supplier = ServiceUidSuppliers.newSupplier("serviceName", uidFetcher, 1, TimeUnit.MILLISECONDS);
+        ServiceUidSupplier supplier = ServiceUidSuppliers.newSupplier("serviceName", uidFetcher, 1, TimeUnit.MILLISECONDS);
 
         assertThatThrownBy(supplier::get).isInstanceOf(UidException.class);
     }
@@ -40,7 +40,7 @@ class ServiceUidSuppliersTest {
     void returnNullOnMissingServiceUid() {
         UidFetcher uidFetcher = serviceName -> CompletableFuture.completedFuture(null);
 
-        Supplier<ServiceUid> supplier = ServiceUidSuppliers.newSupplier("serviceName", uidFetcher);
+        ServiceUidSupplier supplier = ServiceUidSuppliers.newSupplier("serviceName", uidFetcher);
 
         assertThat(supplier.get()).isNull();
     }
@@ -51,7 +51,7 @@ class ServiceUidSuppliersTest {
             throw new RuntimeException("error");
         };
 
-        Supplier<ServiceUid> supplier = ServiceUidSuppliers.newSupplier("serviceName", uidFetcher);
+        ServiceUidSupplier supplier = ServiceUidSuppliers.newSupplier("serviceName", uidFetcher);
 
         assertThatThrownBy(supplier::get).isInstanceOf(UidException.class);
     }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanOwner.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanOwner.java
@@ -17,13 +17,17 @@
 package com.navercorp.pinpoint.common.server.bo;
 
 import com.navercorp.pinpoint.common.server.io.ServerHeader;
+import com.navercorp.pinpoint.common.server.uid.FixedServiceName;
+import com.navercorp.pinpoint.common.server.uid.FixedServiceUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.uid.ServiceUidSupplier;
 import com.navercorp.pinpoint.common.server.util.NumberPrecondition;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
+import com.navercorp.pinpoint.common.server.uid.ServiceNameSupplier;
+import com.navercorp.pinpoint.common.server.uid.WrappedServiceNameSupplier;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 /**
  * Identifies the source of a span: the service/application and the agent
@@ -36,6 +40,10 @@ import java.util.function.Supplier;
  */
 public class SpanOwner {
 
+    // named constants (not lambdas) so toString() shows the captured state
+    private static final ServiceNameSupplier DEFAULT_SERVICE_NAME = FixedServiceName.DEFAULT;
+    private static final ServiceUidSupplier DEFAULT_SERVICE_UID = FixedServiceUid.DEFAULT;
+
     @NonNull
     private String agentId;
     private String agentName;
@@ -44,8 +52,8 @@ public class SpanOwner {
     private String applicationName;
 
     @NonNull
-    private String serviceName = ServiceUid.DEFAULT_SERVICE_UID_NAME;
-    private Supplier<ServiceUid> serviceUidSupplier = () -> ServiceUid.DEFAULT;
+    private ServiceNameSupplier serviceNameSupplier = DEFAULT_SERVICE_NAME;
+    private ServiceUidSupplier serviceUidSupplier = DEFAULT_SERVICE_UID;
 
     private long agentStartTime;
 
@@ -90,18 +98,23 @@ public class SpanOwner {
 
     @NonNull
     public String getServiceName() {
-        return serviceName;
+        return serviceNameSupplier.get();
     }
 
     public void setServiceName(String serviceName) {
-        this.serviceName = StringPrecondition.requireHasLength(serviceName, "serviceName");
+        StringPrecondition.requireHasLength(serviceName, "serviceName");
+        this.serviceNameSupplier = new WrappedServiceNameSupplier(serviceName);
+    }
+
+    public void setServiceName(ServiceNameSupplier serviceNameSupplier) {
+        this.serviceNameSupplier = Objects.requireNonNull(serviceNameSupplier, "serviceNameSupplier");
     }
 
     public ServiceUid getServiceUid() {
         return serviceUidSupplier.get();
     }
 
-    public void setServiceUid(Supplier<ServiceUid> serviceUidSupplier) {
+    public void setServiceUid(ServiceUidSupplier serviceUidSupplier) {
         this.serviceUidSupplier = Objects.requireNonNull(serviceUidSupplier, "serviceUidSupplier");
     }
 
@@ -119,8 +132,8 @@ public class SpanOwner {
                 "agentId='" + agentId + '\'' +
                 ", agentName='" + agentName + '\'' +
                 ", applicationName='" + applicationName + '\'' +
-                ", serviceName='" + serviceName + '\'' +
-                ", serviceUid='" + serviceUidSupplier.get() + '\'' +
+                ", serviceName='" + serviceNameSupplier + '\'' +
+                ", serviceUid='" + serviceUidSupplier + '\'' +
                 ", agentStartTime=" + agentStartTime +
                 '}';
     }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
@@ -28,7 +28,6 @@ import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.SpanOwner;
-import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.bo.filter.SequenceSpanEventFilter;
 import com.navercorp.pinpoint.common.server.bo.filter.SpanEventFilter;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.SpanBitField;
@@ -37,6 +36,7 @@ import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.Span
 import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
 import com.navercorp.pinpoint.common.server.io.SpanEventWriter;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.io.SpanVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -62,25 +62,24 @@ public class SpanDecoderV0 implements SpanDecoder {
 
         final SpanHeader header = SpanHeader.of(type);
         if (header == null) {
-            logger.warn("Unknown span type {}", type);
-            return null;
+            throw new IllegalStateException("Unknown span qualifier type: " + Byte.toUnsignedInt(type));
         }
         if (header.isSpanChunk()) {
-            return readSpanChunk(qualifier, columnValue, decodingContext, header.getTraceSourceType());
+            return readSpanChunk(qualifier, columnValue, decodingContext, header);
         }
-        return readSpan(qualifier, columnValue, decodingContext, header.getTraceSourceType());
+        return readSpan(qualifier, columnValue, decodingContext, header);
     }
 
     private SpanChunkBo readSpanChunk(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext,
-                                      TraceSourceType traceSourceType) {
-        final SpanChunkBo spanChunk = new SpanChunkBo(traceSourceType, new SpanOwner());
+                                      SpanHeader header) {
+        final SpanChunkBo spanChunk = new SpanChunkBo(header.getTraceSourceType(), new SpanOwner());
 
         final ServerTraceId transactionId = decodingContext.getTransactionId();
         spanChunk.setTransactionId(transactionId);
         spanChunk.setCollectorAcceptTime(decodingContext.getCollectorAcceptedTime());
 
 
-        readQualifier(spanChunk, qualifier, decodingContext);
+        readQualifier(spanChunk, qualifier, decodingContext, header);
 
         readSpanChunkValue(columnValue, spanChunk, decodingContext);
 
@@ -89,14 +88,14 @@ public class SpanDecoderV0 implements SpanDecoder {
 
 
     private SpanBo readSpan(Buffer qualifier, Buffer columnValue, SpanDecodingContext decodingContext,
-                            TraceSourceType traceSourceType) {
-        final SpanBo span = new SpanBo(traceSourceType, new SpanOwner());
+                            SpanHeader header) {
+        final SpanBo span = new SpanBo(header.getTraceSourceType(), new SpanOwner());
 
         final ServerTraceId transactionId = decodingContext.getTransactionId();
         span.setTransactionId(transactionId);
         span.setCollectorAcceptTime(decodingContext.getCollectorAcceptedTime());
 
-        readQualifier(span, qualifier, decodingContext);
+        readQualifier(span, qualifier, decodingContext, header);
 
         readSpanValue(columnValue, span, decodingContext);
 
@@ -413,20 +412,20 @@ public class SpanDecoderV0 implements SpanDecoder {
         }
     }
 
-    private void readQualifier(BasicSpan basicSpan, Buffer buffer, SpanDecodingContext decodingContext) {
+    private void readQualifier(BasicSpan basicSpan, Buffer buffer, SpanDecodingContext decodingContext, SpanHeader header) {
         final SpanOwner owner = basicSpan.getSpanOwner();
 
-        String applicationName = decodingContext.encoding(buffer.readPrefixedBytes());
-        owner.setApplicationName(applicationName);
-
-        String agentId = decodingContext.encoding(buffer.readPrefixedBytes());
-        owner.setAgentId(agentId);
-
-        long agentStartTime = buffer.readVLong();
-        owner.setAgentStartTime(agentStartTime);
-
-        long spanId = buffer.readLong();
-        basicSpan.setSpanId(spanId);
+        if (header.hasServiceUid()) {
+            // layout: [serviceUid(4)][appNameHash(1)][spanId(8)] then applicationInfo
+            final ServiceUid serviceUid = ServiceUid.of(buffer.readInt());
+            owner.setServiceUid(() -> serviceUid);
+            buffer.readByte(); // applicationName hash: filter-only, the name below is authoritative
+            basicSpan.setSpanId(buffer.readLong());
+            readApplicationInfo(owner, buffer, decodingContext);
+        } else {
+            readApplicationInfo(owner, buffer, decodingContext);
+            basicSpan.setSpanId(buffer.readLong());
+        }
 
         if (!buffer.hasRemaining()) {
             // spanEventList.size() == 0
@@ -443,6 +442,12 @@ public class SpanDecoderV0 implements SpanDecoder {
             }
         }
         setLocalAsyncId(basicSpan, buffer);
+    }
+
+    private void readApplicationInfo(SpanOwner owner, Buffer buffer, SpanDecodingContext decodingContext) {
+        owner.setApplicationName(decodingContext.encoding(buffer.readPrefixedBytes()));
+        owner.setAgentId(decodingContext.encoding(buffer.readPrefixedBytes()));
+        owner.setAgentStartTime(buffer.readVLong());
     }
 
     private void setLocalAsyncId(BasicSpan basicSpan, Buffer buffer) {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0.java
@@ -36,6 +36,7 @@ import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.bitfield.Span
 import com.navercorp.pinpoint.common.server.io.AnnotationWriter;
 import com.navercorp.pinpoint.common.server.io.SpanEventWriter;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import com.navercorp.pinpoint.common.server.uid.FixedServiceUid;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.io.SpanVersion;
 import org.apache.logging.log4j.LogManager;
@@ -418,7 +419,9 @@ public class SpanDecoderV0 implements SpanDecoder {
         if (header.hasServiceUid()) {
             // layout: [serviceUid(4)][appNameHash(1)][spanId(8)] then applicationInfo
             final ServiceUid serviceUid = ServiceUid.of(buffer.readInt());
-            owner.setServiceUid(() -> serviceUid);
+            owner.setServiceName(decodingContext.getServiceName(serviceUid));
+            owner.setServiceUid(new FixedServiceUid(serviceUid));
+
             buffer.readByte(); // applicationName hash: filter-only, the name below is authoritative
             basicSpan.setSpanId(buffer.readLong());
             readApplicationInfo(owner, buffer, decodingContext);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecodingContext.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecodingContext.java
@@ -18,6 +18,13 @@ package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 
 import com.navercorp.pinpoint.common.buffer.StringAllocator;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import com.navercorp.pinpoint.common.server.uid.FixedServiceName;
+import com.navercorp.pinpoint.common.server.uid.ServiceNameFactory;
+import com.navercorp.pinpoint.common.server.uid.ServiceNameSupplier;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+
+import org.eclipse.collections.api.factory.primitive.IntObjectMaps;
+import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -34,8 +41,37 @@ public class SpanDecodingContext {
 
     private StringAllocator stringAllocator = StringAllocator.DEFAULT_ALLOCATOR;
 
+    private ServiceNameFactory serviceNameFactory = ServiceNameFactory.FALLBACK;
+
+    // Row-local cache: one serviceName supplier per distinct serviceUid (primitive int key,
+    // no boxing), shared by every span/chunk of this row. Lazily allocated — legacy (non-UID)
+    // rows never touch it.
+    // Row-scoped state: unlike collectorAcceptedTime, this survives next() on purpose.
+    private MutableIntObjectMap<ServiceNameSupplier> serviceNameCache;
+
     public SpanDecodingContext(ServerTraceId transactionId) {
         this.transactionId = Objects.requireNonNull(transactionId, "transactionId");
+    }
+
+    public void setServiceNameFactory(ServiceNameFactory serviceNameFactory) {
+        this.serviceNameFactory = Objects.requireNonNull(serviceNameFactory, "serviceNameFactory");
+    }
+
+    public ServiceNameSupplier getServiceName(ServiceUid serviceUid) {
+        Objects.requireNonNull(serviceUid, "serviceUid");
+
+        if (serviceUid.getUid() == ServiceUid.DEFAULT_SERVICE_UID_CODE) {
+            // allocation fast path (the factory returns the same constant):
+            // DEFAULT-only rows never allocate the cache map
+            return FixedServiceName.DEFAULT;
+        }
+
+        MutableIntObjectMap<ServiceNameSupplier> cache = this.serviceNameCache;
+        if (cache == null) {
+            cache = IntObjectMaps.mutable.of();
+            this.serviceNameCache = cache;
+        }
+        return cache.getIfAbsentPutWith(serviceUid.getUid(), serviceNameFactory::create, serviceUid);
     }
 
 //    public AnnotationBo getPrevFirstAnnotationBo() {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoder.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoder.java
@@ -22,6 +22,13 @@ public interface SpanEncoder {
     byte TYPE_PASSIVE_SPAN = 4;
     byte TYPE_INDEX = 7;
 
+    // serviceUid-bearing variants. Same span/chunk and source-type semantics as the
+    // codes above, but the qualifier additionally carries a serviceUid.
+    byte TYPE_SPAN_UID = 8;
+    byte TYPE_SPAN_CHUNK_UID = 9;
+    byte TYPE_OTEL_SPAN_UID = 10;
+    byte TYPE_OTEL_SPAN_CHUNK_UID = 11;
+
     ByteBuffer encodeSpanQualifier(SpanEncodingContext<SpanBo> encodingContext);
 
     ByteBuffer encodeSpanColumnValue(SpanEncodingContext<SpanBo> encodingContext);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderV0.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderV0.java
@@ -20,20 +20,26 @@ import com.navercorp.pinpoint.io.SpanVersion;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.stereotype.Component;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
  * @author Woonduk Kang(emeroad)
  */
-@Component
 public class SpanEncoderV0 implements SpanEncoder {
     private final Logger logger = LogManager.getLogger(this.getClass());
     private static final AnnotationTranscoder transcoder = new AnnotationTranscoder();
     private static final AttributeTranscoder attributeTranscoder = new AttributeTranscoder();
+
+    // resolves the qualifier header for the encoder's fixed serviceUid mode
+    private final SpanHeaderFactory spanHeaderFactory;
+
+    public SpanEncoderV0(SpanHeaderFactory spanHeaderFactory) {
+        this.spanHeaderFactory = Objects.requireNonNull(spanHeaderFactory, "spanHeaderFactory");
+    }
 
     @Override
     public ByteBuffer encodeSpanQualifier(SpanEncodingContext<SpanBo> encodingContext) {
@@ -41,7 +47,7 @@ public class SpanEncoderV0 implements SpanEncoder {
         final List<SpanEventBo> spanEventBoList = spanBo.getSpanEventBoList();
         final SpanEventBo firstEvent = getFirstSpanEvent(spanEventBoList);
 
-        final SpanHeader header = SpanHeader.span(spanBo.getTraceSourceType());
+        final SpanHeader header = spanHeaderFactory.span(spanBo.getTraceSourceType());
         return encodeQualifier(header, spanBo, firstEvent, null);
     }
 
@@ -53,7 +59,7 @@ public class SpanEncoderV0 implements SpanEncoder {
         final SpanEventBo firstEvent = getFirstSpanEvent(spanEventBoList);
 
         LocalAsyncIdBo localAsyncId = spanChunkBo.getLocalAsyncId();
-        final SpanHeader header = SpanHeader.spanChunk(spanChunkBo.getTraceSourceType());
+        final SpanHeader header = spanHeaderFactory.spanChunk(spanChunkBo.getTraceSourceType());
         return encodeQualifier(header, spanChunkBo, firstEvent, localAsyncId);
     }
 
@@ -61,10 +67,20 @@ public class SpanEncoderV0 implements SpanEncoder {
         final SpanOwner owner = basicSpan.getSpanOwner();
         final Buffer buffer = new AutomaticBuffer(128);
         buffer.putByte(header.getCode());
-        buffer.putPrefixedString(owner.getApplicationName());
-        buffer.putPrefixedString(owner.getAgentId());
-        buffer.putVLong(owner.getAgentStartTime());
-        buffer.putLong(basicSpan.getSpanId());
+        if (header.hasServiceUid()) {
+            // Front-load the fixed-width fields so an HBase QualifierFilter can match a
+            // [type][serviceUid][appNameHash][spanId] prefix without decoding the tail.
+            // serviceUid: fixed 4 bytes (full-range random int; a varint would average
+            // ~5 bytes). appNameHash: 1-byte lossy bucket for server-side application
+            // pre-filtering (the appName string in the tail stays authoritative).
+            buffer.putInt(owner.getServiceUid().getUid());
+            buffer.putByte(SpanQualifierHash.applicationName(owner.getApplicationName()));
+            buffer.putLong(basicSpan.getSpanId());
+            writeApplicationInfo(buffer, owner);
+        } else {
+            writeApplicationInfo(buffer, owner);
+            buffer.putLong(basicSpan.getSpanId());
+        }
 
         if (firstEvent != null) {
             buffer.putSVInt(firstEvent.getSequence());
@@ -88,7 +104,11 @@ public class SpanEncoderV0 implements SpanEncoder {
         return buffer.wrapByteBuffer();
     }
 
-
+    private void writeApplicationInfo(Buffer buffer, SpanOwner owner) {
+        buffer.putPrefixedString(owner.getApplicationName());
+        buffer.putPrefixedString(owner.getAgentId());
+        buffer.putVLong(owner.getAgentStartTime());
+    }
 
     private SpanEventBo getFirstSpanEvent(List<SpanEventBo> spanEventBoList) {
         if (CollectionUtils.isEmpty(spanEventBoList)) {

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeader.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeader.java
@@ -17,6 +17,9 @@
 package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 
 /**
  * First byte of the trace qualifier. The code doubles as both the span/chunk
@@ -25,19 +28,26 @@ import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
  * the HBase qualifier filters.
  */
 public enum SpanHeader {
-    SPAN(SpanEncoder.TYPE_SPAN, TraceSourceType.PINPOINT, false),
-    SPAN_CHUNK(SpanEncoder.TYPE_SPAN_CHUNK, TraceSourceType.PINPOINT, true),
-    OTEL_SPAN(SpanEncoder.TYPE_OTEL_SPAN, TraceSourceType.OPENTELEMETRY, false),
-    OTEL_SPAN_CHUNK(SpanEncoder.TYPE_OTEL_SPAN_CHUNK, TraceSourceType.OPENTELEMETRY, true);
+    SPAN(SpanEncoder.TYPE_SPAN, TraceSourceType.PINPOINT, false, false),
+    SPAN_CHUNK(SpanEncoder.TYPE_SPAN_CHUNK, TraceSourceType.PINPOINT, true, false),
+    OTEL_SPAN(SpanEncoder.TYPE_OTEL_SPAN, TraceSourceType.OPENTELEMETRY, false, false),
+    OTEL_SPAN_CHUNK(SpanEncoder.TYPE_OTEL_SPAN_CHUNK, TraceSourceType.OPENTELEMETRY, true, false),
+
+    SPAN_UID(SpanEncoder.TYPE_SPAN_UID, TraceSourceType.PINPOINT, false, true),
+    SPAN_CHUNK_UID(SpanEncoder.TYPE_SPAN_CHUNK_UID, TraceSourceType.PINPOINT, true, true),
+    OTEL_SPAN_UID(SpanEncoder.TYPE_OTEL_SPAN_UID, TraceSourceType.OPENTELEMETRY, false, true),
+    OTEL_SPAN_CHUNK_UID(SpanEncoder.TYPE_OTEL_SPAN_CHUNK_UID, TraceSourceType.OPENTELEMETRY, true, true);
 
     private final byte code;
     private final TraceSourceType traceSourceType;
     private final boolean spanChunk;
+    private final boolean serviceUid;
 
-    SpanHeader(byte code, TraceSourceType traceSourceType, boolean spanChunk) {
+    SpanHeader(byte code, TraceSourceType traceSourceType, boolean spanChunk, boolean serviceUid) {
         this.code = code;
-        this.traceSourceType = traceSourceType;
+        this.traceSourceType = Objects.requireNonNull(traceSourceType, "traceSourceType");
         this.spanChunk = spanChunk;
+        this.serviceUid = serviceUid;
     }
 
     public byte getCode() {
@@ -52,18 +62,15 @@ public enum SpanHeader {
         return spanChunk;
     }
 
-    public static SpanHeader span(TraceSourceType traceSourceType) {
-        if (traceSourceType == TraceSourceType.OPENTELEMETRY) {
-            return OTEL_SPAN;
-        }
-        return SPAN;
+    public boolean isSpan() {
+        return !spanChunk;
     }
 
-    public static SpanHeader spanChunk(TraceSourceType traceSourceType) {
-        if (traceSourceType == TraceSourceType.OPENTELEMETRY) {
-            return OTEL_SPAN_CHUNK;
-        }
-        return SPAN_CHUNK;
+    /**
+     * @return {@code true} if the qualifier carries a serviceUid.
+     */
+    public boolean hasServiceUid() {
+        return serviceUid;
     }
 
     /**
@@ -71,12 +78,16 @@ public enum SpanHeader {
      * unknown or reserved codes ({@code TYPE_PASSIVE_SPAN}, {@code TYPE_INDEX})
      * so decoders can skip them leniently.
      */
-    public static SpanHeader of(byte code) {
+    public static @Nullable SpanHeader of(byte code) {
         return switch (code) {
             case SpanEncoder.TYPE_SPAN -> SPAN;
             case SpanEncoder.TYPE_SPAN_CHUNK -> SPAN_CHUNK;
             case SpanEncoder.TYPE_OTEL_SPAN -> OTEL_SPAN;
             case SpanEncoder.TYPE_OTEL_SPAN_CHUNK -> OTEL_SPAN_CHUNK;
+            case SpanEncoder.TYPE_SPAN_UID -> SPAN_UID;
+            case SpanEncoder.TYPE_SPAN_CHUNK_UID -> SPAN_CHUNK_UID;
+            case SpanEncoder.TYPE_OTEL_SPAN_UID -> OTEL_SPAN_UID;
+            case SpanEncoder.TYPE_OTEL_SPAN_CHUNK_UID -> OTEL_SPAN_CHUNK_UID;
             default -> null;
         };
     }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeaderFactory.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeaderFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
+
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
+
+import java.util.Objects;
+
+/**
+ * Resolves the {@link SpanHeader} for an encoder that emits qualifiers with a
+ * fixed serviceUid mode. Owning the serviceUid flag here keeps it out of every
+ * {@link #span}/{@link #spanChunk} call site.
+ */
+public class SpanHeaderFactory {
+
+    private final boolean serviceUid;
+
+    public SpanHeaderFactory(boolean serviceUid) {
+        this.serviceUid = serviceUid;
+    }
+
+    public SpanHeader span(TraceSourceType traceSourceType) {
+        Objects.requireNonNull(traceSourceType, "traceSourceType");
+        if (traceSourceType == TraceSourceType.OPENTELEMETRY) {
+            return serviceUid ? SpanHeader.OTEL_SPAN_UID : SpanHeader.OTEL_SPAN;
+        }
+        return serviceUid ? SpanHeader.SPAN_UID : SpanHeader.SPAN;
+    }
+
+    public SpanHeader spanChunk(TraceSourceType traceSourceType) {
+        Objects.requireNonNull(traceSourceType, "traceSourceType");
+        if (traceSourceType == TraceSourceType.OPENTELEMETRY) {
+            return serviceUid ? SpanHeader.OTEL_SPAN_CHUNK_UID : SpanHeader.OTEL_SPAN_CHUNK;
+        }
+        return serviceUid ? SpanHeader.SPAN_CHUNK_UID : SpanHeader.SPAN_CHUNK;
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanQualifierHash.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanQualifierHash.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
+
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+
+/**
+ * Lossy, filter-only hashes embedded in the span qualifier so an HBase
+ * QualifierFilter can pre-filter cells at the region server. Every value here is
+ * a coarse bucket, never an identity: the exact field (e.g. the applicationName
+ * string) still travels in the qualifier and stays authoritative for the final
+ * client-side match.
+ *
+ * <p>These hashes are part of the stored qualifier layout, so the algorithm must
+ * stay stable across versions. The write side (encoder) and the read side (query
+ * filter builder) must call the same method to agree on the bucket.
+ */
+public final class SpanQualifierHash {
+
+    // murmur3 avalanches into all bits, so the low byte is a uniform 256-bucket value;
+    // this is the same function/input the scatter and agentId row keys hash applicationName
+    // with (see TraceIndexRowKeyUtils/AgentIdRowKeyUtils). _fixed guarantees a stable algorithm.
+    private static final HashFunction HASH = Hashing.murmur3_32_fixed();
+
+    private SpanQualifierHash() {
+    }
+
+    /**
+     * 1-byte (256-bucket) hash of applicationName. Filtering runs within a single
+     * trace row, where the number of distinct applications is small, so 256 buckets
+     * make collisions between co-resident applications rare; the exact applicationName
+     * check remains the source of truth.
+     */
+    public static byte applicationName(String applicationName) {
+        if (applicationName == null) {
+            return 0;
+        }
+        return (byte) HASH.hashUnencodedChars(applicationName).asInt();
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/config/SpanSerializeConfiguration.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/config/SpanSerializeConfiguration.java
@@ -5,10 +5,12 @@ import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanChunkSeri
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoderV0;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoderV0;
+import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanHeaderFactory;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanSerializerV2;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.TraceRowKeyDecoderV2;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.TraceRowKeyEncoderV2;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -30,8 +32,13 @@ public class SpanSerializeConfiguration {
     }
 
     @Bean
-    public SpanEncoderV0 spanEncoderV0() {
-        return new SpanEncoderV0();
+    public SpanHeaderFactory spanHeaderFactory(@Value("${collector.span.serviceuid.enabled:false}") boolean serviceUid) {
+        return new SpanHeaderFactory(serviceUid);
+    }
+
+    @Bean
+    public SpanEncoderV0 spanEncoderV0(SpanHeaderFactory spanHeaderFactory) {
+        return new SpanEncoderV0(spanHeaderFactory);
     }
 
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/DefaultServerHeader.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/DefaultServerHeader.java
@@ -1,11 +1,10 @@
 package com.navercorp.pinpoint.common.server.io;
 
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.uid.ServiceUidSupplier;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 public class DefaultServerHeader implements ServerHeader {
 
@@ -17,11 +16,11 @@ public class DefaultServerHeader implements ServerHeader {
     private final long agentStartTime;
     private final int serviceType;
 
-    private final Supplier<ServiceUid> uidSupplier;
+    private final ServiceUidSupplier uidSupplier;
     private final boolean grpcBuiltInRetry;
 
     public DefaultServerHeader(String agentId, String agentName, String applicationName, String serviceName,
-                               Supplier<ServiceUid> uidSupplier,
+                               ServiceUidSupplier uidSupplier,
                                long agentStartTime, int serviceType, boolean grpcBuiltInRetry) {
         this.agentId = StringPrecondition.requireHasLength(agentId, "agentId");
         this.agentName = StringPrecondition.requireHasLength(agentName, "agentName");
@@ -61,7 +60,7 @@ public class DefaultServerHeader implements ServerHeader {
     }
 
     @Override
-    public Supplier<ServiceUid> getServiceUid() {
+    public ServiceUidSupplier getServiceUid() {
         return uidSupplier;
     }
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/ServerHeader.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/io/ServerHeader.java
@@ -1,9 +1,7 @@
 package com.navercorp.pinpoint.common.server.io;
 
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.uid.ServiceUidSupplier;
 import org.jspecify.annotations.NonNull;
-
-import java.util.function.Supplier;
 
 public interface ServerHeader {
 
@@ -20,7 +18,7 @@ public interface ServerHeader {
     // Service -----------------
     String getServiceName();
 
-    Supplier<ServiceUid> getServiceUid();
+    ServiceUidSupplier getServiceUid();
 
     // ----------------------
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/FixedServiceName.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/FixedServiceName.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.uid;
+
+import java.util.Objects;
+
+/**
+ * Constant serviceName supplier for reserved serviceUids whose name is fixed by
+ * definition (e.g. DEFAULT): no registry lookup, safe to share across rows.
+ */
+public final class FixedServiceName implements ServiceNameSupplier {
+
+    /**
+     * uid 0's name is a system constant, not a registry mapping — shared across all rows.
+     */
+    public static final ServiceNameSupplier DEFAULT =
+            new FixedServiceName(ServiceUid.DEFAULT_SERVICE_UID_CODE, ServiceUid.DEFAULT_SERVICE_UID_NAME);
+
+    private final int serviceUid;
+    private final String serviceName;
+
+    public FixedServiceName(int serviceUid, String serviceName) {
+        this.serviceUid = serviceUid;
+        this.serviceName = Objects.requireNonNull(serviceName, "serviceName");
+    }
+
+    @Override
+    public String get() {
+        return serviceName;
+    }
+
+    @Override
+    public String toString() {
+        return serviceName + "/" + serviceUid;
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/FixedServiceUid.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/FixedServiceUid.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.uid;
+
+
+import java.util.Objects;
+
+/**
+ * Constant serviceUid supplier restored from a UID-bearing span qualifier.
+ * A named type (instead of a lambda) so debuggers, stack traces and
+ * {@code SpanOwner.toString()} show the captured state.
+ */
+public final class FixedServiceUid implements ServiceUidSupplier {
+
+    /**
+     * Shared constant for the DEFAULT serviceUid.
+     */
+    public static final ServiceUidSupplier DEFAULT = new FixedServiceUid(ServiceUid.DEFAULT);
+
+    private final ServiceUid serviceUid;
+
+    public FixedServiceUid(ServiceUid serviceUid) {
+        this.serviceUid = Objects.requireNonNull(serviceUid, "serviceUid");
+    }
+
+    @Override
+    public ServiceUid get() {
+        return serviceUid;
+    }
+
+    public ServiceUid serviceUid() {
+        return serviceUid;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        FixedServiceUid that = (FixedServiceUid) obj;
+        return this.serviceUid.getUid() == that.serviceUid.getUid();
+    }
+
+    @Override
+    public int hashCode() {
+        return serviceUid.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return Integer.toString(serviceUid.getUid());
+    }
+
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/LazyServiceName.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/LazyServiceName.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.uid;
+
+
+import java.util.Objects;
+
+/**
+ * Lazy serviceName supplier for a serviceUid restored from a UID-bearing span
+ * qualifier: the registry is consulted only when {@code getServiceName()} is
+ * actually called. A named type (instead of a lambda) so debuggers, stack traces
+ * and {@code SpanOwner.toString()} show the captured state.
+ */
+public final class LazyServiceName implements ServiceNameSupplier {
+    private final ServiceNameResolver resolver;
+    private final ServiceUid serviceUid;
+
+    // Memoized result. This instance is shared row-wide via SpanDecodingContext's
+    // serviceUid cache, so the registry is consulted at most once per row per uid.
+    // Benign race: a concurrent first get() may resolve twice with an identical result.
+    private String resolved;
+
+    public LazyServiceName(ServiceNameResolver resolver, ServiceUid serviceUid) {
+        this.resolver = Objects.requireNonNull(resolver, "resolver");
+        this.serviceUid = Objects.requireNonNull(serviceUid, "serviceUid");
+    }
+
+    @Override
+    public String get() {
+        String name = this.resolved;
+        if (name == null) {
+            name = resolver.resolve(serviceUid);
+            this.resolved = name;
+        }
+        return name;
+    }
+
+    public ServiceUid serviceUid() {
+        return serviceUid;
+    }
+
+    @Override
+    public String toString() {
+        // report the memoized name if already resolved, but never trigger resolution here —
+        // debuggers and log statements must not cause a registry lookup
+        final String name = this.resolved;
+        if (name != null) {
+            return name + '/' + serviceUid;
+        }
+        return "?/" + serviceUid;
+    }
+
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/LazyServiceNameFactory.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/LazyServiceNameFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.uid;
+
+
+import java.util.Objects;
+
+/**
+ * Creates {@link LazyServiceName} suppliers bound to this factory's
+ * {@link ServiceNameResolver}. Owning the resolver here keeps the decoder's
+ * per-span code free of supplier wiring.
+ */
+public class LazyServiceNameFactory implements ServiceNameFactory {
+
+    private final ServiceNameResolver resolver;
+
+    public LazyServiceNameFactory(ServiceNameResolver resolver) {
+        this.resolver = Objects.requireNonNull(resolver, "resolver");
+    }
+
+    @Override
+    public ServiceNameSupplier create(ServiceUid serviceUid) {
+        if (serviceUid.getUid() == ServiceUid.DEFAULT_SERVICE_UID_CODE) {
+            return FixedServiceName.DEFAULT;
+        }
+        return new LazyServiceName(resolver, serviceUid);
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceNameFactory.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceNameFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.uid;
+
+/**
+ * Creates a {@link ServiceNameSupplier} for a serviceUid. How the name is obtained
+ * (registry lookup, constant, ...) is up to the implementation.
+ */
+@FunctionalInterface
+public interface ServiceNameFactory {
+
+    /**
+     * Registry-less fallback (e.g. collector side): every uid maps to the DEFAULT name.
+     */
+    ServiceNameFactory FALLBACK = new LazyServiceNameFactory(ServiceNameResolver.FALLBACK);
+
+    ServiceNameSupplier create(ServiceUid serviceUid);
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceNameResolver.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceNameResolver.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.uid;
+
+
+/**
+ * Resolves a serviceUid restored from a UID-bearing span qualifier back to its
+ * serviceName. The qualifier stores only the uid; the name lives in the service
+ * registry, which is a read-side (web) concern — this port keeps the decoder free
+ * of that dependency.
+ */
+@FunctionalInterface
+public interface ServiceNameResolver {
+
+    /**
+     * Write-side / registry-less fallback: every uid maps to the DEFAULT name.
+     */
+    ServiceNameResolver FALLBACK = serviceUid -> ServiceUid.DEFAULT_SERVICE_UID_NAME;
+
+    String resolve(ServiceUid serviceUid);
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceNameSupplier.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceNameSupplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.uid;
+
+import java.util.function.Supplier;
+
+/**
+ * Explicit supplier type for a serviceName: a plain {@code Supplier<String>}
+ * says nothing about what it supplies and is invisible to type-based search —
+ * this interface makes the serviceName flow traceable across module boundaries.
+ */
+@FunctionalInterface
+public interface ServiceNameSupplier extends Supplier<String> {
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceUidSupplier.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceUidSupplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.uid;
+
+import java.util.function.Supplier;
+
+/**
+ * Explicit supplier type for {@link ServiceUid}: a plain {@code Supplier<ServiceUid>}
+ * is erased at runtime and invisible to type-based search — this interface makes the
+ * serviceUid flow traceable across module boundaries.
+ */
+@FunctionalInterface
+public interface ServiceUidSupplier extends Supplier<ServiceUid> {
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/WrappedServiceNameSupplier.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/WrappedServiceNameSupplier.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.uid;
+
+import java.util.Objects;
+
+/**
+ * Wraps an already-resolved serviceName (e.g. from the write-path {@code ServerHeader})
+ * where no serviceUid is available — unlike {@link FixedServiceName}, which pairs the
+ * name with its uid. A named type (instead of a lambda) so debuggers, stack traces and
+ * {@code SpanOwner.toString()} show the captured state.
+ */
+public final class WrappedServiceNameSupplier implements ServiceNameSupplier {
+
+    private final String serviceName;
+
+    public WrappedServiceNameSupplier(String serviceName) {
+        this.serviceName = Objects.requireNonNull(serviceName, "serviceName");
+    }
+
+    @Override
+    public String get() {
+        return serviceName;
+    }
+
+    @Override
+    public String toString() {
+        return serviceName;
+    }
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0Test.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0Test.java
@@ -25,12 +25,14 @@ import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.io.SpanVersion;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Focused tests for {@link SpanDecoderV0#decode} type-byte dispatch.
@@ -39,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class SpanDecoderV0Test {
 
-    private final SpanEncoderV0 encoder = new SpanEncoderV0();
+    private final SpanEncoderV0 encoder = new SpanEncoderV0(new SpanHeaderFactory(false));
     private final SpanDecoderV0 decoder = new SpanDecoderV0();
 
     @Test
@@ -79,16 +81,74 @@ class SpanDecoderV0Test {
     }
 
     @Test
-    void decode_unknownType_returnsNull() {
+    void decode_typeSpanUid_roundTripsServiceUid() {
+        SpanEncoderV0 uidEncoder = new SpanEncoderV0(new SpanHeaderFactory(true));
+        ServiceUid serviceUid = ServiceUid.of(100);
+
+        SpanBo input = newMinimalSpan(TraceSourceType.PINPOINT);
+        input.getSpanOwner().setServiceUid(() -> serviceUid);
+        BasicSpan decoded = roundTripSpan(uidEncoder, input);
+
+        assertThat(decoded).isInstanceOf(SpanBo.class);
+        assertThat(decoded.getTraceSourceType()).isEqualTo(TraceSourceType.PINPOINT);
+        assertThat(decoded.getServiceUid()).isEqualTo(serviceUid);
+        // fields around the front-loaded serviceUid layout survive the reorder
+        assertThat(decoded.getSpanId()).isEqualTo(input.getSpanId());
+        assertThat(decoded.getApplicationName()).isEqualTo(input.getApplicationName());
+        assertThat(decoded.getAgentId()).isEqualTo(input.getAgentId());
+    }
+
+    @Test
+    void decode_fullRangeServiceUid_roundTrips() {
+        // serviceUid is a full-range random int; the fixed 4-byte layout must survive
+        // values that a varint would have widened (or a narrower read would truncate).
+        SpanEncoderV0 uidEncoder = new SpanEncoderV0(new SpanHeaderFactory(true));
+        for (int uid : new int[]{Integer.MAX_VALUE, Integer.MIN_VALUE, 0x12345678}) {
+            ServiceUid serviceUid = ServiceUid.of(uid);
+
+            SpanBo input = newMinimalSpan(TraceSourceType.PINPOINT);
+            input.getSpanOwner().setServiceUid(() -> serviceUid);
+            BasicSpan decoded = roundTripSpan(uidEncoder, input);
+
+            assertThat(decoded.getServiceUid()).isEqualTo(serviceUid);
+        }
+    }
+
+    @Test
+    void decode_typeOtelSpanChunkUid_roundTripsServiceUid() {
+        SpanEncoderV0 uidEncoder = new SpanEncoderV0(new SpanHeaderFactory(true));
+        ServiceUid serviceUid = ServiceUid.of(-100);
+
+        SpanChunkBo input = newMinimalSpanChunk(TraceSourceType.OPENTELEMETRY);
+        input.getSpanOwner().setServiceUid(() -> serviceUid);
+        BasicSpan decoded = roundTripSpanChunk(uidEncoder, input);
+
+        assertThat(decoded).isInstanceOf(SpanChunkBo.class);
+        assertThat(decoded.getTraceSourceType()).isEqualTo(TraceSourceType.OPENTELEMETRY);
+        assertThat(decoded.getServiceUid()).isEqualTo(serviceUid);
+    }
+
+    @Test
+    void decode_serviceUidDisabled_keepsDefaultServiceUid() {
+        SpanBo input = newMinimalSpan(TraceSourceType.PINPOINT);
+        input.getSpanOwner().setServiceUid(() -> ServiceUid.of(100));
+        BasicSpan decoded = roundTripSpan(input);
+
+        // the plain SPAN qualifier does not carry a serviceUid
+        assertThat(decoded.getServiceUid()).isEqualTo(ServiceUid.DEFAULT);
+    }
+
+    @Test
+    void decode_unknownType_throws() {
         Buffer qualifier = new FixedBuffer(1);
         qualifier.putByte((byte) 99);
         qualifier.setOffset(0);
         Buffer value = new FixedBuffer(new byte[]{0});
 
         SpanDecodingContext ctx = new SpanDecodingContext(newTransactionId());
-        BasicSpan decoded = decoder.decode(qualifier, value, ctx);
 
-        assertThat(decoded).isNull();
+        assertThatThrownBy(() -> decoder.decode(qualifier, value, ctx))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     private SpanBo newMinimalSpan(TraceSourceType type) {
@@ -119,6 +179,10 @@ class SpanDecoderV0Test {
     }
 
     private BasicSpan roundTripSpan(SpanBo input) {
+        return roundTripSpan(encoder, input);
+    }
+
+    private BasicSpan roundTripSpan(SpanEncoderV0 encoder, SpanBo input) {
         SpanEncodingContext<SpanBo> encCtx = new SpanEncodingContext<>(input);
         Buffer qualifier = wrap(encoder.encodeSpanQualifier(encCtx));
         Buffer value = wrap(encoder.encodeSpanColumnValue(encCtx));
@@ -129,6 +193,10 @@ class SpanDecoderV0Test {
     }
 
     private BasicSpan roundTripSpanChunk(SpanChunkBo input) {
+        return roundTripSpanChunk(encoder, input);
+    }
+
+    private BasicSpan roundTripSpanChunk(SpanEncoderV0 encoder, SpanChunkBo input) {
         SpanEncodingContext<SpanChunkBo> encCtx = new SpanEncodingContext<>(input);
         Buffer qualifier = wrap(encoder.encodeSpanChunkQualifier(encCtx));
         Buffer value = wrap(encoder.encodeSpanChunkColumnValue(encCtx));

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0Test.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanDecoderV0Test.java
@@ -25,11 +25,14 @@ import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import com.navercorp.pinpoint.common.server.uid.LazyServiceNameFactory;
+import com.navercorp.pinpoint.common.server.uid.ServiceNameResolver;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.io.SpanVersion;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -139,6 +142,77 @@ class SpanDecoderV0Test {
     }
 
     @Test
+    void decode_typeSpanUid_resolvesServiceNameLazily() {
+        SpanEncoderV0 uidEncoder = new SpanEncoderV0(new SpanHeaderFactory(true));
+
+        SpanDecodingContext rowContext = newRowContext(uid -> "service-" + uid.getUid());
+        BasicSpan decoded = decodeWith(uidEncoder, decoder, rowContext, newUidSpan(100));
+
+        // serviceName is not stored in the qualifier; it resolves from the serviceUid
+        assertThat(decoded.getServiceName()).isEqualTo("service-100");
+    }
+
+    @Test
+    void decode_serviceUidLayout_defaultFactory_keepsDefaultServiceName() {
+        SpanEncoderV0 uidEncoder = new SpanEncoderV0(new SpanHeaderFactory(true));
+
+        SpanBo input = newMinimalSpan(TraceSourceType.PINPOINT);
+        input.getSpanOwner().setServiceUid(() -> ServiceUid.of(100));
+        // context without an explicit factory (e.g. collector side): DEFAULT name for every uid
+        BasicSpan decoded = roundTripSpan(uidEncoder, input);
+
+        assertThat(decoded.getServiceName()).isEqualTo(ServiceUid.DEFAULT_SERVICE_UID_NAME);
+    }
+
+    @Test
+    void decode_sameRow_sameServiceUid_resolvesOnce() {
+        SpanEncoderV0 uidEncoder = new SpanEncoderV0(new SpanHeaderFactory(true));
+        AtomicInteger resolveCount = new AtomicInteger();
+
+        // one context = one row; both spans carry the same serviceUid
+        SpanDecodingContext rowContext = newRowContext(uid -> {
+            resolveCount.incrementAndGet();
+            return "service-" + uid.getUid();
+        });
+        BasicSpan first = decodeWith(uidEncoder, decoder, rowContext, newUidSpan(100));
+        BasicSpan second = decodeWith(uidEncoder, decoder, rowContext, newUidSpan(100));
+
+        assertThat(first.getServiceName()).isEqualTo("service-100");
+        assertThat(second.getServiceName()).isEqualTo("service-100");
+        // row-local cache shares one memoizing supplier across the row's spans
+        assertThat(resolveCount).hasValue(1);
+    }
+
+    @Test
+    void decode_sameRow_distinctServiceUids_resolveSeparately() {
+        SpanEncoderV0 uidEncoder = new SpanEncoderV0(new SpanHeaderFactory(true));
+        AtomicInteger resolveCount = new AtomicInteger();
+
+        SpanDecodingContext rowContext = newRowContext(uid -> {
+            resolveCount.incrementAndGet();
+            return "service-" + uid.getUid();
+        });
+        BasicSpan first = decodeWith(uidEncoder, decoder, rowContext, newUidSpan(100));
+        BasicSpan second = decodeWith(uidEncoder, decoder, rowContext, newUidSpan(200));
+
+        assertThat(first.getServiceName()).isEqualTo("service-100");
+        assertThat(second.getServiceName()).isEqualTo("service-200");
+        assertThat(resolveCount).hasValue(2);
+    }
+
+    @Test
+    void decode_plainLayout_doesNotConsultResolver() {
+        SpanDecodingContext rowContext = newRowContext(uid -> {
+            throw new AssertionError("resolver must not be consulted for a non-UID qualifier");
+        });
+
+        SpanBo input = newMinimalSpan(TraceSourceType.PINPOINT);
+        BasicSpan decoded = decodeWith(encoder, decoder, rowContext, input);
+
+        assertThat(decoded.getServiceName()).isEqualTo(ServiceUid.DEFAULT_SERVICE_UID_NAME);
+    }
+
+    @Test
     void decode_unknownType_throws() {
         Buffer qualifier = new FixedBuffer(1);
         qualifier.putByte((byte) 99);
@@ -183,13 +257,29 @@ class SpanDecoderV0Test {
     }
 
     private BasicSpan roundTripSpan(SpanEncoderV0 encoder, SpanBo input) {
+        SpanDecodingContext decCtx = new SpanDecodingContext(newTransactionId());
+        return decodeWith(encoder, decoder, decCtx, input);
+    }
+
+    private SpanDecodingContext newRowContext(ServiceNameResolver resolver) {
+        SpanDecodingContext rowContext = new SpanDecodingContext(newTransactionId());
+        rowContext.setServiceNameFactory(new LazyServiceNameFactory(resolver));
+        return rowContext;
+    }
+
+    private BasicSpan decodeWith(SpanEncoderV0 encoder, SpanDecoderV0 decoder, SpanDecodingContext decCtx, SpanBo input) {
         SpanEncodingContext<SpanBo> encCtx = new SpanEncodingContext<>(input);
         Buffer qualifier = wrap(encoder.encodeSpanQualifier(encCtx));
         Buffer value = wrap(encoder.encodeSpanColumnValue(encCtx));
 
-        SpanDecodingContext decCtx = new SpanDecodingContext(newTransactionId());
         decCtx.setCollectorAcceptedTime(input.getCollectorAcceptTime());
         return decoder.decode(qualifier, value, decCtx);
+    }
+
+    private SpanBo newUidSpan(int uid) {
+        SpanBo span = newMinimalSpan(TraceSourceType.PINPOINT);
+        span.getSpanOwner().setServiceUid(() -> ServiceUid.of(uid));
+        return span;
     }
 
     private BasicSpan roundTripSpanChunk(SpanChunkBo input) {

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
@@ -71,7 +71,7 @@ public class SpanEncoderTest {
     private final SpanEventFilter filter = new EmptySpanEventFilter();
     private final GrpcSpanFactory grpcSpanFactory = new CollectorGrpcSpanFactory(grpcSpanBinder, filter);
 
-    private final SpanEncoder spanEncoder = new SpanEncoderV0();
+    private final SpanEncoder spanEncoder = new SpanEncoderV0(new SpanHeaderFactory(false));
     private final SpanDecoder spanDecoder = new SpanDecoderV0();
 
 

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanEncoderTest.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.common.server.bo.RandomTSpan;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.bo.filter.EmptySpanEventFilter;
 import com.navercorp.pinpoint.common.server.bo.filter.SpanEventFilter;
@@ -220,11 +221,14 @@ public class SpanEncoderTest {
 
         SpanBo decode = (SpanBo) spanDecoder.decode(qualifier, column, decodingContext);
 
-        List<String> excludeField = List.of("parentApplication", "annotationBoList", "spanEventBoList", "owner.agentName");
+        // suppliers are compared by resolved value below, not by implementation type
+        List<String> excludeField = List.of("parentApplication", "annotationBoList", "spanEventBoList",
+                "owner.agentName", "owner.serviceNameSupplier", "owner.serviceUidSupplier");
         Assertions.assertThat(decode)
                 .usingRecursiveComparison()
                 .ignoringFields(excludeField.toArray(new String[0]))
                 .isEqualTo(spanBo);
+        assertSpanOwner(decode.getSpanOwner(), spanBo.getSpanOwner());
 
         logger.debug("{} {}", spanBo.getAnnotationBoList(), decode.getAnnotationBoList());
         Assertions.assertThat(spanBo.getAnnotationBoList())
@@ -238,6 +242,11 @@ public class SpanEncoderTest {
                 .usingRecursiveComparison()
                 .ignoringFields("annotationBoList")
                 .isEqualTo(decodedSpanEventBoList);
+    }
+
+    private void assertSpanOwner(SpanOwner decode, SpanOwner expected) {
+        Assertions.assertThat(decode.getServiceName()).isEqualTo(expected.getServiceName());
+        Assertions.assertThat(decode.getServiceUid()).isEqualTo(expected.getServiceUid());
     }
 
     private void assertSpanChunk(SpanChunkBo spanChunkBo) {
@@ -259,12 +268,15 @@ public class SpanEncoderTest {
         // logger.debug("spanChunk dump \noriginal spanChunkBo:{} \ndecode spanChunkBo:{} ", spanChunkBo, decode);
 
         List<String> notSerializedField = Lists.newArrayList("endPoint", "serviceType", "applicationServiceType");
-        List<String> excludeField = List.of("spanEventBoList", "localAsyncId", "owner.agentName");
+        // suppliers are compared by resolved value below, not by implementation type
+        List<String> excludeField = List.of("spanEventBoList", "localAsyncId",
+                "owner.agentName", "owner.serviceNameSupplier", "owner.serviceUidSupplier");
         notSerializedField.addAll(excludeField);
         Assertions.assertThat(decode)
                 .usingRecursiveComparison()
                 .ignoringFields(notSerializedField.toArray(new String[0]))
                 .isEqualTo(spanChunkBo);
+        assertSpanOwner(decode.getSpanOwner(), spanChunkBo.getSpanOwner());
 
 
         List<SpanEventBo> spanEventBoList = spanChunkBo.getSpanEventBoList();

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeaderFactoryTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeaderFactoryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
+
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpanHeaderFactoryTest {
+
+    private final SpanHeaderFactory factory = new SpanHeaderFactory(false);
+    private final SpanHeaderFactory uidFactory = new SpanHeaderFactory(true);
+
+    @Test
+    void span_factory() {
+        assertThat(factory.span(TraceSourceType.PINPOINT)).isSameAs(SpanHeader.SPAN);
+        assertThat(factory.span(TraceSourceType.OPENTELEMETRY)).isSameAs(SpanHeader.OTEL_SPAN);
+        assertThat(factory.spanChunk(TraceSourceType.PINPOINT)).isSameAs(SpanHeader.SPAN_CHUNK);
+        assertThat(factory.spanChunk(TraceSourceType.OPENTELEMETRY)).isSameAs(SpanHeader.OTEL_SPAN_CHUNK);
+    }
+
+    @Test
+    void span_factory_serviceUid() {
+        assertThat(uidFactory.span(TraceSourceType.PINPOINT)).isSameAs(SpanHeader.SPAN_UID);
+        assertThat(uidFactory.span(TraceSourceType.OPENTELEMETRY)).isSameAs(SpanHeader.OTEL_SPAN_UID);
+        assertThat(uidFactory.spanChunk(TraceSourceType.PINPOINT)).isSameAs(SpanHeader.SPAN_CHUNK_UID);
+        assertThat(uidFactory.spanChunk(TraceSourceType.OPENTELEMETRY)).isSameAs(SpanHeader.OTEL_SPAN_CHUNK_UID);
+    }
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeaderTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanHeaderTest.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 
-import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,18 +40,37 @@ class SpanHeaderTest {
     }
 
     @Test
-    void span_factory() {
-        assertThat(SpanHeader.span(TraceSourceType.PINPOINT)).isSameAs(SpanHeader.SPAN);
-        assertThat(SpanHeader.span(TraceSourceType.OPENTELEMETRY)).isSameAs(SpanHeader.OTEL_SPAN);
-        assertThat(SpanHeader.spanChunk(TraceSourceType.PINPOINT)).isSameAs(SpanHeader.SPAN_CHUNK);
-        assertThat(SpanHeader.spanChunk(TraceSourceType.OPENTELEMETRY)).isSameAs(SpanHeader.OTEL_SPAN_CHUNK);
-    }
-
-    @Test
     void spanChunk_discriminator() {
         assertThat(SpanHeader.SPAN.isSpanChunk()).isFalse();
         assertThat(SpanHeader.OTEL_SPAN.isSpanChunk()).isFalse();
         assertThat(SpanHeader.SPAN_CHUNK.isSpanChunk()).isTrue();
         assertThat(SpanHeader.OTEL_SPAN_CHUNK.isSpanChunk()).isTrue();
+
+        assertThat(SpanHeader.SPAN_UID.isSpanChunk()).isFalse();
+        assertThat(SpanHeader.OTEL_SPAN_UID.isSpanChunk()).isFalse();
+        assertThat(SpanHeader.SPAN_CHUNK_UID.isSpanChunk()).isTrue();
+        assertThat(SpanHeader.OTEL_SPAN_CHUNK_UID.isSpanChunk()).isTrue();
+    }
+
+    @Test
+    void isSpan_isComplementOfIsSpanChunk() {
+        for (SpanHeader header : SpanHeader.values()) {
+            assertThat(header.isSpan())
+                    .as("%s.isSpan() must be the complement of isSpanChunk()", header)
+                    .isEqualTo(!header.isSpanChunk());
+        }
+    }
+
+    @Test
+    void serviceUid_discriminator() {
+        assertThat(SpanHeader.SPAN.hasServiceUid()).isFalse();
+        assertThat(SpanHeader.SPAN_CHUNK.hasServiceUid()).isFalse();
+        assertThat(SpanHeader.OTEL_SPAN.hasServiceUid()).isFalse();
+        assertThat(SpanHeader.OTEL_SPAN_CHUNK.hasServiceUid()).isFalse();
+
+        assertThat(SpanHeader.SPAN_UID.hasServiceUid()).isTrue();
+        assertThat(SpanHeader.SPAN_CHUNK_UID.hasServiceUid()).isTrue();
+        assertThat(SpanHeader.OTEL_SPAN_UID.hasServiceUid()).isTrue();
+        assertThat(SpanHeader.OTEL_SPAN_CHUNK_UID.hasServiceUid()).isTrue();
     }
 }

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanQualifierHashTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/SpanQualifierHashTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
+
+import com.google.common.hash.Hashing;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpanQualifierHashTest {
+
+    @Test
+    void applicationName_isDeterministic() {
+        // stored-format compatibility: the same name must always map to the same bucket
+        assertThat(SpanQualifierHash.applicationName("order-service"))
+                .isEqualTo(SpanQualifierHash.applicationName("order-service"));
+    }
+
+    @Test
+    void applicationName_nullMapsToZero() {
+        assertThat(SpanQualifierHash.applicationName(null)).isEqualTo((byte) 0);
+    }
+
+    @Test
+    void applicationName_matchesMurmur3LowByte() {
+        // pins the algorithm; a change here signals a format-breaking change
+        assertThat(SpanQualifierHash.applicationName("order-service")).isEqualTo(murmur3LowByte("order-service"));
+        assertThat(SpanQualifierHash.applicationName("payment")).isEqualTo(murmur3LowByte("payment"));
+    }
+
+    private static byte murmur3LowByte(String s) {
+        return (byte) Hashing.murmur3_32_fixed().hashUnencodedChars(s).asInt();
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/HbaseOtlpApplicationIndexV2Service.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/HbaseOtlpApplicationIndexV2Service.java
@@ -20,13 +20,13 @@ import com.navercorp.pinpoint.collector.dao.AgentIdDao;
 import com.navercorp.pinpoint.collector.dao.ApplicationDao;
 import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.uid.ServiceUidSupplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 @Service
 public class HbaseOtlpApplicationIndexV2Service {
@@ -45,7 +45,7 @@ public class HbaseOtlpApplicationIndexV2Service {
     }
 
     // TODO get serviceUid from agentInfoBo
-    public void insert(Supplier<ServiceUid> serviceUidSupplier, AgentInfoBo agentInfoBo) {
+    public void insert(ServiceUidSupplier serviceUidSupplier, AgentInfoBo agentInfoBo) {
         if (!v2enabled) {
             return;
         }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
@@ -24,7 +24,8 @@ import com.navercorp.pinpoint.common.server.bo.AgentInfoBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.exception.ExceptionMetaDataBo;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.uid.FixedServiceUid;
+import com.navercorp.pinpoint.common.server.uid.ServiceUidSupplier;
 import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
 import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapper;
 import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperData;
@@ -40,7 +41,6 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Transport-agnostic OTLP trace ingestion: maps the incoming {@link ResourceSpans} into
@@ -55,7 +55,7 @@ import java.util.function.Supplier;
 @Service
 public class OtlpTraceExportService {
 
-    public static final Supplier<ServiceUid> DEFAULT_SERVICE_UID = () -> ServiceUid.DEFAULT;
+    public static final ServiceUidSupplier DEFAULT_SERVICE_UID = FixedServiceUid.DEFAULT;
 
     private static final String INSERT_ERROR_METRIC = "collector.otlptrace.insert.error";
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelCacheConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelCacheConfiguration.java
@@ -1,6 +1,9 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.navercorp.pinpoint.common.server.uid.LazyServiceNameFactory;
+import com.navercorp.pinpoint.common.server.uid.ServiceNameFactory;
+import com.navercorp.pinpoint.common.server.uid.ServiceNameResolver;
 import com.navercorp.pinpoint.common.server.cache.NullValueExpiry;
 import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
@@ -72,5 +75,16 @@ public class ServiceModelCacheConfiguration {
             @Qualifier("webServiceModelCacheProperties") CaffeineCacheProperties cacheProperties,
             ServiceModelLoadProperties loadProperties) {
         return new CachingServiceModelResolver(serviceRegistryService, cacheManager, cacheProperties, loadProperties);
+    }
+
+    /**
+     * Bridges the service registry into the span decoder's serviceUid -> serviceName
+     * resolution (see SpanDecodingContext).
+     */
+    @Bean
+    public ServiceNameFactory serviceNameFactory(ServiceModelResolver serviceModelResolver) {
+        // getService() falls back to Service.DEFAULT on an unknown uid, so this never returns null
+        ServiceNameResolver resolver = serviceUid -> serviceModelResolver.getService(serviceUid.getUid()).getServiceName();
+        return new LazyServiceNameFactory(resolver);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/hbase/HbaseTraceDaoV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/hbase/HbaseTraceDaoV2.java
@@ -247,13 +247,19 @@ public class HbaseTraceDaoV2 implements TraceDao {
     }
 
     public Filter createSpanQualifierFilter() {
-        // Keep span cells only (drop span-chunk cells). TYPE_SPAN marks Pinpoint-origin spans,
-        // TYPE_OTEL_SPAN marks OpenTelemetry-origin spans — both are full Span rows.
-        Filter pinpointSpan = new QualifierFilter(CompareOperator.EQUAL,
-                new BinaryPrefixComparator(new byte[]{SpanHeader.SPAN.getCode()}));
-        Filter otelSpan = new QualifierFilter(CompareOperator.EQUAL,
-                new BinaryPrefixComparator(new byte[]{SpanHeader.OTEL_SPAN.getCode()}));
-        return new FilterList(FilterList.Operator.MUST_PASS_ONE, pinpointSpan, otelSpan);
+        // Keep full span cells only (drop span-chunk cells), across both the legacy and the
+        // serviceUid-bearing layouts (SPAN/OTEL_SPAN and their *_UID variants). The type byte
+        // is always qualifier[0], so a 1-byte prefix match per non-chunk SpanHeader code
+        // selects spans regardless of the rest of the layout. Driving this off SpanHeader keeps
+        // it correct if a variant is added later.
+        List<Filter> spanFilters = new ArrayList<>();
+        for (SpanHeader header : SpanHeader.values()) {
+            if (header.isSpan()) {
+                spanFilters.add(new QualifierFilter(CompareOperator.EQUAL,
+                        new BinaryPrefixComparator(new byte[]{header.getCode()})));
+            }
+        }
+        return new FilterList(FilterList.Operator.MUST_PASS_ONE, spanFilters);
     }
 
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/FilteringSpanDecoder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/FilteringSpanDecoder.java
@@ -47,7 +47,10 @@ public class FilteringSpanDecoder implements SpanDecoder {
         }
         final byte type = qualifier.getByte(0);
         final SpanHeader header = SpanHeader.of(type);
-        if (header == null || header.isSpanChunk()) {
+        if (header == null) {
+            throw new IllegalStateException("Unknown span qualifier type: " + Byte.toUnsignedInt(type));
+        }
+        if (header.isSpanChunk()) {
             return null;
         }
         // span

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperFactory.java
@@ -20,6 +20,7 @@ import com.navercorp.pinpoint.common.buffer.StringAllocatorFactory;
 import com.navercorp.pinpoint.common.hbase.RowMapper;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
+import com.navercorp.pinpoint.common.server.uid.ServiceNameFactory;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoderV0;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
@@ -44,12 +45,16 @@ public class SpanMapperFactory {
 
     private final SpanDecoder spanDecoder = new SpanDecoderV0();
 
+    private final ServiceNameFactory serviceNameFactory;
+
     public SpanMapperFactory(@Qualifier("traceRowKeyDecoderV2") RowKeyDecoder<ServerTraceId> rowKeyDecoder,
-                             StringAllocatorFactory stringAllocatorFactory) {
+                             StringAllocatorFactory stringAllocatorFactory,
+                             ServiceNameFactory serviceNameFactory) {
         this.rowKeyDecoder = Objects.requireNonNull(rowKeyDecoder, "rowKeyDecoder");
         this.stringAllocatorFactory = Objects.requireNonNull(stringAllocatorFactory, "stringAllocatorFactory");
+        this.serviceNameFactory = Objects.requireNonNull(serviceNameFactory, "serviceNameFactory");
 
-        this.mapper = wrap(new SpanMapperV2(rowKeyDecoder, stringAllocatorFactory));
+        this.mapper = wrap(new SpanMapperV2(rowKeyDecoder, spanDecoder, stringAllocatorFactory, serviceNameFactory));
     }
 
     public RowMapper<List<SpanBo>> getSpanMapper() {
@@ -71,6 +76,6 @@ public class SpanMapperFactory {
         }
 
         final SpanDecoder targetSpanDecoder = new FilteringSpanDecoder(spanDecoder, spanFilter);
-        return new SpanMapperV2(rowKeyDecoder, targetSpanDecoder, stringAllocatorFactory);
+        return new SpanMapperV2(rowKeyDecoder, targetSpanDecoder, stringAllocatorFactory, serviceNameFactory);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2.java
@@ -31,6 +31,7 @@ import com.navercorp.pinpoint.common.server.bo.SpanEventComparator;
 import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
+import com.navercorp.pinpoint.common.server.uid.ServiceNameFactory;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoderV0;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecodingContext;
@@ -66,6 +67,8 @@ public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
 
     private final StringAllocatorFactory stringAllocatorFactory;
 
+    private final ServiceNameFactory serviceNameFactory;
+
     public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder) {
         this(rowKeyDecoder, new SpanDecoderV0(), StringAllocatorFactory.DEFAULT);
     }
@@ -79,9 +82,15 @@ public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
     }
 
     public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder, SpanDecoder spanDecoder, StringAllocatorFactory stringAllocatorFactory) {
+        this(rowKeyDecoder, spanDecoder, stringAllocatorFactory, ServiceNameFactory.FALLBACK);
+    }
+
+    public SpanMapperV2(RowKeyDecoder<ServerTraceId> rowKeyDecoder, SpanDecoder spanDecoder,
+                        StringAllocatorFactory stringAllocatorFactory, ServiceNameFactory serviceNameFactory) {
         this.rowKeyDecoder = Objects.requireNonNull(rowKeyDecoder, "rowKeyDecoder");
         this.spanDecoder = Objects.requireNonNull(spanDecoder, "spanDecoder");
         this.stringAllocatorFactory = Objects.requireNonNull(stringAllocatorFactory, "stringAllocatorFactory");
+        this.serviceNameFactory = Objects.requireNonNull(serviceNameFactory, "serviceNameFactory");
     }
 
     @Override
@@ -102,6 +111,8 @@ public class SpanMapperV2 implements RowMapper<List<SpanBo>> {
         final SpanDecodingContext decodingContext = new SpanDecodingContext(transactionId);
         // per-row allocator, see StringAllocatorFactory
         decodingContext.setStringAllocator(stringAllocatorFactory.create());
+        // serviceUid -> serviceName suppliers, cached per row inside the context
+        decodingContext.setServiceNameFactory(serviceNameFactory);
 
         for (Cell cell : rawCells) {
             SpanDecoder spanDecoder = null;

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/hbase/HbaseTraceDaoV2Test.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/hbase/HbaseTraceDaoV2Test.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.trace.dao.hbase;
+
+import com.navercorp.pinpoint.common.hbase.HbaseOperations;
+import com.navercorp.pinpoint.common.hbase.TableNameProvider;
+import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
+import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanHeader;
+import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
+import com.navercorp.pinpoint.web.trace.dao.mapper.SpanMapperFactory;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.filter.QualifierFilter;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class HbaseTraceDaoV2Test {
+
+    @SuppressWarnings("unchecked")
+    private final HbaseTraceDaoV2 dao = new HbaseTraceDaoV2(
+            mock(HbaseOperations.class),
+            mock(TableNameProvider.class),
+            mock(RowKeyEncoder.class),
+            mock(SpanMapperFactory.class));
+
+    @Test
+    void createSpanQualifierFilter_keepsEverySpanVariantAndNoChunk() {
+        Filter filter = dao.createSpanQualifierFilter();
+        assertThat(filter).isInstanceOf(FilterList.class);
+
+        Set<Byte> matchedCodes = new HashSet<>();
+        for (Filter f : ((FilterList) filter).getFilters()) {
+            byte[] value = ((QualifierFilter) f).getComparator().getValue();
+            assertThat(value).as("type prefix is a single byte").hasSize(1);
+            matchedCodes.add(value[0]);
+        }
+
+        Set<Byte> expected = new HashSet<>();
+        for (SpanHeader header : SpanHeader.values()) {
+            if (!header.isSpanChunk()) {
+                expected.add(header.getCode());
+            }
+        }
+
+        // all four span variants (SPAN, OTEL_SPAN, SPAN_UID, OTEL_SPAN_UID), no chunk codes
+        assertThat(matchedCodes).isEqualTo(expected);
+        assertThat(matchedCodes).contains(SpanHeader.SPAN.getCode(), SpanHeader.SPAN_UID.getCode());
+        assertThat(matchedCodes).doesNotContain(
+                SpanHeader.SPAN_CHUNK.getCode(), SpanHeader.OTEL_SPAN_CHUNK_UID.getCode());
+    }
+}

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/mapper/FilteringSpanDecoderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/mapper/FilteringSpanDecoderTest.java
@@ -197,6 +197,23 @@ public class FilteringSpanDecoderTest {
         Assertions.assertNull(result, "TYPE_OTEL_SPAN_CHUNK must be dropped (decoder filters spans only)");
     }
 
+    @Test
+    public void decodeTest_unknownType_throws() {
+        SpanBo spanBo = Random.createSpanBo();
+        SpanDecoder mockSpanDecoder = createMockSpanDecoder(spanBo);
+
+        GetTraceInfo getTraceInfo = createGetTraceInfo(spanBo);
+        SpanQueryBuilder builder = new SpanQueryBuilder();
+        SpanQuery query = builder.build(getTraceInfo);
+
+        FilteringSpanDecoder filteringSpanDecoder = new FilteringSpanDecoder(mockSpanDecoder, query.getSpanFilter());
+
+        Buffer buffer = newQualifierBuffer(SpanEncoder.TYPE_INDEX);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> filteringSpanDecoder.decode(buffer, null, null),
+                "an unresolved qualifier type must fail fast");
+    }
+
     private GetTraceInfo createGetTraceInfo() {
         return createGetTraceInfo(Random.createSpanBo());
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2Test.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/dao/mapper/SpanMapperV2Test.java
@@ -26,6 +26,7 @@ import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecoderV0
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanDecodingContext;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncoderV0;
+import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanHeaderFactory;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanEncodingContext;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
@@ -75,7 +76,7 @@ public class SpanMapperV2Test {
         span.addSpanEvent(nextSpanEventBo);
 
         SpanEncodingContext<SpanBo> encodingContext = new SpanEncodingContext<>(span);
-        SpanEncoder encoder = new SpanEncoderV0();
+        SpanEncoder encoder = new SpanEncoderV0(new SpanHeaderFactory(false));
         ByteBuffer byteBuffer = encoder.encodeSpanColumnValue(encodingContext);
 
         Buffer buffer = new OffsetFixedBuffer(byteBuffer.array(), byteBuffer.arrayOffset(), byteBuffer.remaining());


### PR DESCRIPTION
This pull request refactors how service names and service UIDs are handled throughout the codebase, replacing generic `Supplier` interfaces with more descriptive, domain-specific types (`ServiceNameSupplier` and `ServiceUidSupplier`). It also improves the decoding logic for spans to better support service UIDs and introduces a row-local cache for service names during decoding. These changes enhance type safety, clarity, and performance in service name/UID management.

**Service Name and UID Supplier Refactoring**
- Replaced usages of `Supplier<ServiceUid>` and `String` for service name/UID with `ServiceUidSupplier` and `ServiceNameSupplier` throughout the codebase, including in `SpanOwner`, `GrpcServerHeaderV1`, and related factories and tests. This improves type safety and makes the code’s intent clearer. [[1]](diffhunk://#diff-dc4064166a75870c7f8dcfb70312e189a18bf8fa0beaf0dd2348227efa683634L47-R56) [[2]](diffhunk://#diff-7ddda804704984fe45b37a998c9d1040eef3b2da8b914851aaa7fa3985b19ac7L4-R16) [[3]](diffhunk://#diff-01b420b9ee90c1db20ec53c3e8da4e58292b838d4aec0f731879f0501a92547fL19-R23) [[4]](diffhunk://#diff-ffed7dc1ceb3c46d416681c313a57fac124e0ad6fed1500150e5d9127bd22a62L24-R24)

**Decoding and Caching Improvements**
- Updated `SpanDecoderV0` to distinguish between spans with and without service UIDs, using the new supplier types and reading logic. Introduced a helper method to read application info consistently. [[1]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1L416-R432) [[2]](diffhunk://#diff-4821d693f58d2a67676949380ba97131c92b3b90ea669352f52a19d9905c92c1R451-R456)
- Added a row-local cache for `ServiceNameSupplier` in `SpanDecodingContext` to avoid redundant allocations and improve performance when decoding multiple spans/chunks in the same row.

**API and Behavior Changes**
- Changed method signatures in factories and headers to accept and return the new supplier types instead of generic `Supplier`. [[1]](diffhunk://#diff-21bd880f39d5cd32a1a6976a7db3ea544c38e2f04dcda7bd38708b2d9946c4f4L5-R13) [[2]](diffhunk://#diff-7ddda804704984fe45b37a998c9d1040eef3b2da8b914851aaa7fa3985b19ac7L52-R51) [[3]](diffhunk://#diff-01b420b9ee90c1db20ec53c3e8da4e58292b838d4aec0f731879f0501a92547fL19-R23)
- Updated test code to use `ServiceUidSupplier` in place of `Supplier<ServiceUid>`. [[1]](diffhunk://#diff-ffed7dc1ceb3c46d416681c313a57fac124e0ad6fed1500150e5d9127bd22a62L24-R24) [[2]](diffhunk://#diff-ffed7dc1ceb3c46d416681c313a57fac124e0ad6fed1500150e5d9127bd22a62L34-R34) [[3]](diffhunk://#diff-ffed7dc1ceb3c46d416681c313a57fac124e0ad6fed1500150e5d9127bd22a62L43-R43) [[4]](diffhunk://#diff-ffed7dc1ceb3c46d416681c313a57fac124e0ad6fed1500150e5d9127bd22a62L54-R54)

**Error Handling**
- Improved error handling in `SpanDecoderV0` by throwing an `IllegalStateException` for unknown span types instead of returning null, making failures more explicit and easier to debug.

**Constants and Defaults**
- Introduced named constants for default service name and UID suppliers in `SpanOwner` to ensure consistent default values and improve debuggability (toString output).

These changes collectively modernize and clarify how service names and UIDs are managed and decoded, setting the stage for future enhancements.