### PR TITLE
[#noissue] Wrap the reactor Publisher seams and scheduler task carriers behind config gates

### DIFF
--- a/agent-module/agent-testweb/reactor-netty-plugin-testweb/src/main/java/com/pinpoint/test/plugin/ReactorNettyPluginTestController.java
+++ b/agent-module/agent-testweb/reactor-netty-plugin-testweb/src/main/java/com/pinpoint/test/plugin/ReactorNettyPluginTestController.java
@@ -46,9 +46,9 @@ public class ReactorNettyPluginTestController {
 
     @RequestMapping(value = "/client/get", method = RequestMethod.GET)
     @ResponseBody
-    public String clientGet() {
-        HttpClient client = HttpClient.create().port(80);
-        String response = client.get().uri("https://www.google.com?foo=bar").responseContent().aggregate().asString().block();
+    public String clientGet(HttpServletRequest request) {
+        HttpClient client = HttpClient.create().port(request.getLocalPort());
+        String response = client.get().uri("/client/echo?foo=bar").responseContent().aggregate().asString().block();
         if (response != null) {
             return response;
         }
@@ -57,7 +57,7 @@ public class ReactorNettyPluginTestController {
 
     @RequestMapping(value = "/client/local", method = RequestMethod.GET)
     @ResponseBody
-    public String clientError(HttpServletRequest request) {
+    public String clientLocal(HttpServletRequest request) {
         HttpClient client = HttpClient.create().port(request.getLocalPort());
         String response = client.get().uri("/client/echo").responseContent().aggregate().asString().block();
         if (response != null) {
@@ -68,9 +68,9 @@ public class ReactorNettyPluginTestController {
 
     @RequestMapping(value = "/client/post", method = RequestMethod.GET)
     @ResponseBody
-    public String clientPost() {
-        HttpClient client = HttpClient.create().port(80);
-        HttpClientResponse response = client.post().uri("https://www.google.com/").send(ByteBufFlux.fromString(Mono.just("hello"))).response().block();
+    public String clientPost(HttpServletRequest request) {
+        HttpClient client = HttpClient.create().port(request.getLocalPort());
+        HttpClientResponse response = client.post().uri("/client/post/body").send(ByteBufFlux.fromString(Mono.just("hello"))).response().block();
         if (response != null) {
             return response.toString();
         }
@@ -79,13 +79,25 @@ public class ReactorNettyPluginTestController {
 
     @RequestMapping(value = "/client/unknown", method = RequestMethod.GET)
     @ResponseBody
-    public String clientError() {
+    public String clientUnknown() {
         HttpClient client = HttpClient.create().port(80);
         String response = client.get().uri("http://fjalkjdlfaj.com").responseContent().aggregate().asString().block();
         if (response != null) {
             return response;
         }
         return "OK";
+    }
+
+    @RequestMapping(value = "/client/transportError", method = RequestMethod.GET)
+    @ResponseBody
+    public String clientTransportError() {
+        // Nothing listens on port 1, so the connect fails with an immediate connection-refused.
+        HttpClient client = HttpClient.create().host("127.0.0.1").port(1);
+        try {
+            return client.get().uri("/").responseContent().aggregate().asString().block();
+        } catch (Exception e) {
+            return "TRANSPORT-ERROR " + e.getClass().getSimpleName() + ": " + e.getMessage();
+        }
     }
 
     @GetMapping("/client/get/param")

--- a/agent-module/agent-testweb/reactor-plugin-testweb/src/main/java/com/pinpoint/test/plugin/ReactorPluginController.java
+++ b/agent-module/agent-testweb/reactor-plugin-testweb/src/main/java/com/pinpoint/test/plugin/ReactorPluginController.java
@@ -20,6 +20,7 @@ import com.pinpoint.test.common.view.ApiLinkPage;
 import com.pinpoint.test.common.view.HrefTag;
 import io.netty.channel.ChannelOption;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,6 +37,8 @@ import reactor.core.scheduler.Schedulers;
 import reactor.netty.http.client.HttpClient;
 import reactor.util.retry.Retry;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,9 +49,15 @@ import java.util.Map;
 @RestController
 public class ReactorPluginController {
 
+    // Non-routable address - the connect attempt hangs until the connect timeout fires.
+    private static final String NON_ROUTABLE_URL = "http://10.255.255.1:81";
+
     private final RequestMappingHandlerMapping handlerMapping;
     @Autowired
     private AsyncStorageService asyncStorageService;
+
+    @Value("${server.port:28080}")
+    private int serverPort;
 
     @Autowired
     public ReactorPluginController(RequestMappingHandlerMapping handlerMapping) {
@@ -70,15 +79,22 @@ public class ReactorPluginController {
                 .build();
     }
 
+    @GetMapping("/echo")
+    public Mono<String> echo() {
+        return Mono.just("Echo");
+    }
+
+    @GetMapping("/echo/delay")
+    public Mono<String> echoDelay() {
+        return Mono.just("Echo").delayElement(Duration.ofMillis(200));
+    }
 
     @GetMapping("/parallelFlux/runOn")
     public Mono<String> parallelFluxRunOn() {
         Flux.range(1, 1)
                 .parallel(2)
                 .runOn(Schedulers.parallel())
-                .map(i -> {
-                    return call();
-                })
+                .flatMap(i -> call())
                 .subscribe(i -> System.out.println(Thread.currentThread().getName() + " -> " + i));
 
         return Mono.just("OK");
@@ -92,9 +108,7 @@ public class ReactorPluginController {
                 .range(1, 1)
                 .map(i -> 10 + i)
                 .publishOn(s)
-                .map(i -> {
-                    return call();
-                });
+                .flatMap(i -> call());
         flux.subscribe(System.out::println);
 
         return Mono.just("OK");
@@ -105,9 +119,8 @@ public class ReactorPluginController {
         Scheduler s = Schedulers.newParallel("parallel-scheduler", 4);
 
         final Flux<String> flux = Flux
-                .range(1, 1).map(i -> {
-                    return call();
-                })
+                .range(1, 1)
+                .flatMap(i -> call())
                 .subscribeOn(s)
                 .map(i -> "value " + i);
 
@@ -118,7 +131,7 @@ public class ReactorPluginController {
 
     @GetMapping("/mono/publishOn")
     public Mono<String> monoPublishOn() {
-        Mono.just("test").publishOn(Schedulers.parallel()).map(i -> {
+        Mono.just("test").publishOn(Schedulers.parallel()).flatMap(i -> {
             return call();
         }).subscribe(System.out::println);
 
@@ -128,16 +141,25 @@ public class ReactorPluginController {
     @GetMapping("/mono/subscribeOn")
     public Mono<String> monoSubscribeOn() {
         Mono.fromCallable(() -> Arrays.asList(1, 2))
-                .subscribeOn(Schedulers.parallel()).map(i -> {
+                .subscribeOn(Schedulers.parallel()).flatMap(i -> {
                     return call();
                 }).subscribe(System.out::println);
+        return Mono.just("OK");
+    }
+
+    @GetMapping("/scheduler/schedule")
+    public Mono<String> schedulerSchedule() {
+        Schedulers.parallel().schedule(() -> {
+            System.out.println("SCHEDULE thread=" + Thread.currentThread().getName());
+            call().subscribe(System.out::println);
+        });
         return Mono.just("OK");
     }
 
     @GetMapping("/mono/delay")
     public Mono<String> monoDelay() {
         System.out.println("MAIN thread=" + Thread.currentThread().getName());
-        return Mono.delay(Duration.ofMillis(100L)).map(aLong -> {
+        return Mono.delay(Duration.ofMillis(100L)).flatMap(aLong -> {
             return call();
         });
     }
@@ -145,7 +167,7 @@ public class ReactorPluginController {
     @GetMapping("/mono/delayElement")
     public Mono<String> monoDelayElement() {
         System.out.println("MAIN thread=" + Thread.currentThread().getName());
-        return Mono.just("Hello").delayElement(Duration.ofMillis(100L)).map(o -> {
+        return Mono.just("Hello").delayElement(Duration.ofMillis(100L)).flatMap(o -> {
             System.out.println("DELAY thread=" + Thread.currentThread().getName());
             return call();
         });
@@ -154,7 +176,7 @@ public class ReactorPluginController {
     @GetMapping("/mono/delaySubscription")
     public Mono<String> monoDelaySubscription() {
         System.out.println("MAIN thread=" + Thread.currentThread().getName());
-        return Mono.just("Hello").delaySubscription(Duration.ofMillis(100L)).map(o -> {
+        return Mono.just("Hello").delaySubscription(Duration.ofMillis(100L)).flatMap(o -> {
             return call();
         });
     }
@@ -162,7 +184,7 @@ public class ReactorPluginController {
     @GetMapping("/mono/take")
     public Mono<String> monoTake() {
         System.out.println("MAIN thread=" + Thread.currentThread().getName());
-        return Mono.just("Hello").take(Duration.ofMillis(100L)).map(o -> {
+        return Mono.just("Hello").take(Duration.ofMillis(100L)).flatMap(o -> {
             return call();
         });
     }
@@ -170,7 +192,7 @@ public class ReactorPluginController {
     @GetMapping("/flux/interval")
     public Flux<String> fluxInterval() {
         System.out.println("MAIN thread=" + Thread.currentThread().getName());
-        return Flux.interval(Duration.ofMillis(100L)).take(3).map(o -> {
+        return Flux.interval(Duration.ofMillis(100L)).take(3).flatMap(o -> {
             return call();
         });
     }
@@ -178,7 +200,7 @@ public class ReactorPluginController {
     @GetMapping("/flux/buffer")
     public Flux<String> fluxBuffer() {
         System.out.println(Thread.currentThread().getName());
-        return Flux.just(1, 2, 3).delayElements(Duration.ofMillis(100L)).take(3).map(o -> {
+        return Flux.just(1, 2, 3).delayElements(Duration.ofMillis(100L)).take(3).flatMap(o -> {
             return call();
         });
     }
@@ -187,9 +209,9 @@ public class ReactorPluginController {
     public Mono<String> monoSubscribeDispose() {
         System.out.println(Thread.currentThread().getName());
 
-        WebClient client = WebClient.create("http://httpbin.org");
+        WebClient client = WebClient.create(local());
         WebClient.ResponseSpec response = client.method(HttpMethod.GET)
-                .uri("").retrieve();
+                .uri("/echo").retrieve();
         Mono<String> body = response.bodyToMono(String.class);
         body.subscribe();
 
@@ -200,28 +222,28 @@ public class ReactorPluginController {
     public Mono<String> monoSubscribeReturn() {
         System.out.println(Thread.currentThread().getName());
         HttpClient httpClient = HttpClient.create();
-        WebClient client = WebClient.builder().baseUrl("http://httpbin.org").clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+        WebClient client = WebClient.builder().baseUrl(local()).clientConnector(new ReactorClientHttpConnector(httpClient)).build();
         return client.method(HttpMethod.GET)
-                .uri("").retrieve().bodyToMono(String.class);
+                .uri("/echo").retrieve().bodyToMono(String.class);
     }
 
     @GetMapping("/flux/cancelOn")
     public Mono<String> fluxCancelOn() {
         System.out.println(Thread.currentThread().getName());
-        WebClient client = WebClient.create("http://httpbin.org");
+        WebClient client = WebClient.create(local());
         Mono<String> callback = client.method(HttpMethod.GET)
-                .uri("").retrieve().bodyToMono(String.class);
+                .uri("/echo").retrieve().bodyToMono(String.class);
 
-        WebClient client2 = WebClient.create("http://httpbin.org");
-        return client2.method(HttpMethod.GET).uri("").retrieve().bodyToMono(String.class).cancelOn(Schedulers.parallel()).timeout(Duration.ofMillis(10), callback);
+        WebClient client2 = WebClient.create(local());
+        return client2.method(HttpMethod.GET).uri("/echo/delay").retrieve().bodyToMono(String.class).cancelOn(Schedulers.parallel()).timeout(Duration.ofMillis(10), callback);
     }
 
     @GetMapping("/mono/retry")
     public Mono<String> clientRetry(ServerWebExchange exchange) {
         HttpClient httpClient = HttpClient.create();
-        WebClient client = WebClient.builder().baseUrl("http://httpbin.org").clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+        WebClient client = WebClient.builder().baseUrl(local()).clientConnector(new ReactorClientHttpConnector(httpClient)).build();
         WebClient.ResponseSpec response = client.method(HttpMethod.GET)
-                .uri("").retrieve();
+                .uri("/echo").retrieve();
         response.bodyToMono(String.class).retry(3).subscribe();
 
         return Mono.just("OK");
@@ -242,7 +264,7 @@ public class ReactorPluginController {
     @GetMapping("/mono/retry/connectionTimeout")
     public Mono<String> clientRetryConnectionTimeout(ServerWebExchange exchange) {
         HttpClient httpClient = HttpClient.create().option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 100);
-        WebClient client = WebClient.builder().baseUrl("http://httpbin.org").clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+        WebClient client = WebClient.builder().baseUrl(NON_ROUTABLE_URL).clientConnector(new ReactorClientHttpConnector(httpClient)).build();
         WebClient.ResponseSpec response = client.method(HttpMethod.GET)
                 .uri("").retrieve();
         response.bodyToMono(String.class).retry(3).subscribe();
@@ -264,7 +286,7 @@ public class ReactorPluginController {
     @GetMapping("/mono/retryWhen/connectionTimeout")
     public Mono<String> clientRetryWhenConnectionTimeout(ServerWebExchange exchange) {
         HttpClient httpClient = HttpClient.create().option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 100);
-        WebClient client = WebClient.builder().baseUrl("http://httpbin.org").clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+        WebClient client = WebClient.builder().baseUrl(NON_ROUTABLE_URL).clientConnector(new ReactorClientHttpConnector(httpClient)).build();
         WebClient.ResponseSpec response = client.method(HttpMethod.GET)
                 .uri("").retrieve();
         response.bodyToMono(String.class).retryWhen(Retry.max(3)).subscribe();
@@ -272,60 +294,81 @@ public class ReactorPluginController {
         return Mono.just("OK");
     }
 
+    @GetMapping("/mono/transportError")
+    public Mono<String> clientTransportError() throws IOException {
+        // Bind an ephemeral port and close it again, so the connect below fails with an
+        // immediate connection-refused. A literal low port such as ":1" cannot be used here:
+        // reactor-netty's URI regex only accepts 2..5 digit ports, so ":1" is swallowed into
+        // the hostname and fails DNS resolution instead of connecting.
+        final int closedPort;
+        try (ServerSocket socket = new ServerSocket(0)) {
+            closedPort = socket.getLocalPort();
+        }
+        HttpClient httpClient = HttpClient.create().option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000);
+        WebClient client = WebClient.builder().baseUrl("http://127.0.0.1:" + closedPort).clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+        WebClient.ResponseSpec response = client.method(HttpMethod.GET)
+                .uri("").retrieve();
+        return response.bodyToMono(String.class)
+                .onErrorResume(t -> Mono.just("TRANSPORT-ERROR " + t.getClass().getSimpleName() + ": " + t.getMessage()));
+    }
+
     @GetMapping("/mono/timeout")
     public Mono<String> clientTimeout(ServerWebExchange exchange) {
         HttpClient httpClient = HttpClient.create();
-        WebClient client = WebClient.builder().baseUrl("http://httpbin.org").clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+        WebClient client = WebClient.builder().baseUrl(local()).clientConnector(new ReactorClientHttpConnector(httpClient)).build();
         WebClient.ResponseSpec response = client.method(HttpMethod.GET)
-                .uri("").retrieve();
+                .uri("/echo/delay").retrieve();
         return response.bodyToMono(String.class).timeout(Duration.ofMillis(10));
     }
 
     @GetMapping("/mono/timeout/fallback")
     public Mono<String> clientTimeoutFallback(ServerWebExchange exchange) {
         HttpClient httpClient = HttpClient.create();
-        WebClient client = WebClient.builder().baseUrl("http://httpbin.org").clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+        WebClient client = WebClient.builder().baseUrl(local()).clientConnector(new ReactorClientHttpConnector(httpClient)).build();
         WebClient.ResponseSpec response = client.method(HttpMethod.GET)
-                .uri("").retrieve();
+                .uri("/echo/delay").retrieve();
         return response.bodyToMono(String.class).timeout(Duration.ofMillis(10), Mono.just("TIMEOUT"));
     }
 
     @GetMapping("/mono/timeout/fallback2")
     public Mono<String> clientTimeoutFallback2(ServerWebExchange exchange) {
         HttpClient httpClient = HttpClient.create();
-        WebClient client = WebClient.builder().baseUrl("http://httpbin.org").clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+        WebClient client = WebClient.builder().baseUrl(local()).clientConnector(new ReactorClientHttpConnector(httpClient)).build();
         WebClient.ResponseSpec response = client.method(HttpMethod.GET)
-                .uri("").retrieve();
+                .uri("/echo/delay").retrieve();
         return response.bodyToMono(String.class).timeout(Duration.ofMillis(10), fallback());
     }
 
     private Mono<String> fallback() {
         HttpClient httpClient = HttpClient.create();
-        WebClient client = WebClient.builder().baseUrl("http://httpbin.org").clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+        WebClient client = WebClient.builder().baseUrl(local()).clientConnector(new ReactorClientHttpConnector(httpClient)).build();
         WebClient.ResponseSpec response = client.method(HttpMethod.GET)
-                .uri("").retrieve();
+                .uri("/echo").retrieve();
         return response.bodyToMono(String.class);
     }
 
-    private String call() {
-        WebClient client = WebClient.create("http://httpbin.org");
+    private Mono<String> call() {
+        WebClient client = WebClient.create(local());
         WebClient.ResponseSpec response = client.method(HttpMethod.GET)
-                .uri("").retrieve();
-        Mono<String> body = response.bodyToMono(String.class);
-        return body.block();
+                .uri("/echo").retrieve();
+        return response.bodyToMono(String.class);
+    }
+
+    private String local() {
+        return "http://localhost:" + serverPort;
     }
 
     @GetMapping("/mono/sink")
     public Mono<String> monoSink() {
         HttpClient httpClient = HttpClient.create();
-        WebClient client = WebClient.builder().baseUrl("http://httpbin.org").clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+        WebClient client = WebClient.builder().baseUrl(local()).clientConnector(new ReactorClientHttpConnector(httpClient)).build();
 
         asyncStorageService.submitAsync(
                 "testUser",
                 false,
                 10,
                 client.method(HttpMethod.GET)
-                        .uri("").retrieve().bodyToMono(String.class).doOnError(Throwable::printStackTrace)
+                        .uri("/echo").retrieve().bodyToMono(String.class).doOnError(Throwable::printStackTrace)
         ).subscribe();
 
         return Mono.just("OK");

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/AsyncContext.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/context/AsyncContext.java
@@ -30,6 +30,25 @@ public interface AsyncContext {
     Trace continueAsyncTraceObject();
     Trace continueAsyncTraceObject(boolean asyncTraceBlock);
 
+    /**
+     * Like {@link #continueAsyncTraceObject(boolean)} with {@code false}, but when no trace is
+     * bound to the current thread the given previously-created {@code reuse} trace is rebound
+     * instead of creating a new one. This lets a caller that receives many signals for one
+     * logical async operation (e.g. a reactive subscription) pay the trace creation cost once
+     * and rebind per signal, instead of a create/close cycle per signal.
+     * <p>
+     * If a trace is already bound to the current thread, it is returned (nested) just like
+     * {@link #continueAsyncTraceObject(boolean)}. The caller remains responsible for unbinding
+     * with {@link #close()} when its outermost activation ends, and for eventually closing the
+     * reused trace itself.
+     * <p>
+     * The default implementation ignores {@code reuse} and creates a new trace, so
+     * implementations without rebinding support degrade to the per-signal behavior.
+     */
+    default Trace continueAsyncTraceObject(Trace reuse) {
+        return continueAsyncTraceObject(false);
+    }
+
     Trace currentAsyncTraceObject();
 
     void close();

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/EmptyInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/EmptyInterceptor.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 /**
  * @author emeroad
  */
-public class EmptyInterceptor implements StaticAroundInterceptor, AroundInterceptor, AroundInterceptor0, AroundInterceptor1, AroundInterceptor2, AroundInterceptor3, AroundInterceptor4, AroundInterceptor5, ApiIdAwareAroundInterceptor, InjectedAsyncContextApiIdAwareAroundInterceptor {
+public class EmptyInterceptor implements StaticAroundInterceptor, AroundInterceptor, AroundInterceptor0, AroundInterceptor1, AroundInterceptor2, AroundInterceptor3, AroundInterceptor4, AroundInterceptor5, ApiIdAwareAroundInterceptor, InjectedAsyncContextApiIdAwareAroundInterceptor, ResultReplaceAroundInterceptor {
 
     public static Interceptor EMPTY = new EmptyInterceptor();
 
@@ -63,6 +63,15 @@ public class EmptyInterceptor implements StaticAroundInterceptor, AroundIntercep
 
     @Override
     public void after(Object target, AsyncContext asyncContext, int apiId, Object[] args, Object result, Throwable throwable) {
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        return result;
     }
 
     @Override

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/ExceptionHandleResultReplaceAroundInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/ExceptionHandleResultReplaceAroundInterceptor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.interceptor;
+
+import java.util.Objects;
+
+public class ExceptionHandleResultReplaceAroundInterceptor implements ResultReplaceAroundInterceptor {
+
+    private final ResultReplaceAroundInterceptor delegate;
+    private final ExceptionHandler exceptionHandler;
+
+    public ExceptionHandleResultReplaceAroundInterceptor(ResultReplaceAroundInterceptor delegate, ExceptionHandler exceptionHandler) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.exceptionHandler = Objects.requireNonNull(exceptionHandler, "exceptionHandler");
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        try {
+            this.delegate.before(target, returnType, args);
+        } catch (Throwable t) {
+            exceptionHandler.handleException(t);
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        try {
+            return this.delegate.after(target, returnType, args, result, throwable);
+        } catch (Throwable t) {
+            exceptionHandler.handleException(t);
+            // keep the original return value when the delegate fails.
+            return result;
+        }
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/LoggingInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/LoggingInterceptor.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
 /**
  * @author emeroad
  */
-public class LoggingInterceptor implements StaticAroundInterceptor, AroundInterceptor, AroundInterceptor0, AroundInterceptor1, AroundInterceptor2, AroundInterceptor3, AroundInterceptor4, AroundInterceptor5, ApiIdAwareAroundInterceptor, InjectedAsyncContextApiIdAwareAroundInterceptor {
+public class LoggingInterceptor implements StaticAroundInterceptor, AroundInterceptor, AroundInterceptor0, AroundInterceptor1, AroundInterceptor2, AroundInterceptor3, AroundInterceptor4, AroundInterceptor5, ApiIdAwareAroundInterceptor, InjectedAsyncContextApiIdAwareAroundInterceptor, ResultReplaceAroundInterceptor {
 
     private final Consumer<String> logger;
 
@@ -71,6 +71,15 @@ public class LoggingInterceptor implements StaticAroundInterceptor, AroundInterc
 
     @Override
     public void after(Object target, AsyncContext asyncContext, int apiId, Object[] args, Object result, Throwable throwable) {
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        return result;
     }
 
     @Override

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/ResultReplaceAroundInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/ResultReplaceAroundInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.interceptor;
+
+/**
+ * Like {@link AroundInterceptor}, but the value returned from {@link #after} replaces the
+ * intercepted method's return value. This lets a plugin substitute the object the application
+ * receives (e.g. wrap a returned {@code Publisher}) instead of mutating it through an injected
+ * field.
+ * <p>
+ * Contract:
+ * <ul>
+ * <li>The intercepted method must have a reference (object or array) return type. Attaching this
+ * interceptor to a method returning {@code void} or a primitive, or to a constructor, fails at
+ * instrumentation time.</li>
+ * <li>The replacement takes effect only when it is non-null and an instance of the method's
+ * declared return type ({@code returnType} parameter); otherwise the original {@code result} is
+ * returned to the caller unchanged. Returning {@code result} as-is therefore means "keep".</li>
+ * <li>When {@code throwable} is non-null the method is exiting exceptionally: there is no return
+ * value to replace and the value returned from {@link #after} is discarded.</li>
+ * </ul>
+ * The {@code returnType} parameter carries the intercepted method's declared return type so an
+ * implementation can validate a candidate replacement itself before returning it.
+ */
+public interface ResultReplaceAroundInterceptor extends Interceptor {
+    void before(Object target, Class<?> returnType, Object[] args);
+
+    Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable);
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/ResultReplaceUtils.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/ResultReplaceUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.interceptor;
+
+/**
+ * Invoked from code woven for {@link ResultReplaceAroundInterceptor}. Selecting the value here in
+ * plain Java keeps the woven bytecode branch-free: the weaver emits a single
+ * {@code INVOKESTATIC replace} followed by a {@code CHECKCAST} to the method's declared return
+ * type, which is guaranteed to succeed for either selected value.
+ */
+public final class ResultReplaceUtils {
+
+    private ResultReplaceUtils() {
+    }
+
+    /**
+     * Returns {@code replacement} when it can safely stand in for the original return value,
+     * otherwise the original {@code result}. A null or type-incompatible replacement silently
+     * keeps the original so an interceptor bug degrades to a no-op instead of a
+     * {@code ClassCastException} inside the application.
+     */
+    public static Object replace(Object result, Object replacement, Class<?> returnType) {
+        if (returnType != null && returnType.isInstance(replacement)) {
+            return replacement;
+        }
+        return result;
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/scope/ExceptionHandleScopedResultReplaceAroundInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/scope/ExceptionHandleScopedResultReplaceAroundInterceptor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.interceptor.scope;
+
+import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandler;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+
+import java.util.Objects;
+
+public class ExceptionHandleScopedResultReplaceAroundInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean debugEnabled = logger.isDebugEnabled();
+
+    private final ResultReplaceAroundInterceptor delegate;
+    private final InterceptorScope scope;
+    private final ExecutionPolicy policy;
+    private final ExceptionHandler exceptionHandler;
+
+    public ExceptionHandleScopedResultReplaceAroundInterceptor(ResultReplaceAroundInterceptor delegate, InterceptorScope scope, ExecutionPolicy policy, ExceptionHandler exceptionHandler) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.scope = Objects.requireNonNull(scope, "scope");
+        this.policy = Objects.requireNonNull(policy, "policy");
+        this.exceptionHandler = Objects.requireNonNull(exceptionHandler, "exceptionHandler");
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final InterceptorScopeInvocation transaction = scope.getCurrentInvocation();
+
+        if (transaction.tryEnter(policy)) {
+            try {
+                this.delegate.before(target, returnType, args);
+            } catch (Throwable t) {
+                exceptionHandler.handleException(t);
+            }
+        } else {
+            if (debugEnabled) {
+                logger.debug("tryBefore() returns false: interceptorScopeTransaction: {}, executionPoint: {}. Skip interceptor {}", transaction, policy, delegate.getClass());
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final InterceptorScopeInvocation transaction = scope.getCurrentInvocation();
+
+        if (transaction.canLeave(policy)) {
+            try {
+                return this.delegate.after(target, returnType, args, result, throwable);
+            } catch (Throwable t) {
+                exceptionHandler.handleException(t);
+                // keep the original return value when the delegate fails.
+                return result;
+            } finally {
+                transaction.leave(policy);
+            }
+        } else {
+            if (debugEnabled) {
+                logger.debug("tryAfter() returns false: interceptorScopeTransaction: {}, executionPoint: {}. Skip interceptor {}", transaction, policy, delegate.getClass());
+            }
+            // skipped by scope policy: keep the original return value.
+            return result;
+        }
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/scope/ScopedResultReplaceAroundInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/scope/ScopedResultReplaceAroundInterceptor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.interceptor.scope;
+
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+
+import java.util.Objects;
+
+public class ScopedResultReplaceAroundInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean debugEnabled = logger.isDebugEnabled();
+
+    private final ResultReplaceAroundInterceptor delegate;
+    private final InterceptorScope scope;
+    private final ExecutionPolicy policy;
+
+    public ScopedResultReplaceAroundInterceptor(ResultReplaceAroundInterceptor delegate, InterceptorScope scope, ExecutionPolicy policy) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.scope = Objects.requireNonNull(scope, "scope");
+        this.policy = Objects.requireNonNull(policy, "policy");
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final InterceptorScopeInvocation transaction = scope.getCurrentInvocation();
+
+        if (transaction.tryEnter(policy)) {
+            this.delegate.before(target, returnType, args);
+        } else {
+            if (debugEnabled) {
+                logger.debug("tryBefore() returns false: interceptorScopeTransaction: {}, executionPoint: {}. Skip interceptor {}", transaction, policy, delegate.getClass());
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final InterceptorScopeInvocation transaction = scope.getCurrentInvocation();
+
+        if (transaction.canLeave(policy)) {
+            try {
+                return this.delegate.after(target, returnType, args, result, throwable);
+            } finally {
+                transaction.leave(policy);
+            }
+        } else {
+            if (debugEnabled) {
+                logger.debug("tryAfter() returns false: interceptorScopeTransaction: {}, executionPoint: {}. Skip interceptor {}", transaction, policy, delegate.getClass());
+            }
+            // skipped by scope policy: keep the original return value.
+            return result;
+        }
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/CoreSubscriberConstructorInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/CoreSubscriberConstructorInterceptor.java
@@ -49,7 +49,7 @@ public class CoreSubscriberConstructorInterceptor implements AroundInterceptor {
         }
 
         try {
-            final AsyncContext asyncContext = findAsyncContext(args);
+            final AsyncContext asyncContext = ReactorAsyncContextResolver.findUnique(args);
             if (asyncContext == null) {
                 return;
             }
@@ -74,37 +74,6 @@ public class CoreSubscriberConstructorInterceptor implements AroundInterceptor {
     @Override
     public void after(Object target, Object[] args, Object result, Throwable throwable) {
         // do nothing
-    }
-
-    static AsyncContext findAsyncContext(Object[] args) {
-        if (ArrayUtils.isEmpty(args)) {
-            return null;
-        }
-
-        AsyncContext candidateAsyncContext = null;
-        final int length = args.length - 1;
-        for (int i = 0; i <= length; i++) {
-            final Object arg = args[i];
-            if (arg instanceof AsyncContextAccessor) {
-                final AsyncContextAccessor accessor = (AsyncContextAccessor) arg;
-                final AsyncContext asyncContext = accessor._$PINPOINT$_getAsyncContext();
-                if (asyncContext == null) {
-                    continue;
-                }
-                if (candidateAsyncContext == null) {
-                    candidateAsyncContext = asyncContext;
-                    continue;
-                }
-                if (candidateAsyncContext != asyncContext) {
-                    // Some subscriber constructors receive both a publisher/source and their actual
-                    // subscriber. Both are instrumented as AsyncContextAccessor, and a reusable
-                    // publisher may retain an older context. Do not choose either context arbitrarily:
-                    // the normal subscribe/onSubscribe relay can resolve the carrier later.
-                    return null;
-                }
-            }
-        }
-        return candidateAsyncContext;
     }
 
     /**

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/ReactorAsyncContextResolver.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/ReactorAsyncContextResolver.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.plugin.reactor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.common.util.ArrayUtils;
+
+/**
+ * Resolves the {@link AsyncContext} carried by constructor arguments, choosing one only when the
+ * choice is unambiguous. Shared by {@link CoreSubscriberConstructorInterceptor} (operator
+ * subscribers) and {@link SchedulerTaskConstructorInterceptor} (scheduler task carriers).
+ */
+public final class ReactorAsyncContextResolver {
+
+    private ReactorAsyncContextResolver() {
+    }
+
+    /**
+     * Returns the single distinct non-null {@link AsyncContext} among the arguments, or
+     * {@code null} when there is none — or more than one. Some constructors receive both a
+     * publisher/source and their actual subscriber; both are instrumented as
+     * {@link AsyncContextAccessor}, and a reusable publisher may retain an older context. Two
+     * different contexts cannot be told apart here, so neither is chosen arbitrarily: the caller
+     * falls back to its own recovery path (subscribe/onSubscribe relay, or the current trace).
+     */
+    public static AsyncContext findUnique(Object[] args) {
+        if (ArrayUtils.isEmpty(args)) {
+            return null;
+        }
+
+        AsyncContext candidateAsyncContext = null;
+        for (Object arg : args) {
+            if (arg instanceof AsyncContextAccessor) {
+                final AsyncContext asyncContext = ((AsyncContextAccessor) arg)._$PINPOINT$_getAsyncContext();
+                if (asyncContext == null) {
+                    continue;
+                }
+                if (candidateAsyncContext == null) {
+                    candidateAsyncContext = asyncContext;
+                    continue;
+                }
+                if (candidateAsyncContext != asyncContext) {
+                    return null;
+                }
+            }
+        }
+        return candidateAsyncContext;
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/SchedulerTaskConstructorInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/SchedulerTaskConstructorInterceptor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.plugin.reactor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.annotation.IgnoreMethod;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+
+import java.util.Objects;
+
+/**
+ * Captures the {@link AsyncContext} a scheduler task should carry across the thread hop, at task
+ * construction time. Policy: <b>carrier-first, current-trace fallback</b>.
+ * <ol>
+ * <li>A context already on the target is kept (constructor delegation may fire this twice).</li>
+ * <li>The single distinct context among the constructor arguments is copied — the scheduled
+ * {@code Runnable} is often an instrumented operator subscriber ({@code publishOn}/
+ * {@code subscribeOn} schedule themselves), and reusing its context preserves the async identity
+ * the existing relay established instead of minting a sibling link per schedule.</li>
+ * <li>Otherwise, a task scheduled inside an active trace gets a new boundary context recorded as
+ * a span event — this covers plain application runnables that carry nothing.</li>
+ * </ol>
+ * Runs in the constructor's {@code after} on purpose: a failed constructor must not record a
+ * boundary span event or leak a dangling async link, and scheduler tasks (unlike operator
+ * subscribers) do not hand themselves to inner objects inside the constructor body, so the
+ * before-copy timing {@link CoreSubscriberConstructorInterceptor} needs is unnecessary here.
+ */
+public class SchedulerTaskConstructorInterceptor implements AroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+    private final ServiceType serviceType;
+
+    public SchedulerTaskConstructorInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, ServiceType serviceType) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        this.serviceType = Objects.requireNonNull(serviceType, "serviceType");
+    }
+
+    /**
+     * Not woven in - see {@link IgnoreMethod}. The capture must not run before the constructor has
+     * completed successfully.
+     */
+    @IgnoreMethod
+    @Override
+    public void before(Object target, Object[] args) {
+        // do nothing
+    }
+
+    @Override
+    public void after(Object target, Object[] args, Object result, Throwable throwable) {
+        if (isDebug) {
+            logger.afterInterceptor(target, args, result, throwable);
+        }
+
+        if (throwable != null) {
+            return;
+        }
+
+        try {
+            if (AsyncContextAccessorUtils.getAsyncContext(target) != null) {
+                return;
+            }
+
+            final AsyncContext inherited = ReactorAsyncContextResolver.findUnique(args);
+            if (inherited != null) {
+                AsyncContextAccessorUtils.setAsyncContext(inherited, target);
+                if (isDebug) {
+                    logger.debug("Copy asyncContext from task argument. asyncContext={}", inherited);
+                }
+                return;
+            }
+
+            final Trace trace = traceContext.currentTraceObject();
+            if (trace == null) {
+                return;
+            }
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            try {
+                recorder.recordServiceType(serviceType);
+                recorder.recordApi(methodDescriptor);
+                final AsyncContext nextAsyncContext = recorder.recordNextAsyncContext();
+                AsyncContextAccessorUtils.setAsyncContext(nextAsyncContext, target);
+                if (isDebug) {
+                    logger.debug("Record boundary asyncContext from current trace. asyncContext={}", nextAsyncContext);
+                }
+            } finally {
+                trace.traceBlockEnd();
+            }
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/SchedulerTaskRunInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/SchedulerTaskRunInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.plugin.reactor;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.InjectedAsyncContextSpanEventApiIdAwareAroundInterceptor;
+
+/**
+ * Activates the trace carried by a scheduler task ({@link SchedulerTaskConstructorInterceptor})
+ * around the task body on the worker thread, restore-only: no span event per execution
+ * ({@code asyncTraceBlock=false}), the same flow {@code CoreSubscriberOnNextInterceptor} uses for
+ * signal delivery.
+ * <p>
+ * The carried context is supplied by the weaver as a monomorphic read of the injected field —
+ * the target classes are final, so no shared megamorphic call site forms.
+ * <p>
+ * Lifecycle comes from the async trace scope: a task whose {@code run()} delegates to
+ * {@code call()} (both woven) enters the scope twice and unbinds/closes only when the outermost
+ * frame ends. On an inline executor with a trace already active on the thread, that trace is
+ * returned and — not being an async trace — is never closed here, so the ambient trace is
+ * preserved.
+ */
+public class SchedulerTaskRunInterceptor extends InjectedAsyncContextSpanEventApiIdAwareAroundInterceptor {
+
+    public SchedulerTaskRunInterceptor(TraceContext traceContext) {
+        super(traceContext, false);
+    }
+
+    @Override
+    public void doInBeforeTrace(SpanEventRecorder recorder, AsyncContext asyncContext, Object target, int apiId, Object[] args) {
+        // restore-only: never reached with asyncTraceBlock=false.
+    }
+
+    @Override
+    public void doInAfterTrace(SpanEventRecorder recorder, Object target, int apiId, Object[] args, Object result, Throwable throwable) {
+        // restore-only: never reached with asyncTraceBlock=false.
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/ReactorAsyncContextResolverTest.java
+++ b/agent-module/bootstraps/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/ReactorAsyncContextResolverTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.reactor;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+public class ReactorAsyncContextResolverTest {
+
+    @Test
+    public void nullOrEmptyArgs() {
+        assertNull(ReactorAsyncContextResolver.findUnique(null));
+        assertNull(ReactorAsyncContextResolver.findUnique(new Object[0]));
+    }
+
+    @Test
+    public void noAccessorArgs() {
+        assertNull(ReactorAsyncContextResolver.findUnique(new Object[]{new Object(), "arg", 100L}));
+    }
+
+    @Test
+    public void accessorWithoutContext() {
+        MockAsyncContextAccessor emptyAccessor = new MockAsyncContextAccessor();
+
+        assertNull(ReactorAsyncContextResolver.findUnique(new Object[]{emptyAccessor}));
+    }
+
+    @Test
+    public void singleContext_amongPlainArgs() {
+        AsyncContext asyncContext = mock(AsyncContext.class);
+        MockAsyncContextAccessor carrier = new MockAsyncContextAccessor();
+        carrier._$PINPOINT$_setAsyncContext(asyncContext);
+
+        assertSame(asyncContext, ReactorAsyncContextResolver.findUnique(new Object[]{new Object(), carrier, 100L}));
+    }
+
+    @Test
+    public void emptyAccessorDoesNotMaskContext() {
+        AsyncContext asyncContext = mock(AsyncContext.class);
+        MockAsyncContextAccessor emptyAccessor = new MockAsyncContextAccessor();
+        MockAsyncContextAccessor carrier = new MockAsyncContextAccessor();
+        carrier._$PINPOINT$_setAsyncContext(asyncContext);
+
+        assertSame(asyncContext, ReactorAsyncContextResolver.findUnique(new Object[]{emptyAccessor, carrier}));
+    }
+
+    @Test
+    public void sameContextRepeated() {
+        AsyncContext asyncContext = mock(AsyncContext.class);
+        MockAsyncContextAccessor first = new MockAsyncContextAccessor();
+        MockAsyncContextAccessor second = new MockAsyncContextAccessor();
+        first._$PINPOINT$_setAsyncContext(asyncContext);
+        second._$PINPOINT$_setAsyncContext(asyncContext);
+
+        assertSame(asyncContext, ReactorAsyncContextResolver.findUnique(new Object[]{first, second}));
+    }
+
+    @Test
+    public void conflictingContexts_notChosenArbitrarily() {
+        MockAsyncContextAccessor first = new MockAsyncContextAccessor();
+        MockAsyncContextAccessor second = new MockAsyncContextAccessor();
+        first._$PINPOINT$_setAsyncContext(mock(AsyncContext.class));
+        second._$PINPOINT$_setAsyncContext(mock(AsyncContext.class));
+
+        assertNull(ReactorAsyncContextResolver.findUnique(new Object[]{first, second}));
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/SchedulerTaskConstructorInterceptorTest.java
+++ b/agent-module/bootstraps/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/SchedulerTaskConstructorInterceptorTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.reactor;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Gate arithmetic of the carrier-first, current-trace-fallback capture policy. The interceptor runs
+ * in the constructor's after() — before() is {@code @IgnoreMethod} — so every case drives after().
+ */
+public class SchedulerTaskConstructorInterceptorTest {
+
+    private TraceContext traceContext;
+    private MethodDescriptor methodDescriptor;
+    private ServiceType serviceType;
+    private SchedulerTaskConstructorInterceptor interceptor;
+
+    @BeforeEach
+    public void setUp() {
+        traceContext = mock(TraceContext.class);
+        methodDescriptor = mock(MethodDescriptor.class);
+        serviceType = mock(ServiceType.class);
+        interceptor = new SchedulerTaskConstructorInterceptor(traceContext, methodDescriptor, serviceType);
+    }
+
+    @Test
+    public void failedConstructor_capturesNothing() {
+        MockAsyncContextAccessor target = new MockAsyncContextAccessor();
+        MockAsyncContextAccessor carrier = new MockAsyncContextAccessor();
+        carrier._$PINPOINT$_setAsyncContext(mock(AsyncContext.class));
+
+        interceptor.after(target, new Object[]{carrier}, null, new RuntimeException("ctor failed"));
+
+        assertNull(target._$PINPOINT$_getAsyncContext());
+        verifyNoInteractions(traceContext);
+    }
+
+    @Test
+    public void existingContext_kept() {
+        AsyncContext existing = mock(AsyncContext.class);
+        MockAsyncContextAccessor target = new MockAsyncContextAccessor();
+        target._$PINPOINT$_setAsyncContext(existing);
+        MockAsyncContextAccessor carrier = new MockAsyncContextAccessor();
+        carrier._$PINPOINT$_setAsyncContext(mock(AsyncContext.class));
+
+        interceptor.after(target, new Object[]{carrier}, null, null);
+
+        assertSame(existing, target._$PINPOINT$_getAsyncContext());
+        verifyNoInteractions(traceContext);
+    }
+
+    @Test
+    public void carrierCopied_withoutTouchingCurrentTrace() {
+        AsyncContext inherited = mock(AsyncContext.class);
+        MockAsyncContextAccessor target = new MockAsyncContextAccessor();
+        MockAsyncContextAccessor carrier = new MockAsyncContextAccessor();
+        carrier._$PINPOINT$_setAsyncContext(inherited);
+
+        interceptor.after(target, new Object[]{carrier, mock(Object.class)}, null, null);
+
+        assertSame(inherited, target._$PINPOINT$_getAsyncContext());
+        // carrier-first: the fallback must not run, no sibling boundary context is minted.
+        verifyNoInteractions(traceContext);
+    }
+
+    @Test
+    public void conflictingCarriers_fallBackToCurrentTrace() {
+        MockAsyncContextAccessor target = new MockAsyncContextAccessor();
+        MockAsyncContextAccessor first = new MockAsyncContextAccessor();
+        MockAsyncContextAccessor second = new MockAsyncContextAccessor();
+        first._$PINPOINT$_setAsyncContext(mock(AsyncContext.class));
+        second._$PINPOINT$_setAsyncContext(mock(AsyncContext.class));
+
+        Trace trace = mock(Trace.class);
+        SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        AsyncContext boundary = mock(AsyncContext.class);
+        when(traceContext.currentTraceObject()).thenReturn(trace);
+        when(trace.traceBlockBegin()).thenReturn(recorder);
+        when(recorder.recordNextAsyncContext()).thenReturn(boundary);
+
+        interceptor.after(target, new Object[]{first, second}, null, null);
+
+        // neither conflicting context is chosen arbitrarily - a fresh boundary context is recorded.
+        assertSame(boundary, target._$PINPOINT$_getAsyncContext());
+        verify(trace).traceBlockEnd();
+    }
+
+    @Test
+    public void noCarrier_recordsBoundarySpanEvent() {
+        MockAsyncContextAccessor target = new MockAsyncContextAccessor();
+
+        Trace trace = mock(Trace.class);
+        SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        AsyncContext boundary = mock(AsyncContext.class);
+        when(traceContext.currentTraceObject()).thenReturn(trace);
+        when(trace.traceBlockBegin()).thenReturn(recorder);
+        when(recorder.recordNextAsyncContext()).thenReturn(boundary);
+
+        interceptor.after(target, new Object[]{mock(Runnable.class)}, null, null);
+
+        assertSame(boundary, target._$PINPOINT$_getAsyncContext());
+        verify(recorder).recordServiceType(serviceType);
+        verify(recorder).recordApi(methodDescriptor);
+        verify(trace).traceBlockEnd();
+    }
+
+    @Test
+    public void noCarrierAndNoCurrentTrace_capturesNothing() {
+        MockAsyncContextAccessor target = new MockAsyncContextAccessor();
+        when(traceContext.currentTraceObject()).thenReturn(null);
+
+        interceptor.after(target, new Object[]{mock(Runnable.class)}, null, null);
+
+        assertNull(target._$PINPOINT$_getAsyncContext());
+    }
+
+    @Test
+    public void recorderFailure_stillEndsTraceBlock_andDoesNotPropagate() {
+        MockAsyncContextAccessor target = new MockAsyncContextAccessor();
+
+        Trace trace = mock(Trace.class);
+        SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        when(traceContext.currentTraceObject()).thenReturn(trace);
+        when(trace.traceBlockBegin()).thenReturn(recorder);
+        when(recorder.recordNextAsyncContext()).thenThrow(new IllegalStateException("recorder failed"));
+
+        interceptor.after(target, new Object[]{mock(Runnable.class)}, null, null);
+
+        assertNull(target._$PINPOINT$_getAsyncContext());
+        verify(trace).traceBlockEnd();
+    }
+
+    @Test
+    public void nonAccessorTarget_isHarmless() {
+        Trace trace = mock(Trace.class);
+        SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        when(traceContext.currentTraceObject()).thenReturn(trace);
+        when(trace.traceBlockBegin()).thenReturn(recorder);
+        when(recorder.recordNextAsyncContext()).thenReturn(mock(AsyncContext.class));
+
+        // a target without the injected field (mispaired transform) must not break the app.
+        interceptor.after(new Object(), new Object[]{mock(Runnable.class)}, null, null);
+
+        verify(trace).traceBlockEnd();
+        verify(trace, never()).close();
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/SchedulerTaskRunInterceptorTest.java
+++ b/agent-module/bootstraps/bootstrap-core/src/test/java/com/navercorp/pinpoint/bootstrap/plugin/reactor/SchedulerTaskRunInterceptorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.plugin.reactor;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Activation arithmetic of the restore-only run/call window: the async trace scope depth decides
+ * when the thread is unbound and the trace closed, so a task whose run() delegates to call()
+ * (both woven) activates exactly once, and an ambient (non-async) trace is never closed here.
+ */
+public class SchedulerTaskRunInterceptorTest {
+
+    private static final int API_ID = 99;
+    private static final Object[] ARGS = new Object[0];
+
+    private SchedulerTaskRunInterceptor interceptor;
+    private AsyncContext asyncContext;
+    private Trace trace;
+    private TraceScope scope;
+    private Object target;
+
+    @BeforeEach
+    public void setUp() {
+        interceptor = new SchedulerTaskRunInterceptor(mock(TraceContext.class));
+        asyncContext = mock(AsyncContext.class);
+        trace = mock(Trace.class);
+        scope = mock(TraceScope.class);
+        target = new Object();
+
+        when(asyncContext.continueAsyncTraceObject(false)).thenReturn(trace);
+        when(asyncContext.currentAsyncTraceObject()).thenReturn(trace);
+        when(trace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(scope);
+        when(trace.isAsync()).thenReturn(true);
+        when(scope.canLeave()).thenReturn(true);
+    }
+
+    @Test
+    public void noAsyncContext_noop() {
+        interceptor.before(target, null, API_ID, ARGS);
+        interceptor.after(target, null, API_ID, ARGS, null, null);
+    }
+
+    @Test
+    public void singleExecution_bindsAndClosesOnce() {
+        when(scope.isActive()).thenReturn(false);
+
+        interceptor.before(target, asyncContext, API_ID, ARGS);
+        interceptor.after(target, asyncContext, API_ID, ARGS, null, null);
+
+        verify(scope).tryEnter();
+        verify(scope).leave();
+        verify(trace).close();
+        verify(asyncContext).close();
+    }
+
+    @Test
+    public void nestedRunToCall_activatesOnce() {
+        // inner after sees the scope still active, outer after sees it ended.
+        when(scope.isActive()).thenReturn(true, false);
+
+        interceptor.before(target, asyncContext, API_ID, ARGS);            // run()
+        interceptor.before(target, asyncContext, API_ID, ARGS);            // -> call()
+        interceptor.after(target, asyncContext, API_ID, ARGS, null, null); // call() end
+        interceptor.after(target, asyncContext, API_ID, ARGS, null, null); // run() end
+
+        verify(scope, times(2)).tryEnter();
+        verify(scope, times(2)).leave();
+        verify(trace, times(1)).close();
+        verify(asyncContext, times(1)).close();
+    }
+
+    @Test
+    public void ambientTrace_isPreserved() {
+        // inline executor: the thread already runs inside an entry trace - continueAsyncTraceObject
+        // returns it, it has no async trace scope and is not async, so nothing is closed here.
+        Trace ambient = mock(Trace.class);
+        when(asyncContext.continueAsyncTraceObject(false)).thenReturn(ambient);
+        when(asyncContext.currentAsyncTraceObject()).thenReturn(ambient);
+        when(ambient.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(null);
+        when(ambient.isAsync()).thenReturn(false);
+
+        interceptor.before(target, asyncContext, API_ID, ARGS);
+        interceptor.after(target, asyncContext, API_ID, ARGS, null, null);
+
+        verify(ambient, never()).close();
+        verify(asyncContext, never()).close();
+    }
+
+    @Test
+    public void taskBodyException_stillUnbinds() {
+        when(scope.isActive()).thenReturn(false);
+
+        interceptor.before(target, asyncContext, API_ID, ARGS);
+        interceptor.after(target, asyncContext, API_ID, ARGS, null, new RuntimeException("task failed"));
+
+        verify(trace).close();
+        verify(asyncContext).close();
+    }
+
+    @Test
+    public void unbalancedScope_deletesUnstableTrace() {
+        when(scope.canLeave()).thenReturn(false);
+
+        interceptor.before(target, asyncContext, API_ID, ARGS);
+        interceptor.after(target, asyncContext, API_ID, ARGS, null, null);
+
+        // leave failed: the unstable trace is deleted instead of leaking on the worker thread.
+        verify(trace).close();
+        verify(asyncContext).close();
+    }
+
+    @Test
+    public void continueFailure_afterWithoutBinding_noop() {
+        AsyncContext deadContext = mock(AsyncContext.class);
+        when(deadContext.continueAsyncTraceObject(false)).thenReturn(null);
+        when(deadContext.currentAsyncTraceObject()).thenReturn(null);
+
+        interceptor.before(target, deadContext, API_ID, ARGS);
+        interceptor.after(target, deadContext, API_ID, ARGS, null, null);
+
+        verifyNoInteractions(trace);
+    }
+}

--- a/agent-module/plugins-it/pom.xml
+++ b/agent-module/plugins-it/pom.xml
@@ -77,6 +77,7 @@
         <module>spring-data-r2dbc-it</module>
         <module>redis-lettuce-it</module>
         <module>redis-redisson-it</module>
+        <module>spring-tx-it</module>
         <module>pulsar-it</module>
         <module>reactor-it</module>
     </modules>

--- a/agent-module/plugins-it/reactor-it/src/test/java/com/navercorp/pinpoint/it/plugin/reactor/SchedulerTaskCarrier_IT.java
+++ b/agent-module/plugins-it/reactor-it/src/test/java/com/navercorp/pinpoint/it/plugin/reactor/SchedulerTaskCarrier_IT.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.reactor;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import test.pinpoint.plugin.reactor.Echo;
+import test.pinpoint.plugin.reactor.ReactorFlow;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Assertions for the scheduler task carrier ({@code profiler.reactor.trace.scheduler.task=true}):
+ * reactor's built-in schedulers wrap every submitted Runnable in a task object
+ * ({@code SchedulerTask}, {@code WorkerTask}, ...) before it crosses to a worker thread, and the
+ * carrier instrumentation parks the AsyncContext on that task and re-activates it around
+ * {@code run()}/{@code call()}.
+ *
+ * <h2>What only the carrier covers</h2>
+ * A <b>plain application Runnable</b> handed to {@code Scheduler.schedule(...)} inside an active
+ * trace. No operator subscriber is involved, so nothing else records or relays a context — the
+ * carrier's current-trace fallback records a REACTOR boundary event on the scheduling side and the
+ * task activation binds it on the worker. The async-link assertion
+ * ({@link Expectations#async(ExpectedTrace, ExpectedTrace...)}, see {@code ReactorPropagation_IT}
+ * for why only that assertion discriminates) links the two.
+ *
+ * <p><b>Discriminating probe (manual)</b>: flip {@code profiler.reactor.trace.scheduler.task=false}
+ * in {@code pinpoint-scheduler-task.config} — the plain-Runnable cases must fail (no boundary
+ * event, callback becomes a standalone trace), then flip it back.
+ *
+ * <h2>onScheduleHook decorators</h2>
+ * From reactor 3.4 the scheduler passes the Runnable through {@code Schedulers.onSchedule(...)}
+ * BEFORE constructing the task, so a decorator registered by the application or another agent
+ * makes the constructor argument an anonymous wrapper. The carrier then cannot see a carried
+ * context and must degrade to the current-trace fallback — the link survives, only the carrier
+ * identity is lost. {@link #onScheduleHookDecorator_fallbackStillLinks} pins that behaviour.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-scheduler-task.config")
+@Dependency({"io.projectreactor:reactor-core:[3.6.9][3.7.19]"})
+public class SchedulerTaskCarrier_IT {
+
+    private static final String REACTOR = "REACTOR";
+    private static final String INTERNAL_METHOD = "INTERNAL_METHOD";
+
+    private static final String FLUX_PUBLISH_ON =
+            "reactor.core.publisher.Flux.publishOn(reactor.core.scheduler.Scheduler, boolean, int, int)";
+
+    private static final long AWAIT_UNIT_MILLIS = 20L;
+    private static final long AWAIT_MAX_MILLIS = 5000L;
+
+    private static Method echoGet() throws NoSuchMethodException {
+        return Echo.class.getDeclaredMethod("get", String.class);
+    }
+
+    /**
+     * {@code Scheduler.schedule(Runnable)} goes through {@code Schedulers.directSchedule} which
+     * constructs {@code SchedulerTask} — the boundary event is recorded from its constructor.
+     */
+    private static Constructor<?> schedulerTaskConstructor() throws Exception {
+        final Class<?> schedulerTask = Class.forName("reactor.core.scheduler.SchedulerTask");
+        return schedulerTask.getDeclaredConstructors()[0];
+    }
+
+    // ------------------------------------------------------------------
+    // the carrier's own coverage: plain Runnable, no operator involved
+    // ------------------------------------------------------------------
+
+    @Test
+    public void plainRunnable_currentTraceFallback_linksAcrossThread() throws Exception {
+        final Scheduler scheduler = Schedulers.newParallel("it-plain-runnable", 2);
+        try {
+            runPlainScheduleAndVerifyAsyncLink(scheduler);
+        } finally {
+            scheduler.dispose();
+        }
+    }
+
+    @Test
+    public void onScheduleHookDecorator_fallbackStillLinks() throws Exception {
+        // the decorator hides any carried context from the task constructor (the argument becomes
+        // this anonymous wrapper) - the carrier must fall back to the current trace, not break.
+        Schedulers.onScheduleHook("it-decorator", runnable -> () -> runnable.run());
+        final Scheduler scheduler = Schedulers.newParallel("it-hook-decorator", 2);
+        try {
+            runPlainScheduleAndVerifyAsyncLink(scheduler);
+        } finally {
+            scheduler.dispose();
+            Schedulers.resetOnScheduleHook("it-decorator");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // coexistence: the per-operator relay keeps working with the carrier on
+    // ------------------------------------------------------------------
+
+    /**
+     * publishOn schedules its own subscriber (an instrumented carrier), so here the task copies
+     * the existing context (carrier-first, no extra boundary event) and the established
+     * per-operator async link must be unchanged. Also guards against double activation: the task
+     * window and the subscriber's own run window nest on the same scope.
+     */
+    @Test
+    public void publishOn_withCarrierOn_relayLinkUnchanged() throws Exception {
+        final Scheduler scheduler = Schedulers.newParallel("it-carrier-publishOn", 2);
+        try {
+            final CountDownLatch latch = new CountDownLatch(1);
+            final List<String> callbackThreads = new CopyOnWriteArrayList<>();
+            final String mainThread = Thread.currentThread().getName();
+
+            new ReactorFlow().execute(() ->
+                    Flux.range(1, 1)
+                            .publishOn(scheduler)
+                            .map(v -> echoOnce(latch, callbackThreads, v))
+                            .subscribe());
+
+            assertTrue(latch.await(AWAIT_MAX_MILLIS, TimeUnit.MILLISECONDS), "callback was not invoked");
+            assertEquals(1, callbackThreads.size(), "callback ran an unexpected number of times");
+            assertNotEquals(mainThread, callbackThreads.get(0), "no scheduler hop");
+
+            final ExpectedTrace callback = Expectations.event(INTERNAL_METHOD, echoGet());
+            final ExpectedTrace asyncLink = Expectations.async(
+                    Expectations.event(REACTOR, FLUX_PUBLISH_ON), callback);
+
+            final PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+            verifier.awaitTrace(callback, AWAIT_UNIT_MILLIS, AWAIT_MAX_MILLIS);
+            verifier.printCache();
+            verifier.verifyDiscreteTrace(asyncLink);
+        } finally {
+            scheduler.dispose();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    private void runPlainScheduleAndVerifyAsyncLink(Scheduler scheduler) throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final List<String> callbackThreads = new CopyOnWriteArrayList<>();
+        final String mainThread = Thread.currentThread().getName();
+
+        new ReactorFlow().execute(() ->
+                scheduler.schedule(() -> echoOnce(latch, callbackThreads, "plain")));
+
+        assertTrue(latch.await(AWAIT_MAX_MILLIS, TimeUnit.MILLISECONDS), "task was not executed");
+        assertEquals(1, callbackThreads.size(), "task ran an unexpected number of times");
+        assertNotEquals(mainThread, callbackThreads.get(0),
+                "task ran on the scheduling thread - no hop, the assertion would be vacuous");
+
+        final ExpectedTrace callback = Expectations.event(INTERNAL_METHOD, echoGet());
+        final ExpectedTrace asyncLink = Expectations.async(
+                Expectations.event(REACTOR, schedulerTaskConstructor()), callback);
+
+        final PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.awaitTrace(callback, AWAIT_UNIT_MILLIS, AWAIT_MAX_MILLIS);
+        verifier.printCache();
+        verifier.verifyDiscreteTrace(asyncLink);
+    }
+
+    private String echoOnce(CountDownLatch latch, List<String> threads, Object value) {
+        threads.add(Thread.currentThread().getName());
+        try {
+            return new Echo().get("Hello" + value);
+        } finally {
+            latch.countDown();
+        }
+    }
+}

--- a/agent-module/plugins-it/reactor-it/src/test/resources/pinpoint-scheduler-task.config
+++ b/agent-module/plugins-it/reactor-it/src/test/resources/pinpoint-scheduler-task.config
@@ -1,0 +1,12 @@
+###########################################################
+# user defined classes                                    #
+###########################################################
+# Same entrypoints as pinpoint-propagation.config - see that file for the assertion rationale.
+profiler.entrypoint=test.pinpoint.plugin.reactor.ReactorFlow.execute,test.pinpoint.plugin.reactor.Echo.get
+
+###########################################################
+# reactor scheduler task carrier (experimental)           #
+###########################################################
+# SchedulerTaskCarrier_IT discriminating probe: flip this to false and the plain-Runnable cases
+# must fail (no carrier -> no REACTOR boundary event -> no async link).
+profiler.reactor.trace.scheduler.task=true

--- a/agent-module/plugins-it/redis-lettuce-it/pom.xml
+++ b/agent-module/plugins-it/redis-lettuce-it/pom.xml
@@ -39,6 +39,13 @@
             <artifactId>pinpoint-plugin-it-utils</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- @PluginTest loads only plugins on the test classpath: needed for profiler.entrypoint
+             (user plugin) used by the seam-wrap async-link assertions -->
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-user-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-redis-lettuce-plugin</artifactId>

--- a/agent-module/plugins-it/redis-lettuce-it/src/test/java/com/navercorp/pinpoint/it/plugin/lettuce/RedisClientSeamWrap_IT.java
+++ b/agent-module/plugins-it/redis-lettuce-it/src/test/java/com/navercorp/pinpoint/it/plugin/lettuce/RedisClientSeamWrap_IT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.lettuce;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.it.plugin.utils.TestcontainersOption;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import com.navercorp.pinpoint.test.plugin.shared.SharedDependency;
+import com.navercorp.pinpoint.test.plugin.shared.SharedTestBeforeAllResult;
+import com.navercorp.pinpoint.test.plugin.shared.SharedTestLifeCycleClass;
+import io.lettuce.core.AbstractRedisAsyncCommands;
+import io.lettuce.core.AbstractRedisReactiveCommands;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.reactive.RedisStringReactiveCommands;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import test.pinpoint.plugin.lettuce.Echo;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Runtime assertions for {@code profiler.redis.lettuce.wrap.publisher=true} (the seam wrapper
+ * variant of the lettuce command interceptor).
+ *
+ * <p>The config also sets {@code profiler.reactor.enable=false}: without the reactor plugin there
+ * are no per-operator relays and no accessor fields on reactor publishers, so a reactive
+ * async link can only be produced by the wrapped publisher — the same wrapper-only proof
+ * {@code R2dbcPostgresqlSeamWrap_IT} uses. The callback assertion is the async-link relation
+ * ({@link Expectations#async(ExpectedTrace, ExpectedTrace...)}); see {@code ReactorPropagation_IT}
+ * for why nothing weaker discriminates.
+ *
+ * <p><b>Discriminating probe (manual)</b>: flip {@code wrap.publisher=false} in
+ * {@code pinpoint-lettuce-seam-wrap.config} — {@code reactive_wrapperAloneLinksAcrossThread}
+ * must fail — then flip back.
+ *
+ * <p>The async/sync command surface shares the same interceptor: with wrap on, a non-reactor
+ * result must keep the original injection fallback (hybrid), which the async case pins.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-lettuce-seam-wrap.config")
+@Dependency({"io.lettuce:lettuce-core:[6.2.0.RELEASE],[6.5.0.RELEASE]",
+        "org.latencyutils:LatencyUtils:[2.0.3]",
+        PluginITConstants.VERSION})
+@SharedDependency({PluginITConstants.VERSION, TestcontainersOption.TEST_CONTAINER})
+@SharedTestLifeCycleClass(RedisServer.class)
+public class RedisClientSeamWrap_IT {
+    private static final String REDIS_LETTUCE = "REDIS_LETTUCE";
+    private static final String INTERNAL_METHOD = "INTERNAL_METHOD";
+
+    private static final long AWAIT_UNIT_MILLIS = 20L;
+    private static final long AWAIT_MAX_MILLIS = 5000L;
+
+    private static String host;
+    private static int port;
+    @AutoClose("shutdown")
+    private static RedisClient redisClient;
+
+    @SharedTestBeforeAllResult
+    public static void setBeforeAllResult(Properties beforeAllResult) {
+    }
+
+    @BeforeAll
+    public static void beforeClass() {
+        port = Integer.parseInt(System.getProperty("PORT"));
+        host = System.getProperty("HOST");
+        redisClient = RedisClient.create(String.format("redis://%s:%s", host, port));
+    }
+
+    private static Method echoGet() throws NoSuchMethodException {
+        return Echo.class.getDeclaredMethod("get", String.class);
+    }
+
+    @Test
+    public void reactive_wrapperAloneLinksAcrossThread() throws Exception {
+        StatefulRedisConnection<String, String> connection = redisClient.connect();
+        try {
+            RedisStringReactiveCommands<String, String> commands = connection.reactive();
+
+            final CountDownLatch latch = new CountDownLatch(1);
+            final List<String> callbackThreads = new CopyOnWriteArrayList<>();
+            final String testThread = Thread.currentThread().getName();
+
+            // the seam fires inside the @PluginTest root trace; the value is delivered on the
+            // lettuce netty event loop - a real thread hop.
+            commands.set("foo", "bar")
+                    .map(v -> {
+                        callbackThreads.add(Thread.currentThread().getName());
+                        try {
+                            return new Echo().get("Hello" + v);
+                        } finally {
+                            latch.countDown();
+                        }
+                    })
+                    .subscribe();
+
+            assertTrue(latch.await(AWAIT_MAX_MILLIS, TimeUnit.MILLISECONDS), "callback was not invoked");
+            assertEquals(1, callbackThreads.size(), "callback ran an unexpected number of times");
+            assertNotEquals(testThread, callbackThreads.get(0),
+                    "callback ran on the test thread - no hop, the assertion would be vacuous");
+
+            // io.lettuce.core.AbstractRedisReactiveCommands.set(java.lang.Object, java.lang.Object)
+            Method reactiveSet = AbstractRedisReactiveCommands.class.getDeclaredMethod("set", Object.class, Object.class);
+            final ExpectedTrace callback = Expectations.event(INTERNAL_METHOD, echoGet());
+            final ExpectedTrace asyncLink = Expectations.async(
+                    Expectations.event(REDIS_LETTUCE, reactiveSet), callback);
+
+            PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+            verifier.awaitTrace(callback, AWAIT_UNIT_MILLIS, AWAIT_MAX_MILLIS);
+            verifier.printCache();
+            verifier.verifyDiscreteTrace(asyncLink);
+        } finally {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void async_hybridFallbackKeepsCommandEvents() throws Exception {
+        StatefulRedisConnection<String, String> connection = redisClient.connect();
+        try {
+            RedisAsyncCommands<String, String> commands = connection.async();
+
+            RedisFuture<String> future = commands.set("foo", "bar");
+            future.get(1000, TimeUnit.MILLISECONDS);
+            future = commands.get("foo");
+            future.get(1000, TimeUnit.MILLISECONDS);
+
+            PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+            Method setMethod = AbstractRedisAsyncCommands.class.getDeclaredMethod("set", Object.class, Object.class);
+            Method getMethod = AbstractRedisAsyncCommands.class.getDeclaredMethod("get", Object.class);
+            verifier.printCache();
+            verifier.verifyTrace(Expectations.event(REDIS_LETTUCE, setMethod));
+            verifier.verifyTrace(Expectations.event(REDIS_LETTUCE, getMethod));
+        } finally {
+            connection.close();
+        }
+    }
+}

--- a/agent-module/plugins-it/redis-lettuce-it/src/test/java/test/pinpoint/plugin/lettuce/Echo.java
+++ b/agent-module/plugins-it/redis-lettuce-it/src/test/java/test/pinpoint/plugin/lettuce/Echo.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.pinpoint.plugin.lettuce;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * profiler.entrypoint leaf for the seam-wrap async-link assertions - an INTERNAL_METHOD event
+ * when the trace propagated, a STAND_ALONE root when it did not (see reactor-it's Echo).
+ */
+public class Echo {
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    public String get(String message) {
+        logger.info("echo:{}", message);
+        return message;
+    }
+}

--- a/agent-module/plugins-it/redis-lettuce-it/src/test/resources/pinpoint-lettuce-seam-wrap.config
+++ b/agent-module/plugins-it/redis-lettuce-it/src/test/resources/pinpoint-lettuce-seam-wrap.config
@@ -1,0 +1,14 @@
+###########################################################
+# lettuce seam wrapper IT                                 #
+###########################################################
+# Echo.get is the INTERNAL_METHOD leaf for the async-link assertion (@PluginTest already wraps
+# the test method itself in a root trace).
+profiler.entrypoint=test.pinpoint.plugin.lettuce.Echo.get
+
+# Wrapping variant of the lettuce command interceptor.
+# Discriminating probe (manual): flip to false - the reactive async-link case must fail.
+profiler.redis.lettuce.wrap.publisher=true
+
+# Wrapper-only proof: with the reactor plugin off there are no per-operator relays or accessor
+# fields, so the async link can only come from the wrapped publisher.
+profiler.reactor.enable=false

--- a/agent-module/plugins-it/redis-redisson-it/pom.xml
+++ b/agent-module/plugins-it/redis-redisson-it/pom.xml
@@ -39,6 +39,13 @@
             <artifactId>pinpoint-plugin-it-utils</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- @PluginTest loads only plugins on the test classpath: needed for profiler.entrypoint
+             (user plugin) used by the seam-wrap async-link assertions -->
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-user-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-redis-redisson-plugin</artifactId>

--- a/agent-module/plugins-it/redis-redisson-it/src/test/java/com/navercorp/pinpoint/it/plugin/redisson/RedissonSeamWrap_IT.java
+++ b/agent-module/plugins-it/redis-redisson-it/src/test/java/com/navercorp/pinpoint/it/plugin/redisson/RedissonSeamWrap_IT.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.redisson;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.it.plugin.utils.TestcontainersOption;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import com.navercorp.pinpoint.test.plugin.shared.SharedDependency;
+import com.navercorp.pinpoint.test.plugin.shared.SharedTestBeforeAllResult;
+import com.navercorp.pinpoint.test.plugin.shared.SharedTestLifeCycleClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.redisson.Redisson;
+import org.redisson.api.RBucketReactive;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.RedissonReactiveClient;
+import org.redisson.config.Config;
+import reactor.core.publisher.Mono;
+import test.pinpoint.plugin.redisson.Echo;
+
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Runtime assertions for {@code profiler.redis.redisson.wrap.publisher=true} (the seam wrapper
+ * variant of the redisson reactive method interceptor, woven into
+ * {@code org.redisson.reactive.ReactiveProxyBuilder$1.execute}).
+ *
+ * <p>The config also sets {@code profiler.reactor.enable=false}: without the reactor plugin there
+ * are no per-operator relays and no accessor fields on reactor publishers, so a reactive async
+ * link can only be produced by the wrapped publisher — the same wrapper-only proof
+ * {@code R2dbcPostgresqlSeamWrap_IT} and {@code RedisClientSeamWrap_IT} use.
+ *
+ * <p><b>Discriminating probe (manual)</b>: flip {@code wrap.publisher=false} in
+ * {@code pinpoint-redisson-seam-wrap.config} — the async-link assertion must fail — then flip back.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-redisson-seam-wrap.config")
+@Dependency({"org.redisson:redisson:[3.17.7],[3.27.2]",
+        PluginITConstants.VERSION})
+@SharedDependency({PluginITConstants.VERSION, TestcontainersOption.TEST_CONTAINER})
+@SharedTestLifeCycleClass(RedisServer.class)
+public class RedissonSeamWrap_IT {
+    private static final String REDISSON_REACTIVE = "REDIS_REDISSON_REACTIVE";
+    private static final String INTERNAL_METHOD = "INTERNAL_METHOD";
+
+    private static final long AWAIT_UNIT_MILLIS = 20L;
+    private static final long AWAIT_MAX_MILLIS = 5000L;
+
+    private static RedissonClient redisson;
+
+    @SharedTestBeforeAllResult
+    public static void setBeforeAllResult(Properties beforeAllResult) {
+    }
+
+    @BeforeAll
+    public static void beforeClass() {
+        final String host = System.getProperty("HOST");
+        final int port = Integer.parseInt(System.getProperty("PORT"));
+        final Config config = new Config();
+        config.useSingleServer().setAddress(String.format("redis://%s:%s", host, port));
+        redisson = Redisson.create(config);
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        if (redisson != null) {
+            redisson.shutdown();
+        }
+    }
+
+    private static Method echoGet() throws NoSuchMethodException {
+        return Echo.class.getDeclaredMethod("get", String.class);
+    }
+
+    /**
+     * The reactive proxy funnels every command through the woven {@code execute} — resolve it by
+     * reflection because the owner is an anonymous class ({@code ReactiveProxyBuilder$1}) and the
+     * signature changed across redisson versions (3.17+: {@code execute(Callable, Method)}).
+     */
+    private static Member reactiveExecuteMethod() throws Exception {
+        final Class<?> owner = Class.forName("org.redisson.reactive.ReactiveProxyBuilder$1");
+        try {
+            // redisson 3.19+
+            return owner.getDeclaredMethod("execute", java.util.concurrent.Callable.class, Method.class);
+        } catch (NoSuchMethodException e1) {
+            try {
+                // redisson ~3.17.x
+                return owner.getDeclaredMethod("execute", Method.class, Object.class, Method.class, Object[].class);
+            } catch (NoSuchMethodException e2) {
+                // older
+                return owner.getDeclaredMethod("execute", Method.class, Object.class, Object[].class);
+            }
+        }
+    }
+
+    @Test
+    public void reactive_wrapperAloneLinksAcrossThread() throws Exception {
+        // seed OUTSIDE the reactive seam (sync api): the reactive set would record a second
+        // initiator with the same api descriptor but no chunk (Mono<Void> has no user callback),
+        // and the discrete matcher binds to the first candidate without backtracking.
+        redisson.getBucket("foo").set("bar");
+
+        final RedissonReactiveClient reactive = redisson.reactive();
+        final RBucketReactive<String> bucket = reactive.getBucket("foo");
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final List<String> callbackThreads = new CopyOnWriteArrayList<>();
+        final String testThread = Thread.currentThread().getName();
+
+        final Mono<String> get = bucket.get();
+        get.map(v -> {
+                    callbackThreads.add(Thread.currentThread().getName());
+                    try {
+                        return new Echo().get("Hello" + v);
+                    } finally {
+                        latch.countDown();
+                    }
+                })
+                .subscribe();
+
+        assertTrue(latch.await(AWAIT_MAX_MILLIS, TimeUnit.MILLISECONDS), "callback was not invoked");
+        assertEquals(1, callbackThreads.size(), "callback ran an unexpected number of times");
+        assertNotEquals(testThread, callbackThreads.get(0),
+                "callback ran on the test thread - no hop, the assertion would be vacuous");
+
+        final ExpectedTrace callback = Expectations.event(INTERNAL_METHOD, echoGet());
+        final ExpectedTrace asyncLink = Expectations.async(
+                Expectations.event(REDISSON_REACTIVE, reactiveExecuteMethod()), callback);
+
+        final PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.awaitTrace(callback, AWAIT_UNIT_MILLIS, AWAIT_MAX_MILLIS);
+        verifier.printCache();
+        verifier.verifyDiscreteTrace(asyncLink);
+    }
+}

--- a/agent-module/plugins-it/redis-redisson-it/src/test/java/test/pinpoint/plugin/redisson/Echo.java
+++ b/agent-module/plugins-it/redis-redisson-it/src/test/java/test/pinpoint/plugin/redisson/Echo.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.pinpoint.plugin.redisson;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * profiler.entrypoint leaf for the seam-wrap async-link assertions - an INTERNAL_METHOD event
+ * when the trace propagated, a STAND_ALONE root when it did not (see reactor-it's Echo).
+ */
+public class Echo {
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    public String get(String message) {
+        logger.info("echo:{}", message);
+        return message;
+    }
+}

--- a/agent-module/plugins-it/redis-redisson-it/src/test/resources/pinpoint-redisson-seam-wrap.config
+++ b/agent-module/plugins-it/redis-redisson-it/src/test/resources/pinpoint-redisson-seam-wrap.config
@@ -1,0 +1,18 @@
+###########################################################
+# redisson seam wrapper IT                                #
+###########################################################
+# Echo.get is the INTERNAL_METHOD leaf for the async-link assertion (@PluginTest already wraps
+# the test method itself in a root trace).
+profiler.entrypoint=test.pinpoint.plugin.redisson.Echo.get
+
+# Wrapping variant of the redisson reactive method interceptor.
+# Discriminating probe (manual): flip to false - the reactive async-link case must fail.
+profiler.redis.redisson.wrap.publisher=true
+
+# Wrapper-only proof: with the reactor plugin off there are no per-operator relays or accessor
+# fields, so the async link can only come from the wrapped publisher.
+profiler.reactor.enable=false
+
+# keytrace records an args[0] annotation on the seam event; the verifier requires exact
+# annotation matches, so keep the assertion surface minimal.
+profiler.redis.redisson.keytrace=false

--- a/agent-module/plugins-it/spring-data-r2dbc-it/pom.xml
+++ b/agent-module/plugins-it/spring-data-r2dbc-it/pom.xml
@@ -49,6 +49,12 @@
             <artifactId>pinpoint-spring-data-r2dbc-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- instruments the profiler.entrypoint (Echo) used by the seam-wrap IT -->
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-user-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- Spring data r2dbc -->
         <dependency>
             <groupId>org.springframework.data</groupId>

--- a/agent-module/plugins-it/spring-data-r2dbc-it/src/test/java/com/navercorp/pinpoint/it/plugin/jdbc/r2dbc/R2dbcPostgresqlSeamWrap_IT.java
+++ b/agent-module/plugins-it/spring-data-r2dbc-it/src/test/java/com/navercorp/pinpoint/it/plugin/jdbc/r2dbc/R2dbcPostgresqlSeamWrap_IT.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.jdbc.r2dbc;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.it.plugin.utils.TestcontainersOption;
+import com.navercorp.pinpoint.it.plugin.utils.jdbc.DriverProperties;
+import com.navercorp.pinpoint.it.plugin.utils.jdbc.JDBCTestConstants;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import com.navercorp.pinpoint.test.plugin.shared.SharedDependency;
+import com.navercorp.pinpoint.test.plugin.shared.SharedTestLifeCycleClass;
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import io.r2dbc.postgresql.api.PostgresqlConnection;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import test.pinpoint.plugin.r2dbc.Echo;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Seam-wrapper PoC (PINPOINT_REQ-1739): proves the async link at the postgresql
+ * {@code Statement.execute()} seam holds through the wrapped publisher ALONE.
+ * <p>
+ * The config turns the wrapper on ({@code profiler.spring.data.r2dbc.wrap.publisher=true} — no
+ * field injection at this seam) and turns reactor per-operator instrumentation OFF
+ * ({@code profiler.reactor.enable=false}), so nothing else can restore the trace on the driver's
+ * delivery thread. The {@code Echo.get} entrypoint invoked in {@code map()} directly downstream of
+ * the wrapped publisher must therefore be recorded inside the async trace created at the seam;
+ * if the wrapper fails, Echo lands in a standalone trace and the async assertion fails.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-r2dbc-seam-wrap.config")
+@Dependency({"org.postgresql:r2dbc-postgresql:[0.8.12.RELEASE],[0.9.1.RELEASE]",
+        "org.postgresql:postgresql:9.4.1207",
+        "org.springframework.data:spring-data-r2dbc:1.5.1",
+        PluginITConstants.VERSION, JDBCTestConstants.VERSION})
+@SharedDependency({"org.postgresql:postgresql:42.3.2", PluginITConstants.VERSION, JDBCTestConstants.VERSION, TestcontainersOption.TEST_CONTAINER, TestcontainersOption.POSTGRESQL})
+@SharedTestLifeCycleClass(PostgreSqlServer.class)
+public class R2dbcPostgresqlSeamWrap_IT extends SqlBase {
+
+    private static final String SELECT_QUERY = "SELECT first_name, last_name, age FROM persons";
+    private static final long AWAIT_UNIT_MILLIS = 100;
+    private static final long AWAIT_MAX_MILLIS = 5000;
+
+    @Test
+    public void wrappedExecute_deliversDownstreamSignalInsideSeamAsyncTrace() throws Exception {
+        final DriverProperties driverProperties = getDriverProperties();
+        final String host = driverProperties.getProperty(DriverProperties.HOST);
+        final int port = Integer.parseInt(driverProperties.getProperty(DriverProperties.PORT));
+        final String database = driverProperties.getProperty(DriverProperties.DATABASE);
+
+        final PostgresqlConnectionFactory connectionFactory = new PostgresqlConnectionFactory(
+                PostgresqlConnectionConfiguration.builder()
+                        .host(host)
+                        .port(port)
+                        .username(driverProperties.getUser())
+                        .password(driverProperties.getPassword())
+                        .database(database)
+                        .build());
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final List<String> callbackThreads = new CopyOnWriteArrayList<>();
+        final String mainThread = Thread.currentThread().getName();
+
+        final PostgresqlConnection connection = Mono.from(connectionFactory.create()).block();
+        try {
+            // map() sits directly downstream of the wrapped execute() publisher: its lambda runs
+            // inside TracedSubscriber's onNext window on the driver's delivery thread.
+            Flux.from(connection.createStatement(SELECT_QUERY).execute())
+                    .map(result -> {
+                        callbackThreads.add(Thread.currentThread().getName());
+                        try {
+                            return new Echo().get(result);
+                        } finally {
+                            latch.countDown();
+                        }
+                    })
+                    .flatMap(result -> result.map((row, metadata) -> String.valueOf(row.get(0))))
+                    .blockLast();
+        } finally {
+            Mono.from(connection.close()).block();
+        }
+
+        assertTrue(latch.await(AWAIT_MAX_MILLIS, TimeUnit.MILLISECONDS), "callback was not invoked");
+        assertNotEquals(mainThread, callbackThreads.get(0),
+                "callback ran on the subscribing thread - the async assertion would be vacuous");
+
+        final Method echoGet = Echo.class.getDeclaredMethod("get", Object.class);
+        final ExpectedTrace callback = Expectations.event("INTERNAL_METHOD", echoGet);
+
+        final Method executeMethod = Class.forName("io.r2dbc.postgresql.PostgresqlStatement").getDeclaredMethod("execute");
+        final String databaseAddress = host + ":" + port;
+        final ExpectedTrace asyncLink = Expectations.async(
+                Expectations.event("R2DBC_POSTGRESQL_EXECUTE_QUERY", executeMethod, null, databaseAddress, database,
+                        Expectations.sql(SELECT_QUERY, null)),
+                callback);
+
+        final PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        // read-only wait until the callback event is recorded; awaitTrace does nothing on timeout,
+        // the assertion below is what actually decides the result.
+        verifier.awaitTrace(callback, AWAIT_UNIT_MILLIS, AWAIT_MAX_MILLIS);
+        verifier.printCache();
+        verifier.verifyDiscreteTrace(asyncLink);
+    }
+
+    /**
+     * Deterministic pin of the NESTED seam semantics (W3). The DatabaseClient path wraps several
+     * publishers under the one config gate, and they are NOT one doubly-wrapped chain — each seam
+     * wraps a different level:
+     * <ul>
+     * <li>the execute seam wraps the {@code Flux<Result>} (one Result object, no row signals),</li>
+     * <li>the fetch-spec seam is a PURE RELAY: it wraps the row-level {@code Flux} with the
+     * context already parked on the fetch spec — which the {@code DefaultDatabaseClient.sql()}
+     * seam recorded.</li>
+     * </ul>
+     * Rows are therefore delivered inside the <b>sql() seam's</b> window and the callback chunk
+     * links to the SPRING_DATA_R2DBC {@code sql()} event. The execute/create links carry no row
+     * callback in this flow (their windows see no user signal) and stay dangling — accepted
+     * policy P4, unit-pinned in seam-support's NestedSeamWindowTest. If this ownership ever
+     * shifts (e.g. the relay stops using the sql() context), this assertion fails.
+     */
+    @Test
+    public void nestedSeams_sourceSideExecuteSeamCarriesTheCallback() throws Exception {
+        final DriverProperties driverProperties = getDriverProperties();
+        final String host = driverProperties.getProperty(DriverProperties.HOST);
+        final int port = Integer.parseInt(driverProperties.getProperty(DriverProperties.PORT));
+        final String database = driverProperties.getProperty(DriverProperties.DATABASE);
+        final PostgresqlConnectionFactory connectionFactory = new PostgresqlConnectionFactory(
+                PostgresqlConnectionConfiguration.builder()
+                        .host(host)
+                        .port(port)
+                        .username(driverProperties.getUser())
+                        .password(driverProperties.getPassword())
+                        .database(database)
+                        .build());
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final List<String> callbackThreads = new CopyOnWriteArrayList<>();
+        final String mainThread = Thread.currentThread().getName();
+
+        // all() emits per ROW (the sibling test maps per-Result and works on an empty table):
+        // seed one row via the RAW driver api. Seeding through DatabaseClient would record a
+        // second, indistinguishable sql() initiator and the discrete matcher binds to the first
+        // candidate without backtracking (same pitfall as the redisson seam IT).
+        final PostgresqlConnection seedConnection = Mono.from(connectionFactory.create()).block();
+        try {
+            Flux.from(seedConnection.createStatement("INSERT INTO persons (first_name, last_name, age) VALUES ('foo', 'bar', 30)").execute())
+                    .flatMap(io.r2dbc.spi.Result::getRowsUpdated)
+                    .blockLast();
+        } finally {
+            Mono.from(seedConnection.close()).block();
+        }
+
+        // fetch().all() is the fetch-spec seam (a pure relay of the sql() seam's context); the
+        // statement execute() it subscribes to inside is the execute seam.
+        org.springframework.r2dbc.core.DatabaseClient.create(connectionFactory)
+                .sql(SELECT_QUERY)
+                .fetch()
+                .all()
+                .map(row -> {
+                    callbackThreads.add(Thread.currentThread().getName());
+                    try {
+                        return new Echo().get(row);
+                    } finally {
+                        latch.countDown();
+                    }
+                })
+                .blockLast();
+
+        assertTrue(latch.await(AWAIT_MAX_MILLIS, TimeUnit.MILLISECONDS), "callback was not invoked");
+        assertNotEquals(mainThread, callbackThreads.get(0),
+                "callback ran on the subscribing thread - the async assertion would be vacuous");
+
+        final Method echoGet = Echo.class.getDeclaredMethod("get", Object.class);
+        final ExpectedTrace callback = Expectations.event("INTERNAL_METHOD", echoGet);
+
+        final Method sqlMethod = Class.forName("org.springframework.r2dbc.core.DefaultDatabaseClient")
+                .getDeclaredMethod("sql", java.util.function.Supplier.class);
+        final ExpectedTrace asyncLink = Expectations.async(
+                Expectations.event("SPRING_DATA_R2DBC", sqlMethod),
+                callback);
+
+        final PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.awaitTrace(callback, AWAIT_UNIT_MILLIS, AWAIT_MAX_MILLIS);
+        verifier.printCache();
+        verifier.verifyDiscreteTrace(asyncLink);
+    }
+}

--- a/agent-module/plugins-it/spring-data-r2dbc-it/src/test/java/test/pinpoint/plugin/r2dbc/Echo.java
+++ b/agent-module/plugins-it/spring-data-r2dbc-it/src/test/java/test/pinpoint/plugin/r2dbc/Echo.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.pinpoint.plugin.r2dbc;
+
+/**
+ * Instrumented via {@code profiler.entrypoint} — the recorded INTERNAL_METHOD event marks where a
+ * downstream callback actually ran, so the IT can assert the async link to the seam event.
+ */
+public class Echo {
+
+    public <T> T get(T value) {
+        return value;
+    }
+}

--- a/agent-module/plugins-it/spring-data-r2dbc-it/src/test/resources/pinpoint-r2dbc-seam-wrap.config
+++ b/agent-module/plugins-it/spring-data-r2dbc-it/src/test/resources/pinpoint-r2dbc-seam-wrap.config
@@ -1,0 +1,22 @@
+#
+# Pinpoint agent configuration for the seam-wrapper PoC IT (PINPOINT_REQ-1739).
+#
+profiler.sampling.enable=true
+profiler.sampling.rate=1
+
+# postgresql r2dbc driver plugin gate
+profiler.jdbc.postgresql=true
+
+# PoC: at the postgresql Statement.execute() seam, replace the returned publisher with a
+# wrapped one instead of injecting the AsyncContext into its accessor field.
+profiler.spring.data.r2dbc.wrap.publisher=true
+
+# Isolate the wrapper: with reactor per-operator instrumentation off, the only thing that can
+# restore the trace on the driver's delivery thread is the seam wrapper. If the wrapper does not
+# work, the Echo callback below is recorded as a standalone trace and the async-link assertion
+# fails — this is what makes the IT discriminating.
+profiler.reactor.enable=false
+
+# In-window discriminator: recorded as INTERNAL_METHOD, expected inside the async trace created
+# at the execute() seam.
+profiler.entrypoint=test.pinpoint.plugin.r2dbc.Echo.get

--- a/agent-module/plugins-it/spring-tx-it/pom.xml
+++ b/agent-module/plugins-it/spring-tx-it/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 NAVER Corp.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint-plugins-it</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-spring-tx-plugin-it</artifactId>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <jdk.version>1.8</jdk.version>
+        <jdk.home>${env.JAVA_8_HOME}</jdk.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-plugin-it-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- @PluginTest loads only plugins on the test classpath: needed for profiler.entrypoint
+             (user plugin) used by the seam-wrap async-link assertions -->
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-user-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-spring-tx-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <version>5.3.39</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>5.3.39</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.4.30</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <jvm>${env.JAVA_8_HOME}/bin/java</jvm>
+                    <testFailureIgnore>true</testFailureIgnore>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/agent-module/plugins-it/spring-tx-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/tx/SpringTxSeamWrap_IT.java
+++ b/agent-module/plugins-it/spring-tx-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/tx/SpringTxSeamWrap_IT.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.tx;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.transaction.ReactiveTransaction;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.interceptor.MatchAlwaysTransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+import reactor.core.publisher.Mono;
+import test.pinpoint.plugin.tx.Echo;
+
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Runtime assertions for {@code profiler.spring.tx.wrap.publisher=true} (the seam wrapper variant
+ * woven into {@code TransactionAspectSupport$ReactiveTransactionSupport.invokeWithinTransaction}).
+ *
+ * <p>No Spring context or database: a {@link ProxyFactory} + {@link TransactionInterceptor} with a
+ * no-op {@link ReactiveTransactionManager} drives the exact woven method — the reactive branch is
+ * selected because the service returns a {@link Mono} and the manager is reactive.
+ *
+ * <p>The config also sets {@code profiler.reactor.enable=false}: without the reactor plugin there
+ * are no per-operator relays and no accessor fields on reactor publishers, so the async link can
+ * only come from the wrapped publisher — the same wrapper-only proof the r2dbc/lettuce/redisson
+ * seam ITs use. The service hops threads via {@code Mono.delay} (reactor parallel timer), making
+ * the async-link assertion non-vacuous.
+ *
+ * <p><b>Discriminating probe (manual)</b>: flip {@code wrap.publisher=false} in
+ * {@code pinpoint-tx-seam-wrap.config} — the async-link assertion must fail — then flip back.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-tx-seam-wrap.config")
+@Dependency({"org.springframework:spring-tx:[5.3.39]",
+        "org.springframework:spring-aop:5.3.39",
+        "io.projectreactor:reactor-core:3.4.30",
+        PluginITConstants.VERSION})
+public class SpringTxSeamWrap_IT {
+    private static final String SPRING_TX = "SPRING_TX";
+    private static final String INTERNAL_METHOD = "INTERNAL_METHOD";
+
+    private static final long AWAIT_UNIT_MILLIS = 20L;
+    private static final long AWAIT_MAX_MILLIS = 5000L;
+
+    private static Method echoGet() throws NoSuchMethodException {
+        return Echo.class.getDeclaredMethod("get", String.class);
+    }
+
+    private static Member invokeWithinTransactionMethod() throws Exception {
+        final Class<?> owner = Class.forName(
+                "org.springframework.transaction.interceptor.TransactionAspectSupport$ReactiveTransactionSupport");
+        final Class<?> invocationCallback = Class.forName(
+                "org.springframework.transaction.interceptor.TransactionAspectSupport$InvocationCallback");
+        final Class<?> transactionAttribute = Class.forName(
+                "org.springframework.transaction.interceptor.TransactionAttribute");
+        return owner.getDeclaredMethod("invokeWithinTransaction",
+                Method.class, Class.class, invocationCallback, transactionAttribute, ReactiveTransactionManager.class);
+    }
+
+    @Test
+    public void reactiveTransaction_wrapperAloneLinksAcrossThread() throws Exception {
+        final TransactionInterceptor transactionInterceptor = new TransactionInterceptor();
+        transactionInterceptor.setTransactionManager(new NoopReactiveTransactionManager());
+        transactionInterceptor.setTransactionAttributeSource(new MatchAlwaysTransactionAttributeSource());
+
+        final ProxyFactory proxyFactory = new ProxyFactory(new GreetServiceImpl());
+        proxyFactory.addInterface(GreetService.class);
+        proxyFactory.addAdvice(transactionInterceptor);
+        final GreetService service = (GreetService) proxyFactory.getProxy();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final List<String> callbackThreads = new CopyOnWriteArrayList<>();
+        final String testThread = Thread.currentThread().getName();
+
+        // the proxy call runs inside the @PluginTest root trace and returns the wrapped publisher;
+        // Mono.delay delivers the value on the reactor parallel timer thread.
+        service.greet()
+                .map(v -> {
+                    callbackThreads.add(Thread.currentThread().getName());
+                    try {
+                        return new Echo().get("Hello" + v);
+                    } finally {
+                        latch.countDown();
+                    }
+                })
+                .subscribe();
+
+        assertTrue(latch.await(AWAIT_MAX_MILLIS, TimeUnit.MILLISECONDS), "callback was not invoked");
+        assertEquals(1, callbackThreads.size(), "callback ran an unexpected number of times");
+        assertNotEquals(testThread, callbackThreads.get(0),
+                "callback ran on the test thread - no hop, the assertion would be vacuous");
+
+        final ExpectedTrace callback = Expectations.event(INTERNAL_METHOD, echoGet());
+        final ExpectedTrace asyncLink = Expectations.async(
+                Expectations.event(SPRING_TX, invokeWithinTransactionMethod()), callback);
+
+        final PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.awaitTrace(callback, AWAIT_UNIT_MILLIS, AWAIT_MAX_MILLIS);
+        verifier.printCache();
+        verifier.verifyDiscreteTrace(asyncLink);
+    }
+
+    public interface GreetService {
+        Mono<String> greet();
+    }
+
+    public static class GreetServiceImpl implements GreetService {
+        @Override
+        public Mono<String> greet() {
+            return Mono.delay(Duration.ofMillis(50L)).map(t -> "hello");
+        }
+    }
+
+    /**
+     * The transaction lifecycle itself is not under test - only the woven seam is. Begin/commit
+     * are inert Monos.
+     */
+    static class NoopReactiveTransactionManager implements ReactiveTransactionManager {
+        @Override
+        public Mono<ReactiveTransaction> getReactiveTransaction(TransactionDefinition definition) {
+            return Mono.just(new NoopReactiveTransaction());
+        }
+
+        @Override
+        public Mono<Void> commit(ReactiveTransaction transaction) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Void> rollback(ReactiveTransaction transaction) {
+            return Mono.empty();
+        }
+    }
+
+    static class NoopReactiveTransaction implements ReactiveTransaction {
+        private boolean rollbackOnly;
+
+        @Override
+        public boolean isNewTransaction() {
+            return true;
+        }
+
+        @Override
+        public void setRollbackOnly() {
+            this.rollbackOnly = true;
+        }
+
+        @Override
+        public boolean isRollbackOnly() {
+            return rollbackOnly;
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return false;
+        }
+    }
+}

--- a/agent-module/plugins-it/spring-tx-it/src/test/java/test/pinpoint/plugin/tx/Echo.java
+++ b/agent-module/plugins-it/spring-tx-it/src/test/java/test/pinpoint/plugin/tx/Echo.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.pinpoint.plugin.tx;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * profiler.entrypoint leaf for the seam-wrap async-link assertions - an INTERNAL_METHOD event
+ * when the trace propagated, a STAND_ALONE root when it did not (see reactor-it's Echo).
+ */
+public class Echo {
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    public String get(String message) {
+        logger.info("echo:{}", message);
+        return message;
+    }
+}

--- a/agent-module/plugins-it/spring-tx-it/src/test/resources/pinpoint-tx-seam-wrap.config
+++ b/agent-module/plugins-it/spring-tx-it/src/test/resources/pinpoint-tx-seam-wrap.config
@@ -1,0 +1,14 @@
+###########################################################
+# spring-tx seam wrapper IT                               #
+###########################################################
+# Echo.get is the INTERNAL_METHOD leaf for the async-link assertion (@PluginTest already wraps
+# the test method itself in a root trace).
+profiler.entrypoint=test.pinpoint.plugin.tx.Echo.get
+
+# Wrapping variant of the reactive transaction support interceptor.
+# Discriminating probe (manual): flip to false - the async-link case must fail.
+profiler.spring.tx.wrap.publisher=true
+
+# Wrapper-only proof: with the reactor plugin off there are no per-operator relays or accessor
+# fields, so the async link can only come from the wrapped publisher.
+profiler.reactor.enable=false

--- a/agent-module/plugins/pom.xml
+++ b/agent-module/plugins/pom.xml
@@ -32,6 +32,7 @@
     <modules>
         <module>assembly</module>
         <module>common-servlet</module>
+        <module>reactor-seam-support</module>
         <module>external</module>
 
         <module>httpclient3</module>

--- a/agent-module/plugins/reactor-seam-support/pom.xml
+++ b/agent-module/plugins/reactor-seam-support/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint-plugins</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-reactor-seam-support</artifactId>
+    <name>pinpoint-reactor-seam-support</name>
+    <packaging>jar</packaging>
+
+    <!--
+        Shared seam-wrapper support (TracedSubscriber / SeamPublisherWrapper). NOT a plugin:
+        consumers embed it with maven-shade-plugin and MUST relocate
+        com.navercorp.pinpoint.plugin.reactorsupport under their own plugin package
+        (e.g. com.navercorp.pinpoint.plugin.<consumer>.reactorsupport). Reactor-family plugins
+        inject into the same application classloader, and PlainClassLoaderHandler tolerates no
+        duplicate definitions across plugin jars - an unrelocated copy in two plugins fails with
+        a LinkageError. See the tomcat plugin's common-servlet shading for the pattern.
+    -->
+
+    <dependencies>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-bootstrap-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+   </dependencies>
+</project>

--- a/agent-module/plugins/reactor-seam-support/src/main/java/com/navercorp/pinpoint/plugin/reactorsupport/SeamPublisherWrapper.java
+++ b/agent-module/plugins/reactor-seam-support/src/main/java/com/navercorp/pinpoint/plugin/reactorsupport/SeamPublisherWrapper.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.publisher.ConnectableFlux;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.GroupedFlux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+
+import java.util.function.Function;
+
+/**
+ * Wraps a {@link Mono}/{@link Flux} returned from an I/O seam so that each subscription gets its
+ * own {@link TracedSubscriber} carrying the seam's {@link AsyncContext} — "own instead of inject":
+ * no field write on the reactor object, and no cross-subscription leak when the application reuses
+ * the publisher.
+ * <p>
+ * {@code Operators.lift} does the wrapping so the vendor code handles the publisher subtype zoo
+ * and {@code Scannable} delegation. Guards, in order:
+ * <ul>
+ * <li>{@link Fuseable.ScalarCallable} ({@code Mono.just/empty/error}) is left alone — wrapping
+ * would destroy the scalar fast path (OTel excludes these as well).</li>
+ * <li>Only plain {@code Mono}/{@code Flux} are wrapped. {@code ConnectableFlux}/{@code GroupedFlux}
+ * are skipped: reactor 3.1.x lift has no variants for them, so wrapping would lose the subtype.</li>
+ * </ul>
+ * Skipping is POLICY, not a gap left for a later fallback: the injection path this wrapper
+ * replaces is a no-op for the very same types — scalar publishers extend {@code Mono}/{@code Flux}
+ * directly, no transform gives them an accessor field, so the old {@code instanceof
+ * AsyncContextAccessor} write never fired either. A skipped seam behaves exactly like the
+ * injection path did; scalar delivery is synchronous in subscribe() and rides the ambient trace.
+ * <p>
+ * Any internal failure returns the original publisher — the seam degrades to untraced, never broken.
+ */
+public final class SeamPublisherWrapper {
+    private static final PluginLogger logger = PluginLogManager.getLogger(SeamPublisherWrapper.class);
+
+    private SeamPublisherWrapper() {
+    }
+
+    /**
+     * Whether {@link #wrap} would actually wrap this object. Callers that create an
+     * {@link AsyncContext} just to wrap should check this first to avoid dangling async links.
+     */
+    public static boolean isWrappable(final Object result) {
+        if (!(result instanceof Mono) && !(result instanceof Flux)) {
+            return false;
+        }
+        if (result instanceof Fuseable.ScalarCallable) {
+            return false;
+        }
+        if (result instanceof ConnectableFlux || result instanceof GroupedFlux) {
+            return false;
+        }
+        return true;
+    }
+
+    public static Object wrap(final Object result, final AsyncContext asyncContext) {
+        try {
+            if (asyncContext == null || result == null || !isWrappable(result)) {
+                return result;
+            }
+            return lift((Publisher<?>) result, asyncContext);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to wrap publisher {}. Caused:{}", result, th.getMessage(), th);
+            }
+            return result;
+        }
+    }
+
+    private static <T> Publisher<T> lift(final Publisher<T> source, final AsyncContext asyncContext) {
+        final Function<? super Publisher<T>, ? extends Publisher<T>> lift =
+                Operators.lift((scannable, actual) -> newTracedSubscriber(actual, asyncContext));
+        return lift.apply(source);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> TracedSubscriber<T> newTracedSubscriber(final CoreSubscriber<? super T> actual, final AsyncContext asyncContext) {
+        if (actual instanceof Fuseable.ConditionalSubscriber) {
+            // preserve the downstream's tryOnNext optimization.
+            return new TracedSubscriber.Conditional<T>((Fuseable.ConditionalSubscriber<? super T>) actual, asyncContext);
+        }
+        return new TracedSubscriber<T>(actual, asyncContext);
+    }
+}

--- a/agent-module/plugins/reactor-seam-support/src/main/java/com/navercorp/pinpoint/plugin/reactorsupport/TracedSubscriber.java
+++ b/agent-module/plugins/reactor-seam-support/src/main/java/com/navercorp/pinpoint/plugin/reactorsupport/TracedSubscriber.java
@@ -1,0 +1,549 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.util.context.Context;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Sits between a wrapped publisher and the application subscriber ({@code actual}) so that every
+ * signal is delivered inside a trace window bound to the seam's {@link AsyncContext} — whichever
+ * thread delivers it. The window is the same restore-only flow the reactor plugin's
+ * {@code CoreSubscriberOnNextInterceptor} uses ({@code continueAsyncTraceObject(false)} + async
+ * trace scope, no per-signal span event).
+ * <p>
+ * Fusion suppressor (same shape as reactor's {@code FluxHide.SuppressFuseableSubscriber}): this
+ * class implements {@link Fuseable.QueueSubscription}, passes itself downstream in
+ * {@link #onSubscribe}, and answers every {@link #requestFusion} with {@link Fuseable#NONE}. The
+ * downstream can never enter fused mode and this class never requests fusion upstream, so the
+ * pull-only (poll) path that would bypass the {@link #onNext} window is cut in both directions.
+ * Being a {@code QueueSubscription} also keeps {@code Operators.lift} from inserting its own
+ * suppressor, and covers reactor 3.1.x where lift has no automatic suppressor at all.
+ */
+public class TracedSubscriber<T> implements CoreSubscriber<T>, Fuseable.QueueSubscription<T> {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+
+    private final CoreSubscriber<? super T> actual;
+    private final AsyncContext asyncContext;
+    // package-private for tests: also the value handed downstream in onSubscribe is `this`.
+    Subscription subscription;
+    // reactive streams defense: signals after a terminal one are dropped (serial delivery, so a
+    // plain flag is enough). cancel() intentionally does not set this - racing signals after
+    // cancel are legal and still delivered.
+    private boolean done;
+    // last (trace, scope) pair; on high-cardinality streams the per-signal trace.getScope()
+    // hash lookup was the window's dominant cost. Signals are delivered serially (reactive
+    // streams spec) and the holder's final fields keep the pair consistent even under a data
+    // race, so a plain reference is enough - a stale read just falls back to a fresh lookup.
+    private ScopeCache scopeCache;
+    // the async trace this subscription owns. Created by the first owned window and REBOUND per
+    // signal instead of the create/close cycle per signal (the dominant high-cardinality cost:
+    // LocalAsyncId + ChildTrace + recorders + scope registration each time). The thread binding
+    // stays signal-scoped - only the trace object's lifetime is subscription-scoped. Closed at
+    // the terminal signal, or on cancel by whoever wins the heldTraceState handoff below.
+    // volatile: the cancel thread closes it after winning the CAS.
+    private volatile Trace heldTrace;
+    // cancel() may race an in-flight signal on the delivery thread (reactive streams 2.7
+    // serializes request/cancel only with each other), so the held trace has an explicit owner
+    // state instead of a GC fallback:
+    //   IDLE   - no delivery window is using the held trace
+    //   WINDOW - a delivery frame owns it (bound to the delivery thread)
+    //   DONE   - the trace has been closed; late (racing) signals get a frame-local trace
+    // Delivery claims IDLE|DONE -> WINDOW before touching heldTrace, so cancel can never close a
+    // trace mid-rebind. Every transition to DONE is a CAS or happens while cancel is fenced out
+    // (state==WINDOW), so the trace is closed exactly once.
+    private static final int IDLE = 0;
+    private static final int WINDOW = 1;
+    private static final int DONE = 2;
+    private final AtomicInteger heldTraceState = new AtomicInteger(IDLE);
+    // Dekker pair with heldTraceState: cancel writes cancelled then CASes IDLE->DONE; the
+    // delivery side releases WINDOW->IDLE then rechecks cancelled - at least one side sees the
+    // other, so a cancel arriving during a window is never lost.
+    private volatile boolean cancelled;
+
+    public TracedSubscriber(CoreSubscriber<? super T> actual, AsyncContext asyncContext) {
+        this.actual = Objects.requireNonNull(actual, "actual");
+        this.asyncContext = asyncContext;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        if (this.subscription != null) {
+            // reactive streams 2.5: cancel the duplicate; downstream already has `this`.
+            s.cancel();
+            if (logger.isWarnEnabled()) {
+                logger.warn("Duplicate onSubscribe cancelled. subscription={}", s);
+            }
+            return;
+        }
+        this.subscription = s;
+        final Trace trace = openWindow();
+        try {
+            actual.onSubscribe(this);
+        } finally {
+            closeWindow(trace, false);
+        }
+    }
+
+    @Override
+    public void onNext(T t) {
+        if (done) {
+            droppedSignal("onNext", t);
+            return;
+        }
+        final Trace trace = openWindow();
+        try {
+            actual.onNext(t);
+        } finally {
+            closeWindow(trace, false);
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        if (done) {
+            droppedSignal("onError", throwable);
+            return;
+        }
+        this.done = true;
+        final Trace trace = openWindow();
+        try {
+            actual.onError(throwable);
+        } finally {
+            closeWindow(trace, true);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        if (done) {
+            droppedSignal("onComplete", null);
+            return;
+        }
+        this.done = true;
+        final Trace trace = openWindow();
+        try {
+            actual.onComplete();
+        } finally {
+            closeWindow(trace, true);
+        }
+    }
+
+    boolean isDone() {
+        return done;
+    }
+
+    void droppedSignal(final String signal, final Object value) {
+        // a signal after a terminal one violates the spec; downstream reactor operators guard
+        // against this themselves, so dropping here matches what they would do anyway.
+        if (logger.isDebugEnabled()) {
+            logger.debug("Dropped {} after a terminal signal. value={}", signal, value);
+        }
+    }
+
+    @Override
+    public Context currentContext() {
+        // mandatory delegation: the application's Reactor Context must flow through unchanged.
+        return actual.currentContext();
+    }
+
+    @Override
+    public void request(long n) {
+        final ControlWindow window = openControlWindow();
+        try {
+            subscription.request(n);
+        } finally {
+            closeControlWindow(window);
+        }
+    }
+
+    @Override
+    public void cancel() {
+        this.cancelled = true;
+        // no delivery window is using the held trace -> close it here; a common cancel (e.g.
+        // take(1)) arrives inside the onNext frame instead, and that frame's closeWindow sees
+        // cancelled and closes. Either way the trace no longer waits for a signal that may never
+        // come.
+        closeHeldTraceIfIdle();
+        final ControlWindow window = openControlWindow();
+        try {
+            subscription.cancel();
+        } finally {
+            closeControlWindow(window);
+        }
+    }
+
+    /**
+     * Window for request()/cancel(): upstream may run synchronous work in these frames (e.g. a
+     * driver submitting the query on demand), so they deserve a trace window too. Unlike delivery
+     * signals they may run CONCURRENTLY with them (reactive streams 2.7 serializes request/cancel
+     * only with each other), so the subscription-held trace must never be bound here - a trace
+     * already on this thread is borrowed, otherwise a frame-local trace is created and fully
+     * closed at the frame end.
+     */
+    private ControlWindow openControlWindow() {
+        final AsyncContext asyncContext = this.asyncContext;
+        if (asyncContext == null) {
+            return null;
+        }
+        boolean created = false;
+        Trace trace = null;
+        try {
+            trace = asyncContext.currentAsyncTraceObject();
+            if (trace == null) {
+                trace = asyncContext.continueAsyncTraceObject(false);
+                if (trace == null) {
+                    return null;
+                }
+                created = true;
+            }
+            ScopeUtils.entryAsyncTraceScope(trace);
+            return new ControlWindow(trace, created);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to open control window. Caused:{}", th.getMessage(), th);
+            }
+            if (created) {
+                try {
+                    asyncContext.close();
+                } catch (Throwable ignored) {
+                }
+                // this frame owns the trace it just created - no later frame will ever see it,
+                // so it must be closed here or it stays open until GC.
+                try {
+                    trace.close();
+                } catch (Throwable ignored) {
+                }
+            }
+            return null;
+        }
+    }
+
+    private void closeControlWindow(final ControlWindow window) {
+        if (window == null) {
+            return;
+        }
+        final Trace trace = window.trace;
+        try {
+            if (!ScopeUtils.leaveAsyncTraceScope(trace)) {
+                if (logger.isWarnEnabled()) {
+                    logger.warn("Failed to leave scope of control trace {}.", trace);
+                }
+                endControlWindow(window);
+                return;
+            }
+            if (ScopeUtils.isAsyncTraceEndScope(trace)) {
+                endControlWindow(window);
+            }
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to close control window. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    private void endControlWindow(final ControlWindow window) {
+        asyncContext.close();
+        if (window.created) {
+            // frame-local trace: fully closed here, the held delivery trace is untouched.
+            window.trace.close();
+        }
+    }
+
+    @Override
+    public int requestFusion(int requestedMode) {
+        return Fuseable.NONE;
+    }
+
+    @Override
+    public T poll() {
+        return null;
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    Trace openWindow() {
+        final AsyncContext asyncContext = this.asyncContext;
+        if (asyncContext == null) {
+            return null;
+        }
+        boolean boundHere = false;
+        boolean claimed = false;
+        int priorState = IDLE;
+        Trace createdHere = null;
+        try {
+            Trace trace = asyncContext.currentAsyncTraceObject();
+            if (trace == null) {
+                // no trace on this thread: bind ours. Only a trace this subscription created is
+                // held for reuse - a borrowed (nested) trace above belongs to another activation.
+                // Claim the held trace BEFORE reading it, so a concurrent cancel cannot close it
+                // between the read and the rebind. After DONE (cancel already closed it) the
+                // held reference is null and this frame gets a fresh trace, which the frame end
+                // closes again because cancelled is set.
+                priorState = claimHeldTrace();
+                claimed = true;
+                final Trace held = this.heldTrace;
+                if (held == null) {
+                    trace = asyncContext.continueAsyncTraceObject(false);
+                    if (trace == null) {
+                        releaseClaim(priorState);
+                        return null;
+                    }
+                    this.heldTrace = trace;
+                    createdHere = trace;
+                } else {
+                    trace = asyncContext.continueAsyncTraceObject(held);
+                    if (trace == null) {
+                        releaseClaim(priorState);
+                        return null;
+                    }
+                }
+                boundHere = true;
+            }
+            // same flow as ScopeUtils.entryAsyncTraceScope, with the scope lookup cached.
+            final TraceScope scope = scopeOf(trace);
+            if (scope != null) {
+                scope.tryEnter();
+            }
+            return trace;
+        } catch (Throwable th) {
+            // failure isolation: signal delivery must not depend on the window.
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to open trace window. Caused:{}", th.getMessage(), th);
+            }
+            if (boundHere) {
+                // undo the thread binding this frame installed - an agent failure must not
+                // leave the trace bound to a shared delivery thread.
+                try {
+                    asyncContext.close();
+                } catch (Throwable ignored) {
+                }
+            }
+            if (createdHere != null) {
+                // undo the hold too: if this signal was terminal no later frame exists, so a
+                // trace left in the slot could never be closed again (GC-dependent leak).
+                this.heldTrace = null;
+                try {
+                    createdHere.close();
+                } catch (Throwable ignored) {
+                }
+            }
+            if (claimed) {
+                releaseClaim(priorState);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Claims the held trace for this delivery frame: {@code IDLE|DONE -> WINDOW}. While in
+     * {@code WINDOW}, {@link #closeHeldTraceIfIdle()} (the cancel side) can never win its CAS.
+     * Signals are delivered serially, so only one frame ever claims at a time.
+     */
+    private int claimHeldTrace() {
+        for (; ; ) {
+            final int state = heldTraceState.get();
+            if (heldTraceState.compareAndSet(state, WINDOW)) {
+                return state;
+            }
+        }
+    }
+
+    /**
+     * Reverts a claim whose window never materialized (bind failure): restores the prior state
+     * and, like the normal release in {@link #endWindow}, rechecks a cancel that arrived while
+     * the claim fenced it out.
+     */
+    private void releaseClaim(final int priorState) {
+        if (priorState == DONE) {
+            heldTraceState.set(DONE);
+            return;
+        }
+        heldTraceState.set(IDLE);
+        if (cancelled) {
+            closeHeldTraceIfIdle();
+        }
+    }
+
+    /**
+     * The single place the held trace is closed off the delivery frame: transitions
+     * {@code IDLE -> DONE} and closes on success. Losing the CAS means either a delivery frame
+     * owns the trace right now (its window end will observe {@code cancelled} and close) or the
+     * trace is already {@code DONE} - in both cases closing here would be a double close.
+     */
+    private void closeHeldTraceIfIdle() {
+        if (heldTraceState.compareAndSet(IDLE, DONE)) {
+            final Trace held = this.heldTrace;
+            this.heldTrace = null;
+            if (held != null) {
+                try {
+                    held.close();
+                } catch (Throwable th) {
+                    // cleanup failure must never leak into the caller: cancel() still has to
+                    // cancel the upstream subscription after this returns.
+                    if (logger.isWarnEnabled()) {
+                        logger.warn("Failed to close held trace. Caused:{}", th.getMessage(), th);
+                    }
+                }
+            }
+        }
+    }
+
+    void closeWindow(final Trace trace, final boolean terminal) {
+        if (trace == null) {
+            return;
+        }
+        try {
+            // same flow as ScopeUtils.leaveAsyncTraceScope/isAsyncTraceEndScope, scope lookup cached.
+            final TraceScope scope = scopeOf(trace);
+            if (scope != null) {
+                if (scope.canLeave()) {
+                    scope.leave();
+                } else {
+                    if (logger.isWarnEnabled()) {
+                        logger.warn("Failed to leave scope of async trace {}.", trace);
+                    }
+                    endWindow(trace, true);
+                    return;
+                }
+            }
+            if (scope != null && !scope.isActive() && trace.isAsync()) {
+                // `done` matters when the terminal signal was delivered NESTED inside an outer
+                // frame (synchronous sources emit during request within onSubscribe): the nested
+                // terminal frame skips endWindow because the scope is still active, so the
+                // outermost frame - whose own `terminal` flag is false - must close on its
+                // behalf or the held trace would wait for a signal that never comes.
+                endWindow(trace, terminal || cancelled || done);
+            }
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to close trace window. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    /**
+     * Ends the outermost window on this thread: always unbinds the thread, but closes the trace
+     * object only at a terminal signal (or after cancel) - between signals the held trace stays
+     * open for rebinding.
+     */
+    private void endWindow(final Trace trace, final boolean closeTrace) {
+        asyncContext.close();
+        if (closeTrace) {
+            // drop the reference so a late (spec-violating) signal creates a fresh trace
+            // instead of rebinding a closed one. cancel is fenced out (state is WINDOW), so
+            // this close cannot race the cancel-side close.
+            this.heldTrace = null;
+            heldTraceState.set(DONE);
+            trace.close();
+        } else {
+            // release, then recheck: a cancel that arrived during this window lost its CAS and
+            // is waiting for us - without this the subscription could end (no further signals)
+            // with the trace still open.
+            heldTraceState.set(IDLE);
+            if (cancelled) {
+                closeHeldTraceIfIdle();
+            }
+        }
+    }
+
+    private TraceScope scopeOf(final Trace trace) {
+        final ScopeCache cached = this.scopeCache;
+        if (cached != null && cached.trace == trace) {
+            return cached.scope;
+        }
+        final TraceScope scope = trace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE);
+        if (scope != null) {
+            // a null scope is not cached: it may be added to the trace later.
+            this.scopeCache = new ScopeCache(trace, scope);
+        }
+        return scope;
+    }
+
+    /**
+     * Variant chosen when the downstream is a {@link Fuseable.ConditionalSubscriber}
+     * (filter/distinct style chains): implementing it here preserves the upstream's
+     * {@code tryOnNext} optimization - a plain middle subscriber would force every conditional
+     * source down the request-refill path.
+     */
+    static final class Conditional<T> extends TracedSubscriber<T> implements Fuseable.ConditionalSubscriber<T> {
+
+        private final Fuseable.ConditionalSubscriber<? super T> actualConditional;
+
+        Conditional(Fuseable.ConditionalSubscriber<? super T> actual, AsyncContext asyncContext) {
+            super(actual, asyncContext);
+            this.actualConditional = actual;
+        }
+
+        @Override
+        public boolean tryOnNext(T t) {
+            if (isDone()) {
+                droppedSignal("tryOnNext", t);
+                // consumed: the stream is over, no replenish is wanted.
+                return true;
+            }
+            final Trace trace = openWindow();
+            try {
+                return actualConditional.tryOnNext(t);
+            } finally {
+                closeWindow(trace, false);
+            }
+        }
+    }
+
+    private static final class ControlWindow {
+        final Trace trace;
+        final boolean created;
+
+        ControlWindow(Trace trace, boolean created) {
+            this.trace = trace;
+            this.created = created;
+        }
+    }
+
+    private static final class ScopeCache {
+        final Trace trace;
+        final TraceScope scope;
+
+        ScopeCache(Trace trace, TraceScope scope) {
+            this.trace = trace;
+            this.scope = scope;
+        }
+    }
+}

--- a/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/DepthScope.java
+++ b/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/DepthScope.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+
+/** Test double for the scope-depth contract: active while entered more often than left. */
+final class DepthScope implements TraceScope {
+    private int depth;
+
+    @Override
+    public String getName() {
+        return ScopeUtils.ASYNC_TRACE_SCOPE;
+    }
+
+    @Override
+    public boolean tryEnter() {
+        depth++;
+        return true;
+    }
+
+    @Override
+    public boolean canLeave() {
+        return depth > 0;
+    }
+
+    @Override
+    public void leave() {
+        depth--;
+    }
+
+    @Override
+    public boolean isActive() {
+        return depth > 0;
+    }
+}

--- a/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/NestedSeamWindowTest.java
+++ b/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/NestedSeamWindowTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Deterministic pins for NESTED seam windows — two seams wrapping the same delivery chain, the
+ * shape a request produces when e.g. an r2dbc execute seam (source side) and a fetch-spec seam
+ * (framework side) both wrap. The semantics under test (design policy P3: nested windows are
+ * legal, the window borrows an already-bound trace):
+ *
+ * <ul>
+ * <li><b>Same delivery thread: the seam closest to the source wins.</b> Its subscriber receives
+ * every signal first, binds its trace, and the downstream seam's window finds a bound trace and
+ * borrows — the downstream seam's own AsyncContext never activates on that thread (its async link
+ * stays dangling, accepted policy P4).</li>
+ * <li><b>Same AsyncContext wrapped twice: single activation.</b> The nested window is a scope
+ * re-entry on the same trace; nothing double-binds or double-closes.</li>
+ * </ul>
+ *
+ * The mocks simulate the thread-local contract explicitly (the outer context's
+ * {@code currentAsyncTraceObject()} returns the trace the inner frame bound) — the contract
+ * itself is exercised for real in the r2dbc nested-seam IT.
+ */
+public class NestedSeamWindowTest {
+
+    private AsyncContext sourceSideContext;   // the seam closest to the source (e.g. execute)
+    private Trace sourceSideTrace;
+    private TraceScope sourceSideScope;
+    private AsyncContext downstreamContext;   // the seam wrapping further down (e.g. fetch-spec)
+    private Trace downstreamTrace;
+
+    @BeforeEach
+    public void setUp() {
+        sourceSideContext = mock(AsyncContext.class);
+        sourceSideTrace = mock(Trace.class);
+        sourceSideScope = mock(TraceScope.class);
+        downstreamContext = mock(AsyncContext.class);
+        downstreamTrace = mock(Trace.class);
+
+        when(sourceSideContext.continueAsyncTraceObject(false)).thenReturn(sourceSideTrace);
+        when(sourceSideContext.continueAsyncTraceObject(sourceSideTrace)).thenReturn(sourceSideTrace);
+        when(sourceSideTrace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(sourceSideScope);
+        when(sourceSideTrace.isAsync()).thenReturn(true);
+        when(sourceSideScope.tryEnter()).thenReturn(true);
+        when(sourceSideScope.canLeave()).thenReturn(true);
+        // the delivery frames nest: only the outermost close on this trace ends the window.
+        when(sourceSideScope.isActive()).thenReturn(true);
+
+        // thread-local contract simulation: the very first window bind sees an empty thread,
+        // afterwards ANY context on this thread (nested windows, control windows) sees the
+        // trace the source-side frame bound.
+        when(sourceSideContext.currentAsyncTraceObject()).thenReturn(null, sourceSideTrace);
+        when(downstreamContext.currentAsyncTraceObject()).thenReturn(sourceSideTrace);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Flux<T> doubleWrapped(Flux<T> source) {
+        final Object inner = SeamPublisherWrapper.wrap(source, sourceSideContext);
+        final Flux<T> mid = ((Flux<T>) inner).map(v -> v);
+        return (Flux<T>) SeamPublisherWrapper.wrap(mid, downstreamContext);
+    }
+
+    @Test
+    public void sameThreadNesting_sourceSideSeamWins_downstreamNeverActivates() {
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+
+        doubleWrapped(Flux.range(1, 3).hide()).subscribe(downstream);
+
+        assertEquals(Arrays.asList(1, 2, 3), downstream.received);
+        assertTrue(downstream.completed);
+
+        // the source-side seam bound its trace for every delivery frame...
+        verify(sourceSideContext, times(1)).continueAsyncTraceObject(false);
+        // ...and the downstream seam only ever borrowed it: its own context never created or
+        // rebound a trace on this thread — its async link intentionally stays dangling (P4).
+        verify(downstreamContext, never()).continueAsyncTraceObject(any(Trace.class));
+        verify(downstreamContext, never()).continueAsyncTraceObject(false);
+        verify(downstreamContext, never()).close();
+        verify(downstreamTrace, never()).close();
+    }
+
+    @Test
+    public void sameThreadNesting_scopeArithmetic_bothFramesNestOnOneTrace() {
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+
+        doubleWrapped(Flux.range(1, 2).hide()).subscribe(downstream);
+
+        // per signal both windows enter/leave the SAME trace's scope: onSubscribe + 2 x onNext +
+        // onComplete = 4 signals x 2 windows = 8 enters/leaves, plus the request() control
+        // windows of BOTH wrappers (each borrows the same bound trace) add 2.
+        verify(sourceSideScope, times(10)).tryEnter();
+        verify(sourceSideScope, times(10)).leave();
+        // scope stays active in this mock (nested), so the held trace is never closed here.
+        verify(sourceSideTrace, never()).close();
+    }
+
+    @Test
+    public void sameContextWrappedTwice_singleActivationPerSignal() {
+        // both seams got the SAME AsyncContext (e.g. a relay handed the same context to two
+        // wrap points): the nested window degenerates to a scope re-entry, nothing double-binds.
+        // (setUp already stubs the TL simulation: first open binds, every later open borrows.)
+        final Object inner = SeamPublisherWrapper.wrap(Flux.range(1, 1).hide(), sourceSideContext);
+        @SuppressWarnings("unchecked") final Flux<Integer> mid = ((Flux<Integer>) inner).map(v -> v);
+        final Object outer = SeamPublisherWrapper.wrap(mid, sourceSideContext);
+
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+        ((Flux<Integer>) outer).subscribe(downstream);
+
+        assertEquals(Arrays.asList(1), downstream.received);
+        // one bind for the very first frame; every nested/subsequent frame borrowed.
+        verify(sourceSideContext, times(1)).continueAsyncTraceObject(false);
+        verify(sourceSideContext, never()).continueAsyncTraceObject(sourceSideTrace);
+    }
+}

--- a/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/ReactorAbsenceClassLoadingTest.java
+++ b/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/ReactorAbsenceClassLoadingTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * classpath-negative pin (W9 / doc 18 §4.7): what happens when a wrap gate is enabled but
+ * reactor-core is NOT on the application classpath.
+ *
+ * <p>Defining the (shaded) {@code SeamPublisherWrapper} already requires reactor types — class
+ * verification resolves them — so the failure is a {@link NoClassDefFoundError} raised the
+ * moment the class is first needed. That moment is safe by construction: the interceptor class
+ * itself carries no reactor types in its own signatures, so weaving and interceptor construction
+ * succeed, and the wrapper is first referenced from inside the interceptor's
+ * {@code catch (Throwable)}-guarded call path, which returns the original result (pinned
+ * per-interceptor in the plugins, e.g. redisson's {@code WrappingReactiveMethodInterceptorTest}).
+ * The call degrades to untraced (with a warn per call), never broken.
+ *
+ * <p>Realism note: lettuce-core and redisson both declare reactor-core as a required dependency,
+ * and the spring-tx reactive seam only fires with a ReactiveTransactionManager — the negative
+ * classpath needs a deliberate exclusion plus the opt-in flag. This test is the cheap insurance
+ * that even then the agent degrades instead of breaking the call.
+ */
+public class ReactorAbsenceClassLoadingTest {
+
+    private static final String SUPPORT_PACKAGE = "com.navercorp.pinpoint.plugin.reactorsupport.";
+
+    @Test
+    public void withoutReactor_wrapperFailsAsErrorAtFirstResolution() {
+        final ReactorHidingClassLoader classLoader = new ReactorHidingClassLoader();
+
+        // the very first resolution of the wrapper class fails as an Error (not an exception) -
+        // exactly what the wrapping interceptors' catch(Throwable) must and does contain.
+        assertThrows(NoClassDefFoundError.class,
+                () -> Class.forName(SUPPORT_PACKAGE + "SeamPublisherWrapper", true, classLoader));
+    }
+
+    /**
+     * Delegates everything to the test classpath EXCEPT reactor (hidden, as if absent) and the
+     * seam-support package itself (redefined here so its reactor references resolve against this
+     * loader) - the same visibility a shaded plugin copy has in an app without reactor.
+     */
+    private static final class ReactorHidingClassLoader extends ClassLoader {
+        ReactorHidingClassLoader() {
+            super(ReactorAbsenceClassLoadingTest.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("reactor.") || name.startsWith("org.reactivestreams.")) {
+                throw new ClassNotFoundException(name + " (hidden: simulating reactor absence)");
+            }
+            if (name.startsWith(SUPPORT_PACKAGE)) {
+                synchronized (getClassLoadingLock(name)) {
+                    final Class<?> loaded = findLoadedClass(name);
+                    if (loaded != null) {
+                        return loaded;
+                    }
+                    final byte[] bytes = readClassBytes(name);
+                    final Class<?> defined = defineClass(name, bytes, 0, bytes.length);
+                    if (resolve) {
+                        resolveClass(defined);
+                    }
+                    return defined;
+                }
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private byte[] readClassBytes(String name) throws ClassNotFoundException {
+            final String resource = name.replace('.', '/') + ".class";
+            try (InputStream in = getParent().getResourceAsStream(resource)) {
+                if (in == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                final ByteArrayOutputStream out = new ByteArrayOutputStream();
+                final byte[] buffer = new byte[8192];
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                }
+                return out.toByteArray();
+            } catch (IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+    }
+}

--- a/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/SeamPublisherWrapperTest.java
+++ b/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/SeamPublisherWrapperTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.ConnectableFlux;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.GroupedFlux;
+import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class SeamPublisherWrapperTest {
+
+    private AsyncContext asyncContext;
+
+    @BeforeEach
+    public void setUp() {
+        // continueAsyncTraceObject(false) returns null by default: windows are no-ops here,
+        // these tests only exercise the wrap guards and reactive mechanics.
+        asyncContext = mock(AsyncContext.class);
+    }
+
+    @Test
+    public void scalarCallable_leftAlone() {
+        Mono<String> just = Mono.just("a");
+        Mono<Object> empty = Mono.empty();
+        Mono<Object> error = Mono.error(new IllegalStateException("boom"));
+
+        assertSame(just, SeamPublisherWrapper.wrap(just, asyncContext));
+        assertSame(empty, SeamPublisherWrapper.wrap(empty, asyncContext));
+        assertSame(error, SeamPublisherWrapper.wrap(error, asyncContext));
+    }
+
+    @Test
+    public void subtypesAndNonPublishers_leftAlone() {
+        ConnectableFlux<Integer> connectable = Flux.range(1, 3).publish();
+        GroupedFlux<Integer, Integer> grouped = Flux.range(0, 4).groupBy(i -> i % 2).blockFirst();
+
+        assertSame(connectable, SeamPublisherWrapper.wrap(connectable, asyncContext));
+        assertSame(grouped, SeamPublisherWrapper.wrap(grouped, asyncContext));
+        assertEquals("not a publisher", SeamPublisherWrapper.wrap("not a publisher", asyncContext));
+        assertNull(SeamPublisherWrapper.wrap(null, asyncContext));
+    }
+
+    @Test
+    public void nullAsyncContext_leftAlone() {
+        Flux<Integer> source = Flux.range(1, 3);
+
+        assertSame(source, SeamPublisherWrapper.wrap(source, null));
+    }
+
+    @Test
+    public void wrappedTypeMatchesSource() {
+        Object wrappedMono = SeamPublisherWrapper.wrap(Mono.defer(() -> Mono.just("a")), asyncContext);
+        Object wrappedFlux = SeamPublisherWrapper.wrap(Flux.range(1, 3), asyncContext);
+
+        assertTrue(wrappedMono instanceof Mono, "a wrapped Mono must still be a Mono");
+        assertTrue(wrappedFlux instanceof Flux, "a wrapped Flux must still be a Flux");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void reactorContext_flowsThroughTheWrapper() {
+        Mono<String> source = Mono.deferContextual(ctx -> Mono.just((String) ctx.getOrDefault("k", "missing")));
+        Mono<String> wrapped = (Mono<String>) SeamPublisherWrapper.wrap(source, asyncContext);
+        TestFusionSubscriber<String> downstream = new TestFusionSubscriber<String>(Context.of("k", "v"));
+
+        wrapped.subscribe(downstream);
+
+        assertEquals(Collections.singletonList("v"), downstream.received);
+        assertTrue(downstream.completed);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void resubscription_isolatedPerSubscriber() {
+        Flux<Integer> wrapped = (Flux<Integer>) SeamPublisherWrapper.wrap(Flux.range(1, 2), asyncContext);
+        TestFusionSubscriber<Integer> first = new TestFusionSubscriber<Integer>();
+        TestFusionSubscriber<Integer> second = new TestFusionSubscriber<Integer>();
+
+        wrapped.subscribe(first);
+        wrapped.subscribe(second);
+
+        assertEquals(Arrays.asList(1, 2), first.received);
+        assertEquals(Arrays.asList(1, 2), second.received);
+        assertTrue(first.subscription instanceof TracedSubscriber);
+        assertTrue(second.subscription instanceof TracedSubscriber);
+        assertNotSame(first.subscription, second.subscription, "each subscription must get its own TracedSubscriber");
+    }
+}

--- a/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/SeamWrapperLifecycleTest.java
+++ b/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/SeamWrapperLifecycleTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.util.context.Context;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Lifecycle-attribution pins for the wrapped publisher (W7 / doc 18 §4.5): what happens when the
+ * application holds on to a wrapped publisher longer than one delivery.
+ *
+ * <ul>
+ * <li><b>Cached publisher (announced limit P5)</b>: the wrapper owns the AsyncContext it was
+ * created with — every later subscription, from whatever request, is attributed to the FIRST
+ * caller's context. Each subscription still gets its own subscription-held trace, created and
+ * closed independently: caching shares attribution, never trace state.</li>
+ * <li><b>retry resubscription</b>: the retry machinery resubscribes from its subscription-stack
+ * drain loop, outside any window frame — each attempt is an independent subscription with an
+ * independently created and closed held trace; a failed attempt cannot leak into the next.</li>
+ * <li><b>hot/never publisher</b>: with no terminal signal the held trace stays open for the
+ * subscription's whole lifetime BY DESIGN; cancel() is the bounded cleanup (the W1 state machine
+ * closes it exactly once).</li>
+ * </ul>
+ *
+ * Instead of positional stubs, {@link StubAsyncContext} and {@link DepthScope} faithfully
+ * simulate the single-threaded thread-local binding and scope-depth contracts — the observed
+ * close/creation counts are emergent, not choreographed.
+ */
+public class SeamWrapperLifecycleTest {
+
+    /** the one delivery thread of these tests: at most one bound trace at a time. */
+    private final Trace[] boundSlot = new Trace[1];
+
+    private Trace firstTrace;
+    private Trace secondTrace;
+    private StubAsyncContext seamContext;
+
+    @BeforeEach
+    public void setUp() {
+        firstTrace = newTrace();
+        secondTrace = newTrace();
+        seamContext = new StubAsyncContext(boundSlot, firstTrace, secondTrace);
+    }
+
+    private static Trace newTrace() {
+        final Trace trace = mock(Trace.class);
+        when(trace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(new DepthScope());
+        when(trace.isAsync()).thenReturn(true);
+        return trace;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Flux<T> wrapped(Flux<T> source) {
+        return (Flux<T>) SeamPublisherWrapper.wrap(source, seamContext);
+    }
+
+    @Test
+    public void cachedPublisher_everySubscriptionAttributedToFirstCallersContext() {
+        // the app caches the wrapped publisher across requests; a later subscription has no way
+        // to carry its own context here - announced limit P5.
+        final Flux<Integer> cached = wrapped(Flux.range(1, 2).hide());
+
+        final TestFusionSubscriber<Integer> requestA = new TestFusionSubscriber<Integer>();
+        final TestFusionSubscriber<Integer> requestB = new TestFusionSubscriber<Integer>();
+        cached.subscribe(requestA);
+        cached.subscribe(requestB);
+
+        assertTrue(requestA.completed);
+        assertTrue(requestB.completed);
+        // both subscriptions drew their trace from the seam's (first caller's) context...
+        assertEquals(2, seamContext.creations);
+        // ...but as independent subscription-held traces, each closed exactly once at its own
+        // terminal - caching shares attribution, never trace state.
+        verify(firstTrace, times(1)).close();
+        verify(secondTrace, times(1)).close();
+    }
+
+    @Test
+    public void retryResubscription_independentHeldTracePerAttempt_eachClosedOnce() {
+        final AtomicInteger attempts = new AtomicInteger();
+        final Flux<Integer> failsOnce = Flux.defer(() ->
+                attempts.incrementAndGet() == 1
+                        ? Flux.<Integer>error(new IllegalStateException("first attempt fails"))
+                        : Flux.just(42).hide());
+
+        final TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+        wrapped(failsOnce).retry(1).subscribe(downstream);
+
+        assertEquals(2, attempts.get());
+        assertTrue(downstream.completed);
+        assertEquals(Arrays.asList(42), downstream.received);
+        // the retry machinery resubscribes from its subscription-stack drain loop - OUTSIDE any
+        // window frame - so each attempt is an independent subscription with its own held trace,
+        // created once and closed exactly once at its own terminal. A failed attempt leaks
+        // nothing into the next one.
+        assertEquals(2, seamContext.creations);
+        verify(firstTrace, times(1)).close();
+        verify(secondTrace, times(1)).close();
+    }
+
+    @Test
+    public void neverPublisher_heldTraceLivesUntilCancel_thenClosedExactlyOnce() {
+        final SubscriptionCapturingSubscriber<Integer> downstream = new SubscriptionCapturingSubscriber<Integer>();
+        wrapped(Flux.<Integer>never()).subscribe(downstream);
+
+        // no terminal signal ever arrives: the subscription-held trace stays open BY DESIGN
+        // (long-lived stream semantics - doc 18 §4.5).
+        verify(firstTrace, never()).close();
+
+        // cancel is the bounded cleanup: the W1 ownership handoff closes the HELD trace exactly
+        // once. (cancel's control window creates and fully closes its own frame-local trace -
+        // secondTrace here - which is unrelated to the held one.)
+        downstream.subscription.cancel();
+        verify(firstTrace, times(1)).close();
+        verify(secondTrace, times(1)).close();
+
+        downstream.subscription.cancel();
+        verify(firstTrace, times(1)).close();
+    }
+
+    private static class SubscriptionCapturingSubscriber<T> implements CoreSubscriber<T> {
+        Subscription subscription;
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            this.subscription = s;
+            // no request: keep the window accounting to the onSubscribe frame only.
+        }
+
+        @Override
+        public void onNext(T value) {
+        }
+
+        @Override
+        public void onError(Throwable t) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
+
+        @Override
+        public Context currentContext() {
+            return Context.empty();
+        }
+    }
+}

--- a/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/StubAsyncContext.java
+++ b/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/StubAsyncContext.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
+/**
+ * Test double faithfully simulating DefaultAsyncContext's single-threaded binding contract:
+ * creating or rebinding a trace binds it to the (one) simulated thread, {@link #close()} unbinds,
+ * and every context sharing the {@code boundSlot} sees the same binding — exactly what nested
+ * windows and control windows observe for real. Counts are emergent, not choreographed.
+ */
+final class StubAsyncContext implements AsyncContext {
+    private final Trace[] boundSlot;
+    private final Deque<Trace> tracesToCreate;
+    int creations;
+    int unbinds;
+
+    StubAsyncContext(Trace[] boundSlot, Trace... tracesToCreate) {
+        this.boundSlot = boundSlot;
+        this.tracesToCreate = new ArrayDeque<>(Arrays.asList(tracesToCreate));
+    }
+
+    @Override
+    public Trace continueAsyncTraceObject() {
+        return continueAsyncTraceObject(false);
+    }
+
+    @Override
+    public Trace continueAsyncTraceObject(boolean asyncTraceBlock) {
+        final Trace created = tracesToCreate.poll();
+        if (created == null) {
+            return null;
+        }
+        creations++;
+        boundSlot[0] = created;
+        return created;
+    }
+
+    @Override
+    public Trace continueAsyncTraceObject(Trace reuse) {
+        boundSlot[0] = reuse;
+        return reuse;
+    }
+
+    @Override
+    public Trace currentAsyncTraceObject() {
+        return boundSlot[0];
+    }
+
+    @Override
+    public void close() {
+        unbinds++;
+        boundSlot[0] = null;
+    }
+
+    @Override
+    public boolean finish() {
+        return false;
+    }
+}

--- a/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/TestFusionSubscriber.java
+++ b/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/TestFusionSubscriber.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.util.context.Context;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Downstream test subscriber that negotiates fusion when offered and records everything it sees.
+ */
+class TestFusionSubscriber<T> implements CoreSubscriber<T> {
+    final List<T> received = new ArrayList<T>();
+    Subscription subscription;
+    int negotiatedFusionMode = Integer.MIN_VALUE;
+    boolean completed;
+    Throwable error;
+    private final Context context;
+
+    TestFusionSubscriber() {
+        this(Context.empty());
+    }
+
+    TestFusionSubscriber(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        this.subscription = s;
+        if (s instanceof Fuseable.QueueSubscription) {
+            this.negotiatedFusionMode = ((Fuseable.QueueSubscription<?>) s).requestFusion(Fuseable.ANY);
+        }
+        s.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(T t) {
+        received.add(t);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        this.error = t;
+    }
+
+    @Override
+    public void onComplete() {
+        this.completed = true;
+    }
+
+    @Override
+    public Context currentContext() {
+        return context;
+    }
+}

--- a/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/TracedSubscriberCancelLifecycleTest.java
+++ b/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/TracedSubscriberCancelLifecycleTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.util.context.Context;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Held-trace lifecycle around cancel(). The contract under test: the subscription-held trace is
+ * closed <b>exactly once</b> on every cancel path — including a cancel after which no signal ever
+ * arrives (previously that path relied on GC) — and never while a delivery frame is using it.
+ * <p>
+ * Mock geography: {@code held} is the trace the first owned window creates and holds;
+ * {@code ctrl} is what request/cancel control windows create in mock-land (no real thread-local),
+ * kept scope-less and non-async so it never contributes to close() counts.
+ */
+public class TracedSubscriberCancelLifecycleTest {
+
+    private AsyncContext asyncContext;
+    private Trace held;
+    private TraceScope heldScope;
+    private Trace ctrl;
+    private Subscription subscription;
+
+    @BeforeEach
+    public void setUp() {
+        asyncContext = mock(AsyncContext.class);
+        held = mock(Trace.class);
+        heldScope = mock(TraceScope.class);
+        ctrl = mock(Trace.class);
+        subscription = mock(Subscription.class);
+
+        // first owned window creates the held trace; control windows get the inert ctrl trace.
+        when(asyncContext.continueAsyncTraceObject(false)).thenReturn(held, ctrl, ctrl, ctrl);
+        when(asyncContext.continueAsyncTraceObject(held)).thenReturn(held);
+        when(held.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(heldScope);
+        when(held.isAsync()).thenReturn(true);
+        when(heldScope.tryEnter()).thenReturn(true);
+        when(heldScope.canLeave()).thenReturn(true);
+        // every window is outermost: it unbinds at the frame end.
+        when(heldScope.isActive()).thenReturn(false);
+        // ctrl stays scope-less and non-async: control windows never close it.
+        when(ctrl.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(null);
+        when(ctrl.isAsync()).thenReturn(false);
+    }
+
+    private TracedSubscriber<Integer> traced(CoreSubscriber<Integer> actual) {
+        return new TracedSubscriber<Integer>(actual, asyncContext);
+    }
+
+    @Test
+    public void cancelWithNoSignalInFlight_closesHeldTraceExactlyOnce() {
+        TracedSubscriber<Integer> traced = traced(new NoopSubscriber());
+
+        traced.onSubscribe(subscription);
+        traced.onNext(1);
+        verify(held, never()).close();
+
+        traced.cancel();
+        verify(held, times(1)).close();
+        verify(subscription).cancel();
+
+        // second cancel: the state is DONE, nothing closes twice.
+        traced.cancel();
+        verify(held, times(1)).close();
+        verify(ctrl, never()).close();
+    }
+
+    @Test
+    public void cancelRightAfterOnSubscribe_closesHeldTraceExactlyOnce() {
+        TracedSubscriber<Integer> traced = traced(new NoopSubscriber());
+
+        traced.onSubscribe(subscription);
+        verify(held, never()).close();
+
+        traced.cancel();
+        verify(held, times(1)).close();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void cancelInsideDeliveryFrame_closedAtFrameEnd_notByCancel() {
+        // take(1) shape: the downstream cancels synchronously inside onNext. The frame owns the
+        // held trace (state WINDOW), so cancel's own close must lose and the frame end closes.
+        final TracedSubscriber<Integer>[] ref = new TracedSubscriber[1];
+        TracedSubscriber<Integer> traced = traced(new NoopSubscriber() {
+            @Override
+            public void onNext(Integer value) {
+                ref[0].cancel();
+                // still inside the frame: cancel must not have closed the trace in use.
+                verify(held, never()).close();
+            }
+        });
+        ref[0] = traced;
+        // cancel's control window borrows the delivery window's bound trace here.
+        when(asyncContext.currentAsyncTraceObject()).thenReturn(null, null, held);
+        // onSubscribe close -> outermost(false); control window close -> still active(true);
+        // onNext close -> outermost(false).
+        when(heldScope.isActive()).thenReturn(false, true, false);
+
+        traced.onSubscribe(subscription);
+        traced.onNext(1);
+
+        verify(held, times(1)).close();
+        verify(subscription).cancel();
+    }
+
+    @Test
+    public void cancelBeforeAnySignal_lateRacingSignalIsStillCleanedUp() {
+        // legal per reactive streams: a signal may still arrive after cancel. The fresh trace the
+        // late frame creates must be closed at its own frame end because cancelled is set.
+        when(asyncContext.continueAsyncTraceObject(false)).thenReturn(ctrl, held);
+        TracedSubscriber<Integer> traced = traced(new NoopSubscriber());
+        traced.subscription = subscription;
+
+        traced.cancel();                    // nothing held yet - nothing to close
+        verify(held, never()).close();
+        verify(ctrl, never()).close();
+
+        traced.onNext(42);                  // racing late signal: fresh trace, closed at frame end
+        verify(held, times(1)).close();
+    }
+
+    @Test
+    public void cancelStillCancelsUpstreamWhenHeldTraceCloseFails() {
+        // fault injection: the held trace refuses to close. The agent-side cleanup failure must
+        // never block the application's reactive cancellation.
+        org.mockito.Mockito.doThrow(new RuntimeException("close failure")).when(held).close();
+        TracedSubscriber<Integer> traced = traced(new NoopSubscriber());
+
+        traced.onSubscribe(subscription);
+        traced.onNext(1);
+
+        traced.cancel();
+        verify(subscription, times(1)).cancel();
+
+        // the slot is DONE: a second cancel never retries the failing close.
+        traced.cancel();
+        verify(held, times(1)).close();
+        verify(subscription, times(2)).cancel();
+    }
+
+    @Test
+    public void terminalWindowOpenFailure_closesCreatedTraceExactlyOnce() {
+        // fault injection: the very first (and terminal) frame creates the trace, stores it in
+        // the held slot, then fails on the scope lookup. The frame must take the trace back out
+        // of the slot and close it - a terminal frame has no successor to do it later.
+        when(held.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenThrow(new RuntimeException("scope failure"));
+        TracedSubscriber<Integer> traced = traced(new NoopSubscriber());
+        traced.subscription = subscription;
+
+        traced.onComplete();
+        verify(held, times(1)).close();
+        verify(asyncContext, times(1)).close();
+
+        // the slot was emptied: a later cancel finds nothing and never double-closes.
+        traced.cancel();
+        verify(held, times(1)).close();
+    }
+
+    @Test
+    public void terminalThenCancel_noDoubleClose() {
+        TracedSubscriber<Integer> traced = traced(new NoopSubscriber());
+
+        traced.onSubscribe(subscription);
+        traced.onNext(1);
+        traced.onComplete();
+        verify(held, times(1)).close();
+
+        traced.cancel();
+        verify(held, times(1)).close();
+        verify(ctrl, never()).close();
+    }
+
+    private static class NoopSubscriber implements CoreSubscriber<Integer> {
+        @Override
+        public void onSubscribe(Subscription s) {
+        }
+
+        @Override
+        public void onNext(Integer value) {
+        }
+
+        @Override
+        public void onError(Throwable t) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
+
+        @Override
+        public Context currentContext() {
+            return Context.empty();
+        }
+    }
+}

--- a/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/TracedSubscriberTest.java
+++ b/agent-module/plugins/reactor-seam-support/src/test/java/com/navercorp/pinpoint/plugin/reactorsupport/TracedSubscriberTest.java
@@ -1,0 +1,509 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.reactorsupport;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.publisher.Flux;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TracedSubscriberTest {
+
+    private AsyncContext asyncContext;
+    private Trace trace;
+    private TraceScope scope;
+
+    @BeforeEach
+    public void setUp() {
+        asyncContext = mock(AsyncContext.class);
+        trace = mock(Trace.class);
+        scope = mock(TraceScope.class);
+        // first owned window creates the trace, later windows rebind the held one.
+        when(asyncContext.continueAsyncTraceObject(false)).thenReturn(trace);
+        when(asyncContext.continueAsyncTraceObject(trace)).thenReturn(trace);
+        when(trace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(scope);
+        when(scope.tryEnter()).thenReturn(true);
+        when(scope.canLeave()).thenReturn(true);
+        // scope stays active by default: windows neither unbind nor close the trace here.
+        when(scope.isActive()).thenReturn(true);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Flux<Integer> wrapped(Flux<Integer> source) {
+        Object wrapped = SeamPublisherWrapper.wrap(source, asyncContext);
+        assertNotSame(source, wrapped);
+        return (Flux<Integer>) wrapped;
+    }
+
+    @Test
+    public void fusedSource_downstreamNegotiationRefused_allSignalsDeliveredViaOnNext() {
+        // Flux.range(..).map(..) is a SYNC-fuseable chain: without the suppressor the downstream
+        // could switch to pull-only poll() and bypass onNext entirely.
+        Flux<Integer> source = Flux.range(1, 5).map(i -> i);
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+
+        wrapped(source).subscribe(downstream);
+
+        assertEquals(Fuseable.NONE, downstream.negotiatedFusionMode);
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), downstream.received);
+        assertTrue(downstream.completed);
+        assertTrue(downstream.subscription instanceof TracedSubscriber);
+    }
+
+    @Test
+    public void queueSubscriptionDownstream_noVendorSuppressorInserted() {
+        // Because TracedSubscriber is itself a QueueSubscription, Mono/FluxLiftFuseable's automatic
+        // SuppressFuseableSubscriber branch must not fire — no double wrapping.
+        Flux<Integer> source = Flux.range(1, 3);
+        QueueTestFusionSubscriber<Integer> downstream = new QueueTestFusionSubscriber<Integer>();
+
+        wrapped(source).subscribe(downstream);
+
+        assertTrue(downstream.subscription instanceof TracedSubscriber);
+        TracedSubscriber<?> traced = (TracedSubscriber<?>) downstream.subscription;
+        assertNotNull(traced.subscription);
+        assertFalse(traced.subscription.getClass().getName().contains("SuppressFuseable"));
+        assertEquals(Arrays.asList(1, 2, 3), downstream.received);
+    }
+
+    @Test
+    public void upstreamFusionNeverRequested() {
+        final AtomicInteger upstreamFusionCalls = new AtomicInteger();
+        Publisher<Integer> raw = new Publisher<Integer>() {
+            @Override
+            public void subscribe(final Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(new Fuseable.QueueSubscription<Integer>() {
+                    @Override
+                    public int requestFusion(int requestedMode) {
+                        upstreamFusionCalls.incrementAndGet();
+                        return Fuseable.SYNC;
+                    }
+
+                    @Override
+                    public void request(long n) {
+                        subscriber.onNext(42);
+                        subscriber.onComplete();
+                    }
+
+                    @Override
+                    public void cancel() {
+                    }
+
+                    @Override
+                    public Integer poll() {
+                        return null;
+                    }
+
+                    @Override
+                    public int size() {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean isEmpty() {
+                        return true;
+                    }
+
+                    @Override
+                    public void clear() {
+                    }
+                });
+            }
+        };
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+
+        wrapped(Flux.from(raw)).subscribe(downstream);
+
+        assertEquals(0, upstreamFusionCalls.get(), "TracedSubscriber must not open the fused path upstream");
+        assertEquals(Arrays.asList(42), downstream.received);
+        assertTrue(downstream.completed);
+    }
+
+    @Test
+    public void windowArithmetic_onePerSignal() {
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+
+        wrapped(Flux.range(1, 5)).subscribe(downstream);
+
+        // 7 delivery windows (onSubscribe + 5 x onNext + onComplete): the trace is created ONCE
+        // and rebound for the remaining 6 - the per-signal create/close churn is gone. The
+        // downstream's request() adds one control window (frame-local creation: the mock has no
+        // real thread-local, so it does not observe the enclosing delivery window).
+        verify(asyncContext, times(2)).continueAsyncTraceObject(false);
+        verify(asyncContext, times(6)).continueAsyncTraceObject(trace);
+        verify(scope, times(8)).tryEnter();
+        verify(scope, times(8)).leave();
+        verify(trace, never()).close();
+        // delivery windows share one cached scope lookup; the control window adds its own
+        // (uncached) enter/leave lookups.
+        verify(trace, times(3)).getScope(ScopeUtils.ASYNC_TRACE_SCOPE);
+    }
+
+    @Test
+    public void errorSignal_deliveredInsideWindow() {
+        Flux<Integer> source = Flux.range(1, 3).concatWith(Flux.error(new IllegalStateException("boom")));
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+
+        wrapped(source).subscribe(downstream);
+
+        assertEquals(Arrays.asList(1, 2, 3), downstream.received);
+        assertNotNull(downstream.error);
+        // 5 delivery windows (1 creation + 4 rebinds) + 1 control window (request)
+        verify(asyncContext, times(2)).continueAsyncTraceObject(false);
+        verify(asyncContext, times(4)).continueAsyncTraceObject(trace);
+        verify(scope, times(6)).tryEnter();
+        verify(scope, times(6)).leave();
+    }
+
+    @Test
+    public void terminalCleanup_whenAsyncScopeEnds() {
+        // faithful thread-local/scope-depth simulation: the synchronous source delivers every
+        // signal NESTED inside the onSubscribe frame (emission happens during request), so the
+        // outermost frame end is the one that unbinds and - because the stream is done - closes
+        // the held trace, exactly once.
+        final Trace realTrace = mock(Trace.class);
+        when(realTrace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(new DepthScope());
+        when(realTrace.isAsync()).thenReturn(true);
+        final StubAsyncContext simulatedContext = new StubAsyncContext(new Trace[1], realTrace);
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+
+        // note: a 1-element range collapses to FluxJust, a ScalarCallable the wrapper skips.
+        @SuppressWarnings("unchecked")
+        Flux<Integer> wrapped = (Flux<Integer>) SeamPublisherWrapper.wrap(Flux.range(1, 2), simulatedContext);
+        wrapped.subscribe(downstream);
+
+        assertTrue(downstream.completed);
+        assertEquals(1, simulatedContext.creations);
+        assertEquals(1, simulatedContext.unbinds);
+        verify(realTrace, times(1)).close();
+    }
+
+    @Test
+    public void cancel_closesHeldTraceImmediately_lateSignalCleanedUp() {
+        when(trace.isAsync()).thenReturn(true);
+        when(scope.isActive()).thenReturn(false);
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+        TracedSubscriber<Integer> traced = new TracedSubscriber<Integer>(downstream, asyncContext);
+
+        traced.onSubscribe(mock(Subscription.class));
+        // the downstream's request(MAX) inside onSubscribe opened one control window whose
+        // frame-local trace (same mock instance) was closed; the held delivery trace was not.
+        verify(trace, times(1)).close();
+
+        traced.cancel();
+        // no delivery frame is using the held trace, so cancel closes it right away instead of
+        // waiting for a signal that may never come (+1), and its control window adds its
+        // frame-local close (+1, same mock instance).
+        verify(trace, times(3)).close();
+
+        traced.onNext(1);
+        // a racing late signal is legal: it gets a fresh trace which its own frame end closes
+        // because cancelled is set - nothing waits for GC.
+        verify(trace, times(4)).close();
+
+        // see TracedSubscriberCancelLifecycleTest for the per-path close-once assertions.
+    }
+
+    @Test
+    public void borrowedTrace_notHeldAndNotUnbound() {
+        // a trace bound by another activation is used for the window but never held or unbound here.
+        Trace borrowed = mock(Trace.class);
+        TraceScope borrowedScope = mock(TraceScope.class);
+        when(asyncContext.currentAsyncTraceObject()).thenReturn(borrowed);
+        when(borrowed.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(borrowedScope);
+        when(borrowedScope.tryEnter()).thenReturn(true);
+        when(borrowedScope.canLeave()).thenReturn(true);
+        when(borrowedScope.isActive()).thenReturn(true);
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+
+        wrapped(Flux.range(1, 2)).subscribe(downstream);
+
+        assertEquals(Arrays.asList(1, 2), downstream.received);
+        verify(asyncContext, never()).continueAsyncTraceObject(false);
+        verify(asyncContext, never()).continueAsyncTraceObject(borrowed);
+        verify(asyncContext, never()).close();
+        verify(borrowed, never()).close();
+        // 4 delivery windows + 1 control window (request), all borrowed
+        verify(borrowedScope, times(5)).tryEnter();
+        verify(borrowedScope, times(5)).leave();
+    }
+
+    @Test
+    public void duplicateOnSubscribe_cancelsTheSecond() {
+        Subscription first = mock(Subscription.class);
+        Subscription second = mock(Subscription.class);
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+        TracedSubscriber<Integer> traced = new TracedSubscriber<Integer>(downstream, asyncContext);
+
+        traced.onSubscribe(first);
+        Subscription seenByDownstream = downstream.subscription;
+        traced.onSubscribe(second);
+
+        // reactive streams 2.5: the duplicate is cancelled and nothing is re-delivered downstream.
+        verify(second, times(1)).cancel();
+        verify(first, never()).cancel();
+        assertTrue(seenByDownstream == downstream.subscription, "downstream must not be re-subscribed");
+    }
+
+    @Test
+    public void signalsAfterTerminal_droppedWithoutWindow() {
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                this.subscription = s;
+                // no request: signals are pushed manually below
+            }
+        };
+        TracedSubscriber<Integer> traced = new TracedSubscriber<Integer>(downstream, asyncContext);
+        traced.onSubscribe(mock(Subscription.class));
+        traced.onComplete();
+
+        traced.onNext(1);
+        traced.onError(new IllegalStateException("late"));
+        traced.onComplete();
+
+        assertTrue(downstream.completed);
+        assertTrue(downstream.received.isEmpty(), "late onNext must be dropped");
+        assertTrue(downstream.error == null, "late onError must be dropped");
+        // windows: onSubscribe (creation) + first onComplete (rebind) only - dropped signals open none.
+        verify(asyncContext, times(1)).continueAsyncTraceObject(false);
+        verify(asyncContext, times(1)).continueAsyncTraceObject(trace);
+    }
+
+    @Test
+    public void conditionalDownstream_getsConditionalVariantAndTryOnNextWindow() {
+        // lifter selection: a conditional downstream gets the Conditional variant...
+        ConditionalTestSubscriber<Integer> downstream = new ConditionalTestSubscriber<Integer>();
+        Object wrapped = SeamPublisherWrapper.wrap(Flux.range(1, 5).map(i -> i), asyncContext);
+        ((Flux<Integer>) wrapped).subscribe((CoreSubscriber<Integer>) downstream);
+        assertTrue(downstream.subscription instanceof Fuseable.ConditionalSubscriber,
+                "a conditional downstream must get the conditional traced variant");
+        assertEquals(Arrays.asList(1, 2, 3, 4, 5), downstream.received);
+        assertTrue(downstream.completed);
+
+        // ...and tryOnNext is delivered inside a window.
+        ConditionalTestSubscriber<Integer> direct = new ConditionalTestSubscriber<Integer>();
+        TracedSubscriber.Conditional<Integer> traced = new TracedSubscriber.Conditional<Integer>(direct, asyncContext);
+        traced.onSubscribe(mock(Subscription.class));
+        int windowsBefore = mockingDetails(asyncContext).getInvocations().size();
+        assertTrue(traced.tryOnNext(42));
+        assertEquals(Arrays.asList(42), direct.received);
+        assertTrue(mockingDetails(asyncContext).getInvocations().size() > windowsBefore,
+                "tryOnNext must interact with the window machinery");
+    }
+
+    @Test
+    public void requestOnBareThread_opensAndFullyClosesFrameLocalWindow() {
+        // request may race delivery signals, so it must never bind the held trace - on a bare
+        // thread it creates a frame-local trace and fully closes it at the frame end.
+        when(trace.isAsync()).thenReturn(true);
+        when(scope.isActive()).thenReturn(false);
+        Subscription upstream = mock(Subscription.class);
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+        TracedSubscriber<Integer> traced = new TracedSubscriber<Integer>(downstream, asyncContext);
+        traced.subscription = upstream;
+
+        traced.request(7);
+
+        verify(upstream).request(7);
+        verify(asyncContext, times(1)).continueAsyncTraceObject(false);
+        verify(asyncContext, times(1)).close();
+        verify(trace, times(1)).close();
+    }
+
+    @Test
+    public void requestInsideExistingWindow_borrowsWithoutBinding() {
+        Trace borrowed = mock(Trace.class);
+        TraceScope borrowedScope = mock(TraceScope.class);
+        when(asyncContext.currentAsyncTraceObject()).thenReturn(borrowed);
+        when(borrowed.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(borrowedScope);
+        when(borrowedScope.canLeave()).thenReturn(true);
+        Subscription upstream = mock(Subscription.class);
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+        TracedSubscriber<Integer> traced = new TracedSubscriber<Integer>(downstream, asyncContext);
+        traced.subscription = upstream;
+
+        traced.request(3);
+
+        verify(upstream).request(3);
+        verify(asyncContext, never()).continueAsyncTraceObject(false);
+        verify(asyncContext, never()).close();
+        verify(borrowed, never()).close();
+        verify(borrowedScope, times(1)).tryEnter();
+        verify(borrowedScope, times(1)).leave();
+    }
+
+    @Test
+    public void windowOpenFailureAfterBind_unbindsTheThreadAndClosesCreatedTrace() {
+        // if the window fails AFTER the trace was bound (e.g. the scope lookup throws), the
+        // binding this frame installed must be undone - it must not leak onto the delivery
+        // thread - and the trace this frame created must be closed: had the failing signal been
+        // terminal, no later frame would ever close it (GC-dependent leak otherwise).
+        when(trace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenThrow(new RuntimeException("scope failure"));
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+
+        wrapped(Flux.range(1, 3)).subscribe(downstream);
+
+        assertEquals(Arrays.asList(1, 2, 3), downstream.received);
+        assertTrue(downstream.completed);
+        // 5 delivery windows + 1 control window (request) each bind, fail on the scope lookup,
+        // unbind, and close the trace they created.
+        verify(asyncContext, times(6)).close();
+        verify(trace, times(6)).close();
+    }
+
+    @Test
+    public void windowFailure_doesNotAffectDelivery() {
+        when(asyncContext.continueAsyncTraceObject(anyBoolean())).thenThrow(new RuntimeException("window failure"));
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+
+        wrapped(Flux.range(1, 3)).subscribe(downstream);
+
+        assertEquals(Arrays.asList(1, 2, 3), downstream.received);
+        assertTrue(downstream.completed);
+    }
+
+    @Test
+    public void nullAsyncContext_deliversWithoutWindow() {
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>();
+        TracedSubscriber<Integer> traced = new TracedSubscriber<Integer>(downstream, null);
+
+        Flux.range(1, 3).subscribe((CoreSubscriber<Integer>) traced);
+
+        assertEquals(Arrays.asList(1, 2, 3), downstream.received);
+        assertTrue(downstream.completed);
+    }
+
+    @Test
+    public void downstreamOnNextThrows_windowStillClosed() {
+        final AtomicInteger enters = new AtomicInteger();
+        final AtomicInteger leaves = new AtomicInteger();
+        when(scope.tryEnter()).thenAnswer(invocation -> {
+            enters.incrementAndGet();
+            return true;
+        });
+        when(scope.canLeave()).thenAnswer(invocation -> {
+            leaves.incrementAndGet();
+            return true;
+        });
+
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>() {
+            @Override
+            public void onNext(Integer value) {
+                throw new IllegalStateException("downstream failure");
+            }
+        };
+
+        try {
+            wrapped(Flux.range(1, 3)).subscribe(downstream);
+        } catch (Throwable ignored) {
+        }
+
+        assertTrue(enters.get() >= 2, "expected at least the onSubscribe and onNext windows");
+        assertEquals(enters.get(), leaves.get(), "every opened window must be closed");
+    }
+
+    @Test
+    public void requestAndCancel_delegatedUpstream() {
+        final Subscription upstream = mock(Subscription.class);
+        Publisher<Integer> raw = new Publisher<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(upstream);
+            }
+        };
+        TestFusionSubscriber<Integer> downstream = new TestFusionSubscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                this.subscription = s;
+                s.request(7);
+                s.cancel();
+            }
+        };
+
+        wrapped(Flux.from(raw)).subscribe(downstream);
+
+        verify(upstream).request(7);
+        verify(upstream).cancel();
+    }
+
+    static class ConditionalTestSubscriber<T> extends TestFusionSubscriber<T> implements Fuseable.ConditionalSubscriber<T> {
+        @Override
+        public boolean tryOnNext(T t) {
+            received.add(t);
+            return true;
+        }
+    }
+
+    static class QueueTestFusionSubscriber<T> extends TestFusionSubscriber<T> implements Fuseable.QueueSubscription<T> {
+        @Override
+        public int requestFusion(int requestedMode) {
+            return Fuseable.NONE;
+        }
+
+        @Override
+        public void request(long n) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+
+        @Override
+        public T poll() {
+            return null;
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public void clear() {
+        }
+    }
+}

--- a/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/ReactorPlugin.java
+++ b/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/ReactorPlugin.java
@@ -35,6 +35,8 @@ import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
 import com.navercorp.pinpoint.bootstrap.plugin.reactor.CoreSubscriberOnSubscribeInterceptor;
 import com.navercorp.pinpoint.bootstrap.plugin.reactor.CoreSubscriberConstructorInterceptor;
 import com.navercorp.pinpoint.bootstrap.plugin.reactor.CoreSubscriberOnNextInterceptor;
+import com.navercorp.pinpoint.bootstrap.plugin.reactor.SchedulerTaskConstructorInterceptor;
+import com.navercorp.pinpoint.bootstrap.plugin.reactor.SchedulerTaskRunInterceptor;
 import com.navercorp.pinpoint.bootstrap.plugin.reactor.FluxAndMonoOperatorSubscribeInterceptor;
 import com.navercorp.pinpoint.bootstrap.plugin.reactor.FluxAndMonoSubscribeInterceptor;
 import com.navercorp.pinpoint.bootstrap.plugin.reactor.FluxAndMonoSubscribeOrReturnInterceptor;
@@ -88,6 +90,9 @@ public class ReactorPlugin implements ProfilerPlugin, MatchableTransformTemplate
 
         addFluxAndMono();
         addThreadingAndSchedulers();
+        if (config.isTraceSchedulerTask()) {
+            addSchedulerTasks();
+        }
         addProcessor();
         addFlux();
         addMono();
@@ -114,6 +119,27 @@ public class ReactorPlugin implements ProfilerPlugin, MatchableTransformTemplate
         transformTemplate.transform("reactor.core.publisher.FluxSubscribeOnCallable$CallableSubscribeOnSubscription", RunnableSubscriptionTransform.class);
         transformTemplate.transform("reactor.core.publisher.FluxInterval$IntervalRunnable", RunnableSubscriptionTransform.class);
         transformTemplate.transform("reactor.core.publisher.MonoDelay$MonoDelayRunnable", RunnableSubscriptionTransform.class);
+    }
+
+    /**
+     * Scheduler task carriers: every task the built-in schedulers wrap a submitted Runnable in
+     * before it crosses to a worker thread. The carrier receives the AsyncContext at construction
+     * (the scheduled Runnable is often an instrumented operator subscriber — publishOn/subscribeOn
+     * schedule themselves) and re-activates it around run()/call() on the worker thread.
+     * <p>
+     * The virtual-thread boundedElastic task exists only as a {@code META-INF/versions/21} entry
+     * (reactor 3.6+), so on JDK 8~20 — and on versions without the other classes (3.1.x has no
+     * InstantPeriodicWorkerTask) — the unmatched transform is a no-op.
+     */
+    private void addSchedulerTasks() {
+        transformTemplate.transform("reactor.core.scheduler.SchedulerTask", SchedulerTaskTransform.class);
+        transformTemplate.transform("reactor.core.scheduler.WorkerTask", SchedulerTaskTransform.class);
+        transformTemplate.transform("reactor.core.scheduler.PeriodicSchedulerTask", SchedulerTaskTransform.class);
+        transformTemplate.transform("reactor.core.scheduler.PeriodicWorkerTask", SchedulerTaskTransform.class);
+        transformTemplate.transform("reactor.core.scheduler.InstantPeriodicWorkerTask", SchedulerTaskTransform.class);
+        transformTemplate.transform("reactor.core.scheduler.ExecutorScheduler$ExecutorPlainRunnable", SchedulerTaskTransform.class);
+        transformTemplate.transform("reactor.core.scheduler.ExecutorScheduler$ExecutorTrackedRunnable", SchedulerTaskTransform.class);
+        transformTemplate.transform("reactor.core.scheduler.BoundedElasticThreadPerTaskScheduler$SchedulerTask", SchedulerTaskTransform.class);
     }
 
     private void addProcessor() {
@@ -267,6 +293,42 @@ public class ReactorPlugin implements ProfilerPlugin, MatchableTransformTemplate
             final InstrumentMethod runMethod = target.getDeclaredMethod("run");
             if (runMethod != null) {
                 runMethod.addInterceptor(RunnableSubscriptionInterceptor.class);
+            }
+
+            return target.toBytecode();
+        }
+    }
+
+    public static class SchedulerTaskTransform implements TransformCallback {
+        // ASM ACC_SYNTHETIC: skips the bridge call():Object the compiler adds next to call():Void.
+        private static final int ACC_SYNTHETIC = 0x1000;
+
+        @Override
+        public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
+            final InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
+            // Async Object
+            target.addField(AsyncContextAccessor.class);
+
+            for (InstrumentMethod constructorMethod : target.getDeclaredConstructors()) {
+                final String[] parameterTypes = constructorMethod.getParameterTypes();
+                if (ArrayUtils.hasLength(parameterTypes)) {
+                    constructorMethod.addInterceptor(SchedulerTaskConstructorInterceptor.class, va(ReactorConstants.REACTOR));
+                }
+            }
+            // the execution entry point differs per version and class (run() delegating to call(),
+            // call() only, run() only) - weave both; the async trace scope activates only once.
+            for (InstrumentMethod method : target.getDeclaredMethods()) {
+                final String name = method.getName();
+                if (!"run".equals(name) && !"call".equals(name)) {
+                    continue;
+                }
+                if (ArrayUtils.hasLength(method.getParameterTypes())) {
+                    continue;
+                }
+                if ((method.getModifiers() & ACC_SYNTHETIC) != 0) {
+                    continue;
+                }
+                method.addInterceptor(SchedulerTaskRunInterceptor.class);
             }
 
             return target.toBytecode();

--- a/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/ReactorPluginConfig.java
+++ b/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/ReactorPluginConfig.java
@@ -68,6 +68,10 @@ public class ReactorPluginConfig {
         return config.readBoolean("profiler.reactor.trace.subscribe", true);
     }
 
+    public static boolean isTraceSchedulerTask(ProfilerConfig config) {
+        return config.readBoolean("profiler.reactor.trace.scheduler.task", false);
+    }
+
     private final boolean enable;
 
     private final boolean traceOnError;
@@ -78,6 +82,7 @@ public class ReactorPluginConfig {
     private final boolean traceRetry;
     private final boolean traceTimeout;
     private final boolean traceSubscribe;
+    private final boolean traceSchedulerTask;
     private final boolean markErrorRetry;
     private final boolean markErrorOnError;
 
@@ -98,6 +103,7 @@ public class ReactorPluginConfig {
 
         this.traceTimeout = isTraceTimeout(config);
         this.traceSubscribe = isTraceSubscribe(config);
+        this.traceSchedulerTask = isTraceSchedulerTask(config);
     }
 
     public boolean isEnable() {
@@ -136,6 +142,10 @@ public class ReactorPluginConfig {
         return traceSubscribe;
     }
 
+    public boolean isTraceSchedulerTask() {
+        return traceSchedulerTask;
+    }
+
     public boolean isMarkErrorRetry() {
         return markErrorRetry;
     }
@@ -156,6 +166,7 @@ public class ReactorPluginConfig {
                 ", traceRetry=" + traceRetry +
                 ", traceTimeout=" + traceTimeout +
                 ", traceSubscribe=" + traceSubscribe +
+                ", traceSchedulerTask=" + traceSchedulerTask +
                 ", markErrorRetry=" + markErrorRetry +
                 ", markErrorOnError=" + markErrorOnError +
                 '}';

--- a/agent-module/plugins/redis-lettuce/pom.xml
+++ b/agent-module/plugins/redis-lettuce/pom.xml
@@ -29,5 +29,58 @@
             <artifactId>lettuce-core</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-reactor-seam-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${plugin.shade.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.navercorp.pinpoint:pinpoint-reactor-seam-support</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>com.navercorp.pinpoint:pinpoint-reactor-seam-support</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <!-- reactor-family plugins inject into the same application classloader
+                                 and duplicate definitions across plugin jars fail with a LinkageError,
+                                 so every consumer must relocate the support classes under its own
+                                 plugin package. -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.navercorp.pinpoint.plugin.reactorsupport</pattern>
+                                    <shadedPattern>com.navercorp.pinpoint.plugin.redis.lettuce.reactorsupport</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <dependencyReducedPomLocation>
+                                ${project.build.directory}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/agent-module/plugins/redis-lettuce/src/main/java/com/navercorp/pinpoint/plugin/redis/lettuce/LettucePlugin.java
+++ b/agent-module/plugins/redis-lettuce/src/main/java/com/navercorp/pinpoint/plugin/redis/lettuce/LettucePlugin.java
@@ -45,6 +45,8 @@ import com.navercorp.pinpoint.plugin.redis.lettuce.interceptor.RedisCluserClient
 import com.navercorp.pinpoint.plugin.redis.lettuce.interceptor.RedisClusterClientConstructorInterceptor;
 
 import com.navercorp.pinpoint.plugin.redis.lettuce.interceptor.RedisPubSubListenerInterceptor;
+import com.navercorp.pinpoint.plugin.redis.lettuce.interceptor.WrappingLettuceMethodInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
 
 import java.security.ProtectionDomain;
 
@@ -55,6 +57,16 @@ public class LettucePlugin implements ProfilerPlugin, MatchableTransformTemplate
     private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
 
     private MatchableTransformTemplate transformTemplate;
+
+    // profiler.redis.lettuce.wrap.publisher selects the wrapping variant, which hands the
+    // AsyncContext to a wrapped publisher instead of injecting it into the returned one.
+    static Class<? extends Interceptor> lettuceMethodInterceptor(Instrumentor instrumentor) {
+        final LettucePluginConfig config = new LettucePluginConfig(instrumentor.getProfilerConfig());
+        if (config.isWrapPublisher()) {
+            return WrappingLettuceMethodInterceptor.class;
+        }
+        return LettuceMethodInterceptor.class;
+    }
 
     @Override
     public void setup(ProfilerPluginSetupContext context) {
@@ -213,7 +225,7 @@ public class LettucePlugin implements ProfilerPlugin, MatchableTransformTemplate
             final LettuceMethodNameFilter lettuceMethodNameFilter = new LettuceMethodNameFilter();
             for (InstrumentMethod method : target.getDeclaredMethods(MethodFilters.chain(lettuceMethodNameFilter, MethodFilters.modifierNot(MethodFilters.SYNTHETIC)))) {
                 try {
-                    method.addScopedInterceptor(LettuceMethodInterceptor.class, LettuceConstants.REDIS_SCOPE);
+                    method.addScopedInterceptor(lettuceMethodInterceptor(instrumentor), LettuceConstants.REDIS_SCOPE);
                 } catch (Exception e) {
                     final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
                     if (logger.isWarnEnabled()) {

--- a/agent-module/plugins/redis-lettuce/src/main/java/com/navercorp/pinpoint/plugin/redis/lettuce/LettucePluginConfig.java
+++ b/agent-module/plugins/redis-lettuce/src/main/java/com/navercorp/pinpoint/plugin/redis/lettuce/LettucePluginConfig.java
@@ -26,11 +26,17 @@ public class LettucePluginConfig {
     private final boolean enable;
     private final boolean tracePubSubListener;
     private final List<String> redisPubSubListenerBasePackageList;
+    private final boolean wrapPublisher;
 
     public LettucePluginConfig(ProfilerConfig src) {
         this.enable = src.readBoolean("profiler.redis.lettuce.enable", true);
         this.tracePubSubListener = src.readBoolean("profiler.redis.lettuce.trace.pubsub-listener", true);
         this.redisPubSubListenerBasePackageList = src.readList("profiler.redis.lettuce.pubsub-listener.base-packages");
+        this.wrapPublisher = src.readBoolean("profiler.redis.lettuce.wrap.publisher", false);
+    }
+
+    public boolean isWrapPublisher() {
+        return wrapPublisher;
     }
 
     public boolean isEnable() {
@@ -51,6 +57,7 @@ public class LettucePluginConfig {
                 "enable=" + enable +
                 ", tracePubSubListener=" + tracePubSubListener +
                 ", redisPubSubListenerBasePackageList=" + redisPubSubListenerBasePackageList +
+                ", wrapPublisher=" + wrapPublisher +
                 '}';
     }
 }

--- a/agent-module/plugins/redis-lettuce/src/main/java/com/navercorp/pinpoint/plugin/redis/lettuce/interceptor/WrappingLettuceMethodInterceptor.java
+++ b/agent-module/plugins/redis-lettuce/src/main/java/com/navercorp/pinpoint/plugin/redis/lettuce/interceptor/WrappingLettuceMethodInterceptor.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.redis.lettuce.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+import com.navercorp.pinpoint.plugin.redis.lettuce.EndPointAccessor;
+import com.navercorp.pinpoint.plugin.redis.lettuce.LettuceConstants;
+import com.navercorp.pinpoint.plugin.redis.lettuce.StatefulConnectionGetter;
+
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link LettuceMethodInterceptor} (config-gated by
+ * {@code profiler.redis.lettuce.wrap.publisher}). This interceptor covers both the async and
+ * the reactive command surface: a reactor Mono/Flux result is replaced with a wrapped one,
+ * while any other async result (futures, non-reactor publishers) keeps the original injection.
+ */
+public class WrappingLettuceMethodInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+
+    public WrappingLettuceMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(LettuceConstants.REDIS_LETTUCE);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            final String endPoint = toEndPoint(target);
+            recorder.recordApi(methodDescriptor);
+            recorder.recordEndPoint(Objects.toString(endPoint, "Unknown"));
+            recorder.recordDestinationId(LettuceConstants.REDIS_LETTUCE.getName());
+            recorder.recordException(throwable);
+
+            if (throwable != null) {
+                return result;
+            }
+
+            if (SeamPublisherWrapper.isWrappable(result)) {
+                final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+                final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+                if (isDebug) {
+                    logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
+                }
+                return wrapped;
+            }
+            // non-reactor async result: keep the original injection.
+            if (result instanceof AsyncContextAccessor) {
+                if (AsyncContextAccessorUtils.getAsyncContext(result) == null) {
+                    // Avoid duplicate async context
+                    final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+                    ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
+                    if (isDebug) {
+                        logger.debug("Set asyncContext to result. asyncContext={}", asyncContext);
+                    }
+                }
+            }
+            return result;
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            return result;
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+
+    private String toEndPoint(final Object target) {
+        if (!(target instanceof StatefulConnectionGetter)) {
+            return null;
+        }
+
+        final Object connection = ((StatefulConnectionGetter) target)._$PINPOINT$_getConnection();
+        if (!(connection instanceof EndPointAccessor)) {
+            return null;
+        }
+
+        return ((EndPointAccessor) connection)._$PINPOINT$_getEndPoint();
+    }
+}

--- a/agent-module/plugins/redis-redisson/pom.xml
+++ b/agent-module/plugins/redis-redisson/pom.xml
@@ -30,5 +30,58 @@
             <artifactId>redisson</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-reactor-seam-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${plugin.shade.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.navercorp.pinpoint:pinpoint-reactor-seam-support</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>com.navercorp.pinpoint:pinpoint-reactor-seam-support</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <!-- reactor-family plugins inject into the same application classloader
+                                 and duplicate definitions across plugin jars fail with a LinkageError,
+                                 so every consumer must relocate the support classes under its own
+                                 plugin package. -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.navercorp.pinpoint.plugin.reactorsupport</pattern>
+                                    <shadedPattern>com.navercorp.pinpoint.plugin.redis.redisson.reactorsupport</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <dependencyReducedPomLocation>
+                                ${project.build.directory}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/RedissonPlugin.java
+++ b/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/RedissonPlugin.java
@@ -31,6 +31,8 @@ import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
 import com.navercorp.pinpoint.plugin.redis.redisson.interceptor.CommandAsyncServiceMethodInterceptor;
 import com.navercorp.pinpoint.plugin.redis.redisson.interceptor.ReactiveMethodInterceptor;
 import com.navercorp.pinpoint.plugin.redis.redisson.interceptor.RedissonMethodInterceptor;
+import com.navercorp.pinpoint.plugin.redis.redisson.interceptor.WrappingReactiveMethodInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
 
 import java.security.ProtectionDomain;
 
@@ -43,6 +45,15 @@ public class RedissonPlugin implements ProfilerPlugin, TransformTemplateAware {
 
     private TransformTemplate transformTemplate;
 
+    // profiler.redis.redisson.wrap.publisher selects the wrapping variant, which hands the
+    // AsyncContext to a wrapped publisher instead of injecting it into the returned one.
+    static Class<? extends Interceptor> reactiveMethodInterceptor(Instrumentor instrumentor) {
+        final RedissonPluginConfig config = new RedissonPluginConfig(instrumentor.getProfilerConfig());
+        if (config.isWrapPublisher()) {
+            return WrappingReactiveMethodInterceptor.class;
+        }
+        return ReactiveMethodInterceptor.class;
+    }
 
     @Override
     public void setup(ProfilerPluginSetupContext context) {
@@ -189,17 +200,17 @@ public class RedissonPlugin implements ProfilerPlugin, TransformTemplateAware {
 
             final InstrumentMethod executeMethod = target.getDeclaredMethod("execute", "java.lang.reflect.Method", "java.lang.Object", "java.lang.Object[]");
             if (executeMethod != null) {
-                executeMethod.addInterceptor(ReactiveMethodInterceptor.class);
+                executeMethod.addInterceptor(reactiveMethodInterceptor(instrumentor));
             }
             // redisson ~3.17.x: ProxyBuilder$Callback.execute(Method, Object, Method, Object[])
             final InstrumentMethod instanceExecuteMethod = target.getDeclaredMethod("execute", "java.lang.reflect.Method", "java.lang.Object", "java.lang.reflect.Method", "java.lang.Object[]");
             if (instanceExecuteMethod != null) {
-                instanceExecuteMethod.addInterceptor(ReactiveMethodInterceptor.class);
+                instanceExecuteMethod.addInterceptor(reactiveMethodInterceptor(instrumentor));
             }
             // redisson 3.19+: ProxyBuilder$Callback.execute(Callable, Method)
             final InstrumentMethod callableExecuteMethod = target.getDeclaredMethod("execute", "java.util.concurrent.Callable", "java.lang.reflect.Method");
             if (callableExecuteMethod != null) {
-                callableExecuteMethod.addInterceptor(ReactiveMethodInterceptor.class);
+                callableExecuteMethod.addInterceptor(reactiveMethodInterceptor(instrumentor));
             }
 
             return target.toBytecode();

--- a/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/RedissonPluginConfig.java
+++ b/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/RedissonPluginConfig.java
@@ -25,10 +25,16 @@ public class RedissonPluginConfig {
 
     private final boolean enable;
     private final boolean keyTrace;
+    private final boolean wrapPublisher;
 
     public RedissonPluginConfig(ProfilerConfig src) {
         this.enable = src.readBoolean("profiler.redis.redisson.enable", true);
         this.keyTrace = src.readBoolean("profiler.redis.redisson.keytrace", false);
+        this.wrapPublisher = src.readBoolean("profiler.redis.redisson.wrap.publisher", false);
+    }
+
+    public boolean isWrapPublisher() {
+        return wrapPublisher;
     }
 
     public boolean isEnable() {
@@ -44,6 +50,7 @@ public class RedissonPluginConfig {
         final StringBuilder sb = new StringBuilder("RedissonPluginConfig{");
         sb.append("enable=").append(enable);
         sb.append(", keyTrace=").append(keyTrace);
+        sb.append(", wrapPublisher=").append(wrapPublisher);
         sb.append('}');
         return sb.toString();
     }

--- a/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/WrappingReactiveMethodInterceptor.java
+++ b/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/WrappingReactiveMethodInterceptor.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.redis.redisson.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import com.navercorp.pinpoint.common.util.ArrayArgumentUtils;
+import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+import com.navercorp.pinpoint.plugin.redis.redisson.RedissonConstants;
+import com.navercorp.pinpoint.plugin.redis.redisson.RedissonPluginConfig;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link ReactiveMethodInterceptor} (config-gated by
+ * {@code profiler.redis.redisson.wrap.publisher}). A reactor Mono/Flux result is replaced with
+ * a wrapped one instead of relying on the accessor field the reactor plugin injects into
+ * reactor.core.publisher types; any other async result keeps the original injection.
+ */
+public class WrappingReactiveMethodInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+    private final boolean keyTrace;
+
+    public WrappingReactiveMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        final RedissonPluginConfig config = new RedissonPluginConfig(traceContext.getProfilerConfig());
+        this.keyTrace = config.isKeyTrace();
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(RedissonConstants.REDISSON_REACTIVE);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+
+            Object ret = result;
+            if (throwable == null) {
+                if (SeamPublisherWrapper.isWrappable(result)) {
+                    final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+                    ret = SeamPublisherWrapper.wrap(result, asyncContext);
+                    if (isDebug) {
+                        logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
+                    }
+                } else if (result instanceof AsyncContextAccessor) {
+                    // non-reactor async result: keep the original injection.
+                    if (AsyncContextAccessorUtils.getAsyncContext(result) == null) {
+                        // Avoid duplicate async context
+                        final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+                        ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
+                    }
+                }
+            }
+
+            if (this.keyTrace) {
+                Method method = ArrayArgumentUtils.getArgument(args, 0, Method.class);
+                if (method == null) {
+                    // redisson 3.17+: execute(Callable, Method)
+                    method = ArrayArgumentUtils.getArgument(args, 1, Method.class);
+                }
+                if (method != null && StringUtils.hasLength(method.getName())) {
+                    recorder.recordAttribute(AnnotationKey.ARGS0, method.getName());
+                }
+            }
+
+            recorder.recordApi(methodDescriptor);
+            recorder.recordException(throwable);
+            return ret;
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            return result;
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+}

--- a/agent-module/plugins/redis-redisson/src/test/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/WrappingReactiveMethodInterceptorTest.java
+++ b/agent-module/plugins/redis-redisson/src/test/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/WrappingReactiveMethodInterceptorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.redis.redisson.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * classpath-negative containment pin (W9 / doc 18 §4.7): all five wrapping interceptors run the
+ * wrap path inside a {@code catch (Throwable)}. When reactor is absent, the first use of the
+ * shaded SeamPublisherWrapper throws {@link NoClassDefFoundError} (lazy resolution — pinned in
+ * seam-support's ReactorAbsenceClassLoadingTest); an ERROR, not an exception. This test proves
+ * the catch really contains Error-class throwables from the wrap path and hands the original
+ * result back — the call degrades to untraced, never broken. The redisson interceptor stands in
+ * for the shared template.
+ */
+public class WrappingReactiveMethodInterceptorTest {
+
+    private WrappingReactiveMethodInterceptor interceptor;
+    private TraceContext traceContext;
+    private Trace trace;
+    private SpanEventRecorder recorder;
+
+    @BeforeEach
+    public void setUp() {
+        final ProfilerConfig profilerConfig = mock(ProfilerConfig.class);
+        when(profilerConfig.readBoolean(anyString(), anyBoolean())).thenAnswer(inv -> inv.getArgument(1));
+        when(profilerConfig.readInt(anyString(), anyInt())).thenAnswer(inv -> inv.getArgument(1));
+
+        traceContext = mock(TraceContext.class);
+        when(traceContext.getProfilerConfig()).thenReturn(profilerConfig);
+        interceptor = new WrappingReactiveMethodInterceptor(traceContext, mock(MethodDescriptor.class));
+
+        trace = mock(Trace.class);
+        recorder = mock(SpanEventRecorder.class);
+        when(traceContext.currentTraceObject()).thenReturn(trace);
+        when(trace.traceBlockBegin()).thenReturn(recorder);
+        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+    }
+
+    @Test
+    public void errorOnWrapPath_isContained_originalResultReturned() {
+        // simulate the reactor-absence failure mode: an Error (NoClassDefFoundError) thrown from
+        // the wrap path inside after()'s try block.
+        when(recorder.recordNextAsyncContext())
+                .thenThrow(new NoClassDefFoundError("reactor/core/publisher/Mono"));
+        final Object result = Flux.range(1, 2).hide(); // wrappable, so the wrap path is entered
+
+        interceptor.before(new Object(), Object.class, new Object[0]);
+        final Object returned = interceptor.after(new Object(), Object.class, new Object[0], result, null);
+
+        // contained: the app gets its original publisher back, nothing propagates.
+        assertSame(result, returned);
+    }
+}

--- a/agent-module/plugins/spring-data-r2dbc/pom.xml
+++ b/agent-module/plugins/spring-data-r2dbc/pom.xml
@@ -24,6 +24,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-reactor-seam-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-r2dbc</artifactId>
             <scope>provided</scope>
@@ -72,4 +78,51 @@
             <scope>provided</scope>
         </dependency>
    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${plugin.shade.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.navercorp.pinpoint:pinpoint-reactor-seam-support</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>com.navercorp.pinpoint:pinpoint-reactor-seam-support</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <!-- reactor-family plugins inject into the same application classloader
+                                 and duplicate definitions across plugin jars fail with a LinkageError,
+                                 so every consumer must relocate the support classes under its own
+                                 plugin package. -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.navercorp.pinpoint.plugin.reactorsupport</pattern>
+                                    <shadedPattern>com.navercorp.pinpoint.plugin.spring.r2dbc.reactorsupport</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <dependencyReducedPomLocation>
+                                ${project.build.directory}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/SpringDataR2dbcConfiguration.java
+++ b/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/SpringDataR2dbcConfiguration.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.bootstrap.plugin.jdbc.JdbcConfig;
 public class SpringDataR2dbcConfiguration {
 
     private final boolean enabled;
+    private final boolean wrapPublisher;
     private final JdbcConfig mssqlConfig;
     private final JdbcConfig oracleConfig;
     private final JdbcConfig mariadbConfig;
@@ -31,6 +32,9 @@ public class SpringDataR2dbcConfiguration {
 
     public SpringDataR2dbcConfiguration(ProfilerConfig config) {
         this.enabled = config.readBoolean("profiler.spring.data.r2dbc.enable", true);
+        // experimental (PoC): wrap the publisher returned from an I/O seam instead of injecting
+        // the AsyncContext into it. Currently applied to the postgresql Statement.execute() seam only.
+        this.wrapPublisher = config.readBoolean("profiler.spring.data.r2dbc.wrap.publisher", false);
 
         this.mssqlConfig = JdbcConfig.of("mssql", config);
         this.oracleConfig = JdbcConfig.of("oracle", config);
@@ -68,10 +72,15 @@ public class SpringDataR2dbcConfiguration {
         return enabled;
     }
 
+    public boolean isWrapPublisher() {
+        return wrapPublisher;
+    }
+
     @Override
     public String toString() {
         return "SpringDataR2dbcConfiguration{" +
                 "enabled=" + enabled +
+                ", wrapPublisher=" + wrapPublisher +
                 ", mssqlConfig=" + mssqlConfig +
                 ", oracleConfig=" + oracleConfig +
                 ", mariadbConfig=" + mariadbConfig +

--- a/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/SpringDataR2dbcPlugin.java
+++ b/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/SpringDataR2dbcPlugin.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.bootstrap.instrument.matcher.Matchers;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.MatchableTransformTemplate;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.MatchableTransformTemplateAware;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformCallback;
+import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExecutionPolicy;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
@@ -49,6 +50,9 @@ import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.SetDatabaseInfoCon
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.StatementBindInterceptor;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.StatementBindNullInterceptor;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.StatementExecuteInterceptor;
+import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.WrappingConnectionFactoryCreateInterceptor;
+import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.WrappingDefaultFetchSpecInterceptor;
+import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.WrappingStatementExecuteInterceptor;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.h2.H2ConnectionConfigurationConstructorInterceptor;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.h2.H2ConnectionConstructorInterceptor;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.h2.H2ConnectionFactoryConstructorInterceptor;
@@ -67,6 +71,7 @@ import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.mssql.MssqlConnect
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.mssql.MssqlStatementBindInterceptor;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.mssql.MssqlStatementBindNullInterceptor;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.mssql.MssqlStatementExecuteInterceptor;
+import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.mssql.WrappingMssqlStatementExecuteInterceptor;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.mysql.AsyncerInitFlowInitHandshakeInterceptor;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.mysql.AsyncerMySqlStatementConstructorInterceptor;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.mysql.MySqlConnectionConfigurationInterceptor;
@@ -90,6 +95,30 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
     private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
 
     private MatchableTransformTemplate transformTemplate;
+
+    // profiler.spring.data.r2dbc.wrap.publisher selects the wrapping variants, which hand the
+    // AsyncContext to a wrapped publisher instead of injecting it into the returned one.
+    static Class<? extends Interceptor> connectionFactoryCreateInterceptor(Instrumentor instrumentor) {
+        final SpringDataR2dbcConfiguration config = new SpringDataR2dbcConfiguration(instrumentor.getProfilerConfig());
+        if (config.isWrapPublisher()) {
+            return WrappingConnectionFactoryCreateInterceptor.class;
+        }
+        return ConnectionFactoryCreateInterceptor.class;
+    }
+
+    static Class<? extends Interceptor> statementExecuteInterceptor(SpringDataR2dbcConfiguration config) {
+        if (config.isWrapPublisher()) {
+            return WrappingStatementExecuteInterceptor.class;
+        }
+        return StatementExecuteInterceptor.class;
+    }
+
+    static Class<? extends Interceptor> mssqlStatementExecuteInterceptor(SpringDataR2dbcConfiguration config) {
+        if (config.isWrapPublisher()) {
+            return WrappingMssqlStatementExecuteInterceptor.class;
+        }
+        return MssqlStatementExecuteInterceptor.class;
+    }
 
     @Override
     public void setup(ProfilerPluginSetupContext context) {
@@ -232,7 +261,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
             }
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -284,7 +313,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod executeMethod = target.getDeclaredMethod("execute");
             if (executeMethod != null) {
-                executeMethod.addInterceptor(StatementExecuteInterceptor.class, va(postgresqlConfig.getMaxSqlBindValueSize()));
+                executeMethod.addInterceptor(statementExecuteInterceptor(config), va(postgresqlConfig.getMaxSqlBindValueSize()));
             }
 
             return target.toBytecode();
@@ -323,7 +352,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -392,7 +421,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod executeMethod = target.getDeclaredMethod("execute");
             if (executeMethod != null) {
-                executeMethod.addInterceptor(StatementExecuteInterceptor.class, va(h2Config.getMaxSqlBindValueSize()));
+                executeMethod.addInterceptor(statementExecuteInterceptor(config), va(h2Config.getMaxSqlBindValueSize()));
             }
 
             return target.toBytecode();
@@ -430,7 +459,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -482,7 +511,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod executeMethod = target.getDeclaredMethod("execute");
             if (executeMethod != null) {
-                executeMethod.addInterceptor(StatementExecuteInterceptor.class, va(mysqlConfig.getMaxSqlBindValueSize()));
+                executeMethod.addInterceptor(statementExecuteInterceptor(config), va(mysqlConfig.getMaxSqlBindValueSize()));
             }
 
             return target.toBytecode();
@@ -533,7 +562,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -592,7 +621,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod executeMethod = target.getDeclaredMethod("execute");
             if (executeMethod != null) {
-                executeMethod.addInterceptor(StatementExecuteInterceptor.class, va(mysqlConfig.getMaxSqlBindValueSize()));
+                executeMethod.addInterceptor(statementExecuteInterceptor(config), va(mysqlConfig.getMaxSqlBindValueSize()));
             }
 
             return target.toBytecode();
@@ -681,7 +710,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -733,7 +762,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod executeMethod = target.getDeclaredMethod("execute");
             if (executeMethod != null) {
-                executeMethod.addInterceptor(StatementExecuteInterceptor.class, va(mysqlConfig.getMaxSqlBindValueSize()));
+                executeMethod.addInterceptor(statementExecuteInterceptor(config), va(mysqlConfig.getMaxSqlBindValueSize()));
             }
 
             return target.toBytecode();
@@ -770,7 +799,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -820,7 +849,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod executeMethod = target.getDeclaredMethod("execute");
             if (executeMethod != null) {
-                executeMethod.addInterceptor(StatementExecuteInterceptor.class, va(mariadbConfig.getMaxSqlBindValueSize()));
+                executeMethod.addInterceptor(statementExecuteInterceptor(config), va(mariadbConfig.getMaxSqlBindValueSize()));
             }
 
             return target.toBytecode();
@@ -841,7 +870,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -910,7 +939,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod executeMethod = target.getDeclaredMethod("execute");
             if (executeMethod != null) {
-                executeMethod.addInterceptor(StatementExecuteInterceptor.class, va(oracleConfig.getMaxSqlBindValueSize()));
+                executeMethod.addInterceptor(statementExecuteInterceptor(config), va(oracleConfig.getMaxSqlBindValueSize()));
             }
 
             return target.toBytecode();
@@ -951,7 +980,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -1011,7 +1040,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
             // public Publisher<? extends Result> execute()
             final InstrumentMethod executeMethod = target.getDeclaredMethod("execute");
             if (executeMethod != null) {
-                executeMethod.addInterceptor(MssqlStatementExecuteInterceptor.class, va(mssqlConfig.getMaxSqlBindValueSize()));
+                executeMethod.addInterceptor(mssqlStatementExecuteInterceptor(config), va(mssqlConfig.getMaxSqlBindValueSize()));
             }
 
             return target.toBytecode();
@@ -1094,8 +1123,14 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
             target.addField(DatabaseInfoAccessor.class);
             target.addField(AsyncContextAccessor.class);
 
+            final SpringDataR2dbcConfiguration config = new SpringDataR2dbcConfiguration(instrumentor.getProfilerConfig());
             for (InstrumentMethod method : target.getDeclaredMethods(MethodFilters.name("one", "first", "all", "rowsUpdated"))) {
-                method.addScopedInterceptor(DefaultFetchSpecInterceptor.class, "DefaultFetchSpec", ExecutionPolicy.BOUNDARY);
+                if (config.isWrapPublisher()) {
+                    // PoC: wrap the returned row publisher instead of injecting the AsyncContext into it.
+                    method.addScopedInterceptor(WrappingDefaultFetchSpecInterceptor.class, "DefaultFetchSpec", ExecutionPolicy.BOUNDARY);
+                } else {
+                    method.addScopedInterceptor(DefaultFetchSpecInterceptor.class, "DefaultFetchSpec", ExecutionPolicy.BOUNDARY);
+                }
             }
 
             return target.toBytecode();
@@ -1134,7 +1169,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
             }
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -1155,7 +1190,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
             }
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -1176,7 +1211,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
             }
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -1192,7 +1227,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -1207,7 +1242,7 @@ public class SpringDataR2dbcPlugin implements ProfilerPlugin, MatchableTransform
 
             final InstrumentMethod createMethod = target.getDeclaredMethod("create");
             if (createMethod != null) {
-                createMethod.addInterceptor(ConnectionFactoryCreateInterceptor.class);
+                createMethod.addInterceptor(connectionFactoryCreateInterceptor(instrumentor));
             }
 
             return target.toBytecode();

--- a/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/WrappingConnectionFactoryCreateInterceptor.java
+++ b/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/WrappingConnectionFactoryCreateInterceptor.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+import com.navercorp.pinpoint.plugin.spring.r2dbc.SpringDataR2dbcConstants;
+
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link ConnectionFactoryCreateInterceptor} (config-gated by
+ * {@code profiler.spring.data.r2dbc.wrap.publisher}): the connection publisher returned from
+ * {@code ConnectionFactory.create()} is replaced with a wrapped one instead of receiving the
+ * AsyncContext through its injected accessor field.
+ */
+public class WrappingConnectionFactoryCreateInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+
+    public WrappingConnectionFactoryCreateInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(SpringDataR2dbcConstants.SPRING_DATA_R2DBC);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            recorder.recordException(throwable);
+            recorder.recordApi(methodDescriptor);
+
+            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
+                return result;
+            }
+
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+            if (isDebug) {
+                logger.debug("Wrapped connection publisher. asyncContext={}", asyncContext);
+            }
+            return wrapped;
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            return result;
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+}

--- a/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/WrappingDefaultFetchSpecInterceptor.java
+++ b/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/WrappingDefaultFetchSpecInterceptor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+
+/**
+ * Wrapping variant of {@link DefaultFetchSpecInterceptor} (PoC, config-gated by
+ * {@code profiler.spring.data.r2dbc.wrap.publisher}). The original relays the target's
+ * AsyncContext into the returned row publisher's injected field; this variant hands back a
+ * wrapped publisher carrying the same context instead. {@code all()} returns a per-row Flux,
+ * so every row is delivered inside the trace window here.
+ */
+public class WrappingDefaultFetchSpecInterceptor implements ResultReplaceAroundInterceptor {
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null) {
+            return result;
+        }
+        // pure relay, same as the original: no new AsyncContext is created here.
+        final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(target);
+        return SeamPublisherWrapper.wrap(result, asyncContext);
+    }
+}

--- a/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/WrappingStatementExecuteInterceptor.java
+++ b/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/WrappingStatementExecuteInterceptor.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.ParsingResult;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.BindValueAccessor;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.ParsingResultAccessor;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.UnKnownDatabaseInfo;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link StatementExecuteInterceptor} (PoC, config-gated by
+ * {@code profiler.spring.data.r2dbc.wrap.publisher}). Records the same execute span event, but
+ * instead of injecting the {@link AsyncContext} into the returned publisher's accessor field it
+ * replaces the return value with a wrapped publisher that delivers every signal inside the
+ * async trace — no reactor-core field write, no dependency on the reactor plugin's per-operator
+ * relay for this seam.
+ */
+public class WrappingStatementExecuteInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    protected final TraceContext traceContext;
+    protected final MethodDescriptor methodDescriptor;
+    private final int maxSqlBindValueSize;
+
+    public WrappingStatementExecuteInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, int maxSqlBindValueSize) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        this.maxSqlBindValueSize = maxSqlBindValueSize;
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recordStatement(recorder, target);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    // same recording as StatementExecuteInterceptor.doInBeforeTrace
+    private void recordStatement(SpanEventRecorder recorder, Object target) {
+        DatabaseInfo databaseInfo = (target instanceof DatabaseInfoAccessor) ? ((DatabaseInfoAccessor) target)._$PINPOINT$_getDatabaseInfo() : null;
+        if (databaseInfo == null) {
+            databaseInfo = UnKnownDatabaseInfo.INSTANCE;
+        }
+
+        recorder.recordDatabaseInfo(databaseInfo, true);
+
+        ParsingResult parsingResult = null;
+        if (target instanceof ParsingResultAccessor) {
+            parsingResult = ((ParsingResultAccessor) target)._$PINPOINT$_getParsingResult();
+        }
+        Map<Integer, String> bindValue = null;
+        if (target instanceof BindValueAccessor) {
+            bindValue = ((BindValueAccessor) target)._$PINPOINT$_getBindValue();
+        }
+        if (bindValue != null) {
+            String bindString = toBindVariable(bindValue);
+            recorder.recordSqlParsingResult(parsingResult, bindString);
+        } else {
+            recorder.recordSqlParsingResult(parsingResult);
+        }
+        clean(target);
+    }
+
+    private String toBindVariable(Map<Integer, String> bindValue) {
+        return traceContext.getJdbcContext().getBindVariableService().bindVariableToString(bindValue, maxSqlBindValueSize);
+    }
+
+    private void clean(Object target) {
+        if (target instanceof BindValueAccessor) {
+            ((BindValueAccessor) target)._$PINPOINT$_setBindValue(new HashMap<>());
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            recorder.recordException(throwable);
+            recorder.recordApi(methodDescriptor);
+
+            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
+                return result;
+            }
+
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+            if (isDebug) {
+                logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
+            }
+            return wrapped;
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            return result;
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+}

--- a/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/mssql/WrappingMssqlStatementExecuteInterceptor.java
+++ b/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/mssql/WrappingMssqlStatementExecuteInterceptor.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor.mssql;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.ParsingResult;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.BindValueAccessor;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.ParsingResultAccessor;
+import com.navercorp.pinpoint.bootstrap.plugin.jdbc.UnKnownDatabaseInfo;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+import com.navercorp.pinpoint.plugin.spring.r2dbc.BindNameValueAccessor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link MssqlStatementExecuteInterceptor} (config-gated by
+ * {@code profiler.spring.data.r2dbc.wrap.publisher}). See
+ * {@code WrappingStatementExecuteInterceptor} - identical flow with the mssql named-bind variant.
+ */
+public class WrappingMssqlStatementExecuteInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+    private final int maxSqlBindValueSize;
+
+    public WrappingMssqlStatementExecuteInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, int maxSqlBindValueSize) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        this.maxSqlBindValueSize = maxSqlBindValueSize;
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recordStatement(recorder, target);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    // same recording as MssqlStatementExecuteInterceptor.doInBeforeTrace
+    private void recordStatement(SpanEventRecorder recorder, Object target) {
+        DatabaseInfo databaseInfo = (target instanceof DatabaseInfoAccessor) ? ((DatabaseInfoAccessor) target)._$PINPOINT$_getDatabaseInfo() : null;
+        if (databaseInfo == null) {
+            databaseInfo = UnKnownDatabaseInfo.INSTANCE;
+        }
+
+        recorder.recordDatabaseInfo(databaseInfo, true);
+
+        ParsingResult parsingResult = null;
+        if (target instanceof ParsingResultAccessor) {
+            parsingResult = ((ParsingResultAccessor) target)._$PINPOINT$_getParsingResult();
+        }
+        Map<String, String> bindValue = null;
+        if (target instanceof BindNameValueAccessor) {
+            bindValue = ((BindNameValueAccessor) target)._$PINPOINT$_getBindValue();
+        }
+        if (bindValue != null) {
+            String bindString = toBindVariable(bindValue);
+            recorder.recordSqlParsingResult(parsingResult, bindString);
+        } else {
+            recorder.recordSqlParsingResult(parsingResult);
+        }
+        clean(target);
+    }
+
+    private String toBindVariable(Map<String, String> bindValue) {
+        return traceContext.getJdbcContext().getBindVariableService().bindNameVariableToString(bindValue, maxSqlBindValueSize);
+    }
+
+    private void clean(Object target) {
+        if (target instanceof BindValueAccessor) {
+            ((BindValueAccessor) target)._$PINPOINT$_setBindValue(new HashMap<>());
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            recorder.recordException(throwable);
+            recorder.recordApi(methodDescriptor);
+
+            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
+                return result;
+            }
+
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+            if (isDebug) {
+                logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
+            }
+            return wrapped;
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            return result;
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+}

--- a/agent-module/plugins/spring-tx/pom.xml
+++ b/agent-module/plugins/spring-tx/pom.xml
@@ -18,5 +18,58 @@
             <artifactId>pinpoint-bootstrap-core</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-reactor-seam-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${plugin.shade.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.navercorp.pinpoint:pinpoint-reactor-seam-support</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>com.navercorp.pinpoint:pinpoint-reactor-seam-support</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <!-- reactor-family plugins inject into the same application classloader
+                                 and duplicate definitions across plugin jars fail with a LinkageError,
+                                 so every consumer must relocate the support classes under its own
+                                 plugin package. -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.navercorp.pinpoint.plugin.reactorsupport</pattern>
+                                    <shadedPattern>com.navercorp.pinpoint.plugin.spring.tx.reactorsupport</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <dependencyReducedPomLocation>
+                                ${project.build.directory}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/agent-module/plugins/spring-tx/src/main/java/com/navercorp/pinpoint/plugin/spring/tx/SpringTxConfig.java
+++ b/agent-module/plugins/spring-tx/src/main/java/com/navercorp/pinpoint/plugin/spring/tx/SpringTxConfig.java
@@ -21,10 +21,16 @@ import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 public class SpringTxConfig {
     private final boolean enabled;
     private final boolean markError;
+    private final boolean wrapPublisher;
 
     public SpringTxConfig(ProfilerConfig config) {
         this.enabled = config.readBoolean("profiler.spring.tx.enable", true);
         this.markError = config.readBoolean("profiler.spring.tx.mark.error", false);
+        this.wrapPublisher = config.readBoolean("profiler.spring.tx.wrap.publisher", false);
+    }
+
+    public boolean isWrapPublisher() {
+        return wrapPublisher;
     }
 
     public boolean isEnabled() {
@@ -40,6 +46,7 @@ public class SpringTxConfig {
         return "SpringTxConfig{" +
                 "enabled=" + enabled +
                 ", markError=" + markError +
+                ", wrapPublisher=" + wrapPublisher +
                 '}';
     }
 }

--- a/agent-module/plugins/spring-tx/src/main/java/com/navercorp/pinpoint/plugin/spring/tx/SpringTxPlugin.java
+++ b/agent-module/plugins/spring-tx/src/main/java/com/navercorp/pinpoint/plugin/spring/tx/SpringTxPlugin.java
@@ -23,12 +23,14 @@ import com.navercorp.pinpoint.bootstrap.instrument.Instrumentor;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.MatchableTransformTemplate;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.MatchableTransformTemplateAware;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformCallback;
+import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
 import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
 import com.navercorp.pinpoint.plugin.spring.tx.interceptor.ReactiveTransactionSupportInterceptor;
 import com.navercorp.pinpoint.plugin.spring.tx.interceptor.TransactionAspectSupportInterceptor;
+import com.navercorp.pinpoint.plugin.spring.tx.interceptor.WrappingReactiveTransactionSupportInterceptor;
 
 import java.security.ProtectionDomain;
 
@@ -37,6 +39,16 @@ public class SpringTxPlugin implements ProfilerPlugin, MatchableTransformTemplat
     private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
 
     private MatchableTransformTemplate transformTemplate;
+
+    // profiler.spring.tx.wrap.publisher selects the wrapping variant, which hands the
+    // AsyncContext to a wrapped publisher instead of injecting it into the returned one.
+    static Class<? extends Interceptor> reactiveTransactionSupportInterceptor(Instrumentor instrumentor) {
+        final SpringTxConfig config = new SpringTxConfig(instrumentor.getProfilerConfig());
+        if (config.isWrapPublisher()) {
+            return WrappingReactiveTransactionSupportInterceptor.class;
+        }
+        return ReactiveTransactionSupportInterceptor.class;
+    }
 
     @Override
     public void setup(ProfilerPluginSetupContext context) {
@@ -80,7 +92,7 @@ public class SpringTxPlugin implements ProfilerPlugin, MatchableTransformTemplat
 
             final InstrumentMethod invokeWithinTransactionMethod = target.getDeclaredMethod("invokeWithinTransaction", "java.lang.reflect.Method", "java.lang.Class", "org.springframework.transaction.interceptor.TransactionAspectSupport$InvocationCallback", "org.springframework.transaction.interceptor.TransactionAttribute", "org.springframework.transaction.ReactiveTransactionManager");
             if (invokeWithinTransactionMethod != null) {
-                invokeWithinTransactionMethod.addInterceptor(ReactiveTransactionSupportInterceptor.class);
+                invokeWithinTransactionMethod.addInterceptor(reactiveTransactionSupportInterceptor(instrumentor));
             }
 
             return target.toBytecode();

--- a/agent-module/plugins/spring-tx/src/main/java/com/navercorp/pinpoint/plugin/spring/tx/interceptor/WrappingReactiveTransactionSupportInterceptor.java
+++ b/agent-module/plugins/spring-tx/src/main/java/com/navercorp/pinpoint/plugin/spring/tx/interceptor/WrappingReactiveTransactionSupportInterceptor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.spring.tx.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+import com.navercorp.pinpoint.plugin.spring.tx.SpringTxConfig;
+import com.navercorp.pinpoint.plugin.spring.tx.SpringTxConstants;
+
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link ReactiveTransactionSupportInterceptor} (config-gated by
+ * {@code profiler.spring.tx.wrap.publisher}). A reactor Mono/Flux result is replaced with a
+ * wrapped one instead of relying on the accessor field the reactor plugin injects into
+ * reactor.core.publisher types; any other async result keeps the original injection.
+ */
+public class WrappingReactiveTransactionSupportInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+    private final boolean markError;
+
+    public WrappingReactiveTransactionSupportInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        final SpringTxConfig config = new SpringTxConfig(traceContext.getProfilerConfig());
+        this.markError = config.isMarkError();
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(SpringTxConstants.SPRING_TX);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            recorder.recordException(markError, throwable);
+            recorder.recordApi(methodDescriptor);
+
+            if (throwable != null) {
+                return result;
+            }
+
+            if (SeamPublisherWrapper.isWrappable(result)) {
+                final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+                final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+                if (isDebug) {
+                    logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
+                }
+                return wrapped;
+            }
+            // non-reactor async result: keep the original injection.
+            if (result instanceof AsyncContextAccessor) {
+                final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+                ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
+            }
+            return result;
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            return result;
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+}

--- a/agent-module/plugins/spring-webflux/pom.xml
+++ b/agent-module/plugins/spring-webflux/pom.xml
@@ -28,6 +28,12 @@
 
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-reactor-seam-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-spring-stub</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -68,6 +74,48 @@
                         <include>META-INF/**/*</include>
                     </includes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${plugin.shade.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.navercorp.pinpoint:pinpoint-reactor-seam-support</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>com.navercorp.pinpoint:pinpoint-reactor-seam-support</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <!-- reactor-family plugins inject into the same application classloader
+                                 and duplicate definitions across plugin jars fail with a LinkageError,
+                                 so every consumer must relocate the support classes under its own
+                                 plugin package. -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.navercorp.pinpoint.plugin.reactorsupport</pattern>
+                                    <shadedPattern>com.navercorp.pinpoint.plugin.spring.webflux.reactorsupport</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <dependencyReducedPomLocation>
+                                ${project.build.directory}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringWebFluxPlugin.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringWebFluxPlugin.java
@@ -29,6 +29,7 @@ import com.navercorp.pinpoint.bootstrap.instrument.transformer.MatchableTransfor
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.MatchableTransformTemplateAware;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformCallback;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformCallbackParametersBuilder;
+import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
 import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPlugin;
@@ -47,6 +48,11 @@ import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.DispatchHandlerG
 import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.DispatchHandlerHandleMethodInterceptor;
 import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.DispatchHandlerInvokeHandlerMethodInterceptor;
 import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.ExchangeFunctionMethodInterceptor;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.WrappingBodyInserterRequestBuilderWriteToInterceptor;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.WrappingDefaultWebClientExchangeMethodInterceptor;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.WrappingDispatchHandlerInvokeHandlerMethodInterceptor;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.WrappingDispatchHandlerHandleMethodInterceptor;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.WrappingExchangeFunctionMethodInterceptor;
 import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.InvocableHandlerMethodInterceptor;
 
 import java.security.ProtectionDomain;
@@ -59,6 +65,47 @@ import static com.navercorp.pinpoint.common.util.VarArgs.va;
 public class SpringWebFluxPlugin implements ProfilerPlugin, MatchableTransformTemplateAware {
     private final PluginLogger logger = PluginLogManager.getLogger(getClass());
     private MatchableTransformTemplate transformTemplate;
+
+    // profiler.spring.webflux.wrap.publisher selects the wrapping variants, which hand the
+    // AsyncContext to a wrapped publisher instead of injecting it into the returned one.
+    static Class<? extends Interceptor> dispatchHandlerHandleMethodInterceptor(Instrumentor instrumentor) {
+        if (isWrapPublisher(instrumentor)) {
+            return WrappingDispatchHandlerHandleMethodInterceptor.class;
+        }
+        return DispatchHandlerHandleMethodInterceptor.class;
+    }
+
+    static Class<? extends Interceptor> defaultWebClientExchangeMethodInterceptor(Instrumentor instrumentor) {
+        if (isWrapPublisher(instrumentor)) {
+            return WrappingDefaultWebClientExchangeMethodInterceptor.class;
+        }
+        return DefaultWebClientExchangeMethodInterceptor.class;
+    }
+
+    static Class<? extends Interceptor> exchangeFunctionMethodInterceptor(Instrumentor instrumentor) {
+        if (isWrapPublisher(instrumentor)) {
+            return WrappingExchangeFunctionMethodInterceptor.class;
+        }
+        return ExchangeFunctionMethodInterceptor.class;
+    }
+
+    static Class<? extends Interceptor> dispatchHandlerInvokeHandlerMethodInterceptor(Instrumentor instrumentor) {
+        if (isWrapPublisher(instrumentor)) {
+            return WrappingDispatchHandlerInvokeHandlerMethodInterceptor.class;
+        }
+        return DispatchHandlerInvokeHandlerMethodInterceptor.class;
+    }
+
+    static Class<? extends Interceptor> bodyInserterRequestBuilderWriteToInterceptor(Instrumentor instrumentor) {
+        if (isWrapPublisher(instrumentor)) {
+            return WrappingBodyInserterRequestBuilderWriteToInterceptor.class;
+        }
+        return BodyInserterRequestBuilderWriteToInterceptor.class;
+    }
+
+    private static boolean isWrapPublisher(Instrumentor instrumentor) {
+        return new SpringWebFluxPluginConfig(instrumentor.getProfilerConfig()).isWrapPublisher();
+    }
 
     @Override
     public void setup(ProfilerPluginSetupContext context) {
@@ -141,27 +188,27 @@ public class SpringWebFluxPlugin implements ProfilerPlugin, MatchableTransformTe
             // Dispatch
             final InstrumentMethod handleMethod = target.getDeclaredMethod("handle", "org.springframework.web.server.ServerWebExchange");
             if (handleMethod != null) {
-                handleMethod.addInterceptor(DispatchHandlerHandleMethodInterceptor.class);
+                handleMethod.addInterceptor(dispatchHandlerHandleMethodInterceptor(instrumentor));
             }
             // Invoke
             final InstrumentMethod invokerHandlerMethod = target.getDeclaredMethod("invokeHandler", "org.springframework.web.server.ServerWebExchange", "java.lang.Object");
             if (invokerHandlerMethod != null) {
-                invokerHandlerMethod.addInterceptor(DispatchHandlerInvokeHandlerMethodInterceptor.class, va(this.uriStatEnable, Boolean.FALSE));
+                invokerHandlerMethod.addInterceptor(dispatchHandlerInvokeHandlerMethodInterceptor(instrumentor), va(this.uriStatEnable, Boolean.FALSE));
             }
             // 6.x, 7.x
             final InstrumentMethod handleRequestWithMethod = target.getDeclaredMethod("handleRequestWith", "org.springframework.web.server.ServerWebExchange", "java.lang.Object");
             if (handleRequestWithMethod != null) {
-                handleRequestWithMethod.addInterceptor(DispatchHandlerInvokeHandlerMethodInterceptor.class, va(this.uriStatEnable, Boolean.FALSE));
+                handleRequestWithMethod.addInterceptor(dispatchHandlerInvokeHandlerMethodInterceptor(instrumentor), va(this.uriStatEnable, Boolean.FALSE));
             }
             // Result
             final InstrumentMethod handleResultMethod = target.getDeclaredMethod("handleResult", "org.springframework.web.server.ServerWebExchange", "org.springframework.web.reactive.HandlerResult");
             if (handleResultMethod != null) {
-                handleResultMethod.addInterceptor(DispatchHandlerInvokeHandlerMethodInterceptor.class, va(this.uriStatEnable, this.uriStatUseUserInput));
+                handleResultMethod.addInterceptor(dispatchHandlerInvokeHandlerMethodInterceptor(instrumentor), va(this.uriStatEnable, this.uriStatUseUserInput));
             }
             // 6.x, 7.x
             final InstrumentMethod handleResultMethod2 = target.getDeclaredMethod("handleResult", "org.springframework.web.server.ServerWebExchange", "org.springframework.web.reactive.HandlerResult", "java.lang.String");
             if (handleResultMethod2 != null) {
-                handleResultMethod2.addInterceptor(DispatchHandlerInvokeHandlerMethodInterceptor.class, va(this.uriStatEnable, this.uriStatUseUserInput));
+                handleResultMethod2.addInterceptor(dispatchHandlerInvokeHandlerMethodInterceptor(instrumentor), va(this.uriStatEnable, this.uriStatUseUserInput));
             }
 
             return target.toBytecode();
@@ -217,7 +264,7 @@ public class SpringWebFluxPlugin implements ProfilerPlugin, MatchableTransformTe
             // Set AsyncContext
             final InstrumentMethod exchangeMethod = target.getDeclaredMethod("exchange");
             if (exchangeMethod != null) {
-                exchangeMethod.addInterceptor(DefaultWebClientExchangeMethodInterceptor.class);
+                exchangeMethod.addInterceptor(defaultWebClientExchangeMethodInterceptor(instrumentor));
             }
 
             return target.toBytecode();
@@ -231,7 +278,7 @@ public class SpringWebFluxPlugin implements ProfilerPlugin, MatchableTransformTe
             // Set AsyncContext
             final InstrumentMethod exchangeMethod = target.getDeclaredMethod("exchange", "org.springframework.web.reactive.function.client.ClientRequest");
             if (exchangeMethod != null) {
-                exchangeMethod.addInterceptor(ExchangeFunctionMethodInterceptor.class);
+                exchangeMethod.addInterceptor(exchangeFunctionMethodInterceptor(instrumentor));
             }
 
             final InstrumentMethod logResponseMethod = target.getDeclaredMethod("logResponse", "org.springframework.http.client.reactive.ClientHttpResponse", "java.lang.String");
@@ -253,7 +300,7 @@ public class SpringWebFluxPlugin implements ProfilerPlugin, MatchableTransformTe
             // RPC
             final InstrumentMethod method = target.getDeclaredMethod("writeTo", "org.springframework.http.client.reactive.ClientHttpRequest", "org.springframework.web.reactive.function.client.ExchangeStrategies");
             if (method != null) {
-                method.addInterceptor(BodyInserterRequestBuilderWriteToInterceptor.class);
+                method.addInterceptor(bodyInserterRequestBuilderWriteToInterceptor(instrumentor));
             }
 
             return target.toBytecode();

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringWebFluxPluginConfig.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringWebFluxPluginConfig.java
@@ -34,6 +34,7 @@ public class SpringWebFluxPluginConfig {
     private final boolean uriStatEnable;
     private final boolean uriStatUseUserInput;
     private final boolean uriStatCollectMethod;
+    private final boolean wrapPublisher;
     public SpringWebFluxPluginConfig(ProfilerConfig config) {
         Objects.requireNonNull(config, "config");
 
@@ -50,6 +51,11 @@ public class SpringWebFluxPluginConfig {
         this.uriStatEnable = config.readBoolean("profiler.uri.stat.spring.webflux.enable", false);
         this.uriStatUseUserInput = config.readBoolean("profiler.uri.stat.spring.webflux.useuserinput", false);
         this.uriStatCollectMethod = config.readBoolean("profiler.uri.stat.collect.http.method", false);
+        this.wrapPublisher = config.readBoolean("profiler.spring.webflux.wrap.publisher", false);
+    }
+
+    public boolean isWrapPublisher() {
+        return wrapPublisher;
     }
 
     public boolean isEnable() {
@@ -88,6 +94,7 @@ public class SpringWebFluxPluginConfig {
         sb.append(", httpDumpConfig=").append(httpDumpConfig);
         sb.append(", uriStatEnable=").append(uriStatEnable);
         sb.append(", uriStatUseUserInput=").append(uriStatUseUserInput);
+        sb.append(", wrapPublisher=").append(wrapPublisher);
         sb.append('}');
         return sb.toString();
     }

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingBodyInserterRequestBuilderWriteToInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingBodyInserterRequestBuilderWriteToInterceptor.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.context.TraceId;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapperAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.DefaultRequestTraceWriter;
+import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
+import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieRecorder;
+import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieRecorderFactory;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+import com.navercorp.pinpoint.common.util.ArrayArgumentUtils;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxConstants;
+import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxPluginConfig;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link BodyInserterRequestBuilderWriteToInterceptor} (config-gated by
+ * {@code profiler.spring.webflux.wrap.publisher}). The returned publisher is replaced with a
+ * wrapped one instead of receiving the next AsyncContext through its injected accessor field.
+ * The original passes its conditionally-begun TraceBlock from before() to after() through the
+ * weaver; a result-replace interceptor has no such channel, so the state travels on a
+ * per-thread frame stack (writeTo runs synchronously, so before/after pair up on one thread).
+ * <p>
+ * The pairing is structural: before() pushes EXACTLY one frame on every invocation — including
+ * early returns and failures — and after() polls exactly one, so a frame can never be claimed by
+ * the wrong (e.g. an outer recursive) invocation. after() operates on the trace the frame
+ * carries, never on the ambient thread-local, so a lost or foreign binding cannot mispair the
+ * cleanup either.
+ */
+public class WrappingBodyInserterRequestBuilderWriteToInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    // one entry per before() invocation; EMPTY marks "my before() did nothing to undo".
+    static final class Frame {
+        static final Frame EMPTY = new Frame();
+        AsyncContext asyncContext;
+        Trace trace;
+        boolean begun;
+    }
+
+    private static final ThreadLocal<Deque<Frame>> FRAMES = new ThreadLocal<Deque<Frame>>() {
+        @Override
+        protected Deque<Frame> initialValue() {
+            return new ArrayDeque<>();
+        }
+    };
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+    private final ClientRequestRecorder<ClientRequestWrapper> clientRequestRecorder;
+    private final CookieRecorder<ClientHttpRequest> cookieRecorder;
+    private final RequestTraceWriter<ClientHttpRequest> requestTraceWriter;
+
+    public WrappingBodyInserterRequestBuilderWriteToInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+
+        final SpringWebFluxPluginConfig config = new SpringWebFluxPluginConfig(traceContext.getProfilerConfig());
+        final ClientRequestAdaptor<ClientRequestWrapper> clientRequestAdaptor = ClientRequestWrapperAdaptor.INSTANCE;
+        this.clientRequestRecorder = new ClientRequestRecorder<>(config.isParam(), clientRequestAdaptor);
+
+        final CookieExtractor<ClientHttpRequest> cookieExtractor = new ClientHttpRequestCookieExtractor();
+        this.cookieRecorder = CookieRecorderFactory.newCookieRecorder(config.getHttpDumpConfig(), cookieExtractor);
+
+        final ClientHttpRequestClientHeaderAdaptor clientHeaderAdaptor = new ClientHttpRequestClientHeaderAdaptor();
+        this.requestTraceWriter = new DefaultRequestTraceWriter<>(clientHeaderAdaptor, traceContext);
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        Frame frame = Frame.EMPTY;
+        try {
+            final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(target);
+            if (asyncContext == null) {
+                return;
+            }
+            final Trace trace = asyncContext.continueAsyncTraceObject(true);
+            if (trace == null) {
+                return;
+            }
+
+            ScopeUtils.entryAsyncTraceScope(trace);
+            // the frame records exactly how far this invocation got, so after() unwinds no more
+            // and no less than what actually happened.
+            frame = new Frame();
+            frame.asyncContext = asyncContext;
+            frame.trace = trace;
+
+            if (checkBeforeTraceBlockBegin(trace, args)) {
+                final SpanEventRecorder recorder = trace.traceBlockBegin();
+                frame.begun = true;
+
+                final ClientHttpRequest request = ArrayArgumentUtils.getArgument(args, 0, ClientHttpRequest.class);
+                final TraceId nextId = trace.getTraceId().getNextTraceId();
+                recorder.recordNextSpanId(nextId.getSpanId());
+                final ClientRequestWrapper clientRequestWrapper = new WebClientRequestWrapper(request);
+                requestTraceWriter.write(request, nextId, clientRequestWrapper.getDestinationId());
+
+                recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX_CLIENT);
+            }
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        } finally {
+            // structural pairing: EVERY before() pushes exactly one frame - early returns and
+            // failures push EMPTY - so after() can never claim another invocation's frame.
+            FRAMES.get().push(frame);
+        }
+    }
+
+    // same gate as BodyInserterRequestBuilderWriteToInterceptor.checkBeforeTraceBlockBegin
+    private boolean checkBeforeTraceBlockBegin(Trace trace, Object[] args) {
+        final ClientHttpRequest request = ArrayArgumentUtils.getArgument(args, 0, ClientHttpRequest.class);
+        if (request == null) {
+            return false;
+        }
+
+        if (requestTraceWriter.isNested(request)) {
+            return false;
+        }
+
+        if (Boolean.FALSE == trace.canSampled()) {
+            requestTraceWriter.write(request);
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Deque<Frame> frames = FRAMES.get();
+        final Frame frame = frames.poll();
+        if (frames.isEmpty()) {
+            // do not leave an empty deque parked on every pooled thread.
+            FRAMES.remove();
+        }
+        if (frame == null || frame.trace == null) {
+            // frame == null: no paired before() ran (defensive); EMPTY: before() did nothing.
+            return result;
+        }
+        // unwind exactly what the paired before() recorded - never the ambient thread-local,
+        // which may belong to an outer invocation or have been unbound in between.
+        final AsyncContext asyncContext = frame.asyncContext;
+        final Trace trace = frame.trace;
+        final boolean begun = frame.begun;
+
+        if (!ScopeUtils.leaveAsyncTraceScope(trace)) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to leave scope of async trace {}.", trace);
+            }
+            deleteAsyncContext(trace, asyncContext);
+            return result;
+        }
+
+        Object ret = result;
+        try {
+            if (begun) {
+                final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+                recorder.recordApi(methodDescriptor);
+                recorder.recordException(throwable);
+
+                final ClientHttpRequest request = ArrayArgumentUtils.getArgument(args, 0, ClientHttpRequest.class);
+                final ClientRequestWrapper clientRequestWrapper = new WebClientRequestWrapper(request);
+                this.clientRequestRecorder.record(recorder, clientRequestWrapper, throwable);
+                this.cookieRecorder.record(recorder, request, throwable);
+
+                if (throwable == null && SeamPublisherWrapper.isWrappable(result)) {
+                    // make asynchronous trace-id
+                    final AsyncContext nextAsyncContext = recorder.recordNextAsyncContext();
+                    ret = SeamPublisherWrapper.wrap(result, nextAsyncContext);
+                    if (isDebug) {
+                        logger.debug("Wrapped result publisher. asyncContext={}", nextAsyncContext);
+                    }
+                }
+            }
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            ret = result;
+        } finally {
+            if (begun) {
+                trace.traceBlockEnd();
+            }
+            if (ScopeUtils.isAsyncTraceEndScope(trace)) {
+                deleteAsyncContext(trace, asyncContext);
+            }
+        }
+        return ret;
+    }
+
+    private void deleteAsyncContext(Trace trace, AsyncContext asyncContext) {
+        if (isDebug) {
+            logger.debug("Delete async trace {}.", trace);
+        }
+        trace.close();
+        asyncContext.close();
+    }
+}

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDefaultWebClientExchangeMethodInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDefaultWebClientExchangeMethodInterceptor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxConstants;
+
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link DefaultWebClientExchangeMethodInterceptor} (config-gated by
+ * {@code profiler.spring.webflux.wrap.publisher}): the returned response publisher is replaced
+ * with a wrapped one instead of receiving the AsyncContext through its injected accessor field.
+ * As in the original, the next AsyncContext is recorded even for unsampled traces.
+ */
+public class WrappingDefaultWebClientExchangeMethodInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+
+    public WrappingDefaultWebClientExchangeMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final Trace trace = traceContext.currentRawTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Trace trace = traceContext.currentRawTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            if (trace.canSampled()) {
+                recorder.recordApi(methodDescriptor);
+                recorder.recordException(throwable);
+            }
+
+            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
+                return result;
+            }
+
+            // make asynchronous trace-id
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+            if (isDebug) {
+                logger.debug("Wrapped response publisher. asyncContext={}", asyncContext);
+            }
+            return wrapped;
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            return result;
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+}

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDispatchHandlerHandleMethodInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDispatchHandlerHandleMethodInterceptor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxConstants;
+
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link DispatchHandlerHandleMethodInterceptor} (config-gated by
+ * {@code profiler.spring.webflux.wrap.publisher}). The exchange (args[0]) still receives the
+ * AsyncContext through its injected accessor field - downstream interceptors read it from
+ * there - but the returned publisher is replaced with a wrapped one instead of being injected.
+ */
+public class WrappingDispatchHandlerHandleMethodInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+
+    public WrappingDispatchHandlerHandleMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final Trace trace = traceContext.currentRawTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
+            if (args != null && args.length > 0 && args[0] instanceof AsyncContextAccessor) {
+                // make asynchronous trace-id
+                final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+                ((AsyncContextAccessor) args[0])._$PINPOINT$_setAsyncContext(asyncContext);
+                if (isDebug) {
+                    logger.debug("Set AsyncContext {}", asyncContext);
+                }
+            }
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Trace trace = traceContext.currentRawTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            recorder.recordApi(methodDescriptor);
+            recorder.recordException(throwable);
+
+            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
+                return result;
+            }
+
+            final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 0);
+            if (asyncContext == null) {
+                return result;
+            }
+            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+            if (isDebug) {
+                logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
+            }
+            return wrapped;
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            return result;
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+}

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDispatchHandlerInvokeHandlerMethodInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDispatchHandlerInvokeHandlerMethodInterceptor.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.SpanRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+import com.navercorp.pinpoint.common.util.ArrayArgumentUtils;
+import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxConstants;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.pattern.PathPattern;
+
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link DispatchHandlerInvokeHandlerMethodInterceptor} (config-gated by
+ * {@code profiler.spring.webflux.wrap.publisher}). The span event still runs inside the async
+ * trace continued from the exchange's AsyncContext, but the returned publisher is replaced with
+ * a wrapped one (carrying the same context) instead of being injected.
+ */
+public class WrappingDispatchHandlerInvokeHandlerMethodInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+    private final Boolean uriStatEnable;
+    private final Boolean uriStatUseUserInput;
+
+    public WrappingDispatchHandlerInvokeHandlerMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, Boolean uriStatEnable, Boolean uriStatUseUserInput) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        this.uriStatEnable = uriStatEnable;
+        this.uriStatUseUserInput = uriStatUseUserInput;
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 0);
+        if (asyncContext == null) {
+            return;
+        }
+        final Trace trace = asyncContext.continueAsyncTraceObject(true);
+        if (trace == null) {
+            return;
+        }
+
+        ScopeUtils.entryAsyncTraceScope(trace);
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
+            if (uriStatEnable) {
+                recordUriTemplate(args);
+            }
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    // same recording as DispatchHandlerInvokeHandlerMethodInterceptor.doInBeforeTrace
+    private void recordUriTemplate(Object[] args) {
+        final Trace trace = traceContext.currentRawTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        final ServerWebExchange exchange = ArrayArgumentUtils.getArgument(args, 0, ServerWebExchange.class);
+        if (exchange != null) {
+            String uriTemplate = "";
+
+            if (uriStatUseUserInput) {
+                for (String attributeName : SpringWebFluxConstants.SPRING_WEBFLUX_URI_USER_INPUT_ATTRIBUTE_KEYS) {
+                    final Object uriMapping = exchange.getAttribute(attributeName);
+                    if (!(uriMapping instanceof String)) {
+                        continue;
+                    }
+                    uriTemplate = (String) uriMapping;
+                }
+            }
+            if (!StringUtils.hasLength(uriTemplate)) {
+                for (String attributeName : SpringWebFluxConstants.SPRING_WEBFLUX_DEFAULT_URI_ATTRIBUTE_KEYS) {
+                    final Object uriMapping = exchange.getAttribute(attributeName);
+                    if (!(uriMapping instanceof PathPattern)) {
+                        continue;
+                    }
+                    uriTemplate = ((PathPattern) uriMapping).getPatternString();
+                }
+            }
+
+            if (StringUtils.hasLength(uriTemplate)) {
+                final SpanRecorder spanRecorder = trace.getSpanRecorder();
+                spanRecorder.recordUriTemplate(uriTemplate, true);
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 0);
+        if (asyncContext == null) {
+            return result;
+        }
+        final Trace trace = asyncContext.currentAsyncTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        if (!ScopeUtils.leaveAsyncTraceScope(trace)) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to leave scope of async trace {}.", trace);
+            }
+            deleteAsyncContext(trace, asyncContext);
+            return result;
+        }
+
+        Object ret = result;
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            recorder.recordApi(methodDescriptor);
+            recorder.recordException(throwable);
+
+            if (throwable == null && SeamPublisherWrapper.isWrappable(result)) {
+                // hand the exchange's AsyncContext to the wrapped publisher.
+                ret = SeamPublisherWrapper.wrap(result, asyncContext);
+                if (isDebug) {
+                    logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
+                }
+            }
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            ret = result;
+        } finally {
+            trace.traceBlockEnd();
+            if (ScopeUtils.isAsyncTraceEndScope(trace)) {
+                deleteAsyncContext(trace, asyncContext);
+            }
+        }
+        return ret;
+    }
+
+    private void deleteAsyncContext(Trace trace, AsyncContext asyncContext) {
+        if (isDebug) {
+            logger.debug("Delete async trace {}.", trace);
+        }
+        trace.close();
+        asyncContext.close();
+    }
+}

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingExchangeFunctionMethodInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingExchangeFunctionMethodInterceptor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxConstants;
+
+import java.util.Objects;
+
+/**
+ * Wrapping variant of {@link ExchangeFunctionMethodInterceptor} (config-gated by
+ * {@code profiler.spring.webflux.wrap.publisher}). The request (args[0]) still receives the
+ * AsyncContext through its injected accessor field, but the returned response publisher is
+ * replaced with a wrapped one instead of being injected.
+ */
+public class WrappingExchangeFunctionMethodInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+
+    public WrappingExchangeFunctionMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final Trace trace = traceContext.currentRawTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
+            if (args != null && args.length > 0 && args[0] instanceof AsyncContextAccessor) {
+                // make asynchronous trace-id
+                final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+                ((AsyncContextAccessor) args[0])._$PINPOINT$_setAsyncContext(asyncContext);
+                if (isDebug) {
+                    logger.debug("Set closeable-AsyncContext {}", asyncContext);
+                }
+            }
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Trace trace = traceContext.currentRawTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            recorder.recordApi(methodDescriptor);
+            recorder.recordException(throwable);
+
+            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
+                return result;
+            }
+
+            final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 0);
+            if (asyncContext == null) {
+                return result;
+            }
+            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+            if (isDebug) {
+                logger.debug("Wrapped response publisher. asyncContext={}", asyncContext);
+            }
+            return wrapped;
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            return result;
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+}

--- a/agent-module/plugins/spring-webflux/src/test/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingBodyInserterRequestBuilderWriteToInterceptorTest.java
+++ b/agent-module/plugins/spring-webflux/src/test/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingBodyInserterRequestBuilderWriteToInterceptorTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Frame-stack pairing of the wrapping BodyInserter interceptor (W4): every before() pushes
+ * exactly one frame — early return and failure push EMPTY — and after() polls exactly one and
+ * unwinds only what its own paired before() recorded. The cases that used to mispair under the
+ * old boolean stack (an inner no-op invocation stealing the outer frame; a before() failure
+ * leaving a stale flag) are pinned here.
+ */
+public class WrappingBodyInserterRequestBuilderWriteToInterceptorTest {
+
+    private static final Object[] NO_REQUEST_ARGS = new Object[]{null};
+
+    private WrappingBodyInserterRequestBuilderWriteToInterceptor interceptor;
+    private AsyncContext outerContext;
+    private Trace outerTrace;
+    private TraceScope outerScope;
+
+    @BeforeEach
+    public void setUp() {
+        final ProfilerConfig profilerConfig = mock(ProfilerConfig.class);
+        when(profilerConfig.readBoolean(anyString(), anyBoolean())).thenAnswer(inv -> inv.getArgument(1));
+        when(profilerConfig.readInt(anyString(), anyInt())).thenAnswer(inv -> inv.getArgument(1));
+        when(profilerConfig.readString(anyString())).thenReturn("ALWAYS");
+        when(profilerConfig.readString(anyString(), anyString())).thenAnswer(inv -> inv.getArgument(1));
+
+        final TraceContext traceContext = mock(TraceContext.class);
+        when(traceContext.getProfilerConfig()).thenReturn(profilerConfig);
+        // DefaultRequestTraceWriter requires the identity fields at construction.
+        when(traceContext.getApplicationName()).thenReturn("test-app");
+        when(traceContext.getAgentId()).thenReturn("test-agent");
+        interceptor = new WrappingBodyInserterRequestBuilderWriteToInterceptor(traceContext, mock(MethodDescriptor.class));
+
+        outerContext = mock(AsyncContext.class);
+        outerTrace = mock(Trace.class);
+        outerScope = mock(TraceScope.class);
+        when(outerContext.continueAsyncTraceObject(true)).thenReturn(outerTrace);
+        when(outerTrace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(outerScope);
+        when(outerTrace.isAsync()).thenReturn(true);
+        when(outerScope.tryEnter()).thenReturn(true);
+        when(outerScope.canLeave()).thenReturn(true);
+        when(outerScope.isActive()).thenReturn(false);
+    }
+
+    private static Object accessorTarget(AsyncContext asyncContext) {
+        final MockAccessor target = new MockAccessor();
+        target._$PINPOINT$_setAsyncContext(asyncContext);
+        return target;
+    }
+
+    @Test
+    public void innerNoopInvocation_cannotStealOuterFrame() {
+        final Object outerTarget = accessorTarget(outerContext);
+        final Object innerTarget = new MockAccessor(); // no context: inner before() is a no-op
+
+        interceptor.before(outerTarget, Object.class, NO_REQUEST_ARGS);   // pushes real frame
+        interceptor.before(innerTarget, Object.class, NO_REQUEST_ARGS);   // pushes EMPTY
+        interceptor.after(innerTarget, Object.class, NO_REQUEST_ARGS, null, null);
+
+        // the inner after() consumed only its own EMPTY frame - the outer trace is untouched.
+        verify(outerScope, never()).leave();
+        verify(outerTrace, never()).close();
+
+        interceptor.after(outerTarget, Object.class, NO_REQUEST_ARGS, null, null);
+
+        // the outer after() unwinds its own frame exactly once (scope leave + end-scope cleanup).
+        verify(outerScope, times(1)).leave();
+        verify(outerTrace, times(1)).close();
+        verify(outerContext, times(1)).close();
+    }
+
+    @Test
+    public void beforeFailure_pushesEmptyFrame_afterIsHarmless() {
+        final AsyncContext failing = mock(AsyncContext.class);
+        when(failing.continueAsyncTraceObject(true)).thenThrow(new IllegalStateException("continue failed"));
+        final Object target = accessorTarget(failing);
+
+        interceptor.before(target, Object.class, NO_REQUEST_ARGS);
+        interceptor.after(target, Object.class, NO_REQUEST_ARGS, null, null);
+
+        verify(failing, never()).close();
+    }
+
+    @Test
+    public void recursion_unwindsInLifoOrder_eachFrameOnce() {
+        final AsyncContext innerContext = mock(AsyncContext.class);
+        final Trace innerTrace = mock(Trace.class);
+        final TraceScope innerScope = mock(TraceScope.class);
+        when(innerContext.continueAsyncTraceObject(true)).thenReturn(innerTrace);
+        when(innerTrace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(innerScope);
+        when(innerTrace.isAsync()).thenReturn(true);
+        when(innerScope.tryEnter()).thenReturn(true);
+        when(innerScope.canLeave()).thenReturn(true);
+        when(innerScope.isActive()).thenReturn(false);
+
+        final Object outerTarget = accessorTarget(outerContext);
+        final Object innerTarget = accessorTarget(innerContext);
+
+        interceptor.before(outerTarget, Object.class, NO_REQUEST_ARGS);
+        interceptor.before(innerTarget, Object.class, NO_REQUEST_ARGS);
+        interceptor.after(innerTarget, Object.class, NO_REQUEST_ARGS, null, null);
+        interceptor.after(outerTarget, Object.class, NO_REQUEST_ARGS, null, null);
+
+        verify(innerTrace, times(1)).close();
+        verify(outerTrace, times(1)).close();
+        verify(innerContext, times(1)).close();
+        verify(outerContext, times(1)).close();
+    }
+
+    @Test
+    public void afterWithoutPairedBefore_isHarmless() {
+        final Object target = accessorTarget(outerContext);
+
+        interceptor.after(target, Object.class, NO_REQUEST_ARGS, null, null);
+
+        verify(outerTrace, never()).close();
+        verify(outerContext, never()).close();
+    }
+
+    @Test
+    public void unbalancedScope_deletesUnstableTraceFromOwnFrame() {
+        when(outerScope.canLeave()).thenReturn(false);
+        final Object target = accessorTarget(outerContext);
+
+        interceptor.before(target, Object.class, NO_REQUEST_ARGS);
+        interceptor.after(target, Object.class, NO_REQUEST_ARGS, null, null);
+
+        verify(outerTrace, times(1)).close();
+        verify(outerContext, times(1)).close();
+    }
+
+    private static class MockAccessor implements AsyncContextAccessor {
+        private AsyncContext asyncContext;
+
+        @Override
+        public void _$PINPOINT$_setAsyncContext(AsyncContext asyncContext) {
+            this.asyncContext = asyncContext;
+        }
+
+        @Override
+        public AsyncContext _$PINPOINT$_getAsyncContext() {
+            return asyncContext;
+        }
+    }
+}

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncContext.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncContext.java
@@ -110,6 +110,26 @@ public class DefaultAsyncContext implements AsyncContext {
         return asyncTrace;
     }
 
+    @Override
+    public Trace continueAsyncTraceObject(Trace reuse) {
+        if (reuse == null) {
+            return continueAsyncTraceObject(false);
+        }
+        final Reference<Trace> reference = remote.binder().get();
+        final Trace nestedTrace = reference.get();
+        if (nestedTrace != null) {
+            // same nesting semantics as continueAsyncTraceObject(boolean)
+            if (nestedTrace.canSampled()) {
+                return nestedTrace;
+            }
+            return null;
+        }
+        // rebind the caller's previously-created trace: no new LocalAsyncId, ChildTrace,
+        // recorders or scope registration - just the thread binding.
+        reference.set(reuse);
+        return reuse;
+    }
+
     private void bind(Reference<Trace> reference, Trace asyncTrace) {
         if (reference.get() != null) {
             throw new IllegalStateException("traceReference is null");

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMMethod.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMMethod.java
@@ -245,7 +245,7 @@ public class ASMMethod implements InstrumentMethod {
         return ASMInterceptorHolder.create(interceptorHolderIdGenerator, declaringClass.getClassLoader(), factory, interceptorClass, constructorArgs, scopeInfo, descriptor);
     }
 
-    private void addInterceptor0(Class<? extends Interceptor> interceptorClass, ASMInterceptorHolder interceptorHolder) {
+    private void addInterceptor0(Class<? extends Interceptor> interceptorClass, ASMInterceptorHolder interceptorHolder) throws InstrumentException {
         Objects.requireNonNull(interceptorClass, "interceptorClass");
 
         final InterceptorDefinition interceptorDefinition = this.engineComponent.createInterceptorDefinition(interceptorClass);
@@ -264,6 +264,13 @@ public class ASMMethod implements InstrumentMethod {
         final InterceptorType interceptorType = interceptorDefinition.getInterceptorType();
         if (interceptorType == InterceptorType.API_ID_AWARE || interceptorType == InterceptorType.ASYNC_CONTEXT_API_ID_AWARE) {
             apiId = this.engineComponent.cacheApi(this.descriptor);
+        }
+
+        if (interceptorType == InterceptorType.RESULT_REPLACE && !this.methodNode.hasObjectOrArrayReturnType()) {
+            // constructors and void/primitive returns have no reference return value to replace.
+            throw new InstrumentException("result-replace interceptor requires an object or array return type."
+                    + " class=" + this.declaringClass.getName() + ", method=" + this.methodNode.getName() + this.methodNode.getDesc()
+                    + ", interceptor=" + interceptorClass.getName());
         }
 
         // add before interceptor.

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMMethodNodeAdapter.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMMethodNodeAdapter.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.profiler.instrument;
 import com.navercorp.pinpoint.profiler.instrument.interceptor.CaptureType;
 import com.navercorp.pinpoint.profiler.instrument.interceptor.InterceptorDefinition;
 import com.navercorp.pinpoint.profiler.instrument.interceptor.InterceptorHolder;
+import com.navercorp.pinpoint.profiler.instrument.interceptor.InterceptorType;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
@@ -65,6 +66,10 @@ public class ASMMethodNodeAdapter {
     // find interceptor local variable.
     public boolean hasInterceptor() {
         return this.methodVariables.hasInterceptor();
+    }
+
+    public boolean hasObjectOrArrayReturnType() {
+        return this.methodVariables.hasObjectOrArrayReturnType();
     }
 
     public String getName() {
@@ -273,6 +278,8 @@ public class ASMMethodNodeAdapter {
         this.methodNode.instructions.insertBefore(this.methodVariables.getEnterInsnNode(), tryCatch.getStartLabelNode());
         this.methodNode.instructions.insert(this.methodVariables.getExitInsnNode(), tryCatch.getEndLabelNode());
 
+        final boolean resultReplace = interceptorDefinition.getInterceptorType() == InterceptorType.RESULT_REPLACE;
+
         // find return.
         AbstractInsnNode insnNode = this.methodNode.instructions.getFirst();
         while (insnNode != null) {
@@ -281,6 +288,14 @@ public class ASMMethodNodeAdapter {
                 final InsnList instructions = new InsnList();
                 this.methodVariables.storeResultVar(instructions, opcode);
                 invokeAfterInterceptor(instructions, interceptorDefinition, false);
+                if (resultReplace) {
+                    if (opcode == Opcodes.ARETURN) {
+                        this.methodVariables.replaceReturnValue(instructions);
+                    } else {
+                        // defensive: only reachable when the reference-return validation was bypassed.
+                        this.methodVariables.discardReturnValue(instructions);
+                    }
+                }
                 this.methodNode.instructions.insertBefore(insnNode, instructions);
             }
             insnNode = insnNode.getNext();
@@ -290,6 +305,10 @@ public class ASMMethodNodeAdapter {
         InsnList instructions = new InsnList();
         this.methodVariables.storeThrowableVar(instructions);
         invokeAfterInterceptor(instructions, interceptorDefinition, true);
+        if (resultReplace) {
+            // exiting exceptionally: there is no return value to replace.
+            this.methodVariables.discardReturnValue(instructions);
+        }
         // throw exception.
         this.methodVariables.loadInterceptorThrowVar(instructions);
         this.methodNode.instructions.insert(tryCatch.getEndLabelNode(), instructions);

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMMethodVariables.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMMethodVariables.java
@@ -63,6 +63,9 @@ public class ASMMethodVariables {
     private static final String ASYNC_CONTEXT_ACCESSOR_UTILS = "com/navercorp/pinpoint/bootstrap/async/AsyncContextAccessorUtils";
     private static final String ASYNC_CONTEXT_DESC = "Lcom/navercorp/pinpoint/bootstrap/context/AsyncContext;";
 
+    private static final Type VOID_OBJECT_TYPE = Type.getObjectType("java/lang/Void");
+    private static final String RESULT_REPLACE_UTILS = "com/navercorp/pinpoint/bootstrap/interceptor/ResultReplaceUtils";
+
     private static final Comparator<LocalVariableNode> INDEX_COMPARATOR = new Comparator<LocalVariableNode>() {
         @Override
         public int compare(LocalVariableNode o1, LocalVariableNode o2) {
@@ -259,6 +262,9 @@ public class ASMMethodVariables {
             initApiIdVar(apiId, instructions);
             initArgsVar(instructions);
             initAsyncContextVar(instructions);
+        } else if (interceptorType == InterceptorType.RESULT_REPLACE) {
+            // Object target, Class returnType, Object[] args
+            initArgsVar(instructions);
         } else if (interceptorType == InterceptorType.BASIC) {
             int interceptorMethodParameterCount = getInterceptorParameterCount(interceptorDefinition);
             final int methodParameterCount = this.argumentTypes.length;
@@ -459,6 +465,52 @@ public class ASMMethodVariables {
         storeVar(instructions, this.blockVarIndex);
     }
 
+    /**
+     * Emitted after a result-replace interceptor's {@code after} call on a normal exit whose
+     * opcode is ARETURN. Stack on entry: the original return value with the interceptor's
+     * candidate on top. Selects between the two through
+     * {@link com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceUtils#replace} — plain Java
+     * instead of a branch here, so both verifier paths keep a single frame — and CHECKCASTs the
+     * winner to the declared return type for the original ARETURN.
+     */
+    public void replaceReturnValue(final InsnList instructions) {
+        assertInitializedInterceptorLocalVariables();
+        // stack: original, candidate
+        instructions.add(new LdcInsnNode(this.returnType));
+        instructions.add(new MethodInsnNode(Opcodes.INVOKESTATIC, RESULT_REPLACE_UTILS, "replace", "(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Class;)Ljava/lang/Object;", false));
+        // stack: selected
+        final String internalName = this.returnType.getSort() == Type.ARRAY ? this.returnType.getDescriptor() : this.returnType.getInternalName();
+        instructions.add(new TypeInsnNode(Opcodes.CHECKCAST, internalName));
+    }
+
+    /**
+     * Pops the value a result-replace interceptor's {@code after} call left on the stack when
+     * there is no reference return value to replace: the exception handler path, and — only when
+     * the instrument-time reference-return validation was bypassed — void/primitive exits.
+     */
+    public void discardReturnValue(final InsnList instructions) {
+        assertInitializedInterceptorLocalVariables();
+        pop(instructions);
+    }
+
+    private void loadReturnTypeClass(final InsnList instructions) {
+        Type type = this.returnType;
+        final int sort = type.getSort();
+        if (sort == Type.VOID) {
+            type = VOID_OBJECT_TYPE;
+        } else if (sort != Type.OBJECT && sort != Type.ARRAY) {
+            // LDC cannot push a primitive class constant; the boxed class is informative enough
+            // for the degraded (validation-bypassed) path where the result is discarded anyway.
+            type = getBoxedType(type);
+        }
+        instructions.add(new LdcInsnNode(type));
+    }
+
+    boolean hasObjectOrArrayReturnType() {
+        final int sort = this.returnType.getSort();
+        return sort == Type.OBJECT || sort == Type.ARRAY;
+    }
+
     public void loadInterceptorLocalVariables(final InsnList instructions, final InterceptorDefinition interceptorDefinition, final boolean after) {
         assertInitializedInterceptorLocalVariables();
         loadVar(instructions, this.interceptorVarIndex);
@@ -492,6 +544,10 @@ public class ASMMethodVariables {
             // Object target, AsyncContext asyncContext, int apiId, Object[] args
             loadVar(instructions, this.asyncContextVarIndex);
             loadInt(instructions, this.apiIdVarIndex);
+            loadVar(instructions, this.argsVarIndex);
+        } else if (interceptorType == InterceptorType.RESULT_REPLACE) {
+            // Object target, Class returnType, Object[] args
+            loadReturnTypeClass(instructions);
             loadVar(instructions, this.argsVarIndex);
         } else if (interceptorType == InterceptorType.BASIC) {
             int interceptorMethodParameterCount = getInterceptorParameterCount(interceptorDefinition);

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/interceptor/InterceptorDefinitionFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/interceptor/InterceptorDefinitionFactory.java
@@ -36,6 +36,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.BlockAroundInterceptor4;
 import com.navercorp.pinpoint.bootstrap.interceptor.BlockAroundInterceptor5;
 import com.navercorp.pinpoint.bootstrap.interceptor.BlockStaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.StaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.annotation.IgnoreMethod;
 import org.apache.logging.log4j.LogManager;
@@ -85,6 +86,7 @@ public class InterceptorDefinitionFactory {
         addTypeHandler(typeHandlerList, StaticAroundInterceptor.class, InterceptorType.STATIC);
         addTypeHandler(typeHandlerList, ApiIdAwareAroundInterceptor.class, InterceptorType.API_ID_AWARE);
         addTypeHandler(typeHandlerList, InjectedAsyncContextApiIdAwareAroundInterceptor.class, InterceptorType.ASYNC_CONTEXT_API_ID_AWARE);
+        addTypeHandler(typeHandlerList, ResultReplaceAroundInterceptor.class, InterceptorType.RESULT_REPLACE);
         // block
         addTypeHandler(typeHandlerList, BlockAroundInterceptor.class, InterceptorType.ARRAY_ARGS);
         addTypeHandler(typeHandlerList, BlockAroundInterceptor0.class, InterceptorType.BASIC);
@@ -184,6 +186,10 @@ public class InterceptorDefinitionFactory {
             }
             final boolean afterIgnoreMethod = afterMethod.isAnnotationPresent(IgnoreMethod.class);
 
+            if (interceptorType == InterceptorType.RESULT_REPLACE && afterMethod.getReturnType() != Object.class) {
+                // a covariant override would change the weaved call descriptor and break the INVOKEINTERFACE site.
+                throw new RuntimeException(after + " must return java.lang.Object. " + targetInterceptorClazz.getName());
+            }
 
             if (beforeIgnoreMethod && afterIgnoreMethod) {
                 return new DefaultInterceptorDefinition(interceptorClazz, targetInterceptorClazz, interceptorType, CaptureType.NON, null, null);

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/interceptor/InterceptorType.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/interceptor/InterceptorType.java
@@ -20,5 +20,5 @@ package com.navercorp.pinpoint.profiler.instrument.interceptor;
  * @author Woonduk Kang(emeroad)
  */
 public enum InterceptorType {
-    ARRAY_ARGS, STATIC, BASIC, API_ID_AWARE, ASYNC_CONTEXT_API_ID_AWARE
+    ARRAY_ARGS, STATIC, BASIC, API_ID_AWARE, ASYNC_CONTEXT_API_ID_AWARE, RESULT_REPLACE
 }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/interceptor/factory/AnnotatedInterceptorFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/interceptor/factory/AnnotatedInterceptorFactory.java
@@ -57,8 +57,10 @@ import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandleBlockAroundIn
 import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandleBlockAroundInterceptor5;
 import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandleBlockStaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandleStaticAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandleResultReplaceAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandler;
 import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.StaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedApiIdAwareAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInjectedAsyncContextApiIdAwareAroundInterceptor;
@@ -78,6 +80,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedI
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor3;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor4;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor5;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedResultReplaceAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedStaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExecutionPolicy;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope;
@@ -99,6 +102,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedInterceptor2;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedInterceptor3;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedInterceptor4;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedInterceptor5;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedResultReplaceAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedStaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.plugin.RequestRecorderFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.monitor.DataSourceMonitorRegistry;
@@ -201,6 +205,8 @@ public class AnnotatedInterceptorFactory implements InterceptorFactory {
             return new ScopedApiIdAwareAroundInterceptor((ApiIdAwareAroundInterceptor) interceptor, scope, policy);
         } else if (interceptor instanceof InjectedAsyncContextApiIdAwareAroundInterceptor) {
             return new ScopedInjectedAsyncContextApiIdAwareAroundInterceptor((InjectedAsyncContextApiIdAwareAroundInterceptor) interceptor, scope, policy);
+        } else if (interceptor instanceof ResultReplaceAroundInterceptor) {
+            return new ScopedResultReplaceAroundInterceptor((ResultReplaceAroundInterceptor) interceptor, scope, policy);
         } else if (interceptor instanceof BlockAroundInterceptor) {
             return new ScopedBlockInterceptor((BlockAroundInterceptor) interceptor, scope, policy);
         } else if (interceptor instanceof BlockStaticAroundInterceptor) {
@@ -246,6 +252,8 @@ public class AnnotatedInterceptorFactory implements InterceptorFactory {
             return new ExceptionHandleScopedApiIdAwareAroundInterceptor((ApiIdAwareAroundInterceptor) interceptor, scope, policy, exceptionHandler);
         } else if (interceptor instanceof InjectedAsyncContextApiIdAwareAroundInterceptor) {
             return new ExceptionHandleScopedInjectedAsyncContextApiIdAwareAroundInterceptor((InjectedAsyncContextApiIdAwareAroundInterceptor) interceptor, scope, policy, exceptionHandler);
+        } else if (interceptor instanceof ResultReplaceAroundInterceptor) {
+            return new ExceptionHandleScopedResultReplaceAroundInterceptor((ResultReplaceAroundInterceptor) interceptor, scope, policy, exceptionHandler);
         } else if (interceptor instanceof BlockAroundInterceptor) {
             return new ExceptionHandleScopedBlockInterceptor((BlockAroundInterceptor) interceptor, scope, policy, exceptionHandler);
         } else if (interceptor instanceof BlockStaticAroundInterceptor) {
@@ -291,6 +299,8 @@ public class AnnotatedInterceptorFactory implements InterceptorFactory {
             return new ExceptionHandleApiIdAwareAroundInterceptor((ApiIdAwareAroundInterceptor) interceptor, exceptionHandler);
         } else if (interceptor instanceof InjectedAsyncContextApiIdAwareAroundInterceptor) {
             return new ExceptionHandleInjectedAsyncContextApiIdAwareAroundInterceptor((InjectedAsyncContextApiIdAwareAroundInterceptor) interceptor, exceptionHandler);
+        } else if (interceptor instanceof ResultReplaceAroundInterceptor) {
+            return new ExceptionHandleResultReplaceAroundInterceptor((ResultReplaceAroundInterceptor) interceptor, exceptionHandler);
         } else if (interceptor instanceof BlockAroundInterceptor) {
             return new ExceptionHandleBlockAroundInterceptor((BlockAroundInterceptor) interceptor, exceptionHandler);
         } else if (interceptor instanceof BlockStaticAroundInterceptor) {

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMMethodNodeAdapterAddInterceptorTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMMethodNodeAdapterAddInterceptorTest.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.profiler.instrument.mock.ArgsArrayInterceptor;
 import com.navercorp.pinpoint.profiler.instrument.mock.BaseEnum;
 import com.navercorp.pinpoint.profiler.instrument.mock.BasicInterceptor;
 import com.navercorp.pinpoint.profiler.instrument.mock.ExceptionInterceptor;
+import com.navercorp.pinpoint.profiler.instrument.mock.ResultReplaceInterceptor;
 import com.navercorp.pinpoint.profiler.instrument.mock.StaticInterceptor;
 import com.navercorp.pinpoint.profiler.interceptor.factory.ExceptionHandlerFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -91,6 +92,87 @@ public class ASMMethodNodeAdapterAddInterceptorTest {
     @Test
     public void addBasicInterceptor() throws Exception {
         addInterceptor(new BasicInterceptor());
+    }
+
+    @Test
+    public void addResultReplaceInterceptor() throws Exception {
+        // without a replacement the interceptor behaves like a plain around interceptor,
+        // so the whole shared suite (constructors, primitives, exceptions) must pass unchanged.
+        addInterceptor(new ResultReplaceInterceptor());
+    }
+
+    @Test
+    public void resultReplaceReturnValue() throws Exception {
+        ResultReplaceInterceptor interceptor = new ResultReplaceInterceptor();
+        Class<?> clazz = addInterceptor0("com.navercorp.pinpoint.profiler.instrument.mock.ReturnClass", interceptor);
+        Object instance = clazz.newInstance();
+        Method returnString = clazz.getDeclaredMethod("returnString");
+
+        // a replacement of the declared return type is handed to the caller.
+        ResultReplaceInterceptor.clear();
+        ResultReplaceInterceptor.useReplacement = true;
+        ResultReplaceInterceptor.replacement = "replaced";
+        assertEquals("replaced", returnString.invoke(instance));
+        assertEquals("s", ResultReplaceInterceptor.result);
+        assertEquals(String.class, ResultReplaceInterceptor.afterReturnType);
+        assertEquals(String.class, ResultReplaceInterceptor.beforeReturnType);
+
+        // null keeps the original.
+        ResultReplaceInterceptor.clear();
+        ResultReplaceInterceptor.useReplacement = true;
+        ResultReplaceInterceptor.replacement = null;
+        assertEquals("s", returnString.invoke(instance));
+
+        // a type-incompatible replacement keeps the original.
+        ResultReplaceInterceptor.clear();
+        ResultReplaceInterceptor.useReplacement = true;
+        ResultReplaceInterceptor.replacement = Integer.valueOf(1);
+        assertEquals("s", returnString.invoke(instance));
+
+        // array return type.
+        ResultReplaceInterceptor.clear();
+        ResultReplaceInterceptor.useReplacement = true;
+        ResultReplaceInterceptor.replacement = new String[]{"replaced"};
+        Method returnStringArray = clazz.getDeclaredMethod("returnStringArray");
+        assertThat((String[]) returnStringArray.invoke(instance)).containsExactly("replaced");
+        assertEquals(String[].class, ResultReplaceInterceptor.afterReturnType);
+
+        // primitive return: the interceptor's value is discarded (defensive path).
+        ResultReplaceInterceptor.clear();
+        ResultReplaceInterceptor.useReplacement = true;
+        ResultReplaceInterceptor.replacement = Integer.valueOf(99);
+        Method returnInt = clazz.getDeclaredMethod("returnInt");
+        assertEquals(1, returnInt.invoke(instance));
+        assertEquals(Integer.class, ResultReplaceInterceptor.afterReturnType);
+
+        // void return: no value to replace, interceptor still runs.
+        ResultReplaceInterceptor.clear();
+        ResultReplaceInterceptor.useReplacement = true;
+        ResultReplaceInterceptor.replacement = "ignored";
+        Method voidType = clazz.getDeclaredMethod("voidType");
+        assertNull(voidType.invoke(instance));
+        assertTrue(ResultReplaceInterceptor.after);
+        assertEquals(Void.class, ResultReplaceInterceptor.afterReturnType);
+    }
+
+    @Test
+    public void resultReplaceExceptionPath() throws Exception {
+        ResultReplaceInterceptor interceptor = new ResultReplaceInterceptor();
+        Class<?> clazz = addInterceptor0("com.navercorp.pinpoint.profiler.instrument.mock.ExceptionClass", interceptor);
+
+        // exiting exceptionally: the interceptor's value is discarded and the original exception propagates.
+        ResultReplaceInterceptor.clear();
+        ResultReplaceInterceptor.useReplacement = true;
+        ResultReplaceInterceptor.replacement = "ignored";
+        Method method = clazz.getDeclaredMethod("throwable");
+        try {
+            method.invoke(clazz.newInstance());
+            fail("expected an exception");
+        } catch (Throwable expected) {
+        }
+        assertTrue(ResultReplaceInterceptor.after);
+        assertNotNull(ResultReplaceInterceptor.throwable);
+        assertNull(ResultReplaceInterceptor.result);
     }
 
     @Disabled
@@ -298,6 +380,7 @@ public class ASMMethodNodeAdapterAddInterceptorTest {
         ApiIdAwareInterceptor.clear();
         BasicInterceptor.clear();
         ExceptionInterceptor.clear();
+        ResultReplaceInterceptor.clear();
 
         Constructor<?> constructor;
         Method method = null;
@@ -436,6 +519,33 @@ public class ASMMethodNodeAdapterAddInterceptorTest {
             assertEquals(returnValue, ApiIdAwareInterceptor.result, name);
             if (throwable) {
                 assertNotNull(ApiIdAwareInterceptor.throwable, name);
+            }
+        } else if (interceptorClass == ResultReplaceInterceptor.class) {
+            assertTrue(ResultReplaceInterceptor.before, name);
+            assertTrue(ResultReplaceInterceptor.after, name);
+
+            if (method != null && Modifier.isStatic(method.getModifiers())) {
+                assertNull(ResultReplaceInterceptor.beforeTarget, name);
+                assertNull(ResultReplaceInterceptor.afterTarget, name);
+            } else if (method != null) {
+                assertNotNull(ResultReplaceInterceptor.beforeTarget, name);
+                assertNotNull(ResultReplaceInterceptor.afterTarget, name);
+            }
+            assertEquals(ResultReplaceInterceptor.beforeTarget, ResultReplaceInterceptor.afterTarget, name);
+
+            assertNotNull(ResultReplaceInterceptor.beforeReturnType, name);
+            assertNotNull(ResultReplaceInterceptor.afterReturnType, name);
+
+            if (ResultReplaceInterceptor.beforeArgs != null) {
+                assertThat(args).as(name).containsExactly(ResultReplaceInterceptor.beforeArgs);
+            }
+
+            if (ResultReplaceInterceptor.afterArgs != null) {
+                assertThat(args).as(name).containsExactly(ResultReplaceInterceptor.afterArgs);
+            }
+            assertEquals(returnValue, ResultReplaceInterceptor.result, name);
+            if (throwable) {
+                assertNotNull(ResultReplaceInterceptor.throwable, name);
             }
         } else if (interceptorClass == BasicInterceptor.class) {
             assertTrue(BasicInterceptor.before, name);

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/interceptor/InterceptorDefinitionFactoryTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/interceptor/InterceptorDefinitionFactoryTest.java
@@ -25,8 +25,10 @@ import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor3;
 import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor4;
 import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor5;
 import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.StaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.annotation.IgnoreMethod;
+import com.navercorp.pinpoint.profiler.instrument.mock.ResultReplaceInterceptor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -77,6 +79,25 @@ public class InterceptorDefinitionFactoryTest {
 
     }
 
+
+    @Test
+    public void testGetInterceptorType_ResultReplace() {
+        InterceptorDefinitionFactory typeDetector = new InterceptorDefinitionFactory();
+
+        final InterceptorDefinition definition = typeDetector.createInterceptorDefinition(ResultReplaceInterceptor.class);
+        Assertions.assertSame(InterceptorType.RESULT_REPLACE, definition.getInterceptorType());
+        Assertions.assertSame(CaptureType.AROUND, definition.getCaptureType());
+        Assertions.assertEquals(Object.class, definition.getAfterMethod().getReturnType());
+    }
+
+    @Test
+    public void testGetInterceptorType_ResultReplace_covariantAfterRejected() {
+        // a covariant override changes the weaved call descriptor and must be rejected.
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            InterceptorDefinitionFactory typeDetector = new InterceptorDefinitionFactory();
+            typeDetector.createInterceptorDefinition(CovariantResultReplaceInterceptor.class);
+        });
+    }
 
     @Test
     public void testGetType_Error() {
@@ -178,5 +199,16 @@ public class InterceptorDefinitionFactoryTest {
 
     public static class InheritedAroundInterceptor extends TestAroundInterceptor {
 
+    }
+
+    public static class CovariantResultReplaceInterceptor implements ResultReplaceAroundInterceptor {
+        @Override
+        public void before(Object target, Class<?> returnType, Object[] args) {
+        }
+
+        @Override
+        public String after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+            return null;
+        }
     }
 }

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/mock/ResultReplaceInterceptor.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/mock/ResultReplaceInterceptor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.profiler.instrument.mock;
+
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+
+public class ResultReplaceInterceptor implements ResultReplaceAroundInterceptor {
+
+    public static boolean before;
+    public static boolean after;
+    public static Object beforeTarget;
+    public static Class<?> beforeReturnType;
+    public static Object[] beforeArgs;
+    public static Object afterTarget;
+    public static Class<?> afterReturnType;
+    public static Object[] afterArgs;
+    public static Object result;
+    public static Throwable throwable;
+
+    public static boolean useReplacement;
+    public static Object replacement;
+
+    public static void clear() {
+        before = false;
+        after = false;
+        beforeTarget = null;
+        beforeReturnType = null;
+        beforeArgs = null;
+        afterTarget = null;
+        afterReturnType = null;
+        afterArgs = null;
+        result = null;
+        throwable = null;
+        useReplacement = false;
+        replacement = null;
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        before = true;
+        beforeTarget = target;
+        beforeReturnType = returnType;
+        beforeArgs = args;
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        after = true;
+        afterTarget = target;
+        afterReturnType = returnType;
+        afterArgs = args;
+        ResultReplaceInterceptor.result = result;
+        ResultReplaceInterceptor.throwable = throwable;
+        if (useReplacement) {
+            return replacement;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
…rs behind config gates

Instead of injecting an AsyncContext field into the Publisher a plugin returns at an I/O seam, wrap it (Operators.lift) with a TracedSubscriber that delivers every signal inside a try/finally trace window. reactor-core types are left untouched and every hot read is a getfield on our own class. All gates default to false; behavior is unchanged unless opted in.

Weaving infrastructure (ResultReplaceAroundInterceptor): after()'s return value replaces the intercepted method's return value on ARETURN exits (null or type-incompatible replacements silently keep the original, exception exits discard). Reference return types only - constructors, void and primitive returns fail at instrumentation time; covariant after() overrides are rejected at definition time. Scope and exception-handle wrappers are registered on all three factory wrap paths.

Seam support module (reactor-seam-support, shaded per consumer with a package relocation so each classloader sees its own copy):
- Fusion is suppressed in both directions; a Conditional variant preserves tryOnNext. Scalar, Connectable and Grouped publishers are intentionally not wrapped (documented policy - the injection path was a no-op for them as well).
- The subscription holds one async trace across signals and closes it exactly once: terminal and cancel race through a CAS ownership state machine, and a terminal delivered nested inside another window closes the held trace at the outermost frame.
- request()/cancel() borrow the caller's trace or open a frame-local window; duplicate onSubscribe cancels the extra subscription and post-terminal signals are dropped. A window that fails after binding unbinds the thread again, and a missing reactor-core class degrades the wrap call to the original publisher.

Consumers, one gate per plugin:
- profiler.spring.data.r2dbc.wrap.publisher: ConnectionFactory.create (12 vendors), Statement.execute (7 vendors), the MSSQL execute variant and the DefaultFetchSpec row publishers.
- profiler.spring.webflux.wrap.publisher: DispatchHandler.handle / invokeHandler (async-continue, uri-stat preserved), the WebClient exchange pair and BodyInserter writeTo. BodyInserter pairs before/after through a per-invocation frame stack, so recursive and failed invocations cannot steal each other's state.
- profiler.spring.tx.wrap.publisher, profiler.redis.lettuce.wrap.publisher, profiler.redis.redisson.wrap.publisher: hybrid variant - only Mono/Flux results are wrapped, other async results keep the original injection. The redisson interceptor degrades a reactor-less classpath to untraced instead of breaking the call. mongodb stays on injection - its driver does not return reactor types.
- Each consumer has a seam IT with a discriminating probe (wrap on, reactor plugin off) proving the wrapper alone links the async chunk.

Scheduler task carrier (profiler.reactor.trace.scheduler.task): instruments the eight scheduler task carrier classes (addField + constructor capture + non-synthetic run/call), so a Runnable scheduled directly on a reactor Scheduler carries the trace across the thread hop even when no wrapped publisher is involved. The constructor interceptor resolves the carrier first and falls back to the current trace with a REACTOR boundary span event; ReactorAsyncContextResolver extracts the unique-lookup semantics CoreSubscriberConstructorInterceptor already had. The IT pins the plain-Runnable fallback, an onScheduleHook decorator and publishOn coexistence.

Testwebs (verification harnesses for the above): the reactor and reactor-netty testwebs are now self-contained (self-calls via /echo and request.getLocalPort() instead of live external sites), the scheduler-hop scenarios actually make their downstream call (Mono.block() on parallel threads was rejected by reactor and errored in the background), and /mono/transportError + /client/transportError probe transport-level connect failures deterministically via a bound-and-closed ephemeral port. /scheduler/schedule adds direct Scheduler.schedule(Runnable) coverage - the carrier's only path with no operator relay in front.