### PR TITLE
[#14125] Apply service context to apdex score endpoints

### DIFF
--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
@@ -34,6 +34,7 @@ import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.vo.Service;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -59,13 +60,15 @@ public class AgentInspectorStatController {
     private final ApdexStatService apdexStatService;
     private final TenantProvider tenantProvider;
     private final RangeValidator rangeValidator;
+    private final ServiceModelResolver serviceModelResolver;
 
-    public AgentInspectorStatController(AgentStatService agentStatService, ApdexStatService apdexStatService, TenantProvider tenantProvider, InspectorWebProperties inspectorWebProperties) {
+    public AgentInspectorStatController(AgentStatService agentStatService, ApdexStatService apdexStatService, TenantProvider tenantProvider, InspectorWebProperties inspectorWebProperties, ServiceModelResolver serviceModelResolver) {
         this.agentStatService = Objects.requireNonNull(agentStatService, "agentStatService");
         this.apdexStatService = Objects.requireNonNull(apdexStatService, "apdexStatService");
         this.tenantProvider = Objects.requireNonNull(tenantProvider, "tenantProvider");
         Objects.requireNonNull(inspectorWebProperties, "inspectorWebProperties");
         this.rangeValidator = new ForwardRangeValidator(Duration.ofDays(inspectorWebProperties.getInspectorPeriodMax()));
+        this.serviceModelResolver = Objects.requireNonNull(serviceModelResolver, "serviceModelResolver");
     }
 
     // TODO : (minwoo) tenantId should be considered. The collector side should also be considered.
@@ -102,7 +105,8 @@ public class AgentInspectorStatController {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 
-        InspectorMetricData inspectorMetricData = apdexStatService.selectAgentStat(Service.DEFAULT, applicationName, serviceTypeName, metricDefinitionId, agentId, from.getEpochMillis(), to.getEpochMillis());
+        Service service = serviceModelResolver.getService(serviceName.getName());
+        InspectorMetricData inspectorMetricData = apdexStatService.selectAgentStat(service, applicationName, serviceTypeName, metricDefinitionId, agentId, from.getEpochMillis(), to.getEpochMillis());
         return new InspectorMetricView(inspectorMetricData);
     }
 
@@ -139,8 +143,9 @@ public class AgentInspectorStatController {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 
+        Service service = serviceModelResolver.getService(serviceName.getName());
         InspectorMetricGroupData inspectorMetricGroupData = apdexStatService.selectAgentStatGroupedByAgentId(
-                Service.DEFAULT, applicationName, serviceTypeName, metricDefinitionId, agentIds, from.getEpochMillis(), to.getEpochMillis()
+                service, applicationName, serviceTypeName, metricDefinitionId, agentIds, from.getEpochMillis(), to.getEpochMillis()
         );
         return new InspectorMetricGroupDataView(inspectorMetricGroupData);
     }

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
@@ -18,6 +18,7 @@ import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.vo.Service;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -37,13 +38,15 @@ public class ApplicationInspectorStatController {
     private final ApplicationStatService applicationStatService;
     private final ApdexStatService apdexStatService;
     private final RangeValidator rangeValidator;
+    private final ServiceModelResolver serviceModelResolver;
 
-    public ApplicationInspectorStatController(ApplicationStatService applicationStatService, TenantProvider tenantProvider, ApdexStatService apdexStatService, InspectorWebProperties inspectorWebProperties) {
+    public ApplicationInspectorStatController(ApplicationStatService applicationStatService, TenantProvider tenantProvider, ApdexStatService apdexStatService, InspectorWebProperties inspectorWebProperties, ServiceModelResolver serviceModelResolver) {
         this.applicationStatService = Objects.requireNonNull(applicationStatService, "applicationStatService");
         this.apdexStatService = Objects.requireNonNull(apdexStatService, "apdexStatService");
         this.tenantProvider = Objects.requireNonNull(tenantProvider, "tenantProvider");
         Objects.requireNonNull(inspectorWebProperties, "inspectorWebProperties");
         this.rangeValidator = new ForwardRangeValidator(Duration.ofDays(inspectorWebProperties.getInspectorPeriodMax()));
+        this.serviceModelResolver = Objects.requireNonNull(serviceModelResolver, "serviceModelResolver");
     }
 
     @PreAuthorize("@naverPermissionEvaluator.hasInspectorPermission(#serviceName.getName(), #applicationName)")
@@ -77,7 +80,8 @@ public class ApplicationInspectorStatController {
         Range range = Range.between(from, to);
         rangeValidator.validate(range.getFromInstant(), range.getToInstant());
 
-        InspectorMetricData inspectorMetricData = apdexStatService.selectApplicationStat(Service.DEFAULT, applicationName, serviceTypeName, metricDefinitionId, from.getEpochMillis(), to.getEpochMillis());
+        Service service = serviceModelResolver.getService(serviceName.getName());
+        InspectorMetricData inspectorMetricData = apdexStatService.selectApplicationStat(service, applicationName, serviceTypeName, metricDefinitionId, from.getEpochMillis(), to.getEpochMillis());
         return new InspectorMetricView(inspectorMetricData);
     }
 

--- a/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatControllerTest.java
+++ b/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatControllerTest.java
@@ -10,6 +10,8 @@ import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
+import com.navercorp.pinpoint.web.vo.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +23,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,6 +39,8 @@ class AgentInspectorStatControllerTest {
     private TenantProvider tenantProvider;
     @Mock
     private InspectorWebProperties inspectorWebProperties;
+    @Mock
+    private ServiceModelResolver serviceModelResolver;
 
     private AgentInspectorStatController controller;
 
@@ -44,7 +50,7 @@ class AgentInspectorStatControllerTest {
     @BeforeEach
     void setUp() {
         when(inspectorWebProperties.getInspectorPeriodMax()).thenReturn(42);
-        controller = new AgentInspectorStatController(agentStatService, apdexStatService, tenantProvider, inspectorWebProperties);
+        controller = new AgentInspectorStatController(agentStatService, apdexStatService, tenantProvider, inspectorWebProperties, serviceModelResolver);
     }
 
     @Test
@@ -105,5 +111,34 @@ class AgentInspectorStatControllerTest {
                 new ServiceName("DEFAULT"), "testApp", List.of("agent-01"), "cpu", FROM, TO);
 
         assertThat(result.getTitle()).isEqualTo("cpu");
+    }
+
+    @Test
+    void getApdexStatChart_passesResolvedService() {
+        Service service = new Service("my-service", 123);
+        when(serviceModelResolver.getService("my-service")).thenReturn(service);
+        InspectorMetricData metricData = new InspectorMetricData("Apdex Score", Collections.emptyList(), Collections.emptyList());
+        when(apdexStatService.selectAgentStat(eq(service), any(), any(), any(), any(), anyLong(), anyLong())).thenReturn(metricData);
+
+        InspectorMetricView result = controller.getApdexStatChart(
+                new ServiceName("my-service"), "testApp", "SPRING_BOOT", "agent-01", "apdex", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("Apdex Score");
+        verify(apdexStatService).selectAgentStat(eq(service), eq("testApp"), eq("SPRING_BOOT"), eq("apdex"), eq("agent-01"), anyLong(), anyLong());
+    }
+
+    @Test
+    void getApdexStatChartGroupedByAgentId_passesResolvedService() {
+        Service service = new Service("my-service", 123);
+        when(serviceModelResolver.getService("my-service")).thenReturn(service);
+        InspectorMetricGroupData groupData = new InspectorMetricGroupData("Apdex Score", Collections.emptyList(), Collections.emptyMap());
+        when(apdexStatService.selectAgentStatGroupedByAgentId(eq(service), any(), any(), any(), any(), anyLong(), anyLong())).thenReturn(groupData);
+
+        InspectorMetricGroupDataView result = controller.getApdexStatChartGroupedByAgentId(
+                new ServiceName("my-service"), "testApp", "SPRING_BOOT", List.of("agent-01", "agent-02"), "apdex", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("Apdex Score");
+        verify(apdexStatService).selectAgentStatGroupedByAgentId(
+                eq(service), eq("testApp"), eq("SPRING_BOOT"), eq("apdex"), eq(List.of("agent-01", "agent-02")), anyLong(), anyLong());
     }
 }

--- a/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatControllerTest.java
+++ b/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatControllerTest.java
@@ -10,6 +10,8 @@ import com.navercorp.pinpoint.inspector.web.view.InspectorMetricGroupDataView;
 import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
+import com.navercorp.pinpoint.web.vo.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +22,8 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +38,8 @@ class ApplicationInspectorStatControllerTest {
     private TenantProvider tenantProvider;
     @Mock
     private InspectorWebProperties inspectorWebProperties;
+    @Mock
+    private ServiceModelResolver serviceModelResolver;
 
     private ApplicationInspectorStatController controller;
 
@@ -43,7 +49,7 @@ class ApplicationInspectorStatControllerTest {
     @BeforeEach
     void setUp() {
         when(inspectorWebProperties.getInspectorPeriodMax()).thenReturn(42);
-        controller = new ApplicationInspectorStatController(applicationStatService, tenantProvider, apdexStatService, inspectorWebProperties);
+        controller = new ApplicationInspectorStatController(applicationStatService, tenantProvider, apdexStatService, inspectorWebProperties, serviceModelResolver);
     }
 
     @Test
@@ -79,5 +85,20 @@ class ApplicationInspectorStatControllerTest {
 
         assertThat(result.getTitle()).isEqualTo("jvmCpu");
         verify(applicationStatService).selectApplicationStatWithGrouping(any(), any());
+    }
+
+    @Test
+    void getApdexStatChart_passesResolvedService() {
+        Service service = new Service("my-service", 123);
+        when(serviceModelResolver.getService("my-service")).thenReturn(service);
+        InspectorMetricData metricData = new InspectorMetricData("Apdex Score", Collections.emptyList(), Collections.emptyList());
+        when(apdexStatService.selectApplicationStat(eq(service), any(), any(), any(), anyLong(), anyLong())).thenReturn(metricData);
+
+        InspectorMetricView result = controller.getApdexStatChart(
+                new ServiceName("my-service"), "testApp", "SPRING_BOOT", "apdex", FROM, TO);
+
+        assertThat(result.getTitle()).isEqualTo("Apdex Score");
+        verify(apdexStatService).selectApplicationStat(
+                eq(service), eq("testApp"), eq("SPRING_BOOT"), eq("apdex"), anyLong(), anyLong());
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/ApdexScoreController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/ApdexScoreController.java
@@ -4,9 +4,12 @@ import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowSampler;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindowSlotCentricSampler;
+import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.applicationmap.histogram.ApdexScore;
 import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.service.ApdexScoreService;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.stat.chart.StatChart;
@@ -28,14 +31,17 @@ public class ApdexScoreController {
 
     private final ApplicationFactory applicationFactory;
     private final ApdexScoreService apdexScoreService;
+    private final ServiceModelResolver serviceModelResolver;
 
-    public ApdexScoreController(ApplicationFactory applicationFactory, ApdexScoreService apdexScoreService) {
+    public ApdexScoreController(ApplicationFactory applicationFactory, ApdexScoreService apdexScoreService, ServiceModelResolver serviceModelResolver) {
         this.applicationFactory = Objects.requireNonNull(applicationFactory, "applicationFactory");
         this.apdexScoreService = Objects.requireNonNull(apdexScoreService, "apdexScoreService");
+        this.serviceModelResolver = Objects.requireNonNull(serviceModelResolver, "serviceModelResolver");
     }
 
     @GetMapping(value = "/getApdexScore")
     public ApdexScore getApdexScore(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
             @RequestParam("from") Timestamp from,
@@ -43,13 +49,15 @@ public class ApdexScoreController {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range);
 
-        Application application = applicationFactory.createApplication(Service.DEFAULT, applicationName, serviceTypeCode);
+        Service service = serviceModelResolver.getService(serviceName.getName());
+        Application application = applicationFactory.createApplication(service, applicationName, serviceTypeCode);
 
         return apdexScoreService.selectApdexScoreData(application, timeWindow);
     }
 
     @GetMapping(value = "/getApdexScore", params = "serviceTypeName")
     public ApdexScore getApdexScore(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("from") Timestamp from,
@@ -57,13 +65,15 @@ public class ApdexScoreController {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range);
 
-        Application application = applicationFactory.createApplicationByTypeName(Service.DEFAULT, applicationName, serviceTypeName);
+        Service service = serviceModelResolver.getService(serviceName.getName());
+        Application application = applicationFactory.createApplicationByTypeName(service, applicationName, serviceTypeName);
 
         return apdexScoreService.selectApdexScoreData(application, timeWindow);
     }
 
     @GetMapping(value = "/getApdexScore", params = {"agentId"})
     public ApdexScore getApdexScore(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
             @RequestParam("agentId") @NotBlank String agentId,
@@ -72,13 +82,15 @@ public class ApdexScoreController {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range);
 
-        Application application = applicationFactory.createApplication(Service.DEFAULT, applicationName, serviceTypeCode);
+        Service service = serviceModelResolver.getService(serviceName.getName());
+        Application application = applicationFactory.createApplication(service, applicationName, serviceTypeCode);
 
         return apdexScoreService.selectApdexScoreData(application, agentId, timeWindow);
     }
 
     @GetMapping(value = "/getApdexScore", params = {"agentId", "serviceTypeName"})
     public ApdexScore getApdexScore(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationName") @NotBlank String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("agentId") @NotBlank String agentId,
@@ -87,13 +99,15 @@ public class ApdexScoreController {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range);
 
-        Application application = applicationFactory.createApplicationByTypeName(Service.DEFAULT, applicationName, serviceTypeName);
+        Service service = serviceModelResolver.getService(serviceName.getName());
+        Application application = applicationFactory.createApplicationByTypeName(service, applicationName, serviceTypeName);
 
         return apdexScoreService.selectApdexScoreData(application, agentId, timeWindow);
     }
 
     @GetMapping(value = "/getApplicationStat/apdexScore/chart")
     public StatChart<?> getApplicationApdexScoreChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationId") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
             @RequestParam("from") Timestamp from,
@@ -101,13 +115,15 @@ public class ApdexScoreController {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range, APDEX_SCORE_TIME_WINDOW_SAMPLER);
 
-        Application application = applicationFactory.createApplication(Service.DEFAULT, applicationName, serviceTypeCode);
+        Service service = serviceModelResolver.getService(serviceName.getName());
+        Application application = applicationFactory.createApplication(service, applicationName, serviceTypeCode);
 
         return apdexScoreService.selectApplicationChart(application, timeWindow);
     }
 
     @GetMapping(value = "/getApplicationStat/apdexScore/chart", params = "serviceTypeName")
     public StatChart<?> getApplicationApdexScoreChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationId") @NotBlank String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("from") Timestamp from,
@@ -115,13 +131,15 @@ public class ApdexScoreController {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range, APDEX_SCORE_TIME_WINDOW_SAMPLER);
 
-        Application application = applicationFactory.createApplicationByTypeName(Service.DEFAULT, applicationName, serviceTypeName);
+        Service service = serviceModelResolver.getService(serviceName.getName());
+        Application application = applicationFactory.createApplicationByTypeName(service, applicationName, serviceTypeName);
 
         return apdexScoreService.selectApplicationChart(application, timeWindow);
     }
 
     @GetMapping(value = "/getAgentStat/apdexScore/chart")
     public StatChart<?> getAgentApdexScoreChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationId") @NotBlank String applicationName,
             @RequestParam("serviceTypeCode") Short serviceTypeCode,
             @RequestParam("agentId") @NotBlank String agentId,
@@ -130,13 +148,15 @@ public class ApdexScoreController {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range, APDEX_SCORE_TIME_WINDOW_SAMPLER);
 
-        Application application = applicationFactory.createApplication(Service.DEFAULT, applicationName, serviceTypeCode);
+        Service service = serviceModelResolver.getService(serviceName.getName());
+        Application application = applicationFactory.createApplication(service, applicationName, serviceTypeCode);
 
         return apdexScoreService.selectAgentChart(application, timeWindow, agentId);
     }
 
     @GetMapping(value = "/getAgentStat/apdexScore/chart", params = "serviceTypeName")
     public StatChart<?> getAgentApdexScoreChart(
+            @ServiceParam ServiceName serviceName,
             @RequestParam("applicationId") @NotBlank String applicationName,
             @RequestParam("serviceTypeName") @NotBlank String serviceTypeName,
             @RequestParam("agentId") @NotBlank String agentId,
@@ -145,7 +165,8 @@ public class ApdexScoreController {
         final Range range = Range.between(from, to);
         TimeWindow timeWindow = new TimeWindow(range, APDEX_SCORE_TIME_WINDOW_SAMPLER);
 
-        Application application = applicationFactory.createApplicationByTypeName(Service.DEFAULT, applicationName, serviceTypeName);
+        Service service = serviceModelResolver.getService(serviceName.getName());
+        Application application = applicationFactory.createApplicationByTypeName(service, applicationName, serviceTypeName);
 
         return apdexScoreService.selectAgentChart(application, timeWindow, agentId);
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/controller/ApdexScoreControllerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/controller/ApdexScoreControllerTest.java
@@ -1,0 +1,117 @@
+package com.navercorp.pinpoint.web.controller;
+
+import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
+import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.service.web.vo.ServiceName;
+import com.navercorp.pinpoint.web.component.ApplicationFactory;
+import com.navercorp.pinpoint.web.service.ApdexScoreService;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
+import com.navercorp.pinpoint.web.vo.Application;
+import com.navercorp.pinpoint.web.vo.Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApdexScoreControllerTest {
+
+    private static final Timestamp FROM = Timestamp.ofEpochMilli(0);
+    private static final Timestamp TO = Timestamp.ofEpochMilli(300000);
+    private static final Service SERVICE = new Service("my-service", 123);
+    private static final Application APPLICATION = new Application(SERVICE, "testApp", ServiceType.STAND_ALONE);
+
+    @Mock
+    private ApplicationFactory applicationFactory;
+    @Mock
+    private ApdexScoreService apdexScoreService;
+    @Mock
+    private ServiceModelResolver serviceModelResolver;
+
+    private ApdexScoreController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new ApdexScoreController(applicationFactory, apdexScoreService, serviceModelResolver);
+        when(serviceModelResolver.getService("my-service")).thenReturn(SERVICE);
+    }
+
+    @Test
+    void getApdexScoreByServiceTypeCode() {
+        when(applicationFactory.createApplication(SERVICE, "testApp", 1400)).thenReturn(APPLICATION);
+
+        controller.getApdexScore(new ServiceName("my-service"), "testApp", (short) 1400, FROM, TO);
+
+        verify(apdexScoreService).selectApdexScoreData(eq(APPLICATION), any(TimeWindow.class));
+    }
+
+    @Test
+    void getApdexScoreByServiceTypeName() {
+        when(applicationFactory.createApplicationByTypeName(SERVICE, "testApp", "SPRING_BOOT")).thenReturn(APPLICATION);
+
+        controller.getApdexScore(new ServiceName("my-service"), "testApp", "SPRING_BOOT", FROM, TO);
+
+        verify(apdexScoreService).selectApdexScoreData(eq(APPLICATION), any(TimeWindow.class));
+    }
+
+    @Test
+    void getAgentApdexScoreByServiceTypeCode() {
+        when(applicationFactory.createApplication(SERVICE, "testApp", 1400)).thenReturn(APPLICATION);
+
+        controller.getApdexScore(new ServiceName("my-service"), "testApp", (short) 1400, "agent-01", FROM, TO);
+
+        verify(apdexScoreService).selectApdexScoreData(eq(APPLICATION), eq("agent-01"), any(TimeWindow.class));
+    }
+
+    @Test
+    void getAgentApdexScoreByServiceTypeName() {
+        when(applicationFactory.createApplicationByTypeName(SERVICE, "testApp", "SPRING_BOOT")).thenReturn(APPLICATION);
+
+        controller.getApdexScore(new ServiceName("my-service"), "testApp", "SPRING_BOOT", "agent-01", FROM, TO);
+
+        verify(apdexScoreService).selectApdexScoreData(eq(APPLICATION), eq("agent-01"), any(TimeWindow.class));
+    }
+
+    @Test
+    void getApplicationApdexScoreChartByServiceTypeCode() {
+        when(applicationFactory.createApplication(SERVICE, "testApp", 1400)).thenReturn(APPLICATION);
+
+        controller.getApplicationApdexScoreChart(new ServiceName("my-service"), "testApp", (short) 1400, FROM, TO);
+
+        verify(apdexScoreService).selectApplicationChart(eq(APPLICATION), any(TimeWindow.class));
+    }
+
+    @Test
+    void getApplicationApdexScoreChartByServiceTypeName() {
+        when(applicationFactory.createApplicationByTypeName(SERVICE, "testApp", "SPRING_BOOT")).thenReturn(APPLICATION);
+
+        controller.getApplicationApdexScoreChart(new ServiceName("my-service"), "testApp", "SPRING_BOOT", FROM, TO);
+
+        verify(apdexScoreService).selectApplicationChart(eq(APPLICATION), any(TimeWindow.class));
+    }
+
+    @Test
+    void getAgentApdexScoreChartByServiceTypeCode() {
+        when(applicationFactory.createApplication(SERVICE, "testApp", 1400)).thenReturn(APPLICATION);
+
+        controller.getAgentApdexScoreChart(new ServiceName("my-service"), "testApp", (short) 1400, "agent-01", FROM, TO);
+
+        verify(apdexScoreService).selectAgentChart(eq(APPLICATION), any(TimeWindow.class), eq("agent-01"));
+    }
+
+    @Test
+    void getAgentApdexScoreChartByServiceTypeName() {
+        when(applicationFactory.createApplicationByTypeName(SERVICE, "testApp", "SPRING_BOOT")).thenReturn(APPLICATION);
+
+        controller.getAgentApdexScoreChart(new ServiceName("my-service"), "testApp", "SPRING_BOOT", "agent-01", FROM, TO);
+
+        verify(apdexScoreService).selectAgentChart(eq(APPLICATION), any(TimeWindow.class), eq("agent-01"));
+    }
+}


### PR DESCRIPTION
## Summary

- Resolves #14125
- The apdex endpoints received `@ServiceParam ServiceName` but ignored it and always queried with the hardcoded `Service.DEFAULT`, so applications under a non-default service returned apdex 0.0 (or an empty inspector chart).
- Inject `ServiceModelResolver` and pass the resolved `Service` down, the same pattern as scatter (#14079) and histogram/statistics (#14095):
  - `web` `ApdexScoreController` — all 8 handlers
  - `inspector-web` `AgentInspectorStatController` — apdex chart handler and its `agentIds` variant
  - `inspector-web` `ApplicationInspectorStatController` — apdex chart handler
- Behaviour is unchanged when no service is specified (resolves to DEFAULT); an unregistered service name is rejected with 400 by the resolver (#14099).

## Test plan

- [x] New unit tests verifying the resolved service is passed down: `ApdexScoreControllerTest` (8), `AgentInspectorStatControllerTest` (+2), `ApplicationInspectorStatControllerTest` (+1)
- [x] Existing tests: web 585, inspector-web 14 — all pass
- [x] E2E against a local stack (collector/agent/web, service lookup on): `/getApdexScore` with a registered service returns non-zero score; without the header it stays isolated to DEFAULT; unregistered service returns 400; apdex charts (`/getApplicationStat`, `/getAgentStat`, `/api/inspector/agentStat`, `/api/inspector/applicationStat`) return data for the selected service only