### PR TITLE
[#noissue] Add ServiceHeaderEnabled to gate SpanHeaderFactory via pinpoint.modules.service-header.enabled

### DIFF
--- a/collector/src/main/resources/application.yml
+++ b/collector/src/main/resources/application.yml
@@ -73,3 +73,5 @@ pinpoint:
       enabled: false
     uid:
       version: v3
+    service-header:
+      enabled: true

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/CommonsServerConfiguration.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/CommonsServerConfiguration.java
@@ -17,10 +17,12 @@
 package com.navercorp.pinpoint.common.server;
 
 import com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule;
+import com.navercorp.pinpoint.common.server.uid.ServiceHeaderEnabled;
 import com.navercorp.pinpoint.common.server.util.AgentEventMessageDeserializerV1;
 import com.navercorp.pinpoint.common.server.util.AgentEventMessageSerializerV1;
 import com.navercorp.pinpoint.common.timeseries.window.DefaultTimeSlot;
 import com.navercorp.pinpoint.common.timeseries.window.TimeSlot;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -48,4 +50,10 @@ public class CommonsServerConfiguration {
     public com.fasterxml.jackson.databind.Module eclipseCollectionsModule() {
         return new EclipseCollectionsModule();
     }
+
+    @Bean
+    public ServiceHeaderEnabled serviceHeaderEnabled(@Value("${" + ServiceHeaderEnabled.ENABLED + ":true}") boolean enabled) {
+        return new ServiceHeaderEnabled(enabled);
+    }
+
 }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/config/SpanSerializeConfiguration.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/bo/serializer/trace/v2/config/SpanSerializeConfiguration.java
@@ -9,8 +9,8 @@ import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanHeaderFac
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.SpanSerializerV2;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.TraceRowKeyDecoderV2;
 import com.navercorp.pinpoint.common.server.bo.serializer.trace.v2.TraceRowKeyEncoderV2;
+import com.navercorp.pinpoint.common.server.uid.ServiceHeaderEnabled;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -32,8 +32,8 @@ public class SpanSerializeConfiguration {
     }
 
     @Bean
-    public SpanHeaderFactory spanHeaderFactory(@Value("${collector.span.serviceuid.enabled:false}") boolean serviceUid) {
-        return new SpanHeaderFactory(serviceUid);
+    public SpanHeaderFactory spanHeaderFactory(ServiceHeaderEnabled serviceHeaderEnabled) {
+        return new SpanHeaderFactory(serviceHeaderEnabled.isEnabled());
     }
 
     @Bean

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceHeaderEnabled.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceHeaderEnabled.java
@@ -1,0 +1,21 @@
+package com.navercorp.pinpoint.common.server.uid;
+
+public class ServiceHeaderEnabled {
+
+    public static final String ENABLED = "pinpoint.modules.service-header.enabled";
+
+    private final boolean enabled;
+
+    public ServiceHeaderEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceHeaderEnabled{" + ENABLED + '=' + enabled + '}';
+    }
+}

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/ServiceModule.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/ServiceModule.java
@@ -7,5 +7,4 @@ import org.springframework.context.annotation.Import;
         WebServiceConfiguration.class,
 })
 public class ServiceModule {
-
 }


### PR DESCRIPTION
…point.modules.service-header.enabled

This pull request introduces support for a new `service-header` feature flag in the configuration, enabling or disabling related functionality via a centralized configuration bean. The main changes include adding the `ServiceHeaderEnabled` class, updating configuration files and beans to use it, and refactoring dependent code to use this new approach.

**Configuration and Feature Flag Support:**

* Added `service-header.enabled` property under `pinpoint.modules` in `application.yml` to control the feature flag for service headers.
* Introduced the `ServiceHeaderEnabled` class to encapsulate the `service-header` feature flag logic.
* Registered `ServiceHeaderEnabled` as a Spring bean in `CommonsServerConfiguration`, reading from the new configuration property.

**Refactoring for Consistency:**

* Updated `SpanSerializeConfiguration` to use the new `ServiceHeaderEnabled` bean instead of directly reading the property, improving dependency injection and centralizing feature flag logic.
* Added necessary imports and cleaned up unused ones in affected configuration files. [[1]](diffhunk://#diff-d0da5ef3781a8c33e6cab3e45b53f8e43395671652fb8c30fa0d50fe8b052e93R20-R25) [[2]](diffhunk://#diff-1d6f4cac7c83dbaf15dcbc9e335f4c5e8c7af43f571568383712d6b1eeb89a0dR12-L13)