### PR TITLE
[#14099] Return 400 for invalid serviceName and missing applicationName in serviceMap API

### DIFF
--- a/web/src/main/java/com/navercorp/pinpoint/web/problem/CustomExceptionHandler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/problem/CustomExceptionHandler.java
@@ -16,6 +16,7 @@
 package com.navercorp.pinpoint.web.problem;
 
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.navercorp.pinpoint.web.service.ServiceNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.logging.log4j.LogManager;
@@ -111,6 +112,23 @@ public final class CustomExceptionHandler extends ResponseEntityExceptionHandler
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, ex.getMessage());
 
         problemDetail.setTitle("Forbidden");
+        addProperties(problemDetail, request);
+
+        return ResponseEntity
+                .status(status)
+                .body(problemDetail);
+    }
+
+    @ExceptionHandler(ServiceNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handleServiceNotFoundException(
+            ServiceNotFoundException ex,
+            WebRequest request
+    ) {
+        logger.debug("handleServiceNotFoundException: {}", ex.getMessage());
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, ex.getMessage());
+        problemDetail.setTitle(status.getReasonPhrase());
+
         addProperties(problemDetail, request);
 
         return ResponseEntity

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
@@ -31,7 +31,7 @@ public class ServiceModelResolver {
         }
         Service service = resolveService(serviceName);
         if (service == null) {
-            return Service.DEFAULT;
+            throw new ServiceNotFoundException(serviceName);
         }
         return service;
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceNotFoundException.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceNotFoundException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.web.service;
+
+/**
+ * @author minwoo.jung
+ */
+public class ServiceNotFoundException extends RuntimeException {
+
+    private final String serviceName;
+
+    public ServiceNotFoundException(String serviceName) {
+        super("serviceName:" + serviceName + " not found");
+        this.serviceName = serviceName;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/util/ApplicationValidator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/util/ApplicationValidator.java
@@ -71,8 +71,8 @@ public class ApplicationValidator {
         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid serviceTypeCode or serviceTypeName");
     }
 
-    private void validateName(String applicationName) {
-        if (!IdValidateUtils.validateId(applicationName, MAX_LENGTH)) {
+    public void validateName(String applicationName) {
+        if (!StringUtils.hasLength(applicationName) || !IdValidateUtils.validateId(applicationName, MAX_LENGTH)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid applicationName " + applicationName);
         }
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeast;
@@ -76,8 +77,8 @@ class CachingServiceModelResolverTest {
 
         Mockito.when(serviceRegistryService.getService(unRegisteredServiceName)).thenReturn(null);
 
-        assertThat(resolver.getService(unRegisteredServiceName)).isEqualTo(Service.DEFAULT);
-        assertThat(resolver.getService(unRegisteredServiceName)).isEqualTo(Service.DEFAULT);
+        assertThatThrownBy(() -> resolver.getService(unRegisteredServiceName)).isInstanceOf(ServiceNotFoundException.class);
+        assertThatThrownBy(() -> resolver.getService(unRegisteredServiceName)).isInstanceOf(ServiceNotFoundException.class);
 
         Mockito.verify(serviceRegistryService, times(1)).getService(unRegisteredServiceName);
     }
@@ -93,10 +94,10 @@ class CachingServiceModelResolverTest {
 
         assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100004));
         assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100004));
-        assertThat(resolver.getService(unRegisteredServiceName)).isEqualTo(Service.DEFAULT);
+        assertThatThrownBy(() -> resolver.getService(unRegisteredServiceName)).isInstanceOf(ServiceNotFoundException.class);
 
         await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
-            assertThat(resolver.getService(unRegisteredServiceName)).isEqualTo(Service.DEFAULT);
+            assertThatThrownBy(() -> resolver.getService(unRegisteredServiceName)).isInstanceOf(ServiceNotFoundException.class);
             Mockito.verify(serviceRegistryService, atLeast(2)).getService(unRegisteredServiceName);
         });
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.times;
 
 class ServiceModelResolverTest {
@@ -37,13 +38,25 @@ class ServiceModelResolverTest {
     }
 
     @Test
-    void missingServiceReturnsDefault() {
+    void missingServiceThrows() {
         String unRegisteredServiceName = "unRegisteredServiceName";
         ServiceModelResolver resolver = new ServiceModelResolver(serviceRegistryService);
 
         Mockito.when(serviceRegistryService.getService(unRegisteredServiceName)).thenReturn(null);
 
-        assertThat(resolver.getService(unRegisteredServiceName)).isEqualTo(Service.DEFAULT);
+        assertThatThrownBy(() -> resolver.getService(unRegisteredServiceName))
+                .isInstanceOf(ServiceNotFoundException.class)
+                .hasMessageContaining(unRegisteredServiceName);
+    }
+
+    @Test
+    void missingServiceUidReturnsDefault() {
+        int unRegisteredServiceUid = 999999;
+        ServiceModelResolver resolver = new ServiceModelResolver(serviceRegistryService);
+
+        Mockito.when(serviceRegistryService.getService(unRegisteredServiceUid)).thenReturn(null);
+
+        assertThat(resolver.getService(unRegisteredServiceUid)).isEqualTo(Service.DEFAULT);
     }
 
     private ServiceEntity serviceEntity(int uid, String name) {

--- a/web/src/test/java/com/navercorp/pinpoint/web/util/ApplicationValidatorTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/util/ApplicationValidatorTest.java
@@ -65,4 +65,16 @@ class ApplicationValidatorTest {
                 () -> validator.newApplication(appName, -1, null));
 
     }
+
+    @Test
+    void newApplication_null_appName() {
+
+        ServiceTypeRegistryService registry = mock(ServiceTypeRegistryService.class);
+        ApplicationValidator validator = new ApplicationValidator(registry);
+
+        Assertions.assertThrows(ResponseStatusException.class,
+                () -> validator.newApplication(null, -1, "TOMCAT"));
+        Assertions.assertThrows(ResponseStatusException.class,
+                () -> validator.newApplication("", -1, "TOMCAT"));
+    }
 }


### PR DESCRIPTION
resolve #14099

### Changes
- `ApplicationValidator.validateName`: handle null/empty applicationName as a 400 validation error (was an unhandled NPE 500), and make it public
- `ServiceModelResolver.getService(String)`: throw `ServiceNotFoundException` for an unregistered serviceName instead of silently falling back to DEFAULT (`getService(int uid)` keeps the fallback for rendering paths)
- `CustomExceptionHandler`: map `ServiceNotFoundException` to 400

### Behavior (`/api/serviceMap`)
| Case | Before | After |
|---|---|---|
| non-DEFAULT service, no application params | 200 | 200 (unchanged) |
| DEFAULT + application params | 200 | 200 (unchanged) |
| DEFAULT, no application params | 500 NPE | 400 "Invalid applicationName null" |
| Unknown serviceName | 500 NPE (silently treated as DEFAULT) | 400 "serviceName:xxx not found" |

### Verified
- Unit tests: ServiceModelResolverTest / CachingServiceModelResolverTest / ApplicationValidatorTest
- Local E2E: the 4 cases above plus regression on scatter, histogram/statistics, serverMap, applications APIs