### PR TITLE
[#noissue] Fetch configuration once instead of on every page entry

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfiguration.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfiguration.test.tsx
@@ -1,36 +1,29 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
 
-const mockOnQueryError = jest.fn();
+// reactQueryHelper는 ErrorToast를 통해 ECharts(ESM) 스택을 전이적으로 import 한다.
+// 그 한 줄만 끊어 두면 실제 queryClient·queryFn·글로벌 에러 핸들러를 그대로 검증할 수 있다.
+jest.mock('../../components/Error/ErrorToast', () => ({ ErrorToast: () => null }));
+// 글로벌 에러 토스트가 떴는지 관찰하기 위한 목.
+jest.mock('react-toastify', () => ({ toast: { error: jest.fn() } }));
 
-// reactQueryHelper transitively imports the ECharts (ESM) stack via ErrorToast.
-// Expose a plain QueryClient so the cache shared by the hook and the loader path stays real,
-// with the same meta-aware error handler the real queryCache uses for the global error toast.
-jest.mock('./reactQueryHelper', () => {
-  const { QueryClient: ActualQueryClient, QueryCache } =
-    jest.requireActual('@tanstack/react-query');
-  return {
-    queryClient: new ActualQueryClient({
-      queryCache: new QueryCache({
-        onError: (error: unknown, query: { meta?: { ignoreGlobalError?: boolean } }) => {
-          if (query.meta?.ignoreGlobalError) return;
-          mockOnQueryError(error);
-        },
-      }),
-      defaultOptions: { queries: { retry: false } },
-    }),
-  };
-});
-
+import { toast } from 'react-toastify';
 import { getConfiguration, useGetConfiguration } from './useGetConfiguration';
 import { queryClient } from './reactQueryHelper';
 
-const createWrapper = (client: QueryClient) =>
-  function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
-  };
+// 훅의 실패를 즉시 관측하려면 재시도를 끈다. (로더 경로는 이미 retry: false)
+// 나머지 기본 옵션(queryKeyHashFn 등)은 실제 설정을 유지한다.
+const defaultOptions = queryClient.getDefaultOptions();
+queryClient.setDefaultOptions({
+  ...defaultOptions,
+  queries: { ...defaultOptions.queries, retry: false },
+});
+
+const wrapper = function Wrapper({ children }: { children: React.ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+};
 
 describe('useGetConfiguration', () => {
   beforeEach(() => {
@@ -42,7 +35,6 @@ describe('useGetConfiguration', () => {
 
   afterEach(() => {
     queryClient.clear();
-    mockOnQueryError.mockClear();
     jest.clearAllMocks();
   });
 
@@ -62,16 +54,13 @@ describe('useGetConfiguration', () => {
   test('the hook reuses the value the loader already fetched', async () => {
     await getConfiguration();
 
-    const { result } = renderHook(() => useGetConfiguration(), {
-      wrapper: createWrapper(queryClient),
-    });
+    const { result } = renderHook(() => useGetConfiguration(), { wrapper });
 
     await waitFor(() => expect(result.current.data).toEqual({ 'periodMax.inspector': 42 }));
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   test('the hook does not refetch when it remounts on page navigation', async () => {
-    const wrapper = createWrapper(queryClient);
     const first = renderHook(() => useGetConfiguration(), { wrapper });
     await waitFor(() => expect(first.result.current.data).toBeDefined());
     first.unmount();
@@ -82,9 +71,21 @@ describe('useGetConfiguration', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
+  test('the cached configuration survives with no observer left', async () => {
+    // 로더만 값을 읽고 훅이 아직 마운트되지 않은 구간에도 캐시가 수거되지 않아야 한다.
+    await getConfiguration();
+
+    expect(queryClient.getQueryData([END_POINTS.CONFIGURATION])).toEqual({
+      'periodMax.inspector': 42,
+    });
+    const [query] = queryClient.getQueryCache().findAll({ queryKey: [END_POINTS.CONFIGURATION] });
+    expect(query.gcTime).toBe(Infinity);
+  });
+
   test('a failed fetch is not cached, so the next attempt retries the request', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: false,
+      status: 500,
       json: async () => ({ message: 'backend down' }),
     });
 
@@ -93,22 +94,49 @@ describe('useGetConfiguration', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
+  test('a non-JSON error body still reports a readable message', async () => {
+    // 백엔드가 아니라 앞단 프록시가 HTML 502를 돌려주는 경우. 공용 queryFn이 파싱 실패를
+    // 흡수해 상태 코드가 담긴 메시지를 만든다.
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new SyntaxError('Unexpected token <');
+      },
+    });
+
+    await expect(getConfiguration()).rejects.toThrow('Request failed with status 502');
+  });
+
+  test('a ProblemDetail error keeps its fields for the error toast', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ status: 500, title: 'Internal Server Error', detail: 'db is down' }),
+    });
+
+    await expect(getConfiguration()).rejects.toMatchObject({
+      message: 'db is down',
+      status: 500,
+      title: 'Internal Server Error',
+    });
+  });
+
   test('a loader failure stays silent while the hook failure still reports globally', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: false,
+      status: 500,
       json: async () => ({ message: 'backend down' }),
     });
 
     // 로더 경로: catch 해서 기본값으로 진행하므로 글로벌 에러 토스트를 띄우지 않는다.
     await expect(getConfiguration()).rejects.toThrow('backend down');
-    expect(mockOnQueryError).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
 
     // 훅 경로: 화면이 실제로 configuration을 필요로 하므로 사용자에게 알린다.
-    const { result } = renderHook(() => useGetConfiguration(), {
-      wrapper: createWrapper(queryClient),
-    });
+    const { result } = renderHook(() => useGetConfiguration(), { wrapper });
 
     await waitFor(() => expect(result.current.error).toBeTruthy());
-    expect(mockOnQueryError).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfiguration.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfiguration.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
+
+const mockOnQueryError = jest.fn();
+
+// reactQueryHelper transitively imports the ECharts (ESM) stack via ErrorToast.
+// Expose a plain QueryClient so the cache shared by the hook and the loader path stays real,
+// with the same meta-aware error handler the real queryCache uses for the global error toast.
+jest.mock('./reactQueryHelper', () => {
+  const { QueryClient: ActualQueryClient, QueryCache } =
+    jest.requireActual('@tanstack/react-query');
+  return {
+    queryClient: new ActualQueryClient({
+      queryCache: new QueryCache({
+        onError: (error: unknown, query: { meta?: { ignoreGlobalError?: boolean } }) => {
+          if (query.meta?.ignoreGlobalError) return;
+          mockOnQueryError(error);
+        },
+      }),
+      defaultOptions: { queries: { retry: false } },
+    }),
+  };
+});
+
+import { getConfiguration, useGetConfiguration } from './useGetConfiguration';
+import { queryClient } from './reactQueryHelper';
+
+const createWrapper = (client: QueryClient) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+
+describe('useGetConfiguration', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ 'periodMax.inspector': 42 }),
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    mockOnQueryError.mockClear();
+    jest.clearAllMocks();
+  });
+
+  test('getConfiguration requests the configuration endpoint', async () => {
+    await expect(getConfiguration()).resolves.toEqual({ 'periodMax.inspector': 42 });
+    expect(global.fetch).toHaveBeenCalledWith(END_POINTS.CONFIGURATION);
+  });
+
+  test('getConfiguration fetches once no matter how many route loaders ask for it', async () => {
+    await getConfiguration();
+    await getConfiguration();
+    await getConfiguration();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('the hook reuses the value the loader already fetched', async () => {
+    await getConfiguration();
+
+    const { result } = renderHook(() => useGetConfiguration(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual({ 'periodMax.inspector': 42 }));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('the hook does not refetch when it remounts on page navigation', async () => {
+    const wrapper = createWrapper(queryClient);
+    const first = renderHook(() => useGetConfiguration(), { wrapper });
+    await waitFor(() => expect(first.result.current.data).toBeDefined());
+    first.unmount();
+
+    const second = renderHook(() => useGetConfiguration(), { wrapper });
+    await waitFor(() => expect(second.result.current.data).toBeDefined());
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('a failed fetch is not cached, so the next attempt retries the request', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: 'backend down' }),
+    });
+
+    await expect(getConfiguration()).rejects.toThrow('backend down');
+    await expect(getConfiguration()).resolves.toEqual({ 'periodMax.inspector': 42 });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('a loader failure stays silent while the hook failure still reports globally', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: 'backend down' }),
+    });
+
+    // 로더 경로: catch 해서 기본값으로 진행하므로 글로벌 에러 토스트를 띄우지 않는다.
+    await expect(getConfiguration()).rejects.toThrow('backend down');
+    expect(mockOnQueryError).not.toHaveBeenCalled();
+
+    // 훅 경로: 화면이 실제로 configuration을 필요로 하므로 사용자에게 알린다.
+    const { result } = renderHook(() => useGetConfiguration(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(mockOnQueryError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfiguration.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfiguration.ts
@@ -1,25 +1,56 @@
 import { useQuery } from '@tanstack/react-query';
 import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
+import { queryClient } from './reactQueryHelper';
+
+/**
+ * configuration은 웹이 뜬 뒤 바뀌지 않는 서버 설정이므로 캐시 엔트리를 하나만 두고 공유한다.
+ * (`serviceScopedQueryKeyHashFn`의 service 무관 엔드포인트라 service를 바꿔도 같은 키다.)
+ */
+const CONFIGURATION_QUERY_KEY = [END_POINTS.CONFIGURATION];
+
+const fetchConfiguration = async <T>(): Promise<T> => {
+  const response = await fetch(`${END_POINTS.CONFIGURATION}`);
+
+  if (!response?.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData?.message);
+  }
+
+  return await response.json();
+};
 
 export const useGetConfiguration = <T>() => {
   const { data, error, isLoading, refetch } = useQuery<T>({
-    queryKey: [END_POINTS.CONFIGURATION],
-    queryFn: getConfiguration,
+    queryKey: CONFIGURATION_QUERY_KEY,
+    queryFn: fetchConfiguration,
+    // 한 번 받은 값을 계속 쓴다. 페이지를 옮기며 이 훅이 remount 되어도 재요청하지 않는다.
+    // (실패한 쿼리는 data가 없으므로 다음 mount에서 정상적으로 다시 시도된다.)
+    staleTime: Infinity,
+    gcTime: Infinity,
   });
   return { data, error, isLoading, refetch };
 };
 
-export const getConfiguration = async <T>(): Promise<T> => {
-  try {
-    const response = await fetch(`${END_POINTS.CONFIGURATION}`);
-
-    if (!response?.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData?.message);
-    }
-
-    return await response.json();
-  } catch (error) {
-    throw error;
-  }
-};
+/**
+ * 렌더 밖(라우트 로더 등)에서 configuration을 읽는 경로.
+ *
+ * 라우트 로더는 페이지에 진입할 때마다, 그리고 날짜 파라미터를 정규화하며 redirect 할 때마다
+ * 다시 실행된다. 그래서 이 함수가 매번 fetch를 하면 페이지 이동마다 `/api/configuration`이
+ * 재요청된다. `useGetConfiguration`과 같은 queryKey로 공유 캐시에 넣어 두어, 웹 접근 후
+ * 최초 1회만 실제 요청이 나가고 이후에는 캐시된 값을 그대로 반환한다.
+ *
+ * 백엔드가 죽었을 때 로더가 기본값으로 진행하는 기존 동작을 유지하려면 재시도 없이 즉시
+ * 실패해야 하므로 `retry: false`를 준다. 같은 이유로 `ignoreGlobalError`를 켜서 로더 단계의
+ * 실패는 조용히 넘긴다. 이 실패는 로더가 catch 해 기본값으로 진행하는, 사용자에게 알릴 필요가
+ * 없는 경로다. 사용자에게 보이는 에러 토스트는 (변경 전과 동일하게) 화면에서 실제로
+ * configuration을 필요로 하는 `useGetConfiguration` 쪽 실패에서만 발생한다.
+ * (`meta`는 fetch 단위 옵션이라 훅의 재요청에는 이 설정이 묻지 않는다.)
+ */
+export const getConfiguration = <T>(): Promise<T> =>
+  queryClient.ensureQueryData<T>({
+    queryKey: CONFIGURATION_QUERY_KEY,
+    queryFn: fetchConfiguration,
+    staleTime: Infinity,
+    retry: false,
+    meta: { ignoreGlobalError: true },
+  });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfiguration.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetConfiguration.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
-import { queryClient } from './reactQueryHelper';
+import { queryClient, queryFn } from './reactQueryHelper';
 
 /**
  * configuration은 웹이 뜬 뒤 바뀌지 않는 서버 설정이므로 캐시 엔트리를 하나만 두고 공유한다.
@@ -8,21 +8,10 @@ import { queryClient } from './reactQueryHelper';
  */
 const CONFIGURATION_QUERY_KEY = [END_POINTS.CONFIGURATION];
 
-const fetchConfiguration = async <T>(): Promise<T> => {
-  const response = await fetch(`${END_POINTS.CONFIGURATION}`);
-
-  if (!response?.ok) {
-    const errorData = await response.json();
-    throw new Error(errorData?.message);
-  }
-
-  return await response.json();
-};
-
 export const useGetConfiguration = <T>() => {
   const { data, error, isLoading, refetch } = useQuery<T>({
     queryKey: CONFIGURATION_QUERY_KEY,
-    queryFn: fetchConfiguration,
+    queryFn: queryFn(END_POINTS.CONFIGURATION),
     // 한 번 받은 값을 계속 쓴다. 페이지를 옮기며 이 훅이 remount 되어도 재요청하지 않는다.
     // (실패한 쿼리는 data가 없으므로 다음 mount에서 정상적으로 다시 시도된다.)
     staleTime: Infinity,
@@ -49,8 +38,12 @@ export const useGetConfiguration = <T>() => {
 export const getConfiguration = <T>(): Promise<T> =>
   queryClient.ensureQueryData<T>({
     queryKey: CONFIGURATION_QUERY_KEY,
-    queryFn: fetchConfiguration,
+    queryFn: queryFn(END_POINTS.CONFIGURATION),
+    // 로더가 먼저 캐시를 만드는 경로에서도 gcTime을 함께 지정해야 한다. 로더만 이 값을 읽는
+    // 구간(훅이 마운트되기 전, 또는 훅 없이 로더만 도는 경로)에는 관찰자가 없어서, 기본
+    // gcTime(5분)이면 캐시가 수거되고 다음 페이지 진입에서 다시 요청이 나간다.
     staleTime: Infinity,
+    gcTime: Infinity,
     retry: false,
     meta: { ignoreGlobalError: true },
   });


### PR DESCRIPTION
## Summary
- `/api/configuration` was requested on every page entry. Route loaders read `periodMax.*` to validate date params via `getConfiguration`, which was a raw `fetch` that bypassed the query cache — so each navigation, plus each loader re-run caused by a date-normalizing redirect, hit the endpoint again. The hook also ran on the global 3s `staleTime`.
- The loader path and `useGetConfiguration` now share a single cache entry (`staleTime: Infinity`), so only the first access reaches the network. Configuration holds server-side feature flags and period limits that no client action can change, and no endpoint mutates it, so nothing needs to re-read it.
- Previous failure semantics are preserved on the loader path: `retry: false` so a dead backend does not block navigation for ~7s of retry backoff, and `meta.ignoreGlobalError` so the failure the loader already swallows stays silent — the user-facing error toast still comes from the hook that actually needs the value.

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (98 suites / 765 tests)
- [x] New `useGetConfiguration.test.tsx`: single fetch across repeated loader calls, hook reuses the loader-fetched value, no refetch when the hook remounts on navigation, failures are not cached so the next attempt retries, loader failure stays silent while the hook failure still reports globally
- [ ] Manual: navigate across ServerMap / Inspector / Transaction / Error Analysis and confirm `/api/configuration` is requested only once in the Network tab
- [ ] Manual: with the backend down, confirm the app still redirects to `/apiCheck` without a multi-second stall