### PR TITLE
[#noissue] Resolve parent serviceUid via ServiceLookupService in application map

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/ApplicationMapModule.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/ApplicationMapModule.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.collector.applicationmap.service.HbaseApplicationM
 import com.navercorp.pinpoint.collector.applicationmap.service.LinkService;
 import com.navercorp.pinpoint.collector.applicationmap.service.LinkServiceImpl;
 import com.navercorp.pinpoint.collector.applicationmap.statistics.config.BulkConfiguration;
+import com.navercorp.pinpoint.collector.uid.service.ServiceLookupService;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -65,9 +66,10 @@ public class ApplicationMapModule {
     @Bean
     public ApplicationMapService applicationMapService(HostApplicationMapDao[] hostApplicationMapDaos,
                                                        LinkService linkService,
-                                                       ServiceTypeRegistryService registry) {
+                                                       ServiceTypeRegistryService registry,
+                                                       ServiceLookupService serviceLookupService) {
         HostApplicationMapDao hostApplicationMapDao = deleageHostApplicationMapDao(hostApplicationMapDaos);
-        return new HbaseApplicationMapService(hostApplicationMapDao, linkService, registry);
+        return new HbaseApplicationMapService(hostApplicationMapDao, linkService, registry, serviceLookupService);
     }
 
     private HostApplicationMapDao deleageHostApplicationMapDao(HostApplicationMapDao[] hostApplicationMapDaos) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.collector.applicationmap.service;
 
 import com.navercorp.pinpoint.collector.applicationmap.dao.HostApplicationMapDao;
+import com.navercorp.pinpoint.collector.uid.service.ServiceLookupService;
 import com.navercorp.pinpoint.common.profiler.logging.ThrottledLogger;
 import com.navercorp.pinpoint.common.server.applicationmap.Vertex;
 import com.navercorp.pinpoint.common.server.bo.BasicSpan;
@@ -27,7 +28,6 @@ import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.SpanOwner;
 import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
-import com.navercorp.pinpoint.common.server.uid.ServiceUidService;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeCategory;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
@@ -40,6 +40,10 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Trace service implementation for HBase storage.
@@ -52,6 +56,8 @@ public class HbaseApplicationMapService implements ApplicationMapService {
     private static final String MERGE_AGENT = "_";
     private static final String MERGE_QUEUE = "_";
 
+    private static final long UID_LOOKUP_TIMEOUT_MILLIS = 3000;
+
     private final ThrottledLogger throttledLogger = ThrottledLogger.getUncountedIntervalLogger(logger);
 
     private final HostApplicationMapDao hostApplicationMapDao;
@@ -59,13 +65,16 @@ public class HbaseApplicationMapService implements ApplicationMapService {
     private final LinkService linkService;
 
     private final ServiceTypeRegistryService registry;
+    private final ServiceLookupService serviceLookupService;
 
     public HbaseApplicationMapService(HostApplicationMapDao hostApplicationMapDao,
                                       LinkService linkService,
-                                      ServiceTypeRegistryService registry) {
+                                      ServiceTypeRegistryService registry,
+                                      ServiceLookupService serviceLookupService) {
         this.hostApplicationMapDao = Objects.requireNonNull(hostApplicationMapDao, "hostApplicationMapDao");
         this.linkService = Objects.requireNonNull(linkService, "statisticsService");
         this.registry = Objects.requireNonNull(registry, "registry");
+        this.serviceLookupService = Objects.requireNonNull(serviceLookupService, "serviceLookupService");
     }
 
     @Override
@@ -160,7 +169,25 @@ public class HbaseApplicationMapService implements ApplicationMapService {
     }
 
     private int getServiceUid(String serviceName) {
-        return ServiceUidService.getServiceUid(serviceName).getUid();
+        final CompletableFuture<ServiceUid> future = serviceLookupService.getServiceUid(serviceName);
+        try {
+            ServiceUid serviceUid = future.get(UID_LOOKUP_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            if (serviceUid == null) {
+                // ServiceLookupService completes with null when the serviceName is not registered
+                throttledLogger.info("Unregistered service. serviceName:{}", serviceName);
+                return ServiceUid.UNKNOWN.getUid();
+            }
+            return serviceUid.getUid();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return ServiceUid.ERROR.getUid();
+        } catch (ExecutionException e) {
+            throttledLogger.info("Failed to get serviceUid. serviceName:{} cause:{}", serviceName, e.getCause());
+            return ServiceUid.ERROR.getUid();
+        } catch (TimeoutException e) {
+            throttledLogger.info("Timed out getting serviceUid. serviceName:{} timeout:{}ms", serviceName, UID_LOOKUP_TIMEOUT_MILLIS);
+            return ServiceUid.ERROR.getUid();
+        }
     }
 
     private void insertSpanStat(SpanBo span, Vertex selfVertex) {


### PR DESCRIPTION
…ication map

This pull request refactors how service UIDs are looked up in the `HbaseApplicationMapService` class, switching from a static synchronous method to an asynchronous service with timeout handling. It introduces dependency injection for the new `ServiceLookupService` and updates the relevant configuration and constructor logic. The most important changes are grouped below.

### Service UID Lookup Refactoring

* Replaced the usage of the static `ServiceUidService.getServiceUid` method with the asynchronous `ServiceLookupService.getServiceUid`, adding timeout and error handling to improve reliability and observability. The method now handles unregistered services, exceptions, and timeouts explicitly.
* Added a constant `UID_LOOKUP_TIMEOUT_MILLIS` (set to 3000 ms) to control the maximum wait time for service UID lookup operations.
* Added imports for `CompletableFuture`, `ExecutionException`, `TimeoutException`, and `TimeUnit` to support asynchronous UID lookup and timeout handling.

### Dependency Injection and Configuration

* Updated the constructor of `HbaseApplicationMapService` to require a `ServiceLookupService` parameter, and ensured it is not null.
* Modified the `ApplicationMapModule` configuration to inject the new `ServiceLookupService` dependency into `HbaseApplicationMapService`.

These changes improve the robustness and flexibility of service UID lookups in the application map service.