### PR TITLE
[#14079] Apply the selected service to scatter chart V2 query

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/job/ApplicationCleanupTasklet.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/job/ApplicationCleanupTasklet.java
@@ -252,7 +252,7 @@ public class ApplicationCleanupTasklet implements Tasklet {
 
     private Dot getTraceIndexData(Application application, long baseTimestamp) {
         Range range = Range.between(baseTimestamp - Duration.ofDays(inactiveDays).toMillis(), baseTimestamp);
-        LimitedScanResult<List<Dot>> result = traceIndexDao.scanTraceScatterData(application.getService().getServiceUid().getUid(), application.getApplicationName(), application.getServiceTypeCode(), range, 1);
+        LimitedScanResult<List<Dot>> result = traceIndexDao.scanTraceScatterData(application.getService(), application.getApplicationName(), application.getServiceTypeCode(), range, 1);
         if (!result.scanData().isEmpty()) {
             return result.scanData().get(0);
         }

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ScatterChartController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ScatterChartController.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.web.authorization.controller;
 
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
@@ -26,7 +25,9 @@ import com.navercorp.pinpoint.web.scatter.ScatterData;
 import com.navercorp.pinpoint.web.scatter.ScatterView;
 import com.navercorp.pinpoint.web.scatter.Status;
 import com.navercorp.pinpoint.web.service.ScatterChartService;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.util.LimitUtils;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.view.transactionlist.TransactionMetaDataViewModel;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.GetTraceInfoParser;
@@ -64,6 +65,7 @@ public class ScatterChartController implements AccessDeniedExceptionHandler {
 
     private final ScatterChartService scatterChartService;
     private final ServiceTypeRegistryService serviceTypeRegistryService;
+    private final ServiceModelResolver serviceModelResolver;
     private final boolean defaultTraceIndexReadV2;
 
     private final GetTraceInfoParser getTraceInfoParser = new GetTraceInfoParser();
@@ -71,9 +73,11 @@ public class ScatterChartController implements AccessDeniedExceptionHandler {
     public ScatterChartController(
             ScatterChartService scatterChartService,
             ServiceTypeRegistryService serviceTypeRegistryService,
+            ServiceModelResolver serviceModelResolver,
             @Value("${pinpoint.web.trace.index.read.v2:true}") boolean defaultTraceIndexReadV2) {
         this.scatterChartService = Objects.requireNonNull(scatterChartService, "scatterChartService");
         this.serviceTypeRegistryService = Objects.requireNonNull(serviceTypeRegistryService, "serviceTypeRegistryService");
+        this.serviceModelResolver = Objects.requireNonNull(serviceModelResolver, "serviceModelResolver");
         this.defaultTraceIndexReadV2 = defaultTraceIndexReadV2;
     }
 
@@ -135,8 +139,8 @@ public class ScatterChartController implements AccessDeniedExceptionHandler {
             scatterData = scatterChartService.selectScatterData(applicationName, range, xGroupUnit, yGroupUnit, limit, backwardDirection);
         } else {
             final ServiceType serviceType = findServiceType(serviceTypeCode, serviceTypeName);
-            // always scan backwardDirection in V2
-            scatterData = scatterChartService.selectScatterDataV2(ServiceUid.DEFAULT_SERVICE_UID_CODE, applicationName, serviceType.getCode(), range, xGroupUnit, yGroupUnit, limit);
+            final Service service = serviceModelResolver.getService(serviceName.getName());
+            scatterData = scatterChartService.selectScatterDataV2(service, applicationName, serviceType.getCode(), range, xGroupUnit, yGroupUnit, limit);
         }
         final boolean requestComplete = scatterData.getDotSize() < limit;
         ScatterView.DotView dotView = new ScatterView.DotView(scatterData, requestComplete);

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/TraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/TraceIndexDao.java
@@ -19,6 +19,7 @@ package com.navercorp.pinpoint.web.scatter.dao;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 
@@ -29,7 +30,7 @@ public interface TraceIndexDao {
 
     LimitedScanResult<List<DotMetaData>> scanTraceIndex(int serviceUid, String applicationName, int serviceTypeCode, Range range, int limit);
 
-    LimitedScanResult<List<Dot>> scanTraceScatterData(int serviceUid, String applicationName, int serviceTypeCode, Range range, int limit);
+    LimitedScanResult<List<Dot>> scanTraceScatterData(Service service, String applicationName, int serviceTypeCode, Range range, int limit);
 
     LimitedScanResult<List<DotMetaData>> scanScatterDataV2(int serviceUid, String applicationName, int serviceTypeCode, DragAreaQuery dragAreaQuery, String rpcRegex, int limit);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java
@@ -40,6 +40,7 @@ import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 import com.navercorp.pinpoint.web.util.ListListUtils;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
+import com.navercorp.pinpoint.web.vo.Service;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.FilterList;
@@ -110,13 +111,15 @@ public class HbaseTraceIndexDao implements TraceIndexDao {
     }
 
     @Override
-    public LimitedScanResult<List<Dot>> scanTraceScatterData(int serviceUid, String applicationName, int serviceTypeCode, Range range, int limitWithTies) {
+    public LimitedScanResult<List<Dot>> scanTraceScatterData(Service service, String applicationName, int serviceTypeCode, Range range, int limitWithTies) {
+        Objects.requireNonNull(service, "service");
         Objects.requireNonNull(applicationName, "applicationName");
         Objects.requireNonNull(range, "range");
         if (limitWithTies < 0) {
             throw new IllegalArgumentException("negative limitWithTies:" + limitWithTies);
         }
         logger.debug("scanTraceScatterDataMadeOfDotGroup");
+        final int serviceUid = service.getServiceUid().getUid();
         Scan scan = createScan(serviceUid, applicationName, serviceTypeCode, range);
 
         RowMapper<List<Dot>> dotMapper = new TraceIndexDotMapper(TraceIndexRowKeyUtils.createApplicationNamePredicate(applicationName));

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartService.java
@@ -21,6 +21,7 @@ import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.scatter.ScatterData;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
+import com.navercorp.pinpoint.web.vo.Service;
 
 import java.util.List;
 
@@ -32,5 +33,5 @@ public interface ScatterChartService {
 
     ScatterData selectScatterData(String applicationName, Range range, int xGroupUnit, int yGroupUnit, int limit, boolean backwardDirection);
 
-    ScatterData selectScatterDataV2(int serviceUid, String applicationName, int serviceTypeCode, Range range, int xGroupUnit, int yGroupUnit, int limit);
+    ScatterData selectScatterDataV2(Service service, String applicationName, int serviceTypeCode, Range range, int xGroupUnit, int yGroupUnit, int limit);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartServiceImpl.java
@@ -30,9 +30,9 @@ import com.navercorp.pinpoint.web.trace.service.SpanService;
 import com.navercorp.pinpoint.web.util.ListListUtils;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
+import com.navercorp.pinpoint.web.vo.Service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.List;
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  * @author netspider
  * @author emeroad
  */
-@Service
+@org.springframework.stereotype.Service
 public class ScatterChartServiceImpl implements ScatterChartService {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
@@ -112,10 +112,11 @@ public class ScatterChartServiceImpl implements ScatterChartService {
     }
 
     @Override
-    public ScatterData selectScatterDataV2(int serviceUid, String applicationName, int serviceTypeCode, Range range, int xGroupUnit, int yGroupUnit, int limit) {
+    public ScatterData selectScatterDataV2(Service service, String applicationName, int serviceTypeCode, Range range, int xGroupUnit, int yGroupUnit, int limit) {
+        Objects.requireNonNull(service, "service");
         Objects.requireNonNull(applicationName, "applicationName");
         Objects.requireNonNull(range, "range");
-        LimitedScanResult<List<Dot>> scanResult = traceIndexDao.scanTraceScatterData(serviceUid, applicationName, serviceTypeCode, range, limit);
+        LimitedScanResult<List<Dot>> scanResult = traceIndexDao.scanTraceScatterData(service, applicationName, serviceTypeCode, range, limit);
 
         ScatterDataBuilder builder = new ScatterDataBuilder(range.getFrom(), range.getTo(), xGroupUnit, yGroupUnit);
         builder.addDot(scanResult.scanData());

--- a/web/src/test/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDaoTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDaoTest.java
@@ -24,6 +24,7 @@ import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.config.ScatterChartProperties;
@@ -58,6 +59,7 @@ public class HbaseTraceIndexDaoTest {
     private static final ServerTraceId EMPTY = new PinpointServerTraceId("EMPTY", 0, 0);
 
     private static final int serviceUid = ServiceUid.DEFAULT_SERVICE_UID_CODE;
+    private static final Service service = Service.DEFAULT;
     private static final DotMetaData testDotMetaData = new DotMetaData(new Dot(EMPTY, 10, 10, 0, "testAgentId"),
             "testAgentName", "remoteAddr", "rpc", "endpoint", -1, 0);
 
@@ -106,7 +108,7 @@ public class HbaseTraceIndexDaoTest {
 
     @Test
     public void scanTraceScatterDataExceptionTest() {
-        assertThrows(IllegalArgumentException.class, () -> this.traceIndexDao.scanTraceScatterData(serviceUid, "app", ServiceType.TEST_STAND_ALONE.getCode(), Range.between(1000L, 5000L), -10));
+        assertThrows(IllegalArgumentException.class, () -> this.traceIndexDao.scanTraceScatterData(service, "app", ServiceType.TEST_STAND_ALONE.getCode(), Range.between(1000L, 5000L), -10));
     }
 
     @Test
@@ -116,7 +118,7 @@ public class HbaseTraceIndexDaoTest {
                 any(ResultsExtractor.class), anyInt())).thenReturn(List.of());
         Range range = Range.between(1000L, 5000L);
         LimitedScanResult<List<Dot>> scanResult
-                = this.traceIndexDao.scanTraceScatterData(serviceUid, "app", ServiceType.TEST_STAND_ALONE.getCode(), range, 10);
+                = this.traceIndexDao.scanTraceScatterData(service, "app", ServiceType.TEST_STAND_ALONE.getCode(), range, 10);
         ScatterDataBuilder builder = new ScatterDataBuilder(range.getFrom(), range.getTo(), 1, 5);
         scanResult.scanData().forEach(builder::addDot);
         ScatterData result = builder.build();
@@ -133,7 +135,7 @@ public class HbaseTraceIndexDaoTest {
                 any(ResultsExtractor.class), anyInt())).thenReturn(scanResult);
         Range range = Range.between(1000L, 5000L);
         LimitedScanResult<List<Dot>> limitedScanResult
-                = this.traceIndexDao.scanTraceScatterData(serviceUid, "app", ServiceType.TEST_STAND_ALONE.getCode(), range, 10);
+                = this.traceIndexDao.scanTraceScatterData(service, "app", ServiceType.TEST_STAND_ALONE.getCode(), range, 10);
         ScatterDataBuilder builder = new ScatterDataBuilder(range.getFrom(), range.getTo(), 1, 5);
         limitedScanResult.scanData().forEach(builder::addDot);
         ScatterData result = builder.build();


### PR DESCRIPTION
## Issue
Closes #14079

## Problem
`ScatterChartController#getScatterData` (V2 path) receives the service via `@ServiceParam` but uses it only for the `@PreAuthorize` permission check. For the actual query it passed a hardcoded `ServiceUid.DEFAULT_SERVICE_UID_CODE` to `selectScatterDataV2`, so the trace index scan always ran against the DEFAULT service uid regardless of the requested service. A non-DEFAULT service returned no scatter data.

## Change
- Resolve `serviceName` to a `Service` (via `ServiceModelResolver`) in the controller and pass the `Service` object down through `ScatterChartService` to `TraceIndexDao`.
- Convert `Service` to `serviceUid` only right before the HBase scan in `HbaseTraceIndexDao`, keeping the service identity available at the query boundary.
- Update the batch caller (`ApplicationCleanupTasklet`) and `HbaseTraceIndexDaoTest` for the new signature.

Scope: V2 read path only (`pinpoint.web.trace.index.read.v2=true`). The V1 path supports the DEFAULT service only and is unchanged.

## Test
- `web` / `batch` build and `HbaseTraceIndexDaoTest` pass.
- Local E2E: `getScatterData` returns dots for the selected service and an empty result for DEFAULT (proper isolation).