### PR TITLE
[#noissue] Fix redisson reactive command tracing for redisson 3.17+

### DIFF
--- a/agent-module/plugins-it/pom.xml
+++ b/agent-module/plugins-it/pom.xml
@@ -76,6 +76,7 @@
         <module>mysql-jdbc-driver-plugin-it</module>
         <module>spring-data-r2dbc-it</module>
         <module>redis-lettuce-it</module>
+        <module>redis-redisson-it</module>
         <module>pulsar-it</module>
         <module>reactor-it</module>
     </modules>

--- a/agent-module/plugins-it/redis-redisson-it/pom.xml
+++ b/agent-module/plugins-it/redis-redisson-it/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 NAVER Corp.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint-plugins-it</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-redis-redisson-plugin-it</artifactId>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <jdk.version>1.8</jdk.version>
+        <jdk.home>${env.JAVA_8_HOME}</jdk.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-plugin-it-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-redis-redisson-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson</artifactId>
+            <version>3.27.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <jvm>${env.JAVA_8_HOME}/bin/java</jvm>
+                    <testFailureIgnore>true</testFailureIgnore>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/agent-module/plugins-it/redis-redisson-it/src/test/java/com/navercorp/pinpoint/it/plugin/redisson/RedisServer.java
+++ b/agent-module/plugins-it/redis-redisson-it/src/test/java/com/navercorp/pinpoint/it/plugin/redisson/RedisServer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.redisson;
+
+import com.navercorp.pinpoint.test.plugin.shared.SharedTestLifeCycle;
+import org.junit.jupiter.api.Assumptions;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Properties;
+
+public class RedisServer implements SharedTestLifeCycle {
+    private GenericContainer<?> redisServer;
+
+    @Override
+    @SuppressWarnings("resource")
+    public Properties beforeAll() {
+        Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker not enabled");
+
+        this.redisServer = new GenericContainer<>(DockerImageName.parse("redis:5.0.14-alpine"))
+                .withExposedPorts(6379);
+        redisServer.start();
+
+        Properties properties = new Properties();
+        properties.setProperty("HOST", redisServer.getHost());
+        properties.setProperty("PORT", String.valueOf(redisServer.getMappedPort(6379)));
+        System.getProperties().putAll(properties);
+
+        return properties;
+    }
+
+    @Override
+    public void afterAll() {
+        if (redisServer != null) {
+            redisServer.close();
+        }
+    }
+}

--- a/agent-module/plugins-it/redis-redisson-it/src/test/java/com/navercorp/pinpoint/it/plugin/redisson/RedissonReactive_IT.java
+++ b/agent-module/plugins-it/redis-redisson-it/src/test/java/com/navercorp/pinpoint/it/plugin/redisson/RedissonReactive_IT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.redisson;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.it.plugin.utils.TestcontainersOption;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import com.navercorp.pinpoint.test.plugin.shared.SharedDependency;
+import com.navercorp.pinpoint.test.plugin.shared.SharedTestBeforeAllResult;
+import com.navercorp.pinpoint.test.plugin.shared.SharedTestLifeCycleClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.redisson.Redisson;
+import org.redisson.api.RBucketReactive;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.RedissonReactiveClient;
+import org.redisson.config.Config;
+
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The reactive command surface funnels every call through
+ * {@code org.redisson.reactive.ReactiveProxyBuilder$1.execute}, whose signature changed across
+ * redisson versions — {@code (Method, Object, Object[])}, then {@code (Method, Object, Method,
+ * Object[])} (~3.17.x), then {@code (Callable, Method)} (3.19+). The plugin matched only the
+ * first, so reactive tracing was silently dead on modern redisson. This IT pins the weaving on
+ * both current shapes, and the {@code args[0]} annotation additionally pins the keytrace Method
+ * argument lookup (the Method moved to args[1] in the 3.19+ shape).
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.redisson:redisson:[3.17.7],[3.27.2]",
+        PluginITConstants.VERSION})
+@SharedDependency({PluginITConstants.VERSION, TestcontainersOption.TEST_CONTAINER})
+@SharedTestLifeCycleClass(RedisServer.class)
+public class RedissonReactive_IT {
+    private static final String REDISSON_REACTIVE = "REDIS_REDISSON_REACTIVE";
+
+    private static RedissonClient redisson;
+
+    @SharedTestBeforeAllResult
+    public static void setBeforeAllResult(Properties beforeAllResult) {
+    }
+
+    @BeforeAll
+    public static void beforeClass() {
+        final String host = System.getProperty("HOST");
+        final int port = Integer.parseInt(System.getProperty("PORT"));
+        final Config config = new Config();
+        config.useSingleServer().setAddress(String.format("redis://%s:%s", host, port));
+        redisson = Redisson.create(config);
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        if (redisson != null) {
+            redisson.shutdown();
+        }
+    }
+
+    /**
+     * Resolve the woven execute by reflection: the owner is an anonymous class and the signature
+     * is version-dependent.
+     */
+    private static Member reactiveExecuteMethod() throws Exception {
+        final Class<?> owner = Class.forName("org.redisson.reactive.ReactiveProxyBuilder$1");
+        try {
+            // redisson 3.19+
+            return owner.getDeclaredMethod("execute", Callable.class, Method.class);
+        } catch (NoSuchMethodException e1) {
+            try {
+                // redisson ~3.17.x
+                return owner.getDeclaredMethod("execute", Method.class, Object.class, Method.class, Object[].class);
+            } catch (NoSuchMethodException e2) {
+                // older
+                return owner.getDeclaredMethod("execute", Method.class, Object.class, Object[].class);
+            }
+        }
+    }
+
+    @Test
+    public void reactiveCommands_recordReactiveEvents() throws Exception {
+        final RedissonReactiveClient reactive = redisson.reactive();
+        final RBucketReactive<String> bucket = reactive.getBucket("foo");
+
+        bucket.set("bar").block();
+        final String value = bucket.get().block();
+        assertEquals("bar", value);
+
+        final Member execute = reactiveExecuteMethod();
+        // the recorded method name depends on which Method the signature carries at the keytrace
+        // position: the 3.19+ (Callable, Method) shape sees the interface method ("set"), the
+        // ~3.17.x (Method, Object, Method, Object[]) shape sees the underlying async method
+        // ("setAsync") at args[0].
+        final boolean callableShape = ((Method) execute).getParameterTypes()[0] == Callable.class;
+        final String setName = callableShape ? "set" : "setAsync";
+        final String getName = callableShape ? "get" : "getAsync";
+
+        final PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.printCache();
+        // discrete: the surrounding REDIS_REDISSON (sync/async surface) events are not under test.
+        verifier.verifyDiscreteTrace(Expectations.event(REDISSON_REACTIVE, execute,
+                Expectations.annotation("args[0]", setName)));
+        verifier.verifyDiscreteTrace(Expectations.event(REDISSON_REACTIVE, execute,
+                Expectations.annotation("args[0]", getName)));
+    }
+}

--- a/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/RedissonPlugin.java
+++ b/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/RedissonPlugin.java
@@ -191,6 +191,16 @@ public class RedissonPlugin implements ProfilerPlugin, TransformTemplateAware {
             if (executeMethod != null) {
                 executeMethod.addInterceptor(ReactiveMethodInterceptor.class);
             }
+            // redisson ~3.17.x: ProxyBuilder$Callback.execute(Method, Object, Method, Object[])
+            final InstrumentMethod instanceExecuteMethod = target.getDeclaredMethod("execute", "java.lang.reflect.Method", "java.lang.Object", "java.lang.reflect.Method", "java.lang.Object[]");
+            if (instanceExecuteMethod != null) {
+                instanceExecuteMethod.addInterceptor(ReactiveMethodInterceptor.class);
+            }
+            // redisson 3.19+: ProxyBuilder$Callback.execute(Callable, Method)
+            final InstrumentMethod callableExecuteMethod = target.getDeclaredMethod("execute", "java.util.concurrent.Callable", "java.lang.reflect.Method");
+            if (callableExecuteMethod != null) {
+                callableExecuteMethod.addInterceptor(ReactiveMethodInterceptor.class);
+            }
 
             return target.toBytecode();
         }

--- a/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/ReactiveMethodInterceptor.java
+++ b/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/ReactiveMethodInterceptor.java
@@ -60,6 +60,10 @@ public class ReactiveMethodInterceptor extends SpanEventSimpleAroundInterceptorF
 
         if (this.keyTrace) {
             Method method = ArrayArgumentUtils.getArgument(args, 0, Method.class);
+            if (method == null) {
+                // redisson 3.19+: ProxyBuilder$Callback.execute(Callable, Method)
+                method = ArrayArgumentUtils.getArgument(args, 1, Method.class);
+            }
             if (method != null && StringUtils.hasLength(method.getName())) {
                 recorder.recordAttribute(AnnotationKey.ARGS0, method.getName());
             }


### PR DESCRIPTION
The reactive proxy callback ReactiveProxyBuilder$1.execute changed its signature across redisson versions - (Method, Object, Object[]), then (Method, Object, Method, Object[]) around 3.17.x, then (Callable, Method) since 3.19 - and the plugin matched only the oldest shape, so reactive command tracing was silently dead on modern redisson. Match all three shapes and look up the keytrace Method argument at both positions.

Verified by the new redis-redisson-it module against redisson 3.17.7 and 3.27.2 (the assertion fails with the transform fix reverted).