### PR TITLE
[#noissue] Read configuration from configurationAtom in packages/ui

### DIFF
--- a/web-frontend/src/main/v3/.claude/rules/components.md
+++ b/web-frontend/src/main/v3/.claude/rules/components.md
@@ -10,18 +10,30 @@ paths:
 ## 페이지 컴포넌트 (apps/web/src/pages/)
 - 페이지는 얇은 래퍼: `@pinpoint-fe/ui`에서 페이지 컴포넌트를 임포트하여 렌더링
 - 레이아웃 감싸기는 `apps/web/src/routes/index.tsx`의 중첩 레이아웃 라우트(`SideNavigationOutlet`, `InitialFetchOutlet`, `ConfigurationOutlet`)에서 처리
-- 설정이 필요한 페이지는 `useAtomValue`로 `configurationAtom`에서 읽음
-- 패턴:
+- **configuration은 prop으로 내려주지 않음** — 필요한 컴포넌트가 `useConfiguration()`으로 직접 읽음
+- 넘길 prop이 없는 래퍼는 재수출로 끝냄:
   ```tsx
-  import { useAtomValue } from 'jotai';
+  export { SomePageComponent as default } from '@pinpoint-fe/ui';
+  ```
+- 이 저장소 전용 prop이 있을 때만 래퍼 컴포넌트를 유지:
+  ```tsx
   import { SomePageComponent } from '@pinpoint-fe/ui';
-  import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
+  import { ApplicationCombinedList } from '@pinpoint-fe/web/src/components/Application/ApplicationCombinedList';
 
   export default function SomePage() {
-    const configuration = useAtomValue(configurationAtom);
-    return <SomePageComponent configuration={configuration} />;
+    return <SomePageComponent ApplicationList={ApplicationCombinedList} />;
   }
   ```
+
+## configuration 읽기
+- `packages/ui`는 `useConfiguration()`(`@pinpoint-fe/ui/src/hooks`)으로 `configurationAtom`을 읽음 — prop으로 받지 않음
+- 저장소는 ui의 `configurationAtom` 하나뿐. `apps/web`에서 별도 atom을 만들지 않음
+- `Configuration`을 확장한 저장소는 래퍼 훅을 하나 두고, 호출부는 타입 인자 없이 사용:
+  ```tsx
+  // apps/web/src/hooks/useConfiguration.ts
+  export const useConfiguration = () => useCommonConfiguration<Configuration>();
+  ```
+- React 밖(라우트 로더)에서는 atom이 아직 비어 있으므로 `getConfiguration()`을 직접 호출
 
 ## 도메인 컴포넌트 (packages/ui/src/components/)
 - 도메인별 컴포넌트는 자체 서브디렉토리에 배치 (예: `ServerMap/`, `ErrorAnalysis/`)

--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
@@ -39,7 +39,7 @@ export const InitialFetchOutlet = () => {
   const requestService = resolveRequestService(selectedService);
 
   useExperimentals(data);
-  useServicesFetch(configuration);
+  useServicesFetch();
   useClearApplicationOnServiceChange(enableServiceMap);
 
   React.useEffect(() => {

--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/LayoutWithSideNavigation.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/LayoutWithSideNavigation.tsx
@@ -4,9 +4,7 @@ import {
   SideNavigationMenuItem,
   useServiceSideNavigation,
 } from '@pinpoint-fe/ui';
-import { useAtomValue } from 'jotai';
 import { FaCog } from 'react-icons/fa';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 import { LuCircleUser } from 'react-icons/lu';
 import { CONFIG_MENU_MAP } from './LayoutWithConfiguration';
@@ -14,7 +12,6 @@ import { MdOutlineAdminPanelSettings } from 'react-icons/md';
 import { useMenuItems } from '@pinpoint-fe/web/src/hooks/useMenuItems';
 
 export const LayoutWithSideNavigation = ({ ...props }: LayoutWithSideNavigationProps) => {
-  const configuration = useAtomValue(configurationAtom);
   const { menuItems } = useMenuItems();
 
   const serviceGroupItems: SideNavigationMenuItem[] = [
@@ -25,7 +22,7 @@ export const LayoutWithSideNavigation = ({ ...props }: LayoutWithSideNavigationP
     },
   ];
 
-  const { serviceMenuItems } = useServiceSideNavigation(configuration, serviceGroupItems);
+  const { serviceMenuItems } = useServiceSideNavigation(serviceGroupItems);
 
   const topMenuItems = menuItems;
 

--- a/web-frontend/src/main/v3/apps/web/src/main.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/main.tsx
@@ -6,7 +6,6 @@ import { IconContext } from 'react-icons';
 // import { ReactToastContainer, queryClient } from '@pinpoint-fe/ui';
 import { ReactToastContainer } from '@pinpoint-fe/ui/src/components';
 import { queryClient, installServiceNameFetchInterceptor } from '@pinpoint-fe/ui/src/hooks';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
 import router from './routes';
 import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n';
@@ -18,9 +17,8 @@ const jotaiStore = getDefaultStore();
 
 // configuration의 experimental.enableServiceMap이 켜져 있을 때, 모든 /api 요청 헤더에
 // 현재 선택된 service를 주입한다. 렌더링/최초 fetch 이전에 한 번 설치해야 한다.
-// configuration은 부트스트랩 이후 비동기로 로드되므로, 매 요청 시 store에서 최신값을
-// 읽도록 getter를 주입한다.
-installServiceNameFetchInterceptor(() => jotaiStore.get(configurationAtom));
+// 인터셉터는 매 요청 시 store에서 configuration/service 최신값을 직접 읽는다.
+installServiceNameFetchInterceptor();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.Fragment>

--- a/web-frontend/src/main/v3/apps/web/src/pages/ErrorAnalysis.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/ErrorAnalysis.tsx
@@ -1,8 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { ErrorAnalysisPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-
-export default function ErrorAnalysis() {
-  const configuration = useAtomValue(configurationAtom);
-  return <ErrorAnalysisPage configuration={configuration} />;
-}
+export { ErrorAnalysisPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/FilteredMap.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/FilteredMap.tsx
@@ -1,11 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { FilteredMapPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
-
-export default function FilteredMap() {
-  const configuration = useAtomValue(configurationAtom) as
-    | (Configuration & Record<string, string>)
-    | undefined;
-  return <FilteredMapPage configuration={configuration} />;
-}
+export { FilteredMapPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/Inspector.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/Inspector.tsx
@@ -1,8 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { InspectorPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-
-export default function Inspector() {
-  const configuration = useAtomValue(configurationAtom);
-  return <InspectorPage configuration={configuration} />;
-}
+export { InspectorPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/OpenTelemetry.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/OpenTelemetry.tsx
@@ -1,11 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { OpenTelemetryPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
-
-export default function OpenTelemetry() {
-  const configuration = useAtomValue(configurationAtom) as
-    | (Configuration & Record<string, unknown>)
-    | undefined;
-  return <OpenTelemetryPage configuration={configuration} />;
-}
+export { OpenTelemetryPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/ScatterOrHeatmapFullScreen.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/ScatterOrHeatmapFullScreen.tsx
@@ -1,11 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { ScatterOrHeatmapFullScreenPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
-
-export default function ScatterOrHeatmapFullScreen() {
-  const configuration = useAtomValue(configurationAtom) as
-    | (Configuration & Record<string, unknown>)
-    | undefined;
-  return <ScatterOrHeatmapFullScreenPage configuration={configuration} />;
-}
+export { ScatterOrHeatmapFullScreenPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/ServerMap/Realtime.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/ServerMap/Realtime.tsx
@@ -1,11 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { RealtimePage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
-
-export default function Realtime() {
-  const configuration = useAtomValue(configurationAtom) as
-    | (Configuration & Record<string, string>)
-    | undefined;
-  return <RealtimePage configuration={configuration} />;
-}
+export { RealtimePage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/ServerMap/index.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/ServerMap/index.tsx
@@ -1,11 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { ServerMapPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
-
-export default function ServerMap() {
-  const configuration = useAtomValue(configurationAtom) as
-    | (Configuration & Record<string, string>)
-    | undefined;
-  return <ServerMapPage configuration={configuration} />;
-}
+export { ServerMapPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/ServiceMap.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/ServiceMap.tsx
@@ -1,11 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { ServiceMapPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
-
-export default function ServiceMap() {
-  const configuration = useAtomValue(configurationAtom) as
-    | (Configuration & Record<string, string>)
-    | undefined;
-  return <ServiceMapPage configuration={configuration} />;
-}
+export { ServiceMapPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/SystemMetric.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/SystemMetric.tsx
@@ -1,11 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { SystemMetricPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
-
-export default function SystemMetric() {
-  const configuration = useAtomValue(configurationAtom) as
-    | (Configuration & Record<string, unknown>)
-    | undefined;
-  return <SystemMetricPage configuration={configuration} />;
-}
+export { SystemMetricPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/UrlStatistic.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/UrlStatistic.tsx
@@ -1,11 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { UrlStatisticPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
-
-export default function UrlStatistic() {
-  const configuration = useAtomValue(configurationAtom) as
-    | (Configuration & Record<string, unknown>)
-    | undefined;
-  return <UrlStatisticPage configuration={configuration} />;
-}
+export { UrlStatisticPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/config/AgentManagement.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/config/AgentManagement.tsx
@@ -1,8 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { AgentManagementPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-
-export default function AgentManagement() {
-  const configuration = useAtomValue(configurationAtom);
-  return <AgentManagementPage configuration={configuration} />;
-}
+export { AgentManagementPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/config/AgentStatistic.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/config/AgentStatistic.tsx
@@ -1,8 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { AgentStatisticPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-
-export default function AgentStatistic() {
-  const configuration = useAtomValue(configurationAtom);
-  return <AgentStatisticPage configuration={configuration} />;
-}
+export { AgentStatisticPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/config/Alarm.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/config/Alarm.tsx
@@ -1,8 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { AlarmPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-
-export default function Alarm() {
-  const configuration = useAtomValue(configurationAtom);
-  return <AlarmPage configuration={configuration} />;
-}
+export { AlarmPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/config/Experimentals.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/config/Experimentals.tsx
@@ -1,8 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { ExperimentalPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-
-export default function Experimentals() {
-  const configuration = useAtomValue(configurationAtom);
-  return <ExperimentalPage configuration={configuration} />;
-}
+export { ExperimentalPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/config/ServiceSetting.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/config/ServiceSetting.tsx
@@ -1,8 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { ServiceSettingPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-
-export default function ServiceSetting() {
-  const configuration = useAtomValue(configurationAtom);
-  return <ServiceSettingPage configuration={configuration} />;
-}
+export { ServiceSettingPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/config/UserGroup.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/config/UserGroup.tsx
@@ -1,8 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { UserGroupPage as CommonUserGroupPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-
-export default function UserGroup() {
-  const configuration = useAtomValue(configurationAtom);
-  return <CommonUserGroupPage configuration={configuration} />;
-}
+export { UserGroupPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/config/Users.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/config/Users.tsx
@@ -1,8 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { UsersPage as CommonUsersPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-
-export default function Users() {
-  const configuration = useAtomValue(configurationAtom);
-  return <CommonUsersPage configuration={configuration} />;
-}
+export { UsersPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/pages/config/Webhook.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/pages/config/Webhook.tsx
@@ -1,8 +1,1 @@
-import { useAtomValue } from 'jotai';
-import { WebhookPage } from '@pinpoint-fe/ui';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-
-export default function Webhook() {
-  const configuration = useAtomValue(configurationAtom);
-  return <WebhookPage configuration={configuration} />;
-}
+export { WebhookPage as default } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/configuration.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/configuration.ts
@@ -1,4 +1,13 @@
 import { atom } from 'jotai';
 import { Configuration } from '@pinpoint-fe/ui/src/constants';
 
+/**
+ * 모든 화면이 공유하는 단일 configuration 저장소.
+ *
+ * 타입은 OSS 기준인 `Configuration`으로 고정한다. `Configuration`을 확장한 저장소
+ * (naver 등)도 구조적 타이핑상 확장 객체를 그대로 넣을 수 있으므로 쓰기에는 제약이 없다.
+ * 확장 필드를 "읽는" 쪽만 타입을 넓혀야 하는데, 그건 이 atom을 넓히는 대신
+ * `useConfiguration<T>()`에서 처리한다. atom 자체를 넓히면(예: 인덱스 시그니처)
+ * 기존 필드의 오타 검출과 확장 필드의 정확한 타입을 모두 잃는다.
+ */
 export const configurationAtom = atom<Configuration | undefined>(undefined);

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/serverMap.ts
@@ -7,7 +7,6 @@ import {
   AgentOverview,
 } from '@pinpoint-fe/ui/src/constants';
 import { Node, Edge } from '@pinpoint-fe/server-map';
-import { configurationAtom } from './configuration';
 
 export type CurrentTarget = {
   id?: string;

--- a/web-frontend/src/main/v3/packages/ui/src/components/Alarm/AlarmDetail.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Alarm/AlarmDetail.tsx
@@ -7,6 +7,7 @@ import { AlarmRule } from '@pinpoint-fe/ui/src/constants';
 import omit from 'lodash.omit';
 import {
   useAlarmRuleMutation,
+  useConfiguration,
   useGetAlarmRuleChecker,
   useGetUserGroup,
   useGetWebhook,
@@ -37,8 +38,6 @@ import { useReactToastifyToast } from '../../components/Toast';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../components/ui/dialog';
 import { WebhookDetail } from '../../components/Webhook/WebhookDetail';
 import { cn } from '../../lib/utils';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
-import { useAtomValue } from 'jotai';
 import { HelpPopover } from '../../components/HelpPopover';
 
 export interface AlarmDetailProps {
@@ -149,7 +148,7 @@ export const AlarmDetail = ({
       }),
     [t],
   );
-  const configuration = useAtomValue(configurationAtom);
+  const configuration = useConfiguration();
   const [openWebhookDialog, setOpenWebhookDialog] = React.useState(false);
   const { data: chekerList } = useGetAlarmRuleChecker({ disableFetch: !editable });
   const { refetch: refetchWebhookList } = useGetWebhook({

--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/agentStatistic/AgentStatisticFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/agentStatistic/AgentStatisticFetcher.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { HiOutlineRefresh } from 'react-icons/hi';
 import { useTranslation } from 'react-i18next';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import { Button, Separator } from '../../../components';
 import { useGetAgentsStatistics, useTimezone } from '@pinpoint-fe/ui/src/hooks';
 import { CgSpinner } from 'react-icons/cg';
@@ -10,13 +9,7 @@ import { AgentStatisticContainer } from './AgentStatisticChartContainer';
 import { AgentStatisticTable } from './AgentStatisticTable';
 import { formatInTimeZone } from 'date-fns-tz';
 
-export interface AgentStatisticFetcherProps {
-  configuration?: Configuration;
-}
-
-export const AgentStatisticFetcher = ({ configuration }: AgentStatisticFetcherProps) => {
-  void configuration; // Not use configuration
-
+export const AgentStatisticFetcher = () => {
   const { t } = useTranslation();
   const [timezone] = useTimezone();
   const [load, setLoad] = React.useState(false);

--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/user-group/user-group/UserGroup.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/user-group/user-group/UserGroup.tsx
@@ -1,11 +1,9 @@
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
+import { useConfiguration } from '@pinpoint-fe/ui/src/hooks';
 import { UserGroupTable } from './UserGroupTable';
 
-export interface UserGroupProps {
-  configuration?: Configuration;
-}
+export const UserGroup = () => {
+  const configuration = useConfiguration();
 
-export const UserGroup = ({ configuration }: UserGroupProps) => {
   return (
     configuration && <UserGroupTable enableUserGroupAdd={true} enableAllUserGroupRemove={true} />
   );

--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/users/UsersTableFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/users/UsersTableFetcher.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
+  useConfiguration,
   useGetConfigUsers,
   usePostConfigUser,
   usePutConfigUser,
   useDeleteConfigUser,
 } from '@pinpoint-fe/ui/src/hooks';
-import { Configuration, ConfigUsers } from '@pinpoint-fe/ui/src/constants';
+import { ConfigUsers } from '@pinpoint-fe/ui/src/constants';
 import { UsersTable } from './UsersTable';
 import { FaRegTrashCan } from 'react-icons/fa6';
 import { UserForm } from './UserForm';
@@ -14,15 +15,12 @@ import { UsersSheet } from './UsersSheet';
 import { UserRemovePopup } from './UserRemovePopup';
 import { useReactToastifyToast, Button } from '../../../components';
 
-export interface UsersTableFetcherProps {
-  configuration?: Configuration;
-}
-
 export interface UsersTableAction {
   refresh: () => void;
 }
 
-export const UsersTableFetcher = ({ configuration }: UsersTableFetcherProps) => {
+export const UsersTableFetcher = () => {
+  const configuration = useConfiguration();
   const { t } = useTranslation();
   const toast = useReactToastifyToast();
   const enableUserEdit = configuration?.editUserInfo;

--- a/web-frontend/src/main/v3/packages/ui/src/components/FilterMap/FilteredMapChartsBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/FilterMap/FilteredMapChartsBoard.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ChartsBoard, ChartsBoardProps } from '../ChartsBoard';
 import {
   BASE_PATH,
-  Configuration,
   FilteredMapType as FilteredMap,
   GetHistogramStatistics,
   GetServerMap,
@@ -49,7 +48,6 @@ export interface FilteredMapChartsBoardProps extends Omit<
   SERVER_LIST_WIDTH: number;
   resizeHandleWidth: number;
   FILTERED_MAP_CONTAINER_ID: string;
-  configuration?: Configuration;
 }
 
 export const FilteredMapChartsBoard = ({
@@ -58,13 +56,12 @@ export const FilteredMapChartsBoard = ({
   SERVER_LIST_WIDTH,
   resizeHandleWidth,
   FILTERED_MAP_CONTAINER_ID,
-  configuration,
   children,
   ...props
 }: FilteredMapChartsBoardProps) => {
   const { t } = useTranslation();
   const { dateRange, application, searchParameters } = useFilteredMapParameters();
-  const serviceNameForLink = useServiceNameForLink(configuration);
+  const serviceNameForLink = useServiceNameForLink();
 
   const [openServerView, setOpenServerView] = React.useState(false);
 
@@ -206,7 +203,6 @@ export const FilteredMapChartsBoard = ({
                         }
                         range={[dateRange.from.getTime(), dateRange.to.getTime()]}
                         selectedAgentId={SCATTER_DATA_TOTAL_KEY}
-                        configuration={configuration}
                         onDragEnd={(data, checkedLables) => {
                           if (checkedLables.length) {
                             window.__pp_scatter_data__ =
@@ -297,7 +293,6 @@ export const FilteredMapChartsBoard = ({
                     }
                     range={[dateRange.from.getTime(), dateRange.to.getTime()]}
                     selectedAgentId={currentServer?.agentId}
-                    configuration={configuration}
                     onDragEnd={(data, checkedLables) => {
                       if (checkedLables.length) {
                         window.__pp_scatter_data__ =

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapFetcher.tsx
@@ -13,7 +13,7 @@ const DefaultAxisY = [0, 10000];
 
 export type HeatmapFetcherProps = {
   agentId?: string;
-} & Pick<HeatmapChartCoreProps, 'toolbarOption' | 'nodeData' | 'configuration'>;
+} & Pick<HeatmapChartCoreProps, 'toolbarOption' | 'nodeData'>;
 
 export const HeatmapFetcher = ({ nodeData, agentId, ...props }: HeatmapFetcherProps) => {
   const { t } = useTranslation();

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapRealtimeFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapRealtimeFetcher.tsx
@@ -29,7 +29,7 @@ function ceilTo10SecAndSubtract30(date: Date): Date {
 export type HeatmapRealtimeFetcherProps = {
   nodeData: GetServerMap.NodeData | ApplicationType;
   agentId?: string;
-} & Pick<HeatmapChartCoreProps, 'toolbarOption' | 'configuration'>;
+} & Pick<HeatmapChartCoreProps, 'toolbarOption'>;
 
 export const HeatmapRealtimeFetcher = ({
   nodeData,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/core/HeatmapChartCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/core/HeatmapChartCore.tsx
@@ -6,7 +6,6 @@ import {
   GetHeatmapAppData,
   GetServerMap,
   ApplicationType,
-  Configuration,
 } from '@pinpoint-fe/ui/src/constants';
 import HeatmapChart from './HeatmapChart';
 import {
@@ -38,8 +37,6 @@ export type HeatmapChartCoreProps = {
       hide?: boolean;
     };
   };
-  /** transactionList 링크에 실을 service를 판단하는 데 쓴다(`useServiceNameForLink`). */
-  configuration?: Configuration;
 };
 
 const HeatmapChartCore = ({
@@ -49,12 +46,11 @@ const HeatmapChartCore = ({
   data,
   agentId,
   toolbarOption,
-  configuration,
 }: HeatmapChartCoreProps) => {
   const chartContainerRef = React.useRef<HTMLDivElement>(null);
 
   const { dateRange, searchParameters } = useServerMapSearchParameters();
-  const serviceNameForLink = useServiceNameForLink(configuration);
+  const serviceNameForLink = useServiceNameForLink();
   const [showSetting, setShowSetting] = React.useState(false);
   const [isCapturingImage, setIsCapturingImage] = React.useState(false);
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/Layout/LayoutWithAlarm.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Layout/LayoutWithAlarm.tsx
@@ -1,15 +1,16 @@
-import { APP_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
+import { useConfiguration } from '@pinpoint-fe/ui/src/hooks';
 import { Separator } from '../../components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../components/ui/tabs';
 import { t } from 'i18next';
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 export interface LayoutWithAlarmProps {
-  configuration?: Configuration;
   children?: React.ReactNode;
 }
 
-export const LayoutWithAlarm = ({ children, configuration }: LayoutWithAlarmProps) => {
+export const LayoutWithAlarm = ({ children }: LayoutWithAlarmProps) => {
+  const configuration = useConfiguration();
   const { pathname } = useLocation();
   const navigate = useNavigate();
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
@@ -28,20 +28,11 @@ import {
   serverMapDataAtom,
   serverMapChartTypeAtom,
 } from '@pinpoint-fe/ui/src/atoms';
-import {
-  APP_SETTING_KEYS,
-  ApplicationType,
-  GetServerMap,
-  Configuration,
-} from '@pinpoint-fe/ui/src/constants';
+import { APP_SETTING_KEYS, ApplicationType, GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { getServerImagePath } from '@pinpoint-fe/ui/src/utils';
 import { cn } from '@pinpoint-fe/ui/src/lib';
 
-export interface RealtimeProps {
-  configuration?: Configuration;
-}
-
-export const Realtime = ({ configuration }: RealtimeProps) => {
+export const Realtime = () => {
   const chartType = useAtomValue(serverMapChartTypeAtom);
   const isFocus = useTabFocus();
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -164,7 +155,7 @@ export const Realtime = ({ configuration }: RealtimeProps) => {
             <>
               {(currentTargetData as GetServerMap.NodeData)?.instanceCount ? (
                 <div className="flex items-center h-12 py-2.5 px-4">
-                  <ChartTypeButtons configuration={configuration} />
+                  <ChartTypeButtons />
                   <InstanceCount className="ml-auto" nodeData={currentTargetData} />
                 </div>
               ) : null}
@@ -186,14 +177,12 @@ export const Realtime = ({ configuration }: RealtimeProps) => {
                       <ScatterChart
                         node={serverMapCurrentTarget || (application as ApplicationType)}
                         realtime={true}
-                        configuration={configuration}
                       />
                     ) : (
                       // <div className="w-full pl-3 pt-5 pr-10 pb-8 aspect-[1.3]">
                       <Heatmap
                         nodeData={currentTargetData || (application as ApplicationType)}
                         realtime={true}
-                        configuration={configuration}
                       />
                       // </div>
                     )}

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartFetcher.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  SCATTER_DATA_TOTAL_KEY,
-  BASE_PATH,
-  ApplicationType,
-  Configuration,
-} from '@pinpoint-fe/ui/src/constants';
+import { SCATTER_DATA_TOTAL_KEY, BASE_PATH, ApplicationType } from '@pinpoint-fe/ui/src/constants';
 import { CurrentTarget } from '@pinpoint-fe/ui/src/atoms';
 import {
   convertParamsToQueryString,
@@ -26,19 +21,16 @@ export interface ScatterChartFetcherProps {
   node: CurrentTarget;
   agentId?: string;
   toolbarOption?: ScatterChartCoreProps['toolbarOption'];
-  /** transactionList 링크에 실을 service를 판단하는 데 쓴다(`useServiceNameForLink`). */
-  configuration?: Configuration;
 }
 
 export const ScatterChartFetcher = ({
   node,
   agentId = SCATTER_DATA_TOTAL_KEY,
   toolbarOption,
-  configuration,
 }: ScatterChartFetcherProps) => {
   const scatterRef = React.useRef<ScatterChartHandle>(null);
   const { dateRange, searchParameters } = useServerMapSearchParameters();
-  const serviceNameForLink = useServiceNameForLink(configuration);
+  const serviceNameForLink = useServiceNameForLink();
   const from = dateRange.from.getTime();
   const to = dateRange.to.getTime();
   const currentNode = `${node.applicationName}^${node.serviceType}`;

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartRealtimeFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartRealtimeFetcher.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  SCATTER_DATA_TOTAL_KEY,
-  BASE_PATH,
-  GetScatter,
-  Configuration,
-} from '@pinpoint-fe/ui/src/constants';
+import { SCATTER_DATA_TOTAL_KEY, BASE_PATH, GetScatter } from '@pinpoint-fe/ui/src/constants';
 import { CurrentTarget } from '@pinpoint-fe/ui/src/atoms';
 import {
   convertParamsToQueryString,
@@ -28,19 +23,16 @@ export interface ScatterChartRealtimeFetcherProps {
   node: CurrentTarget;
   agentId?: string;
   toolbarOption?: ScatterChartCoreProps['toolbarOption'];
-  /** transactionList 링크에 실을 service를 판단하는 데 쓴다(`useServiceNameForLink`). */
-  configuration?: Configuration;
 }
 
 export const ScatterChartRealtimeFetcher = ({
   node,
   agentId = SCATTER_DATA_TOTAL_KEY,
   toolbarOption,
-  configuration,
 }: ScatterChartRealtimeFetcherProps) => {
   const scatterRef = React.useRef<ScatterChartHandle>(null);
   const { dateRange } = useServerMapSearchParameters();
-  const serviceNameForLink = useServiceNameForLink(configuration);
+  const serviceNameForLink = useServiceNameForLink();
   const from = dateRange.from.getTime();
   const to = dateRange.to.getTime();
   const currentNode = `${node.applicationName}^${node.serviceType}`;

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartStatic.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartStatic.tsx
@@ -11,7 +11,6 @@ import {
   SCATTER_DATA_TOTAL_KEY,
   SEARCH_PARAMETER_DATE_FORMAT,
   BASE_PATH,
-  Configuration,
 } from '@pinpoint-fe/ui/src/constants';
 import { formatInTimeZone } from 'date-fns-tz';
 import {
@@ -34,8 +33,6 @@ export interface ScatterChartStaticProps extends Pick<
   data?: ScatterDataType[];
   range: [number, number];
   selectedAgentId?: string;
-  /** transactionList 링크에 실을 service를 판단하는 데 쓴다(`useServiceNameForLink`). */
-  configuration?: Configuration;
 }
 
 export const ScatterChartStatic = ({
@@ -43,11 +40,10 @@ export const ScatterChartStatic = ({
   data = [],
   range,
   selectedAgentId,
-  configuration,
   ...props
 }: ScatterChartStaticProps) => {
   const { searchParameters } = useServerMapSearchParameters();
-  const serviceNameForLink = useServiceNameForLink(configuration);
+  const serviceNameForLink = useServiceNameForLink();
   const [timezone] = useTimezone();
   const scatterRef = React.useRef<ScatterChartHandle>(null);
   const [x, setX] = React.useState<[number, number]>([range[0], range[1]]);

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ChartTypeButtons.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ChartTypeButtons.tsx
@@ -5,9 +5,10 @@ import { PiChartScatterBold } from 'react-icons/pi';
 import { AiOutlineTable } from 'react-icons/ai';
 import { TooltipContent, TooltipProvider, Tooltip, TooltipTrigger, Button } from '../ui';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
+import { useConfiguration } from '@pinpoint-fe/ui/src/hooks';
 
-export const ChartTypeButtons = ({ configuration }: { configuration?: Configuration }) => {
+export const ChartTypeButtons = () => {
+  const configuration = useConfiguration();
   const [chartType, setChartType] = useAtom(serverMapChartTypeAtom);
 
   useEffect(() => {

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
@@ -18,7 +18,7 @@ import {
   ScatterChartStatic,
   ChartsBoardHeader,
 } from '@pinpoint-fe/ui/src/components';
-import { Configuration, GetServerMap } from '@pinpoint-fe/ui/src/constants';
+import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { useExperimentals, useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { MdArrowBackIosNew, MdArrowForwardIos } from 'react-icons/md';
 import { PiArrowSquareOut } from 'react-icons/pi';
@@ -61,7 +61,6 @@ export interface ServerMapChartsBoardFetcherProps extends Omit<
   SERVER_LIST_WIDTH: number;
   resizeHandleWidth: number;
   SERVERMAP_CONTAINER_ID: string;
-  configuration?: Configuration;
 }
 
 export const ServerMapChartsBoardFetcher = ({
@@ -70,7 +69,6 @@ export const ServerMapChartsBoardFetcher = ({
   SERVER_LIST_WIDTH,
   resizeHandleWidth,
   SERVERMAP_CONTAINER_ID,
-  configuration,
   children,
   ...props
 }: ServerMapChartsBoardFetcherProps) => {
@@ -250,12 +248,12 @@ export const ServerMapChartsBoardFetcher = ({
                       {openServerView ? <MdArrowForwardIos /> : <MdArrowBackIosNew />}
                       <span className="ml-2">VIEW SERVERS</span>
                     </Button>
-                    {!shouldHideScatter() && <ChartTypeButtons configuration={configuration} />}
+                    {!shouldHideScatter() && <ChartTypeButtons />}
                     <InstanceCount nodeData={data as unknown as GetServerMap.NodeData} />
                   </div>
                 ) : !shouldHideScatter() ? (
                   <div className="flex items-center h-12 py-2.5 px-4 gap-2">
-                    <ChartTypeButtons configuration={configuration} />
+                    <ChartTypeButtons />
                   </div>
                 ) : null}
                 {!shouldHideScatter() && (
@@ -274,12 +272,10 @@ export const ServerMapChartsBoardFetcher = ({
                       {chartType === 'scatter' ? (
                         <ScatterChart
                           node={(serverMapCurrentTarget || application) as CurrentTarget}
-                          configuration={configuration}
                         />
                       ) : (
                         <Heatmap
                           nodeData={(currentTargetData as GetServerMap.NodeData) || application}
-                          configuration={configuration}
                         />
                       )}
                     </div>
@@ -348,7 +344,6 @@ export const ServerMapChartsBoardFetcher = ({
                     }
                     range={[dateRange.from.getTime(), dateRange.to.getTime()]}
                     selectedAgentId={currentServer?.agentId || ''}
-                    configuration={configuration}
                   />
                   {isScatterDataOutdated && (
                     <div className="absolute top-0 left-0 z-[1000] flex flex-col items-center justify-center w-full h-[calc(100%+48px)] bg-background/50 text-center">

--- a/web-frontend/src/main/v3/packages/ui/src/components/Service/useServiceSideNavigation.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Service/useServiceSideNavigation.tsx
@@ -9,15 +9,14 @@ import {
   selectedServiceAtom,
   servicesAtom,
 } from '@pinpoint-fe/ui/src/atoms';
-import { APP_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
+import { useConfiguration } from '@pinpoint-fe/ui/src/hooks';
 import { buildServiceSidebarItems } from '../Layout/serviceMenu';
 import { SERVICE_CONFIG_MENU } from './serviceConfigMenu';
 import type { SideNavigationMenuItem } from '../Layout/LayoutWithSideNavigation';
 
-export const useServiceSideNavigation = (
-  configuration: Configuration | undefined,
-  serviceGroupItems: SideNavigationMenuItem[] = [],
-) => {
+export const useServiceSideNavigation = (serviceGroupItems: SideNavigationMenuItem[] = []) => {
+  const configuration = useConfiguration();
   const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
   const services = useAtomValue(servicesAtom);
   const selectedService = useAtomValue(selectedServiceAtom);

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
@@ -24,9 +24,9 @@ const headerOfLastCall = (): string | null => {
 describe('serviceNameFetchInterceptor', () => {
   beforeAll(() => {
     // 패치 대상이 될 원본 fetch를 먼저 심어두고, 인터셉터를 한 번 설치한다.
-    // 인터셉터는 매 요청 시 getter로 최신 configuration을 읽으므로, store에서 읽도록 주입한다.
+    // 인터셉터는 매 요청 시 configurationAtom에서 최신값을 직접 읽으므로 주입할 것이 없다.
     window.fetch = originalFetch as typeof window.fetch;
-    installServiceNameFetchInterceptor(() => store.get(configurationAtom));
+    installServiceNameFetchInterceptor();
   });
 
   beforeEach(() => {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
@@ -1,6 +1,6 @@
 import { getDefaultStore } from 'jotai';
-import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
-import { BASE_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { configurationAtom, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+import { BASE_PATH } from '@pinpoint-fe/ui/src/constants';
 import { getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';
 
 /**
@@ -64,18 +64,14 @@ let installed = false;
  * `/api` 요청 헤더에 그 요청이 해석되는 service(`resolveRequestService`)를 주입한다.
  * 화면별 예외는 없다. 설정이 꺼져 있으면 헤더를 아예 붙이지 않아 백엔드가 기본 service로 해석한다.
  *
- * configuration은 부트스트랩 이후 비동기로 로드/갱신되므로, 값이 아니라
- * 매 요청 시 최신 configuration을 반환하는 getter(`getConfiguration`)를 받는다.
- * 이를 통해 ui 패키지가 `configurationAtom`에 직접 의존하지 않고,
- * web 앱이 configuration의 출처를 주입한다.
+ * configuration은 부트스트랩 이후 비동기로 로드/갱신되므로, 값을 캡처하지 않고
+ * 매 요청 시 `configurationAtom`에서 최신값을 읽는다.
  *
- * service는 Jotai 기본 store(`getDefaultStore`)에서 읽으므로 컴포넌트의
- * `useAtomValue`/`useSetAtom`과 동일한 상태를 참조한다.
+ * configuration과 service 모두 Jotai 기본 store(`getDefaultStore`)에서 읽으므로
+ * 컴포넌트의 `useAtomValue`/`useSetAtom`과 동일한 상태를 참조한다.
  * 앱 부트스트랩(main.tsx)에서 렌더링 전에 한 번 호출한다.
  */
-export const installServiceNameFetchInterceptor = (
-  getConfiguration: () => Configuration | undefined,
-) => {
+export const installServiceNameFetchInterceptor = () => {
   if (installed) return;
   if (typeof window === 'undefined' || typeof window.fetch !== 'function') return;
   installed = true;
@@ -85,7 +81,7 @@ export const installServiceNameFetchInterceptor = (
 
   window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
     try {
-      const configuration = getConfiguration();
+      const configuration = store.get(configurationAtom);
       const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
 
       if (enableServiceMap && isApiRequest(input)) {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
@@ -1,6 +1,7 @@
 export * from './useAgentListSortBy';
 export * from './useCaptureKeydown';
 export * from './useClearApplicationOnServiceChange';
+export * from './useConfiguration';
 export * from './useDateFormat';
 export * from './useExperimentals';
 export * from './useHeightToBottom';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useConfiguration.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useConfiguration.test.ts
@@ -1,0 +1,70 @@
+import { renderHook, act } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration } from '@pinpoint-fe/ui/src/constants';
+import { useConfiguration } from './useConfiguration';
+
+const store = getDefaultStore();
+
+/** 확장 저장소(naver 등)의 Configuration을 흉내낸 타입. */
+interface ExtendedConfiguration extends Configuration {
+  showSqlStat: boolean;
+  'periodMax.sqlStat': number;
+}
+
+const setConfiguration = (configuration: Configuration | undefined) =>
+  act(() => {
+    store.set(configurationAtom, configuration);
+  });
+
+describe('useConfiguration', () => {
+  beforeEach(() => {
+    setConfiguration(undefined);
+  });
+
+  test('returns undefined before the configuration is loaded', () => {
+    // configuration은 부트스트랩 이후 비동기로 로드되므로 초기에는 비어 있다.
+    expect(renderHook(() => useConfiguration()).result.current).toBeUndefined();
+  });
+
+  test('returns the configuration stored in the atom', () => {
+    const configuration = { showHeatmap: true } as Configuration;
+    setConfiguration(configuration);
+
+    expect(renderHook(() => useConfiguration()).result.current).toEqual(configuration);
+  });
+
+  test('reflects a configuration update', () => {
+    const { result } = renderHook(() => useConfiguration());
+
+    setConfiguration({ showHeatmap: true } as Configuration);
+    expect(result.current?.showHeatmap).toBe(true);
+
+    setConfiguration({ showHeatmap: false } as Configuration);
+    expect(result.current?.showHeatmap).toBe(false);
+  });
+
+  test('returns undefined again when the configuration is cleared', () => {
+    setConfiguration({ showHeatmap: true } as Configuration);
+    setConfiguration(undefined);
+
+    expect(renderHook(() => useConfiguration()).result.current).toBeUndefined();
+  });
+
+  test('keeps the fields of an extended configuration when read with a type argument', () => {
+    // 확장 저장소는 자기 타입을 타입 인자로 넘겨 추가 필드까지 읽는다.
+    // atom은 base 타입이지만 구조적 타이핑상 확장 객체가 그대로 들어가고 값도 보존된다.
+    const configuration = {
+      showHeatmap: true,
+      showSqlStat: true,
+      'periodMax.sqlStat': 7,
+    } as ExtendedConfiguration;
+    setConfiguration(configuration);
+
+    const { result } = renderHook(() => useConfiguration<ExtendedConfiguration>());
+
+    expect(result.current?.showSqlStat).toBe(true);
+    expect(result.current?.['periodMax.sqlStat']).toBe(7);
+    expect(result.current?.showHeatmap).toBe(true);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useConfiguration.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useConfiguration.ts
@@ -1,0 +1,28 @@
+import { useAtomValue } from 'jotai';
+import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration } from '@pinpoint-fe/ui/src/constants';
+
+/**
+ * `configurationAtom`에 담긴 현재 configuration을 읽는다.
+ *
+ * `Configuration`을 확장한 저장소(naver 등)는 타입 인자로 자기 타입을 넘겨,
+ * 추가 필드까지 정확한 타입으로 읽는다.
+ *
+ * ```ts
+ * // ui 패키지 내부 — 공용 필드만 쓰므로 타입 인자 없이
+ * const configuration = useConfiguration();
+ *
+ * // 확장 저장소의 apps/web — 래퍼 훅을 하나 두고 호출부는 타입 인자 없이 쓴다
+ * export const useConfiguration = () => useBaseConfiguration<NaverConfiguration>();
+ * ```
+ *
+ * 타입 단언은 이 한 줄에만 둔다. atom을 넓히거나 호출부마다
+ * `Configuration & Record<string, unknown>`으로 캐스팅하면 확장 필드가 `unknown`/`any`가 되어
+ * 기존 필드의 오타 검출까지 함께 잃는다.
+ *
+ * configuration은 부트스트랩 이후 비동기로 로드되므로 채워지기 전에는 `undefined`다.
+ * 페이지 서브트리는 `InitialFetchOutlet`이 atom이 채워질 때까지 렌더를 막지만,
+ * 그 바깥(사이드 네비게이션 등)에서는 `undefined`를 그대로 만날 수 있다.
+ */
+export const useConfiguration = <T extends Configuration = Configuration>() =>
+  useAtomValue(configurationAtom) as T | undefined;

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { getDefaultStore } from 'jotai';
-import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
+import { configurationAtom, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
 import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import { useServiceNameForLink } from './useServiceNameForLink';
 
@@ -17,13 +17,17 @@ const configWithServiceMap = (enable: boolean) =>
 
 const renderServiceNameForLink = (pathname: string, configuration?: Configuration) => {
   mockLocation.pathname = pathname;
-  return renderHook(() => useServiceNameForLink(configuration)).result.current;
+  act(() => {
+    store.set(configurationAtom, configuration);
+  });
+  return renderHook(() => useServiceNameForLink()).result.current;
 };
 
 describe('useServiceNameForLink', () => {
   beforeEach(() => {
     act(() => {
       store.set(selectedServiceAtom, 'my-service');
+      store.set(configurationAtom, undefined);
     });
   });
 
@@ -39,7 +43,7 @@ describe('useServiceNameForLink', () => {
     ).toBeUndefined();
   });
 
-  test('returns undefined when no configuration is given yet', () => {
+  test('returns undefined when no configuration is loaded yet', () => {
     // configuration은 부트스트랩 이후 비동기로 로드되므로 아직 없을 수 있다.
     expect(renderServiceNameForLink('/serviceMap/test-app@SPRING_BOOT')).toBeUndefined();
   });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.ts
@@ -1,15 +1,15 @@
 import { useLocation } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
 import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import { getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';
+import { useConfiguration } from './useConfiguration';
 
 /**
  * 다른 화면으로 넘기는 링크(`getTransactionListPath`)에 실을 service 이름.
  * 실을 필요가 없으면 undefined를 반환하므로 링크 형태는 그대로 유지된다.
  *
- * configuration은 이 저장소의 관례대로 호출부에서 받는다. 페이지가 web 앱에서 받은
- * configuration을 prop으로 내려주므로, ui 패키지가 `configurationAtom`에 직접 의존하지 않는다.
+ * configuration은 `configurationAtom`에서 직접 읽는다. 저장소는 그 atom 하나뿐이므로
+ * 확장 저장소(naver 등)에서 이 파일을 그대로 복사해도 같은 값을 본다.
  *
  * 판단 규칙은 요청 헤더/캐시 키와 같은 `resolveRequestService`를 그대로 따른다.
  * - enableServiceMap이 꺼져 있으면 service 개념 자체가 없으므로 싣지 않는다.
@@ -17,7 +17,8 @@ import { getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';
  * - 이미 URL에 serviceName이 실려 있으면(transactionList) 전역 선택값보다 그것을 우선해,
  *   화면 안에서 이동해도 처음 열었을 때의 service가 유지된다.
  */
-export const useServiceNameForLink = (configuration?: Configuration) => {
+export const useServiceNameForLink = () => {
+  const configuration = useConfiguration();
   const selectedService = useAtomValue(selectedServiceAtom);
   const { pathname } = useLocation();
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.test.ts
@@ -1,9 +1,10 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { getDefaultStore } from 'jotai';
-import { servicesAtom } from '@pinpoint-fe/ui/src/atoms';
+import { configurationAtom, servicesAtom } from '@pinpoint-fe/ui/src/atoms';
 import { Configuration } from '@pinpoint-fe/ui/src/constants';
 
 // useGetServices는 React Query/네트워크에 의존하므로 barrel을 모킹해 격리한다.
+// (useConfiguration은 barrel이 아닌 상대 경로로 임포트되므로 이 모킹에 영향받지 않는다.)
 jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
   useGetServices: jest.fn(),
 }));
@@ -17,16 +18,23 @@ const store = getDefaultStore();
 const configWith = (enable: boolean) =>
   ({ 'experimental.enableServiceMap.value': enable }) as unknown as Configuration;
 
+const setConfiguration = (configuration: Configuration | undefined) =>
+  act(() => {
+    store.set(configurationAtom, configuration);
+  });
+
 beforeEach(() => {
   mockedUseGetServices.mockReset();
   store.set(servicesAtom, undefined);
+  store.set(configurationAtom, undefined);
 });
 
 describe('useServicesFetch', () => {
   test('keeps servicesAtom undefined and disables the query when enableServiceMap is off', () => {
     mockedUseGetServices.mockReturnValue({ data: ['DEFAULT', 'a'] });
+    setConfiguration(configWith(false));
 
-    renderHook(() => useServicesFetch(configWith(false)));
+    renderHook(() => useServicesFetch());
 
     expect(mockedUseGetServices).toHaveBeenCalledWith({ enabled: false });
     expect(store.get(servicesAtom)).toBeUndefined();
@@ -34,17 +42,18 @@ describe('useServicesFetch', () => {
 
   test('syncs servicesAtom from the query and enables it when enableServiceMap is on', () => {
     mockedUseGetServices.mockReturnValue({ data: ['DEFAULT', 'a', 'b'] });
+    setConfiguration(configWith(true));
 
-    renderHook(() => useServicesFetch(configWith(true)));
+    renderHook(() => useServicesFetch());
 
     expect(mockedUseGetServices).toHaveBeenCalledWith({ enabled: true });
     expect(store.get(servicesAtom)).toEqual(['DEFAULT', 'a', 'b']);
   });
 
-  test('keeps servicesAtom undefined when configuration is undefined', () => {
+  test('keeps servicesAtom undefined when configuration is not loaded yet', () => {
     mockedUseGetServices.mockReturnValue({ data: undefined });
 
-    renderHook(() => useServicesFetch(undefined));
+    renderHook(() => useServicesFetch());
 
     expect(mockedUseGetServices).toHaveBeenCalledWith({ enabled: false });
     expect(store.get(servicesAtom)).toBeUndefined();
@@ -52,13 +61,13 @@ describe('useServicesFetch', () => {
 
   test('resets servicesAtom to undefined when enableServiceMap is turned off', () => {
     mockedUseGetServices.mockReturnValue({ data: ['DEFAULT', 'a'] });
+    setConfiguration(configWith(true));
 
-    const { rerender } = renderHook(({ config }) => useServicesFetch(config), {
-      initialProps: { config: configWith(true) },
-    });
+    renderHook(() => useServicesFetch());
     expect(store.get(servicesAtom)).toEqual(['DEFAULT', 'a']);
 
-    rerender({ config: configWith(false) });
+    // atom을 바꾸면 훅이 구독하고 있으므로 다시 렌더되어 동기화된다.
+    setConfiguration(configWith(false));
     expect(store.get(servicesAtom)).toBeUndefined();
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.ts
@@ -1,15 +1,15 @@
 import React from 'react';
 import { useSetAtom } from 'jotai';
 import { servicesAtom } from '@pinpoint-fe/ui/src/atoms';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import { useGetServices } from '@pinpoint-fe/ui/src/hooks';
+import { useConfiguration } from './useConfiguration';
 
-export const useServicesFetch = (configuration: Configuration | undefined) => {
-  // configurationAtom(전역 store)에서 읽은 값을 그대로 받아 enable한다. fetch 인터셉터가
-  // 동일한 atom으로 enableServiceMap을 판단하므로, atom이 채워진 뒤에 /api/v2/services가
-  // 발생해야 pServiceName 헤더가 누락되지 않는다. (raw config로 enable하면 atom이
-  // useEffect로 채워지기 전에 요청이 나가 헤더가 빠지므로, 호출자는 raw config가 아니라
-  // configurationAtom 값을 넘겨야 한다.)
+export const useServicesFetch = () => {
+  // configurationAtom에서 직접 읽어 enable을 판단한다. fetch 인터셉터도 동일한 atom으로
+  // enableServiceMap을 판단하므로, atom이 채워진 뒤에 /api/v2/services가 발생해야
+  // pServiceName 헤더가 누락되지 않는다. (raw config로 enable하면 atom이 채워지기 전에
+  // 요청이 나가 헤더가 빠진다. atom을 직접 읽는 지금 구조가 그 순서를 보장한다.)
+  const configuration = useConfiguration();
   const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
   const { data: services } = useGetServices({ enabled: enableServiceMap });
   const setServices = useSetAtom(servicesAtom);

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ErrorAnalysis.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ErrorAnalysis.tsx
@@ -27,17 +27,13 @@ import {
   getTransactionDetailQueryString,
 } from '@pinpoint-fe/ui/src/utils';
 import {
+  useConfiguration,
   useErrorAnalysisSearchParameters,
   useServiceNameForLink,
   useTimezone,
 } from '@pinpoint-fe/ui/src/hooks';
 import { useTranslation } from 'react-i18next';
-import {
-  ErrorAnalysisErrorList,
-  BASE_PATH,
-  Configuration,
-  APP_SETTING_KEYS,
-} from '@pinpoint-fe/ui/src/constants';
+import { ErrorAnalysisErrorList, BASE_PATH, APP_SETTING_KEYS } from '@pinpoint-fe/ui/src/constants';
 import { formatInTimeZone } from 'date-fns-tz';
 import { IoMdClose } from 'react-icons/io';
 import { PiBugBeetleDuotone } from 'react-icons/pi';
@@ -46,21 +42,20 @@ import { FaChevronRight } from 'react-icons/fa6';
 import { ServerIcon } from '../components/Application/ServerIcon';
 
 export interface ErrorAnalysisPageProps {
-  configuration?: Configuration;
   ApplicationList?: (props: ApplicationCombinedListProps) => React.ReactElement;
 }
 
 export const ErrorAnalysisPage = ({
-  configuration,
   ApplicationList = ApplicationCombinedList,
 }: ErrorAnalysisPageProps) => {
+  const configuration = useConfiguration();
   const periodMax = configuration?.['periodMax.exceptionTrace'];
   const periodInterval = configuration?.['periodInterval.exceptionTrace'];
   const navigate = useNavigate();
   const [timezone] = useTimezone();
   // errorAnalysis 경로는 URL에 service를 싣지 않으므로, 새 탭으로 여는 transactionDetail에는
   // 클릭 시점의 선택된 service를 실어 그 탭이 전역 선택값 변화에 흔들리지 않게 한다.
-  const serviceNameForLink = useServiceNameForLink(configuration);
+  const serviceNameForLink = useServiceNameForLink();
   const {
     searchParameters,
     application,

--- a/web-frontend/src/main/v3/packages/ui/src/pages/FilteredMap.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/FilteredMap.tsx
@@ -8,18 +8,14 @@ import {
   getApplicationKey,
   getServerMapPath,
 } from '@pinpoint-fe/ui/src/utils';
-import { useFilteredMapParameters } from '@pinpoint-fe/ui/src/hooks';
+import { useConfiguration, useFilteredMapParameters } from '@pinpoint-fe/ui/src/hooks';
 import {
   serverMapDataAtom,
   serverMapCurrentTargetAtom,
   scatterDataByApplicationKeyAtom,
   CurrentTarget,
 } from '@pinpoint-fe/ui/src/atoms';
-import {
-  FilteredMapType as FilteredMap,
-  GetServerMap,
-  Configuration,
-} from '@pinpoint-fe/ui/src/constants';
+import { FilteredMapType as FilteredMap, GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import {
   ApplicationCombinedList,
   ApplicationCombinedListProps,
@@ -45,7 +41,6 @@ import { FilteredMapChartsBoard } from '@pinpoint-fe/ui/src/components/FilterMap
 
 export interface FilteredMapPageProps {
   authorizationGuideUrl?: string;
-  configuration?: Configuration & Record<string, string>;
   ApplicationList?: (props: ApplicationCombinedListProps) => React.ReactElement;
 }
 
@@ -53,9 +48,9 @@ const FILTERED_MAP_CONTAINER_ID = 'filtered-map-main-container';
 
 export const FilteredMapPage = ({
   authorizationGuideUrl,
-  configuration,
   ApplicationList = ApplicationCombinedList,
 }: FilteredMapPageProps) => {
+  const configuration = useConfiguration();
   const periodMax = configuration?.[`periodMax.serverMap`];
   const periodInterval = configuration?.['periodInterval.serverMap'];
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -274,7 +269,6 @@ export const FilteredMapPage = ({
                 SERVER_LIST_WIDTH={SERVER_LIST_WIDTH}
                 resizeHandleWidth={resizeHandleWidth}
                 FILTERED_MAP_CONTAINER_ID={FILTERED_MAP_CONTAINER_ID}
-                configuration={configuration}
               />
             )}
           </LayoutWithHorizontalResizable>

--- a/web-frontend/src/main/v3/packages/ui/src/pages/Inspector.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/Inspector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useInspectorSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import { useConfiguration, useInspectorSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { useTranslation } from 'react-i18next';
 import {
   DatetimePicker,
@@ -19,17 +19,16 @@ import {
 import { convertParamsToQueryString, getInspectorPath } from '@pinpoint-fe/ui/src/utils';
 import { PiChartLineDuotone } from 'react-icons/pi';
 import { TimeUnitFormat } from '@pinpoint-fe/datetime-picker';
-import { APP_SETTING_KEYS, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { APP_SETTING_KEYS } from '@pinpoint-fe/ui/src/constants';
 
 export interface InspectorPageProps {
-  configuration?: Configuration;
   ApplicationList?: (props: ApplicationCombinedListProps) => React.ReactElement;
 }
 
 export const InspectorPage = ({
-  configuration,
   ApplicationList = ApplicationCombinedList,
 }: InspectorPageProps) => {
+  const configuration = useConfiguration();
   const periodMax = configuration?.['periodMax.inspector'];
   const periodInterval = configuration?.['periodInterval.inspector'];
   const navigate = useNavigate();

--- a/web-frontend/src/main/v3/packages/ui/src/pages/OpenTelemetry.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/OpenTelemetry.tsx
@@ -12,19 +12,18 @@ import {
   OpenTelemetryDashboard,
 } from '../components';
 import { convertParamsToQueryString, getOpenTelemetryPath } from '@pinpoint-fe/ui/src/utils';
-import { useOpenTelemetrySearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import { useConfiguration, useOpenTelemetrySearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { SiOpentelemetry } from 'react-icons/si';
-import { APP_SETTING_KEYS, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { APP_SETTING_KEYS } from '@pinpoint-fe/ui/src/constants';
 
 export interface OpenTelemetryPageProps {
-  configuration?: Configuration & Record<string, unknown>;
   ApplicationList?: (props: ApplicationCombinedListProps) => React.ReactElement;
 }
 
 export const OpenTelemetryPage = ({
-  configuration,
   ApplicationList = ApplicationCombinedList,
 }: OpenTelemetryPageProps) => {
+  const configuration = useConfiguration();
   const periodMax = configuration?.['periodMax.otlpMetric'];
   const periodInterval = configuration?.['periodInterval.otlpMetric'];
   const navigate = useNavigate();

--- a/web-frontend/src/main/v3/packages/ui/src/pages/Realtime.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/Realtime.tsx
@@ -7,7 +7,6 @@ import { useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import {
   ApplicationCombinedList,
   ApplicationCombinedListProps,
-  Configuration,
   DatetimePicker,
   DatetimePickerChangeHandler,
   HelpPopover,
@@ -17,14 +16,10 @@ import {
 import { PiTreeStructureDuotone } from 'react-icons/pi';
 
 export interface RealtimePageProps {
-  configuration?: Configuration & Record<string, string>;
   ApplicationList?: (props: ApplicationCombinedListProps) => React.ReactElement;
 }
 
-export const RealtimePage = ({
-  ApplicationList = ApplicationCombinedList,
-  configuration,
-}: RealtimePageProps) => {
+export const RealtimePage = ({ ApplicationList = ApplicationCombinedList }: RealtimePageProps) => {
   const navigate = useNavigate();
   const { application, searchParameters } = useServerMapSearchParameters();
   const [serverMapCurrentTarget, setServerMapCurrentTarget] = useAtom(serverMapCurrentTargetAtom);
@@ -93,7 +88,7 @@ export const RealtimePage = ({
           )}
         </div>
       </MainHeader>
-      {serverMapCurrentTarget && <Realtime configuration={configuration} />}
+      {serverMapCurrentTarget && <Realtime />}
     </div>
   );
 };

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ScatterOrHeatmapFullScreen.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ScatterOrHeatmapFullScreen.tsx
@@ -8,8 +8,8 @@ import {
   getScatterFullScreenRealtimePath,
   getServerMapPath,
 } from '@pinpoint-fe/ui/src/utils';
-import { useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
-import { APP_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { useConfiguration, useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
   ApplicationCombinedList,
@@ -23,11 +23,8 @@ import { useTranslation } from 'react-i18next';
 import { capitalize } from 'lodash';
 import { Heatmap } from '@pinpoint-fe/ui/src/components/Heatmap/Heatmap';
 
-export const ScatterOrHeatmapFullScreenPage = ({
-  configuration,
-}: {
-  configuration?: Configuration & Record<string, unknown>;
-}) => {
+export const ScatterOrHeatmapFullScreenPage = () => {
+  const configuration = useConfiguration();
   const periodMax = configuration?.[`periodMax.serverMap`];
   const periodInterval = configuration?.[`periodInterval.serverMap`];
   const navigate = useNavigate();
@@ -117,7 +114,6 @@ export const ScatterOrHeatmapFullScreenPage = ({
                 node={application}
                 realtime={isRealtime}
                 toolbarOption={{ expand: { hide: true } }}
-                configuration={configuration}
               />
             ) : (
               <Heatmap
@@ -125,7 +121,6 @@ export const ScatterOrHeatmapFullScreenPage = ({
                 agentId={agentId}
                 nodeData={application}
                 toolbarOption={{ expand: { hide: true } }}
-                configuration={configuration}
               />
             ))}
         </div>

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
@@ -10,17 +10,13 @@ import {
   getFormattedDateRange,
   getRealtimePath,
 } from '@pinpoint-fe/ui/src/utils';
-import { useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import { useConfiguration, useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import {
   serverMapDataAtom,
   serverMapCurrentTargetAtom,
   CurrentTarget,
 } from '@pinpoint-fe/ui/src/atoms';
-import {
-  FilteredMapType as FilteredMap,
-  GetServerMap,
-  Configuration,
-} from '@pinpoint-fe/ui/src/constants';
+import { FilteredMapType as FilteredMap, GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { IoMdClose } from 'react-icons/io';
 import {
   DatetimePicker,
@@ -42,7 +38,6 @@ import { ServerMapChartsBoard } from '@pinpoint-fe/ui/src/components/ServerMap/S
 
 export interface ServermapPageProps {
   authorizationGuideUrl?: string;
-  configuration?: Configuration & Record<string, string>;
   ApplicationList?: (props: ApplicationCombinedListProps) => React.ReactElement;
   MapView?: typeof ServerMap;
   title?: 'Servermap' | 'Servicemap';
@@ -54,12 +49,12 @@ const SERVERMAP_CONTAINER_ID = 'server-map-main-container';
 
 export const ServerMapPage = ({
   authorizationGuideUrl,
-  configuration,
   ApplicationList = ApplicationCombinedList,
   MapView = ServerMap,
   title = 'Servermap',
   getPagePath = getServerMapPath,
 }: ServermapPageProps) => {
+  const configuration = useConfiguration();
   const periodMax = configuration?.[`periodMax.serverMap`];
   const periodInterval = configuration?.[`periodInterval.serverMap`];
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -248,7 +243,6 @@ export const ServerMapPage = ({
                 SERVER_LIST_WIDTH={SERVER_LIST_WIDTH}
                 resizeHandleWidth={resizeHandleWidth}
                 SERVERMAP_CONTAINER_ID={SERVERMAP_CONTAINER_ID}
-                configuration={configuration}
               />
             )}
           </LayoutWithHorizontalResizable>

--- a/web-frontend/src/main/v3/packages/ui/src/pages/SystemMetric.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/SystemMetric.tsx
@@ -9,17 +9,14 @@ import {
   LayoutWithContentSidebar,
 } from '../components';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useSystemMetricSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import { useConfiguration, useSystemMetricSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { convertParamsToQueryString, getSystemMetricPath } from '@pinpoint-fe/ui/src/utils';
 import { useTranslation } from 'react-i18next';
 import { PiHardDrivesDuotone } from 'react-icons/pi';
-import { APP_SETTING_KEYS, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { APP_SETTING_KEYS } from '@pinpoint-fe/ui/src/constants';
 
-export const SystemMetricPage = ({
-  configuration,
-}: {
-  configuration?: Configuration & Record<string, unknown>;
-}) => {
+export const SystemMetricPage = ({}: {}) => {
+  const configuration = useConfiguration();
   const periodMax = configuration?.['periodMax.systemMetric'];
   const periodInterval = configuration?.['periodInterval.systemMetric'];
   const navigate = useNavigate();

--- a/web-frontend/src/main/v3/packages/ui/src/pages/UrlStatistic.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/UrlStatistic.tsx
@@ -12,13 +12,12 @@ import {
 } from '../components';
 import { useNavigate } from 'react-router-dom';
 import { convertParamsToQueryString, getUrlStatPath } from '@pinpoint-fe/ui/src/utils';
-import { useUrlStatSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import { useConfiguration, useUrlStatSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { useTranslation } from 'react-i18next';
 import { PiChartBarDuotone } from 'react-icons/pi';
 // import { ErrorBoundary } from '../../Error/ErrorBoundary';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@pinpoint-fe/ui/src/components';
 import { APP_SETTING_KEYS, UrlStatSummary } from '../constants';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
 
 const TAB_LIST = [
   { id: 'total', display: 'Total Count' },
@@ -30,14 +29,13 @@ const TAB_LIST = [
 type TYPE = UrlStatSummary.Parameters['type'];
 
 export interface UrlStatisticPageProps {
-  configuration?: Configuration & Record<string, unknown>;
   ApplicationList?: (props: ApplicationCombinedListProps) => React.ReactElement;
 }
 
 export const UrlStatisticPage = ({
-  configuration,
   ApplicationList = ApplicationCombinedList,
 }: UrlStatisticPageProps) => {
+  const configuration = useConfiguration();
   const periodMax = configuration?.['periodMax.uriStat'];
   const periodInterval = configuration?.['periodInterval.uriStat'];
   const navigate = useNavigate();

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/AgentManagement.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/AgentManagement.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
-import { ApplicationType, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { ApplicationType } from '@pinpoint-fe/ui/src/constants';
 import { DataTableSkeleton, ErrorBoundary, ScrollArea, Separator } from '../../components';
 import { ApplicationCombinedList } from '../../components/Application';
 import { AgentManagementFetcher } from '@pinpoint-fe/ui/src/components/Config/agentManagement';
 
-export interface AgentManagementPageProps {
-  configuration?: Configuration;
-}
-
-export const AgentManagementPage = ({ configuration }: AgentManagementPageProps) => {
-  void configuration; // Not use configuration
+export const AgentManagementPage = () => {
   const [application, setApplication] = React.useState<ApplicationType>();
 
   return (

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/AgentStatistic.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/AgentStatistic.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import { DataTableSkeleton, ErrorBoundary } from '../../components';
 import { AgentStatisticFetcher } from '../../components/Config/agentStatistic';
 
-export interface AgentStatisticPageProps {
-  configuration?: Configuration;
-}
-
-export const AgentStatisticPage = (props: AgentStatisticPageProps) => {
+export const AgentStatisticPage = () => {
   return (
     <div className="h-full space-y-6">
       <ErrorBoundary>
         <React.Suspense fallback={<DataTableSkeleton hideRowBox={true} />}>
-          <AgentStatisticFetcher {...props} />
+          <AgentStatisticFetcher />
         </React.Suspense>
       </ErrorBoundary>
     </div>

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/Alarm.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/Alarm.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  APP_SETTING_KEYS,
-  AlarmRule,
-  ApplicationType,
-  Configuration,
-} from '@pinpoint-fe/ui/src/constants';
+import { APP_SETTING_KEYS, AlarmRule, ApplicationType } from '@pinpoint-fe/ui/src/constants';
 import { cn } from '../../lib';
 import { Separator } from '../../components/ui/separator';
 import {
@@ -41,24 +36,19 @@ import {
   useLocalStorage,
 } from '@pinpoint-fe/ui/src/hooks';
 import { LayoutWithAlarm } from '../../components/Layout/LayoutWithAlarm';
-import { useSetAtom } from 'jotai';
-import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
 import { AlarmPermissionContext } from '../../components';
 import { MdOutlineAdd } from 'react-icons/md';
 
 export interface AlarmPageProps {
-  configuration?: Configuration;
   ApplicationList?: (props: ApplicationCombinedListProps) => React.ReactElement;
   onChangeApplication?: (application: ApplicationType) => void;
 }
 
 export const AlarmPage = ({
   ApplicationList = ApplicationCombinedList,
-  configuration,
   onChangeApplication,
 }: AlarmPageProps) => {
   const toast = useReactToastifyToast();
-  const setConfigurationAtom = useSetAtom(configurationAtom);
   const { t } = useTranslation();
   const [selectedApplication, setSelectedApplication] = useLocalStorage<
     ApplicationType | undefined
@@ -85,19 +75,13 @@ export const AlarmPage = ({
   const { permissionContext } = React.useContext(AlarmPermissionContext);
 
   React.useEffect(() => {
-    if (configuration) {
-      setConfigurationAtom(configuration);
-    }
-  }, [configuration]);
-
-  React.useEffect(() => {
     if (selectedApplication) {
       onChangeApplication?.(selectedApplication);
     }
   }, [selectedApplication]);
 
   return (
-    <LayoutWithAlarm configuration={configuration}>
+    <LayoutWithAlarm>
       <div className="space-y-3">
         <div className="flex gap-2">
           <ApplicationList

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/Experimentals.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/Experimentals.tsx
@@ -1,13 +1,10 @@
 import { useTranslation } from 'react-i18next';
 import { Checkbox } from '../../components';
-import { Configuration, EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
-import { useExperimentals } from '@pinpoint-fe/ui/src/hooks';
+import { EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
+import { useConfiguration, useExperimentals } from '@pinpoint-fe/ui/src/hooks';
 
-export interface ExperimentalPageProps {
-  configuration?: Configuration;
-}
-
-export const ExperimentalPage = ({ configuration }: ExperimentalPageProps) => {
+export const ExperimentalPage = () => {
+  const configuration = useConfiguration();
   const { t } = useTranslation();
   const experimentalMap = useExperimentals(configuration);
 

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/ServiceSetting.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/ServiceSetting.tsx
@@ -1,11 +1,6 @@
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import { ServiceSettingTable } from '../../components/Config/serviceSetting';
 
-export interface ServiceSettingPageProps {
-  configuration?: Configuration;
-}
-
-export const ServiceSettingPage = (_props: ServiceSettingPageProps) => {
+export const ServiceSettingPage = () => {
   return (
     <div className="space-y-6">
       <div>

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/UserGroup.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/UserGroup.tsx
@@ -1,14 +1,10 @@
-import { APP_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
+import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 import { useSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { MdArrowForwardIos } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import { UserGroup, GroupMember } from '../../components/Config';
 
-export interface UserGroupPageProps {
-  configuration?: Configuration;
-}
-
-export const UserGroupPage = (props: UserGroupPageProps) => {
+export const UserGroupPage = () => {
   const { searchParameters } = useSearchParameters();
   const userGroupName = searchParameters?.groupName;
 
@@ -37,7 +33,7 @@ export const UserGroupPage = (props: UserGroupPageProps) => {
         role="none"
         className="shrink-0 bg-border h-[1px] w-full"
       ></div>
-      {userGroupName ? <GroupMember /> : <UserGroup {...props} />}
+      {userGroupName ? <GroupMember /> : <UserGroup />}
     </div>
   );
 };

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/Users.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/Users.tsx
@@ -1,13 +1,8 @@
-import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import { DataTableSkeleton, ErrorBoundary } from '../../components';
 import { UsersTableFetcher } from '../../components/Config/users/UsersTableFetcher';
 import React from 'react';
 
-export interface UsersPageProps {
-  configuration?: Configuration;
-}
-
-export const UsersPage = (props: UsersPageProps) => {
+export const UsersPage = () => {
   return (
     <div className="space-y-6">
       <div>
@@ -20,7 +15,7 @@ export const UsersPage = (props: UsersPageProps) => {
       ></div>
       <ErrorBoundary>
         <React.Suspense fallback={<DataTableSkeleton hideRowBox={true} />}>
-          <UsersTableFetcher {...props} />
+          <UsersTableFetcher />
         </React.Suspense>
       </ErrorBoundary>
     </div>

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/Webhook.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/Webhook.tsx
@@ -8,12 +8,7 @@ import {
   Separator,
   useReactToastifyToast,
 } from '../../components';
-import {
-  APP_SETTING_KEYS,
-  ApplicationType,
-  Configuration,
-  Webhook,
-} from '@pinpoint-fe/ui/src/constants';
+import { APP_SETTING_KEYS, ApplicationType, Webhook } from '@pinpoint-fe/ui/src/constants';
 import { cn } from '../../lib/utils';
 import { WebhookList } from '../../components/Webhook/WebhookList';
 import { WebhookTable } from '../../components/Webhook/WebhookTable';
@@ -42,13 +37,9 @@ import { MdOutlineAdd } from 'react-icons/md';
 
 export interface WebhookPageProps {
   ApplicationList?: (props: ApplicationCombinedListProps) => React.ReactElement;
-  configuration?: Configuration;
 }
 
-export const WebhookPage = ({
-  ApplicationList = ApplicationCombinedList,
-  configuration,
-}: WebhookPageProps) => {
+export const WebhookPage = ({ ApplicationList = ApplicationCombinedList }: WebhookPageProps) => {
   const toast = useReactToastifyToast();
   const { t } = useTranslation();
   const [selectedApplication, setSelectedApplication] = useLocalStorage<
@@ -75,7 +66,7 @@ export const WebhookPage = ({
   });
 
   return (
-    <LayoutWithAlarm configuration={configuration}>
+    <LayoutWithAlarm>
       <div className="space-y-3">
         <div className="flex gap-2">
           <ApplicationList


### PR DESCRIPTION
## Summary

- `packages/ui` now reads `configurationAtom` directly instead of receiving `configuration` through props — removes 29 prop declarations and 17 pass-down sites.
- Widen the type at the read site, not on the atom: `useConfiguration<T>()` keeps the atom declared as the base `Configuration`, so repos that extend it pass their own type and keep exact field types plus typo detection (an index signature on the atom would lose both).
- `useServiceNameForLink` / `useServicesFetch` / `useServiceSideNavigation` and the fetch interceptor read the atom themselves, so `main.tsx` no longer injects a configuration getter. Page wrappers that only forwarded `configuration` collapse to re-exports.

Also drops the vestigial `Configuration & Record<string, unknown>` casts — the keys they existed for (`periodMax.serverMap` etc.) are already declared on `Configuration`.

Route loaders keep calling `getConfiguration()` directly: they run before render, so the atom is still empty there.

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (753 tests, 97 suites)
- [x] `yarn lint` passes with no new errors
- [x] Prettier clean across all changed files
- [x] `tsc` on `apps/web` reports 0 errors; `packages/ui` pre-existing error count drops 82 → 76
- [x] Code splitting preserved — 46 lazy chunks still emitted, `index` chunk shrinks 2190 → 2139 kB
- [x] `configurationAtom` has exactly one writer (`InitialFetchOutlet`); the redundant write-back in `AlarmPage` is removed
- [x] Verified `LayoutWithSideNavigation` (rendered above the `InitialFetchOutlet` gate) sees the same `undefined` → populated sequence as before, since it previously read the same atom in `apps/web`