### PR TITLE
[#14114] Add uncounted interval logger to ThrottledLogger

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/ThrottledLogCallStackOverflowListener.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/ThrottledLogCallStackOverflowListener.java
@@ -33,7 +33,7 @@ public class ThrottledLogCallStackOverflowListener implements CallStackOverflowL
     public ThrottledLogCallStackOverflowListener(final int maxDepth, final int maxSequence, final long overflowLogIntervalMillis) {
         this.maxDepth = maxDepth;
         this.maxSequence = maxSequence;
-        this.throttledLogger = ThrottledLogger.getIntervalLogger(logger, Duration.ofMillis(overflowLogIntervalMillis));
+        this.throttledLogger = ThrottledLogger.getUncountedIntervalLogger(logger, Duration.ofMillis(overflowLogIntervalMillis));
     }
 
     @Override

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/GrpcSpanMessageConverter.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/GrpcSpanMessageConverter.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 public class GrpcSpanMessageConverter implements MessageConverter<SpanType, GeneratedMessageV3> {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final ThrottledLogger throttledLogger = ThrottledLogger.getIntervalLogger(this.logger);
+    private final ThrottledLogger throttledLogger = ThrottledLogger.getUncountedIntervalLogger(this.logger);
 
     private final String agentId;
     private final short applicationServiceType;

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/sender/grpc/AbstractGrpcDataSender.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/sender/grpc/AbstractGrpcDataSender.java
@@ -55,7 +55,7 @@ public abstract class AbstractGrpcDataSender<T> implements DataSender<T> {
     public AbstractGrpcDataSender(String host, int port,
                                   MessageConverter<T, GeneratedMessageV3> messageConverter,
                                   ChannelFactory channelFactory) {
-        this.tLogger = ThrottledLogger.getIntervalLogger(logger);
+        this.tLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
         this.channelFactory = Objects.requireNonNull(channelFactory, "channelFactory");
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -52,7 +52,7 @@ public class HbaseApplicationMapService implements ApplicationMapService {
     private static final String MERGE_AGENT = "_";
     private static final String MERGE_QUEUE = "_";
 
-    private final ThrottledLogger throttledLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger throttledLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final HostApplicationMapDao hostApplicationMapDao;
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/grpc/config/GrpcKeepAliveScheduler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/grpc/config/GrpcKeepAliveScheduler.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 @Component
 public class GrpcKeepAliveScheduler {
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final ThrottledLogger throttledLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger throttledLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final KeepAliveService keepAliveService;
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/metric/AgentMetricBatchHandler.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/handler/grpc/metric/AgentMetricBatchHandler.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 @Service
 public class AgentMetricBatchHandler implements SimpleHandler<PAgentStatBatch> {
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final ThrottledLogger throttledLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger throttledLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final GrpcAgentStatBatchMapper agentStatBatchMapper;
     private final AgentStatGroupService agentStatGroupService;

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/flow/RateLimitClientStreamServerInterceptor.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/flow/RateLimitClientStreamServerInterceptor.java
@@ -54,7 +54,7 @@ public class RateLimitClientStreamServerInterceptor implements ServerInterceptor
         this.bandwidth = Objects.requireNonNull(bandwidth, "bandwidth");
         this.bucketBuilder = Bucket.builder().addLimit(bandwidth);
 
-        this.bandwidthLogger = ThrottledLogger.getIntervalLogger(logger, throttledLoggerInterval);
+        this.bandwidthLogger = ThrottledLogger.getUncountedIntervalLogger(logger, throttledLoggerInterval);
     }
 
     @Override

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/AgentService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/AgentService.java
@@ -55,7 +55,7 @@ import java.util.concurrent.RejectedExecutionException;
 public class AgentService extends AgentGrpc.AgentImplBase {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final ThrottledLogger tLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger tLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final RequestResponseHandler<PAgentInfo, PResult> handler;
 
@@ -135,7 +135,7 @@ public class AgentService extends AgentGrpc.AgentImplBase {
         responseObserver.setOnCancelHandler(() -> disconnect(pingSession));
 
         return new StreamObserver<>() {
-            private final ThrottledLogger thLogger = ThrottledLogger.getIntervalLogger(AgentService.this.logger);
+            private final ThrottledLogger thLogger = ThrottledLogger.getUncountedIntervalLogger(AgentService.this.logger);
 
             @Override
             public void onNext(PPing ping) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/receiver/grpc/service/SpanService.java
@@ -51,7 +51,7 @@ public class SpanService extends SpanGrpc.SpanImplBase {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
     private final boolean isDebug = logger.isDebugEnabled();
-    private final ThrottledLogger tLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger tLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final AtomicLong serverStreamId = new AtomicLong();
 

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/scatter/service/HbaseScatterService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/scatter/service/HbaseScatterService.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 @Service
 public class HbaseScatterService implements ScatterService {
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final ThrottledLogger tLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger tLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final ApplicationTraceIndexDao applicationTraceIndexDao;
     private final TraceIndexDao traceIndexDao;

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/service/AgentListStateService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/service/AgentListStateService.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 public class AgentListStateService {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final ThrottledLogger tLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger tLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final AgentIdDao agentIdDao;
     private final boolean v2enabled;

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/service/ApplicationIndexV2Service.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/service/ApplicationIndexV2Service.java
@@ -18,7 +18,7 @@ import java.util.Set;
 @Service
 public class ApplicationIndexV2Service {
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final ThrottledLogger tLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger tLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final ApplicationDao applicationDao;
     private final AgentIdDao agentIdDao;

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/uid/service/CachingServiceLookupService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/uid/service/CachingServiceLookupService.java
@@ -28,7 +28,7 @@ public class CachingServiceLookupService implements ServiceLookupService, Applic
     private static final int DEFAULT_LOAD_LIMIT_PERCENT = 90;
 
     private final Logger logger = LogManager.getLogger(getClass());
-    private final ThrottledLogger tLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger tLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final CaffeineCacheProperties properties;
     private final ServiceLookupLoadProperties loadProperties;

--- a/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/AsyncPollerThread.java
+++ b/commons-hbase/src/main/java/com/navercorp/pinpoint/common/hbase/async/AsyncPollerThread.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class AsyncPollerThread implements Closeable {
 
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final ThrottledLogger tLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger tLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final TableWriterFactory writerFactory;
 

--- a/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/logging/CountLogThrottle.java
+++ b/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/logging/CountLogThrottle.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * Allows one log per {@code ratio} calls.
  *
  * @author Woonduk Kang(emeroad)
- * @deprecated call-count throttling emits in bursts under load spikes; use {@link TimeLogThrottle} instead
+ * @deprecated call-count throttling emits in bursts under load spikes; use {@link CountingTimeLogThrottle} instead
  */
 @Deprecated
 public class CountLogThrottle implements LogThrottle {

--- a/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/logging/CountingTimeLogThrottle.java
+++ b/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/logging/CountingTimeLogThrottle.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.profiler.logging;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.function.LongSupplier;
+
+/**
+ * {@link TimeLogThrottle} that also counts calls;
+ * suppressed calls are still counted and visible through {@link #getCounter()}.
+ *
+ * @author Woonduk Kang(emeroad)
+ */
+public class CountingTimeLogThrottle extends TimeLogThrottle {
+    private static final AtomicLongFieldUpdater<CountingTimeLogThrottle> COUNTER
+            = AtomicLongFieldUpdater.newUpdater(CountingTimeLogThrottle.class, "counter");
+
+    private volatile long counter;
+
+    public CountingTimeLogThrottle(long intervalMillis) {
+        super(intervalMillis);
+    }
+
+    CountingTimeLogThrottle(long intervalMillis, LongSupplier clock) {
+        super(intervalMillis, clock);
+    }
+
+    @Override
+    public boolean tryAcquire() {
+        COUNTER.getAndIncrement(this);
+        return super.tryAcquire();
+    }
+
+    @Override
+    public long getCounter() {
+        return COUNTER.get(this);
+    }
+}

--- a/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/logging/LogThrottle.java
+++ b/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/logging/LogThrottle.java
@@ -18,13 +18,21 @@ package com.navercorp.pinpoint.common.profiler.logging;
 
 /**
  * Decides whether a log call is allowed to be emitted.
- * Every {@link #tryAcquire()} call is counted, whether it is emitted or not.
+ * Counting implementations count every {@link #tryAcquire()} call, whether it is emitted or not.
  *
  * @author Woonduk Kang(emeroad)
  */
 public interface LogThrottle {
 
+    /**
+     * Returned by {@link #getCounter()} when the implementation does not count calls.
+     */
+    long DISABLED_COUNTER = -1;
+
     boolean tryAcquire();
 
+    /**
+     * @return number of {@link #tryAcquire()} calls, or {@link #DISABLED_COUNTER} if counting is not supported
+     */
     long getCounter();
 }

--- a/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/logging/ThrottledLogger.java
+++ b/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/logging/ThrottledLogger.java
@@ -57,6 +57,24 @@ public class ThrottledLogger {
     public static ThrottledLogger getIntervalLogger(Logger logger, Duration interval) {
         Objects.requireNonNull(logger, "logger");
         Objects.requireNonNull(interval, "interval");
+        return new ThrottledLogger(logger, new CountingTimeLogThrottle(interval.toMillis()));
+    }
+
+    /**
+     * Logs at most once per {@link #DEFAULT_INTERVAL} without counting suppressed calls;
+     * {@link #getCounter()} returns {@link LogThrottle#DISABLED_COUNTER}.
+     */
+    public static ThrottledLogger getUncountedIntervalLogger(Logger logger) {
+        return getUncountedIntervalLogger(logger, DEFAULT_INTERVAL);
+    }
+
+    /**
+     * Logs at most once per {@code interval} without counting suppressed calls;
+     * {@link #getCounter()} returns {@link LogThrottle#DISABLED_COUNTER}.
+     */
+    public static ThrottledLogger getUncountedIntervalLogger(Logger logger, Duration interval) {
+        Objects.requireNonNull(logger, "logger");
+        Objects.requireNonNull(interval, "interval");
         return new ThrottledLogger(logger, new TimeLogThrottle(interval.toMillis()));
     }
 

--- a/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/logging/TimeLogThrottle.java
+++ b/commons-profiler/src/main/java/com/navercorp/pinpoint/common/profiler/logging/TimeLogThrottle.java
@@ -21,19 +21,18 @@ import java.util.function.LongSupplier;
 
 /**
  * Allows one log per {@code intervalMillis}; the first call always logs.
- * Suppressed calls are still counted and visible through {@link #getCounter()}.
+ * Calls are not counted, so a burst of suppressed calls only reads a volatile field
+ * instead of contending on a shared counter, and {@link #getCounter()} always returns
+ * {@link LogThrottle#DISABLED_COUNTER}.
+ * <p>
+ * See {@link CountingTimeLogThrottle} for the counting variant.
  *
  * @author Woonduk Kang(emeroad)
  */
 public class TimeLogThrottle implements LogThrottle {
-    private static final AtomicLongFieldUpdater<TimeLogThrottle> COUNTER
-            = AtomicLongFieldUpdater.newUpdater(TimeLogThrottle.class, "counter");
     private static final AtomicLongFieldUpdater<TimeLogThrottle> NEXT_LOG_TIME
             = AtomicLongFieldUpdater.newUpdater(TimeLogThrottle.class, "nextLogTime");
 
-    // adjacent fields: every tryAcquire() writes counter then reads nextLogTime,
-    // so sharing a cache line serves both accesses with a single line transfer
-    private volatile long counter;
     private volatile long nextLogTime;
 
     private final long intervalMillis;
@@ -53,7 +52,6 @@ public class TimeLogThrottle implements LogThrottle {
 
     @Override
     public boolean tryAcquire() {
-        COUNTER.getAndIncrement(this);
 
         final long now = clock.getAsLong();
         final long next = this.nextLogTime;
@@ -66,6 +64,6 @@ public class TimeLogThrottle implements LogThrottle {
 
     @Override
     public long getCounter() {
-        return COUNTER.get(this);
+        return DISABLED_COUNTER;
     }
 }

--- a/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/logging/CountingTimeLogThrottleTest.java
+++ b/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/logging/CountingTimeLogThrottleTest.java
@@ -23,12 +23,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class TimeLogThrottleTest {
+public class CountingTimeLogThrottleTest {
 
     @Test
     public void firstCallAlwaysLogs() {
         AtomicLong clock = new AtomicLong(1000);
-        TimeLogThrottle throttle = new TimeLogThrottle(3000, clock::get);
+        CountingTimeLogThrottle throttle = new CountingTimeLogThrottle(3000, clock::get);
 
         assertThat(throttle.tryAcquire()).isTrue();
     }
@@ -36,7 +36,7 @@ public class TimeLogThrottleTest {
     @Test
     public void suppressWithinInterval() {
         AtomicLong clock = new AtomicLong(1000);
-        TimeLogThrottle throttle = new TimeLogThrottle(3000, clock::get);
+        CountingTimeLogThrottle throttle = new CountingTimeLogThrottle(3000, clock::get);
 
         assertThat(throttle.tryAcquire()).isTrue();
 
@@ -53,22 +53,22 @@ public class TimeLogThrottleTest {
     }
 
     @Test
-    public void counterDisabled() {
+    public void countSuppressedCalls() {
         AtomicLong clock = new AtomicLong(1000);
-        TimeLogThrottle throttle = new TimeLogThrottle(3000, clock::get);
+        CountingTimeLogThrottle throttle = new CountingTimeLogThrottle(3000, clock::get);
 
         throttle.tryAcquire();
         throttle.tryAcquire();
         throttle.tryAcquire();
 
-        assertThat(throttle.getCounter()).isEqualTo(LogThrottle.DISABLED_COUNTER);
+        assertThat(throttle.getCounter()).isEqualTo(3);
     }
 
     @Test
     public void invalidInterval() {
-        assertThatThrownBy(() -> new TimeLogThrottle(0))
+        assertThatThrownBy(() -> new CountingTimeLogThrottle(0))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new TimeLogThrottle(-1))
+        assertThatThrownBy(() -> new CountingTimeLogThrottle(-1))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/logging/ThrottledLoggerTest.java
+++ b/commons-profiler/src/test/java/com/navercorp/pinpoint/common/profiler/logging/ThrottledLoggerTest.java
@@ -92,6 +92,21 @@ public class ThrottledLoggerTest {
     }
 
     @Test
+    public void uncountedTimeBasedEmission() {
+        final Logger logger = mock(Logger.class);
+        when(logger.isEnabled(Level.INFO)).thenReturn(true);
+
+        // interval is long enough that only the first call within this test is emitted
+        final ThrottledLogger throttledLogger = ThrottledLogger.getUncountedIntervalLogger(logger, Duration.ofSeconds(10));
+        throttledLogger.info("uncounted time based");
+        throttledLogger.info("uncounted time based");
+        throttledLogger.info("uncounted time based");
+
+        verify(logger, times(1)).log(Level.INFO, "uncounted time based");
+        assertThat(throttledLogger.getCounter()).isEqualTo(LogThrottle.DISABLED_COUNTER);
+    }
+
+    @Test
     public void disabledLevelDoesNotCount() {
         final Logger logger = mock(Logger.class);
         when(logger.isEnabled(Level.INFO)).thenReturn(false);

--- a/grpc/src/main/java/com/navercorp/pinpoint/grpc/server/HeaderPropagationInterceptor.java
+++ b/grpc/src/main/java/com/navercorp/pinpoint/grpc/server/HeaderPropagationInterceptor.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  */
 public class HeaderPropagationInterceptor implements ServerInterceptor {
     private final Logger logger = LogManager.getLogger(this.getClass());
-    private final ThrottledLogger throttledLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger throttledLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final HeaderReader<Header> headerReader;
     private final Context.Key<Header> contextKey;

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentStartTimeResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAgentStartTimeResolver.java
@@ -59,7 +59,7 @@ public class OtlpAgentStartTimeResolver {
     private final Logger logger = LogManager.getLogger(this.getClass());
     // Throttled so a fleet-wide misconfigured exporter (every batch failing to parse) does not
     // flood the log; the true failure rate stays observable via the parse-error counter.
-    private final ThrottledLogger throttledLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger throttledLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final Counter creationTimeCounter;
     private final Counter spanTimeCounter;

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/HbaseOtlpTraceService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/HbaseOtlpTraceService.java
@@ -41,7 +41,7 @@ import java.util.concurrent.Executor;
 public class HbaseOtlpTraceService implements TraceService {
     private final Logger logger = LogManager.getLogger(getClass());
     // Throttled so an HBase outage (every span failing) does not flood the log.
-    private final ThrottledLogger throttledLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger throttledLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final TraceDao traceDao;
     private final ScatterService scatterService;

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
@@ -62,7 +62,7 @@ public class OtlpTraceExportService {
     // Throttled so an HBase outage (every span/chunk failing synchronously) does not flood the log.
     // Mirrors HbaseOtlpTraceService's async-path pattern (throttled WARN + a per-op error counter so
     // the true failure rate stays observable even while logs are throttled).
-    private final ThrottledLogger throttledLogger = ThrottledLogger.getIntervalLogger(logger);
+    private final ThrottledLogger throttledLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     @NotNull
     private final TraceService[] traceServiceList;


### PR DESCRIPTION
UncountedTimeLogThrottle skips the shared counter so suppressed calls
avoid contending on it; getCounter() returns LogThrottle.DISABLED_COUNTER.
