### PR TITLE
[#noissue] Replace duplicated reserved-uid check with ServiceUid.isReservedUid

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/RandomServiceUidGenerator.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/util/RandomServiceUidGenerator.java
@@ -11,15 +11,11 @@ public class RandomServiceUidGenerator implements IdGenerator<ServiceUid> {
 
     @Override
     public ServiceUid generate() {
-        int randomInt;
+        int serviceUid;
         do {
-            randomInt = random.nextInt();
-        } while (isReservedServiceUid(randomInt));
+            serviceUid = random.nextInt();
+        } while (ServiceUid.isReservedUid(serviceUid));
 
-        return ServiceUid.of(randomInt);
-    }
-
-    private boolean isReservedServiceUid(int uid) {
-        return -ServiceUid.RESERVED_NEGATIVE_UID_COUNT <= uid && uid <= ServiceUid.RESERVED_POSITIVE_UID_COUNT;
+        return ServiceUid.of(serviceUid);
     }
 }


### PR DESCRIPTION
…servedUid

This pull request simplifies the logic for generating random service UIDs by removing a redundant private method and directly using an existing static method for reserved UID checking.

Refactoring and simplification:

* In `RandomServiceUidGenerator`, replaced the custom `isReservedServiceUid` method with the static `ServiceUid.isReservedUid` method for checking reserved UIDs, reducing code duplication.
* Removed the now-unnecessary private `isReservedServiceUid` method from `RandomServiceUidGenerator`.