### PR TITLE
[#noissue] Gate the generic reactor CoreSubscriber instrumentation be…

### DIFF
--- a/agent-module/agent-testweb/spring-boot3-webflux-plugin-testweb/src/main/java/com/pinpoint/test/plugin/SpringBoot3WebfluxPluginController.java
+++ b/agent-module/agent-testweb/spring-boot3-webflux-plugin-testweb/src/main/java/com/pinpoint/test/plugin/SpringBoot3WebfluxPluginController.java
@@ -39,6 +39,7 @@ import org.springframework.web.reactive.result.method.annotation.RequestMappingH
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.net.URI;
 import java.time.Duration;
@@ -170,5 +171,26 @@ public class SpringBoot3WebfluxPluginController {
         return Flux.interval(Duration.ofSeconds(1))
                 .map(sequence -> "Stream Data " + sequence)
                 .take(10);
+    }
+
+    @GetMapping("/seam/publishOn/flux")
+    public Mono<String> seamPublishOnFlux() {
+        // Response-coupled publishOn chain for the seam wrapper A/B: assembled per request under
+        // the server trace, 1000 elements so the publishOn->map ASYNC fusion the wrapper suppresses
+        // actually carries weight. The response completes only after the hop.
+        return Flux.range(1, 1000)
+                .publishOn(Schedulers.parallel())
+                .map(value -> value + 1)
+                .reduce(0, Integer::sum)
+                .map(String::valueOf);
+    }
+
+    @GetMapping("/seam/publishOn/mono")
+    public Mono<String> seamPublishOnMono() {
+        // Single-element variant: dominated by the per-subscription wrapper and window cost
+        // rather than fusion.
+        return Mono.just("seam")
+                .publishOn(Schedulers.parallel())
+                .map(value -> value + "-done");
     }
 }

--- a/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
@@ -1163,6 +1163,7 @@ profiler.reactor.trace.onError=false
 profiler.reactor.mark.error.onError=false
 # Set whether to trace the publishOn(), subscribeOn() methods
 profiler.reactor.trace.publishOn=true
+profiler.reactor.wrap.publisher.publishOn=false
 profiler.reactor.trace.subscribeOn=true
 profiler.reactor.trace.delay=true
 profiler.reactor.trace.interval=true
@@ -1172,10 +1173,12 @@ profiler.reactor.mark.error.retry=false
 profiler.reactor.trace.timeout=true
 # FLUX/MONO subscribe
 profiler.reactor.trace.subscribe=true
-# Trace one-shot scheduler task carriers.
+# Trace one-shot scheduler task carriers. Automatically enabled when subscriber instrumentation is disabled.
 profiler.reactor.trace.scheduler.task=false
 # Periodic scheduler tasks are not instrumented by default. When enabled, each tick is a new independent transaction.
 profiler.reactor.trace.scheduler.task.periodic=false
+# Generic CoreSubscriber instrumentation. Disabling this reduces per-operator instrumentation.
+profiler.reactor.subscriber.instrument=true
 
 ###########################################################
 # log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)

--- a/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
@@ -1159,6 +1159,7 @@ profiler.reactor.trace.onError=false
 profiler.reactor.mark.error.onError=false
 # Set whether to trace the publishOn(), subscribeOn() methods
 profiler.reactor.trace.publishOn=true
+profiler.reactor.wrap.publisher.publishOn=false
 profiler.reactor.trace.subscribeOn=true
 profiler.reactor.trace.delay=true
 profiler.reactor.trace.interval=true
@@ -1168,10 +1169,12 @@ profiler.reactor.mark.error.retry=false
 profiler.reactor.trace.timeout=true
 # FLUX/MONO subscribe
 profiler.reactor.trace.subscribe=true
-# Trace one-shot scheduler task carriers.
+# Trace one-shot scheduler task carriers. Automatically enabled when subscriber instrumentation is disabled.
 profiler.reactor.trace.scheduler.task=false
 # Periodic scheduler tasks are not instrumented by default. When enabled, each tick is a new independent transaction.
 profiler.reactor.trace.scheduler.task.periodic=false
+# Generic CoreSubscriber instrumentation. Disabling this reduces per-operator instrumentation.
+profiler.reactor.subscriber.instrument=true
 
 ###########################################################
 # log4j (guide url : https://github.com/pinpoint-apm/pinpoint-apm.github.io/blob/main/documents/per-request_feature_guide.md)

--- a/agent-module/plugins-it/reactor-it/src/test/java/com/navercorp/pinpoint/it/plugin/reactor/ReactorPublishOnSeam_IT.java
+++ b/agent-module/plugins-it/reactor-it/src/test/java/com/navercorp/pinpoint/it/plugin/reactor/ReactorPublishOnSeam_IT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.reactor;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import test.pinpoint.plugin.reactor.Echo;
+import test.pinpoint.plugin.reactor.ReactorFlow;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Correctness probe for the publishOn-only seam. Assembly happens under a root trace and
+ * subscription happens after that root has left the thread. Generic subscriber instrumentation
+ * and direct subscribe tracing are both disabled by the config, so the callback can be linked to
+ * the publishOn event only when the returned Publisher was actually replaced by the seam wrapper.
+ */
+@Disabled("publishOn seam parked after the G2 verdict (2026-08-10): the wrapper's per-signal window "
+        + "cost and fusion suppression cost ~2-3% RPS on the very chain it targets, cancelling the "
+        + "expected relay recovery. The known failure here is a double async link - the forced-on "
+        + "scheduler task carrier mints a sibling link inside the seam window and the leaf attaches "
+        + "to it, leaving the wrapper's link dangling. Both are documented in "
+        + "pinpoint-req-1739-review docs 35 (5-1a) and 41. Re-enable together with the carrier "
+        + "hop-ownership fix if the seam design is revived.")
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@PinpointConfig("pinpoint-publishon-seam.config")
+@Dependency({"io.projectreactor:reactor-core:[3.6.9][3.7.19]"})
+public class ReactorPublishOnSeam_IT {
+    private static final String REACTOR = "REACTOR";
+    private static final String INTERNAL_METHOD = "INTERNAL_METHOD";
+    private static final String FLUX_PUBLISH_ON =
+            "reactor.core.publisher.Flux.publishOn(reactor.core.scheduler.Scheduler, boolean, int, int)";
+    private static final String MONO_PUBLISH_ON =
+            "reactor.core.publisher.Mono.publishOn(reactor.core.scheduler.Scheduler)";
+
+    private static final long AWAIT_UNIT_MILLIS = 20L;
+    private static final long AWAIT_MAX_MILLIS = 5000L;
+
+    @Test
+    public void fluxOnNextPropagatesWhenSubscribedWithoutAmbientTrace() throws Exception {
+        Scheduler scheduler = Schedulers.newParallel("it-seam-flux", 2);
+        try {
+            CountDownLatch callback = new CountDownLatch(1);
+            Flux<?>[] assembled = new Flux<?>[1];
+
+            new ReactorFlow().execute(() -> assembled[0] = Flux.range(1, 1)
+                    .publishOn(scheduler)
+                    .map(value -> echo(callback, "flux-" + value)));
+
+            assembled[0].subscribe();
+
+            awaitAndVerify(callback, FLUX_PUBLISH_ON);
+        } finally {
+            scheduler.dispose();
+        }
+    }
+
+    @Test
+    public void monoCompletePropagatesWhenSubscribedWithoutAmbientTrace() throws Exception {
+        Scheduler scheduler = Schedulers.newParallel("it-seam-mono-complete", 2);
+        try {
+            CountDownLatch callback = new CountDownLatch(1);
+            Mono<?>[] assembled = new Mono<?>[1];
+
+            new ReactorFlow().execute(() -> assembled[0] = Mono.empty()
+                    .publishOn(scheduler)
+                    .doOnSuccess(value -> echo(callback, "complete")));
+
+            assembled[0].subscribe();
+
+            awaitAndVerify(callback, MONO_PUBLISH_ON);
+        } finally {
+            scheduler.dispose();
+        }
+    }
+
+    @Test
+    public void monoErrorPropagatesWhenSubscribedWithoutAmbientTrace() throws Exception {
+        Scheduler scheduler = Schedulers.newParallel("it-seam-mono-error", 2);
+        try {
+            CountDownLatch callback = new CountDownLatch(1);
+            Mono<?>[] assembled = new Mono<?>[1];
+
+            new ReactorFlow().execute(() -> assembled[0] = Mono.error(new IllegalStateException("test"))
+                    .publishOn(scheduler)
+                    .doOnError(error -> echo(callback, "error")));
+
+            assembled[0].subscribe(value -> {
+            }, error -> {
+            });
+
+            awaitAndVerify(callback, MONO_PUBLISH_ON);
+        } finally {
+            scheduler.dispose();
+        }
+    }
+
+    private String echo(CountDownLatch callback, String value) {
+        try {
+            return new Echo().get(value);
+        } finally {
+            callback.countDown();
+        }
+    }
+
+    private void awaitAndVerify(CountDownLatch callback, String publishOnApi) throws Exception {
+        assertTrue(callback.await(AWAIT_MAX_MILLIS, TimeUnit.MILLISECONDS), "callback was not invoked");
+
+        Method echoGet = Echo.class.getDeclaredMethod("get", String.class);
+        ExpectedTrace leaf = Expectations.event(INTERNAL_METHOD, echoGet);
+        ExpectedTrace asyncLink = Expectations.async(Expectations.event(REACTOR, publishOnApi), leaf);
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.awaitTrace(leaf, AWAIT_UNIT_MILLIS, AWAIT_MAX_MILLIS);
+        verifier.printCache();
+        verifier.verifyDiscreteTrace(asyncLink);
+    }
+}

--- a/agent-module/plugins-it/reactor-it/src/test/resources/pinpoint-publishon-seam.config
+++ b/agent-module/plugins-it/reactor-it/src/test/resources/pinpoint-publishon-seam.config
@@ -1,0 +1,13 @@
+###########################################################
+# user defined classes                                    #
+###########################################################
+profiler.entrypoint=test.pinpoint.plugin.reactor.ReactorFlow.execute,test.pinpoint.plugin.reactor.Echo.get
+
+###########################################################
+# publishOn-only seam PoC                                 #
+###########################################################
+# Remove the two generic fallbacks so the assembled-under-trace/subscribed-without-trace tests
+# can pass only through the publishOn result wrapper.
+profiler.reactor.wrap.publisher.publishOn=true
+profiler.reactor.subscriber.instrument=false
+profiler.reactor.trace.subscribe=false

--- a/agent-module/plugins/reactor/README.md
+++ b/agent-module/plugins/reactor/README.md
@@ -13,13 +13,36 @@ pinpoint.config
 # Reactor
 ###########################################################
 profiler.reactor.enable=true
-# Set whether to trace the Subscriber.onError(Throwable t) method
-profiler.reactor.trace.subscribe.error=true
-# Trace one-shot scheduler task carriers.
+# Set whether to trace the onErrorComplete(), onErrorResume(), onErrorMap(), onErrorReturn() methods
+profiler.reactor.trace.onError=false
+profiler.reactor.mark.error.onError=false
+# Set whether to trace the publishOn(), subscribeOn() methods
+profiler.reactor.trace.publishOn=true
+profiler.reactor.trace.subscribeOn=true
+profiler.reactor.trace.delay=true
+profiler.reactor.trace.interval=true
+# retry, retryWhen, timeout
+profiler.reactor.trace.retry=true
+profiler.reactor.mark.error.retry=false
+profiler.reactor.trace.timeout=true
+# FLUX/MONO subscribe
+profiler.reactor.trace.subscribe=true
+~~~
+
+#### Experimental options.
+~~~
+# Trace the one-shot scheduler task carriers, so that a task submitted to a Scheduler keeps the
+# trace across the thread hop even when it is not an operator subscriber. See Schedulers below.
 profiler.reactor.trace.scheduler.task=false
-# Periodic scheduler tasks are excluded from instrumentation by default. If enabled, every
-# execution is recorded as a new transaction and never continues the trace that scheduled it.
+# Periodic scheduler tasks are excluded from instrumentation by default. When enabled, every
+# execution is recorded as a new independent transaction and never continues the trace that
+# happened to schedule the job. See Periodic tasks below.
 profiler.reactor.trace.scheduler.task.periodic=false
+# Instrument the generic per-operator CoreSubscriber layer. See Lightweight mode below.
+profiler.reactor.subscriber.instrument=true
+# publishOn-only seam wrapper: replace the legacy publisher field injection on publishOn results
+# with a wrapping subscriber. Parked after its cost/benefit measurement - see the note below.
+profiler.reactor.wrap.publisher.publishOn=false
 ~~~
 
 ### Trace
@@ -30,9 +53,110 @@ A Reactive Streams Publisher with basic flow operators.
 #### Mono
 A Reactive Streams Publisher constrained to ZERO or ONE element with appropriate operators.
 
-### TODO
+### Lightweight mode
 
-#### Schedulers
-Reactor uses a Scheduler as a contract for arbitrary task execution. It provides some guarantees required by Reactive Streams flows like FIFO execution.
+By default the plugin instruments every `CoreSubscriber` implementation in
+`reactor.core.publisher` - 200+ classes get an injected `AsyncContextAccessor` field plus
+constructor, `onSubscribe`, `onNext` and `run` interceptors. That generic per-operator layer is
+what carries the trace along an operator chain, and it is also where most of the plugin's CPU
+cost sits, because every operator type shares the same context read.
+
+Setting `profiler.reactor.subscriber.instrument=false` skips the registration of that layer
+entirely, so the classes it would have matched are never transformed and carry no residency
+cost. Everything registered by exact class name stays: the timeout, retry and onError
+subscribers, the interval and delay timer tasks, the scheduler task carriers, the publisher
+field injection and the subscribe relay.
+
+The one-shot scheduler task carrier is **required** in this mode and is therefore enabled
+automatically (with a log line) even if `profiler.reactor.trace.scheduler.task` is left at
+`false`. Without the generic layer a scheduler hop has no operator relay, so user code running
+after the hop - for example a WebClient call assembled inside `flatMap` - would run outside the
+trace and outbound header propagation would silently break.
+
+The mode is experimental and off by default. Enable it only if the coverage trade-off below is
+acceptable for your service.
+
+#### Coverage trade-off
+
+| Signal | Default | Lightweight |
+|---|---|---|
+| Distributed trace propagation (outbound headers, async links) | traced | traced, through the scheduler task carrier and the subscribe relay instead of the operator chain |
+| Operator boundary events - the REACTOR frames from operator construction, `onNext` and `run` | recorded | not recorded |
+| Scheduler hops | linked by the operator relay | linked by the carrier's `run()` window. A hop that finds no async context on the task falls back to the current trace and records one REACTOR event per task, so a hop-intensive workload sees noticeably more boundary events than it does by default |
+| `retry` / `retryWhen` re-subscription | every attempt stays in the originating transaction: the two retry subscribers are exact-name transforms that seed an async context at construction and restore it around `resubscribe()` | unchanged - the seed and the re-subscription window are exact-name transforms and survive this mode |
+| Per-attempt retry failure events | not recorded at the re-subscription boundary - the restore-only window deliberately records no span event per attempt (`retryWhen` failures are still visible through its companion `whenError` instrumentation) | same |
+| `timeout` | traced | unchanged |
+| `Flux` / `Mono` subscribe, `publishOn` / `subscribeOn`, `delay` / `interval`, `onError` | traced | unchanged - these are exact-name transforms and are not gated |
+
+Weigh the boundary-event loss against the throughput gain: single-endpoint WebFlux benchmarks
+measured 5 to 8% more throughput with the mode on (JDK 25), and how much of that a given service
+sees depends on how operator-dense its chains are.
+
+### Schedulers
+
+Reactor uses a Scheduler as a contract for arbitrary task execution. It provides some guarantees
+required by Reactive Streams flows like FIFO execution.
+
+A task crossing to a worker thread keeps its trace in one of two ways:
+
+* The scheduled task is itself an instrumented operator subscriber - `publishOn` and
+  `subscribeOn` schedule their own subscriber - so the generic per-operator layer carries the
+  context across the hop. This is what covers scheduler hops by default.
+* The task is wrapped by one of reactor's one-shot scheduler task carriers, which Pinpoint
+  instruments when `profiler.reactor.trace.scheduler.task` is enabled. This is the only thing
+  that links a plain `Runnable` handed straight to `Scheduler.schedule()`, and it is what
+  replaces the operator relay in lightweight mode.
+
+#### Periodic tasks
+
+A periodic task is constructed once and runs until it is disposed. If it adopted the trace that
+happened to schedule it - a request-scoped trace, say - every tick would keep appending async
+chunks to that one transaction for as long as the job lives, and the transaction could never
+end. The periodic carriers (`PeriodicSchedulerTask`, `PeriodicWorkerTask`,
+`InstantPeriodicWorkerTask`) are therefore not instrumented at all by default.
+
+`profiler.reactor.trace.scheduler.task.periodic=true` opts in with different semantics: each
+execution is recorded as a new independent transaction (rpc `Reactor periodic scheduler task`,
+endpoint `LOCAL`), and a trace already bound to the worker thread is suspended for the duration
+of the tick and restored afterwards, never continued into the periodic work. Reactor's own
+periodic sources are unaffected either way - `Flux.interval` runs an instrumented
+`FluxInterval$IntervalRunnable`, which carries its context through its own exact-name
+instrumentation, not through the periodic carrier.
+
+#### Carrier coverage
+
+Reactor asks custom `Scheduler` implementations to pass every submitted task through
+`Schedulers.onSchedule()`, but the carrier that Pinpoint instruments is created by
+`Schedulers.directSchedule()` / `Schedulers.workerSchedule()` a step later. A custom scheduler
+that calls `onSchedule` and then submits the task itself is therefore invisible to the carrier.
+
+| Scheduler | Task carrier | Covered |
+|---|---|---|
+| Built-in schedulers (`parallel`, `single`, `boundedElastic`, `newParallel`, ...), which go through `Schedulers.directSchedule()` / `workerSchedule()` | `SchedulerTask`, `WorkerTask` for one-shot schedules | yes |
+| The same built-in schedulers, periodic schedules | `PeriodicSchedulerTask`, `PeriodicWorkerTask`, `InstantPeriodicWorkerTask` | excluded by default; opt-in records each tick as an independent transaction (see Periodic tasks) |
+| `Schedulers.fromExecutor()` | `ExecutorScheduler$ExecutorPlainRunnable`, `ExecutorScheduler$ExecutorTrackedRunnable` | yes |
+| `Schedulers.fromExecutorService()` | `SchedulerTask` for direct schedules, `WorkerTask` for worker schedules | yes |
+| Virtual-thread `boundedElastic` (reactor 3.6+ on JDK 21+) | `BoundedElasticThreadPerTaskScheduler$SchedulerTask` | yes |
+| `Schedulers.immediate()` | none - the task runs inline | not applicable, there is no thread hop to cross |
+| Custom `Scheduler` that calls `Schedulers.onSchedule()` and then submits the task through its own carrier | its own | no |
+| Custom `Scheduler` that does not call `Schedulers.onSchedule()` at all | its own | no |
+
+The virtual-thread `boundedElastic` scheduler is worth a note: reactor-core is a multi-release
+JAR, and the `BoundedElasticThreadPerTaskScheduler` on the Java 8 class path is a stub whose
+methods all throw `UnsupportedOperationException`. The real implementation, and the nested
+`SchedulerTask` that Pinpoint instruments, live under `META-INF/versions/21`. Reading only the
+base entry makes the scheduler look uninstrumented when it is not.
+
+### publishOn seam wrapper (parked)
+
+`profiler.reactor.wrap.publisher.publishOn=true` replaces the legacy field injection on
+`publishOn` results with a wrapping subscriber that delivers every signal inside a trace window.
+The experiment is parked: an A/B on a response-coupled 1000-element publishOn chain measured a
+consistent 2-3% throughput cost from the per-signal window and the fusion suppression the
+wrapper requires, cancelling the relay-removal gain it was meant to earn. The gate stays off by
+default and its propagation IT (`ReactorPublishOnSeam_IT`) is disabled; both carry pointers to
+the measurement record.
+
+### TODO
 
 #### ParallelFlux

--- a/agent-module/plugins/reactor/pom.xml
+++ b/agent-module/plugins/reactor/pom.xml
@@ -26,9 +26,58 @@
         </dependency>
 
         <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-reactor-seam-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${plugin.shade.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.navercorp.pinpoint:pinpoint-reactor-seam-support</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>com.navercorp.pinpoint:pinpoint-reactor-seam-support</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.navercorp.pinpoint.plugin.reactorsupport</pattern>
+                                    <shadedPattern>com.navercorp.pinpoint.plugin.reactor.reactorsupport</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <dependencyReducedPomLocation>
+                                ${project.build.directory}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/ReactorPlugin.java
+++ b/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/ReactorPlugin.java
@@ -28,6 +28,7 @@ import com.navercorp.pinpoint.bootstrap.instrument.matcher.operand.SuperClassInt
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.MatchableTransformTemplate;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.MatchableTransformTemplateAware;
 import com.navercorp.pinpoint.bootstrap.instrument.transformer.TransformCallback;
+import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExecutionPolicy;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
@@ -57,6 +58,7 @@ import com.navercorp.pinpoint.plugin.reactor.interceptor.RetryWhenMainSubscriber
 import com.navercorp.pinpoint.plugin.reactor.interceptor.RunnableSubscriptionConstructorInterceptor;
 import com.navercorp.pinpoint.plugin.reactor.interceptor.RunnableSubscriptionInterceptor;
 import com.navercorp.pinpoint.plugin.reactor.interceptor.TimeoutMainSubscriberDoTimeoutInterceptor;
+import com.navercorp.pinpoint.plugin.reactor.interceptor.WrappingFluxAndMonoPublishOnInterceptor;
 
 import java.security.ProtectionDomain;
 
@@ -94,9 +96,16 @@ public class ReactorPlugin implements ProfilerPlugin, MatchableTransformTemplate
         }
         logger.info("{}, config:{}", this.getClass().getSimpleName(), config);
 
-        addFluxAndMono();
+        addFluxAndMono(config.isTracePublishOn() && config.isWrapPublisherPublishOn());
         addThreadingAndSchedulers();
-        if (config.isTraceSchedulerTask()) {
+        if (config.isTraceSchedulerTask() || !config.isSubscriberInstrument()) {
+            // The carrier is REQUIRED when the generic subscriber layer is off: a scheduler hop
+            // then has no operator relay, so without the carrier's run() trace window, user code
+            // after the hop (e.g. a WebClient call assembled inside flatMap) runs out-of-trace
+            // and outbound header propagation silently breaks (verified end to end).
+            if (!config.isTraceSchedulerTask()) {
+                logger.info("profiler.reactor.subscriber.instrument=false requires the scheduler task carrier - enabling it (profiler.reactor.trace.scheduler.task)");
+            }
             addSchedulerTasks();
         }
         if (config.isTracePeriodicSchedulerTask()) {
@@ -109,7 +118,15 @@ public class ReactorPlugin implements ProfilerPlugin, MatchableTransformTemplate
         addTimeout();
         addRetry();
         addOnError();
-        addCoreSubscriber();
+        if (config.isSubscriberInstrument()) {
+            // The generic per-operator layer (200+ reactor.core.publisher CoreSubscriber types:
+            // addField + constructor/onSubscribe/onNext/run). The dedicated subscriber transforms
+            // above (timeout/retry/onError/scheduler tasks) are exact-name registrations, so they
+            // stay regardless of this gate. Turning this off keeps the publisher field injection
+            // and the subscribe relay; boundary linking then travels through the scheduler-task
+            // carrier (forced on above) and the seam wrappers instead of the operator chain.
+            addCoreSubscriber();
+        }
     }
 
     @Override
@@ -117,7 +134,12 @@ public class ReactorPlugin implements ProfilerPlugin, MatchableTransformTemplate
         this.transformTemplate = transformTemplate;
     }
 
-    private void addFluxAndMono() {
+    private void addFluxAndMono(boolean wrapPublishOn) {
+        if (wrapPublishOn) {
+            transformTemplate.transform("reactor.core.publisher.Flux", FluxPublishOnSeamMethodTransform.class);
+            transformTemplate.transform("reactor.core.publisher.Mono", MonoPublishOnSeamMethodTransform.class);
+            return;
+        }
         transformTemplate.transform("reactor.core.publisher.Flux", FluxMethodTransform.class);
         transformTemplate.transform("reactor.core.publisher.Mono", MonoMethodTransform.class);
     }
@@ -222,27 +244,39 @@ public class ReactorPlugin implements ProfilerPlugin, MatchableTransformTemplate
     public static class FluxMethodTransform implements TransformCallback {
         @Override
         public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
-            final InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
-
-            final InstrumentMethod subscribeMethod = target.getDeclaredMethod("subscribe", "org.reactivestreams.Subscriber");
-            if (subscribeMethod != null) {
-                subscribeMethod.addInterceptor(FluxAndMonoSubscribeMethodInterceptor.class);
-            }
-            final InstrumentMethod publishOnMethod = target.getDeclaredMethod("publishOn", "reactor.core.scheduler.Scheduler", "boolean", "int", "int");
-            if (publishOnMethod != null) {
-                publishOnMethod.addInterceptor(FluxAndMonoPublishOnInterceptor.class);
-            }
-            final InstrumentMethod subscribeOnMethod = target.getDeclaredMethod("subscribeOn", "reactor.core.scheduler.Scheduler", "boolean");
-            if (subscribeOnMethod != null) {
-                subscribeOnMethod.addInterceptor(FluxAndMonoSubscribeOnInterceptor.class);
-            }
-            final InstrumentMethod intervalMethod = target.getDeclaredMethod("interval", "java.time.Duration", "java.time.Duration", "reactor.core.scheduler.Scheduler");
-            if (intervalMethod != null) {
-                intervalMethod.addInterceptor(FluxAndMonoIntervalInterceptor.class);
-            }
-
-            return target.toBytecode();
+            return transformFluxMethods(instrumentor, loader, className, classfileBuffer, FluxAndMonoPublishOnInterceptor.class);
         }
+    }
+
+    public static class FluxPublishOnSeamMethodTransform implements TransformCallback {
+        @Override
+        public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
+            return transformFluxMethods(instrumentor, loader, className, classfileBuffer, WrappingFluxAndMonoPublishOnInterceptor.class);
+        }
+    }
+
+    private static byte[] transformFluxMethods(Instrumentor instrumentor, ClassLoader loader, String className, byte[] classfileBuffer,
+                                               Class<? extends Interceptor> publishOnInterceptor) throws InstrumentException {
+        final InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
+
+        final InstrumentMethod subscribeMethod = target.getDeclaredMethod("subscribe", "org.reactivestreams.Subscriber");
+        if (subscribeMethod != null) {
+            subscribeMethod.addInterceptor(FluxAndMonoSubscribeMethodInterceptor.class);
+        }
+        final InstrumentMethod publishOnMethod = target.getDeclaredMethod("publishOn", "reactor.core.scheduler.Scheduler", "boolean", "int", "int");
+        if (publishOnMethod != null) {
+            publishOnMethod.addInterceptor(publishOnInterceptor);
+        }
+        final InstrumentMethod subscribeOnMethod = target.getDeclaredMethod("subscribeOn", "reactor.core.scheduler.Scheduler", "boolean");
+        if (subscribeOnMethod != null) {
+            subscribeOnMethod.addInterceptor(FluxAndMonoSubscribeOnInterceptor.class);
+        }
+        final InstrumentMethod intervalMethod = target.getDeclaredMethod("interval", "java.time.Duration", "java.time.Duration", "reactor.core.scheduler.Scheduler");
+        if (intervalMethod != null) {
+            intervalMethod.addInterceptor(FluxAndMonoIntervalInterceptor.class);
+        }
+
+        return target.toBytecode();
     }
 
     public static class FluxTransform implements TransformCallback {
@@ -389,31 +423,45 @@ public class ReactorPlugin implements ProfilerPlugin, MatchableTransformTemplate
     public static class MonoMethodTransform implements TransformCallback {
         @Override
         public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
-            final InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
-
-            final InstrumentMethod subscribeMethod = target.getDeclaredMethod("subscribe", "org.reactivestreams.Subscriber");
-            if (subscribeMethod != null) {
-                subscribeMethod.addInterceptor(FluxAndMonoSubscribeMethodInterceptor.class);
-            }
-            final InstrumentMethod publishOnMethod = target.getDeclaredMethod("publishOn", "reactor.core.scheduler.Scheduler");
-            if (publishOnMethod != null) {
-                publishOnMethod.addInterceptor(FluxAndMonoPublishOnInterceptor.class);
-            }
-            final InstrumentMethod subscribeOnMethod = target.getDeclaredMethod("subscribeOn", "reactor.core.scheduler.Scheduler");
-            if (subscribeOnMethod != null) {
-                subscribeOnMethod.addInterceptor(FluxAndMonoPublishOnInterceptor.class);
-            }
-            final InstrumentMethod delayMethod = target.getDeclaredMethod("delay", "java.time.Duration", "reactor.core.scheduler.Scheduler");
-            if (delayMethod != null) {
-                delayMethod.addInterceptor(FluxAndMonoDelayInterceptor.class);
-            }
-            final InstrumentMethod delayElementMethod = target.getDeclaredMethod("delayElement", "java.time.Duration", "reactor.core.scheduler.Scheduler");
-            if (delayElementMethod != null) {
-                delayElementMethod.addInterceptor(FluxAndMonoDelayInterceptor.class);
-            }
-
-            return target.toBytecode();
+            return transformMonoMethods(instrumentor, loader, className, classfileBuffer, FluxAndMonoPublishOnInterceptor.class);
         }
+    }
+
+    public static class MonoPublishOnSeamMethodTransform implements TransformCallback {
+        @Override
+        public byte[] doInTransform(Instrumentor instrumentor, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws InstrumentException {
+            return transformMonoMethods(instrumentor, loader, className, classfileBuffer, WrappingFluxAndMonoPublishOnInterceptor.class);
+        }
+    }
+
+    private static byte[] transformMonoMethods(Instrumentor instrumentor, ClassLoader loader, String className, byte[] classfileBuffer,
+                                               Class<? extends Interceptor> publishOnInterceptor) throws InstrumentException {
+        final InstrumentClass target = instrumentor.getInstrumentClass(loader, className, classfileBuffer);
+
+        final InstrumentMethod subscribeMethod = target.getDeclaredMethod("subscribe", "org.reactivestreams.Subscriber");
+        if (subscribeMethod != null) {
+            subscribeMethod.addInterceptor(FluxAndMonoSubscribeMethodInterceptor.class);
+        }
+        final InstrumentMethod publishOnMethod = target.getDeclaredMethod("publishOn", "reactor.core.scheduler.Scheduler");
+        if (publishOnMethod != null) {
+            publishOnMethod.addInterceptor(publishOnInterceptor);
+        }
+        // Keep the pre-existing Mono.subscribeOn wiring unchanged in this PoC so the seam effect
+        // is isolated to publishOn.
+        final InstrumentMethod subscribeOnMethod = target.getDeclaredMethod("subscribeOn", "reactor.core.scheduler.Scheduler");
+        if (subscribeOnMethod != null) {
+            subscribeOnMethod.addInterceptor(FluxAndMonoPublishOnInterceptor.class);
+        }
+        final InstrumentMethod delayMethod = target.getDeclaredMethod("delay", "java.time.Duration", "reactor.core.scheduler.Scheduler");
+        if (delayMethod != null) {
+            delayMethod.addInterceptor(FluxAndMonoDelayInterceptor.class);
+        }
+        final InstrumentMethod delayElementMethod = target.getDeclaredMethod("delayElement", "java.time.Duration", "reactor.core.scheduler.Scheduler");
+        if (delayElementMethod != null) {
+            delayElementMethod.addInterceptor(FluxAndMonoDelayInterceptor.class);
+        }
+
+        return target.toBytecode();
     }
 
     public static class MonoTransform implements TransformCallback {

--- a/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/ReactorPluginConfig.java
+++ b/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/ReactorPluginConfig.java
@@ -40,6 +40,10 @@ public class ReactorPluginConfig {
         return config.readBoolean("profiler.reactor.trace.publishOn", true);
     }
 
+    public static boolean isWrapPublisherPublishOn(ProfilerConfig config) {
+        return config.readBoolean("profiler.reactor.wrap.publisher.publishOn", false);
+    }
+
     public static boolean isTraceSubscribeOn(ProfilerConfig config) {
         return config.readBoolean("profiler.reactor.trace.subscribeOn", true);
     }
@@ -76,10 +80,15 @@ public class ReactorPluginConfig {
         return config.readBoolean("profiler.reactor.trace.scheduler.task.periodic", false);
     }
 
+    public static boolean isSubscriberInstrument(ProfilerConfig config) {
+        return config.readBoolean("profiler.reactor.subscriber.instrument", true);
+    }
+
     private final boolean enable;
 
     private final boolean traceOnError;
     private final boolean tracePublishOn;
+    private final boolean wrapPublisherPublishOn;
     private final boolean traceSubscribeOn;
     private final boolean traceDelay;
     private final boolean traceInterval;
@@ -88,6 +97,7 @@ public class ReactorPluginConfig {
     private final boolean traceSubscribe;
     private final boolean traceSchedulerTask;
     private final boolean tracePeriodicSchedulerTask;
+    private final boolean subscriberInstrument;
     private final boolean markErrorRetry;
     private final boolean markErrorOnError;
 
@@ -99,6 +109,7 @@ public class ReactorPluginConfig {
         this.traceOnError = isTraceOnError(config);
         this.markErrorOnError = isMarkErrorOnError(config);
         this.tracePublishOn = isTracePublishOn(config);
+        this.wrapPublisherPublishOn = isWrapPublisherPublishOn(config);
         this.traceSubscribeOn = isTraceSubscribeOn(config);
         this.traceDelay = isTraceDelay(config);
         this.traceInterval = isTraceInterval(config);
@@ -110,6 +121,7 @@ public class ReactorPluginConfig {
         this.traceSubscribe = isTraceSubscribe(config);
         this.traceSchedulerTask = isTraceSchedulerTask(config);
         this.tracePeriodicSchedulerTask = isTracePeriodicSchedulerTask(config);
+        this.subscriberInstrument = isSubscriberInstrument(config);
     }
 
     public boolean isEnable() {
@@ -122,6 +134,10 @@ public class ReactorPluginConfig {
 
     public boolean isTracePublishOn() {
         return tracePublishOn;
+    }
+
+    public boolean isWrapPublisherPublishOn() {
+        return wrapPublisherPublishOn;
     }
 
     public boolean isTraceSubscribeOn() {
@@ -156,6 +172,10 @@ public class ReactorPluginConfig {
         return tracePeriodicSchedulerTask;
     }
 
+    public boolean isSubscriberInstrument() {
+        return subscriberInstrument;
+    }
+
     public boolean isMarkErrorRetry() {
         return markErrorRetry;
     }
@@ -170,6 +190,7 @@ public class ReactorPluginConfig {
                 "enable=" + enable +
                 ", traceOnError=" + traceOnError +
                 ", tracePublishOn=" + tracePublishOn +
+                ", wrapPublisherPublishOn=" + wrapPublisherPublishOn +
                 ", traceSubscribeOn=" + traceSubscribeOn +
                 ", traceDelay=" + traceDelay +
                 ", traceInterval=" + traceInterval +
@@ -178,6 +199,7 @@ public class ReactorPluginConfig {
                 ", traceSubscribe=" + traceSubscribe +
                 ", traceSchedulerTask=" + traceSchedulerTask +
                 ", tracePeriodicSchedulerTask=" + tracePeriodicSchedulerTask +
+                ", subscriberInstrument=" + subscriberInstrument +
                 ", markErrorRetry=" + markErrorRetry +
                 ", markErrorOnError=" + markErrorOnError +
                 '}';

--- a/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/interceptor/WrappingFluxAndMonoPublishOnInterceptor.java
+++ b/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/interceptor/WrappingFluxAndMonoPublishOnInterceptor.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.reactor.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.plugin.reactor.ReactorConstants;
+import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
+
+import java.util.Objects;
+
+/**
+ * Experimental {@code publishOn} seam. The transform selects this interceptor instead of
+ * {@link FluxAndMonoPublishOnInterceptor}, so one returned publisher is owned by either the
+ * wrapper or the legacy injected field, never both.
+ */
+public class WrappingFluxAndMonoPublishOnInterceptor implements ResultReplaceAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean isDebug = logger.isDebugEnabled();
+
+    private final TraceContext traceContext;
+    private final MethodDescriptor methodDescriptor;
+
+    public WrappingFluxAndMonoPublishOnInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+    }
+
+    @Override
+    public void before(Object target, Class<?> returnType, Object[] args) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.traceBlockBegin();
+            recorder.recordServiceType(ReactorConstants.REACTOR);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+    }
+
+    @Override
+    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final Trace trace = traceContext.currentTraceObject();
+        if (trace == null) {
+            return result;
+        }
+
+        try {
+            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
+            recorder.recordApi(methodDescriptor);
+            recorder.recordException(throwable);
+
+            // Check before minting. Unsupported publisher shapes keep the exact legacy no-op and
+            // must not leave a dangling async link.
+            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
+                return result;
+            }
+
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+            if (wrapped != result && returnType.isInstance(wrapped)) {
+                if (isDebug) {
+                    logger.debug("Wrapped publishOn result. asyncContext={}", asyncContext);
+                }
+                return wrapped;
+            }
+
+            // A wrapping failure must not strand the link that was just minted. Runtime Reactor
+            // publishers normally have the legacy accessor, so use it only as a failure fallback.
+            if (result instanceof AsyncContextAccessor) {
+                ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
+                if (isDebug) {
+                    logger.debug("Fell back to publishOn field injection. asyncContext={}", asyncContext);
+                }
+            }
+            return result;
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            return result;
+        } finally {
+            trace.traceBlockEnd();
+        }
+    }
+}

--- a/agent-module/plugins/reactor/src/test/java/com/navercorp/pinpoint/plugin/reactor/ReactorPluginConfigTest.java
+++ b/agent-module/plugins/reactor/src/test/java/com/navercorp/pinpoint/plugin/reactor/ReactorPluginConfigTest.java
@@ -26,6 +26,46 @@ import java.util.Properties;
 public class ReactorPluginConfigTest {
 
     @Test
+    public void subscriberInstrument_defaultsToTrue() {
+        ReactorPluginConfig config = createConfig(new Properties());
+
+        Assertions.assertTrue(config.isSubscriberInstrument());
+    }
+
+    @Test
+    public void publishOnPublisherWrapper_defaultsToFalse() {
+        ReactorPluginConfig config = createConfig(new Properties());
+
+        Assertions.assertFalse(config.isWrapPublisherPublishOn());
+    }
+
+    @Test
+    public void publishOnPublisherWrapper_on() {
+        Properties properties = new Properties();
+        properties.put("profiler.reactor.wrap.publisher.publishOn", "true");
+
+        ReactorPluginConfig config = createConfig(properties);
+
+        Assertions.assertTrue(config.isWrapPublisherPublishOn());
+        Assertions.assertTrue(config.isTracePublishOn());
+    }
+
+    @Test
+    public void subscriberInstrument_off() {
+        Properties properties = new Properties();
+        properties.put("profiler.reactor.subscriber.instrument", "false");
+
+        ReactorPluginConfig config = createConfig(properties);
+
+        Assertions.assertFalse(config.isSubscriberInstrument());
+        // the gate stands alone - the plugin and the retained layers are unaffected.
+        Assertions.assertTrue(config.isEnable());
+        Assertions.assertTrue(config.isTraceSubscribe());
+        Assertions.assertTrue(config.isTraceTimeout());
+        Assertions.assertTrue(config.isTraceRetry());
+    }
+
+    @Test
     public void periodicSchedulerTask_defaultsToFalse() {
         ReactorPluginConfig config = createConfig(new Properties());
 

--- a/agent-module/plugins/reactor/src/test/java/com/navercorp/pinpoint/plugin/reactor/ReactorPluginSetupTest.java
+++ b/agent-module/plugins/reactor/src/test/java/com/navercorp/pinpoint/plugin/reactor/ReactorPluginSetupTest.java
@@ -50,6 +50,56 @@ public class ReactorPluginSetupTest {
     }
 
     @Test
+    public void publishOnUsesLegacyTransformByDefault() {
+        setup(new Properties());
+
+        verify(transformTemplate).transform("reactor.core.publisher.Flux", ReactorPlugin.FluxMethodTransform.class);
+        verify(transformTemplate).transform("reactor.core.publisher.Mono", ReactorPlugin.MonoMethodTransform.class);
+        verify(transformTemplate, never()).transform("reactor.core.publisher.Flux", ReactorPlugin.FluxPublishOnSeamMethodTransform.class);
+        verify(transformTemplate, never()).transform("reactor.core.publisher.Mono", ReactorPlugin.MonoPublishOnSeamMethodTransform.class);
+    }
+
+    @Test
+    public void publishOnSeamReplacesOnlyFluxAndMonoBaseTransforms() {
+        Properties properties = new Properties();
+        properties.put("profiler.reactor.wrap.publisher.publishOn", "true");
+
+        setup(properties);
+
+        verify(transformTemplate).transform("reactor.core.publisher.Flux", ReactorPlugin.FluxPublishOnSeamMethodTransform.class);
+        verify(transformTemplate).transform("reactor.core.publisher.Mono", ReactorPlugin.MonoPublishOnSeamMethodTransform.class);
+        verify(transformTemplate, never()).transform("reactor.core.publisher.Flux", ReactorPlugin.FluxMethodTransform.class);
+        verify(transformTemplate, never()).transform("reactor.core.publisher.Mono", ReactorPlugin.MonoMethodTransform.class);
+        // ParallelFlux.runOn remains on the legacy path during the publishOn-only PoC.
+        verify(transformTemplate).transform("reactor.core.publisher.ParallelFlux", ReactorPlugin.ParallelFluxMethodTransform.class);
+    }
+
+    @Test
+    public void publishOnSeamDoesNotOverrideTracePublishOnOff() {
+        Properties properties = new Properties();
+        properties.put("profiler.reactor.wrap.publisher.publishOn", "true");
+        properties.put("profiler.reactor.trace.publishOn", "false");
+
+        setup(properties);
+
+        verify(transformTemplate).transform("reactor.core.publisher.Flux", ReactorPlugin.FluxMethodTransform.class);
+        verify(transformTemplate).transform("reactor.core.publisher.Mono", ReactorPlugin.MonoMethodTransform.class);
+        verify(transformTemplate, never()).transform("reactor.core.publisher.Flux", ReactorPlugin.FluxPublishOnSeamMethodTransform.class);
+        verify(transformTemplate, never()).transform("reactor.core.publisher.Mono", ReactorPlugin.MonoPublishOnSeamMethodTransform.class);
+    }
+
+    @Test
+    public void lightweightCarrierDoesNotImplicitlyRegisterPeriodicTasks() {
+        Properties properties = new Properties();
+        properties.put("profiler.reactor.subscriber.instrument", "false");
+
+        setup(properties);
+
+        verify(transformTemplate).transform("reactor.core.scheduler.SchedulerTask", ReactorPlugin.SchedulerTaskTransform.class);
+        verifyPeriodicTransformsNeverRegistered();
+    }
+
+    @Test
     public void periodicSchedulerTasksUseIndependentTransactionTransformWhenEnabled() {
         Properties properties = new Properties();
         properties.put("profiler.reactor.trace.scheduler.task.periodic", "true");

--- a/agent-module/plugins/reactor/src/test/java/com/navercorp/pinpoint/plugin/reactor/interceptor/WrappingFluxAndMonoPublishOnInterceptorTest.java
+++ b/agent-module/plugins/reactor/src/test/java/com/navercorp/pinpoint/plugin/reactor/interceptor/WrappingFluxAndMonoPublishOnInterceptorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.reactor.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WrappingFluxAndMonoPublishOnInterceptorTest {
+    private static final Object[] ARGS = new Object[0];
+
+    private TraceContext traceContext;
+    private Trace trace;
+    private SpanEventRecorder recorder;
+    private AsyncContext asyncContext;
+    private WrappingFluxAndMonoPublishOnInterceptor interceptor;
+
+    @BeforeEach
+    public void setUp() {
+        traceContext = mock(TraceContext.class);
+        trace = mock(Trace.class);
+        recorder = mock(SpanEventRecorder.class);
+        asyncContext = mock(AsyncContext.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+
+        when(traceContext.currentTraceObject()).thenReturn(trace);
+        when(trace.traceBlockBegin()).thenReturn(recorder);
+        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+        when(recorder.recordNextAsyncContext()).thenReturn(asyncContext);
+        interceptor = new WrappingFluxAndMonoPublishOnInterceptor(traceContext, methodDescriptor);
+    }
+
+    @Test
+    public void wrappableResultIsReplaced() {
+        Flux<Integer> result = Flux.range(1, 2);
+
+        interceptor.before(result, Flux.class, ARGS);
+        Object replacement = interceptor.after(result, Flux.class, ARGS, result, null);
+
+        assertNotSame(result, replacement);
+        assertTrue(replacement instanceof Flux);
+        verify(recorder).recordNextAsyncContext();
+        verify(trace).traceBlockEnd();
+    }
+
+    @Test
+    public void scalarResultDoesNotMintDanglingContext() {
+        Mono<Integer> result = Mono.just(1);
+
+        interceptor.before(result, Mono.class, ARGS);
+        Object replacement = interceptor.after(result, Mono.class, ARGS, result, null);
+
+        assertSame(result, replacement);
+        verify(recorder, never()).recordNextAsyncContext();
+        verify(trace).traceBlockEnd();
+    }
+
+    @Test
+    public void exceptionalExitDoesNotWrapOrMint() {
+        Flux<Integer> result = Flux.range(1, 2);
+
+        interceptor.before(result, Flux.class, ARGS);
+        Object replacement = interceptor.after(result, Flux.class, ARGS, result, new IllegalStateException("test"));
+
+        assertSame(result, replacement);
+        verify(recorder, never()).recordNextAsyncContext();
+        verify(trace).traceBlockEnd();
+    }
+
+    @Test
+    public void noActiveTraceKeepsOriginalResult() {
+        when(traceContext.currentTraceObject()).thenReturn(null);
+        Flux<Integer> result = Flux.range(1, 2);
+
+        interceptor.before(result, Flux.class, ARGS);
+        Object replacement = interceptor.after(result, Flux.class, ARGS, result, null);
+
+        assertSame(result, replacement);
+        verify(recorder, never()).recordNextAsyncContext();
+        verify(trace, never()).traceBlockEnd();
+    }
+}


### PR DESCRIPTION
…hind a config flag

profiler.reactor.subscriber.instrument (default true) controls the generic per-operator layer: the package-based CoreSubscriber matcher that adds the AsyncContextAccessor field and the constructor / onSubscribe / onNext / run interceptors to 200+ reactor.core.publisher subscriber types. Turning it off skips the transform registration entirely, so the gated classes carry no residency cost; everything registered by exact class name stays, and boundary linking then travels through the seam wrappers and the scheduler-task carrier instead of the operator chain.

Also included:
- An opt-in publishOn seam wrapper (default off). Its propagation IT ships @Disabled with the G2 verdict: on a response-coupled 1000-element publishOn chain the wrapper costs a consistent 2-3% RPS through the per-signal window's ThreadLocal churn and fusion suppression, cancelling the relay-removal recovery the conversion was projected to earn.
- Response-coupled /seam/publishOn/{flux,mono} endpoints in the webflux testweb, so the wrapper cost shows up in closed-loop throughput instead of a fire-and-forget subscribe.
- README documentation of lightweight mode, scheduler coverage, retry semantics, periodic-task opt-in and the parked seam.