### PR TITLE
[#noissue] Generate a monomorphic exception-guard wrapper per interce…

### DIFF
--- a/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/local/pinpoint.config
@@ -126,6 +126,9 @@ profiler.callstack.overflow.log.interval.millis=3000
 
 # weather or not to propagate exceptions occurred at interceptor
 profiler.interceptor.exception.propagate=false
+# Experimental. Generate one exception-guard wrapper class per interceptor class so the guarded
+# delegate call stays monomorphic. Ineligible shapes fall back to the shared wrappers.
+profiler.interceptor.exception.guard.codegen=false
 
 # Allow bytecode framework (ASM only)
 profiler.instrument.engine=ASM

--- a/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
+++ b/agent-module/agent/src/main/resources/profiles/release/pinpoint.config
@@ -125,6 +125,9 @@ profiler.callstack.overflow.log.interval.millis=3000
 
 # weather or not to propagate exceptions occurred at interceptor
 profiler.interceptor.exception.propagate=false
+# Experimental. Generate one exception-guard wrapper class per interceptor class so the guarded
+# delegate call stays monomorphic. Ineligible shapes fall back to the shared wrappers.
+profiler.interceptor.exception.guard.codegen=false
 
 # Allow bytecode framework (ASM only)
 profiler.instrument.engine=ASM

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/ObjectBinderFactoryProvider.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/ObjectBinderFactoryProvider.java
@@ -23,6 +23,7 @@ import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.plugin.RequestRecorderFactory;
 import com.navercorp.pinpoint.profiler.context.monitor.DataSourceMonitorRegistryService;
 import com.navercorp.pinpoint.profiler.context.monitor.metric.CustomMetricRegistryService;
+import com.navercorp.pinpoint.profiler.instrument.classloading.BootstrapCore;
 import com.navercorp.pinpoint.profiler.interceptor.factory.ExceptionHandlerFactory;
 import com.navercorp.pinpoint.profiler.metadata.ApiMetaDataService;
 import com.navercorp.pinpoint.profiler.objectfactory.ObjectBinderFactory;
@@ -40,6 +41,7 @@ public class ObjectBinderFactoryProvider implements Provider<ObjectBinderFactory
     private final CustomMetricRegistryService customMetricRegistryService;
     private final Provider<ApiMetaDataService> apiMetaDataServiceProvider;
 
+    private final BootstrapCore bootstrapCore;
     private final ExceptionHandlerFactory exceptionHandlerFactory;
     private final RequestRecorderFactory requestRecorderFactory;
 
@@ -49,6 +51,7 @@ public class ObjectBinderFactoryProvider implements Provider<ObjectBinderFactory
                                        CustomMetricRegistryService customMetricRegistryService,
                                        DataSourceMonitorRegistryService dataSourceMonitorRegistryService,
                                        Provider<ApiMetaDataService> apiMetaDataServiceProvider,
+                                       BootstrapCore bootstrapCore,
                                        ExceptionHandlerFactory exceptionHandlerFactory,
                                        RequestRecorderFactory requestRecorderFactory) {
         this.profilerConfig = Objects.requireNonNull(profilerConfig, "profilerConfig");
@@ -57,6 +60,7 @@ public class ObjectBinderFactoryProvider implements Provider<ObjectBinderFactory
         this.customMetricRegistryService = Objects.requireNonNull(customMetricRegistryService, "customMetricRegistryService");
         this.apiMetaDataServiceProvider = Objects.requireNonNull(apiMetaDataServiceProvider, "apiMetaDataServiceProvider");
 
+        this.bootstrapCore = Objects.requireNonNull(bootstrapCore, "bootstrapCore");
         this.exceptionHandlerFactory = Objects.requireNonNull(exceptionHandlerFactory, "exceptionHandlerFactory");
         this.requestRecorderFactory = Objects.requireNonNull(requestRecorderFactory, "requestRecorderFactory");
     }
@@ -65,7 +69,7 @@ public class ObjectBinderFactoryProvider implements Provider<ObjectBinderFactory
     public ObjectBinderFactory get() {
         return new ObjectBinderFactory(profilerConfig, traceContextProvider, dataSourceMonitorRegistryService,
                 customMetricRegistryService, apiMetaDataServiceProvider,
-                exceptionHandlerFactory, requestRecorderFactory);
+                bootstrapCore, exceptionHandlerFactory, requestRecorderFactory);
     }
 
 }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMGuardedInterceptorFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/ASMGuardedInterceptorFactory.java
@@ -1,0 +1,511 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.profiler.instrument;
+
+import com.navercorp.pinpoint.bootstrap.interceptor.ApiIdAwareAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor0;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor1;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor2;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor3;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor4;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor5;
+import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandler;
+import com.navercorp.pinpoint.bootstrap.interceptor.InjectedAsyncContextApiIdAwareAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.StaticAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedApiIdAwareAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInjectedAsyncContextApiIdAwareAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor0;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor1;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor2;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor3;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor4;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor5;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedStaticAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExecutionPolicy;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope;
+import com.navercorp.pinpoint.common.util.IOUtils;
+import com.navercorp.pinpoint.profiler.instrument.classloading.BootstrapCore;
+import com.navercorp.pinpoint.profiler.instrument.classloading.InterceptorDefineClassHelper;
+import com.navercorp.pinpoint.profiler.util.JavaAssistUtils;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.ClassRemapper;
+import org.objectweb.asm.commons.SimpleRemapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Generates one exception-guard wrapper class per interceptor <b>class</b>, so the guarded
+ * delegate call is a monomorphic {@code invokevirtual} on a concrete type instead of the shared
+ * wrapper's single megamorphic {@code invokeinterface} site that every interceptor of a shape
+ * funnels through. The generated class is functionally identical to the shared
+ * {@code ExceptionHandle*} wrapper: every base-interface method delegates inside
+ * {@code try/catch(Throwable)} and hands the throwable to the {@link ExceptionHandler}.
+ * <p>
+ * Generation is best-effort: any failure returns {@code null} and the caller falls back to the
+ * shared wrapper, so the worst case is exactly today's behavior. Only interfaces whose methods
+ * all return {@code void} are eligible (result-replacing shapes must not lose the return value).
+ * <p>
+ * The class is defined in the delegate's class loader (bootstrap-core types are visible from
+ * everywhere; the concrete delegate type only from its own loader) under a pinpoint-owned name,
+ * the same pattern {@code ASMInterceptorHolder} uses. One class per delegate class, cached via
+ * {@link ClassValue} so unloading follows the delegate's loader.
+ */
+public final class ASMGuardedInterceptorFactory {
+    // JUL on purpose: this can run before the plugin logging bridge is ready.
+    private static final Logger logger = Logger.getLogger(ASMGuardedInterceptorFactory.class.getName());
+
+    private static final String CLASS_NAME_PREFIX = "com.navercorp.pinpoint.profiler.instrument.interceptor.GuardedInterceptor$$";
+    private static final String SCOPED_CLASS_NAME_PREFIX = "com.navercorp.pinpoint.profiler.instrument.interceptor.GuardedScopedInterceptor$$";
+    private static final AtomicInteger CLASS_ID = new AtomicInteger();
+
+    /**
+     * Scoped wrappers carry real logic (scope enter/leave, execution policy) beyond the guarded
+     * delegation, so instead of emitting them from scratch they are produced by rewriting the
+     * compiled bytes of the shared wrapper — the semantics stay maintained in one Java source.
+     * One template per void-only shape; the non-void shapes (Block, ResultReplace) keep the
+     * shared wrappers.
+     */
+    private static final Map<Class<?>, Class<?>> SCOPED_TEMPLATES = buildScopedTemplates();
+
+    private static Map<Class<?>, Class<?>> buildScopedTemplates() {
+        final Map<Class<?>, Class<?>> templates = new HashMap<>();
+        templates.put(AroundInterceptor.class, ExceptionHandleScopedInterceptor.class);
+        templates.put(AroundInterceptor0.class, ExceptionHandleScopedInterceptor0.class);
+        templates.put(AroundInterceptor1.class, ExceptionHandleScopedInterceptor1.class);
+        templates.put(AroundInterceptor2.class, ExceptionHandleScopedInterceptor2.class);
+        templates.put(AroundInterceptor3.class, ExceptionHandleScopedInterceptor3.class);
+        templates.put(AroundInterceptor4.class, ExceptionHandleScopedInterceptor4.class);
+        templates.put(AroundInterceptor5.class, ExceptionHandleScopedInterceptor5.class);
+        templates.put(StaticAroundInterceptor.class, ExceptionHandleScopedStaticAroundInterceptor.class);
+        templates.put(ApiIdAwareAroundInterceptor.class, ExceptionHandleScopedApiIdAwareAroundInterceptor.class);
+        templates.put(InjectedAsyncContextApiIdAwareAroundInterceptor.class, ExceptionHandleScopedInjectedAsyncContextApiIdAwareAroundInterceptor.class);
+        return templates;
+    }
+
+    /**
+     * The templates live in bootstrap-core, which the packaged agent appends to the bootstrap
+     * class loader search — appended jars serve classes but not resources, so
+     * {@code Class.getResourceAsStream} returns null there and the template bytes must be read
+     * straight from the bootstrap jar list instead. Absent (unit tests, plain-classpath runs)
+     * the resource lookup alone suffices.
+     */
+    private static volatile BootstrapCore templateSource;
+    private static final ConcurrentMap<Class<?>, byte[]> TEMPLATE_BYTES_CACHE = new ConcurrentHashMap<>();
+
+    public static void initTemplateSource(BootstrapCore bootstrapCore) {
+        if (bootstrapCore != null && templateSource == null) {
+            templateSource = bootstrapCore;
+        }
+    }
+
+    private static final String DELEGATE_FIELD = "delegate";
+    private static final String HANDLER_FIELD = "exceptionHandler";
+    private static final Type HANDLER_TYPE = Type.getType(ExceptionHandler.class);
+    private static final String HANDLE_EXCEPTION_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Throwable.class));
+
+    /**
+     * Wrapper classes keyed by delegate class. {@code ClassValue} keeps the association on the
+     * delegate class itself, so a discarded class loader takes its generated wrappers with it.
+     * A failed generation is cached as {@code null} holder content and never retried — the
+     * fallback path is permanent for that class.
+     */
+    private static final ClassValue<GeneratedWrapper> WRAPPER_CLASSES = new ClassValue<GeneratedWrapper>() {
+        @Override
+        protected GeneratedWrapper computeValue(Class<?> delegateClass) {
+            return generate(delegateClass);
+        }
+    };
+
+    private static final ClassValue<GeneratedWrapper> SCOPED_WRAPPER_CLASSES = new ClassValue<GeneratedWrapper>() {
+        @Override
+        protected GeneratedWrapper computeValue(Class<?> delegateClass) {
+            return generateScoped(delegateClass);
+        }
+    };
+
+    private ASMGuardedInterceptorFactory() {
+    }
+
+    /**
+     * Returns the delegate wrapped in its per-class generated guard, or {@code null} when the
+     * shape is ineligible or generation failed — the caller must then use the shared wrapper.
+     * The generated class implements the delegate's single interceptor interface, so the woven
+     * CHECKCAST to the shape's base interface holds and the shared-wrapper {@code instanceof}
+     * cascade would have picked the same shape.
+     */
+    public static Interceptor wrap(Interceptor delegate, ExceptionHandler exceptionHandler) {
+        final GeneratedWrapper wrapper = WRAPPER_CLASSES.get(delegate.getClass());
+        if (wrapper == null) {
+            return null;
+        }
+        try {
+            return (Interceptor) wrapper.constructor.newInstance(delegate, exceptionHandler);
+        } catch (Throwable th) {
+            logger.log(Level.WARNING, "Guarded interceptor instantiation failed, falling back to the shared wrapper. delegate=" + delegate.getClass().getName(), th);
+            return null;
+        }
+    }
+
+    /**
+     * Scoped variant: returns the delegate wrapped in a per-class rewrite of the shared scoped
+     * guard template, or {@code null} when ineligible or generation failed — the caller falls
+     * back to the shared scoped wrapper. Same monomorphic-delegate goal as {@link #wrap}, but the
+     * class is produced by retyping the template's delegate field instead of emitting from
+     * scratch, so the scope enter/leave semantics stay in the template's Java source.
+     */
+    public static Interceptor wrapScoped(Interceptor delegate, InterceptorScope scope, ExecutionPolicy policy, ExceptionHandler exceptionHandler) {
+        final GeneratedWrapper wrapper = SCOPED_WRAPPER_CLASSES.get(delegate.getClass());
+        if (wrapper == null) {
+            return null;
+        }
+        try {
+            return (Interceptor) wrapper.constructor.newInstance(delegate, scope, policy, exceptionHandler);
+        } catch (Throwable th) {
+            logger.log(Level.WARNING, "Scoped guarded interceptor instantiation failed, falling back to the shared wrapper. delegate=" + delegate.getClass().getName(), th);
+            return null;
+        }
+    }
+
+    private static GeneratedWrapper generate(Class<?> delegateClass) {
+        try {
+            if (!Modifier.isPublic(delegateClass.getModifiers())) {
+                // the generated class lives in a pinpoint-owned package; a non-public delegate
+                // would fail the invokevirtual access check at first execution.
+                return null;
+            }
+            final Class<?> baseInterface = findEligibleBaseInterface(delegateClass);
+            if (baseInterface == null) {
+                return null;
+            }
+            final String className = CLASS_NAME_PREFIX + CLASS_ID.getAndIncrement();
+            final byte[] bytes = emit(className, delegateClass, baseInterface);
+            final Class<?> wrapperClass = InterceptorDefineClassHelper.defineClass(delegateClass.getClassLoader(), className, bytes);
+            final Constructor<?> constructor = wrapperClass.getConstructor(delegateClass, ExceptionHandler.class);
+            return new GeneratedWrapper(constructor);
+        } catch (Throwable th) {
+            logger.log(Level.WARNING, "Guarded interceptor generation failed, falling back to the shared wrapper. delegate=" + delegateClass.getName(), th);
+            return null;
+        }
+    }
+
+    private static GeneratedWrapper generateScoped(Class<?> delegateClass) {
+        try {
+            if (!Modifier.isPublic(delegateClass.getModifiers())) {
+                return null;
+            }
+            final Class<?> baseInterface = findEligibleBaseInterface(delegateClass);
+            if (baseInterface == null) {
+                return null;
+            }
+            final Class<?> template = SCOPED_TEMPLATES.get(baseInterface);
+            if (template == null) {
+                return null;
+            }
+            final String className = SCOPED_CLASS_NAME_PREFIX + CLASS_ID.getAndIncrement();
+            final byte[] bytes = rewriteTemplate(template, className, baseInterface, delegateClass);
+            final Class<?> wrapperClass = InterceptorDefineClassHelper.defineClass(delegateClass.getClassLoader(), className, bytes);
+            final Constructor<?> constructor = wrapperClass.getConstructor(delegateClass, InterceptorScope.class, ExecutionPolicy.class, ExceptionHandler.class);
+            return new GeneratedWrapper(constructor);
+        } catch (Throwable th) {
+            logger.log(Level.WARNING, "Scoped guarded interceptor generation failed, falling back to the shared wrapper. delegate=" + delegateClass.getName(), th);
+            return null;
+        }
+    }
+
+    /**
+     * Rewrites the compiled template: the class is renamed, every reference to the base interface
+     * — the delegate field's type, the constructor parameter, the {@code checkcast} javac emits
+     * for {@code Objects.requireNonNull}, the stack map frame entries — is retyped to the
+     * concrete delegate class, and calls dispatched on it switch from {@code invokeinterface} to
+     * a monomorphic {@code invokevirtual}. The {@code implements} clause alone keeps the base
+     * interface, so the woven CHECKCAST to the shape's type still holds.
+     */
+    private static byte[] rewriteTemplate(Class<?> template, String newClassName, Class<?> baseInterface, Class<?> delegateClass) throws IOException {
+        byte[] templateBytes = TEMPLATE_BYTES_CACHE.get(template);
+        if (templateBytes == null) {
+            templateBytes = readTemplateBytes(template);
+            TEMPLATE_BYTES_CACHE.putIfAbsent(template, templateBytes);
+        }
+        final String newInternalName = JavaAssistUtils.javaNameToJvmName(newClassName);
+        final String baseInterfaceInternalName = Type.getInternalName(baseInterface);
+        final String concreteInternalName = Type.getInternalName(delegateClass);
+
+        final Map<String, String> mapping = new HashMap<>();
+        mapping.put(Type.getInternalName(template), newInternalName);
+        mapping.put(baseInterfaceInternalName, concreteInternalName);
+
+        final ClassReader classReader = new ClassReader(templateBytes);
+        // COMPUTE_MAXS: instructions are unchanged, but descriptors change length. EXPAND_FRAMES
+        // because the remapper requires expanded frames to retype their entries.
+        final ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        final ClassRemapper remapper = new RetypingClassRemapper(classWriter, new SimpleRemapper(mapping), concreteInternalName);
+        classReader.accept(remapper, ClassReader.EXPAND_FRAMES);
+        return classWriter.toByteArray();
+    }
+
+    private static byte[] readTemplateBytes(Class<?> template) throws IOException {
+        final InputStream inputStream = openTemplateStream(template);
+        if (inputStream == null) {
+            throw new IOException("not found template class resource " + template.getName());
+        }
+        try {
+            return IOUtils.toByteArray(inputStream);
+        } finally {
+            inputStream.close();
+        }
+    }
+
+    private static InputStream openTemplateStream(Class<?> template) {
+        final InputStream inputStream = template.getResourceAsStream(template.getSimpleName() + ".class");
+        if (inputStream != null) {
+            return inputStream;
+        }
+        final BootstrapCore bootstrapCore = templateSource;
+        if (bootstrapCore != null) {
+            final String resourceName = JavaAssistUtils.javaNameToJvmName(template.getName()) + ".class";
+            return bootstrapCore.openStream(resourceName);
+        }
+        return null;
+    }
+
+    /**
+     * {@link ClassRemapper} variant with the two deviations the template rewrite needs: the
+     * {@code implements} clause is NOT remapped (the wrapper must stay castable to the shape's
+     * base interface at the woven call site), and any {@code invokeinterface} whose owner was
+     * retyped to the concrete delegate class becomes {@code invokevirtual} (an interface call on
+     * a class owner would not link).
+     */
+    private static final class RetypingClassRemapper extends ClassRemapper {
+        private final String concreteInternalName;
+
+        private RetypingClassRemapper(ClassWriter classWriter, SimpleRemapper remapper, String concreteInternalName) {
+            super(classWriter, remapper);
+            this.concreteInternalName = concreteInternalName;
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            // rename the class but keep the implements clause verbatim.
+            cv.visit(version, access, remapper.mapType(name), signature, superName, interfaces);
+        }
+
+        @Override
+        protected MethodVisitor createMethodRemapper(MethodVisitor methodVisitor) {
+            return super.createMethodRemapper(new InterfaceCallFixer(methodVisitor, concreteInternalName));
+        }
+    }
+
+    private static final class InterfaceCallFixer extends MethodVisitor {
+        private final String concreteInternalName;
+
+        private InterfaceCallFixer(MethodVisitor methodVisitor, String concreteInternalName) {
+            super(ASMVersion.VERSION, methodVisitor);
+            this.concreteInternalName = concreteInternalName;
+        }
+
+        @Override
+        public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+            if (opcode == Opcodes.INVOKEINTERFACE && concreteInternalName.equals(owner)) {
+                super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, owner, name, descriptor, false);
+                return;
+            }
+            super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+        }
+    }
+
+    /**
+     * The single interceptor interface the wrapper should implement. Deliberately conservative:
+     * the delegate must expose exactly one direct interceptor interface (walking up the class
+     * hierarchy), and every method of it must return {@code void}. Anything else is the shared
+     * wrapper's job.
+     */
+    private static Class<?> findEligibleBaseInterface(Class<?> delegateClass) {
+        Class<?> found = null;
+        for (Class<?> c = delegateClass; c != null && c != Object.class; c = c.getSuperclass()) {
+            for (Class<?> itf : c.getInterfaces()) {
+                if (Interceptor.class.isAssignableFrom(itf) && itf != Interceptor.class) {
+                    if (found != null && found != itf) {
+                        return null;
+                    }
+                    found = itf;
+                }
+            }
+        }
+        if (found == null) {
+            return null;
+        }
+        for (Method method : found.getMethods()) {
+            if (Modifier.isStatic(method.getModifiers()) || method.isDefault()) {
+                continue;
+            }
+            if (method.getReturnType() != void.class) {
+                return null;
+            }
+        }
+        return found;
+    }
+
+    private static byte[] emit(String className, Class<?> delegateClass, Class<?> baseInterface) {
+        final String internalName = JavaAssistUtils.javaNameToJvmName(className);
+        final Type delegateType = Type.getType(delegateClass);
+
+        // COMPUTE_MAXS only: every frame in the emitted code is trivial (single-block try/catch
+        // per method), and COMPUTE_FRAMES would resolve types through the wrong class loader.
+        final ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SUPER,
+                internalName, null, "java/lang/Object", new String[]{Type.getInternalName(baseInterface)});
+
+        cw.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL, DELEGATE_FIELD, delegateType.getDescriptor(), null, null).visitEnd();
+        cw.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL, HANDLER_FIELD, HANDLER_TYPE.getDescriptor(), null, null).visitEnd();
+
+        emitConstructor(cw, internalName, delegateType);
+        for (Method method : baseInterface.getMethods()) {
+            if (Modifier.isStatic(method.getModifiers()) || method.isDefault()) {
+                continue;
+            }
+            emitDelegatingMethod(cw, internalName, delegateType, method);
+        }
+
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+
+    private static void emitConstructor(ClassWriter cw, String internalName, Type delegateType) {
+        final String ctorDesc = Type.getMethodDescriptor(Type.VOID_TYPE, delegateType, HANDLER_TYPE);
+        final MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", ctorDesc, null, null);
+        mv.visitCode();
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, internalName, DELEGATE_FIELD, delegateType.getDescriptor());
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 2);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, internalName, HANDLER_FIELD, HANDLER_TYPE.getDescriptor());
+        mv.visitInsn(Opcodes.RETURN);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+    }
+
+    /**
+     * <pre>
+     * public void m(...) {
+     *     try {
+     *         this.delegate.m(...);   // invokevirtual on the concrete type
+     *     } catch (Throwable t) {
+     *         this.exceptionHandler.handleException(t);
+     *     }
+     * }
+     * </pre>
+     */
+    private static void emitDelegatingMethod(ClassWriter cw, String internalName, Type delegateType, Method method) {
+        final String methodDesc = Type.getMethodDescriptor(method);
+        final MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, method.getName(), methodDesc, null, null);
+        mv.visitCode();
+
+        final Label start = new Label();
+        final Label end = new Label();
+        final Label handler = new Label();
+        mv.visitTryCatchBlock(start, end, handler, "java/lang/Throwable");
+
+        mv.visitLabel(start);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, internalName, DELEGATE_FIELD, delegateType.getDescriptor());
+        int slot = 1;
+        for (Type argumentType : Type.getArgumentTypes(methodDesc)) {
+            mv.visitVarInsn(argumentType.getOpcode(Opcodes.ILOAD), slot);
+            slot += argumentType.getSize();
+        }
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, delegateType.getInternalName(), method.getName(), methodDesc, false);
+        mv.visitLabel(end);
+        final Label ret = new Label();
+        mv.visitJumpInsn(Opcodes.GOTO, ret);
+
+        mv.visitLabel(handler);
+        // frame: stack=[Throwable], locals=this+args. COMPUTE_MAXS needs the frame spelled out
+        // only on class-file version >= V1_7, which V1_8 is.
+        final Object[] locals = buildLocalsFrame(internalName, methodDesc);
+        mv.visitFrame(Opcodes.F_NEW, locals.length, locals, 1, new Object[]{"java/lang/Throwable"});
+        final int throwableSlot = slot;
+        mv.visitVarInsn(Opcodes.ASTORE, throwableSlot);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, internalName, HANDLER_FIELD, HANDLER_TYPE.getDescriptor());
+        mv.visitVarInsn(Opcodes.ALOAD, throwableSlot);
+        mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, HANDLER_TYPE.getInternalName(), "handleException", HANDLE_EXCEPTION_DESC, true);
+
+        mv.visitLabel(ret);
+        mv.visitFrame(Opcodes.F_NEW, locals.length, locals, 0, new Object[0]);
+        mv.visitInsn(Opcodes.RETURN);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+    }
+
+    private static Object[] buildLocalsFrame(String internalName, String methodDesc) {
+        final Type[] argumentTypes = Type.getArgumentTypes(methodDesc);
+        final Object[] locals = new Object[1 + argumentTypes.length];
+        locals[0] = internalName;
+        for (int i = 0; i < argumentTypes.length; i++) {
+            locals[1 + i] = toFrameType(argumentTypes[i]);
+        }
+        return locals;
+    }
+
+    private static Object toFrameType(Type type) {
+        switch (type.getSort()) {
+            case Type.BOOLEAN:
+            case Type.CHAR:
+            case Type.BYTE:
+            case Type.SHORT:
+            case Type.INT:
+                return Opcodes.INTEGER;
+            case Type.FLOAT:
+                return Opcodes.FLOAT;
+            case Type.LONG:
+                return Opcodes.LONG;
+            case Type.DOUBLE:
+                return Opcodes.DOUBLE;
+            default:
+                return type.getInternalName();
+        }
+    }
+
+    private static final class GeneratedWrapper {
+        private final Constructor<?> constructor;
+
+        private GeneratedWrapper(Constructor<?> constructor) {
+            this.constructor = constructor;
+        }
+    }
+}

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/interceptor/factory/AnnotatedInterceptorFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/interceptor/factory/AnnotatedInterceptorFactory.java
@@ -107,7 +107,9 @@ import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedStaticAroundInte
 import com.navercorp.pinpoint.bootstrap.plugin.RequestRecorderFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.monitor.DataSourceMonitorRegistry;
 import com.navercorp.pinpoint.bootstrap.plugin.monitor.metric.CustomMetricRegistry;
+import com.navercorp.pinpoint.profiler.instrument.ASMGuardedInterceptorFactory;
 import com.navercorp.pinpoint.profiler.instrument.ScopeInfo;
+import com.navercorp.pinpoint.profiler.instrument.classloading.BootstrapCore;
 import com.navercorp.pinpoint.profiler.metadata.ApiMetaDataService;
 import com.navercorp.pinpoint.profiler.objectfactory.AutoBindingObjectFactory;
 import com.navercorp.pinpoint.profiler.objectfactory.InterceptorArgumentProvider;
@@ -119,7 +121,10 @@ import java.util.Objects;
  * @author jaehong.kim
  */
 public class AnnotatedInterceptorFactory implements InterceptorFactory {
+    public static final String GUARD_CODEGEN_KEY = "profiler.interceptor.exception.guard.codegen";
+
     private final ProfilerConfig profilerConfig;
+    private final boolean guardCodegen;
     private final TraceContext traceContext;
     private final DataSourceMonitorRegistry dataSourceMonitorRegistry;
     private final CustomMetricRegistry customMetricRegistry;
@@ -135,9 +140,15 @@ public class AnnotatedInterceptorFactory implements InterceptorFactory {
                                        CustomMetricRegistry customMetricRegistry,
                                        ApiMetaDataService apiMetaDataService,
                                        InstrumentContext pluginContext,
+                                       BootstrapCore bootstrapCore,
                                        ExceptionHandlerFactory exceptionHandlerFactory,
                                        RequestRecorderFactory requestRecorderFactory) {
         this.profilerConfig = Objects.requireNonNull(profilerConfig, "profilerConfig");
+        this.guardCodegen = profilerConfig.readBoolean(GUARD_CODEGEN_KEY, false);
+        if (this.guardCodegen) {
+            // nullable outside the DI wiring (tests); the scoped template fallback then stays off
+            ASMGuardedInterceptorFactory.initTemplateSource(bootstrapCore);
+        }
         this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
         this.dataSourceMonitorRegistry = Objects.requireNonNull(dataSourceMonitorRegistry, "dataSourceMonitorRegistry");
         this.customMetricRegistry = Objects.requireNonNull(customMetricRegistry, "customMetricRegistry");
@@ -232,6 +243,15 @@ public class AnnotatedInterceptorFactory implements InterceptorFactory {
 
     private Interceptor wrapByExceptionHandleScope(Interceptor interceptor, InterceptorScope scope, ExecutionPolicy policy) {
         final ExceptionHandler exceptionHandler = exceptionHandlerFactory.getExceptionHandler();
+        if (guardCodegen) {
+            // Experimental: per-interceptor rewrite of the scoped guard template, keeping the
+            // delegate call monomorphic. Ineligible shapes and any generation failure return null
+            // and take the shared scoped wrapper as before.
+            final Interceptor generated = ASMGuardedInterceptorFactory.wrapScoped(interceptor, scope, policy, exceptionHandler);
+            if (generated != null) {
+                return generated;
+            }
+        }
         if (interceptor instanceof AroundInterceptor) {
             return new ExceptionHandleScopedInterceptor((AroundInterceptor) interceptor, scope, policy, exceptionHandler);
         } else if (interceptor instanceof StaticAroundInterceptor) {
@@ -279,6 +299,16 @@ public class AnnotatedInterceptorFactory implements InterceptorFactory {
 
     private Interceptor wrapByExceptionHandle(Interceptor interceptor) {
         final ExceptionHandler exceptionHandler = exceptionHandlerFactory.getExceptionHandler();
+        if (guardCodegen) {
+            // Experimental: a guard class generated per interceptor class keeps the delegate call
+            // monomorphic, instead of funnelling every interceptor of a shape through the shared
+            // wrapper's single (megamorphic) call site below. Ineligible shapes and any generation
+            // failure return null and take the shared wrapper as before.
+            final Interceptor generated = ASMGuardedInterceptorFactory.wrap(interceptor, exceptionHandler);
+            if (generated != null) {
+                return generated;
+            }
+        }
         if (interceptor instanceof AroundInterceptor) {
             return new ExceptionHandleAroundInterceptor((AroundInterceptor) interceptor, exceptionHandler);
         } else if (interceptor instanceof StaticAroundInterceptor) {

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/objectfactory/ObjectBinderFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/objectfactory/ObjectBinderFactory.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.profiler.context.monitor.DataSourceMonitorRegistry
 import com.navercorp.pinpoint.profiler.context.monitor.DataSourceMonitorRegistryService;
 import com.navercorp.pinpoint.profiler.context.monitor.metric.CustomMetricRegistryAdaptor;
 import com.navercorp.pinpoint.profiler.context.monitor.metric.CustomMetricRegistryService;
+import com.navercorp.pinpoint.profiler.instrument.classloading.BootstrapCore;
 import com.navercorp.pinpoint.profiler.interceptor.factory.AnnotatedInterceptorFactory;
 import com.navercorp.pinpoint.profiler.interceptor.factory.ExceptionHandlerFactory;
 import com.navercorp.pinpoint.profiler.metadata.ApiMetaDataService;
@@ -43,6 +44,7 @@ public class ObjectBinderFactory {
     private final CustomMetricRegistry customMetricRegistry;
     private final Provider<ApiMetaDataService> apiMetaDataServiceProvider;
 
+    private final BootstrapCore bootstrapCore;
     private final ExceptionHandlerFactory exceptionHandlerFactory;
     private final RequestRecorderFactory requestRecorderFactory;
 
@@ -52,6 +54,7 @@ public class ObjectBinderFactory {
                                DataSourceMonitorRegistryService dataSourceMonitorRegistryService,
                                CustomMetricRegistryService customMonitorRegistryService,
                                Provider<ApiMetaDataService> apiMetaDataServiceProvider,
+                               BootstrapCore bootstrapCore,
                                ExceptionHandlerFactory exceptionHandlerFactory,
                                RequestRecorderFactory requestRecorderFactory) {
         this.profilerConfig = Objects.requireNonNull(profilerConfig, "profilerConfig");
@@ -65,6 +68,8 @@ public class ObjectBinderFactory {
 
         this.apiMetaDataServiceProvider = Objects.requireNonNull(apiMetaDataServiceProvider, "apiMetaDataServiceProvider");
 
+        // nullable outside the DI wiring (tests); the scoped guard template fallback then stays off
+        this.bootstrapCore = bootstrapCore;
         this.exceptionHandlerFactory = Objects.requireNonNull(exceptionHandlerFactory, "exceptionHandlerFactory");
         this.requestRecorderFactory = Objects.requireNonNull(requestRecorderFactory, "requestRecorderFactory");
     }
@@ -85,6 +90,6 @@ public class ObjectBinderFactory {
         ApiMetaDataService apiMetaDataService = this.apiMetaDataServiceProvider.get();
 
         return new AnnotatedInterceptorFactory(profilerConfig, traceContext, dataSourceMonitorRegistry, customMetricRegistry, apiMetaDataService,
-                pluginContext, exceptionHandlerFactory, requestRecorderFactory);
+                pluginContext, bootstrapCore, exceptionHandlerFactory, requestRecorderFactory);
     }
 }

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMClassTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMClassTest.java
@@ -123,7 +123,7 @@ public class ASMClassTest {
     private final RequestRecorderFactory requestRecorderFactory = mock(RequestRecorderFactory.class);
 
     private final ObjectBinderFactory objectBinderFactory = new ObjectBinderFactory(profilerConfig, traceContextProvider, dataSourceMonitorRegistryService,
-            customMetricRegistryService, apiMetaDataService, exceptionHandlerFactory, requestRecorderFactory);
+            customMetricRegistryService, apiMetaDataService, null, exceptionHandlerFactory, requestRecorderFactory);
     private final ScopeFactory scopeFactory = new ScopeFactory();
     private final InterceptorDefinitionFactory interceptorDefinitionFactory = new InterceptorDefinitionFactory();
     private final InterceptorHolderIdGenerator interceptorHolderIdGenerator = new InterceptorHolderIdGenerator();

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMGuardedInterceptorFactoryTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMGuardedInterceptorFactoryTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.profiler.instrument;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandler;
+import com.navercorp.pinpoint.bootstrap.interceptor.InjectedAsyncContextApiIdAwareAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExecutionPolicy;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScopeInvocation;
+import com.navercorp.pinpoint.profiler.logging.Log4j2LoggerBinderInitializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ASMGuardedInterceptorFactoryTest {
+
+    private final List<Throwable> handled = new ArrayList<>();
+    private final ExceptionHandler guard = handled::add;
+    private final ExceptionHandler rethrow = t -> {
+        throw new RuntimeException(t);
+    };
+
+    // the scoped guard template initializes a PluginLogger in its constructor.
+    @BeforeAll
+    public static void beforeAll() {
+        Log4j2LoggerBinderInitializer.beforeClass();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        Log4j2LoggerBinderInitializer.afterClass();
+    }
+
+    @Test
+    public void delegatesWithArguments() {
+        RecordingAroundInterceptor delegate = new RecordingAroundInterceptor();
+        Interceptor wrapped = ASMGuardedInterceptorFactory.wrap(delegate, guard);
+
+        assertThat(wrapped).isNotNull().isInstanceOf(AroundInterceptor.class);
+        assertThat(wrapped.getClass()).isNotEqualTo(RecordingAroundInterceptor.class);
+
+        Object target = new Object();
+        Object[] args = {"a", 1};
+        ((AroundInterceptor) wrapped).before(target, args);
+        ((AroundInterceptor) wrapped).after(target, args, "result", null);
+
+        assertThat(delegate.beforeTarget).isSameAs(target);
+        assertThat(delegate.beforeArgs).isSameAs(args);
+        assertThat(delegate.afterResult).isEqualTo("result");
+        assertThat(handled).isEmpty();
+    }
+
+    @Test
+    public void guardSwallowsDelegateThrowable() {
+        Interceptor wrapped = ASMGuardedInterceptorFactory.wrap(new ThrowingAroundInterceptor(), guard);
+
+        assertThat(wrapped).isNotNull();
+        ((AroundInterceptor) wrapped).before(null, null);
+        ((AroundInterceptor) wrapped).after(null, null, null, null);
+
+        assertThat(handled).hasSize(2);
+        assertThat(handled.get(0)).hasMessage("boom-before");
+        assertThat(handled.get(1)).hasMessage("boom-after");
+    }
+
+    @Test
+    public void rethrowHandlerPropagates() {
+        Interceptor wrapped = ASMGuardedInterceptorFactory.wrap(new ThrowingAroundInterceptor(), rethrow);
+
+        assertThat(wrapped).isNotNull();
+        assertThatThrownBy(() -> ((AroundInterceptor) wrapped).before(null, null))
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void generatedClassIsReusedPerDelegateClass() {
+        Interceptor first = ASMGuardedInterceptorFactory.wrap(new RecordingAroundInterceptor(), guard);
+        Interceptor second = ASMGuardedInterceptorFactory.wrap(new RecordingAroundInterceptor(), guard);
+
+        assertThat(first).isNotNull();
+        assertThat(second).isNotNull();
+        assertThat(first).isNotSameAs(second);
+        assertThat(first.getClass()).isSameAs(second.getClass());
+    }
+
+    @Test
+    public void injectedAsyncContextShapeCoversWideDescriptors() {
+        RecordingInjectedInterceptor delegate = new RecordingInjectedInterceptor();
+        Interceptor wrapped = ASMGuardedInterceptorFactory.wrap(delegate, guard);
+
+        assertThat(wrapped).isNotNull().isInstanceOf(InjectedAsyncContextApiIdAwareAroundInterceptor.class);
+
+        Object[] args = {"x"};
+        ((InjectedAsyncContextApiIdAwareAroundInterceptor) wrapped).before("t", null, 42, args);
+        ((InjectedAsyncContextApiIdAwareAroundInterceptor) wrapped).after("t", null, 42, args, "r", null);
+
+        assertThat(delegate.beforeApiId).isEqualTo(42);
+        assertThat(delegate.afterResult).isEqualTo("r");
+        assertThat(handled).isEmpty();
+    }
+
+    @Test
+    public void nonVoidShapeIsIneligible() {
+        assertThat(ASMGuardedInterceptorFactory.wrap(new ResultReplacingInterceptor(), guard)).isNull();
+    }
+
+    @Test
+    public void multiShapeDelegateIsIneligible() {
+        assertThat(ASMGuardedInterceptorFactory.wrap(new MultiShapeInterceptor(), guard)).isNull();
+    }
+
+    @Test
+    public void nonPublicDelegateIsIneligible() {
+        assertThat(ASMGuardedInterceptorFactory.wrap(new PackagePrivateInterceptor(), guard)).isNull();
+    }
+
+    @Test
+    public void scopedDelegatesInsideScope() {
+        InterceptorScope scope = mock(InterceptorScope.class);
+        InterceptorScopeInvocation invocation = mock(InterceptorScopeInvocation.class);
+        when(scope.getCurrentInvocation()).thenReturn(invocation);
+        when(invocation.tryEnter(ExecutionPolicy.BOUNDARY)).thenReturn(true);
+        when(invocation.canLeave(ExecutionPolicy.BOUNDARY)).thenReturn(true);
+
+        RecordingAroundInterceptor delegate = new RecordingAroundInterceptor();
+        Interceptor wrapped = ASMGuardedInterceptorFactory.wrapScoped(delegate, scope, ExecutionPolicy.BOUNDARY, guard);
+
+        assertThat(wrapped).isNotNull().isInstanceOf(AroundInterceptor.class);
+        assertThat(wrapped.getClass().getName()).contains("GuardedScopedInterceptor$$");
+
+        Object target = new Object();
+        Object[] args = {"a"};
+        ((AroundInterceptor) wrapped).before(target, args);
+        ((AroundInterceptor) wrapped).after(target, args, "result", null);
+
+        assertThat(delegate.beforeTarget).isSameAs(target);
+        assertThat(delegate.afterResult).isEqualTo("result");
+        verify(invocation).leave(ExecutionPolicy.BOUNDARY);
+        assertThat(handled).isEmpty();
+    }
+
+    @Test
+    public void scopedSkipsWhenScopeRejects() {
+        InterceptorScope scope = mock(InterceptorScope.class);
+        InterceptorScopeInvocation invocation = mock(InterceptorScopeInvocation.class);
+        when(scope.getCurrentInvocation()).thenReturn(invocation);
+        when(invocation.tryEnter(ExecutionPolicy.BOUNDARY)).thenReturn(false);
+        when(invocation.canLeave(ExecutionPolicy.BOUNDARY)).thenReturn(false);
+
+        RecordingAroundInterceptor delegate = new RecordingAroundInterceptor();
+        Interceptor wrapped = ASMGuardedInterceptorFactory.wrapScoped(delegate, scope, ExecutionPolicy.BOUNDARY, guard);
+
+        assertThat(wrapped).isNotNull();
+        ((AroundInterceptor) wrapped).before(new Object(), null);
+        ((AroundInterceptor) wrapped).after(new Object(), null, null, null);
+
+        assertThat(delegate.beforeTarget).isNull();
+        assertThat(delegate.afterResult).isNull();
+        verify(invocation, never()).leave(ExecutionPolicy.BOUNDARY);
+    }
+
+    @Test
+    public void scopedLeaveRunsEvenWhenDelegateThrows() {
+        InterceptorScope scope = mock(InterceptorScope.class);
+        InterceptorScopeInvocation invocation = mock(InterceptorScopeInvocation.class);
+        when(scope.getCurrentInvocation()).thenReturn(invocation);
+        when(invocation.tryEnter(ExecutionPolicy.ALWAYS)).thenReturn(true);
+        when(invocation.canLeave(ExecutionPolicy.ALWAYS)).thenReturn(true);
+
+        Interceptor wrapped = ASMGuardedInterceptorFactory.wrapScoped(new ThrowingAroundInterceptor(), scope, ExecutionPolicy.ALWAYS, guard);
+
+        assertThat(wrapped).isNotNull();
+        ((AroundInterceptor) wrapped).before(null, null);
+        ((AroundInterceptor) wrapped).after(null, null, null, null);
+
+        assertThat(handled).hasSize(2);
+        verify(invocation).leave(ExecutionPolicy.ALWAYS);
+    }
+
+    @Test
+    public void scopedGeneratedClassIsReusedPerDelegateClass() {
+        InterceptorScope scope = mock(InterceptorScope.class);
+        Interceptor first = ASMGuardedInterceptorFactory.wrapScoped(new RecordingAroundInterceptor(), scope, ExecutionPolicy.BOUNDARY, guard);
+        Interceptor second = ASMGuardedInterceptorFactory.wrapScoped(new RecordingAroundInterceptor(), scope, ExecutionPolicy.BOUNDARY, guard);
+
+        assertThat(first).isNotNull();
+        assertThat(second).isNotNull();
+        assertThat(first.getClass()).isSameAs(second.getClass());
+    }
+
+    @Test
+    public void scopedNonVoidShapeIsIneligible() {
+        InterceptorScope scope = mock(InterceptorScope.class);
+        assertThat(ASMGuardedInterceptorFactory.wrapScoped(new ResultReplacingInterceptor(), scope, ExecutionPolicy.BOUNDARY, guard)).isNull();
+    }
+
+    public static class RecordingAroundInterceptor implements AroundInterceptor {
+        Object beforeTarget;
+        Object[] beforeArgs;
+        Object afterResult;
+
+        @Override
+        public void before(Object target, Object[] args) {
+            this.beforeTarget = target;
+            this.beforeArgs = args;
+        }
+
+        @Override
+        public void after(Object target, Object[] args, Object result, Throwable throwable) {
+            this.afterResult = result;
+        }
+    }
+
+    public static class ThrowingAroundInterceptor implements AroundInterceptor {
+        @Override
+        public void before(Object target, Object[] args) {
+            throw new IllegalStateException("boom-before");
+        }
+
+        @Override
+        public void after(Object target, Object[] args, Object result, Throwable throwable) {
+            throw new IllegalStateException("boom-after");
+        }
+    }
+
+    public static class RecordingInjectedInterceptor implements InjectedAsyncContextApiIdAwareAroundInterceptor {
+        int beforeApiId;
+        Object afterResult;
+
+        @Override
+        public void before(Object target, AsyncContext asyncContext, int apiId, Object[] args) {
+            this.beforeApiId = apiId;
+        }
+
+        @Override
+        public void after(Object target, AsyncContext asyncContext, int apiId, Object[] args, Object result, Throwable throwable) {
+            this.afterResult = result;
+        }
+    }
+
+    public static class ResultReplacingInterceptor implements ResultReplaceAroundInterceptor {
+        @Override
+        public void before(Object target, Class<?> returnType, Object[] args) {
+        }
+
+        @Override
+        public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+            return result;
+        }
+    }
+
+    public static class MultiShapeInterceptor implements AroundInterceptor, InjectedAsyncContextApiIdAwareAroundInterceptor {
+        @Override
+        public void before(Object target, Object[] args) {
+        }
+
+        @Override
+        public void after(Object target, Object[] args, Object result, Throwable throwable) {
+        }
+
+        @Override
+        public void before(Object target, AsyncContext asyncContext, int apiId, Object[] args) {
+        }
+
+        @Override
+        public void after(Object target, AsyncContext asyncContext, int apiId, Object[] args, Object result, Throwable throwable) {
+        }
+    }
+
+    static class PackagePrivateInterceptor implements AroundInterceptor {
+        @Override
+        public void before(Object target, Object[] args) {
+        }
+
+        @Override
+        public void after(Object target, Object[] args, Object result, Throwable throwable) {
+        }
+    }
+
+    // The packaged agent cannot read the scoped templates through Class.getResourceAsStream
+    // (boot-appended jars serve classes, not resources) and falls back to reading the entry from
+    // the bootstrap jar list. Verifies that lookup against a jar built like bootstrap-core.
+    @Test
+    public void scopedTemplate_readableThroughBootstrapJarList() throws Exception {
+        Class<?> template = com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor.class;
+        String resourceName = com.navercorp.pinpoint.profiler.util.JavaAssistUtils.javaNameToJvmName(template.getName()) + ".class";
+
+        byte[] classpathBytes;
+        try (java.io.InputStream in = template.getResourceAsStream(template.getSimpleName() + ".class")) {
+            classpathBytes = com.navercorp.pinpoint.common.util.IOUtils.toByteArray(in);
+        }
+
+        java.nio.file.Path jar = java.nio.file.Files.createTempFile("fake-bootstrap-core", ".jar");
+        try {
+            try (java.util.jar.JarOutputStream out = new java.util.jar.JarOutputStream(java.nio.file.Files.newOutputStream(jar))) {
+                out.putNextEntry(new java.util.jar.JarEntry(resourceName));
+                out.write(classpathBytes);
+                out.closeEntry();
+            }
+
+            com.navercorp.pinpoint.profiler.instrument.classloading.BootstrapCore bootstrapCore =
+                    new com.navercorp.pinpoint.profiler.instrument.classloading.BootstrapCore(java.util.Collections.singletonList(jar));
+            try (java.io.InputStream in = bootstrapCore.openStream(resourceName)) {
+                assertThat(in).isNotNull();
+                byte[] jarBytes = com.navercorp.pinpoint.common.util.IOUtils.toByteArray(in);
+                assertThat(jarBytes).isEqualTo(classpathBytes);
+            }
+        } finally {
+            // the scanner may still hold the jar open on Windows - best effort
+            try {
+                java.nio.file.Files.deleteIfExists(jar);
+            } catch (java.io.IOException ignored) {
+                jar.toFile().deleteOnExit();
+            }
+        }
+    }
+}

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/plugin/AnnotatedInterceptorFactoryTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/plugin/AnnotatedInterceptorFactoryTest.java
@@ -85,7 +85,7 @@ public class AnnotatedInterceptorFactoryTest {
 
     private AnnotatedInterceptorFactory newAnnotatedInterceptorFactory() {
         return new AnnotatedInterceptorFactory(profilerConfig, traceContext, dataSourceMonitorRegistry, customMetricRegistry,
-                apiMetaDataService, pluginContext, exceptionHandlerFactory, requestRecorderFactory);
+                apiMetaDataService, pluginContext, null, exceptionHandlerFactory, requestRecorderFactory);
     }
 
     private ScopeInfo newEmptyScopeInfo() {
@@ -124,7 +124,7 @@ public class AnnotatedInterceptorFactoryTest {
     @Test
     public void injectedAsyncContextInterceptor_exceptionHandleScoped() {
         AnnotatedInterceptorFactory factory = new AnnotatedInterceptorFactory(profilerConfig, traceContext, dataSourceMonitorRegistry, customMetricRegistry,
-                apiMetaDataService, pluginContext, new ExceptionHandlerFactory(true), requestRecorderFactory);
+                apiMetaDataService, pluginContext, null, new ExceptionHandlerFactory(true), requestRecorderFactory);
         final com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope scope = mock(com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope.class);
         final ScopeInfo scopeInfo = new ScopeInfo(scope, com.navercorp.pinpoint.bootstrap.interceptor.scope.ExecutionPolicy.BOUNDARY);
         Interceptor interceptor = factory.newInterceptor(TestInjectedAsyncContextInterceptor.class, null, scopeInfo, instrumentMethod.getDescriptor());


### PR DESCRIPTION
…ptor class

Every interceptor is registered wrapped in an ExceptionHandle* class so an agent bug cannot break the application, but each of those wrapper classes exists once per shape - which makes its single delegate call site the meeting point of every interceptor type of that shape in the agent. That one invokeinterface is megamorphic and blocks inlining, the same dispatch mechanism behind the JDK 25 accessor regression, and an A/B with the wrapper layer switched off (the existing profiler.interceptor.exception.propagate flag) measured it at 38-42% of the agent's per-request CPU samples and +7% throughput in default instrumentation.

profiler.interceptor.exception.guard.codegen (default false) generates the guard class per interceptor class instead: same try/catch and ExceptionHandler contract, but the delegate field is the concrete type, so the woven call site and the delegate call are both monomorphic and the whole chain inlines.

Non-scoped shapes (ASMGuardedInterceptorFactory, next to ASMInterceptorHolder): generation is deliberately conservative - the delegate must be public and expose exactly one interceptor interface whose methods all return void (the three shapes carrying 98% of the measured wrapper samples qualify; result-replacing and TraceBlock shapes keep the shared wrappers) - and any failure falls back to the shared wrapper, so the worst case is today's behavior. The class is defined in the delegate's class loader through the same helper the interceptor holder uses, bootstrap included, and cached per delegate class via ClassValue so it unloads with its loader.

Scoped shapes are covered by rewriting the compiled bytes of the ExceptionHandleScoped* wrapper itself rather than hand-emitting the scope semantics: the class is renamed, every reference to the shape's base interface - delegate field, constructor parameter, requireNonNull checkcast, stack map frames - is retyped to the concrete delegate class, and calls dispatched on it switch to a monomorphic invokevirtual. Only the implements clause keeps the base interface so the woven CHECKCAST still holds; the scope semantics stay maintained in the template's Java source. One template per void-only shape (ten). The templates live in bootstrap-core, which the packaged agent appends to the bootstrap class loader search - appended jars serve classes but not resources - so template bytes are read through BootstrapCore.openStream over the authoritative bootstrap jar list, the same way PluginClassInjector already serves bootstrap-package resources, and cached per template class.

Measured (JDK 25, WebClient self-call, 5 interleaved rounds): the ExceptionHandle top frames drop from 14.08% to 1.49% (the remainder is the intended Block fallback plus non-inlined generated frames) and per-request Pinpoint CPU samples fall 31.5%, about 85% of the no-wrapper upper bound, with RPS positive in all five rounds.

Verified: unit tests for delegation, guard/rethrow semantics, class reuse, every ineligibility rule and the scoped skip/enter/ leave-in-finally semantics against a mocked scope, on JDK 8 and 17; an MVC smoke on the packaged agent (JDK 17 and 25) with the generated classes confirmed defined via class histogram and the ExceptionHandle frames gone from JFR; a static audit of all 501 built-in interceptors - 470 eligible, the 31 fallbacks exactly the Block and ResultReplace shapes, no load failures; and the plugin IT suites green with the gate on as a no-interference check (the IT harness forces the propagate flag, so the codegen path cannot execute there).