### PR TITLE
[#noissue] Extract span timestamp unit conversion into TraceTimeAccessor

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanBo.java
@@ -164,18 +164,16 @@ public class SpanBo implements BasicSpan {
         return owner.getAgentStartTime();
     }
 
+    private TraceTimeAccessor timeAccessor() {
+        return TraceTimeAccessor.ofVersion(this.version);
+    }
+
     public long getStartTimeMillis() {
-        if (getVersion() == SpanVersion.TRACE_V3) {
-            return TimeUnit.NANOSECONDS.toMillis(startTime);
-        }
-        return startTime;
+        return timeAccessor().toMillis(startTime);
     }
 
     public long getStartTimeNanos() {
-        if (getVersion() == SpanVersion.TRACE_V3) {
-            return startTime;
-        }
-        return TimeUnit.MILLISECONDS.toNanos(startTime);
+        return timeAccessor().toNanos(startTime);
     }
 
     /**
@@ -221,20 +219,14 @@ public class SpanBo implements BasicSpan {
 
     public long getEndTimeMillis() {
         if (hasEndTime()) {
-            if (getVersion() == SpanVersion.TRACE_V3) {
-                return TimeUnit.NANOSECONDS.toMillis(endTime);
-            }
-            return endTime;
+            return timeAccessor().toMillis(endTime);
         }
         return getStartTimeMillis() + elapsed;
     }
 
     public long getEndTimeNanos() {
         if (hasEndTime()) {
-            if (getVersion() == SpanVersion.TRACE_V3) {
-                return endTime;
-            }
-            return TimeUnit.MILLISECONDS.toNanos(endTime);
+            return timeAccessor().toNanos(endTime);
         }
         return getStartTimeNanos() + TimeUnit.MILLISECONDS.toNanos(elapsed);
     }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/SpanChunkBo.java
@@ -26,7 +26,6 @@ import org.jspecify.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -139,18 +138,16 @@ public class SpanChunkBo implements BasicSpan {
         this.spanId = spanId;
     }
 
+    private TraceTimeAccessor timeAccessor() {
+        return TraceTimeAccessor.ofVersion(this.version);
+    }
+
     public long getKeyTimeMillis() {
-        if (getVersion() == SpanVersion.TRACE_V3) {
-            return TimeUnit.NANOSECONDS.toMillis(keyTime);
-        }
-        return keyTime;
+        return timeAccessor().toMillis(keyTime);
     }
 
     public long getKeyTimeNanos() {
-        if (getVersion() == SpanVersion.TRACE_V3) {
-            return keyTime;
-        }
-        return TimeUnit.MILLISECONDS.toNanos(keyTime);
+        return timeAccessor().toNanos(keyTime);
     }
 
     /**

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/TraceTimeAccessor.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/TraceTimeAccessor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo;
+
+import com.navercorp.pinpoint.io.SpanVersion;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Accessor for the raw span timestamp fields.
+ * Pre-V3 spans persist epoch millis, TRACE_V3 spans persist epoch nanos;
+ * the raw {@code long} stays on the owning Bo and this enum converts it on access.
+ *
+ * @author Woonduk Kang(emeroad)
+ */
+public enum TraceTimeAccessor {
+
+    MILLIS {
+        @Override
+        public long toMillis(long timestamp) {
+            return timestamp;
+        }
+
+        @Override
+        public long toNanos(long timestamp) {
+            return TimeUnit.MILLISECONDS.toNanos(timestamp);
+        }
+    },
+    NANOS {
+        @Override
+        public long toMillis(long timestamp) {
+            return TimeUnit.NANOSECONDS.toMillis(timestamp);
+        }
+
+        @Override
+        public long toNanos(long timestamp) {
+            return timestamp;
+        }
+    };
+
+    public static TraceTimeAccessor ofVersion(int version) {
+        if (version == SpanVersion.TRACE_V3) {
+            return NANOS;
+        }
+        return MILLIS;
+    }
+
+    public abstract long toMillis(long timestamp);
+
+    public abstract long toNanos(long timestamp);
+}


### PR DESCRIPTION
This pull request refactors how time conversions are handled for span and span chunk objects, centralizing the logic into a new utility class. This improves code maintainability and consistency when dealing with different span versions (millisecond vs nanosecond timestamps).

**Time conversion abstraction:**

* Introduced a new `TraceTimeAccessor` enum in `TraceTimeAccessor.java` to encapsulate logic for converting timestamps between milliseconds and nanoseconds, depending on the span version. This ensures that all time conversions are handled in a single, consistent place.

**Refactoring of time-related methods:**

* Refactored `SpanBo` and `SpanChunkBo` to use the new `TraceTimeAccessor` for all time conversion methods (`getStartTimeMillis`, `getStartTimeNanos`, `getEndTimeMillis`, `getEndTimeNanos`, `getKeyTimeMillis`, `getKeyTimeNanos`), replacing inline version checks and manual conversions. [[1]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL167-R176) [[2]](diffhunk://#diff-2dfec829cec39f9c170856054302da6d041c90d8e30dfa4550c12b3fc580563bL224-R229) [[3]](diffhunk://#diff-1aceaa5172646489614c01aad80d5f37e39cf9da370a0354ca9d257a7e241c7cL142-R150)
* Removed redundant imports of `TimeUnit` from files where direct conversions are no longer needed.

These changes make the codebase easier to maintain and less error-prone when supporting multiple span versions.