### PR TITLE
[#14083] Apply the selected service to heatmap drag query

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatMapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatMapController.java
@@ -17,18 +17,19 @@
 package com.navercorp.pinpoint.web.authorization.controller;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.scatter.DragArea;
 import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
 import com.navercorp.pinpoint.web.service.HeatMapService;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.util.LimitUtils;
 import com.navercorp.pinpoint.web.validation.NullOrNotBlank;
 import com.navercorp.pinpoint.web.view.transactionlist.DotMetaDataView;
 import com.navercorp.pinpoint.web.view.transactionlist.TransactionDotMetaDataViewModel;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
@@ -57,12 +58,15 @@ public class HeatMapController {
 
     private final HeatMapService heatMap;
     private final ServiceTypeRegistryService serviceTypeRegistryService;
+    private final ServiceModelResolver serviceModelResolver;
     private final boolean defaultTraceIndexReadV2;
 
     public HeatMapController(HeatMapService heatMap, ServiceTypeRegistryService serviceTypeRegistryService,
+                             ServiceModelResolver serviceModelResolver,
                              @Value("${pinpoint.web.trace.index.read.v2:true}") boolean defaultTraceIndexReadV2) {
         this.heatMap = Objects.requireNonNull(heatMap, "heatMap");
         this.serviceTypeRegistryService = Objects.requireNonNull(serviceTypeRegistryService, "serviceTypeRegistryService");
+        this.serviceModelResolver = Objects.requireNonNull(serviceModelResolver, "serviceModelResolver");
         this.defaultTraceIndexReadV2 = defaultTraceIndexReadV2;
     }
 
@@ -97,7 +101,8 @@ public class HeatMapController {
             dotMetaData = heatMap.dragScatterDataV2(applicationName, query, limit);
         } else {
             final ServiceType serviceType = findServiceType(serviceTypeCode, serviceTypeName);
-            dotMetaData = heatMap.dragTraceIndex(ServiceUid.DEFAULT_SERVICE_UID_CODE, applicationName, serviceType.getCode(), query, limit);
+            final Service service = serviceModelResolver.getService(serviceName.getName());
+            dotMetaData = heatMap.dragTraceIndex(service, applicationName, serviceType.getCode(), query, limit);
         }
         if (logger.isDebugEnabled()) {
             logger.debug("dragScatterArea applicationName:{} dots:{}", applicationName, dotMetaData.scanData().size());

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/TraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/TraceIndexDao.java
@@ -32,6 +32,6 @@ public interface TraceIndexDao {
 
     LimitedScanResult<List<Dot>> scanTraceScatterData(Service service, String applicationName, int serviceTypeCode, Range range, int limit);
 
-    LimitedScanResult<List<DotMetaData>> scanScatterDataV2(int serviceUid, String applicationName, int serviceTypeCode, DragAreaQuery dragAreaQuery, String rpcRegex, int limit);
+    LimitedScanResult<List<DotMetaData>> scanScatterDataV2(Service service, String applicationName, int serviceTypeCode, DragAreaQuery dragAreaQuery, String rpcRegex, int limit);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java
@@ -136,13 +136,15 @@ public class HbaseTraceIndexDao implements TraceIndexDao {
     }
 
     @Override
-    public LimitedScanResult<List<DotMetaData>> scanScatterDataV2(int serviceUid, String applicationName, int serviceTypeCode,
+    public LimitedScanResult<List<DotMetaData>> scanScatterDataV2(Service service, String applicationName, int serviceTypeCode,
                                                                   DragAreaQuery dragAreaQuery, String rpcRegex, int limitWithTies) {
+        Objects.requireNonNull(service, "service");
         Objects.requireNonNull(applicationName, "applicationName");
         Objects.requireNonNull(dragAreaQuery, "dragAreaQuery");
         DragArea dragArea = dragAreaQuery.getDragArea();
         Range range = Range.unchecked(dragArea.getXLow(), dragArea.getXHigh());
         logger.debug("scanTraceScatterData-range:{}", range);
+        final int serviceUid = service.getServiceUid().getUid();
         Scan scan = createScan(serviceUid, applicationName, serviceTypeCode, range);
         setHbaseFilter(scan, dragAreaQuery, rpcRegex);
         scan.addFamily(META.getName());

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapService.java
@@ -2,6 +2,7 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 
 import java.util.List;
@@ -10,5 +11,5 @@ public interface HeatMapService {
 
     LimitedScanResult<List<DotMetaData>> dragScatterDataV2(String applicationName, DragAreaQuery dragAreaquery, int limit);
 
-    LimitedScanResult<List<DotMetaData>> dragTraceIndex(int serviceUid, String applicationName, int serviceTypeCode, DragAreaQuery dragAreaQuery, int limit);
+    LimitedScanResult<List<DotMetaData>> dragTraceIndex(Service service, String applicationName, int serviceTypeCode, DragAreaQuery dragAreaQuery, int limit);
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapServiceImpl.java
@@ -28,11 +28,11 @@ import com.navercorp.pinpoint.web.trace.dao.TraceDao;
 import com.navercorp.pinpoint.web.trace.service.SpanService;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.SpanHint;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.NonNull;
-import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,7 +42,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-@Service
+@org.springframework.stereotype.Service
 public class HeatMapServiceImpl implements HeatMapService {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
@@ -88,11 +88,12 @@ public class HeatMapServiceImpl implements HeatMapService {
     }
 
     @Override
-    public LimitedScanResult<List<DotMetaData>> dragTraceIndex(int serviceUid, String applicationName, int serviceTypeCode, DragAreaQuery dragAreaQuery, int limit) {
+    public LimitedScanResult<List<DotMetaData>> dragTraceIndex(Service service, String applicationName, int serviceTypeCode, DragAreaQuery dragAreaQuery, int limit) {
+        Objects.requireNonNull(service, "service");
         Objects.requireNonNull(applicationName, "applicationName");
         Objects.requireNonNull(dragAreaQuery, "dragAreaQuery");
 
-        LimitedScanResult<List<DotMetaData>> scanResult = traceIndexDao.scanScatterDataV2(serviceUid, applicationName, serviceTypeCode, dragAreaQuery, null, limit);
+        LimitedScanResult<List<DotMetaData>> scanResult = traceIndexDao.scanScatterDataV2(service, applicationName, serviceTypeCode, dragAreaQuery, null, limit);
         List<DotMetaData> scanData = scanResult.scanData();
         logger.debug("dragScatterArea applicationName:{} dots:{}", applicationName, scanResult);
 


### PR DESCRIPTION
resolve #14083

Pass the resolved Service down the heatmap drag query path instead of the hardcoded DEFAULT service uid.

- HeatMapController: resolve the selected service with ServiceModelResolver and pass it to dragTraceIndex
- HeatMapService / HeatMapServiceImpl: change dragTraceIndex(int serviceUid, ...) to dragTraceIndex(Service service, ...)
- TraceIndexDao / HbaseTraceIndexDao: change scanScatterDataV2 signature the same way, extract the uid right before createScan

Same pattern as #14080 (scatter chart V2 query).