### PR TITLE
Let the HTTP cache revalidate /api/applications

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.test.tsx
@@ -5,36 +5,40 @@ import { getDefaultStore } from 'jotai';
 import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
 import { selectedServiceAtom, DEFAULT_SERVICE } from '@pinpoint-fe/ui/src/atoms/selectedService';
 
-// useGetApplicationList reads the module-level queryClient (from reactQueryHelper,
-// which transitively imports the ECharts ESM stack) only for the 304 cache lookup.
-// Mock it so babel-jest does not choke on echarts and so we can drive the 304 path.
-const mockGetQueryData = jest.fn();
+// useGetApplicationList imports queryFn from reactQueryHelper, which transitively pulls in the
+// ECharts ESM stack. Stub the module with the same fetch behaviour so babel-jest does not choke.
 jest.mock('./reactQueryHelper', () => ({
-  queryClient: { getQueryData: (...args: unknown[]) => mockGetQueryData(...args) },
+  queryFn: (url: string) => async () => {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}.`);
+    }
+    return response.json();
+  },
 }));
 
 import { useGetApplicationList } from './useGetApplicationList';
 
+let testClient: QueryClient;
+
 const createWrapper = () => {
-  const client = new QueryClient({
+  testClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   return ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    <QueryClientProvider client={testClient}>{children}</QueryClientProvider>
   );
 };
 
-const okResponse = (body: unknown, etag?: string) => ({
+const okResponse = (body: unknown) => ({
   ok: true,
   status: 200,
-  headers: { get: (key: string) => (key === 'ETag' ? (etag ?? null) : null) },
   json: async () => body,
 });
 
 describe('useGetApplicationList', () => {
   beforeEach(() => {
     global.fetch = jest.fn();
-    mockGetQueryData.mockReset();
     getDefaultStore().set(selectedServiceAtom, DEFAULT_SERVICE);
     window.history.replaceState({}, '', '/');
   });
@@ -44,7 +48,7 @@ describe('useGetApplicationList', () => {
   });
 
   test('fetches the application list from the applications endpoint', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue(okResponse([{ applicationName: 'A' }], 'v1'));
+    (global.fetch as jest.Mock).mockResolvedValue(okResponse([{ applicationName: 'A' }]));
 
     const { result } = renderHook(() => useGetApplicationList(), { wrapper: createWrapper() });
 
@@ -53,12 +57,10 @@ describe('useGetApplicationList', () => {
     expect(result.current.data).toEqual([{ applicationName: 'A' }]);
   });
 
-  test('sends the cached ETag as If-None-Match and reuses cached data on 304', async () => {
-    // First response establishes the ETag.
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce(okResponse([{ applicationName: 'A' }], 'etag-123'))
-      .mockResolvedValueOnce({ status: 304 });
-    mockGetQueryData.mockReturnValue([{ applicationName: 'A' }]);
+  test('leaves ETag revalidation to the browser HTTP cache', async () => {
+    // 백엔드가 Vary + no-cache를 보내므로 훅이 If-None-Match를 직접 실을 필요가 없다.
+    // 브라우저 캐시를 끄는 cache: 'no-store'도 붙이지 않아야 자동 재검증이 동작한다.
+    (global.fetch as jest.Mock).mockResolvedValue(okResponse([{ applicationName: 'A' }]));
 
     const { result } = renderHook(() => useGetApplicationList(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -68,13 +70,19 @@ describe('useGetApplicationList', () => {
     });
 
     await waitFor(() => expect((global.fetch as jest.Mock).mock.calls.length).toBe(2));
-    const secondInit = (global.fetch as jest.Mock).mock.calls[1][1] as { headers: HeadersInit };
-    expect((secondInit.headers as Record<string, string>)['If-None-Match']).toBe('etag-123');
-    expect(result.current.data).toEqual([{ applicationName: 'A' }]);
+    for (const [, init] of (global.fetch as jest.Mock).mock.calls as [
+      RequestInfo | URL,
+      RequestInit | undefined,
+    ][]) {
+      // init.headers는 평범한 객체일 수도, Headers 인스턴스일 수도 있다(fetch 인터셉터가 후자로
+      // 만든다). Headers에 대괄호 접근은 항상 undefined라 검사가 무의미해지므로 형태를 통일한다.
+      expect(new Headers(init?.headers).get('If-None-Match')).toBeNull();
+      expect(init?.cache).toBeUndefined();
+    }
   });
 
   test('refetchWithClearCache requests the endpoint with clearCache=true', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue(okResponse([{ applicationName: 'A' }], 'v1'));
+    (global.fetch as jest.Mock).mockResolvedValue(okResponse([{ applicationName: 'A' }]));
 
     const { result } = renderHook(() => useGetApplicationList(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -104,8 +112,8 @@ describe('useGetApplicationList', () => {
 
   test('refetches the list when the selected service changes', async () => {
     (global.fetch as jest.Mock)
-      .mockResolvedValueOnce(okResponse([{ applicationName: 'A' }], 'etag-a'))
-      .mockResolvedValueOnce(okResponse([{ applicationName: 'B' }], 'etag-b'));
+      .mockResolvedValueOnce(okResponse([{ applicationName: 'A' }]))
+      .mockResolvedValueOnce(okResponse([{ applicationName: 'B' }]));
 
     const { result } = renderHook(() => useGetApplicationList(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -120,22 +128,16 @@ describe('useGetApplicationList', () => {
   });
 
   test('caches under the selected service, servermap included', async () => {
-    // ServerMap도 예외가 아니라 선택된 service로 조회되므로, 그 service 캐시/ETag를 써야 한다.
+    // ServerMap도 예외가 아니라 선택된 service로 조회되므로, 그 service 캐시를 써야 한다.
     window.history.replaceState({}, '', '/serverMap/app-name@TOMCAT');
     getDefaultStore().set(selectedServiceAtom, 'service-b');
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce(okResponse([{ applicationName: 'A' }], 'etag-b'))
-      .mockResolvedValueOnce({ status: 304 });
-    mockGetQueryData.mockReturnValue([{ applicationName: 'A' }]);
+    (global.fetch as jest.Mock).mockResolvedValue(okResponse([{ applicationName: 'A' }]));
 
     const { result } = renderHook(() => useGetApplicationList(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    await act(async () => {
-      await result.current.refetch();
-    });
-
-    await waitFor(() => expect(mockGetQueryData).toHaveBeenCalled());
-    expect(mockGetQueryData).toHaveBeenCalledWith([END_POINTS.APPLICATION_LIST, 'service-b']);
+    expect(testClient.getQueryData([END_POINTS.APPLICATION_LIST, 'service-b'])).toEqual([
+      { applicationName: 'A' },
+    ]);
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApplicationList.ts
@@ -3,60 +3,27 @@ import { useAtomValue } from 'jotai';
 import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
 import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
 import React from 'react';
-import { queryClient } from './reactQueryHelper';
+import { queryFn } from './reactQueryHelper';
 import { resolveRequestService } from './serviceNameFetchInterceptor';
 
-// ETag는 service별로 응답이 다를 수 있으므로 service마다 따로 보관한다.
-// 하나의 전역 값으로 두면 service 전환 시 이전 service의 ETag를 보내
-// 백엔드가 304를 돌려주며 옛 목록을 그대로 재사용하는 문제가 생긴다.
-const cachedETagByService = new Map<string, string>();
-
-const applicationListQueryFn = async (service: string, clearCache?: boolean) => {
-  const url = clearCache
-    ? `${END_POINTS.APPLICATION_LIST}?clearCache=true`
-    : END_POINTS.APPLICATION_LIST;
-
-  const headers: HeadersInit = {};
-  if (clearCache) {
-    cachedETagByService.delete(service);
-  }
-  const cachedETag = cachedETagByService.get(service);
-  if (cachedETag) {
-    headers['If-None-Match'] = cachedETag;
-  }
-
-  const response = await fetch(url, {
-    cache: 'no-store',
-    headers,
-  });
-
-  if (response.status === 304) {
-    const cached = queryClient.getQueryData([END_POINTS.APPLICATION_LIST, service]);
-    if (cached !== undefined) return cached;
-    cachedETagByService.delete(service);
-    return applicationListQueryFn(service, clearCache);
-  }
-
-  if (!response.ok) {
-    throw new Error(
-      `Request failed with status ${response.status}. An error occurred while fetching the data.`,
-    );
-  }
-
-  const etag = response.headers.get('ETag');
-  if (etag) {
-    cachedETagByService.set(service, etag);
-  }
-
-  return response.json();
-};
-
+/**
+ * ETag 재검증은 브라우저 HTTP 캐시에 맡긴다. 백엔드(`MainController#getApplicationGroup`)가
+ * `Vary: pServiceName`과 `Cache-Control: no-cache`를 보내므로 브라우저가
+ * (1) service별로 응답을 따로 보관하고 (2) 매 요청에 `If-None-Match`를 자동으로 실으며
+ * (3) 304를 받으면 보관해 둔 본문을 200처럼 돌려준다. 그래서 이 훅은 304를 볼 일이 없다.
+ *
+ * 예전에는 `cache: 'no-store'`로 브라우저 캐시를 끄고 ETag를 service별 Map에 직접 들고 있었다.
+ * 응답이 URL이 아니라 pServiceName 헤더에 따라 달라지는데 백엔드가 `Vary`를 보내지 않아,
+ * URL만 보는 브라우저 캐시가 다른 service의 목록을 재사용했기 때문이다. 이제 백엔드가 `Vary`를
+ * 보내므로 직접 관리할 이유가 없다.
+ */
 export const useGetApplicationList = (shouldFetch = true) => {
   // selectedService가 바뀌면 queryKey가 달라져 새 service의 목록을 다시 불러온다.
   // service마다 application 목록이 다르므로 캐시를 service별로 분리한다.
   const selectedService = useAtomValue(selectedServiceAtom);
-  // 이 쿼리는 사이드 네비게이션(remount 대상 밖)에서도 쓰이고 ETag도 service별로 보관하므로,
-  // 해시에만 의존하지 않고 요청에 쓰이는 service를 queryKey에 명시해 직접 다룬다.
+  // 이 쿼리는 사이드 네비게이션(remount 대상 밖)에서도 쓰이므로, queryKeyHashFn에만 의존하면
+  // service가 바뀌어도 리렌더가 없어 재조회가 일어나지 않는다. 요청에 쓰이는 service를
+  // queryKey에 명시해 직접 다룬다.
   const service = resolveRequestService(selectedService);
   const clearCacheRef = React.useRef(false);
 
@@ -65,7 +32,13 @@ export const useGetApplicationList = (shouldFetch = true) => {
     queryFn: () => {
       const shouldClearCache = clearCacheRef.current;
       clearCacheRef.current = false;
-      return applicationListQueryFn(service, shouldClearCache);
+      // clearCache 요청은 URL이 달라 브라우저 캐시 엔트리도 따로 잡히고, 백엔드가 이 파라미터를
+      // 보면 ETag와 무관하게 서버 캐시를 비우고 목록을 다시 만들어 항상 200으로 돌려준다.
+      return queryFn(
+        shouldClearCache
+          ? `${END_POINTS.APPLICATION_LIST}?clearCache=true`
+          : END_POINTS.APPLICATION_LIST,
+      )();
     },
     enabled: shouldFetch,
     refetchOnMount: false,

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.controller;
 
 import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceConstants;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.service.CacheService;
 import com.navercorp.pinpoint.web.service.CommonService;
@@ -31,6 +32,8 @@ import com.navercorp.pinpoint.web.view.TagApplications;
 import com.navercorp.pinpoint.web.vo.Application;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -88,7 +91,7 @@ public class MainController {
             if (cachedApplications != null) {
                 if (eTag.tag().equals(cachedApplications.getTag())) {
                     logger.debug("applicationList {} cache hit", cacheKey);
-                    return notModified();
+                    return notModified(eTag);
                 } else {
                     logger.debug("applicationList {} cache hit, but missed eTag {} = {}",
                             cacheKey, clearCache, cachedApplications.getTag());
@@ -118,15 +121,19 @@ public class MainController {
         // if (cachedApplications.getApplicationList().equals(applicationList))
         //
         // weak
-        return ResponseEntity.ok()
-                .eTag(newETag.toString())
+        return cacheHeaders(ResponseEntity.ok().eTag(newETag.toString()))
                 .body(new ApplicationGroup(applicationList));
     }
 
-    private static ResponseEntity<ApplicationGroup> notModified() {
-        return ResponseEntity
-                .status(HttpStatus.NOT_MODIFIED)
+    private static ResponseEntity<ApplicationGroup> notModified(ETag eTag) {
+        return cacheHeaders(ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(eTag.toString()))
                 .build();
+    }
+
+    private static ResponseEntity.BodyBuilder cacheHeaders(ResponseEntity.BodyBuilder builder) {
+        return builder
+                .varyBy(ServiceConstants.KEY, HttpHeaders.ACCEPT_ENCODING)
+                .cacheControl(CacheControl.noCache());
     }
 
     private static boolean needClearCache(ETag eTag, String clearCache) {


### PR DESCRIPTION
## Summary

- `/api/applications` now declares its caching contract on the response: `Vary: pServiceName, Accept-Encoding` so caches key per service, and `Cache-Control: no-cache` so every use is revalidated. The 304 repeats both headers, since a 304 only updates the stored response's headers.
- `Accept-Encoding` is named explicitly even though Tomcat normally appends it. `CompressionConfig.useCompression()` adds it before it inspects the client's `Accept-Encoding`, so on a 200 it is always present (`server.compression` covers `application/json`) — but `Http11Processor.prepareResponse()` sets `entityBody = false` for a 304 and skips the call entirely. The 304 would otherwise ship a narrower `Vary` than the 200 it revalidates, and since a 304 replaces the stored headers, a shared cache would stop keying the stored entry by `Accept-Encoding`. Tomcat parses the field names through `TokenList.parseTokenList` and de-duplicates, so naming it here leaves the 200 byte-identical.
- `no-cache` rather than `no-store`: `needClearCache()` drops the server-side cache whenever `If-None-Match` is absent, so the conditional request has to keep being sent. Here the ETag protects that cache more than it saves bandwidth.
- `useGetApplicationList` goes back to the shared `queryFn`. The hand-rolled logic arrived in two steps, and the first had nothing to do with `Vary`: 3fedb8f7cb turned the browser HTTP cache off (`cache: 'no-store'`) so the hook could drive ETag revalidation itself out of a single module-level variable — per-service scoping did not exist yet, and the endpoint sent an `ETag` but no `Cache-Control`, so revalidation was left to heuristic freshness. 814b3460bf then widened that variable into a per-service `Map` once requests began carrying `pServiceName`. From that point the work could not have been handed back to the browser even if we had wanted to: with no `Vary`, a URL-keyed cache would have served one service's application list to another. Declaring the contract resolves both steps at once — the browser sends `If-None-Match` and resolves the 304 on its own, so the hook never sees one.

Behaviour is unchanged for every other endpoint: the headers are set inside `MainController#getApplicationGroup` only (a private helper, two call sites), not in a filter or interceptor. `ShallowEtagHeaderFilter` is scoped to `/assets/*`, `*.html` and `/main`, so it does not interact with this endpoint.

## Test plan

- [x] `./mvnw compile -pl web`
- [x] `yarn build`
- [x] `yarn test` (102 suites, 807 tests)
- [x] `yarn lint` (0 errors)
- [x] Conditional request against a running backend: first call returns `200` + `ETag: W/"..."`, second call with `If-None-Match` returns `304` with an empty body, a call without the header returns `200`
- [ ] Response headers include `Cache-Control: no-cache`, and `Vary` lists both field names on the 200 *and* the 304 (needs a rebuilt backend). Tomcat rewrites the header on the 200, so expect `pservicename,accept-encoding` there and `pServiceName, Accept-Encoding` on the 304 — `Vary` field names are case-insensitive and unordered, so the two are equivalent.
- [ ] DevTools Network, **"Disable cache" unchecked**: first load `200`, plain reload (not a hard reload) shows `304` with `If-None-Match` present although no code sets it, and the application list still renders
- [ ] Switching service shows that service's application list, and switching back returns `304` with the correct list — confirms `Vary` keys the browser cache per service
- [ ] The refetch button (`?clearCache=true`) still returns `200` with a freshly built list

Note that in JS `response.status` reads `200` on a revalidated request — the browser resolves the 304 into the stored body before `fetch` sees it, which is the point of this change. The 304 is only visible in the Network panel.

