### PR TITLE
[#noissue] Narrow the agent management error boundary to the table area

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/agentManagement/AgentManagementFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/agentManagement/AgentManagementFetcher.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Configuration, ApplicationType, AgentManagementList } from '@pinpoint-fe/ui/src/constants';
-import { ApplicationCombinedList } from '../../../components/Application';
-import { Button, ScrollArea, Separator, useReactToastifyToast } from '../../../components';
+import { ApplicationType, AgentManagementList } from '@pinpoint-fe/ui/src/constants';
+import { Button, useReactToastifyToast } from '../../../components';
 import { AgentManagementTable } from './AgentManagementTable';
 import {
   useDeleteAgent,
@@ -13,15 +12,17 @@ import { FaRegTrashCan } from 'react-icons/fa6';
 import { AgentManagementRemovePopup } from './AgentManagementRemovePopup';
 
 export interface AgentManagementFetcherProps {
-  configuration?: Configuration;
+  application?: ApplicationType;
+  onRemoveApplicationSuccess?: () => void;
 }
 
-export const AgentManagementFetcher = ({ configuration }: AgentManagementFetcherProps) => {
-  void configuration; // Not use configuration
+export const AgentManagementFetcher = ({
+  application,
+  onRemoveApplicationSuccess,
+}: AgentManagementFetcherProps) => {
   const toast = useReactToastifyToast();
 
   const { t } = useTranslation();
-  const [application, setApplication] = React.useState<ApplicationType>();
 
   const { data, refetch } = useGetAgentManagementList({
     applicationName: application?.applicationName || '',
@@ -44,7 +45,7 @@ export const AgentManagementFetcher = ({ configuration }: AgentManagementFetcher
     onError,
     onSuccess: () => {
       onSuccess();
-      setApplication(undefined);
+      onRemoveApplicationSuccess?.();
     },
   });
 
@@ -74,32 +75,21 @@ export const AgentManagementFetcher = ({ configuration }: AgentManagementFetcher
   }
 
   return (
-    <ScrollArea>
-      <div className="flex gap-10">
-        <h3 className="text-lg font-semibold">Agent management</h3>
-        <ApplicationCombinedList
-          open={!application}
-          selectedApplication={application}
-          onClickApplication={(application) => setApplication(application)}
+    <div className="flex flex-col gap-2">
+      <div className="text-end">
+        <AgentManagementRemovePopup
+          popupTrigger={
+            <Button variant={'destructive'}>
+              <FaRegTrashCan className="mr-0.5" />{' '}
+              {t('CONFIGURATION.AGENT_MANAGEMENT.LABEL.REMOVE_APPLICATION')}
+            </Button>
+          }
+          isApplication={true}
+          application={application}
+          onClickRemove={handleRemoveApplication}
         />
       </div>
-      <Separator className="my-6" />
-      <div className="flex flex-col gap-2">
-        <div className="text-end">
-          <AgentManagementRemovePopup
-            popupTrigger={
-              <Button variant={'destructive'}>
-                <FaRegTrashCan className="mr-0.5" />{' '}
-                {t('CONFIGURATION.AGENT_MANAGEMENT.LABEL.REMOVE_APPLICATION')}
-              </Button>
-            }
-            isApplication={true}
-            application={application}
-            onClickRemove={handleRemoveApplication}
-          />
-        </div>
-        <AgentManagementTable data={data || []} onRemove={handleRemoveAgent} />
-      </div>
-    </ScrollArea>
+      <AgentManagementTable data={data || []} onRemove={handleRemoveAgent} />
+    </div>
   );
 };

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/AgentManagement.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/AgentManagement.tsx
@@ -1,20 +1,39 @@
 import React from 'react';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
-import { DataTableSkeleton, ErrorBoundary } from '../../components';
+import { ApplicationType, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { DataTableSkeleton, ErrorBoundary, ScrollArea, Separator } from '../../components';
+import { ApplicationCombinedList } from '../../components/Application';
 import { AgentManagementFetcher } from '@pinpoint-fe/ui/src/components/Config/agentManagement';
 
 export interface AgentManagementPageProps {
   configuration?: Configuration;
 }
 
-export const AgentManagementPage = (props: AgentManagementPageProps) => {
+export const AgentManagementPage = ({ configuration }: AgentManagementPageProps) => {
+  void configuration; // Not use configuration
+  const [application, setApplication] = React.useState<ApplicationType>();
+
   return (
     <div className="space-y-6">
-      <ErrorBoundary>
-        <React.Suspense fallback={<DataTableSkeleton hideRowBox={true} />}>
-          <AgentManagementFetcher {...props} />
-        </React.Suspense>
-      </ErrorBoundary>
+      <ScrollArea>
+        <div className="flex gap-10">
+          <h3 className="text-lg font-semibold">Agent management</h3>
+          <ApplicationCombinedList
+            open={!application}
+            selectedApplication={application}
+            onClickApplication={(application) => setApplication(application)}
+          />
+        </div>
+        <Separator className="my-6" />
+        {/* agent 목록 조회 실패는 이 영역에서만 fallback을 노출하고, 상단 application 선택 UI는 유지한다. */}
+        <ErrorBoundary resetKeys={[application?.applicationName, application?.serviceType]}>
+          <React.Suspense fallback={<DataTableSkeleton hideRowBox={true} />}>
+            <AgentManagementFetcher
+              application={application}
+              onRemoveApplicationSuccess={() => setApplication(undefined)}
+            />
+          </React.Suspense>
+        </ErrorBoundary>
+      </ScrollArea>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- The Agent management page wrapped its entire content in a single `ErrorBoundary`, so a failed `/api/agents` request replaced the header and the application selector too — leaving the user with no way to pick another application and recover.
- Split the data-fetching part out into `AgentManagementContent` and wrapped only that in the `ErrorBoundary` + `Suspense`. The title and application selector now stay mounted while the table area shows the error fallback.
- Added the selected application to the boundary's `resetKeys`, so choosing a different application clears the error state and refetches automatically.

## Test plan
- [ ] Open Configuration > Agent management and select an application — the agent table loads as before.
- [ ] Force `/api/agents` to fail (e.g. block it in devtools) — only the table area shows the error fallback; the title and application selector remain usable.
- [ ] While the error fallback is shown, select a different application — the error clears and the list is refetched.
- [ ] Remove an agent and remove an application — toasts and list refresh behave as before, and removing an application still clears the selection.
- [ ] `yarn build`, `yarn test`, `yarn lint`