### PR TITLE
Remember the last selected service across browser restarts

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.test.ts
@@ -129,6 +129,33 @@ describe('selectedServiceAtom', () => {
     expect(renderWithFreshModule()).toBe('my-service');
   });
 
+  // 읽기는 되지만 쓰기가 던지는 환경(quota 초과 등)이 있다. 탭 고정 쓰기는 모듈 평가 중에
+  // 일어나므로, 막지 않으면 import만으로 앱이 죽는다.
+  test('keeps working when pinning the inherited service throws', () => {
+    localStorage.setItem(LAST_SELECTED_SERVICE_KEY, JSON.stringify('my-service'));
+
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get: () => ({
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('quota exceeded');
+        },
+        removeItem: () => {},
+      }),
+    });
+
+    try {
+      expect(renderWithFreshModule()).toBe('my-service');
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(window, 'sessionStorage', descriptor);
+      }
+    }
+  });
+
   test('keeps working when local storage access throws', () => {
     const descriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
 

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.test.ts
@@ -1,11 +1,33 @@
-import { renderHook } from '@testing-library/react';
-import { useAtomValue } from 'jotai';
+import { act, renderHook } from '@testing-library/react';
+import { useAtom, useAtomValue } from 'jotai';
+import { APP_SETTING_KEYS } from '@pinpoint-fe/ui/src/constants';
 import {
   DEFAULT_SERVICE,
   RESERVED_SERVICE_NAMES,
+  SELECTED_SERVICE_STORAGE_KEY,
   isReservedServiceName,
   selectedServiceAtom,
 } from './selectedService';
+
+const LAST_SELECTED_SERVICE_KEY = APP_SETTING_KEYS.LAST_SELECTED_SERVICE;
+
+// 모듈 평가 시점(getOnInit)에 저장소를 읽으므로, 저장소 상태별 동작은 모듈을 다시 평가해서 본다.
+const renderWithFreshModule = () => {
+  let value: string | undefined;
+
+  jest.isolateModules(() => {
+    const reloaded = require('./selectedService');
+    const { result } = renderHook(() => useAtomValue(reloaded.selectedServiceAtom));
+    value = result.current;
+  });
+
+  return value;
+};
+
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+});
 
 describe('isReservedServiceName', () => {
   test('returns true for every reserved name', () => {
@@ -59,6 +81,87 @@ describe('selectedServiceAtom', () => {
     } finally {
       if (descriptor) {
         Object.defineProperty(window, 'sessionStorage', descriptor);
+      }
+    }
+  });
+
+  test('persists the selection to both session and local storage', () => {
+    jest.isolateModules(() => {
+      const reloaded = require('./selectedService');
+      const { result } = renderHook(() =>
+        useAtom(reloaded.selectedServiceAtom as typeof selectedServiceAtom),
+      );
+
+      act(() => {
+        result.current[1]('my-service');
+      });
+    });
+
+    expect(sessionStorage.getItem(SELECTED_SERVICE_STORAGE_KEY)).toBe(JSON.stringify('my-service'));
+    expect(localStorage.getItem(LAST_SELECTED_SERVICE_KEY)).toBe(JSON.stringify('my-service'));
+  });
+
+  // 새 탭·브라우저 재기동: sessionStorage는 비어 있고 마지막 선택만 남아 있다.
+  test('falls back to the last selected service when session storage is empty', () => {
+    localStorage.setItem(LAST_SELECTED_SERVICE_KEY, JSON.stringify('my-service'));
+
+    expect(renderWithFreshModule()).toBe('my-service');
+  });
+
+  test('prefers the session value over the last selected service', () => {
+    sessionStorage.setItem(SELECTED_SERVICE_STORAGE_KEY, JSON.stringify('tab-service'));
+    localStorage.setItem(LAST_SELECTED_SERVICE_KEY, JSON.stringify('other-tab-service'));
+
+    expect(renderWithFreshModule()).toBe('tab-service');
+  });
+
+  // 승계한 값은 이 탭의 sessionStorage에 심어 둔다. 그래야 다른 탭이 service를 바꾼 뒤
+  // 이 탭을 새로고침해도 선택이 따라 바뀌지 않는다.
+  test('pins the inherited service to this tab', () => {
+    localStorage.setItem(LAST_SELECTED_SERVICE_KEY, JSON.stringify('my-service'));
+
+    renderWithFreshModule();
+    expect(sessionStorage.getItem(SELECTED_SERVICE_STORAGE_KEY)).toBe(JSON.stringify('my-service'));
+
+    // 다른 탭에서 service를 바꾼 상황
+    localStorage.setItem(LAST_SELECTED_SERVICE_KEY, JSON.stringify('other-tab-service'));
+
+    expect(renderWithFreshModule()).toBe('my-service');
+  });
+
+  test('keeps working when local storage access throws', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new Error('storage blocked');
+      },
+    });
+
+    try {
+      jest.isolateModules(() => {
+        const reloaded = require('./selectedService');
+        const { result } = renderHook(() =>
+          useAtom(reloaded.selectedServiceAtom as typeof selectedServiceAtom),
+        );
+
+        expect(result.current[0]).toBe(DEFAULT_SERVICE);
+
+        // 마지막 선택을 기록하지 못해도 이 탭의 선택은 그대로 동작해야 한다.
+        act(() => {
+          result.current[1]('my-service');
+        });
+
+        expect(result.current[0]).toBe('my-service');
+      });
+
+      expect(sessionStorage.getItem(SELECTED_SERVICE_STORAGE_KEY)).toBe(
+        JSON.stringify('my-service'),
+      );
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(window, 'localStorage', descriptor);
       }
     }
   });

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.ts
@@ -1,4 +1,7 @@
+import { atom } from 'jotai';
 import { atomWithStorage, createJSONStorage } from 'jotai/utils';
+import { APP_SETTING_KEYS } from '@pinpoint-fe/ui/src/constants';
+import { getLocalStorageValue, setLocalStorageValue } from '@pinpoint-fe/ui/src/utils/localStorage';
 
 export const DEFAULT_SERVICE = 'DEFAULT';
 
@@ -11,7 +14,12 @@ export const isReservedServiceName = (name: string) =>
 // localStorage는 origin 단위로 공유되고 storage 이벤트로 탭 간 실시간 동기화까지 되어,
 // 한 탭에서 service를 바꾸면 다른 탭도 따라 바뀌었다. sessionStorage는 탭(브라우징 컨텍스트)
 // 단위라 값이 공유되지 않고 storage 이벤트도 전파되지 않아 탭별 선택이 가능하다.
-// (새 탭·재시작은 값이 없어 DEFAULT로 시작하고, 링크로 연 같은-origin 탭은 복사받아 승계한다.)
+// (링크로 연 같은-origin 탭은 sessionStorage를 복사받아 선택을 승계한다.)
+//
+// 다만 sessionStorage만 쓰면 브라우저를 재기동하거나 새 탭을 열 때마다 DEFAULT로 돌아간다.
+// 그래서 "마지막으로 선택한 service"를 localStorage에도 함께 기록해 두고, sessionStorage가
+// 비어 있는 첫 진입에서만 그 값을 기본값으로 승계한다. 진실의 원천은 여전히 sessionStorage이므로
+// 이미 열려 있는 탭들은 서로의 선택에 영향을 받지 않는다.
 
 /**
  * 스토리지 접근 자체가 던지는 환경이 있다(서드파티 스토리지가 차단된 iframe, 일부 프라이버시
@@ -47,14 +55,58 @@ const getSessionStringStorage = () => {
   }
 };
 
+// 마지막 선택을 기억하는 것은 부가 기능이라, localStorage 접근이 막힌 환경에서는 조용히 포기한다.
+// (sessionStorage와 달리 없어도 탭 안에서의 동작에는 아무 영향이 없다.)
+const readLastSelectedService = () => {
+  try {
+    return getLocalStorageValue(APP_SETTING_KEYS.LAST_SELECTED_SERVICE);
+  } catch {
+    return undefined;
+  }
+};
+
+const writeLastSelectedService = (service: string) => {
+  try {
+    setLocalStorageValue(APP_SETTING_KEYS.LAST_SELECTED_SERVICE, service);
+  } catch {
+    // 저장에 실패해도 이 탭의 선택은 sessionStorage로 유지된다.
+  }
+};
+
+export const SELECTED_SERVICE_STORAGE_KEY = 'pp.selectedService';
+
+const sessionStorageForService = createJSONStorage<string>(getSessionStringStorage);
+
+const lastSelectedService = readLastSelectedService();
+
+// sessionStorage가 비어 있을 때만 쓰이는 기본값이다. 즉 이 탭에서 이미 고른 service가 있으면
+// 그 값이 이기고, 새 탭·브라우저 재기동처럼 빈 상태로 시작할 때만 마지막 선택을 승계한다.
+const initialSelectedService =
+  typeof lastSelectedService === 'string' ? lastSelectedService : DEFAULT_SERVICE;
+
+// 승계한 값은 이 탭의 sessionStorage에 곧바로 심어 둔다. 심어 두지 않으면 다른 탭이 service를
+// 바꾼 뒤 이 탭을 새로고침했을 때 선택이 따라 바뀌어 탭별 독립성이 깨진다.
+if (getSessionStringStorage().getItem(SELECTED_SERVICE_STORAGE_KEY) === null) {
+  sessionStorageForService.setItem(SELECTED_SERVICE_STORAGE_KEY, initialSelectedService);
+}
+
 // getOnInit: true → 첫 렌더부터 sessionStorage 값을 동기로 읽는다.
 // 이로써 fetch 인터셉터의 최초 요청도 저장된 service를 반영하고,
 // 새로고침 시 hydration으로 인한 불필요한 캐시 무효화를 방지한다.
-export const selectedServiceAtom = atomWithStorage<string>(
-  'selectedService',
-  DEFAULT_SERVICE,
-  createJSONStorage(getSessionStringStorage),
+const storedSelectedServiceAtom = atomWithStorage<string>(
+  SELECTED_SERVICE_STORAGE_KEY,
+  initialSelectedService,
+  sessionStorageForService,
   {
     getOnInit: true,
+  },
+);
+
+// 선택할 때마다 마지막 선택을 localStorage에도 기록해 다음 첫 진입의 기본값으로 쓴다.
+export const selectedServiceAtom = atom(
+  (get) => get(storedSelectedServiceAtom),
+  (_get, set, service: string) => {
+    set(storedSelectedServiceAtom, service);
+    writeLastSelectedService(service);
   },
 );

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/selectedService.ts
@@ -86,8 +86,18 @@ const initialSelectedService =
 
 // 승계한 값은 이 탭의 sessionStorage에 곧바로 심어 둔다. 심어 두지 않으면 다른 탭이 service를
 // 바꾼 뒤 이 탭을 새로고침했을 때 선택이 따라 바뀌어 탭별 독립성이 깨진다.
-if (getSessionStringStorage().getItem(SELECTED_SERVICE_STORAGE_KEY) === null) {
-  sessionStorageForService.setItem(SELECTED_SERVICE_STORAGE_KEY, initialSelectedService);
+//
+// 이 쓰기는 모듈 평가 중에 일어나므로 예외가 새어 나가면 import만으로 앱이 죽는다.
+// getSessionStringStorage()는 스토리지 접근이 던지는 경우만 막아 주고, 읽기는 되지만 쓰기가
+// 던지는 환경(quota 초과, 일부 프라이버시 모드)은 막지 못한다. 아톰 초기값은 이 쓰기와 무관하게
+// 정해지므로, 실패하면 탭 고정만 포기하고 넘어간다.
+try {
+  if (getSessionStringStorage().getItem(SELECTED_SERVICE_STORAGE_KEY) === null) {
+    sessionStorageForService.setItem(SELECTED_SERVICE_STORAGE_KEY, initialSelectedService);
+  }
+} catch {
+  // 탭 고정에 실패하면 새로고침 시 다른 탭의 최신 선택을 따라갈 수 있지만, 화면이 아예 뜨지
+  // 않는 것보다는 낫다.
 }
 
 // getOnInit: true → 첫 렌더부터 sessionStorage 값을 동기로 읽는다.

--- a/web-frontend/src/main/v3/packages/ui/src/constants/appSettingKeys.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/appSettingKeys.ts
@@ -24,6 +24,7 @@ export enum APP_SETTING_KEYS {
   SERVER_MAP_HORIZONTAL_RESIZABLE = 'pp.serverMapHorizontalResizable',
   REALTIME_ACTIVE_REQUEST_RESIZABLE = 'pp.realtimeActiveRequestResizable',
   CONFIG_LAST_SELECTED_APPLICATION = 'pp.configLastSelectedApplication',
+  LAST_SELECTED_SERVICE = 'pp.lastSelectedService',
   SERVER_MAP_CHART_TYPE = 'pp.serverMapChartType',
   INSPECTOR_RESIZABLE = 'pp.inspectorResizable',
   URL_STATISTIC_RESIZABLE = 'pp.urlStatisticResizable',

--- a/web-frontend/src/main/v3/packages/ui/src/utils/localStorage.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/localStorage.ts
@@ -17,3 +17,10 @@ export const getLocalStorageValue = (key: APP_SETTING_KEYS | EXPERIMENTAL_CONFIG
 
   return storageValue;
 };
+
+export const setLocalStorageValue = (
+  key: APP_SETTING_KEYS | EXPERIMENTAL_CONFIG_KEYS | string,
+  value: unknown,
+) => {
+  window.localStorage.setItem(key, JSON.stringify(value));
+};


### PR DESCRIPTION
## Summary
- `selectedService` was stored only in sessionStorage so each browser tab could scope its screens to a different service, but that meant a new tab or a browser restart always fell back to `DEFAULT`.
- The last selection is now also recorded in localStorage and used **only** as the initial value for a tab whose sessionStorage is still empty. sessionStorage remains the source of truth, so open tabs keep their own selection and do not follow each other. The inherited value is pinned to the tab's sessionStorage immediately, otherwise a refresh would pull the tab to whatever another tab selected last.
- Reads/writes go through the existing `APP_SETTING_KEYS` + `getLocalStorageValue`/`setLocalStorageValue` utils instead of touching `window.localStorage` directly, and the sessionStorage key is namespaced as `pp.selectedService` to match the other storage keys.

## Test plan
- [x] `yarn build`
- [x] `yarn test` (96 suites / 753 tests)
- [x] New unit tests: inherit last selection when sessionStorage is empty, session value wins over the stored last selection, inherited value is pinned to the tab, selection persists to both storages, and everything keeps working when localStorage access throws
- [ ] Select a non-default service, restart the browser, and confirm the service is preselected on first entry
- [ ] Open two tabs with different services, switch one, refresh the other, and confirm it keeps its own service
- [ ] Delete the currently selected service and confirm the selection falls back to `DEFAULT`