### PR TITLE
[#noissue] Deduplicate identical type-provider definitions by content

### DIFF
--- a/agent-module/plugins-loader/src/main/java/com/navercorp/pinpoint/loader/plugins/trace/TraceMetadataProviderLoader.java
+++ b/agent-module/plugins-loader/src/main/java/com/navercorp/pinpoint/loader/plugins/trace/TraceMetadataProviderLoader.java
@@ -20,14 +20,19 @@ import com.navercorp.pinpoint.common.trace.LoadedTraceMetadataProvider;
 import com.navercorp.pinpoint.common.trace.ParsedTraceMetadataProvider;
 import com.navercorp.pinpoint.common.trace.TraceMetadataProvider;
 import com.navercorp.pinpoint.common.util.Filter;
+import com.navercorp.pinpoint.common.util.IOUtils;
 import com.navercorp.pinpoint.loader.plugins.PinpointPluginLoader;
 import com.navercorp.pinpoint.loader.plugins.trace.yaml.TraceMetadataProviderYamlParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -81,8 +86,14 @@ public class TraceMetadataProviderLoader implements PinpointPluginLoader<TraceMe
 
     private List<TraceMetadataProvider> fromMetaFiles(ClassLoader classLoader) {
         Set<String> loadedProviderIds = new HashSet<>();
+        Set<String> loadedContentDigests = new HashSet<>();
         List<TraceMetadataProvider> traceMetadataProviders = new ArrayList<>();
         for (URL typeProviderUrl : getTypeProviderUrls(classLoader)) {
+            String contentDigest = contentDigest(typeProviderUrl);
+            if (contentDigest != null && !loadedContentDigests.add(contentDigest)) {
+                logger.debug("Skipping trace metadata provider from {} as an identical definition has already been added.", typeProviderUrl);
+                continue;
+            }
             ParsedTraceMetadataProvider parsedTraceMetadataProvider = traceMetadataProviderParser.parse(typeProviderUrl);
             String loadedProviderId = parsedTraceMetadataProvider.getId();
             if (loadedProviderIds.contains(loadedProviderId)) {
@@ -93,6 +104,20 @@ public class TraceMetadataProviderLoader implements PinpointPluginLoader<TraceMe
             }
         }
         return traceMetadataProviders;
+    }
+
+    // The same definition can be visible through multiple classpath entries with different URLs -
+    // e.g. an IDE lists both a module's classes directory and its packaged jar - and the provider
+    // id is derived from the URL, so identical definitions must also be deduplicated by content.
+    private String contentDigest(URL typeProviderUrl) {
+        try (InputStream inputStream = typeProviderUrl.openStream()) {
+            byte[] content = IOUtils.toByteArray(inputStream);
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+            return Base64.getEncoder().encodeToString(messageDigest.digest(content));
+        } catch (IOException | NoSuchAlgorithmException e) {
+            logger.warn("Failed to read type provider definition {} for deduplication", typeProviderUrl, e);
+            return null;
+        }
     }
 
     private List<URL> getTypeProviderUrls(ClassLoader classLoader) {

--- a/agent-module/plugins-loader/src/test/java/com/navercorp/pinpoint/loader/plugins/trace/TraceMetadataProviderLoaderTest.java
+++ b/agent-module/plugins-loader/src/test/java/com/navercorp/pinpoint/loader/plugins/trace/TraceMetadataProviderLoaderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.loader.plugins.trace;
+
+import com.navercorp.pinpoint.common.trace.TraceMetadataProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TraceMetadataProviderLoaderTest {
+
+    private static final String TYPE_A_DEFINITION = "serviceTypes:\n"
+            + "    - code: 1\n"
+            + "      name: 'TYPE_A'\n";
+
+    private static final String TYPE_B_DEFINITION = "serviceTypes:\n"
+            + "    - code: 2\n"
+            + "      name: 'TYPE_B'\n";
+
+    // an IDE lists both a module's classes directory and its packaged jar on the classpath,
+    // so the same definition file can be visible through two different URLs
+    @Test
+    public void identicalDefinitionsFromDifferentUrlsAreLoadedOnce(@TempDir Path tempDir) throws IOException {
+        URL first = writeDefinition(tempDir, "first", TYPE_A_DEFINITION);
+        URL second = writeDefinition(tempDir, "second", TYPE_A_DEFINITION);
+
+        List<TraceMetadataProvider> providers = load(first, second);
+
+        assertThat(providers).hasSize(1);
+    }
+
+    @Test
+    public void distinctDefinitionsAreAllLoaded(@TempDir Path tempDir) throws IOException {
+        URL first = writeDefinition(tempDir, "first", TYPE_A_DEFINITION);
+        URL second = writeDefinition(tempDir, "second", TYPE_B_DEFINITION);
+
+        List<TraceMetadataProvider> providers = load(first, second);
+
+        assertThat(providers).hasSize(2);
+    }
+
+    private List<TraceMetadataProvider> load(URL... typeProviderUrls) {
+        TraceMetadataProviderLoader loader = new TraceMetadataProviderLoader(Arrays.asList(typeProviderUrls));
+        return loader.load(new URLClassLoader(new URL[0], null));
+    }
+
+    private URL writeDefinition(Path tempDir, String subDir, String definition) throws IOException {
+        Path definitionFile = Files.createDirectory(tempDir.resolve(subDir)).resolve("type-provider.yml");
+        Files.write(definitionFile, definition.getBytes(StandardCharsets.UTF_8));
+        return definitionFile.toUri().toURL();
+    }
+}


### PR DESCRIPTION
TraceMetadataProviderLoader already skips duplicate type-provider.yml definitions, but the provider id is derived from the URL: a jar entry maps to '<jar name>:<entry name>' while a plain file URL keeps its full path. When the same definition is visible through two different classpath entries
- an IDE lists both a module's classes directory and its packaged jar when the module builds a shaded artifact - the two URLs produce different ids, the duplicate slips through, and web/collector startup fails with "ServiceType code ... is duplicated".

Deduplicate by a SHA-256 digest of the definition content before the id check, so byte-identical definitions load once regardless of where the classpath entry lives. Genuinely conflicting definitions still fail in TraceMetadataLoader as before.