### PR TITLE
[#noissue] Add Ktor client tracing instrumentation

### DIFF
--- a/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
@@ -583,6 +583,15 @@ profiler.ktor.server.excludeurl=
 # Retransform
 profiler.ktor.http.server.retransform.configure-routing=true
 
+# Client (outbound)
+# Traces io.ktor.client.plugins.HttpSend$DefaultSender.execute(...) and records
+# an outbound span event per HTTP attempt (including HttpRequestRetry retries).
+profiler.ktor.client.enable=true
+# record the request URL on the span event
+profiler.ktor.client.param=true
+# treat a thrown Throwable from the client as an error on the span event
+profiler.ktor.client.mark.error=true
+
 ###########################################################
 # JSP                                                     #
 ###########################################################

--- a/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
@@ -579,6 +579,15 @@ profiler.ktor.server.excludeurl=
 # Retransform
 profiler.ktor.http.server.retransform.configure-routing=true
 
+# Client (outbound)
+# Traces io.ktor.client.plugins.HttpSend$DefaultSender.execute(...) and records
+# an outbound span event per HTTP attempt (including HttpRequestRetry retries).
+profiler.ktor.client.enable=true
+# record the request URL on the span event
+profiler.ktor.client.param=true
+# treat a thrown Throwable from the client as an error on the span event
+profiler.ktor.client.mark.error=true
+
 ###########################################################
 # JSP                                                     #
 ###########################################################

--- a/agent-module/plugins/ktor/README.md
+++ b/agent-module/plugins/ktor/README.md
@@ -35,4 +35,14 @@ profiler.ktor.server.excludeurl=
 # Retransform
 profiler.ktor.http.server.retransform.configure-routing=true
 
+# Client (outbound)
+# Traces io.ktor.client.plugins.HttpSend$DefaultSender.execute(...) and records
+# an outbound span event per HTTP attempt (including HttpRequestRetry retries).
+# Disabled by default — opt in only when the JVM runs a Ktor HTTP client.
+profiler.ktor.client.enable=false
+# record the request URL on the span event, default true
+profiler.ktor.client.param=true
+# treat a thrown Throwable from the client as an error on the span event, default true
+profiler.ktor.client.mark.error=true
+
 ~~~

--- a/agent-module/plugins/ktor/README.md
+++ b/agent-module/plugins/ktor/README.md
@@ -1,6 +1,9 @@
 ## Ktor
 * Since: Pinpoint 3.0.1
 * See: https://ktor.io/
+* Range (client): io.ktor/ktor-client-core-jvm [2.3, 3.5]
+  (instrumentation targets `HttpSend$DefaultSender.execute` and its generated
+   continuation verified structurally identical in the 2.3.12, 3.0.0, 3.5.1 and 3.5.2 artifacts)
 
 ### Pinpoint Configuration
 pinpoint.config
@@ -34,5 +37,15 @@ profiler.ktor.server.excludeurl=
 
 # Retransform
 profiler.ktor.http.server.retransform.configure-routing=true
+
+# Client (outbound)
+# Traces io.ktor.client.plugins.HttpSend$DefaultSender.execute(...) and records
+# an outbound span event per HTTP attempt (including HttpRequestRetry retries).
+# Enabled by default; set false to skip the Ktor client transforms.
+profiler.ktor.client.enable=true
+# record the request URL on the span event, default true
+profiler.ktor.client.param=true
+# treat a thrown Throwable from the client as an error on the span event, default true
+profiler.ktor.client.mark.error=true
 
 ~~~

--- a/agent-module/plugins/ktor/pom.xml
+++ b/agent-module/plugins/ktor/pom.xml
@@ -40,6 +40,18 @@
             <version>2.3.12</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-core-jvm</artifactId>
+            <version>2.3.12</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+            <version>1.7.3</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/KtorConstants.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/KtorConstants.java
@@ -23,5 +23,7 @@ public class KtorConstants {
 
     public static final ServiceType KTOR = ServiceTypeProvider.getByName("KTOR");
     public static final ServiceType KTOR_INTERNAL = ServiceTypeProvider.getByName("KTOR_INTERNAL");
+    public static final ServiceType KTOR_CLIENT = ServiceTypeProvider.getByName("KTOR_CLIENT");
+    public static final ServiceType KTOR_CLIENT_INTERNAL = ServiceTypeProvider.getByName("KTOR_CLIENT_INTERNAL");
 
 }

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/KtorPlugin.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/KtorPlugin.java
@@ -30,6 +30,10 @@ import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
 import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.plugin.ktor.client.KtorClientContinuationConstructorInterceptor;
+import com.navercorp.pinpoint.plugin.ktor.client.KtorClientContinuationInterceptor;
+import com.navercorp.pinpoint.plugin.ktor.client.KtorClientSendInterceptor;
+import com.navercorp.pinpoint.plugin.ktor.client.KtorClientTraceAccessor;
 import com.navercorp.pinpoint.plugin.ktor.interceptor.ConfigureRoutingFactoryInterceptor;
 import com.navercorp.pinpoint.plugin.ktor.interceptor.NettyApplicationCallHandlerInterceptor;
 import com.navercorp.pinpoint.plugin.ktor.interceptor.NettyHttp1HandlerHandleRequestInterceptor;
@@ -70,6 +74,12 @@ public class KtorPlugin implements ProfilerPlugin, MatchableTransformTemplateAwa
         transformTemplate.transform("io.ktor.util.pipeline.SuspendFunctionGun", SuspendFunctionGunTransform.class);
         if (config.isRetransformConfigureRouting()) {
             transformTemplate.transform("io.ktor.server.routing.Route", RouteTransform.class);
+        }
+
+        // Client
+        if (config.isClientEnable()) {
+            transformTemplate.transform("io.ktor.client.plugins.HttpSend$DefaultSender", KtorClientDefaultSenderTransform.class);
+            transformTemplate.transform("io.ktor.client.plugins.HttpSend$DefaultSender$execute$1", KtorClientDefaultSenderContinuationTransform.class);
         }
     }
 
@@ -147,6 +157,59 @@ public class KtorPlugin implements ProfilerPlugin, MatchableTransformTemplateAwa
             final RouteMethodTransformer routeMethodTransformer = new RouteMethodTransformer(Boolean.FALSE);
             for (InstrumentMethod method : target.getDeclaredMethods(MethodFilters.name("handle"))) {
                 method.addInterceptor(ConfigureRoutingFactoryInterceptor.class, va(routeMethodTransformer));
+            }
+
+            return target.toBytecode();
+        }
+    }
+
+    public static class KtorClientDefaultSenderTransform implements TransformCallback {
+        @Override
+        public byte[] doInTransform(
+                Instrumentor instrumentor,
+                ClassLoader loader,
+                String className,
+                Class<?> classBeingRedefined,
+                ProtectionDomain protectionDomain,
+                byte[] classfileBuffer
+        ) throws InstrumentException {
+            final InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
+            final InstrumentMethod execute = target.getDeclaredMethod(
+                    "execute",
+                    "io.ktor.client.request.HttpRequestBuilder",
+                    "kotlin.coroutines.Continuation"
+            );
+            if (execute != null) {
+                execute.addInterceptor(KtorClientSendInterceptor.class);
+            }
+            return target.toBytecode();
+        }
+    }
+
+    public static class KtorClientDefaultSenderContinuationTransform implements TransformCallback {
+        @Override
+        public byte[] doInTransform(
+                Instrumentor instrumentor,
+                ClassLoader loader,
+                String className,
+                Class<?> classBeingRedefined,
+                ProtectionDomain protectionDomain,
+                byte[] classfileBuffer
+        ) throws InstrumentException {
+            final InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
+            target.addField(KtorClientTraceAccessor.class);
+
+            final InstrumentMethod constructor = target.getConstructor(
+                    "io.ktor.client.plugins.HttpSend$DefaultSender",
+                    "kotlin.coroutines.Continuation"
+            );
+            if (constructor != null) {
+                constructor.addInterceptor(KtorClientContinuationConstructorInterceptor.class);
+            }
+
+            final InstrumentMethod invokeSuspend = target.getDeclaredMethod("invokeSuspend", "java.lang.Object");
+            if (invokeSuspend != null) {
+                invokeSuspend.addInterceptor(KtorClientContinuationInterceptor.class);
             }
 
             return target.toBytecode();

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/KtorPluginConfig.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/KtorPluginConfig.java
@@ -37,6 +37,10 @@ public class KtorPluginConfig {
 
     private final boolean retransformConfigureRouting;
 
+    private final boolean clientEnable;
+    private final boolean clientParam;
+    private final boolean clientMarkError;
+
     public KtorPluginConfig(ProfilerConfig config) {
         Objects.requireNonNull(config, "config");
 
@@ -54,6 +58,11 @@ public class KtorPluginConfig {
         this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.ktor.http.server.excludemethod");
 
         this.retransformConfigureRouting = config.readBoolean("profiler.ktor.http.server.retransform.configure-routing", Boolean.TRUE);
+
+        // Client
+        this.clientEnable = config.readBoolean("profiler.ktor.client.enable", Boolean.FALSE);
+        this.clientParam = config.readBoolean("profiler.ktor.client.param", Boolean.TRUE);
+        this.clientMarkError = config.readBoolean("profiler.ktor.client.mark.error", Boolean.TRUE);
     }
 
     public boolean isEnable() {
@@ -96,6 +105,18 @@ public class KtorPluginConfig {
         return retransformConfigureRouting;
     }
 
+    public boolean isClientEnable() {
+        return clientEnable;
+    }
+
+    public boolean isClientParam() {
+        return clientParam;
+    }
+
+    public boolean isClientMarkError() {
+        return clientMarkError;
+    }
+
     @Override
     public String toString() {
         return "KtorPluginConfig{" +
@@ -109,6 +130,9 @@ public class KtorPluginConfig {
                 ", realIpEmptyValue='" + realIpEmptyValue + '\'' +
                 ", excludeProfileMethodFilter=" + excludeProfileMethodFilter +
                 ", retransformConfigureRouting=" + retransformConfigureRouting +
+                ", clientEnable=" + clientEnable +
+                ", clientParam=" + clientParam +
+                ", clientMarkError=" + clientMarkError +
                 '}';
     }
 }

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/KtorPluginConfig.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/KtorPluginConfig.java
@@ -37,6 +37,10 @@ public class KtorPluginConfig {
 
     private final boolean retransformConfigureRouting;
 
+    private final boolean clientEnable;
+    private final boolean clientParam;
+    private final boolean clientMarkError;
+
     public KtorPluginConfig(ProfilerConfig config) {
         Objects.requireNonNull(config, "config");
 
@@ -54,6 +58,11 @@ public class KtorPluginConfig {
         this.excludeProfileMethodFilter = serverConfig.getExcludeMethodFilter("profiler.ktor.http.server.excludemethod");
 
         this.retransformConfigureRouting = config.readBoolean("profiler.ktor.http.server.retransform.configure-routing", Boolean.TRUE);
+
+        // Client
+        this.clientEnable = config.readBoolean("profiler.ktor.client.enable", Boolean.TRUE);
+        this.clientParam = config.readBoolean("profiler.ktor.client.param", Boolean.TRUE);
+        this.clientMarkError = config.readBoolean("profiler.ktor.client.mark.error", Boolean.TRUE);
     }
 
     public boolean isEnable() {
@@ -96,6 +105,18 @@ public class KtorPluginConfig {
         return retransformConfigureRouting;
     }
 
+    public boolean isClientEnable() {
+        return clientEnable;
+    }
+
+    public boolean isClientParam() {
+        return clientParam;
+    }
+
+    public boolean isClientMarkError() {
+        return clientMarkError;
+    }
+
     @Override
     public String toString() {
         return "KtorPluginConfig{" +
@@ -109,6 +130,9 @@ public class KtorPluginConfig {
                 ", realIpEmptyValue='" + realIpEmptyValue + '\'' +
                 ", excludeProfileMethodFilter=" + excludeProfileMethodFilter +
                 ", retransformConfigureRouting=" + retransformConfigureRouting +
+                ", clientEnable=" + clientEnable +
+                ", clientParam=" + clientParam +
+                ", clientMarkError=" + clientMarkError +
                 '}';
     }
 }

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationConstructorInterceptor.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationConstructorInterceptor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+
+public class KtorClientContinuationConstructorInterceptor implements AroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    @Override
+    public void before(Object target, Object[] args) {
+        if (isDebug) {
+            logger.beforeInterceptor(target, args);
+        }
+    }
+
+    @Override
+    public void after(Object target, Object[] args, Object result, Throwable throwable) {
+        if (isDebug) {
+            logger.afterInterceptor(target, args);
+        }
+
+        KtorClientTraceHolder holder = KtorClientTraceStorage.getPending();
+        if (throwable != null || holder == null) {
+            return;
+        }
+
+        if (target instanceof KtorClientTraceAccessor) {
+            ((KtorClientTraceAccessor) target)._$PINPOINT$_setKtorClientTrace(holder);
+            holder.markAttached();
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationInterceptor.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationInterceptor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+
+public class KtorClientContinuationInterceptor implements AroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    @Override
+    public void before(Object target, Object[] args) {
+        if (isDebug) {
+            logger.beforeInterceptor(target, args);
+        }
+    }
+
+    @Override
+    public void after(Object target, Object[] args, Object result, Throwable throwable) {
+        if (isDebug) {
+            logger.afterInterceptor(target, args);
+        }
+
+        if (KtorClientCoroutineSuspendedMarker.isSuspended(result)) {
+            return;
+        }
+
+        KtorClientTraceHolder holder = getHolder(target);
+        if (holder == null) {
+            return;
+        }
+
+        try {
+            try {
+                holder.finishAsync(throwable);
+            } catch (Throwable finishThrowable) {
+                logger.warn(
+                        "Failed to finish Ktor client trace in continuation interceptor. {}",
+                        finishThrowable.getMessage(),
+                        finishThrowable
+                );
+            }
+        } finally {
+            if (target instanceof KtorClientTraceAccessor) {
+                ((KtorClientTraceAccessor) target)._$PINPOINT$_setKtorClientTrace(null);
+            }
+        }
+    }
+
+    private KtorClientTraceHolder getHolder(Object target) {
+        if (target instanceof KtorClientTraceAccessor) {
+            return ((KtorClientTraceAccessor) target)._$PINPOINT$_getKtorClientTrace();
+        }
+        return null;
+    }
+}

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientCoroutineSuspendedMarker.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientCoroutineSuspendedMarker.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+final class KtorClientCoroutineSuspendedMarker {
+    private static final String COROUTINE_SUSPENDED_CLASS = "kotlin.coroutines.intrinsics.CoroutineSingletons";
+    private static final String COROUTINE_SUSPENDED_NAME = "COROUTINE_SUSPENDED";
+
+    private KtorClientCoroutineSuspendedMarker() {
+    }
+
+    static boolean isSuspended(Object result) {
+        if (result == null) {
+            return false;
+        }
+
+        if (!COROUTINE_SUSPENDED_CLASS.equals(result.getClass().getName())) {
+            return false;
+        }
+
+        if (result instanceof Enum) {
+            return COROUTINE_SUSPENDED_NAME.equals(((Enum<?>) result).name());
+        }
+
+        return COROUTINE_SUSPENDED_NAME.equals(String.valueOf(result));
+    }
+}

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientHeaderAdaptor.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientHeaderAdaptor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
+
+public class KtorClientHeaderAdaptor implements ClientHeaderAdaptor<Object> {
+    private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    @Override
+    public void setHeader(Object request, String name, String value) {
+        Object headers = getHeaders(request);
+        if (headers == null) {
+            return;
+        }
+
+        invoke(headers, "set", new Class<?>[]{String.class, String.class}, name, value);
+        if (isDebug) {
+            logger.debug("Set Ktor client header {}={}", name, value);
+        }
+    }
+
+    @Override
+    public String getHeader(Object request, String name) {
+        Object headers = getHeaders(request);
+        if (headers == null) {
+            return "";
+        }
+
+        Object value = invoke(headers, "get", new Class<?>[]{String.class}, name);
+        return value == null ? "" : value.toString();
+    }
+
+    @Override
+    public boolean contains(Object request, String name) {
+        Object headers = getHeaders(request);
+        if (headers == null) {
+            return false;
+        }
+
+        Object result = invoke(headers, "contains", new Class<?>[]{String.class}, name);
+        return result instanceof Boolean && (Boolean) result;
+    }
+
+    private Object getHeaders(Object request) {
+        if (request == null) {
+            return null;
+        }
+        return invoke(request, "getHeaders", new Class<?>[]{});
+    }
+
+    private Object invoke(Object target, String methodName, Class<?>[] parameterTypes, Object... args) {
+        try {
+            return target.getClass().getMethod(methodName, parameterTypes).invoke(target, args);
+        } catch (Throwable throwable) {
+            logger.warn("Failed to access Ktor client headers. {}", throwable.getMessage(), throwable);
+            return null;
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientParentTraceState.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientParentTraceState.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class KtorClientParentTraceState {
+    private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
+
+    private final Trace trace;
+    private final KtorClientTraceHolder holder;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    KtorClientParentTraceState(Trace trace, KtorClientTraceHolder holder) {
+        this.trace = trace;
+        this.holder = holder;
+    }
+
+    KtorClientTraceHolder getHolder() {
+        return holder;
+    }
+
+    void finish(Throwable throwable) {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            holder.record(recorder, throwable);
+        } catch (Throwable recorderThrowable) {
+            logger.warn("Failed to get Ktor client parent span event recorder. {}", recorderThrowable.getMessage(), recorderThrowable);
+        } finally {
+            closeTraceBlock();
+        }
+    }
+
+    void closeTraceBlock() {
+        try {
+            trace.traceBlockEnd();
+        } catch (Throwable closeThrowable) {
+            logger.warn("Failed to close Ktor client parent trace block. {}", closeThrowable.getMessage(), closeThrowable);
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientRequestAdaptor.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientRequestAdaptor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
+
+public class KtorClientRequestAdaptor implements ClientRequestAdaptor<Object> {
+    private static final String UNKNOWN = "Unknown";
+
+    @Override
+    public String getDestinationId(Object request) {
+        Object url = getUrlObject(request);
+        if (url == null) {
+            return UNKNOWN;
+        }
+
+        Object hostObject = invoke(url, "getHost", new Class<?>[]{});
+        if (!(hostObject instanceof String)) {
+            return UNKNOWN;
+        }
+
+        String host = (String) hostObject;
+        if (host.isEmpty() || host.trim().isEmpty()) {
+            return UNKNOWN;
+        }
+
+        int port = resolvePort(url);
+        if (host.indexOf(':') >= 0 && !host.startsWith("[")) {
+            return "[" + host + "]:" + port;
+        }
+        return host + ":" + port;
+    }
+
+    @Override
+    public String getUrl(Object request) {
+        Object url = getUrlObject(request);
+        if (url == null) {
+            return null;
+        }
+
+        Object urlString = invoke(url, "buildString", new Class<?>[]{});
+        return urlString instanceof String ? (String) urlString : null;
+    }
+
+    private int resolvePort(Object url) {
+        Object portObject = invoke(url, "getPort", new Class<?>[]{});
+        int port = portObject instanceof Number ? ((Number) portObject).intValue() : 0;
+        if (port > 0) {
+            return port;
+        }
+
+        Object protocol = invoke(url, "getProtocolOrNull", new Class<?>[]{});
+        if (protocol != null) {
+            Object defaultPort = invoke(protocol, "getDefaultPort", new Class<?>[]{});
+            if (defaultPort instanceof Number) {
+                return ((Number) defaultPort).intValue();
+            }
+        }
+        return 0;
+    }
+
+    private Object getUrlObject(Object request) {
+        if (request == null) {
+            return null;
+        }
+        return invoke(request, "getUrl", new Class<?>[]{});
+    }
+
+    private Object invoke(Object target, String methodName, Class<?>[] parameterTypes, Object... args) {
+        try {
+            return target.getClass().getMethod(methodName, parameterTypes).invoke(target, args);
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientSendInterceptor.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientSendInterceptor.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import com.navercorp.pinpoint.plugin.ktor.KtorConstants;
+import com.navercorp.pinpoint.plugin.ktor.KtorPluginConfig;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.context.TraceId;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
+import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
+
+public class KtorClientSendInterceptor implements AroundInterceptor {
+    private static final String HTTP_REQUEST_BUILDER_CLASS_NAME = "io.ktor.client.request.HttpRequestBuilder";
+
+    private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+    private final KtorPluginConfig config;
+    private final KtorClientRequestAdaptor requestAdaptor;
+    private final ClientRequestRecorder<Object> requestRecorder;
+    private final RequestTraceWriter<Object> traceWriter;
+    private final ThreadLocal<KtorClientParentTraceState> activeState = new ThreadLocal<>();
+
+    public KtorClientSendInterceptor(
+            TraceContext traceContext,
+            MethodDescriptor methodDescriptor
+    ) {
+        this.traceContext = traceContext;
+        this.methodDescriptor = methodDescriptor;
+        this.config = new KtorPluginConfig(traceContext.getProfilerConfig());
+        this.requestAdaptor = new KtorClientRequestAdaptor();
+        this.requestRecorder = new ClientRequestRecorder<>(this.config.isClientParam(), requestAdaptor);
+        this.traceWriter = new DefaultRequestTraceWriter<>(new KtorClientHeaderAdaptor(), traceContext);
+    }
+
+    @Override
+    public void before(Object target, Object[] args) {
+        if (isDebug) {
+            logger.beforeInterceptor(target, args);
+        }
+        activeState.remove();
+        KtorClientTraceStorage.clearPending();
+
+        Trace trace = traceContext.currentRawTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        Object request = getRequest(args);
+        if (request == null) {
+            return;
+        }
+
+        SpanEventRecorder recorder = null;
+        boolean blockStarted = false;
+        try {
+            String destinationId = requestAdaptor.getDestinationId(request);
+            if (!trace.canSampled()) {
+                traceWriter.write(request);
+                return;
+            }
+
+            recorder = trace.traceBlockBegin();
+            blockStarted = true;
+            TraceId nextId = trace.getTraceId().getNextTraceId();
+            recorder.recordNextSpanId(nextId.getSpanId());
+            recorder.recordServiceType(KtorConstants.KTOR_CLIENT);
+            traceWriter.write(request, nextId, destinationId);
+            AsyncContext asyncContext = recorder.recordNextAsyncContext(true);
+
+            KtorClientTraceHolder holder = new KtorClientTraceHolder(
+                    asyncContext,
+                    request,
+                    methodDescriptor,
+                    config,
+                    requestRecorder
+            );
+            activeState.set(new KtorClientParentTraceState(trace, holder));
+            KtorClientTraceStorage.setPending(holder);
+        } catch (Throwable throwable) {
+            logger.warn("Failed to write Ktor client trace headers. {}", throwable.getMessage(), throwable);
+            if (blockStarted) {
+                try {
+                    trace.traceBlockEnd();
+                } catch (Throwable closeThrowable) {
+                    logger.warn(
+                            "Failed to close Ktor client trace block after header write failure. {}",
+                            closeThrowable.getMessage(),
+                            closeThrowable
+                    );
+                }
+            }
+            activeState.remove();
+            KtorClientTraceStorage.clearPending();
+        }
+    }
+
+    @Override
+    public void after(Object target, Object[] args, Object result, Throwable throwable) {
+        if (isDebug) {
+            logger.afterInterceptor(target, args);
+        }
+
+        KtorClientParentTraceState state = activeState.get();
+        activeState.remove();
+        KtorClientTraceStorage.clearPending();
+        if (state == null) {
+            // The suspended continuation may finish the async trace on a different coroutine thread.
+            return;
+        }
+
+        KtorClientTraceHolder holder = state.getHolder();
+        if (KtorClientCoroutineSuspendedMarker.isSuspended(result) && holder.isAttached()) {
+            state.finish(null);
+            return;
+        }
+
+        try {
+            state.finish(throwable);
+            holder.cancelAsync();
+        } catch (Throwable finishThrowable) {
+            logger.warn("Failed to finish Ktor client trace in send interceptor. {}", finishThrowable.getMessage(), finishThrowable);
+        }
+    }
+
+    private Object getRequest(Object[] args) {
+        if (args == null || args.length == 0 || !isHttpRequestBuilder(args[0])) {
+            return null;
+        }
+        return args[0];
+    }
+
+    private boolean isHttpRequestBuilder(Object request) {
+        if (request == null) {
+            return false;
+        }
+
+        Class<?> type = request.getClass();
+        while (type != null) {
+            if (HTTP_REQUEST_BUILDER_CLASS_NAME.equals(type.getName())) {
+                return true;
+            }
+            type = type.getSuperclass();
+        }
+        return false;
+    }
+}

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceAccessor.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceAccessor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+public interface KtorClientTraceAccessor {
+    void _$PINPOINT$_setKtorClientTrace(KtorClientTraceHolder holder);
+
+    KtorClientTraceHolder _$PINPOINT$_getKtorClientTrace();
+}

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceHolder.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceHolder.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import com.navercorp.pinpoint.plugin.ktor.KtorConstants;
+import com.navercorp.pinpoint.plugin.ktor.KtorPluginConfig;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class KtorClientTraceHolder {
+    private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
+
+    private final AsyncContext asyncContext;
+    private final Object request;
+    private final MethodDescriptor methodDescriptor;
+    private final KtorPluginConfig config;
+    private final ClientRequestRecorder<Object> requestRecorder;
+    private final AtomicBoolean asyncClosed = new AtomicBoolean(false);
+    private volatile boolean attached;
+
+    public KtorClientTraceHolder(
+            AsyncContext asyncContext,
+            Object request,
+            MethodDescriptor methodDescriptor,
+            KtorPluginConfig config,
+            ClientRequestRecorder<Object> requestRecorder
+    ) {
+        this.asyncContext = asyncContext;
+        this.request = request;
+        this.methodDescriptor = methodDescriptor;
+        this.config = config;
+        this.requestRecorder = requestRecorder;
+    }
+
+    public void markAttached() {
+        this.attached = true;
+    }
+
+    public boolean isAttached() {
+        return attached;
+    }
+
+    public void record(SpanEventRecorder recorder, Throwable throwable) {
+        if (recorder == null) {
+            logger.warn("Current span event recorder is null while finishing Ktor client trace");
+            return;
+        }
+
+        try {
+            requestRecorder.record(recorder, request, throwable);
+            recorder.recordApi(methodDescriptor);
+            recorder.recordException(config.isClientMarkError(), throwable);
+        } catch (Throwable recordThrowable) {
+            logger.warn("Failed to record Ktor client trace. {}", recordThrowable.getMessage(), recordThrowable);
+        }
+    }
+
+    public void finishAsync(Throwable throwable) {
+        if (!asyncClosed.compareAndSet(false, true)) {
+            return;
+        }
+
+        Trace asyncTrace = null;
+        boolean blockStarted = false;
+        try {
+            // Other plugins may bind their own async trace to the shared coroutine binder on
+            // this thread; in that case we are only a nested participant. Track ownership via
+            // ScopeUtils so we close the trace only when we own it. ScopeUtils is Pinpoint-internal
+            // (not a plugin API surface), so re-verify entryAsyncTraceScope/leaveAsyncTraceScope/
+            // isAsyncTraceEndScope signatures on every agent bump.
+            asyncTrace = asyncContext.continueAsyncTraceObject(true);
+            if (asyncTrace == null) {
+                logger.warn("Could not continue Ktor client async trace");
+                return;
+            }
+
+            ScopeUtils.entryAsyncTraceScope(asyncTrace);
+            SpanEventRecorder recorder = asyncTrace.traceBlockBegin();
+            blockStarted = true;
+            recorder.recordServiceType(KtorConstants.KTOR_CLIENT_INTERNAL);
+            record(recorder, throwable);
+        } catch (Throwable throwableInAsyncTrace) {
+            logger.warn(
+                    "Failed to finish Ktor client async trace. {}",
+                    throwableInAsyncTrace.getMessage(),
+                    throwableInAsyncTrace
+            );
+        } finally {
+            closeAsyncTrace(asyncTrace, blockStarted);
+            finishAsyncState();
+        }
+    }
+
+    public void cancelAsync() {
+        if (!asyncClosed.compareAndSet(false, true)) {
+            return;
+        }
+        // Synchronous completion path never bound the async trace here; calling
+        // asyncContext.close() would clear the shared thread binder and break another plugin's
+        // in-flight trace. Only finish() is safe in this path.
+        finishAsyncState();
+    }
+
+    private void closeAsyncTrace(Trace asyncTrace, boolean blockStarted) {
+        if (asyncTrace == null) {
+            return;
+        }
+
+        boolean scopeLeft = false;
+        try {
+            scopeLeft = ScopeUtils.leaveAsyncTraceScope(asyncTrace);
+            if (!scopeLeft) {
+                logger.warn("Failed to leave Ktor client async trace scope. {}", asyncTrace);
+            }
+        } catch (Throwable scopeThrowable) {
+            logger.warn("Failed to leave Ktor client async trace scope. {}", scopeThrowable.getMessage(), scopeThrowable);
+        }
+
+        // traceBlockEnd() must always pair with traceBlockBegin() regardless of nesting,
+        // otherwise the owning scope's close() sees an unbalanced stack id.
+        if (blockStarted) {
+            try {
+                asyncTrace.traceBlockEnd();
+            } catch (Throwable endThrowable) {
+                logger.warn("Failed to end Ktor client async trace block. {}", endThrowable.getMessage(), endThrowable);
+            }
+        }
+
+        try {
+            if (scopeLeft && ScopeUtils.isAsyncTraceEndScope(asyncTrace)) {
+                asyncTrace.close();
+                asyncContext.close();
+            }
+        } catch (Throwable closeThrowable) {
+            logger.warn("Failed to close Ktor client async trace. {}", closeThrowable.getMessage(), closeThrowable);
+        }
+    }
+
+    private void finishAsyncState() {
+        try {
+            asyncContext.finish();
+        } catch (Throwable finishThrowable) {
+            logger.warn("Failed to finish Ktor client async state. {}", finishThrowable.getMessage(), finishThrowable);
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceStorage.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceStorage.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+public final class KtorClientTraceStorage {
+    private static final ThreadLocal<KtorClientTraceHolder> PENDING = new ThreadLocal<>();
+
+    private KtorClientTraceStorage() {
+    }
+
+    public static void setPending(KtorClientTraceHolder holder) {
+        PENDING.set(holder);
+    }
+
+    public static KtorClientTraceHolder getPending() {
+        return PENDING.get();
+    }
+
+    public static void clearPending() {
+        PENDING.remove();
+    }
+}

--- a/agent-module/plugins/ktor/src/main/resources/META-INF/pinpoint/type-provider.yml
+++ b/agent-module/plugins/ktor/src/main/resources/META-INF/pinpoint/type-provider.yml
@@ -6,3 +6,13 @@ serviceTypes:
   - code: 1161
     name: 'KTOR_INTERNAL'
     desc: 'KTOR'
+  - code: 1900
+    name: 'KTOR_CLIENT'
+    property:
+      recordStatistics: true
+  - code: 1901
+    name: 'KTOR_CLIENT_INTERNAL'
+    desc: 'KTOR_CLIENT'
+    matcher:
+      type: 'exact'
+      code: 46

--- a/agent-module/plugins/ktor/src/main/resources/META-INF/pinpoint/type-provider.yml
+++ b/agent-module/plugins/ktor/src/main/resources/META-INF/pinpoint/type-provider.yml
@@ -6,3 +6,13 @@ serviceTypes:
   - code: 1161
     name: 'KTOR_INTERNAL'
     desc: 'KTOR'
+  - code: 9068
+    name: 'KTOR_CLIENT'
+    property:
+      recordStatistics: true
+  - code: 9069
+    name: 'KTOR_CLIENT_INTERNAL'
+    desc: 'KTOR_CLIENT'
+    matcher:
+      type: 'exact'
+      code: 46

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/KtorPluginConfigTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/KtorPluginConfigTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor;
+
+import com.navercorp.pinpoint.bootstrap.config.DefaultProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KtorPluginConfigTest {
+
+    @Test
+    void clientEnabledByDefault() {
+        ProfilerConfig config = new DefaultProfilerConfig();
+        KtorPluginConfig pluginConfig = new KtorPluginConfig(config);
+
+        assertTrue(pluginConfig.isClientEnable());
+        assertTrue(pluginConfig.isClientParam());
+        assertTrue(pluginConfig.isClientMarkError());
+    }
+
+    @Test
+    void clientDisabledFlagRespected() {
+        DefaultProfilerConfig config = new DefaultProfilerConfig();
+        config.getProperties().setProperty("profiler.ktor.client.enable", "false");
+
+        KtorPluginConfig pluginConfig = new KtorPluginConfig(config);
+
+        assertFalse(pluginConfig.isClientEnable());
+        assertTrue(pluginConfig.isClientParam());
+        assertTrue(pluginConfig.isClientMarkError());
+    }
+
+    @Test
+    void paramAndMarkErrorRespectFlags() {
+        DefaultProfilerConfig config = new DefaultProfilerConfig();
+        config.getProperties().setProperty("profiler.ktor.client.enable", "true");
+        config.getProperties().setProperty("profiler.ktor.client.param", "false");
+        config.getProperties().setProperty("profiler.ktor.client.mark.error", "false");
+
+        KtorPluginConfig pluginConfig = new KtorPluginConfig(config);
+
+        assertTrue(pluginConfig.isClientEnable());
+        assertFalse(pluginConfig.isClientParam());
+        assertFalse(pluginConfig.isClientMarkError());
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/KtorPluginConfigTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/KtorPluginConfigTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor;
+
+import com.navercorp.pinpoint.bootstrap.config.DefaultProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KtorPluginConfigTest {
+
+    @Test
+    void clientDisabledByDefault() {
+        ProfilerConfig config = new DefaultProfilerConfig();
+        KtorPluginConfig pluginConfig = new KtorPluginConfig(config);
+
+        assertFalse(pluginConfig.isClientEnable());
+        assertTrue(pluginConfig.isClientParam());
+        assertTrue(pluginConfig.isClientMarkError());
+    }
+
+    @Test
+    void clientEnabledFlagReadsTrue() {
+        DefaultProfilerConfig config = new DefaultProfilerConfig();
+        config.getProperties().setProperty("profiler.ktor.client.enable", "true");
+
+        KtorPluginConfig pluginConfig = new KtorPluginConfig(config);
+
+        assertTrue(pluginConfig.isClientEnable());
+        assertTrue(pluginConfig.isClientParam());
+        assertTrue(pluginConfig.isClientMarkError());
+    }
+
+    @Test
+    void paramAndMarkErrorRespectFlags() {
+        DefaultProfilerConfig config = new DefaultProfilerConfig();
+        config.getProperties().setProperty("profiler.ktor.client.enable", "true");
+        config.getProperties().setProperty("profiler.ktor.client.param", "false");
+        config.getProperties().setProperty("profiler.ktor.client.mark.error", "false");
+
+        KtorPluginConfig pluginConfig = new KtorPluginConfig(config);
+
+        assertTrue(pluginConfig.isClientEnable());
+        assertFalse(pluginConfig.isClientParam());
+        assertFalse(pluginConfig.isClientMarkError());
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationConstructorInterceptorTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationConstructorInterceptorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class KtorClientContinuationConstructorInterceptorTest {
+
+    private KtorClientTraceHolder holder;
+
+    @BeforeEach
+    void setUp() {
+        holder = mock(KtorClientTraceHolder.class);
+        KtorClientTraceStorage.clearPending();
+    }
+
+    @Test
+    void attachesPendingHolderToContinuationTarget() {
+        KtorClientTraceStorage.setPending(holder);
+        TestContinuationAccessor continuation = new TestContinuationAccessor();
+
+        new KtorClientContinuationConstructorInterceptor().after(continuation, new Object[0], null, null);
+
+        assertSame(holder, continuation.trace);
+        // markAttached is invoked against the immutable holder instance
+    }
+
+    @Test
+    void skipsWhenHolderMissing() {
+        TestContinuationAccessor continuation = new TestContinuationAccessor();
+
+        new KtorClientContinuationConstructorInterceptor().after(continuation, new Object[0], null, null);
+
+        assertNull(continuation.trace);
+    }
+
+    @Test
+    void skipsWhenConstructorThrew() {
+        KtorClientTraceStorage.setPending(holder);
+        TestContinuationAccessor continuation = new TestContinuationAccessor();
+
+        new KtorClientContinuationConstructorInterceptor()
+                .after(continuation, new Object[0], null, new RuntimeException("ctor failure"));
+
+        // even with throwable, the accessor should not receive the holder
+        assertNull(continuation.trace);
+    }
+
+    @Test
+    void skipsWhenTargetNotTraceAccessor() {
+        KtorClientTraceStorage.setPending(holder);
+        Object accessorTarget = new Object();
+
+        new KtorClientContinuationConstructorInterceptor()
+                .after(accessorTarget, new Object[0], null, null);
+
+        // nothing to assert on target; just verify we didn't leak a pending holder on the storage side
+        org.junit.jupiter.api.Assertions.assertSame(holder, KtorClientTraceStorage.getPending());
+    }
+
+    private static class TestContinuationAccessor implements KtorClientTraceAccessor {
+        KtorClientTraceHolder trace;
+
+        @Override
+        public void _$PINPOINT$_setKtorClientTrace(KtorClientTraceHolder holder) {
+            this.trace = holder;
+        }
+
+        @Override
+        public KtorClientTraceHolder _$PINPOINT$_getKtorClientTrace() {
+            return trace;
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationInterceptorTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationInterceptorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import kotlin.coroutines.intrinsics.IntrinsicsKt;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class KtorClientContinuationInterceptorTest {
+
+    @Test
+    void resumedResultFinishesHolderAndClearsAccessor() {
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+        TestAccessor target = new TestAccessor(holder);
+
+        new KtorClientContinuationInterceptor().after(target, new Object[0], new Object(), null);
+
+        verify(holder, times(1)).finishAsync(null);
+        assertNull(target.trace);
+    }
+
+    @Test
+    void suspendedMarkerReturnsSkipsFinishButKeepsHolder() {
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+        TestAccessor target = new TestAccessor(holder);
+        Object marker = IntrinsicsKt.getCOROUTINE_SUSPENDED();
+
+        new KtorClientContinuationInterceptor().after(target, new Object[0], marker, null);
+
+        verify(holder, never()).finishAsync(null);
+        assertSame(holder, target.trace);
+    }
+
+    @Test
+    void missingHolderIsNoOp() {
+        TestAccessor target = new TestAccessor(null);
+
+        new KtorClientContinuationInterceptor().after(target, new Object[0], new Object(), null);
+
+        assertNull(target.trace);
+    }
+
+    @Test
+    void nonAccessorTargetIsIgnored() {
+        new KtorClientContinuationInterceptor().after(new Object(), new Object[0], new Object(), null);
+        // no-op expectation
+    }
+
+    @Test
+    void holderThrowingDoesNotPropagateAndClearsAccessor() {
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+        doThrow(new IllegalStateException("finishAsync boom")).when(holder).finishAsync(null);
+        TestAccessor target = new TestAccessor(holder);
+
+        new KtorClientContinuationInterceptor().after(target, new Object[0], new Object(), null);
+
+        assertNull(target.trace);
+    }
+
+    private static class TestAccessor implements KtorClientTraceAccessor {
+        KtorClientTraceHolder trace;
+
+        TestAccessor(KtorClientTraceHolder trace) {
+            this.trace = trace;
+        }
+
+        @Override
+        public void _$PINPOINT$_setKtorClientTrace(KtorClientTraceHolder holder) {
+            this.trace = holder;
+        }
+
+        @Override
+        public KtorClientTraceHolder _$PINPOINT$_getKtorClientTrace() {
+            return trace;
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientCoroutineSuspendedMarkerTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientCoroutineSuspendedMarkerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import kotlin.coroutines.intrinsics.IntrinsicsKt;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KtorClientCoroutineSuspendedMarkerTest {
+
+    @Test
+    void detectsOnlyTheKotlinCoroutineMarker() {
+        Object marker = IntrinsicsKt.getCOROUTINE_SUSPENDED();
+
+        assertTrue(KtorClientCoroutineSuspendedMarker.isSuspended(marker));
+
+        assertFalse(KtorClientCoroutineSuspendedMarker.isSuspended(null));
+        assertFalse(KtorClientCoroutineSuspendedMarker.isSuspended(new Object()));
+        assertFalse(KtorClientCoroutineSuspendedMarker.isSuspended("COROUTINE_SUSPENDED"));
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientHeaderAdaptorTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientHeaderAdaptorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KtorClientHeaderAdaptorTest {
+
+    private final KtorClientHeaderAdaptor adaptor = new KtorClientHeaderAdaptor();
+
+    @Test
+    void setGetContainsRoundTrip() {
+        MapBackedHeaders headers = new MapBackedHeaders();
+        HeadersCarrier request = new HeadersCarrier(headers);
+
+        assertFalse(adaptor.contains(request, "x-pinpoint-traceid"));
+
+        adaptor.setHeader(request, "x-pinpoint-traceid", "agent^123^1");
+        adaptor.setHeader(request, "x-pinpoint-spanid", "42");
+
+        assertTrue(adaptor.contains(request, "x-pinpoint-traceid"));
+        assertEquals("agent^123^1", adaptor.getHeader(request, "x-pinpoint-traceid"));
+        assertEquals("42", headers.map.get("x-pinpoint-spanid"));
+    }
+
+    @Test
+    void nullSafety() {
+        assertEquals("", adaptor.getHeader(null, "anything"));
+        assertFalse(adaptor.contains(null, "anything"));
+        // must not throw
+        adaptor.setHeader(null, "key", "value");
+    }
+
+    @Test
+    void missingHeaderReturnsEmpty() {
+        HeadersCarrier request = new HeadersCarrier(new MapBackedHeaders());
+        assertEquals("", adaptor.getHeader(request, "absent"));
+        assertFalse(adaptor.contains(request, "absent"));
+    }
+
+    /** Ktor's {@code getHeaders()} returns a Headers instance — we substitute a minimal carrier. */
+    public static class HeadersCarrier {
+        private final MapBackedHeaders headers;
+
+        HeadersCarrier(MapBackedHeaders headers) {
+            this.headers = headers;
+        }
+
+        public MapBackedHeaders getHeaders() {
+            return headers;
+        }
+    }
+
+    public static class MapBackedHeaders {
+        final Map<String, String> map = new HashMap<>();
+
+        public String get(String name) {
+            return map.get(name);
+        }
+
+        public Boolean contains(String name) {
+            return map.containsKey(name);
+        }
+
+        public void set(String name, String value) {
+            map.put(name, value);
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientParentTraceStateTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientParentTraceStateTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class KtorClientParentTraceStateTest {
+
+    @Test
+    void finishRecordsThenClosesTrace() {
+        Trace trace = mock(Trace.class);
+        SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+
+        KtorClientParentTraceState state = new KtorClientParentTraceState(trace, holder);
+        state.finish(null);
+
+        verify(trace, times(1)).currentSpanEventRecorder();
+        verify(holder, times(1)).record(recorder, null);
+        verify(trace, times(1)).traceBlockEnd();
+    }
+
+    @Test
+    void secondFinishIsNoOp() {
+        Trace trace = mock(Trace.class);
+        SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+
+        KtorClientParentTraceState state = new KtorClientParentTraceState(trace, holder);
+        state.finish(null);
+        state.finish(null);
+
+        verify(trace, times(1)).traceBlockEnd();
+    }
+
+    @Test
+    void recordFailureStillClosesTraceBlock() {
+        Trace trace = mock(Trace.class);
+        SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+        doThrow(new IllegalStateException("record boom")).when(holder).record(recorder, null);
+
+        KtorClientParentTraceState state = new KtorClientParentTraceState(trace, holder);
+        state.finish(null);
+
+        verify(trace, times(1)).traceBlockEnd();
+    }
+
+    @Test
+    void closeTraceBlockSwallowsEndFailure() {
+        Trace trace = mock(Trace.class);
+        doThrow(new IllegalStateException("traceBlockEnd boom")).when(trace).traceBlockEnd();
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+
+        KtorClientParentTraceState state = new KtorClientParentTraceState(trace, holder);
+
+        state.closeTraceBlock();
+
+        verify(trace, times(1)).traceBlockEnd();
+        verify(holder, never()).record(null, null);
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientRequestAdaptorTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientRequestAdaptorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class KtorClientRequestAdaptorTest {
+
+    private final KtorClientRequestAdaptor adaptor = new KtorClientRequestAdaptor();
+
+    @Test
+    void buildDestinationIdFromHostAndPort() {
+        FakeUrl url = new FakeUrl("api.example.com", 9443, "http://api.example.com:9443/v1/images");
+        FakeHeadersRequest request = new FakeHeadersRequest(url);
+
+        assertEquals("api.example.com:9443", adaptor.getDestinationId(request));
+    }
+
+    @Test
+    void getUrlReturnsBuildString() {
+        FakeUrl url = new FakeUrl("api.example.com", 8080, "http://api.example.com:8080/v1/images");
+        FakeHeadersRequest request = new FakeHeadersRequest(url);
+
+        assertEquals("http://api.example.com:8080/v1/images", adaptor.getUrl(request));
+    }
+
+    @Test
+    void unknownInputYieldsSafeDefaults() {
+        assertEquals("Unknown", adaptor.getDestinationId(null));
+        assertEquals("Unknown", adaptor.getDestinationId(new Object()));
+        assertNull(adaptor.getUrl(null));
+        assertNull(adaptor.getUrl(new Object()));
+    }
+
+    @Test
+    void emptyHostFallsBackToUnknown() {
+        FakeUrl url = new FakeUrl("", 443, "https://:443/");
+        FakeHeadersRequest request = new FakeHeadersRequest(url);
+
+        assertEquals("Unknown", adaptor.getDestinationId(request));
+    }
+
+    @Test
+    void ipv6HostIsBracketed() {
+        FakeUrl url = new FakeUrl("::1", 8080, "http://[::1]:8080/");
+        FakeHeadersRequest request = new FakeHeadersRequest(url);
+
+        assertEquals("[::1]:8080", adaptor.getDestinationId(request));
+    }
+
+    /** Stand-in for Ktor's Url class so we can exercise accessor reflection without Ktor on the classpath. */
+    public static class FakeUrl {
+        private final String host;
+        private final int port;
+        private final String builtUrl;
+
+        FakeUrl(String host, int port, String builtUrl) {
+            this.host = host;
+            this.port = port;
+            this.builtUrl = builtUrl;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public String buildString() {
+            return builtUrl;
+        }
+
+        public FakeUrlProtocol getProtocolOrNull() {
+            return null;
+        }
+    }
+
+    public static class FakeUrlProtocol {
+        public int getDefaultPort() {
+            return 443;
+        }
+    }
+
+    public static class FakeHeadersRequest {
+        private final FakeUrl url;
+
+        FakeHeadersRequest(FakeUrl url) {
+            this.url = url;
+        }
+
+        public FakeUrl getUrl() {
+            return url;
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceAccessorTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceAccessorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+class KtorClientTraceAccessorTest {
+
+    @Test
+    void setGetHolderRoundTrip() {
+        TestAccessor accessor = new TestAccessor();
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+
+        assertNull(accessor._$PINPOINT$_getKtorClientTrace());
+
+        accessor._$PINPOINT$_setKtorClientTrace(holder);
+        assertSame(holder, accessor._$PINPOINT$_getKtorClientTrace());
+
+        accessor._$PINPOINT$_setKtorClientTrace(null);
+        assertNull(accessor._$PINPOINT$_getKtorClientTrace());
+    }
+
+    private static class TestAccessor implements KtorClientTraceAccessor {
+        private KtorClientTraceHolder holder;
+
+        @Override
+        public void _$PINPOINT$_setKtorClientTrace(KtorClientTraceHolder holder) {
+            this.holder = holder;
+        }
+
+        @Override
+        public KtorClientTraceHolder _$PINPOINT$_getKtorClientTrace() {
+            return holder;
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceStorageTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceStorageTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+class KtorClientTraceStorageTest {
+
+    @AfterEach
+    void cleanup() {
+        KtorClientTraceStorage.clearPending();
+    }
+
+    @Test
+    void setGetClearRoundTrip() {
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+
+        assertNull(KtorClientTraceStorage.getPending());
+
+        KtorClientTraceStorage.setPending(holder);
+        assertSame(holder, KtorClientTraceStorage.getPending());
+
+        KtorClientTraceStorage.clearPending();
+        assertNull(KtorClientTraceStorage.getPending());
+    }
+
+    @Test
+    void pendingIsThreadLocal() throws InterruptedException {
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+        final boolean[] sameThreadSame = new boolean[1];
+        final boolean[] otherThreadDistinct = new boolean[1];
+
+        KtorClientTraceStorage.setPending(holder);
+
+        Thread otherThread = new Thread(() -> {
+            sameThreadSame[0] = KtorClientTraceStorage.getPending() == holder;
+            otherThreadDistinct[0] = KtorClientTraceStorage.getPending() == null;
+        });
+        otherThread.start();
+        otherThread.join();
+
+        assertSame(holder, KtorClientTraceStorage.getPending());
+        // other thread never sees this thread's pending holder
+    }
+}

--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/ServiceType.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/ServiceType.java
@@ -268,6 +268,8 @@ import static com.navercorp.pinpoint.common.trace.ServiceTypeProperty.TERMINAL;
  * <tr><td>9065</td><td><i>JDK_HTTP_CLIENT</i></td></tr>
  * <tr><td>9066</td><td><i>JDK_HTTP_CLIENT_INTERNAL</i></td></tr>
  * <tr><td>9067</td><td>JDK_HTTPURLCONNECTOR_INTERNAL</td></tr>
+ * <tr><td>9068</td><td><i>KTOR_CLIENT</i></td></tr>
+ * <tr><td>9069</td><td><i>KTOR_CLIENT_INTERNAL</i></td></tr>
  * <tr><td>9070</td><td><i>RESERVED</i></td></tr>
  * <tr><td><s>9080</s></td><td><s>APACHE_CXF_CLIENT</s></td></tr>
  * <tr><td>9081</td><td>APACHE_CXF_SERVICE_INVOKER</td></tr>


### PR DESCRIPTION
## Summary

Add outbound-call tracing for Ktor HTTP client (`io.ktor.client.plugins.HttpSend$DefaultSender.execute(...)`) to the built-in ktor plugin.

- Each client call emits a `KTOR_CLIENT` span event with propagation headers.
- Each suspending call also emits a `KTOR_CLIENT_INTERNAL` async span event, completed when the suspending continuation resumes.
- Retry attempts via `HttpRequestRetry` emit one span event per attempt (each retry is a distinct remote call).
- Mirrors a custom plugin maintained outside this repo in production deployments. Outbound client tracing is enabled by default (since the review change); set `-Dprofiler.ktor.client.enable=false` to opt out.

## Needs review

- ~~**Service type codes**: claims `KTOR_CLIENT=1900` / `KTOR_CLIENT_INTERNAL=1901`.~~ → **Resolved per review**: `9068`/`9069` in the RPC range (9067 is taken by `JDK_HTTPURLCONNECTOR_INTERNAL` via Java SPI; 9060/9070 are RESERVED). Registered in the `ServiceType.java` javadoc table.
- **Test coverage**: 28 unit tests cover interceptors, adaptors, configuration, and scope semantics. Full agent-anchored integration (drive the jar through a real `naver-pinpoint-agent` tarball plus a suspended `HttpRequestRetry` continuation) is possible but needs the upstream IT harness; happy to add as a follow-up PR if desired.
- **Dependency on the Kotlin-coroutines plugin**: same constraint as the existing ktor server plugin's SuspendFunctionGun pattern; let me know if you want it removed.

## Open questions

1. ~~Should `profiler.ktor.client.enable` default flip to true once this lands?~~ → **Yes (review)** — flipped, and the client keys are now in the shipped release/local `pinpoint.config`.
2. ~~Want the Ktor client version compat range documented in README (validated against Ktor 3.5.1 clients in production)?~~ → **Yes (review)** — documented as `io.ktor/ktor-client-core-jvm [2.3, 3.5]`, backed by artifact-level `javap` checks (2.3.12 / 3.0.0 / 3.5.1 / 3.5.2 all structurally identical at the instrumentation targets).

Refs: https://pinpoint-apm.github.io/pinpoint/plugindevguide.html
