### PR TITLE
[#noissue] Apply the selected service consistently across every screen

### DIFF
--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
@@ -14,7 +14,7 @@ import {
   selectedServiceAtom,
 } from '@pinpoint-fe/ui/src/atoms';
 import { APP_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
-import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
+import { getApplicationTypeAndNameFromPath } from '@pinpoint-fe/ui/src/utils';
 
 export const InitialFetchOutlet = () => {
   const navigate = useNavigate();
@@ -22,7 +22,9 @@ export const InitialFetchOutlet = () => {
   const setConfiguration = useSetAtom(configurationAtom);
   const configuration = useAtomValue(configurationAtom);
   const { pathname, search } = useLocation();
-  const application = getApplicationTypeAndName(pathname);
+  // transactionList처럼 serviceName이 실린 경로에서도 applicationName만 추려낸다.
+  // (사이드 네비게이션이 이 값으로 다른 페이지 링크를 만든다.)
+  const application = getApplicationTypeAndNameFromPath(pathname);
   const searchParameters = Object.fromEntries(new URLSearchParams(search));
   const setSearchParameters = useSetAtom(searchParametersAtom);
 

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.test.ts
@@ -35,4 +35,31 @@ describe('selectedServiceAtom', () => {
     const { result } = renderHook(() => useAtomValue(selectedServiceAtom));
     expect(result.current).toBe(DEFAULT_SERVICE);
   });
+
+  // 서드파티 스토리지가 차단된 iframe 등에서는 sessionStorage 접근 자체가 던진다.
+  // getOnInit이 켜져 있으면 atomWithStorage가 모듈 평가 시점에 storage.getItem을 호출하므로,
+  // 가드가 없으면 import만으로 앱 전체가 죽는다. 그래서 모듈을 다시 평가해서 확인한다.
+  test('keeps working when storage access throws', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get() {
+        throw new Error('storage blocked');
+      },
+    });
+
+    try {
+      jest.isolateModules(() => {
+        const reloaded = require('./selectedService');
+
+        const { result } = renderHook(() => useAtomValue(reloaded.selectedServiceAtom));
+        expect(result.current).toBe(DEFAULT_SERVICE);
+      });
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(window, 'sessionStorage', descriptor);
+      }
+    }
+  });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.ts
@@ -1,4 +1,4 @@
-import { atomWithStorage } from 'jotai/utils';
+import { atomWithStorage, createJSONStorage } from 'jotai/utils';
 
 export const DEFAULT_SERVICE = 'DEFAULT';
 
@@ -7,13 +7,53 @@ export const RESERVED_SERVICE_NAMES = ['DEFAULT', 'TEST', 'ERROR', 'UNKNOWN', 'N
 export const isReservedServiceName = (name: string) =>
   RESERVED_SERVICE_NAMES.includes(name.toUpperCase());
 
-// getOnInit: true → 첫 렌더부터 localStorage 값을 동기로 읽는다.
+// sessionStorage에 저장해 브라우저 탭마다 selectedService를 독립적으로 유지한다.
+// localStorage는 origin 단위로 공유되고 storage 이벤트로 탭 간 실시간 동기화까지 되어,
+// 한 탭에서 service를 바꾸면 다른 탭도 따라 바뀌었다. sessionStorage는 탭(브라우징 컨텍스트)
+// 단위라 값이 공유되지 않고 storage 이벤트도 전파되지 않아 탭별 선택이 가능하다.
+// (새 탭·재시작은 값이 없어 DEFAULT로 시작하고, 링크로 연 같은-origin 탭은 복사받아 승계한다.)
+
+/**
+ * 스토리지 접근 자체가 던지는 환경이 있다(서드파티 스토리지가 차단된 iframe, 일부 프라이버시
+ * 설정). jotai의 기본 getter는 이를 감싸 폴백하지만, getter를 직접 넘기면 그 방어가 사라진다.
+ * `getOnInit`이 첫 렌더에서 읽으므로 예외가 그대로 전파되면 화면이 아예 뜨지 않는다.
+ *
+ * createJSONStorage의 타입은 getter가 undefined를 돌려주는 것을 허용하지 않으므로(런타임은
+ * 허용한다) 메모리 fallback을 준다. 탭을 벗어나면 값이 유지되지 않지만, 그런 환경에서는
+ * sessionStorage도 어차피 유지되지 않는다.
+ *
+ * `getStringStorage()`는 접근마다 호출되므로 fallback은 반드시 모듈 레벨 싱글턴이어야 한다.
+ * 매번 새 Map을 만들면 같은 탭 안에서도 값이 남지 않는다.
+ */
+const memoryStringStorage = (() => {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, newValue: string) => {
+      store.set(key, newValue);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+})();
+
+const getSessionStringStorage = () => {
+  try {
+    return sessionStorage;
+  } catch {
+    return memoryStringStorage;
+  }
+};
+
+// getOnInit: true → 첫 렌더부터 sessionStorage 값을 동기로 읽는다.
 // 이로써 fetch 인터셉터의 최초 요청도 저장된 service를 반영하고,
 // 새로고침 시 hydration으로 인한 불필요한 캐시 무효화를 방지한다.
 export const selectedServiceAtom = atomWithStorage<string>(
   'selectedService',
   DEFAULT_SERVICE,
-  undefined,
+  createJSONStorage(getSessionStringStorage),
   {
     getOnInit: true,
   },

--- a/web-frontend/src/main/v3/packages/ui/src/components/FilterMap/FilteredMapChartsBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/FilterMap/FilteredMapChartsBoard.tsx
@@ -35,7 +35,7 @@ import {
   getTransactionListPath,
   getTransactionListQueryString,
 } from '@pinpoint-fe/ui/src/utils';
-import { useFilteredMapParameters } from '@pinpoint-fe/ui/src/hooks';
+import { useFilteredMapParameters, useServiceNameForLink } from '@pinpoint-fe/ui/src/hooks';
 import { ServerListForCommon } from '@pinpoint-fe/ui/src/components/ServerList/ServerListForCommon';
 import { MdArrowForwardIos, MdArrowBackIosNew } from 'react-icons/md';
 import { PiArrowSquareOut } from 'react-icons/pi';
@@ -64,6 +64,7 @@ export const FilteredMapChartsBoard = ({
 }: FilteredMapChartsBoardProps) => {
   const { t } = useTranslation();
   const { dateRange, application, searchParameters } = useFilteredMapParameters();
+  const serviceNameForLink = useServiceNameForLink(configuration);
 
   const [openServerView, setOpenServerView] = React.useState(false);
 
@@ -205,6 +206,7 @@ export const FilteredMapChartsBoard = ({
                         }
                         range={[dateRange.from.getTime(), dateRange.to.getTime()]}
                         selectedAgentId={SCATTER_DATA_TOTAL_KEY}
+                        configuration={configuration}
                         onDragEnd={(data, checkedLables) => {
                           if (checkedLables.length) {
                             window.__pp_scatter_data__ =
@@ -215,6 +217,7 @@ export const FilteredMapChartsBoard = ({
                               `${BASE_PATH}${getTransactionListPath(
                                 serverMapCurrentTarget,
                                 searchParameters,
+                                serviceNameForLink,
                               )}&${getTransactionListQueryString({
                                 ...data,
                                 checkedLegends: checkedLables,
@@ -294,6 +297,7 @@ export const FilteredMapChartsBoard = ({
                     }
                     range={[dateRange.from.getTime(), dateRange.to.getTime()]}
                     selectedAgentId={currentServer?.agentId}
+                    configuration={configuration}
                     onDragEnd={(data, checkedLables) => {
                       if (checkedLables.length) {
                         window.__pp_scatter_data__ =
@@ -304,6 +308,7 @@ export const FilteredMapChartsBoard = ({
                           `${BASE_PATH}${getTransactionListPath(
                             application,
                             searchParameters,
+                            serviceNameForLink,
                           )}&${getTransactionListQueryString({
                             ...data,
                             checkedLegends: checkedLables,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapFetcher.tsx
@@ -13,7 +13,7 @@ const DefaultAxisY = [0, 10000];
 
 export type HeatmapFetcherProps = {
   agentId?: string;
-} & Pick<HeatmapChartCoreProps, 'toolbarOption' | 'nodeData'>;
+} & Pick<HeatmapChartCoreProps, 'toolbarOption' | 'nodeData' | 'configuration'>;
 
 export const HeatmapFetcher = ({ nodeData, agentId, ...props }: HeatmapFetcherProps) => {
   const { t } = useTranslation();

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapRealtimeFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapRealtimeFetcher.tsx
@@ -29,7 +29,7 @@ function ceilTo10SecAndSubtract30(date: Date): Date {
 export type HeatmapRealtimeFetcherProps = {
   nodeData: GetServerMap.NodeData | ApplicationType;
   agentId?: string;
-} & Pick<HeatmapChartCoreProps, 'toolbarOption'>;
+} & Pick<HeatmapChartCoreProps, 'toolbarOption' | 'configuration'>;
 
 export const HeatmapRealtimeFetcher = ({
   nodeData,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/core/HeatmapChartCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/core/HeatmapChartCore.tsx
@@ -6,6 +6,7 @@ import {
   GetHeatmapAppData,
   GetServerMap,
   ApplicationType,
+  Configuration,
 } from '@pinpoint-fe/ui/src/constants';
 import HeatmapChart from './HeatmapChart';
 import {
@@ -17,6 +18,7 @@ import {
   getTransactionListPath,
   getTransactionListQueryString,
   useServerMapSearchParameters,
+  useServiceNameForLink,
   useStoragedSetting,
 } from '@pinpoint-fe/ui';
 import { FaDownload, FaExpandArrowsAlt } from 'react-icons/fa';
@@ -36,6 +38,8 @@ export type HeatmapChartCoreProps = {
       hide?: boolean;
     };
   };
+  /** transactionList 링크에 실을 service를 판단하는 데 쓴다(`useServiceNameForLink`). */
+  configuration?: Configuration;
 };
 
 const HeatmapChartCore = ({
@@ -45,10 +49,12 @@ const HeatmapChartCore = ({
   data,
   agentId,
   toolbarOption,
+  configuration,
 }: HeatmapChartCoreProps) => {
   const chartContainerRef = React.useRef<HTMLDivElement>(null);
 
   const { dateRange, searchParameters } = useServerMapSearchParameters();
+  const serviceNameForLink = useServiceNameForLink(configuration);
   const [showSetting, setShowSetting] = React.useState(false);
   const [isCapturingImage, setIsCapturingImage] = React.useState(false);
 
@@ -109,6 +115,7 @@ const HeatmapChartCore = ({
       `${BASE_PATH}${getTransactionListPath(
         nodeData,
         isRealtime ? getFormattedDateRange(dateRange) : searchParameters,
+        serviceNameForLink,
       )}&${getTransactionListQueryString({
         ...data,
         checkedLegends,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
@@ -186,12 +186,14 @@ export const Realtime = ({ configuration }: RealtimeProps) => {
                       <ScatterChart
                         node={serverMapCurrentTarget || (application as ApplicationType)}
                         realtime={true}
+                        configuration={configuration}
                       />
                     ) : (
                       // <div className="w-full pl-3 pt-5 pr-10 pb-8 aspect-[1.3]">
                       <Heatmap
                         nodeData={currentTargetData || (application as ApplicationType)}
                         realtime={true}
+                        configuration={configuration}
                       />
                       // </div>
                     )}

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartFetcher.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { SCATTER_DATA_TOTAL_KEY, BASE_PATH, ApplicationType } from '@pinpoint-fe/ui/src/constants';
+import {
+  SCATTER_DATA_TOTAL_KEY,
+  BASE_PATH,
+  ApplicationType,
+  Configuration,
+} from '@pinpoint-fe/ui/src/constants';
 import { CurrentTarget } from '@pinpoint-fe/ui/src/atoms';
 import {
   convertParamsToQueryString,
@@ -7,7 +12,11 @@ import {
   getTransactionListPath,
   getTransactionListQueryString,
 } from '@pinpoint-fe/ui/src/utils';
-import { useGetScatterData, useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useGetScatterData,
+  useServerMapSearchParameters,
+  useServiceNameForLink,
+} from '@pinpoint-fe/ui/src/hooks';
 import { scatterDataAtom } from '@pinpoint-fe/ui/src/atoms';
 import { useAtom } from 'jotai';
 import { ScatterChartCore, ScatterChartCoreProps, ScatterChartHandle } from './core';
@@ -17,15 +26,19 @@ export interface ScatterChartFetcherProps {
   node: CurrentTarget;
   agentId?: string;
   toolbarOption?: ScatterChartCoreProps['toolbarOption'];
+  /** transactionList 링크에 실을 service를 판단하는 데 쓴다(`useServiceNameForLink`). */
+  configuration?: Configuration;
 }
 
 export const ScatterChartFetcher = ({
   node,
   agentId = SCATTER_DATA_TOTAL_KEY,
   toolbarOption,
+  configuration,
 }: ScatterChartFetcherProps) => {
   const scatterRef = React.useRef<ScatterChartHandle>(null);
   const { dateRange, searchParameters } = useServerMapSearchParameters();
+  const serviceNameForLink = useServiceNameForLink(configuration);
   const from = dateRange.from.getTime();
   const to = dateRange.to.getTime();
   const currentNode = `${node.applicationName}^${node.serviceType}`;
@@ -101,6 +114,7 @@ export const ScatterChartFetcher = ({
           `${BASE_PATH}${getTransactionListPath(
             node,
             searchParameters,
+            serviceNameForLink,
           )}&${getTransactionListQueryString({
             ...data,
             checkedLegends,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartRealtimeFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartRealtimeFetcher.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { SCATTER_DATA_TOTAL_KEY, BASE_PATH, GetScatter } from '@pinpoint-fe/ui/src/constants';
+import {
+  SCATTER_DATA_TOTAL_KEY,
+  BASE_PATH,
+  GetScatter,
+  Configuration,
+} from '@pinpoint-fe/ui/src/constants';
 import { CurrentTarget } from '@pinpoint-fe/ui/src/atoms';
 import {
   convertParamsToQueryString,
@@ -13,6 +18,7 @@ import {
   useGetScatterData,
   useGetScatterRealtimeData,
   useServerMapSearchParameters,
+  useServiceNameForLink,
 } from '@pinpoint-fe/ui/src/hooks';
 import { ScatterChartCore, ScatterChartCoreProps, ScatterChartHandle } from './core';
 import { useStoragedAxisY } from './core/useStoragedAxisY';
@@ -22,15 +28,19 @@ export interface ScatterChartRealtimeFetcherProps {
   node: CurrentTarget;
   agentId?: string;
   toolbarOption?: ScatterChartCoreProps['toolbarOption'];
+  /** transactionList 링크에 실을 service를 판단하는 데 쓴다(`useServiceNameForLink`). */
+  configuration?: Configuration;
 }
 
 export const ScatterChartRealtimeFetcher = ({
   node,
   agentId = SCATTER_DATA_TOTAL_KEY,
   toolbarOption,
+  configuration,
 }: ScatterChartRealtimeFetcherProps) => {
   const scatterRef = React.useRef<ScatterChartHandle>(null);
   const { dateRange } = useServerMapSearchParameters();
+  const serviceNameForLink = useServiceNameForLink(configuration);
   const from = dateRange.from.getTime();
   const to = dateRange.to.getTime();
   const currentNode = `${node.applicationName}^${node.serviceType}`;
@@ -145,6 +155,7 @@ export const ScatterChartRealtimeFetcher = ({
           `${getTransactionListPath(
             node,
             getFormattedDateRange(dateRange),
+            serviceNameForLink,
           )}&${getTransactionListQueryString({
             ...data,
             checkedLegends,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartStatic.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartStatic.tsx
@@ -11,6 +11,7 @@ import {
   SCATTER_DATA_TOTAL_KEY,
   SEARCH_PARAMETER_DATE_FORMAT,
   BASE_PATH,
+  Configuration,
 } from '@pinpoint-fe/ui/src/constants';
 import { formatInTimeZone } from 'date-fns-tz';
 import {
@@ -18,7 +19,11 @@ import {
   ScatterChartCoreProps,
   ScatterChartHandle,
 } from './core/ScatterChartCore';
-import { useServerMapSearchParameters, useTimezone } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useServerMapSearchParameters,
+  useServiceNameForLink,
+  useTimezone,
+} from '@pinpoint-fe/ui/src/hooks';
 import { useStoragedAxisY } from './core/useStoragedAxisY';
 
 export interface ScatterChartStaticProps extends Pick<
@@ -29,6 +34,8 @@ export interface ScatterChartStaticProps extends Pick<
   data?: ScatterDataType[];
   range: [number, number];
   selectedAgentId?: string;
+  /** transactionList 링크에 실을 service를 판단하는 데 쓴다(`useServiceNameForLink`). */
+  configuration?: Configuration;
 }
 
 export const ScatterChartStatic = ({
@@ -36,9 +43,11 @@ export const ScatterChartStatic = ({
   data = [],
   range,
   selectedAgentId,
+  configuration,
   ...props
 }: ScatterChartStaticProps) => {
   const { searchParameters } = useServerMapSearchParameters();
+  const serviceNameForLink = useServiceNameForLink(configuration);
   const [timezone] = useTimezone();
   const scatterRef = React.useRef<ScatterChartHandle>(null);
   const [x, setX] = React.useState<[number, number]>([range[0], range[1]]);
@@ -112,6 +121,7 @@ export const ScatterChartStatic = ({
             `${BASE_PATH}${getTransactionListPath(
               application,
               searchParameters,
+              serviceNameForLink,
             )}&${getTransactionListQueryString({
               ...data,
               checkedLegends,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
@@ -274,10 +274,12 @@ export const ServerMapChartsBoardFetcher = ({
                       {chartType === 'scatter' ? (
                         <ScatterChart
                           node={(serverMapCurrentTarget || application) as CurrentTarget}
+                          configuration={configuration}
                         />
                       ) : (
                         <Heatmap
                           nodeData={(currentTargetData as GetServerMap.NodeData) || application}
+                          configuration={configuration}
                         />
                       )}
                     </div>
@@ -346,6 +348,7 @@ export const ServerMapChartsBoardFetcher = ({
                     }
                     range={[dateRange.from.getTime(), dateRange.to.getTime()]}
                     selectedAgentId={currentServer?.agentId || ''}
+                    configuration={configuration}
                   />
                   {isScatterDataOutdated && (
                     <div className="absolute top-0 left-0 z-[1000] flex flex-col items-center justify-center w-full h-[calc(100%+48px)] bg-background/50 text-center">

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
@@ -475,7 +475,7 @@ const MethodCell = (props: {
   rowData: TransactionInfo.CallStackKeyValueMap;
   onClickDetailView: CallTreeTableColumnsProps['onClickDetailView'];
 }) => {
-  const { application, transactionInfo, pathname, searchParameters } =
+  const { application, transactionInfo, pathname, searchParameters, serviceName } =
     useTransactionSearchParameters();
   const setCallTreeFocusId = useSetAtom(transactionInfoCallTreeFocusId);
   const { metaData, rowData, onClickDetailView } = props;
@@ -536,6 +536,7 @@ const MethodCell = (props: {
         const linkPath = buildOtelLinkPath(otelLink, application, {
           pathname,
           searchParameters,
+          serviceName,
         });
         return (
           <>
@@ -633,6 +634,8 @@ const buildOtelLinkPath = (
   context: {
     pathname: string;
     searchParameters: Record<string, string>;
+    /** URL에 실려 있던 service 이름. transactionList에 머무를 때 다시 실어 헤더를 유지한다. */
+    serviceName?: string;
   },
 ): string => {
   const transactionInfoParams = {
@@ -650,7 +653,8 @@ const buildOtelLinkPath = (
     context.pathname === APP_PATH.TRANSACTION_LIST ||
     context.pathname.startsWith(`${APP_PATH.TRANSACTION_LIST}/`);
   if (onTransactionListPage) {
-    return `${getTransactionListPath(application)}?${convertParamsToQueryString({
+    const path = getTransactionListPath(application, undefined, context.serviceName);
+    return `${path}?${convertParamsToQueryString({
       ...context.searchParameters,
       transactionInfo: JSON.stringify(transactionInfoParams),
     })}`;
@@ -678,6 +682,9 @@ const OtelLinkTransactionListButton = ({
   const queryClient = useQueryClient();
   const toast = useReactToastifyToast();
   const [timezone] = useTimezone();
+  // 이 화면(transactionList)의 URL이 곧 service의 출처다. serviceName이 없으면 링크에도 싣지
+  // 않고, 열린 화면이 전역 선택값으로 조회한다(`resolveRequestService`).
+  const { serviceName } = useTransactionSearchParameters();
 
   const handleClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -701,10 +708,12 @@ const OtelLinkTransactionListButton = ({
     const baseTime = preferred.collectorAcceptTime;
     const from = formatInTimeZone(baseTime - 150000, timezone, SEARCH_PARAMETER_DATE_FORMAT);
     const to = formatInTimeZone(baseTime + 150000, timezone, SEARCH_PARAMETER_DATE_FORMAT);
-    const url = `${BASE_PATH}${getTransactionListPath({
-      applicationName: preferred.applicationName,
-      serviceType: preferred.serviceType,
-    })}?${convertParamsToQueryString({
+    const path = getTransactionListPath(
+      { applicationName: preferred.applicationName, serviceType: preferred.serviceType },
+      undefined,
+      serviceName,
+    );
+    const url = `${BASE_PATH}${path}?${convertParamsToQueryString({
       from,
       to,
       traceInfo: traceId,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
@@ -634,7 +634,7 @@ const buildOtelLinkPath = (
   context: {
     pathname: string;
     searchParameters: Record<string, string>;
-    /** URL에 실려 있던 service 이름. transactionList에 머무를 때 다시 실어 헤더를 유지한다. */
+    /** URL에 실려 있던 service 이름. 어느 화면으로 가든 다시 실어 헤더를 유지한다. */
     serviceName?: string;
   },
 ): string => {
@@ -660,9 +660,8 @@ const buildOtelLinkPath = (
     })}`;
   }
 
-  return `${getTransactionDetailPath(application)}?${getTransactionDetailQueryString(
-    transactionInfoParams,
-  )}`;
+  const path = getTransactionDetailPath(application, undefined, context.serviceName);
+  return `${path}?${getTransactionDetailQueryString(transactionInfoParams)}`;
 };
 
 /**

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-info/TransactionInfoFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-info/TransactionInfoFetcher.tsx
@@ -31,7 +31,9 @@ const tabList = [
 
 export const TransactionInfoFetcher = ({ disableHeader }: TransactionInfoFetcherProps) => {
   const navigate = useNavigate();
-  const { application, transactionInfo } = useTransactionSearchParameters();
+  // URL에 실려 있던 service 이름. 새 탭/같은 탭으로 여는 transactionDetail에 다시 실어야
+  // pServiceName 헤더가 유지된다(`resolveRequestService`).
+  const { application, transactionInfo, serviceName } = useTransactionSearchParameters();
   const { data, tableData, mapData } = useGetTransactionInfo();
   const setTransactionInfo = useSetAtom(transactionInfoDatasAtom);
   const [currentTab, setCurrentTab] = useAtom(transactionInfoCurrentTabId);
@@ -44,10 +46,11 @@ export const TransactionInfoFetcher = ({ disableHeader }: TransactionInfoFetcher
     if (data && data.spanId === -1 && !application) {
       const applicationName = data.applicationName;
       const serviceType = data.serviceType;
-      const navigatePath = `${getTransactionDetailPath({
-        applicationName,
-        serviceType,
-      })}?${getTransactionDetailQueryString({
+      const navigatePath = `${getTransactionDetailPath(
+        { applicationName, serviceType },
+        undefined,
+        serviceName,
+      )}?${getTransactionDetailQueryString({
         agentId: data.agentId,
         traceId: data.transactionId,
         spanId: transactionInfo.spanId,
@@ -87,10 +90,9 @@ export const TransactionInfoFetcher = ({ disableHeader }: TransactionInfoFetcher
               className="ml-auto w-8 h-8 text-base text-muted-foreground py-0.5 px-1"
               variant="ghost"
               onClick={() => {
+                const path = getTransactionDetailPath(application, undefined, serviceName);
                 window.open(
-                  `${BASE_PATH}${getTransactionDetailPath(
-                    application,
-                  )}?${getTransactionDetailQueryString({
+                  `${BASE_PATH}${path}?${getTransactionDetailQueryString({
                     agentId: data.agentId,
                     traceId: data.transactionId,
                     spanId: transactionInfo.spanId,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListByTrace.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListByTrace.tsx
@@ -18,7 +18,8 @@ export interface TransactionListByTraceProps extends TransactionListTableProps {
  */
 export const TransactionListByTrace = (props: TransactionListByTraceProps) => {
   const navigate = useNavigate();
-  const { application, searchParameters, traceInfo } = useTransactionSearchParameters();
+  const { application, searchParameters, traceInfo, serviceName } =
+    useTransactionSearchParameters();
   const setCallTreeFocusId = useSetAtom(transactionInfoCallTreeFocusId);
   const { data } = useGetTransactionTraceMetadata({ traceId: traceInfo });
 
@@ -29,8 +30,10 @@ export const TransactionListByTrace = (props: TransactionListByTraceProps) => {
         setCallTreeFocusId('');
 
         const rowData = row.original;
+        // serviceName을 다시 실어야 화면 안에서 이동해도 pServiceName 헤더가 유지된다.
+        const path = getTransactionListPath(application, undefined, serviceName);
         navigate(
-          `${getTransactionListPath(application)}?${convertParamsToQueryString({
+          `${path}?${convertParamsToQueryString({
             from: searchParameters.from,
             to: searchParameters.to,
             traceInfo,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListTable.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListTable.tsx
@@ -18,7 +18,7 @@ export interface TransactionListTableProps
 
 export const TransactionListTable = ({ data, ...props }: TransactionListTableProps) => {
   const navigate = useNavigate();
-  const { transactionInfo, searchParameters, application, withFilter } =
+  const { transactionInfo, searchParameters, application, withFilter, serviceName } =
     useTransactionSearchParameters();
   const [timezone] = useTimezone();
   const setCallTreeFocusId = useSetAtom(transactionInfoCallTreeFocusId);
@@ -53,8 +53,10 @@ export const TransactionListTable = ({ data, ...props }: TransactionListTablePro
         setCallTreeFocusId('');
 
         const rowData = row.original;
+        // serviceName을 다시 실어야 화면 안에서 이동해도 pServiceName 헤더가 유지된다.
+        const path = getTransactionListPath(application, undefined, serviceName);
         navigate(
-          `${getTransactionListPath(application)}?${convertParamsToQueryString({
+          `${path}?${convertParamsToQueryString({
             from: searchParameters.from,
             to: searchParameters.to,
             dragInfo: searchParameters.dragInfo,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListTable.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListTable.tsx
@@ -23,7 +23,7 @@ export const TransactionListTable = ({ data, ...props }: TransactionListTablePro
   const [timezone] = useTimezone();
   const setCallTreeFocusId = useSetAtom(transactionInfoCallTreeFocusId);
 
-  const columns = transactionListTableColumns(application, timezone);
+  const columns = transactionListTableColumns(application, timezone, serviceName);
 
   return (
     <VirtualizedDataTable

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/transactionListTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/transactionListTableColumns.tsx
@@ -12,6 +12,8 @@ import {
 export const transactionListTableColumns = (
   application: ApplicationType | null,
   timezone: string,
+  /** URL에 실려 있던 service 이름. 새 탭으로 여는 transactionDetail에 다시 실어 헤더를 유지한다. */
+  serviceName?: string,
 ): ColumnDef<Transaction>[] => [
   {
     accessorKey: 'index',
@@ -52,10 +54,9 @@ export const transactionListTableColumns = (
             variant="ghost"
             onClick={(e) => {
               e.stopPropagation();
+              const path = getTransactionDetailPath(application, undefined, serviceName);
               window.open(
-                `${BASE_PATH}${getTransactionDetailPath(
-                  application,
-                )}?${getTransactionDetailQueryString({
+                `${BASE_PATH}${path}?${getTransactionDetailQueryString({
                   agentId: data.agentId,
                   spanId: data.spanId,
                   traceId: data.traceId,

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.test.tsx
@@ -81,30 +81,27 @@ describe('serviceScopedQueryKeyHashFn', () => {
     expect(hashOfA).not.toBe(hashOfB);
   });
 
-  test('hashes the servermap(service-excluded) path as the default service', () => {
-    store.set(selectedServiceAtom, 'DEFAULT');
-    const hashOfDefaultService = serviceScopedQueryKeyHashFn(['/api/agents/search-application']);
-
+  test('hashes the servermap path the same as any other page', () => {
+    // ServerMap도 service 예외가 아니므로, 같은 service라면 페이지가 달라도 같은 캐시를 쓴다.
     store.set(selectedServiceAtom, 'service-a');
+    const hashOnServiceMap = serviceScopedQueryKeyHashFn(['/api/agents/search-application']);
+
     window.history.replaceState({}, '', '/serverMap/app-name@TOMCAT');
 
-    // servermap은 헤더를 생략해 기본 service로 응답받으므로 기본 service 캐시를 써야 한다.
-    expect(serviceScopedQueryKeyHashFn(['/api/agents/search-application'])).toBe(
-      hashOfDefaultService,
-    );
+    expect(serviceScopedQueryKeyHashFn(['/api/agents/search-application'])).toBe(hashOnServiceMap);
   });
 
   test.each([END_POINTS.CONFIGURATION, END_POINTS.SERVICES, END_POINTS.SERVER_TIME])(
     'does not scope %s by service',
     (endPoint) => {
-      // configuration이 service별로 나뉘면 servermap ↔ servicemap 이동마다 다시 로딩되고,
+      // configuration이 service별로 나뉘면 service를 바꿀 때마다 다시 로딩되고,
       // 그동안 InitialFetchOutlet이 자식을 렌더하지 않아 화면이 사라진다.
       store.set(selectedServiceAtom, 'service-a');
-      const hashOnServiceMap = serviceScopedQueryKeyHashFn([endPoint]);
+      const hashOnServiceA = serviceScopedQueryKeyHashFn([endPoint]);
 
-      window.history.replaceState({}, '', '/serverMap/app-name@TOMCAT');
+      store.set(selectedServiceAtom, 'service-b');
 
-      expect(serviceScopedQueryKeyHashFn([endPoint])).toBe(hashOnServiceMap);
+      expect(serviceScopedQueryKeyHashFn([endPoint])).toBe(hashOnServiceA);
     },
   );
 
@@ -117,14 +114,14 @@ describe('serviceScopedQueryKeyHashFn', () => {
     store.set(selectedServiceAtom, 'service-a');
     client.setQueryData(queryKey, 'service-a-data');
 
-    // 같은 queryKey지만 servermap으로 이동하면 기본 service 캐시를 보므로 비어 있어야 한다.
-    window.history.replaceState({}, '', '/serverMap/app-name@TOMCAT');
+    // 같은 queryKey지만 다른 service에서는 캐시가 비어 있어야 한다.
+    store.set(selectedServiceAtom, 'service-b');
     expect(client.getQueryData(queryKey)).toBeUndefined();
 
-    client.setQueryData(queryKey, 'default-service-data');
-    expect(client.getQueryData(queryKey)).toBe('default-service-data');
+    client.setQueryData(queryKey, 'service-b-data');
+    expect(client.getQueryData(queryKey)).toBe('service-b-data');
 
-    window.history.replaceState({}, '', '/serviceMap/app-name@TOMCAT');
+    store.set(selectedServiceAtom, 'service-a');
     expect(client.getQueryData(queryKey)).toBe('service-a-data');
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.tsx
@@ -118,7 +118,7 @@ const queryCache = new QueryCache({
 
 /**
  * service와 무관하게 항상 같은 응답을 주는 엔드포인트. 이들까지 service별로 분리하면
- * servermap ↔ servicemap 이동마다 불필요한 재요청이 생기고, configuration은 특히
+ * service를 바꿀 때마다 불필요한 재요청이 생기고, configuration은 특히
  * `InitialFetchOutlet`이 로드되기 전까지 자식을 렌더하지 않으므로 화면이 잠깐 사라진다.
  * queryKey의 첫 요소가 엔드포인트라는 이 저장소의 관례를 이용해 한 곳에서 예외를 관리한다.
  */
@@ -132,8 +132,8 @@ const SERVICE_AGNOSTIC_ENDPOINTS: string[] = [
  * 위 예외를 제외한 모든 쿼리 캐시를 "그 요청이 해석되는 service" 단위로 분리한다.
  *
  * pServiceName 헤더는 fetch 인터셉터가 붙이기 때문에 queryKey에 드러나지 않는다. 그래서
- * service가 다른 두 요청이 같은 캐시 엔트리를 공유했고, staleTime(3초) 안에 servermap ↔
- * servicemap을 이동하면 재요청 없이 이전 service의 데이터가 그대로 표시됐다.
+ * service가 다른 두 요청이 같은 캐시 엔트리를 공유했고, staleTime(3초) 안에 service를 바꾸면
+ * 재요청 없이 이전 service의 데이터가 그대로 표시됐다.
  * 헤더와 동일한 규칙(`getRequestService`)으로 파생한 service를 해시에만 덧붙여 이를 막는다.
  *
  * queryKey 배열 자체는 그대로 두므로 `invalidateQueries`/`removeQueries`의 부분 매칭

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
@@ -4,7 +4,6 @@ import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import {
   getRequestService,
   installServiceNameFetchInterceptor,
-  isServiceExcludedPath,
   resolveRequestService,
   SERVICE_NAME_HEADER,
 } from './serviceNameFetchInterceptor';
@@ -90,15 +89,40 @@ describe('serviceNameFetchInterceptor', () => {
     expect(init?.method).toBe('POST');
   });
 
-  test('does not add the header on the servermap page, even for a shared API', async () => {
+  test.each([
+    ['/serverMap/app-name@TOMCAT?from=1&to=2'],
+    ['/serverMap/realtime/app-name@TOMCAT'],
+    ['/serviceMap/app-name@TOMCAT?from=1&to=2'],
+    ['/inspector/app-name@TOMCAT'],
+    ['/config/general'],
+  ])('adds the header on every page when enableServiceMap is on: %s', async (pathname) => {
     store.set(configurationAtom, configWithServiceMap(true));
     store.set(selectedServiceAtom, 'my-service');
-    window.history.replaceState({}, '', '/serverMap/app-name@TOMCAT?from=1&to=2');
+    window.history.replaceState({}, '', pathname);
 
     await window.fetch('/api/agents/search-application');
 
-    expect(originalFetch).toHaveBeenCalledTimes(1);
-    expect(headerOfLastCall()).toBeNull();
+    expect(headerOfLastCall()).toBe('my-service');
+  });
+
+  test('sends the service name carried by the transactionList path, not the selected one', async () => {
+    store.set(configurationAtom, configWithServiceMap(true));
+    store.set(selectedServiceAtom, 'my-service');
+    window.history.replaceState({}, '', '/transactionList/url-service@app-name@TOMCAT?from=1&to=2');
+
+    await window.fetch('/api/transactionmetadata');
+
+    expect(headerOfLastCall()).toBe('url-service');
+  });
+
+  test('falls back to the selected service on a legacy transactionList path', async () => {
+    store.set(configurationAtom, configWithServiceMap(true));
+    store.set(selectedServiceAtom, 'my-service');
+    window.history.replaceState({}, '', '/transactionList/app-name@TOMCAT?from=1&to=2');
+
+    await window.fetch('/api/transactionmetadata');
+
+    expect(headerOfLastCall()).toBe('my-service');
   });
 
   describe('resolveRequestService', () => {
@@ -108,11 +132,24 @@ describe('serviceNameFetchInterceptor', () => {
       expect(resolveRequestService('my-service')).toBe('my-service');
     });
 
-    test('resolves to the default service on the servermap page', () => {
-      // 헤더를 생략해 백엔드 기본 service로 응답받으므로, 캐시도 기본 service로 키를 잡아야 한다.
+    test('prefers the service name carried by the path', () => {
+      // 헤더와 캐시 키가 같은 값에서 파생되도록, URL에 실린 serviceName을 전역 선택값보다 앞세운다.
+      window.history.replaceState({}, '', '/transactionList/url-service@app-name@TOMCAT');
+
+      expect(resolveRequestService('my-service')).toBe('url-service');
+    });
+
+    test('ignores the leading segment on paths that do not carry a service name', () => {
+      window.history.replaceState({}, '', '/inspector/svc@app-name@TOMCAT');
+
+      expect(resolveRequestService('my-service')).toBe('my-service');
+    });
+
+    test('resolves to the selected service on the servermap page too', () => {
+      // ServerMap도 예외가 아니다. 헤더가 선택된 service로 나가므로 캐시 키도 같아야 한다.
       window.history.replaceState({}, '', '/serverMap/app-name@TOMCAT');
 
-      expect(resolveRequestService('my-service')).toBe('DEFAULT');
+      expect(resolveRequestService('my-service')).toBe('my-service');
     });
 
     test('getRequestService reads the currently selected service from the store', () => {
@@ -121,19 +158,7 @@ describe('serviceNameFetchInterceptor', () => {
       expect(getRequestService()).toBe('my-service');
 
       window.history.replaceState({}, '', '/serverMap/app-name@TOMCAT');
-      expect(getRequestService()).toBe('DEFAULT');
-    });
-  });
-
-  describe('isServiceExcludedPath', () => {
-    test.each([
-      ['/serverMap', true],
-      ['/serverMap/app-name@TOMCAT', true],
-      ['/serverMap/realtime/app-name@TOMCAT', true],
-      ['/serviceMap/app-name@TOMCAT', false],
-      ['/inspector', false],
-    ])('returns %p → %p', (pathname, expected) => {
-      expect(isServiceExcludedPath(pathname)).toBe(expected);
+      expect(getRequestService()).toBe('my-service');
     });
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
@@ -1,6 +1,7 @@
 import { getDefaultStore } from 'jotai';
-import { DEFAULT_SERVICE, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
-import { APP_PATH, BASE_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+import { BASE_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';
 
 /**
  * 백엔드(service-module)의 `ServiceConstants.KEY`와 동일한 헤더 이름.
@@ -18,24 +19,19 @@ const toRouterPath = (pathname: string) =>
   BASE_PATH && pathname.startsWith(BASE_PATH) ? pathname.slice(BASE_PATH.length) : pathname;
 
 /**
- * service 개념에서 제외되는 경로. enableServiceMap이 켜져 있으면 service 헤더를 붙이는 것이
- * 기본이고, ServerMap만 예외적으로 제외한다. ServerMap은 service 개념이 도입되기 전의
- * 화면이라 다른 페이지와 같은 API를 쓰더라도 헤더 없이 보내 기본 service로 조회해야 한다.
- * 추후 ServiceMap이 ServerMap을 대체하면 이 함수와 호출부를 함께 지우면 된다.
- */
-export const isServiceExcludedPath = (pathname: string = window.location.pathname) =>
-  toRouterPath(pathname).startsWith(APP_PATH.SERVER_MAP);
-
-/**
- * 이 요청이 실제로 어떤 service로 해석되는지 반환한다. 제외 경로에서는 헤더를 생략해
- * 백엔드가 기본 service로 해석하므로 `DEFAULT_SERVICE`다.
+ * 이 요청이 실제로 어떤 service로 해석되는지 반환한다. enableServiceMap이 켜져 있으면
+ * 예외 없이 모든 화면(ServerMap 포함)이 선택된 service 범위에서 조회된다.
+ *
+ * transactionList처럼 URL에 serviceName이 실리는 화면(`hasServiceNameInPath`)은 새 탭으로
+ * 열리므로, 전역 선택값(`selectedServiceAtom`)보다 URL의 serviceName을 우선한다. 전역 선택값은
+ * 탭 간 공유 저장소라서 링크를 연 뒤 원래 탭에서 service를 바꾸면 화면과 어긋날 수 있다.
  *
  * 요청 헤더(아래 인터셉터)와 캐시 키(reactQueryHelper의 `serviceScopedQueryKeyHashFn`)는
  * 반드시 같은 규칙에서 파생되어야 한다. 서로 다른 규칙을 쓰면 헤더는 A service로 나가는데
  * 캐시는 B service 키에 쌓여 다른 service의 데이터가 섞인다.
  */
 export const resolveRequestService = (selectedService: string) =>
-  isServiceExcludedPath() ? DEFAULT_SERVICE : selectedService;
+  getServiceNameFromPath(toRouterPath(window.location.pathname)) || selectedService;
 
 /** `resolveRequestService`를 현재 선택된 service에 적용한 값. 렌더 밖(모듈 레벨)에서 쓴다. */
 export const getRequestService = () =>
@@ -65,8 +61,8 @@ let installed = false;
 /**
  * 전역 `fetch`를 한 번 래핑하여, configuration의
  * `experimental.enableServiceMap.value`가 true일 때 백엔드로 가는 모든
- * `/api` 요청 헤더에 현재 선택된 service(`selectedServiceAtom`)를 주입한다.
- * 단, `isServiceExcludedPath`에 해당하는 경로에서는 예외적으로 주입하지 않는다.
+ * `/api` 요청 헤더에 그 요청이 해석되는 service(`resolveRequestService`)를 주입한다.
+ * 화면별 예외는 없다. 설정이 꺼져 있으면 헤더를 아예 붙이지 않아 백엔드가 기본 service로 해석한다.
  *
  * configuration은 부트스트랩 이후 비동기로 로드/갱신되므로, 값이 아니라
  * 매 요청 시 최신 configuration을 반환하는 getter(`getConfiguration`)를 받는다.
@@ -92,8 +88,9 @@ export const installServiceNameFetchInterceptor = (
       const configuration = getConfiguration();
       const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
 
-      if (enableServiceMap && isApiRequest(input) && !isServiceExcludedPath()) {
-        const selectedService = store.get(selectedServiceAtom);
+      if (enableServiceMap && isApiRequest(input)) {
+        // 캐시 키와 어긋나지 않도록 헤더도 `resolveRequestService`와 같은 규칙에서 파생한다.
+        const selectedService = resolveRequestService(store.get(selectedServiceAtom));
 
         if (selectedService) {
           const headers = new Headers(

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.test.tsx
@@ -119,12 +119,12 @@ describe('useGetApplicationList', () => {
     await waitFor(() => expect(result.current.data).toEqual([{ applicationName: 'B' }]));
   });
 
-  test('caches under the default service on service-excluded paths', async () => {
-    // 헤더가 빠지면 응답은 기본 service의 목록이므로, 선택된 service 캐시를 덮어써선 안 된다.
+  test('caches under the selected service, servermap included', async () => {
+    // ServerMap도 예외가 아니라 선택된 service로 조회되므로, 그 service 캐시/ETag를 써야 한다.
     window.history.replaceState({}, '', '/serverMap/app-name@TOMCAT');
     getDefaultStore().set(selectedServiceAtom, 'service-b');
     (global.fetch as jest.Mock)
-      .mockResolvedValueOnce(okResponse([{ applicationName: 'A' }], 'etag-default'))
+      .mockResolvedValueOnce(okResponse([{ applicationName: 'A' }], 'etag-b'))
       .mockResolvedValueOnce({ status: 304 });
     mockGetQueryData.mockReturnValue([{ applicationName: 'A' }]);
 
@@ -136,6 +136,6 @@ describe('useGetApplicationList', () => {
     });
 
     await waitFor(() => expect(mockGetQueryData).toHaveBeenCalled());
-    expect(mockGetQueryData).toHaveBeenCalledWith([END_POINTS.APPLICATION_LIST, DEFAULT_SERVICE]);
+    expect(mockGetQueryData).toHaveBeenCalledWith([END_POINTS.APPLICATION_LIST, 'service-b']);
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useTransactionSearchParameters.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useTransactionSearchParameters.test.tsx
@@ -32,15 +32,43 @@ describe('useTransactionSearchParameters', () => {
     expect(application).toEqual({ applicationName: 'test-app', serviceType: 'SPRING_BOOT' });
   });
 
-  test('does not split a service name off paths that never carry one', () => {
-    // transactionDetail은 serviceName을 싣지 않으므로, '@'가 든 applicationName이
-    // service/application으로 쪼개지면 안 된다.
+  test('splits the service name off a transactionDetail path too', () => {
+    // transactionList의 외부 링크로 새 탭에서 열리므로 transactionDetail도 serviceName을 싣는다.
     const { application, serviceName } = renderTransactionSearchParameters(
-      '/transactionDetail/test@app@SPRING_BOOT',
+      '/transactionDetail/my-service@test-app@SPRING_BOOT',
+    );
+
+    expect(serviceName).toBe('my-service');
+    expect(application).toEqual({ applicationName: 'test-app', serviceType: 'SPRING_BOOT' });
+  });
+
+  test('keeps a legacy transactionDetail path resolving without a service name', () => {
+    const { application, serviceName } = renderTransactionSearchParameters(
+      '/transactionDetail/test-app@SPRING_BOOT',
+    );
+
+    expect(serviceName).toBeUndefined();
+    expect(application).toEqual({ applicationName: 'test-app', serviceType: 'SPRING_BOOT' });
+  });
+
+  test('does not split a service name off paths that never carry one', () => {
+    // serviceName 분리는 `SERVICE_NAME_IN_PATH_PAGES`에 등록된 경로에서만 해야 한다. 그 외에는
+    // '@'가 든 applicationName이 service/application으로 쪼개지면 안 된다.
+    const { application, serviceName } = renderTransactionSearchParameters(
+      '/serverMap/test@app@SPRING_BOOT',
     );
 
     expect(serviceName).toBeUndefined();
     expect(application).toEqual({ applicationName: 'test@app', serviceType: 'SPRING_BOOT' });
+  });
+
+  test('decodes an encoded service name from the path', () => {
+    const { application, serviceName } = renderTransactionSearchParameters(
+      '/transactionList/a%2Fb@test-app@SPRING_BOOT',
+    );
+
+    expect(serviceName).toBe('a/b');
+    expect(application).toEqual({ applicationName: 'test-app', serviceType: 'SPRING_BOOT' });
   });
 
   test('returns no application when the path has no application segment', () => {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useTransactionSearchParameters.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useTransactionSearchParameters.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react';
+import { useTransactionSearchParameters } from './useTransactionSearchParameters';
+
+const mockLocation = { pathname: '', search: '' };
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => mockLocation,
+}));
+
+const renderTransactionSearchParameters = (pathname: string, search = '') => {
+  mockLocation.pathname = pathname;
+  mockLocation.search = search;
+  return renderHook(() => useTransactionSearchParameters()).result.current;
+};
+
+describe('useTransactionSearchParameters', () => {
+  test('splits the service name off a transactionList path that carries one', () => {
+    const { application, serviceName } = renderTransactionSearchParameters(
+      '/transactionList/my-service@test-app@SPRING_BOOT',
+    );
+
+    expect(serviceName).toBe('my-service');
+    expect(application).toEqual({ applicationName: 'test-app', serviceType: 'SPRING_BOOT' });
+  });
+
+  test('keeps a legacy transactionList path resolving without a service name', () => {
+    const { application, serviceName } = renderTransactionSearchParameters(
+      '/transactionList/test-app@SPRING_BOOT',
+    );
+
+    expect(serviceName).toBeUndefined();
+    expect(application).toEqual({ applicationName: 'test-app', serviceType: 'SPRING_BOOT' });
+  });
+
+  test('does not split a service name off paths that never carry one', () => {
+    // transactionDetail은 serviceName을 싣지 않으므로, '@'가 든 applicationName이
+    // service/application으로 쪼개지면 안 된다.
+    const { application, serviceName } = renderTransactionSearchParameters(
+      '/transactionDetail/test@app@SPRING_BOOT',
+    );
+
+    expect(serviceName).toBeUndefined();
+    expect(application).toEqual({ applicationName: 'test@app', serviceType: 'SPRING_BOOT' });
+  });
+
+  test('returns no application when the path has no application segment', () => {
+    const { application, serviceName } = renderTransactionSearchParameters('/transactionList');
+
+    expect(application).toBeNull();
+    expect(serviceName).toBeUndefined();
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useTransactionSearchParameters.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useTransactionSearchParameters.ts
@@ -1,8 +1,17 @@
+import {
+  getApplicationTypeAndNameFromPath,
+  getServiceNameFromPath,
+} from '@pinpoint-fe/ui/src/utils';
 import { useSearchParameters } from './useSearchParameters';
 import { getDateRange } from './utils';
 
 export const useTransactionSearchParameters = () => {
   const props = useSearchParameters();
+  // transactionList의 application 세그먼트는 `{serviceName}@{applicationName}@{serviceType}`
+  // 형태일 수 있어, 기본 파서(useSearchParameters)로는 applicationName에 serviceName이 섞인다.
+  // 이 훅은 transactionDetail에서도 쓰이므로, serviceName 분리는 그것을 싣는 경로에서만
+  // 해야 한다(`hasServiceNameInPath`). 그 외 경로에서는 기존 파싱 규칙 그대로다.
+  const parsedApplication = getApplicationTypeAndNameFromPath(props.pathname);
   const withFilter = props?.searchParameters?.withFilter === 'true' ? true : false;
   const dateRange = getDateRange(props?.search, false);
   const dragInfo = props?.searchParameters?.dragInfo;
@@ -28,6 +37,9 @@ export const useTransactionSearchParameters = () => {
   const traceInfo = props.searchParameters?.traceInfo;
   return {
     ...props,
+    application: parsedApplication,
+    /** URL에 실려 있는 service 이름. 이 화면의 모든 API가 pServiceName 헤더로 이 값을 보낸다. */
+    serviceName: getServiceNameFromPath(props.pathname),
     dateRange,
     withFilter,
     dragInfo: parseDragInfo,

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
@@ -7,6 +7,7 @@ export * from './useHeightToBottom';
 export * from './useLanguage';
 export * from './useLocalStorage';
 export * from './useServerMapLinkedData';
+export * from './useServiceNameForLink';
 export * from './useServicesFetch';
 export * from './useStoragedSetting';
 export * from './useTabFocus';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.test.tsx
@@ -5,51 +5,16 @@ import {
   searchParametersAtom,
   selectedServiceAtom,
 } from '@pinpoint-fe/ui/src/atoms';
-import { ApplicationType } from '@pinpoint-fe/ui/src/constants';
-import {
-  resolveClearedApplicationPath,
-  useClearApplicationOnServiceChange,
-} from './useClearApplicationOnServiceChange';
+import { APP_PATH, ApplicationType } from '@pinpoint-fe/ui/src/constants';
+import { useClearApplicationOnServiceChange } from './useClearApplicationOnServiceChange';
 
 const mockNavigate = jest.fn();
-const mockLocation = { pathname: '/config/serviceSetting' };
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
-  useLocation: () => mockLocation,
 }));
 
-describe('resolveClearedApplicationPath', () => {
-  test('strips the application segment on the serverMap path', () => {
-    expect(resolveClearedApplicationPath('/serverMap/test-app@SPRING_BOOT')).toBe('/serverMap');
-  });
-
-  test('strips the application segment on any page path', () => {
-    expect(resolveClearedApplicationPath('/inspector/test-app@SPRING_BOOT')).toBe('/inspector');
-  });
-
-  test('handles the `^` separated application key form', () => {
-    expect(resolveClearedApplicationPath('/serverMap/test-app^SPRING_BOOT')).toBe('/serverMap');
-  });
-
-  test('keeps the basename prefix', () => {
-    expect(resolveClearedApplicationPath('/base/serverMap/test-app@SPRING_BOOT')).toBe(
-      '/base/serverMap',
-    );
-  });
-
-  test('returns null when there is no application segment', () => {
-    expect(resolveClearedApplicationPath('/serverMap')).toBeNull();
-    expect(resolveClearedApplicationPath('/config/general')).toBeNull();
-  });
-
-  test('falls back to root when stripping leaves an empty path', () => {
-    expect(resolveClearedApplicationPath('test-app@SPRING_BOOT')).toBe('/');
-  });
-});
-
-// 리다이렉트 경로 계산은 위 resolveClearedApplicationPath 테스트가 커버한다.
-// 여기서는 관측 가능한 부분(searchParametersAtom의 application 무효화, soft navigate 호출)과
+// 관측 가능한 부분(searchParametersAtom의 application 무효화, servicemap으로의 soft navigate)과
 // 게이팅 동작을 검증한다.
 describe('useClearApplicationOnServiceChange', () => {
   const store = getDefaultStore();
@@ -63,7 +28,6 @@ describe('useClearApplicationOnServiceChange', () => {
 
   beforeEach(() => {
     mockNavigate.mockClear();
-    mockLocation.pathname = '/config/serviceSetting';
     act(() => {
       store.set(selectedServiceAtom, DEFAULT_SERVICE);
       store.set(searchParametersAtom, { application: APP, searchParameters: {} });
@@ -99,19 +63,31 @@ describe('useClearApplicationOnServiceChange', () => {
     expect(store.get(searchParametersAtom).application).toEqual(APP);
   });
 
-  test('soft-navigates to the cleared path when an application is in the URL', () => {
-    mockLocation.pathname = '/serverMap/old-app@SPRING_BOOT';
+  test('soft-navigates to the servicemap without an application segment', () => {
     renderClearHook(true);
     act(() => {
       store.set(selectedServiceAtom, 'svc-a');
     });
-    expect(mockNavigate).toHaveBeenCalledWith('/serverMap', { replace: true });
+    expect(mockNavigate).toHaveBeenCalledWith(APP_PATH.SERVICE_MAP, { replace: true });
   });
 
-  test('does not navigate when there is no application in the URL', () => {
+  test('does not navigate on initial mount', () => {
     renderClearHook(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  test('does not navigate when disabled', () => {
+    renderClearHook(false);
     act(() => {
       store.set(selectedServiceAtom, 'svc-a');
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  test('does not navigate when the service value is set but unchanged', () => {
+    renderClearHook(true);
+    act(() => {
+      store.set(selectedServiceAtom, DEFAULT_SERVICE);
     });
     expect(mockNavigate).not.toHaveBeenCalled();
   });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.ts
@@ -1,43 +1,31 @@
 import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { searchParametersAtom, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
-import { ApplicationType } from '@pinpoint-fe/ui/src/constants';
-import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
+import { APP_PATH, ApplicationType } from '@pinpoint-fe/ui/src/constants';
 
 /**
- * 주어진 pathname에서 application 세그먼트를 떼어낸 base 경로를 반환한다.
- * pathname에 application이 없으면 null을 반환한다(리다이렉트 불필요).
- *
- * application 세그먼트는 항상 경로의 마지막 세그먼트다. getApplicationTypeAndName으로
- * 존재를 확인한 뒤 마지막 세그먼트만 떼어내므로, 세그먼트 형식 정규식을 여기서
- * 중복 정의하지 않는다(파싱 규칙이 바뀌어도 어긋날 일이 없다).
- * 마지막 세그먼트만 제거하므로, 넘긴 pathname에 접두사(basename 등)가 있으면 그대로 유지된다.
- */
-export const resolveClearedApplicationPath = (pathname: string): string | null => {
-  if (!getApplicationTypeAndName(pathname)) return null;
-  return pathname.split('/').slice(0, -1).join('/') || '/';
-};
-
-/**
- * selectedService(선택된 서비스)가 바뀌면 이전 서비스에서 고른 application 선택을 무효화한다.
- * 서비스마다 application 목록이 다르므로 이전 선택을 유지하면 안 된다.
+ * selectedService(선택된 서비스)가 바뀌면 이전 서비스에서 고른 application 선택을 무효화하고
+ * 새 서비스의 servicemap으로 이동한다. 서비스마다 application 목록이 다르므로 이전 선택을
+ * 유지하면 안 되고, 서비스를 바꿨다는 것은 그 서비스를 보겠다는 뜻이므로 시작 화면으로 보낸다.
  *
  * 1) searchParametersAtom의 application을 비운다. 사이드바 네비게이션(useMenuItems)이
  *    이 아톰의 application으로 각 페이지 링크를 만들기 때문에, 비우지 않으면 config 등
  *    다른 페이지에서 servermap으로 돌아갈 때 이전 application이 그대로 복원된다.
- * 2) 현재 URL에 application이 있으면 그 세그먼트를 떼어낸 base 경로로 soft navigate 한다.
- *    react-router `navigate`는 basename을 자동으로 붙이므로, basename이 제거된
- *    라우터 pathname(useLocation)을 기준으로 경로를 계산한다.
+ * 2) application 세그먼트가 없는 `/serviceMap`으로 soft navigate 한다. react-router
+ *    `navigate`는 basename을 자동으로 붙이므로 APP_PATH를 그대로 넘기면 된다.
  *    (하드 리다이렉트가 아니므로 React Query 캐시와 ETag 캐시가 유지된다.)
+ *    query string(?from=...&to=...)은 굳이 유지하지 않는다. application이 없는 경로에서는
+ *    지도가 렌더링되지 않고, 사용자가 새 application을 고르는 순간 라우트 로더가
+ *    기본 시간 범위를 채워주기 때문이다.
  *
- * enabled(enableServiceMap)가 아니면 아무 것도 하지 않는다.
+ * enabled(enableServiceMap)가 아니면 아무 것도 하지 않는다. servicemap 자체가
+ * 그 설정이 켜져 있을 때만 존재하는 화면이다.
  */
 export const useClearApplicationOnServiceChange = (enabled: boolean) => {
   const selectedService = useAtomValue(selectedServiceAtom);
   const setSearchParameters = useSetAtom(searchParametersAtom);
   const navigate = useNavigate();
-  const { pathname } = useLocation();
   const prevSelectedServiceRef = React.useRef(selectedService);
 
   React.useEffect(() => {
@@ -48,11 +36,6 @@ export const useClearApplicationOnServiceChange = (enabled: boolean) => {
     // 저장된 application 무효화 → 네비게이션 링크가 base 경로로 바뀐다.
     setSearchParameters((prev) => ({ ...prev, application: {} as ApplicationType }));
 
-    // 현재 URL에 application이 있으면 base 경로로 soft navigate.
-    // query string(?from=...&to=...)은 굳이 유지하지 않는다. application이 비워진
-    // 중간 상태에서는 지도가 렌더링되지 않고, 사용자가 새 application을 고르는 순간
-    // from/to 없는 경로로 이동해 어차피 기본 시간 범위로 리셋되기 때문이다.
-    const target = resolveClearedApplicationPath(pathname);
-    if (target) navigate(target, { replace: true });
-  }, [selectedService, enabled, setSearchParameters, navigate, pathname]);
+    navigate(APP_PATH.SERVICE_MAP, { replace: true });
+  }, [selectedService, enabled, setSearchParameters, navigate]);
 };

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook, act } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration } from '@pinpoint-fe/ui/src/constants';
+import { useServiceNameForLink } from './useServiceNameForLink';
+
+const mockLocation = { pathname: '/serviceMap/test-app@SPRING_BOOT' };
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => mockLocation,
+}));
+
+const store = getDefaultStore();
+
+const configWithServiceMap = (enable: boolean) =>
+  ({ 'experimental.enableServiceMap.value': enable }) as unknown as Configuration;
+
+const renderServiceNameForLink = (pathname: string, configuration?: Configuration) => {
+  mockLocation.pathname = pathname;
+  return renderHook(() => useServiceNameForLink(configuration)).result.current;
+};
+
+describe('useServiceNameForLink', () => {
+  beforeEach(() => {
+    act(() => {
+      store.set(selectedServiceAtom, 'my-service');
+    });
+  });
+
+  test('returns the selected service on a service scoped page', () => {
+    expect(
+      renderServiceNameForLink('/serviceMap/test-app@SPRING_BOOT', configWithServiceMap(true)),
+    ).toBe('my-service');
+  });
+
+  test('returns undefined when enableServiceMap is off', () => {
+    expect(
+      renderServiceNameForLink('/serviceMap/test-app@SPRING_BOOT', configWithServiceMap(false)),
+    ).toBeUndefined();
+  });
+
+  test('returns undefined when no configuration is given yet', () => {
+    // configuration은 부트스트랩 이후 비동기로 로드되므로 아직 없을 수 있다.
+    expect(renderServiceNameForLink('/serviceMap/test-app@SPRING_BOOT')).toBeUndefined();
+  });
+
+  test('returns the selected service on the servermap page too', () => {
+    // ServerMap도 예외가 아니라 선택된 service 범위에서 조회된다.
+    const config = configWithServiceMap(true);
+    expect(renderServiceNameForLink('/serverMap/test-app@SPRING_BOOT', config)).toBe('my-service');
+    expect(renderServiceNameForLink('/serverMap/realtime/test-app@SPRING_BOOT', config)).toBe(
+      'my-service',
+    );
+  });
+
+  test('prefers the service name already carried by the path', () => {
+    expect(
+      renderServiceNameForLink(
+        '/transactionList/url-service@test-app@SPRING_BOOT',
+        configWithServiceMap(true),
+      ),
+    ).toBe('url-service');
+  });
+
+  test('falls back to the selected service on a legacy transactionList path', () => {
+    expect(
+      renderServiceNameForLink('/transactionList/test-app@SPRING_BOOT', configWithServiceMap(true)),
+    ).toBe('my-service');
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.ts
@@ -1,0 +1,29 @@
+import { useLocation } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
+import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration } from '@pinpoint-fe/ui/src/constants';
+import { getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';
+
+/**
+ * 다른 화면으로 넘기는 링크(`getTransactionListPath`)에 실을 service 이름.
+ * 실을 필요가 없으면 undefined를 반환하므로 링크 형태는 그대로 유지된다.
+ *
+ * configuration은 이 저장소의 관례대로 호출부에서 받는다. 페이지가 web 앱에서 받은
+ * configuration을 prop으로 내려주므로, ui 패키지가 `configurationAtom`에 직접 의존하지 않는다.
+ *
+ * 판단 규칙은 요청 헤더/캐시 키와 같은 `resolveRequestService`를 그대로 따른다.
+ * - enableServiceMap이 꺼져 있으면 service 개념 자체가 없으므로 싣지 않는다.
+ * - 켜져 있으면 화면별 예외 없이(ServerMap 포함) 현재 service를 싣는다.
+ * - 이미 URL에 serviceName이 실려 있으면(transactionList) 전역 선택값보다 그것을 우선해,
+ *   화면 안에서 이동해도 처음 열었을 때의 service가 유지된다.
+ */
+export const useServiceNameForLink = (configuration?: Configuration) => {
+  const selectedService = useAtomValue(selectedServiceAtom);
+  const { pathname } = useLocation();
+
+  if (!configuration?.['experimental.enableServiceMap.value']) {
+    return undefined;
+  }
+
+  return getServiceNameFromPath(pathname) || selectedService;
+};

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transaction.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transaction.test.ts
@@ -37,6 +37,29 @@ describe('transactionRouteLoader', () => {
     expect(result).toEqual({ applicationName: 'TestApp', serviceType: 'SPRING_BOOT' });
   });
 
+  test('splits the service name off a serviceName@applicationName@serviceType segment', async () => {
+    const application = `svc@${APP}`;
+    const result = await transactionRouteLoader(
+      makeArgs(`http://localhost${APP_PATH.TRANSACTION_LIST}/${application}?${VALID}`, {
+        application,
+      }),
+    );
+    expect(result).toEqual({
+      serviceName: 'svc',
+      applicationName: 'TestApp',
+      serviceType: 'SPRING_BOOT',
+    });
+  });
+
+  test('keeps the service name in the redirect target', async () => {
+    const application = `svc@${APP}`;
+    const result = (await transactionRouteLoader(
+      makeArgs(`http://localhost${APP_PATH.TRANSACTION_LIST}/${application}`, { application }),
+    )) as unknown as { __isRedirect: boolean; url: string };
+    expect(result.__isRedirect).toBe(true);
+    expect(result.url).toContain(`${APP_PATH.TRANSACTION_LIST}/svc@${APP}`);
+  });
+
   test('redirects to the base path with default dates when no query params exist', async () => {
     const result = (await transactionRouteLoader(
       makeArgs(`http://localhost${BASE}`, { application: APP }),

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transaction.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transaction.test.ts
@@ -60,6 +60,33 @@ describe('transactionRouteLoader', () => {
     expect(result.url).toContain(`${APP_PATH.TRANSACTION_LIST}/svc@${APP}`);
   });
 
+  // react-router는 params를 디코딩하므로 params.application에는 '%2F'가 '/'로 풀려 들어온다.
+  // 그대로 쓰면 세그먼트 경계가 어긋나고 리다이렉트 경로에 원본 '/'가 실려 라우트가 깨진다.
+  test('reads the raw segment so an encoded service name survives the redirect', async () => {
+    const encoded = `a%2Fb@${APP}`;
+    const result = (await transactionRouteLoader(
+      makeArgs(`http://localhost${APP_PATH.TRANSACTION_LIST}/${encoded}`, {
+        application: `a/b@${APP}`,
+      }),
+    )) as unknown as { __isRedirect: boolean; url: string };
+    expect(result.__isRedirect).toBe(true);
+    expect(result.url).toContain(`${APP_PATH.TRANSACTION_LIST}/a%2Fb@${APP}`);
+  });
+
+  test('decodes the encoded service name when returning the application', async () => {
+    const encoded = `a%2Fb@${APP}`;
+    const result = await transactionRouteLoader(
+      makeArgs(`http://localhost${APP_PATH.TRANSACTION_LIST}/${encoded}?${VALID}`, {
+        application: `a/b@${APP}`,
+      }),
+    );
+    expect(result).toEqual({
+      serviceName: 'a/b',
+      applicationName: 'TestApp',
+      serviceType: 'SPRING_BOOT',
+    });
+  });
+
   test('redirects to the base path with default dates when no query params exist', async () => {
     const result = (await transactionRouteLoader(
       makeArgs(`http://localhost${BASE}`, { application: APP }),

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transaction.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transaction.ts
@@ -15,9 +15,16 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const transactionRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
+  const requestUrl = new URL(request.url);
   // 세그먼트가 `{serviceName}@{applicationName}@{serviceType}`일 수 있으므로 serviceName을 분리한다.
-  // 리다이렉트 경로는 원본 세그먼트(params.application)를 그대로 쓰므로 serviceName이 유지된다.
-  const application = getServiceAndApplicationTypeAndName(params.application!);
+  //
+  // react-router의 `params`는 디코딩된 값이라 그대로 쓸 수 없다. serviceName에 인코딩된 '/'가
+  // 있으면 '%2F'가 '/'로 풀려 세그먼트 경계가 어긋나고, 아래 리다이렉트 경로에도 원본 '/'가
+  // 실려 라우트 매칭이 깨진다. 그래서 파싱과 리다이렉트 모두 인코딩된 원본 세그먼트를 쓴다.
+  const applicationSegment = params.application
+    ? requestUrl.pathname.split('/').pop()
+    : params.application;
+  const application = getServiceAndApplicationTypeAndName(applicationSegment);
 
   let configuration: Configuration | undefined;
   try {
@@ -29,8 +36,8 @@ export const transactionRouteLoader = async ({ params, request }: LoaderFunction
   const timezone = getTimezone();
 
   if (application?.applicationName && application.serviceType) {
-    const basePath = `${APP_PATH.TRANSACTION_LIST}/${params.application}`;
-    const queryParam = Object.fromEntries(new URL(request.url).searchParams);
+    const basePath = `${APP_PATH.TRANSACTION_LIST}/${applicationSegment}`;
+    const queryParam = Object.fromEntries(requestUrl.searchParams);
     const conditions = Object.keys(queryParam);
 
     const from = queryParam?.from as string;

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transaction.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transaction.ts
@@ -5,7 +5,7 @@ import {
 } from '@pinpoint-fe/ui/src/constants';
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 import {
-  getApplicationTypeAndName,
+  getServiceAndApplicationTypeAndName,
   getParsedDateRange,
   isValidDateRange,
   getTimezone,
@@ -15,7 +15,9 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const transactionRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
-  const application = getApplicationTypeAndName(params.application!);
+  // 세그먼트가 `{serviceName}@{applicationName}@{serviceType}`일 수 있으므로 serviceName을 분리한다.
+  // 리다이렉트 경로는 원본 세그먼트(params.application)를 그대로 쓰므로 serviceName이 유지된다.
+  const application = getServiceAndApplicationTypeAndName(params.application!);
 
   let configuration: Configuration | undefined;
   try {

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transactionDetail.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transactionDetail.ts
@@ -1,10 +1,13 @@
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
-import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
+import { getServiceAndApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const transactionDetailRouteLoader = ({ params, request }: LoaderFunctionArgs) => {
   try {
-    const application = getApplicationTypeAndName(params.application!);
+    // 세그먼트가 `{serviceName}@{applicationName}@{serviceType}`일 수 있으므로 serviceName을
+    // 분리한다. 리다이렉트가 세그먼트를 재사용하지 않으므로(항상 serverMap으로 보낸다)
+    // transactionRouteLoader처럼 raw 세그먼트를 다시 읽을 필요는 없다.
+    const application = getServiceAndApplicationTypeAndName(params.application!);
 
     if (application?.applicationName && application.serviceType) {
       const queryParam = Object.fromEntries(new URL(request.url).searchParams);

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ErrorAnalysis.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ErrorAnalysis.tsx
@@ -26,7 +26,11 @@ import {
   getTransactionDetailPath,
   getTransactionDetailQueryString,
 } from '@pinpoint-fe/ui/src/utils';
-import { useErrorAnalysisSearchParameters, useTimezone } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useErrorAnalysisSearchParameters,
+  useServiceNameForLink,
+  useTimezone,
+} from '@pinpoint-fe/ui/src/hooks';
 import { useTranslation } from 'react-i18next';
 import {
   ErrorAnalysisErrorList,
@@ -54,6 +58,9 @@ export const ErrorAnalysisPage = ({
   const periodInterval = configuration?.['periodInterval.exceptionTrace'];
   const navigate = useNavigate();
   const [timezone] = useTimezone();
+  // errorAnalysis 경로는 URL에 service를 싣지 않으므로, 새 탭으로 여는 transactionDetail에는
+  // 클릭 시점의 선택된 service를 실어 그 탭이 전역 선택값 변화에 흔들리지 않게 한다.
+  const serviceNameForLink = useServiceNameForLink(configuration);
   const {
     searchParameters,
     application,
@@ -169,10 +176,13 @@ export const ErrorAnalysisPage = ({
                         <div
                           className="flex items-center gap-1 truncate cursor-pointer hover:text-primary hover:underline"
                           onClick={() => {
+                            const path = getTransactionDetailPath(
+                              application,
+                              undefined,
+                              serviceNameForLink,
+                            );
                             window.open(
-                              `${BASE_PATH}${getTransactionDetailPath(
-                                application,
-                              )}?${getTransactionDetailQueryString({
+                              `${BASE_PATH}${path}?${getTransactionDetailQueryString({
                                 agentId: errorInfo.agentId,
                                 spanId: `${errorInfo.spanId}`,
                                 traceId: errorInfo.transactionId,

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ScatterOrHeatmapFullScreen.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ScatterOrHeatmapFullScreen.tsx
@@ -117,6 +117,7 @@ export const ScatterOrHeatmapFullScreenPage = ({
                 node={application}
                 realtime={isRealtime}
                 toolbarOption={{ expand: { hide: true } }}
+                configuration={configuration}
               />
             ) : (
               <Heatmap
@@ -124,6 +125,7 @@ export const ScatterOrHeatmapFullScreenPage = ({
                 agentId={agentId}
                 nodeData={application}
                 toolbarOption={{ expand: { hide: true } }}
+                configuration={configuration}
               />
             ))}
         </div>

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.test.ts
@@ -1,5 +1,12 @@
-import { getApplicationTypeAndName, getApplicationKey } from './application';
-import { ApplicationType } from '@pinpoint-fe/ui/src/constants';
+import {
+  getApplicationTypeAndName,
+  getApplicationKey,
+  getApplicationTypeAndNameFromPath,
+  getServiceAndApplicationTypeAndName,
+  getServiceNameFromPath,
+  hasServiceNameInPath,
+} from './application';
+import { APP_PATH, ApplicationType } from '@pinpoint-fe/ui/src/constants';
 
 describe('Test application helper utils', () => {
   describe('Test "getApplicationTypeAndName"', () => {
@@ -55,6 +62,85 @@ describe('Test application helper utils', () => {
         applicationName: 'appName',
         serviceType: 'serviceType',
       });
+    });
+  });
+
+  describe('Test "hasServiceNameInPath"', () => {
+    test.each([
+      [`${APP_PATH.TRANSACTION_LIST}`, true],
+      [`${APP_PATH.TRANSACTION_LIST}/svc@appName@TOMCAT`, true],
+      [`${APP_PATH.TRANSACTION_DETAIL}/appName@TOMCAT`, false],
+      [`${APP_PATH.SERVICE_MAP}/appName@TOMCAT`, false],
+      [`${APP_PATH.SERVER_MAP}/appName@TOMCAT`, false],
+      ['', false],
+    ])('Return %p → %p', (pathname, expected) => {
+      expect(hasServiceNameInPath(pathname)).toBe(expected);
+    });
+  });
+
+  describe('Test "getServiceAndApplicationTypeAndName"', () => {
+    test('Split service name, application name and service type', () => {
+      const result = getServiceAndApplicationTypeAndName('/transactionList/svc@appName@TOMCAT');
+      expect(result).toEqual({
+        serviceName: 'svc',
+        applicationName: 'appName',
+        serviceType: 'TOMCAT',
+      });
+    });
+
+    test('Return undefined service name for the legacy two part segment', () => {
+      const result = getServiceAndApplicationTypeAndName('/transactionList/appName@TOMCAT');
+      expect(result).toEqual({
+        serviceName: undefined,
+        applicationName: 'appName',
+        serviceType: 'TOMCAT',
+      });
+    });
+
+    test('Keep "@" inside the application name after the service name', () => {
+      const result = getServiceAndApplicationTypeAndName('/transactionList/svc@app@Name@TOMCAT');
+      expect(result).toEqual({
+        serviceName: 'svc',
+        applicationName: 'app@Name',
+        serviceType: 'TOMCAT',
+      });
+    });
+
+    test('Return null when the segment does not match the pattern', () => {
+      expect(getServiceAndApplicationTypeAndName('/transactionList/appName')).toBeNull();
+      expect(getServiceAndApplicationTypeAndName('')).toBeNull();
+    });
+  });
+
+  describe('Test "getApplicationTypeAndNameFromPath"', () => {
+    test('Drop the service name on a path that carries it', () => {
+      const result = getApplicationTypeAndNameFromPath('/transactionList/svc@appName@TOMCAT');
+      expect(result).toEqual({ applicationName: 'appName', serviceType: 'TOMCAT' });
+    });
+
+    test('Keep "@" in the application name on a path that carries no service name', () => {
+      const result = getApplicationTypeAndNameFromPath('/serverMap/svc@appName@TOMCAT');
+      expect(result).toEqual({ applicationName: 'svc@appName', serviceType: 'TOMCAT' });
+    });
+
+    test('Return null when the path has no application segment', () => {
+      expect(getApplicationTypeAndNameFromPath('/transactionList')).toBeNull();
+      expect(getApplicationTypeAndNameFromPath('/serverMap')).toBeNull();
+    });
+  });
+
+  describe('Test "getServiceNameFromPath"', () => {
+    test('Return the service name on a path that carries it', () => {
+      expect(getServiceNameFromPath('/transactionList/svc@appName@TOMCAT')).toBe('svc');
+    });
+
+    test('Return undefined on a legacy path without a service name', () => {
+      expect(getServiceNameFromPath('/transactionList/appName@TOMCAT')).toBeUndefined();
+    });
+
+    test('Return undefined on a path that does not carry a service name', () => {
+      expect(getServiceNameFromPath('/serverMap/svc@appName@TOMCAT')).toBeUndefined();
+      expect(getServiceNameFromPath('/serviceMap/svc@appName@TOMCAT')).toBeUndefined();
     });
   });
 

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.test.ts
@@ -69,7 +69,8 @@ describe('Test application helper utils', () => {
     test.each([
       [`${APP_PATH.TRANSACTION_LIST}`, true],
       [`${APP_PATH.TRANSACTION_LIST}/svc@appName@TOMCAT`, true],
-      [`${APP_PATH.TRANSACTION_DETAIL}/appName@TOMCAT`, false],
+      [`${APP_PATH.TRANSACTION_DETAIL}`, true],
+      [`${APP_PATH.TRANSACTION_DETAIL}/svc@appName@TOMCAT`, true],
       [`${APP_PATH.SERVICE_MAP}/appName@TOMCAT`, false],
       [`${APP_PATH.SERVER_MAP}/appName@TOMCAT`, false],
       ['', false],
@@ -141,6 +142,23 @@ describe('Test application helper utils', () => {
     test('Return undefined on a path that does not carry a service name', () => {
       expect(getServiceNameFromPath('/serverMap/svc@appName@TOMCAT')).toBeUndefined();
       expect(getServiceNameFromPath('/serviceMap/svc@appName@TOMCAT')).toBeUndefined();
+    });
+
+    test('Read the service name on the transactionDetail path too', () => {
+      expect(getServiceNameFromPath('/transactionDetail/svc@appName@TOMCAT')).toBe('svc');
+      expect(getServiceNameFromPath('/transactionDetail/appName@TOMCAT')).toBeUndefined();
+    });
+
+    // `getServiceScopedApplicationPath`가 인코딩해서 넣은 값을 되돌린다.
+    test('Decode the encoded service name', () => {
+      expect(getServiceNameFromPath('/transactionList/a%2Fb@appName@TOMCAT')).toBe('a/b');
+      expect(getServiceNameFromPath('/transactionList/a%40b@appName@TOMCAT')).toBe('a@b');
+      expect(getServiceNameFromPath('/transactionList/a%20b@appName@TOMCAT')).toBe('a b');
+    });
+
+    // 경로는 사용자가 직접 편집할 수 있다. 렌더 중에 호출되므로 던지면 화면이 죽는다.
+    test('Fall back to the raw value on a malformed encoding instead of throwing', () => {
+      expect(getServiceNameFromPath('/transactionList/100%@appName@TOMCAT')).toBe('100%');
     });
   });
 

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.ts
@@ -16,11 +16,15 @@ export const getApplicationTypeAndName = (path = '') => {
  * application 세그먼트에 serviceName까지 함께 싣는 페이지 목록.
  * 이 경로의 세그먼트는 `{serviceName}@{applicationName}@{serviceType}` 형태다.
  *
- * transactionList는 scatter/heatmap의 drag&drop으로 새 탭에서 열리므로, 어떤 service를
- * 보고 있었는지 URL에 남겨두지 않으면 모든 API에 실어야 할 pServiceName 헤더를 복원할 수 없다.
+ * transactionList는 scatter/heatmap의 drag&drop으로, transactionDetail은 transactionList의
+ * 외부 링크 버튼으로 새 탭에서 열리므로, 어떤 service를 보고 있었는지 URL에 남겨두지 않으면
+ * 모든 API에 실어야 할 pServiceName 헤더를 복원할 수 없다.
  * (전역 선택값은 탭 간 공유 저장소라서 링크를 열 시점의 값과 다를 수 있다.)
  */
-const SERVICE_NAME_IN_PATH_PAGES: string[] = [APP_PATH.TRANSACTION_LIST];
+const SERVICE_NAME_IN_PATH_PAGES: string[] = [
+  APP_PATH.TRANSACTION_LIST,
+  APP_PATH.TRANSACTION_DETAIL,
+];
 
 /**
  * 라우터 기준 pathname(basename 제외)이 serviceName을 싣는 경로인지 여부.
@@ -30,11 +34,27 @@ export const hasServiceNameInPath = (pathname = '') =>
   SERVICE_NAME_IN_PATH_PAGES.some((page) => pathname === page || pathname.startsWith(`${page}/`));
 
 /**
+ * URL에 실린 serviceName을 디코딩한다(`getServiceScopedApplicationPath`가 인코딩한다).
+ * 경로는 사용자가 직접 편집할 수 있어 '%' 하나만 있는 등 잘못된 인코딩이 들어올 수 있고,
+ * 이 함수는 렌더 중에 호출되므로 던지면 화면이 죽는다. 실패하면 원본을 그대로 쓴다.
+ */
+const decodeServiceName = (serviceName: string) => {
+  try {
+    return decodeURIComponent(serviceName);
+  } catch {
+    return serviceName;
+  }
+};
+
+/**
  * `{serviceName}@{applicationName}@{serviceType}` 세그먼트를 분해한다.
  * serviceName이 없는 기존 형태(`{applicationName}@{serviceType}`)면 serviceName은 undefined다.
  *
  * serviceName은 첫 '@' 앞부분으로, applicationName/serviceType은 기존 규칙(마지막 구분자)을
  * 그대로 따른다. 경로 전체를 넘겨도 되고 세그먼트만 넘겨도 된다.
+ *
+ * 인코딩된(raw) 경로를 넘겨야 한다. react-router의 `params`는 디코딩된 값이므로 그대로 쓰면
+ * serviceName의 '%2F'가 '/'로 풀려 세그먼트 경계가 어긋난다(`transactionRouteLoader` 참고).
  */
 export const getServiceAndApplicationTypeAndName = (path = '') => {
   const application = getApplicationTypeAndName(path);
@@ -50,7 +70,7 @@ export const getServiceAndApplicationTypeAndName = (path = '') => {
   }
 
   return {
-    serviceName: application.applicationName.slice(0, separatorIndex),
+    serviceName: decodeServiceName(application.applicationName.slice(0, separatorIndex)),
     applicationName: application.applicationName.slice(separatorIndex + 1),
     serviceType: application.serviceType,
   };

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.ts
@@ -1,4 +1,4 @@
-import { ApplicationType } from '@pinpoint-fe/ui/src/constants';
+import { APP_PATH, ApplicationType } from '@pinpoint-fe/ui/src/constants';
 
 export const getApplicationTypeAndName = (path = '') => {
   const splittedPath = path.match(/\/?([^/]+)[@|^]([^/]+)$/);
@@ -11,6 +11,70 @@ export const getApplicationTypeAndName = (path = '') => {
 
   return null;
 };
+
+/**
+ * application 세그먼트에 serviceName까지 함께 싣는 페이지 목록.
+ * 이 경로의 세그먼트는 `{serviceName}@{applicationName}@{serviceType}` 형태다.
+ *
+ * transactionList는 scatter/heatmap의 drag&drop으로 새 탭에서 열리므로, 어떤 service를
+ * 보고 있었는지 URL에 남겨두지 않으면 모든 API에 실어야 할 pServiceName 헤더를 복원할 수 없다.
+ * (전역 선택값은 탭 간 공유 저장소라서 링크를 열 시점의 값과 다를 수 있다.)
+ */
+const SERVICE_NAME_IN_PATH_PAGES: string[] = [APP_PATH.TRANSACTION_LIST];
+
+/**
+ * 라우터 기준 pathname(basename 제외)이 serviceName을 싣는 경로인지 여부.
+ * applicationName 자체에 '@'가 들어갈 수 있으므로, serviceName 분리는 이 경로에서만 해야 한다.
+ */
+export const hasServiceNameInPath = (pathname = '') =>
+  SERVICE_NAME_IN_PATH_PAGES.some((page) => pathname === page || pathname.startsWith(`${page}/`));
+
+/**
+ * `{serviceName}@{applicationName}@{serviceType}` 세그먼트를 분해한다.
+ * serviceName이 없는 기존 형태(`{applicationName}@{serviceType}`)면 serviceName은 undefined다.
+ *
+ * serviceName은 첫 '@' 앞부분으로, applicationName/serviceType은 기존 규칙(마지막 구분자)을
+ * 그대로 따른다. 경로 전체를 넘겨도 되고 세그먼트만 넘겨도 된다.
+ */
+export const getServiceAndApplicationTypeAndName = (path = '') => {
+  const application = getApplicationTypeAndName(path);
+
+  if (!application) {
+    return null;
+  }
+
+  const separatorIndex = application.applicationName.indexOf('@');
+
+  if (separatorIndex < 1) {
+    return { serviceName: undefined, ...application };
+  }
+
+  return {
+    serviceName: application.applicationName.slice(0, separatorIndex),
+    applicationName: application.applicationName.slice(separatorIndex + 1),
+    serviceType: application.serviceType,
+  };
+};
+
+/**
+ * pathname에서 application을 읽는다. serviceName이 실리는 경로에서는 serviceName을 떼어내고,
+ * 그 외에는 기존 규칙 그대로 파싱해 applicationName에 '@'가 포함된 경우가 깨지지 않게 한다.
+ */
+export const getApplicationTypeAndNameFromPath = (pathname = '') => {
+  if (!hasServiceNameInPath(pathname)) {
+    return getApplicationTypeAndName(pathname);
+  }
+
+  const parsed = getServiceAndApplicationTypeAndName(pathname);
+
+  return parsed && { applicationName: parsed.applicationName, serviceType: parsed.serviceType };
+};
+
+/** pathname에 실려 있는 serviceName. serviceName을 싣지 않는 경로에서는 undefined. */
+export const getServiceNameFromPath = (pathname = '') =>
+  hasServiceNameInPath(pathname)
+    ? getServiceAndApplicationTypeAndName(pathname)?.serviceName
+    : undefined;
 
 export const getApplicationKey = (application?: ApplicationType) => {
   return `${application?.applicationName}^${application?.serviceType}`;

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.test.ts
@@ -4,6 +4,7 @@ import {
   getApplicationPath,
   getHostGroupPath,
   getFilteredMapPath,
+  getTransactionListPath,
 } from './route';
 
 describe('Test route helper utils', () => {
@@ -189,6 +190,38 @@ describe('Test route helper utils', () => {
 
       const result = getFilteredMapPath(filterState, sourceIsWas);
       expect(result).toEqual('/filteredMap/toApplication@toServiceType');
+    });
+  });
+
+  describe('Test "getTransactionListPath"', () => {
+    const application = { applicationName: 'appName', serviceType: 'TOMCAT' };
+    const dateRange = { from: 'from', to: 'to' };
+
+    test('Return the page path only when application is not given', () => {
+      expect(getTransactionListPath()).toEqual('/transactionList');
+      expect(getTransactionListPath(null, dateRange, 'svc')).toEqual('/transactionList');
+    });
+
+    test('Return the legacy path when service name is not given', () => {
+      expect(getTransactionListPath(application)).toEqual('/transactionList/appName@TOMCAT');
+      expect(getTransactionListPath(application, dateRange)).toEqual(
+        '/transactionList/appName@TOMCAT?from=from&to=to',
+      );
+    });
+
+    test('Prefix the service name to the application segment', () => {
+      expect(getTransactionListPath(application, undefined, 'svc')).toEqual(
+        '/transactionList/svc@appName@TOMCAT',
+      );
+      expect(getTransactionListPath(application, dateRange, 'svc')).toEqual(
+        '/transactionList/svc@appName@TOMCAT?from=from&to=to',
+      );
+    });
+
+    test('Omit the query string when only one of from/to is given', () => {
+      expect(getTransactionListPath(application, { from: 'from' }, 'svc')).toEqual(
+        '/transactionList/svc@appName@TOMCAT',
+      );
     });
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.test.ts
@@ -5,6 +5,7 @@ import {
   getHostGroupPath,
   getFilteredMapPath,
   getTransactionListPath,
+  getTransactionDetailPath,
 } from './route';
 
 describe('Test route helper utils', () => {
@@ -221,6 +222,49 @@ describe('Test route helper utils', () => {
     test('Omit the query string when only one of from/to is given', () => {
       expect(getTransactionListPath(application, { from: 'from' }, 'svc')).toEqual(
         '/transactionList/svc@appName@TOMCAT',
+      );
+    });
+
+    // 백엔드가 service 이름 형식을 검증하지 않으므로 '/'나 '@'가 들어올 수 있다. 인코딩하지
+    // 않으면 '/'가 세그먼트를 쪼개 라우트 매칭이 실패하고 '@'는 구분자와 구별되지 않는다.
+    test('Encode the service name so it cannot break the path segment', () => {
+      expect(getTransactionListPath(application, undefined, 'a/b')).toEqual(
+        '/transactionList/a%2Fb@appName@TOMCAT',
+      );
+      expect(getTransactionListPath(application, undefined, 'a@b')).toEqual(
+        '/transactionList/a%40b@appName@TOMCAT',
+      );
+      expect(getTransactionListPath(application, undefined, 'a b')).toEqual(
+        '/transactionList/a%20b@appName@TOMCAT',
+      );
+    });
+  });
+
+  describe('Test "getTransactionDetailPath"', () => {
+    const application = { applicationName: 'appName', serviceType: 'TOMCAT' };
+    const dateRange = { from: 'from', to: 'to' };
+
+    test('Return the page path only when application is not given', () => {
+      expect(getTransactionDetailPath()).toEqual('/transactionDetail');
+      expect(getTransactionDetailPath(null, dateRange, 'svc')).toEqual('/transactionDetail');
+    });
+
+    test('Return the legacy path when service name is not given', () => {
+      expect(getTransactionDetailPath(application)).toEqual('/transactionDetail/appName@TOMCAT');
+      expect(getTransactionDetailPath(application, dateRange)).toEqual(
+        '/transactionDetail/appName@TOMCAT?from=from&to=to',
+      );
+    });
+
+    test('Prefix the service name to the application segment', () => {
+      expect(getTransactionDetailPath(application, undefined, 'svc')).toEqual(
+        '/transactionDetail/svc@appName@TOMCAT',
+      );
+    });
+
+    test('Encode the service name so it cannot break the path segment', () => {
+      expect(getTransactionDetailPath(application, undefined, 'a/b')).toEqual(
+        '/transactionDetail/a%2Fb@appName@TOMCAT',
       );
     });
   });

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.ts
@@ -101,6 +101,32 @@ export const getUrlStatPath = getApplicationPath(APP_PATH.URL_STATISTIC);
 export const getInspectorPath = getApplicationPath(APP_PATH.INSPECTOR);
 export const getOpenTelemetryPath = getApplicationPath(APP_PATH.OPEN_TELEMETRY_METRIC);
 export const getSystemMetricPath = getHostGroupPath(APP_PATH.SYSTEM_METRIC);
-export const getTransactionListPath = getApplicationPath(APP_PATH.TRANSACTION_LIST);
+/**
+ * /transactionList
+ *
+ * serviceName이 주어지면 application 세그먼트를 `{serviceName}@{applicationName}@{serviceType}`로
+ * 만든다. transactionList는 scatter/heatmap의 drag&drop으로 새 탭에서 열리므로, 어떤 service를
+ * 보던 중이었는지 URL에 남겨야 그 화면의 모든 API에 pServiceName 헤더를 실을 수 있다.
+ * 파싱은 `getServiceAndApplicationTypeAndName`이 담당한다.
+ */
+export const getTransactionListPath = (
+  application?: ApplicationType | null,
+  queryParams?: {
+    [k: string]: string;
+  },
+  serviceName?: string,
+) => {
+  if (!application?.applicationName || !application?.serviceType) {
+    return APP_PATH.TRANSACTION_LIST;
+  }
+
+  const servicePrefix = serviceName ? `${serviceName}@` : '';
+  const queryString =
+    queryParams?.from && queryParams?.to
+      ? `?${convertParamsToQueryString({ from: queryParams.from, to: queryParams.to })}`
+      : '';
+
+  return `${APP_PATH.TRANSACTION_LIST}/${servicePrefix}${application.applicationName}@${application.serviceType}${queryString}`;
+};
 export const getTransactionDetailPath = getApplicationPath(APP_PATH.TRANSACTION_DETAIL);
 export const getThreadDumpPath = getApplicationPath(APP_PATH.THREAD_DUMP);

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.ts
@@ -102,31 +102,43 @@ export const getInspectorPath = getApplicationPath(APP_PATH.INSPECTOR);
 export const getOpenTelemetryPath = getApplicationPath(APP_PATH.OPEN_TELEMETRY_METRIC);
 export const getSystemMetricPath = getHostGroupPath(APP_PATH.SYSTEM_METRIC);
 /**
- * /transactionList
- *
  * serviceName이 주어지면 application 세그먼트를 `{serviceName}@{applicationName}@{serviceType}`로
- * 만든다. transactionList는 scatter/heatmap의 drag&drop으로 새 탭에서 열리므로, 어떤 service를
- * 보던 중이었는지 URL에 남겨야 그 화면의 모든 API에 pServiceName 헤더를 실을 수 있다.
+ * 만드는 경로 빌더. transaction 화면들은 새 탭으로 열리므로(map의 drag&drop → transactionList,
+ * transactionList의 외부 링크 → transactionDetail), 어떤 service를 보던 중이었는지 URL에 남겨야
+ * 그 화면의 모든 API에 pServiceName 헤더를 실을 수 있다.
  * 파싱은 `getServiceAndApplicationTypeAndName`이 담당한다.
+ *
+ * serviceName은 백엔드에서 형식이 검증되지 않으므로(`ServiceNameRequest`에 제약이 없다) '/'나
+ * '@'가 들어올 수 있어 인코딩한다. 인코딩하지 않으면 '/'가 세그먼트를 쪼개 `:application?`
+ * 라우트 매칭이 실패하고, '@'는 구분자와 구별되지 않는다. applicationName/serviceType은
+ * 백엔드가 `[a-zA-Z0-9._\-]+`로 검증하므로(IdValidateUtils) 기존처럼 그대로 둔다.
  */
-export const getTransactionListPath = (
-  application?: ApplicationType | null,
-  queryParams?: {
-    [k: string]: string;
-  },
-  serviceName?: string,
-) => {
-  if (!application?.applicationName || !application?.serviceType) {
-    return APP_PATH.TRANSACTION_LIST;
-  }
+const getServiceScopedApplicationPath =
+  (pagePath: string) =>
+  (
+    application?: ApplicationType | null,
+    queryParams?: {
+      [k: string]: string;
+    },
+    serviceName?: string,
+  ) => {
+    if (!application?.applicationName || !application?.serviceType) {
+      return pagePath;
+    }
 
-  const servicePrefix = serviceName ? `${serviceName}@` : '';
-  const queryString =
-    queryParams?.from && queryParams?.to
-      ? `?${convertParamsToQueryString({ from: queryParams.from, to: queryParams.to })}`
-      : '';
+    const servicePrefix = serviceName ? `${encodeURIComponent(serviceName)}@` : '';
+    const queryString =
+      queryParams?.from && queryParams?.to
+        ? `?${convertParamsToQueryString({ from: queryParams.from, to: queryParams.to })}`
+        : '';
 
-  return `${APP_PATH.TRANSACTION_LIST}/${servicePrefix}${application.applicationName}@${application.serviceType}${queryString}`;
-};
-export const getTransactionDetailPath = getApplicationPath(APP_PATH.TRANSACTION_DETAIL);
+    return `${pagePath}/${servicePrefix}${application.applicationName}@${application.serviceType}${queryString}`;
+  };
+
+/** /transactionList */
+export const getTransactionListPath = getServiceScopedApplicationPath(APP_PATH.TRANSACTION_LIST);
+/** /transactionDetail */
+export const getTransactionDetailPath = getServiceScopedApplicationPath(
+  APP_PATH.TRANSACTION_DETAIL,
+);
 export const getThreadDumpPath = getApplicationPath(APP_PATH.THREAD_DUMP);


### PR DESCRIPTION
## Summary
- **Send `pServiceName` on every screen when `experimental.enableServiceMap` is on.** The servermap used to be exempt, on the grounds that it predates the service concept and should read the default service. That made it the odd one out: the same API answered from a different service depending on which map the user happened to be looking at. Now the setting alone decides whether the header is sent — with it off, no header goes out at all and the backend resolves the default service as before.
- **Carry the service name in `transactionList` and `transactionDetail` URLs** as `serviceName@applicationName@serviceType`. Both screens open in a new tab — the map opens the transaction list (scatter/heatmap drag&drop), and the transaction list opens the detail — so the service being viewed could not be recovered there. The path segment wins over the global selection, so every request from those screens carries the same service the map was read with, and following rows or an OTel Link inside the screen keeps it. The service name is percent-encoded, since the backend does not validate its format (`ServiceNameRequest` has no constraints) and an unencoded `/` would split the path segment while `@`, `^` or `|` would be indistinguishable from the segment separators.
- **Land on the new service's servicemap after switching service.** Previously the user stayed on the current page with the application segment stripped, leaving them on a screen they cannot use yet (an empty inspector or url-statistic) with no hint of where to go.
- **Keep the selected service per tab by storing it in `sessionStorage`.** `localStorage` is shared per origin and jotai's default storage syncs it across tabs through the `storage` event, so switching service in one tab changed it in every other tab — and the redirect above then pulled those tabs to the servicemap, away from whatever they were showing. `sessionStorage` is scoped to the browsing context, so each tab keeps its own selection and two services can be compared side by side.

## Notes for reviewers
- The request header and the React Query cache key both derive from the single `resolveRequestService` rule, so they cannot drift apart and serve one service's data under another's key.
- The service name is only split off the path on routes known to carry it, so an `@` inside an application name keeps working everywhere else. On a `transactionList`/`transactionDetail` URL for such an application the leading part would be read as the service name; that is inherent to the requested `serviceName@applicationName@serviceType` shape, and the backend rejects `@` in an application name anyway (`IdValidateUtils.ID_PATTERN_VALUE`).
- `transactionRouteLoader` reads the raw path segment instead of `params.application`, because react-router decodes params — `%2F` came back as `/` and leaked into the redirect target the loader builds from that segment.
- `atomWithStorage` with `getOnInit` reads the storage while the module is being evaluated, and passing a getter to `createJSONStorage` drops the guard the default getter has. Since storage access itself throws where third-party storage is blocked, the getter falls back to an in-memory string storage rather than taking the whole app down on import.
- **Trade-off worth a second opinion:** with `sessionStorage`, a new tab or a browser restart starts at the default service. Only `transactionList` and `transactionDetail` carry the service in their URL, so a bookmarked `serverMap`/`inspector`/`urlStatistic`/`errorAnalysis` link now resolves under the default service instead of the last selected one, and it fails quietly — the screen just looks empty. The alternative is to keep `localStorage` and instead skip the service-change redirect on screens whose URL already pins a service, which preserves bookmarks but keeps the selection global. Happy to switch if reviewers prefer that.
- The cache-scoping tests used to prove separation by navigating between the servermap and the servicemap. That no longer changes the resolved service, so they vary the selected service instead — which is what they were really testing.

## Test plan
- [ ] With `enableServiceMap` on and a non-default service selected, open the servermap: requests carry `pServiceName: {service}` and the map renders that service's applications.
- [ ] With `enableServiceMap` off, no request carries `pServiceName` on any screen, and no URL gains a service segment.
- [ ] Drag on the scatter chart and the heatmap from both the servermap and the servicemap: the transaction list opens at `/transactionList/{service}@{app}@{type}` and every request carries that service.
- [ ] From that transaction list, open a transaction detail in a new tab: it opens at `/transactionDetail/{service}@{app}@{type}` and its requests carry the same service.
- [ ] Click rows in the transaction list and follow an OTel Link: the service name stays in the URL and in the headers.
- [ ] Open a legacy `/transactionList/{app}@{type}` or `/transactionDetail/{app}@{type}` URL (no service name): it still resolves through the globally selected service, unchanged.
- [ ] Create a service whose name contains `/` and `@`, then open a transaction list for it: the URL percent-encodes the name, the route still matches, and the header carries the decoded name.
- [ ] Switch service from the side navigation while viewing an application: the app lands on `/serviceMap` with no application selected, and the sidebar links no longer point at the old application.
- [ ] Open two tabs, select a different service in each: both keep their own selection, and switching in one does not navigate the other away.
- [ ] `yarn build`, `yarn test` (748 passing), `yarn lint` (no errors).
