### PR TITLE
[#noissue] Remove the development-only TEST_SERVICE constant

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/uid/service/CachingServiceLookupService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/uid/service/CachingServiceLookupService.java
@@ -59,9 +59,6 @@ public class CachingServiceLookupService implements ServiceLookupService, Applic
         if (ServiceUid.DEFAULT_SERVICE_UID_NAME.equals(serviceName)) {
             return CompletableFuture.completedFuture(ServiceUid.DEFAULT);
         }
-        if (ServiceUid.TEST_SERVICE_UID_NAME.equals(serviceName)) {
-            return CompletableFuture.completedFuture(ServiceUid.TEST_SERVICE);
-        }
         return serviceLookupCache.retrieve(serviceName, () -> loadServiceUidAsync(serviceName));
     }
 

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/uid/service/CachingServiceLookupServiceTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/uid/service/CachingServiceLookupServiceTest.java
@@ -62,7 +62,6 @@ class CachingServiceLookupServiceTest {
         ServiceLookupService service = newService(Duration.ofMinutes(1));
 
         assertThat(service.getServiceUid(ServiceUid.DEFAULT_SERVICE_UID_NAME).join()).isEqualTo(ServiceUid.DEFAULT);
-        assertThat(service.getServiceUid(ServiceUid.TEST_SERVICE_UID_NAME).join()).isEqualTo(ServiceUid.TEST_SERVICE);
 
         Mockito.verifyNoInteractions(serviceRegistryDao);
     }

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceUid.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceUid.java
@@ -12,11 +12,8 @@ public class ServiceUid {
     public static final String DEFAULT_SERVICE_UID_NAME = "DEFAULT";
     public static final String UNKNOWN_SERVICE_UID_NAME = "UNKNOWN";
 
-    public static final String TEST_SERVICE_UID_NAME = "TEST_SERVICE";
-
     // serviceUid
     public static final ServiceUid DEFAULT = new ServiceUid(DEFAULT_SERVICE_UID_CODE);
-    public static final ServiceUid TEST_SERVICE = new ServiceUid(5);
 
     public static final ServiceUid ERROR = new ServiceUid(-1);
     public static final ServiceUid UNKNOWN = new ServiceUid(-2);

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceUidService.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceUidService.java
@@ -12,9 +12,6 @@ public class ServiceUidService {
         if (ServiceUid.DEFAULT_SERVICE_UID_NAME.equals(serviceName)) {
             return ServiceUid.DEFAULT;
         }
-        if (ServiceUid.TEST_SERVICE_UID_NAME.equals(serviceName)) {
-            return ServiceUid.TEST_SERVICE;
-        }
         // TODO ServiceUid query
         return ServiceUid.DEFAULT;
     }

--- a/service-module/src/test/java/com/navercorp/pinpoint/service/component/ReservedServiceRegistryTest.java
+++ b/service-module/src/test/java/com/navercorp/pinpoint/service/component/ReservedServiceRegistryTest.java
@@ -1,6 +1,5 @@
 package com.navercorp.pinpoint.service.component;
 
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,11 +17,6 @@ class ReservedServiceRegistryTest {
     @Test
     void contains_DEFAULT() {
         assertThat(registry.contains("DEFAULT")).isTrue();
-    }
-
-    @Test
-    void contains_TEST_SERVICE() {
-        assertThat(registry.contains(ServiceUid.TEST_SERVICE_UID_NAME)).isTrue();
     }
 
     @Test
@@ -44,7 +38,7 @@ class ReservedServiceRegistryTest {
     void contains_caseInsensitive() {
         assertThat(registry.contains("default")).isTrue();
         assertThat(registry.contains("Default")).isTrue();
-        assertThat(registry.contains("test_service")).isTrue();
+        assertThat(registry.contains("unknown")).isTrue();
     }
 
     @Test
@@ -61,6 +55,6 @@ class ReservedServiceRegistryTest {
     @Test
     void getReservedNames_notEmpty() {
         assertThat(registry.getReservedNames()).isNotEmpty();
-        assertThat(registry.getReservedNames()).contains("DEFAULT", ServiceUid.TEST_SERVICE_UID_NAME, "ERROR", "UNKNOWN", "NULL");
+        assertThat(registry.getReservedNames()).contains("DEFAULT", "ERROR", "UNKNOWN", "NULL");
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
@@ -18,9 +18,6 @@ public class ServiceModelResolver {
         if (Service.DEFAULT.getServiceUid().getUid() == serviceUid) {
             return Service.DEFAULT;
         }
-        if (Service.TEST_SERVICE.getServiceUid().getUid() == serviceUid) {
-            return Service.TEST_SERVICE;
-        }
         Service service = resolveService(serviceUid);
         if (service == null) {
             return Service.DEFAULT;
@@ -31,9 +28,6 @@ public class ServiceModelResolver {
     public Service getService(String serviceName) {
         if (Service.DEFAULT.getServiceName().equals(serviceName)) {
             return Service.DEFAULT;
-        }
-        if (Service.TEST_SERVICE.getServiceName().equals(serviceName)) {
-            return Service.TEST_SERVICE;
         }
         Service service = resolveService(serviceName);
         if (service == null) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/Service.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/Service.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 public class Service {
 
     public static final Service DEFAULT = new Service(ServiceUid.DEFAULT_SERVICE_UID_NAME, ServiceUid.DEFAULT);
-    public static final Service TEST_SERVICE = new Service(ServiceUid.TEST_SERVICE_UID_NAME, ServiceUid.TEST_SERVICE);
 
     private final String serviceName;
     private final ServiceUid serviceUid;

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/AdminServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/AdminServiceImplTest.java
@@ -85,25 +85,25 @@ public class AdminServiceImplTest {
     @Test
     public void removeApplication() {
         // given
-        doNothing().when(applicationIndexService).deleteApplication(Service.TEST_SERVICE, APPLICATION_NAME1, SERVICE_TYPE_CODE);
+        doNothing().when(applicationIndexService).deleteApplication(Service.DEFAULT, APPLICATION_NAME1, SERVICE_TYPE_CODE);
 
         // when
-        adminService.removeApplication(Service.TEST_SERVICE, APPLICATION_NAME1, SERVICE_TYPE_CODE);
+        adminService.removeApplication(Service.DEFAULT, APPLICATION_NAME1, SERVICE_TYPE_CODE);
 
         // then
-        verify(applicationIndexService).deleteApplication(Service.TEST_SERVICE, APPLICATION_NAME1, SERVICE_TYPE_CODE);
+        verify(applicationIndexService).deleteApplication(Service.DEFAULT, APPLICATION_NAME1, SERVICE_TYPE_CODE);
     }
 
     @Test
     public void removeAgent() {
         // given
-        doNothing().when(applicationIndexService).deleteAgentId(Service.TEST_SERVICE, APPLICATION_NAME1, SERVICE_TYPE_CODE, AGENT_ID1);
+        doNothing().when(applicationIndexService).deleteAgentId(Service.DEFAULT, APPLICATION_NAME1, SERVICE_TYPE_CODE, AGENT_ID1);
 
         // when
-        adminService.removeAgent(Service.TEST_SERVICE, APPLICATION_NAME1, SERVICE_TYPE_CODE, AGENT_ID1);
+        adminService.removeAgent(Service.DEFAULT, APPLICATION_NAME1, SERVICE_TYPE_CODE, AGENT_ID1);
 
         // then
-        verify(applicationIndexService).deleteAgentId(Service.TEST_SERVICE, APPLICATION_NAME1, SERVICE_TYPE_CODE, AGENT_ID1);
+        verify(applicationIndexService).deleteAgentId(Service.DEFAULT, APPLICATION_NAME1, SERVICE_TYPE_CODE, AGENT_ID1);
     }
 
     @Test

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
@@ -65,8 +65,6 @@ class CachingServiceModelResolverTest {
 
         assertThat(resolver.getService(Service.DEFAULT.getServiceName())).isEqualTo(Service.DEFAULT);
         assertThat(resolver.getService(Service.DEFAULT.getServiceUid().getUid())).isEqualTo(Service.DEFAULT);
-        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceName())).isEqualTo(Service.TEST_SERVICE);
-        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceUid().getUid())).isEqualTo(Service.TEST_SERVICE);
 
         Mockito.verifyNoInteractions(serviceRegistryService);
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/HeatMapServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/HeatMapServiceImplTest.java
@@ -50,7 +50,7 @@ public class HeatMapServiceImplTest {
     @Mock
     DragAreaQuery dragAreaQuery;
 
-    private static final Service SERVICE = Service.TEST_SERVICE;
+    private static final Service SERVICE = Service.DEFAULT;
     private static final String APPLICATION_NAME = "applicationName";
     private static final int SERVICE_TYPE_CODE = ServiceType.TEST.getCode();
     private static final int LIMIT = 50;

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
@@ -32,8 +32,6 @@ class ServiceModelResolverTest {
 
         assertThat(resolver.getService(Service.DEFAULT.getServiceName())).isEqualTo(Service.DEFAULT);
         assertThat(resolver.getService(Service.DEFAULT.getServiceUid().getUid())).isEqualTo(Service.DEFAULT);
-        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceName())).isEqualTo(Service.TEST_SERVICE);
-        assertThat(resolver.getService(Service.TEST_SERVICE.getServiceUid().getUid())).isEqualTo(Service.TEST_SERVICE);
 
         Mockito.verifyNoInteractions(serviceRegistryService);
     }


### PR DESCRIPTION
This pull request removes the special handling and support for the `TEST_SERVICE` reserved service from the codebase. All logic, constants, and tests related to `TEST_SERVICE` have been deleted, simplifying the handling of reserved services to only include the remaining ones (such as `DEFAULT`, `ERROR`, `UNKNOWN`, and `NULL`).

The most important changes include:

### Removal of `TEST_SERVICE` from core logic

* Deleted the `TEST_SERVICE_UID_NAME` constant and the `TEST_SERVICE` instance from `ServiceUid`, and removed all code paths that checked for or returned `TEST_SERVICE` in both `ServiceUidService` and `CachingServiceLookupService`. [[1]](diffhunk://#diff-9e0e6c7ad9de5abc835bf757fbc5ed896404c7d2be96413a70261da67ba4b9b6L15-L19) [[2]](diffhunk://#diff-caca8120bf12926bf421bbd75a6b2c9733a7222835f912d4e4c04cb456193ae8L15-L17) [[3]](diffhunk://#diff-09bc22db5ec667b4709d025a975df106214dc1862daef0e24980b41c0435e255L62-L64)
* Removed the `TEST_SERVICE` static instance from the `Service` class and all logic in `ServiceModelResolver` that handled `TEST_SERVICE` by name or UID. [[1]](diffhunk://#diff-5bcd9dacf38ffe513455675e4cb1cd942d7368866754a3675781d5f7cd909e03L11) [[2]](diffhunk://#diff-e766f202faf0f40fec61865fb6dec8afa4000e107d58640fe726744ed8ba24d2L21-L23) [[3]](diffhunk://#diff-e766f202faf0f40fec61865fb6dec8afa4000e107d58640fe726744ed8ba24d2L35-L37)

### Test cleanup and updates

* Removed all test cases and assertions related to `TEST_SERVICE` in `ReservedServiceRegistryTest`, `CachingServiceLookupServiceTest`, `CachingServiceModelResolverTest`, and `ServiceModelResolverTest`. [[1]](diffhunk://#diff-5ec8b42cd29e5889b6639f9de95fce1258ee8e68e2ad865597db550deedad626L23-L27) [[2]](diffhunk://#diff-5ec8b42cd29e5889b6639f9de95fce1258ee8e68e2ad865597db550deedad626L47-R41) [[3]](diffhunk://#diff-5ec8b42cd29e5889b6639f9de95fce1258ee8e68e2ad865597db550deedad626L64-R58) [[4]](diffhunk://#diff-b6f8d2f1954d1fb87182ebd2a9729ad282e66c655742f886d32f07668f428bbeL65) [[5]](diffhunk://#diff-e58e634c3a367add09fb5cb71aa0d3b3c80287c7b40348adf5ee28e26ce078a4L68-L69) [[6]](diffhunk://#diff-594f42def7fa214fa78cc83a46b98d2485bad4c308bcf721dc3b279fe0166efeL35-L36)
* Updated tests in `AdminServiceImplTest` to use `Service.DEFAULT` instead of `Service.TEST_SERVICE`.

These changes help streamline the code by focusing on the reserved services that are still in use and removing legacy or unnecessary code related to `TEST_SERVICE`.