### PR TITLE
[#noissue] Inject a dedicated RowKeyDistributor for OTel trace row keys

### DIFF
--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/DistributorConfiguration.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/config/DistributorConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.common.hbase.config;
 
+import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.hbase.HbaseTableConstants;
 import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.OneByteSimpleHash;
@@ -55,6 +56,13 @@ public class DistributorConfiguration {
     @Bean
     public RowKeyDistributorByHashPrefix traceV2Distributor() {
         ByteHasher hasher = newRangeOneByteSimpleHash(32, 40, 256);
+        return new RowKeyDistributorByHashPrefix(hasher);
+    }
+
+    @Bean
+    public RowKeyDistributorByHashPrefix traceV2OtelDistributor() {
+        // hash range must cover the 16-byte OTel trace_id; the traceV2Distributor range [32,40) does not
+        ByteHasher hasher = newRangeOneByteSimpleHash(0, PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN, 256);
         return new RowKeyDistributorByHashPrefix(hasher);
     }
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/OtelTraceRowKeyCodec.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/OtelTraceRowKeyCodec.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
+
+import com.navercorp.pinpoint.common.PinpointConstants;
+import com.navercorp.pinpoint.common.server.trace.OtelServerTraceId;
+
+import java.util.Arrays;
+
+/**
+ * Trace row key layout for OTel spans.
+ * <pre>
+ * salt(1) + trace_id(16)
+ * </pre>
+ * The salt slot is fixed to a single byte; this layout does not honor other salt key sizes.
+ * On read the layout is recognized by total length via {@link #matches(byte[], int)} —
+ * it can never collide with the fixed 41-byte {@link PinpointTraceRowKeyCodec} layout.
+ *
+ * @author Woonduk Kang(emeroad)
+ */
+public final class OtelTraceRowKeyCodec {
+
+    public static final int TRACE_ID_LEN = PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN;
+
+    public static final int SALT_KEY_SIZE = 1;
+
+    private OtelTraceRowKeyCodec() {
+    }
+
+    public static boolean matches(byte[] rowKey, int saltKeySize) {
+        return rowKey.length == saltKeySize + TRACE_ID_LEN;
+    }
+
+    public static byte[] encode(OtelServerTraceId traceId) {
+        byte[] traceIdBytes = traceId.getId();
+        byte[] rowKey = new byte[SALT_KEY_SIZE + TRACE_ID_LEN];
+        System.arraycopy(traceIdBytes, 0, rowKey, SALT_KEY_SIZE, TRACE_ID_LEN);
+        return rowKey;
+    }
+
+    public static OtelServerTraceId decode(byte[] rowKey, int saltKeySize) {
+        byte[] traceId = Arrays.copyOfRange(rowKey, saltKeySize, saltKeySize + TRACE_ID_LEN);
+        return new OtelServerTraceId(traceId);
+    }
+}

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/PinpointTraceRowKeyCodec.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/PinpointTraceRowKeyCodec.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
+
+import com.navercorp.pinpoint.common.PinpointConstants;
+import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
+import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
+import com.navercorp.pinpoint.common.server.util.RowKeyUtils;
+import com.navercorp.pinpoint.common.util.BytesUtils;
+
+/**
+ * Trace row key layout for agent-instrumented spans.
+ * <pre>
+ * salt(saltKeySize) + agentId(24, right-padded) + agentStartTime(8) + transactionSequence(8)
+ * </pre>
+ * The layout is fixed-length, which lets {@link OtelTraceRowKeyCodec#matches(byte[], int)}
+ * tell the two layouts apart by total length on read.
+ *
+ * @author Woonduk Kang(emeroad)
+ */
+public final class PinpointTraceRowKeyCodec {
+
+    public static final int AGENT_ID_MAX_LEN = PinpointConstants.AGENT_ID_MAX_LEN;
+
+    private PinpointTraceRowKeyCodec() {
+    }
+
+    public static byte[] encode(int saltKeySize, PinpointServerTraceId traceId) {
+        return RowKeyUtils.stringLongLongToBytes(saltKeySize, traceId.getAgentId(), AGENT_ID_MAX_LEN,
+                traceId.getAgentStartTime(), traceId.getTransactionSequence());
+    }
+
+    public static PinpointServerTraceId decode(byte[] rowKey, int saltKeySize) {
+        String agentId = BytesUtils.toStringAndRightTrim(rowKey, saltKeySize, AGENT_ID_MAX_LEN);
+        long agentStartTime = ByteArrayUtils.bytesToLong(rowKey, saltKeySize + AGENT_ID_MAX_LEN);
+        long transactionSequence = ByteArrayUtils.bytesToLong(rowKey, saltKeySize + BytesUtils.LONG_BYTE_LENGTH + AGENT_ID_MAX_LEN);
+        return new PinpointServerTraceId(agentId, agentStartTime, transactionSequence);
+    }
+}
+

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyDecoderV2.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyDecoderV2.java
@@ -29,10 +29,6 @@ import java.util.Objects;
 @Component
 public class TraceRowKeyDecoderV2 implements RowKeyDecoder<ServerTraceId> {
 
-    public static final int AGENT_ID_MAX_LEN = TraceRowKeyEncoderV2.AGENT_ID_MAX_LEN;
-
-    private static final int OPENTELEMETRY_TRACE_ID_LEN = TraceRowKeyEncoderV2.OPENTELEMETRY_TRACE_ID_LEN;
-
     private final ByteSaltKey saltKey;
 
     public TraceRowKeyDecoderV2() {
@@ -51,7 +47,10 @@ public class TraceRowKeyDecoderV2 implements RowKeyDecoder<ServerTraceId> {
         return readTransactionId(rowkey, saltKey.size());
     }
 
-    private ServerTraceId readTransactionId(byte[] rowKey, int offset) {
-        return ServerTraceId.decodeTraceRowKey(rowKey, offset);
+    private ServerTraceId readTransactionId(byte[] rowKey, int saltKeySize) {
+        if (OtelTraceRowKeyCodec.matches(rowKey, saltKeySize)) {
+            return OtelTraceRowKeyCodec.decode(rowKey, saltKeySize);
+        }
+        return PinpointTraceRowKeyCodec.decode(rowKey, saltKeySize);
     }
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2.java
@@ -35,10 +35,13 @@ public class TraceRowKeyEncoderV2 implements RowKeyEncoder<ServerTraceId> {
     public static final int OPENTELEMETRY_TRACE_ID_LEN = PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN;
 
     private final ByteHasher byteHasher;
+    private final ByteHasher otelByteHasher;
 
-    public TraceRowKeyEncoderV2(RowKeyDistributor rowKeyDistributor) {
+    public TraceRowKeyEncoderV2(RowKeyDistributor rowKeyDistributor, RowKeyDistributor otelRowKeyDistributor) {
         Objects.requireNonNull(rowKeyDistributor, "rowKeyDistributor");
+        Objects.requireNonNull(otelRowKeyDistributor, "otelRowKeyDistributor");
         this.byteHasher = rowKeyDistributor.getByteHasher();
+        this.otelByteHasher = otelRowKeyDistributor.getByteHasher();
     }
 
     public byte[] encodeRowKey(ServerTraceId transactionId) {
@@ -59,9 +62,7 @@ public class TraceRowKeyEncoderV2 implements RowKeyEncoder<ServerTraceId> {
 
         if (serverTraceId instanceof OtelServerTraceId otelServerTraceId) {
             byte[] rowKey = ServerTraceId.encodeTraceRowKey(saltKeySize, otelServerTraceId);
-            byte saltKey = byteHasher.getHashPrefix(otelServerTraceId.getId());
-            rowKey[0] = saltKey;
-            return rowKey;
+            return otelByteHasher.writeSaltKey(rowKey);
         }
 
         throw new IllegalStateException("Unsupported ServerTraceId:" + serverTraceId);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 
-import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
@@ -30,9 +29,6 @@ import java.util.Objects;
  * @author Woonduk Kang(emeroad)
  */
 public class TraceRowKeyEncoderV2 implements RowKeyEncoder<ServerTraceId> {
-
-    public static final int AGENT_ID_MAX_LEN = PinpointConstants.AGENT_ID_MAX_LEN;
-    public static final int OPENTELEMETRY_TRACE_ID_LEN = PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN;
 
     private final ByteHasher byteHasher;
     private final ByteHasher otelByteHasher;
@@ -53,7 +49,7 @@ public class TraceRowKeyEncoderV2 implements RowKeyEncoder<ServerTraceId> {
         Objects.requireNonNull(serverTraceId, "serverTraceId");
 
         if (serverTraceId instanceof PinpointServerTraceId pinpointServerTraceId) {
-            byte[] rowKey = ServerTraceId.encodeTraceRowKey(saltKeySize, pinpointServerTraceId);
+            byte[] rowKey = PinpointTraceRowKeyCodec.encode(saltKeySize, pinpointServerTraceId);
             if (saltKeySize == 0) {
                 return rowKey;
             }
@@ -61,7 +57,7 @@ public class TraceRowKeyEncoderV2 implements RowKeyEncoder<ServerTraceId> {
         }
 
         if (serverTraceId instanceof OtelServerTraceId otelServerTraceId) {
-            byte[] rowKey = ServerTraceId.encodeTraceRowKey(saltKeySize, otelServerTraceId);
+            byte[] rowKey = OtelTraceRowKeyCodec.encode(otelServerTraceId);
             return otelByteHasher.writeSaltKey(rowKey);
         }
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/config/SpanSerializeConfiguration.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/config/SpanSerializeConfiguration.java
@@ -48,8 +48,9 @@ public class SpanSerializeConfiguration {
     }
 
     @Bean
-    public TraceRowKeyEncoderV2 traceRowKeyEncoderV2(@Qualifier("traceV2Distributor") RowKeyDistributor rowKeyDistributor) {
-        return new TraceRowKeyEncoderV2(rowKeyDistributor);
+    public TraceRowKeyEncoderV2 traceRowKeyEncoderV2(@Qualifier("traceV2Distributor") RowKeyDistributor rowKeyDistributor,
+                                                     @Qualifier("traceV2OtelDistributor") RowKeyDistributor otelRowKeyDistributor) {
+        return new TraceRowKeyEncoderV2(rowKeyDistributor, otelRowKeyDistributor);
     }
 
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/trace/ServerTraceId.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/trace/ServerTraceId.java
@@ -2,12 +2,8 @@ package com.navercorp.pinpoint.common.server.trace;
 
 import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.buffer.Buffer;
-import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
-import com.navercorp.pinpoint.common.server.util.RowKeyUtils;
 import com.navercorp.pinpoint.common.server.util.TransactionIdParser;
-import com.navercorp.pinpoint.common.util.BytesUtils;
 
-import java.util.Arrays;
 import java.util.Objects;
 
 public interface ServerTraceId {
@@ -23,33 +19,6 @@ public interface ServerTraceId {
      */
     static boolean isOpenTelemetry(ServerTraceId traceId) {
         return traceId instanceof OtelServerTraceId;
-    }
-
-    static byte[] encodeTraceRowKey(int saltKeySize, ServerTraceId serverTraceId) {
-        if (serverTraceId instanceof PinpointServerTraceId pinpointServerTraceId) {
-            final String agentId = pinpointServerTraceId.getAgentId();
-            return RowKeyUtils.stringLongLongToBytes(saltKeySize, agentId, PinpointConstants.AGENT_ID_MAX_LEN, pinpointServerTraceId.getAgentStartTime(), pinpointServerTraceId.getTransactionSequence());
-        } else if (serverTraceId instanceof OtelServerTraceId otelServerTraceId) {
-            byte[] otelTraceIdBytes = otelServerTraceId.getId();
-            byte[] rowKey = new byte[PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN + 1];
-            System.arraycopy(otelTraceIdBytes, 0, rowKey, 1, PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN);
-            return rowKey;
-        } else {
-            throw new IllegalStateException("unsupported ServerTraceId=" + serverTraceId);
-        }
-    }
-
-    static ServerTraceId decodeTraceRowKey(byte[] rowKey, int saltKeySize) {
-        if (rowKey.length == saltKeySize + PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN) {
-            byte[] otelTraceId = Arrays.copyOfRange(rowKey, saltKeySize, saltKeySize + PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN);
-            return new OtelServerTraceId(otelTraceId);
-        }
-
-        // PinpointServerTraceId
-        String agentId = BytesUtils.toStringAndRightTrim(rowKey, saltKeySize, PinpointConstants.AGENT_ID_MAX_LEN);
-        long agentStartTime = ByteArrayUtils.bytesToLong(rowKey, saltKeySize + PinpointConstants.AGENT_ID_MAX_LEN);
-        long transactionSequence = ByteArrayUtils.bytesToLong(rowKey, saltKeySize + BytesUtils.LONG_BYTE_LENGTH + PinpointConstants.AGENT_ID_MAX_LEN);
-        return new PinpointServerTraceId(agentId, agentStartTime, transactionSequence);
     }
 
     static byte[] encodeApplicationTraceIndexQualifier(ServerTraceId serverTraceId) {

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2Test.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/TraceRowKeyEncoderV2Test.java
@@ -16,18 +16,22 @@
 
 package com.navercorp.pinpoint.common.server.bo.serializer.trace.v2;
 
+import com.navercorp.pinpoint.common.PinpointConstants;
 import com.navercorp.pinpoint.common.hbase.wd.ByteHasher;
 import com.navercorp.pinpoint.common.hbase.wd.ByteSaltKey;
 import com.navercorp.pinpoint.common.hbase.wd.RangeOneByteSimpleHash;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyDecoder;
 import com.navercorp.pinpoint.common.server.bo.serializer.RowKeyEncoder;
+import com.navercorp.pinpoint.common.server.trace.OtelServerTraceId;
 import com.navercorp.pinpoint.common.server.trace.PinpointServerTraceId;
 import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
 import java.util.Random;
+import java.util.Set;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -45,7 +49,12 @@ public class TraceRowKeyEncoderV2Test {
         return new RowKeyDistributorByHashPrefix(oneByteSimpleHash);
     }
 
-    private final RowKeyEncoder<ServerTraceId> traceRowKeyEncoder = new TraceRowKeyEncoderV2(distributorByHashPrefix);
+    private RowKeyDistributorByHashPrefix newOtelDistributorByHashPrefix() {
+        ByteHasher hasher = new RangeOneByteSimpleHash(0, PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN, 256);
+        return new RowKeyDistributorByHashPrefix(hasher);
+    }
+
+    private final RowKeyEncoder<ServerTraceId> traceRowKeyEncoder = new TraceRowKeyEncoderV2(distributorByHashPrefix, newOtelDistributorByHashPrefix());
 
     private final RowKeyDecoder<ServerTraceId> traceRowKeyDecoder = new TraceRowKeyDecoderV2(ByteSaltKey.SALT);
 
@@ -59,6 +68,36 @@ public class TraceRowKeyEncoderV2Test {
 
         Assertions.assertEquals(transactionId, spanTransactionId);
 
+    }
+
+    @Test
+    public void encodeRowKey_otel() {
+
+        byte[] traceIdBytes = new byte[PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN];
+        random.nextBytes(traceIdBytes);
+        ServerTraceId otelTraceId = new OtelServerTraceId(traceIdBytes);
+
+        byte[] rowKey = traceRowKeyEncoder.encodeRowKey(otelTraceId);
+        ServerTraceId transactionId = traceRowKeyDecoder.decodeRowKey(rowKey);
+
+        Assertions.assertEquals(otelTraceId, transactionId);
+
+    }
+
+    @Test
+    public void encodeRowKey_otel_saltDistribution() {
+
+        Random fixedRandom = new Random(0);
+        Set<Byte> saltKeys = new HashSet<>();
+        for (int i = 0; i < 64; i++) {
+            byte[] traceIdBytes = new byte[PinpointConstants.OPENTELEMETRY_TRACE_ID_LEN];
+            fixedRandom.nextBytes(traceIdBytes);
+
+            byte[] rowKey = traceRowKeyEncoder.encodeRowKey(new OtelServerTraceId(traceIdBytes));
+            saltKeys.add(rowKey[0]);
+        }
+
+        Assertions.assertTrue(saltKeys.size() > 1, () -> "OTel row keys must spread across salt buckets, but got salts=" + saltKeys);
     }
 
 }


### PR DESCRIPTION
The traceV2Distributor hash range [32,40) does not cover a 16-byte OTel
trace_id, so BytesUtils.hashBytes never iterated and every OTel row key
got the constant salt 1, funneling all OTel traces into a single bucket.
