### PR TITLE
[#noissue] Add a ResultReplaceBlock interceptor shape carrying the tr…

### DIFF
--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/AsyncContextSpanEventResultReplaceBlockSimpleAroundInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/AsyncContextSpanEventResultReplaceBlockSimpleAroundInterceptor.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+
+import java.util.Objects;
+
+/**
+ * {@link AsyncContextSpanEventBlockSimpleAroundInterceptor} for result-replace weave points: the
+ * same async-trace block lifecycle, with a {@link #replaceResult} hook whose return value
+ * replaces the intercepted method's return value under the
+ * {@link ResultReplaceBlockAroundInterceptor} contract. The default hook keeps the original.
+ */
+public abstract class AsyncContextSpanEventResultReplaceBlockSimpleAroundInterceptor extends AbstractAsyncContextSpanEventInterceptor implements ResultReplaceBlockAroundInterceptor {
+
+    protected final MethodDescriptor methodDescriptor;
+
+    public AsyncContextSpanEventResultReplaceBlockSimpleAroundInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        this(traceContext, methodDescriptor, true);
+    }
+
+    public AsyncContextSpanEventResultReplaceBlockSimpleAroundInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, boolean asyncTraceBlock) {
+        super(traceContext, asyncTraceBlock);
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+    }
+
+    @Override
+    public TraceBlock before(Object target, Class<?> returnType, Object[] args) {
+        if (isDebug) {
+            logger.beforeInterceptor(target, args);
+        }
+
+        final AsyncContext asyncContext = getAsyncContext(target, args);
+        if (asyncContext == null) {
+            return null;
+        }
+
+        final Trace trace = getAsyncTrace(asyncContext);
+        if (trace == null) {
+            return null;
+        }
+
+        ScopeUtils.entryAsyncTraceScope(trace);
+
+        final TraceBlock traceBlock = trace.getTraceBlock();
+        try {
+            if (asyncTraceBlock && checkBeforeTraceBlockBegin(asyncContext, trace, target, args)) {
+                traceBlock.begin();
+                beforeTrace(asyncContext, trace, traceBlock, target, args);
+                doInBeforeTrace(traceBlock, asyncContext, target, args);
+            }
+            beforeAction(asyncContext, trace, target, args);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+
+        return traceBlock;
+    }
+
+    protected boolean checkBeforeTraceBlockBegin(AsyncContext asyncContext, Trace trace, Object target, Object[] args) {
+        return true;
+    }
+
+    protected void beforeTrace(final AsyncContext asyncContext, final Trace trace, final SpanEventRecorder recorder, final Object target, final Object[] args) {
+    }
+
+    protected abstract void doInBeforeTrace(SpanEventRecorder recorder, AsyncContext asyncContext, Object target, Object[] args);
+
+    protected void beforeAction(AsyncContext asyncContext, Trace trace, Object target, Object[] args) {
+    }
+
+    @Override
+    public Object after(TraceBlock block, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (isDebug) {
+            logger.afterInterceptor(target, args, result, throwable);
+        }
+
+        final AsyncContext asyncContext = getAsyncContext(target, args, result, throwable);
+        if (asyncContext == null) {
+            return result;
+        }
+
+        if (block == null) {
+            return result;
+        }
+
+        final Trace trace = block.getTrace();
+        if (trace == null) {
+            return result;
+        }
+
+        // leave scope.
+        if (!ScopeUtils.leaveAsyncTraceScope(trace)) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to leave scope of async trace {}.", trace);
+            }
+            // delete unstable trace.
+            deleteAsyncContext(trace, asyncContext);
+            return result;
+        }
+
+        Object replaced = result;
+        try (TraceBlock traceBlock = block) {
+            if (asyncTraceBlock && traceBlock.isBegin()) {
+                afterTrace(asyncContext, trace, traceBlock, target, args, result, throwable);
+                doInAfterTrace(traceBlock, target, args, result, throwable);
+                replaced = replaceResult(traceBlock, asyncContext, target, returnType, args, result, throwable);
+            }
+            afterAction(asyncContext, trace, target, args, result, throwable);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            replaced = result;
+        } finally {
+            if (ScopeUtils.isAsyncTraceEndScope(trace)) {
+                deleteAsyncContext(trace, asyncContext);
+            }
+        }
+
+        return replaced;
+    }
+
+    protected void afterTrace(final AsyncContext asyncContext, final Trace trace, final SpanEventRecorder recorder, final Object target, final Object[] args, final Object result, final Throwable throwable) {
+    }
+
+    protected abstract void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable);
+
+    /**
+     * Called only when the trace block was begun by the paired before(). The returned value
+     * replaces the intercepted method's return value; return {@code result} to keep it.
+     * {@code returnType} carries the intercepted method's declared return type so the hook can
+     * validate a candidate itself before minting state that a discarded replacement would strand.
+     */
+    protected Object replaceResult(final SpanEventRecorder recorder, final AsyncContext asyncContext, final Object target, final Class<?> returnType, final Object[] args, final Object result, final Throwable throwable) {
+        return result;
+    }
+
+    protected void afterAction(AsyncContext asyncContext, Trace trace, Object target, Object[] args, Object result, Throwable throwable) {
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/ExceptionHandleResultReplaceBlockAroundInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/ExceptionHandleResultReplaceBlockAroundInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
+
+import java.util.Objects;
+
+public class ExceptionHandleResultReplaceBlockAroundInterceptor implements ResultReplaceBlockAroundInterceptor {
+
+    private final ResultReplaceBlockAroundInterceptor delegate;
+    private final ExceptionHandler exceptionHandler;
+
+    public ExceptionHandleResultReplaceBlockAroundInterceptor(ResultReplaceBlockAroundInterceptor delegate, ExceptionHandler exceptionHandler) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.exceptionHandler = Objects.requireNonNull(exceptionHandler, "exceptionHandler");
+    }
+
+    @Override
+    public TraceBlock before(Object target, Class<?> returnType, Object[] args) {
+        try {
+            return this.delegate.before(target, returnType, args);
+        } catch (Throwable t) {
+            exceptionHandler.handleException(t);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Object after(TraceBlock block, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        try {
+            return this.delegate.after(block, target, returnType, args, result, throwable);
+        } catch (Throwable t) {
+            exceptionHandler.handleException(t);
+            // keep the original return value when the delegate fails.
+            return result;
+        }
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/ResultReplaceBlockAroundInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/ResultReplaceBlockAroundInterceptor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
+
+/**
+ * Combines {@link ResultReplaceAroundInterceptor} and {@link BlockAroundInterceptor}: the value
+ * returned from {@link #after} replaces the intercepted method's return value, and the
+ * {@link TraceBlock} returned from {@link #before} travels to {@link #after} through the weaver.
+ * A result-replace interceptor that needs before/after pairing state would otherwise have to
+ * carry it out-of-band (e.g. a per-thread frame stack); this shape hands it the same proven
+ * channel the block interceptors use.
+ * <p>
+ * Contract:
+ * <ul>
+ * <li>The intercepted method must have a reference (object or array) return type. Attaching this
+ * interceptor to a method returning {@code void} or a primitive, or to a constructor, fails at
+ * instrumentation time.</li>
+ * <li>The replacement takes effect only when it is non-null and an instance of the method's
+ * declared return type ({@code returnType} parameter); otherwise the original {@code result} is
+ * returned to the caller unchanged. Returning {@code result} as-is therefore means "keep".</li>
+ * <li>When {@code throwable} is non-null the method is exiting exceptionally: there is no return
+ * value to replace and the value returned from {@link #after} is discarded.</li>
+ * <li>The {@code block} passed to {@link #after} is exactly what the paired {@link #before}
+ * returned, {@code null} included.</li>
+ * </ul>
+ */
+public interface ResultReplaceBlockAroundInterceptor extends Interceptor {
+    TraceBlock before(Object target, Class<?> returnType, Object[] args);
+
+    Object after(TraceBlock block, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable);
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.bootstrap.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+
+import java.util.Objects;
+
+/**
+ * {@link SpanEventSimpleAroundInterceptorForPlugin} for result-replace weave points: the same
+ * span-event lifecycle around the ambient trace, except the begun {@link TraceBlock} travels
+ * from {@link #before} to {@link #after} through the weaver instead of after() re-resolving
+ * {@link #currentTrace()} — so after() always closes exactly the block its own before() begun,
+ * and a trace bound or unbound between the two calls cannot unbalance the block stack. The
+ * {@link #replaceResult} hook's return value replaces the intercepted method's return value
+ * under the {@link ResultReplaceBlockAroundInterceptor} contract; the default keeps the
+ * original.
+ */
+public abstract class SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin extends AbstractSpanEventInterceptorForPlugin implements ResultReplaceBlockAroundInterceptor {
+    protected final MethodDescriptor methodDescriptor;
+
+    protected SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin(TraceContext traceContext, MethodDescriptor methodDescriptor) {
+        super(traceContext);
+        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+    }
+
+    @Override
+    public TraceBlock before(Object target, Class<?> returnType, Object[] args) {
+        if (isDebug) {
+            logBeforeInterceptor(target, args);
+        }
+
+        prepareBeforeTrace(target, args);
+
+        final Trace trace = currentTrace();
+        if (trace == null) {
+            return null;
+        }
+
+        final TraceBlock traceBlock = trace.getTraceBlock();
+        try {
+            traceBlock.begin();
+            beforeTrace(trace, traceBlock, target, args);
+            doInBeforeTrace(traceBlock, target, args);
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
+            }
+        }
+
+        return traceBlock;
+    }
+
+    protected void prepareBeforeTrace(Object target, Object[] args) {
+    }
+
+    protected void beforeTrace(Trace trace, SpanEventRecorder recorder, Object target, Object[] args) {
+    }
+
+    protected abstract void doInBeforeTrace(final SpanEventRecorder recorder, final Object target, final Object[] args) throws Exception;
+
+    @Override
+    public Object after(TraceBlock block, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (isDebug) {
+            logAfterInterceptor(target, args, result, throwable);
+        }
+
+        prepareAfterTrace(target, args, result, throwable);
+
+        if (block == null) {
+            return result;
+        }
+
+        final Trace trace = block.getTrace();
+        Object replaced = result;
+        try (TraceBlock traceBlock = block) {
+            if (traceBlock.isBegin()) {
+                afterTrace(trace, traceBlock, target, args, result, throwable);
+                doInAfterTrace(traceBlock, target, args, result, throwable);
+                replaced = replaceResult(traceBlock, target, returnType, args, result, throwable);
+            }
+        } catch (Throwable th) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
+            }
+            replaced = result;
+        }
+
+        return replaced;
+    }
+
+    protected void prepareAfterTrace(Object target, Object[] args, Object result, Throwable throwable) {
+    }
+
+    protected void afterTrace(final Trace trace, final SpanEventRecorder recorder, final Object target, final Object[] args, final Object result, final Throwable throwable) {
+    }
+
+    protected abstract void doInAfterTrace(final SpanEventRecorder recorder, final Object target, final Object[] args, final Object result, Throwable throwable) throws Exception;
+
+    /**
+     * Called only when the paired block was begun. The returned value replaces the intercepted
+     * method's return value; return {@code result} to keep it. {@code returnType} carries the
+     * intercepted method's declared return type so the hook can validate a candidate itself
+     * before minting state (e.g. an async link) that a discarded replacement would strand.
+     */
+    protected Object replaceResult(final SpanEventRecorder recorder, final Object target, final Class<?> returnType, final Object[] args, final Object result, final Throwable throwable) {
+        return result;
+    }
+
+    protected MethodDescriptor getMethodDescriptor() {
+        return methodDescriptor;
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/scope/ExceptionHandleScopedResultReplaceBlockAroundInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/scope/ExceptionHandleScopedResultReplaceBlockAroundInterceptor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.interceptor.scope;
+
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
+import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandler;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceBlockAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+
+import java.util.Objects;
+
+public class ExceptionHandleScopedResultReplaceBlockAroundInterceptor implements ResultReplaceBlockAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean debugEnabled = logger.isDebugEnabled();
+
+    private final ResultReplaceBlockAroundInterceptor delegate;
+    private final InterceptorScope scope;
+    private final ExecutionPolicy policy;
+    private final ExceptionHandler exceptionHandler;
+
+    public ExceptionHandleScopedResultReplaceBlockAroundInterceptor(ResultReplaceBlockAroundInterceptor delegate, InterceptorScope scope, ExecutionPolicy policy, ExceptionHandler exceptionHandler) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.scope = Objects.requireNonNull(scope, "scope");
+        this.policy = Objects.requireNonNull(policy, "policy");
+        this.exceptionHandler = Objects.requireNonNull(exceptionHandler, "exceptionHandler");
+    }
+
+    @Override
+    public TraceBlock before(Object target, Class<?> returnType, Object[] args) {
+        final InterceptorScopeInvocation transaction = scope.getCurrentInvocation();
+
+        if (transaction.tryEnter(policy)) {
+            try {
+                return this.delegate.before(target, returnType, args);
+            } catch (Throwable t) {
+                exceptionHandler.handleException(t);
+            }
+        } else {
+            if (debugEnabled) {
+                logger.debug("tryBefore() returns false: interceptorScopeTransaction: {}, executionPoint: {}. Skip interceptor {}", transaction, policy, delegate.getClass());
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public Object after(TraceBlock block, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final InterceptorScopeInvocation transaction = scope.getCurrentInvocation();
+
+        if (transaction.canLeave(policy)) {
+            try {
+                return this.delegate.after(block, target, returnType, args, result, throwable);
+            } catch (Throwable t) {
+                exceptionHandler.handleException(t);
+                // keep the original return value when the delegate fails.
+                return result;
+            } finally {
+                transaction.leave(policy);
+            }
+        } else {
+            if (debugEnabled) {
+                logger.debug("tryAfter() returns false: interceptorScopeTransaction: {}, executionPoint: {}. Skip interceptor {}", transaction, policy, delegate.getClass());
+            }
+            // skipped by scope policy: keep the original return value.
+            return result;
+        }
+    }
+}

--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/scope/ScopedResultReplaceBlockAroundInterceptor.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/interceptor/scope/ScopedResultReplaceBlockAroundInterceptor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.bootstrap.interceptor.scope;
+
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceBlockAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
+import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+
+import java.util.Objects;
+
+public class ScopedResultReplaceBlockAroundInterceptor implements ResultReplaceBlockAroundInterceptor {
+    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
+    private final boolean debugEnabled = logger.isDebugEnabled();
+
+    private final ResultReplaceBlockAroundInterceptor delegate;
+    private final InterceptorScope scope;
+    private final ExecutionPolicy policy;
+
+    public ScopedResultReplaceBlockAroundInterceptor(ResultReplaceBlockAroundInterceptor delegate, InterceptorScope scope, ExecutionPolicy policy) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.scope = Objects.requireNonNull(scope, "scope");
+        this.policy = Objects.requireNonNull(policy, "policy");
+    }
+
+    @Override
+    public TraceBlock before(Object target, Class<?> returnType, Object[] args) {
+        final InterceptorScopeInvocation transaction = scope.getCurrentInvocation();
+
+        if (transaction.tryEnter(policy)) {
+            return this.delegate.before(target, returnType, args);
+        } else {
+            if (debugEnabled) {
+                logger.debug("tryBefore() returns false: interceptorScopeTransaction: {}, executionPoint: {}. Skip interceptor {}", transaction, policy, delegate.getClass());
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public Object after(TraceBlock block, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        final InterceptorScopeInvocation transaction = scope.getCurrentInvocation();
+
+        if (transaction.canLeave(policy)) {
+            try {
+                return this.delegate.after(block, target, returnType, args, result, throwable);
+            } finally {
+                transaction.leave(policy);
+            }
+        } else {
+            if (debugEnabled) {
+                logger.debug("tryAfter() returns false: interceptorScopeTransaction: {}, executionPoint: {}. Skip interceptor {}", transaction, policy, delegate.getClass());
+            }
+            // skipped by scope policy: keep the original return value.
+            return result;
+        }
+    }
+}

--- a/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/interceptor/WrappingFluxAndMonoPublishOnInterceptor.java
+++ b/agent-module/plugins/reactor/src/main/java/com/navercorp/pinpoint/plugin/reactor/interceptor/WrappingFluxAndMonoPublishOnInterceptor.java
@@ -20,93 +20,58 @@ import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
-import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.reactor.ReactorConstants;
 import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
-
-import java.util.Objects;
 
 /**
  * Experimental {@code publishOn} seam. The transform selects this interceptor instead of
  * {@link FluxAndMonoPublishOnInterceptor}, so one returned publisher is owned by either the
  * wrapper or the legacy injected field, never both.
  */
-public class WrappingFluxAndMonoPublishOnInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
+public class WrappingFluxAndMonoPublishOnInterceptor extends SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin {
 
     public WrappingFluxAndMonoPublishOnInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
     }
 
     @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
-            return;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recorder.recordServiceType(ReactorConstants.REACTOR);
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
-        }
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
+        recorder.recordServiceType(ReactorConstants.REACTOR);
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        recorder.recordApi(methodDescriptor);
+        recorder.recordException(throwable);
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        // Check before minting. Unsupported publisher shapes keep the exact legacy no-op and
+        // must not leave a dangling async link.
+        if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
             return result;
         }
 
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-            recorder.recordApi(methodDescriptor);
-            recorder.recordException(throwable);
-
-            // Check before minting. Unsupported publisher shapes keep the exact legacy no-op and
-            // must not leave a dangling async link.
-            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
-                return result;
+        final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+        final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+        if (wrapped != result && returnType.isInstance(wrapped)) {
+            if (isDebug) {
+                logger.debug("Wrapped publishOn result. asyncContext={}", asyncContext);
             }
-
-            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
-            if (wrapped != result && returnType.isInstance(wrapped)) {
-                if (isDebug) {
-                    logger.debug("Wrapped publishOn result. asyncContext={}", asyncContext);
-                }
-                return wrapped;
-            }
-
-            // A wrapping failure must not strand the link that was just minted. Runtime Reactor
-            // publishers normally have the legacy accessor, so use it only as a failure fallback.
-            if (result instanceof AsyncContextAccessor) {
-                ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
-                if (isDebug) {
-                    logger.debug("Fell back to publishOn field injection. asyncContext={}", asyncContext);
-                }
-            }
-            return result;
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            return result;
-        } finally {
-            trace.traceBlockEnd();
+            return wrapped;
         }
+
+        // A wrapping failure must not strand the link that was just minted. Runtime Reactor
+        // publishers normally have the legacy accessor, so use it only as a failure fallback.
+        if (result instanceof AsyncContextAccessor) {
+            ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
+            if (isDebug) {
+                logger.debug("Fell back to publishOn field injection. asyncContext={}", asyncContext);
+            }
+        }
+        return result;
     }
 }

--- a/agent-module/plugins/reactor/src/test/java/com/navercorp/pinpoint/plugin/reactor/interceptor/WrappingFluxAndMonoPublishOnInterceptorTest.java
+++ b/agent-module/plugins/reactor/src/test/java/com/navercorp/pinpoint/plugin/reactor/interceptor/WrappingFluxAndMonoPublishOnInterceptorTest.java
@@ -18,8 +18,8 @@ package com.navercorp.pinpoint.plugin.reactor.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
-import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +27,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -39,7 +40,7 @@ public class WrappingFluxAndMonoPublishOnInterceptorTest {
 
     private TraceContext traceContext;
     private Trace trace;
-    private SpanEventRecorder recorder;
+    private TraceBlock block;
     private AsyncContext asyncContext;
     private WrappingFluxAndMonoPublishOnInterceptor interceptor;
 
@@ -47,14 +48,15 @@ public class WrappingFluxAndMonoPublishOnInterceptorTest {
     public void setUp() {
         traceContext = mock(TraceContext.class);
         trace = mock(Trace.class);
-        recorder = mock(SpanEventRecorder.class);
+        block = mock(TraceBlock.class);
         asyncContext = mock(AsyncContext.class);
         MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
 
         when(traceContext.currentTraceObject()).thenReturn(trace);
-        when(trace.traceBlockBegin()).thenReturn(recorder);
-        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
-        when(recorder.recordNextAsyncContext()).thenReturn(asyncContext);
+        when(trace.getTraceBlock()).thenReturn(block);
+        when(block.getTrace()).thenReturn(trace);
+        when(block.isBegin()).thenReturn(true);
+        when(block.recordNextAsyncContext()).thenReturn(asyncContext);
         interceptor = new WrappingFluxAndMonoPublishOnInterceptor(traceContext, methodDescriptor);
     }
 
@@ -62,37 +64,38 @@ public class WrappingFluxAndMonoPublishOnInterceptorTest {
     public void wrappableResultIsReplaced() {
         Flux<Integer> result = Flux.range(1, 2);
 
-        interceptor.before(result, Flux.class, ARGS);
-        Object replacement = interceptor.after(result, Flux.class, ARGS, result, null);
+        TraceBlock returned = interceptor.before(result, Flux.class, ARGS);
+        Object replacement = interceptor.after(returned, result, Flux.class, ARGS, result, null);
 
+        assertSame(block, returned);
         assertNotSame(result, replacement);
         assertTrue(replacement instanceof Flux);
-        verify(recorder).recordNextAsyncContext();
-        verify(trace).traceBlockEnd();
+        verify(block).recordNextAsyncContext();
+        verify(block).close();
     }
 
     @Test
     public void scalarResultDoesNotMintDanglingContext() {
         Mono<Integer> result = Mono.just(1);
 
-        interceptor.before(result, Mono.class, ARGS);
-        Object replacement = interceptor.after(result, Mono.class, ARGS, result, null);
+        TraceBlock returned = interceptor.before(result, Mono.class, ARGS);
+        Object replacement = interceptor.after(returned, result, Mono.class, ARGS, result, null);
 
         assertSame(result, replacement);
-        verify(recorder, never()).recordNextAsyncContext();
-        verify(trace).traceBlockEnd();
+        verify(block, never()).recordNextAsyncContext();
+        verify(block).close();
     }
 
     @Test
     public void exceptionalExitDoesNotWrapOrMint() {
         Flux<Integer> result = Flux.range(1, 2);
 
-        interceptor.before(result, Flux.class, ARGS);
-        Object replacement = interceptor.after(result, Flux.class, ARGS, result, new IllegalStateException("test"));
+        TraceBlock returned = interceptor.before(result, Flux.class, ARGS);
+        Object replacement = interceptor.after(returned, result, Flux.class, ARGS, result, new IllegalStateException("test"));
 
         assertSame(result, replacement);
-        verify(recorder, never()).recordNextAsyncContext();
-        verify(trace).traceBlockEnd();
+        verify(block, never()).recordNextAsyncContext();
+        verify(block).close();
     }
 
     @Test
@@ -100,11 +103,12 @@ public class WrappingFluxAndMonoPublishOnInterceptorTest {
         when(traceContext.currentTraceObject()).thenReturn(null);
         Flux<Integer> result = Flux.range(1, 2);
 
-        interceptor.before(result, Flux.class, ARGS);
-        Object replacement = interceptor.after(result, Flux.class, ARGS, result, null);
+        TraceBlock returned = interceptor.before(result, Flux.class, ARGS);
+        Object replacement = interceptor.after(returned, result, Flux.class, ARGS, result, null);
 
+        assertNull(returned);
         assertSame(result, replacement);
-        verify(recorder, never()).recordNextAsyncContext();
-        verify(trace, never()).traceBlockEnd();
+        verify(block, never()).recordNextAsyncContext();
+        verify(block, never()).close();
     }
 }

--- a/agent-module/plugins/redis-lettuce/src/main/java/com/navercorp/pinpoint/plugin/redis/lettuce/interceptor/WrappingLettuceMethodInterceptor.java
+++ b/agent-module/plugins/redis-lettuce/src/main/java/com/navercorp/pinpoint/plugin/redis/lettuce/interceptor/WrappingLettuceMethodInterceptor.java
@@ -21,11 +21,8 @@ import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
-import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
 import com.navercorp.pinpoint.plugin.redis.lettuce.EndPointAccessor;
 import com.navercorp.pinpoint.plugin.redis.lettuce.LettuceConstants;
@@ -39,82 +36,52 @@ import java.util.Objects;
  * the reactive command surface: a reactor Mono/Flux result is replaced with a wrapped one,
  * while any other async result (futures, non-reactor publishers) keeps the original injection.
  */
-public class WrappingLettuceMethodInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
+public class WrappingLettuceMethodInterceptor extends SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin {
 
     public WrappingLettuceMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
     }
 
     @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
-            return;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recorder.recordServiceType(LettuceConstants.REDIS_LETTUCE);
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
-        }
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
+        recorder.recordServiceType(LettuceConstants.REDIS_LETTUCE);
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        final String endPoint = toEndPoint(target);
+        recorder.recordApi(methodDescriptor);
+        recorder.recordEndPoint(Objects.toString(endPoint, "Unknown"));
+        recorder.recordDestinationId(LettuceConstants.REDIS_LETTUCE.getName());
+        recorder.recordException(throwable);
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null) {
             return result;
         }
 
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-            final String endPoint = toEndPoint(target);
-            recorder.recordApi(methodDescriptor);
-            recorder.recordEndPoint(Objects.toString(endPoint, "Unknown"));
-            recorder.recordDestinationId(LettuceConstants.REDIS_LETTUCE.getName());
-            recorder.recordException(throwable);
-
-            if (throwable != null) {
-                return result;
+        if (SeamPublisherWrapper.isWrappable(result)) {
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+            if (isDebug) {
+                logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
             }
-
-            if (SeamPublisherWrapper.isWrappable(result)) {
+            return wrapped;
+        }
+        // non-reactor async result: keep the original injection.
+        if (result instanceof AsyncContextAccessor) {
+            if (AsyncContextAccessorUtils.getAsyncContext(result) == null) {
+                // Avoid duplicate async context
                 final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-                final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+                ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
                 if (isDebug) {
-                    logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
-                }
-                return wrapped;
-            }
-            // non-reactor async result: keep the original injection.
-            if (result instanceof AsyncContextAccessor) {
-                if (AsyncContextAccessorUtils.getAsyncContext(result) == null) {
-                    // Avoid duplicate async context
-                    final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-                    ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
-                    if (isDebug) {
-                        logger.debug("Set asyncContext to result. asyncContext={}", asyncContext);
-                    }
+                    logger.debug("Set asyncContext to result. asyncContext={}", asyncContext);
                 }
             }
-            return result;
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            return result;
-        } finally {
-            trace.traceBlockEnd();
         }
+        return result;
     }
 
     private String toEndPoint(final Object target) {

--- a/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/WrappingReactiveMethodInterceptor.java
+++ b/agent-module/plugins/redis-redisson/src/main/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/WrappingReactiveMethodInterceptor.java
@@ -21,11 +21,8 @@ import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
-import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.util.ArrayArgumentUtils;
 import com.navercorp.pinpoint.common.util.StringUtils;
@@ -34,7 +31,6 @@ import com.navercorp.pinpoint.plugin.redis.redisson.RedissonConstants;
 import com.navercorp.pinpoint.plugin.redis.redisson.RedissonPluginConfig;
 
 import java.lang.reflect.Method;
-import java.util.Objects;
 
 /**
  * Wrapping variant of {@link ReactiveMethodInterceptor} (config-gated by
@@ -42,87 +38,59 @@ import java.util.Objects;
  * a wrapped one instead of relying on the accessor field the reactor plugin injects into
  * reactor.core.publisher types; any other async result keeps the original injection.
  */
-public class WrappingReactiveMethodInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
+public class WrappingReactiveMethodInterceptor extends SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin {
     private final boolean keyTrace;
 
     public WrappingReactiveMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
         final RedissonPluginConfig config = new RedissonPluginConfig(traceContext.getProfilerConfig());
         this.keyTrace = config.isKeyTrace();
     }
 
     @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
-            return;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recorder.recordServiceType(RedissonConstants.REDISSON_REACTIVE);
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
-        }
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
+        recorder.recordServiceType(RedissonConstants.REDISSON_REACTIVE);
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        if (this.keyTrace) {
+            Method method = ArrayArgumentUtils.getArgument(args, 0, Method.class);
+            if (method == null) {
+                // redisson 3.17+: execute(Callable, Method)
+                method = ArrayArgumentUtils.getArgument(args, 1, Method.class);
+            }
+            if (method != null && StringUtils.hasLength(method.getName())) {
+                recorder.recordAttribute(AnnotationKey.ARGS0, method.getName());
+            }
+        }
+
+        recorder.recordApi(methodDescriptor);
+        recorder.recordException(throwable);
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null) {
             return result;
         }
 
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-
-            Object ret = result;
-            if (throwable == null) {
-                if (SeamPublisherWrapper.isWrappable(result)) {
-                    final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-                    ret = SeamPublisherWrapper.wrap(result, asyncContext);
-                    if (isDebug) {
-                        logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
-                    }
-                } else if (result instanceof AsyncContextAccessor) {
-                    // non-reactor async result: keep the original injection.
-                    if (AsyncContextAccessorUtils.getAsyncContext(result) == null) {
-                        // Avoid duplicate async context
-                        final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-                        ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
-                    }
-                }
+        if (SeamPublisherWrapper.isWrappable(result)) {
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+            if (isDebug) {
+                logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
             }
-
-            if (this.keyTrace) {
-                Method method = ArrayArgumentUtils.getArgument(args, 0, Method.class);
-                if (method == null) {
-                    // redisson 3.17+: execute(Callable, Method)
-                    method = ArrayArgumentUtils.getArgument(args, 1, Method.class);
-                }
-                if (method != null && StringUtils.hasLength(method.getName())) {
-                    recorder.recordAttribute(AnnotationKey.ARGS0, method.getName());
-                }
-            }
-
-            recorder.recordApi(methodDescriptor);
-            recorder.recordException(throwable);
-            return ret;
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            return result;
-        } finally {
-            trace.traceBlockEnd();
+            return wrapped;
         }
+        // non-reactor async result: keep the original injection.
+        if (result instanceof AsyncContextAccessor) {
+            if (AsyncContextAccessorUtils.getAsyncContext(result) == null) {
+                // Avoid duplicate async context
+                final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+                ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
+            }
+        }
+        return result;
     }
 }

--- a/agent-module/plugins/redis-redisson/src/test/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/WrappingReactiveMethodInterceptorTest.java
+++ b/agent-module/plugins/redis-redisson/src/test/java/com/navercorp/pinpoint/plugin/redis/redisson/interceptor/WrappingReactiveMethodInterceptorTest.java
@@ -17,8 +17,8 @@ package com.navercorp.pinpoint.plugin.redis.redisson.interceptor;
 
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
-import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -45,7 +46,7 @@ public class WrappingReactiveMethodInterceptorTest {
     private WrappingReactiveMethodInterceptor interceptor;
     private TraceContext traceContext;
     private Trace trace;
-    private SpanEventRecorder recorder;
+    private TraceBlock block;
 
     @BeforeEach
     public void setUp() {
@@ -58,24 +59,27 @@ public class WrappingReactiveMethodInterceptorTest {
         interceptor = new WrappingReactiveMethodInterceptor(traceContext, mock(MethodDescriptor.class));
 
         trace = mock(Trace.class);
-        recorder = mock(SpanEventRecorder.class);
+        block = mock(TraceBlock.class);
         when(traceContext.currentTraceObject()).thenReturn(trace);
-        when(trace.traceBlockBegin()).thenReturn(recorder);
-        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+        when(trace.getTraceBlock()).thenReturn(block);
+        when(block.getTrace()).thenReturn(trace);
+        when(block.isBegin()).thenReturn(true);
     }
 
     @Test
     public void errorOnWrapPath_isContained_originalResultReturned() {
         // simulate the reactor-absence failure mode: an Error (NoClassDefFoundError) thrown from
         // the wrap path inside after()'s try block.
-        when(recorder.recordNextAsyncContext())
+        when(block.recordNextAsyncContext())
                 .thenThrow(new NoClassDefFoundError("reactor/core/publisher/Mono"));
         final Object result = Flux.range(1, 2).hide(); // wrappable, so the wrap path is entered
 
-        interceptor.before(new Object(), Object.class, new Object[0]);
-        final Object returned = interceptor.after(new Object(), Object.class, new Object[0], result, null);
+        final TraceBlock returned = interceptor.before(new Object(), Object.class, new Object[0]);
+        final Object kept = interceptor.after(returned, new Object(), Object.class, new Object[0], result, null);
 
-        // contained: the app gets its original publisher back, nothing propagates.
-        assertSame(result, returned);
+        // contained: the app gets its original publisher back, nothing propagates, and the
+        // block is still closed on the error path.
+        assertSame(result, kept);
+        verify(block).close();
     }
 }

--- a/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/WrappingConnectionFactoryCreateInterceptor.java
+++ b/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/WrappingConnectionFactoryCreateInterceptor.java
@@ -19,15 +19,10 @@ package com.navercorp.pinpoint.plugin.spring.r2dbc.interceptor;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
-import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
 import com.navercorp.pinpoint.plugin.spring.r2dbc.SpringDataR2dbcConstants;
-
-import java.util.Objects;
 
 /**
  * Wrapping variant of {@link ConnectionFactoryCreateInterceptor} (config-gated by
@@ -35,64 +30,34 @@ import java.util.Objects;
  * {@code ConnectionFactory.create()} is replaced with a wrapped one instead of receiving the
  * AsyncContext through its injected accessor field.
  */
-public class WrappingConnectionFactoryCreateInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
+public class WrappingConnectionFactoryCreateInterceptor extends SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin {
 
     public WrappingConnectionFactoryCreateInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
     }
 
     @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
-            return;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recorder.recordServiceType(SpringDataR2dbcConstants.SPRING_DATA_R2DBC);
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
-        }
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
+        recorder.recordServiceType(SpringDataR2dbcConstants.SPRING_DATA_R2DBC);
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        recorder.recordException(throwable);
+        recorder.recordApi(methodDescriptor);
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
             return result;
         }
 
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-            recorder.recordException(throwable);
-            recorder.recordApi(methodDescriptor);
-
-            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
-                return result;
-            }
-
-            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
-            if (isDebug) {
-                logger.debug("Wrapped connection publisher. asyncContext={}", asyncContext);
-            }
-            return wrapped;
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            return result;
-        } finally {
-            trace.traceBlockEnd();
+        final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+        final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+        if (isDebug) {
+            logger.debug("Wrapped connection publisher. asyncContext={}", asyncContext);
         }
+        return wrapped;
     }
 }

--- a/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/WrappingStatementExecuteInterceptor.java
+++ b/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/WrappingStatementExecuteInterceptor.java
@@ -21,11 +21,8 @@ import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.ParsingResult;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
-import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.BindValueAccessor;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.ParsingResultAccessor;
@@ -34,7 +31,6 @@ import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Wrapping variant of {@link StatementExecuteInterceptor} (PoC, config-gated by
@@ -44,39 +40,17 @@ import java.util.Objects;
  * async trace — no reactor-core field write, no dependency on the reactor plugin's per-operator
  * relay for this seam.
  */
-public class WrappingStatementExecuteInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    protected final TraceContext traceContext;
-    protected final MethodDescriptor methodDescriptor;
+public class WrappingStatementExecuteInterceptor extends SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin {
     private final int maxSqlBindValueSize;
 
     public WrappingStatementExecuteInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, int maxSqlBindValueSize) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
         this.maxSqlBindValueSize = maxSqlBindValueSize;
     }
 
-    @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
-            return;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recordStatement(recorder, target);
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
-        }
-    }
-
     // same recording as StatementExecuteInterceptor.doInBeforeTrace
-    private void recordStatement(SpanEventRecorder recorder, Object target) {
+    @Override
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
         DatabaseInfo databaseInfo = (target instanceof DatabaseInfoAccessor) ? ((DatabaseInfoAccessor) target)._$PINPOINT$_getDatabaseInfo() : null;
         if (databaseInfo == null) {
             databaseInfo = UnKnownDatabaseInfo.INSTANCE;
@@ -112,34 +86,22 @@ public class WrappingStatementExecuteInterceptor implements ResultReplaceAroundI
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        recorder.recordException(throwable);
+        recorder.recordApi(methodDescriptor);
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
             return result;
         }
 
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-            recorder.recordException(throwable);
-            recorder.recordApi(methodDescriptor);
-
-            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
-                return result;
-            }
-
-            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
-            if (isDebug) {
-                logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
-            }
-            return wrapped;
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            return result;
-        } finally {
-            trace.traceBlockEnd();
+        final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+        final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+        if (isDebug) {
+            logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
         }
+        return wrapped;
     }
 }

--- a/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/mssql/WrappingMssqlStatementExecuteInterceptor.java
+++ b/agent-module/plugins/spring-data-r2dbc/src/main/java/com/navercorp/pinpoint/plugin/spring/r2dbc/interceptor/mssql/WrappingMssqlStatementExecuteInterceptor.java
@@ -21,11 +21,8 @@ import com.navercorp.pinpoint.bootstrap.context.DatabaseInfo;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.ParsingResult;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
-import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.BindValueAccessor;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.DatabaseInfoAccessor;
 import com.navercorp.pinpoint.bootstrap.plugin.jdbc.ParsingResultAccessor;
@@ -35,46 +32,23 @@ import com.navercorp.pinpoint.plugin.spring.r2dbc.BindNameValueAccessor;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Wrapping variant of {@link MssqlStatementExecuteInterceptor} (config-gated by
  * {@code profiler.spring.data.r2dbc.wrap.publisher}). See
  * {@code WrappingStatementExecuteInterceptor} - identical flow with the mssql named-bind variant.
  */
-public class WrappingMssqlStatementExecuteInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
+public class WrappingMssqlStatementExecuteInterceptor extends SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin {
     private final int maxSqlBindValueSize;
 
     public WrappingMssqlStatementExecuteInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, int maxSqlBindValueSize) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
         this.maxSqlBindValueSize = maxSqlBindValueSize;
     }
 
-    @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
-            return;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recordStatement(recorder, target);
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
-        }
-    }
-
     // same recording as MssqlStatementExecuteInterceptor.doInBeforeTrace
-    private void recordStatement(SpanEventRecorder recorder, Object target) {
+    @Override
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
         DatabaseInfo databaseInfo = (target instanceof DatabaseInfoAccessor) ? ((DatabaseInfoAccessor) target)._$PINPOINT$_getDatabaseInfo() : null;
         if (databaseInfo == null) {
             databaseInfo = UnKnownDatabaseInfo.INSTANCE;
@@ -110,34 +84,22 @@ public class WrappingMssqlStatementExecuteInterceptor implements ResultReplaceAr
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        recorder.recordException(throwable);
+        recorder.recordApi(methodDescriptor);
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
             return result;
         }
 
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-            recorder.recordException(throwable);
-            recorder.recordApi(methodDescriptor);
-
-            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
-                return result;
-            }
-
-            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
-            if (isDebug) {
-                logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
-            }
-            return wrapped;
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            return result;
-        } finally {
-            trace.traceBlockEnd();
+        final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+        final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+        if (isDebug) {
+            logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
         }
+        return wrapped;
     }
 }

--- a/agent-module/plugins/spring-tx/src/main/java/com/navercorp/pinpoint/plugin/spring/tx/interceptor/WrappingReactiveTransactionSupportInterceptor.java
+++ b/agent-module/plugins/spring-tx/src/main/java/com/navercorp/pinpoint/plugin/spring/tx/interceptor/WrappingReactiveTransactionSupportInterceptor.java
@@ -20,16 +20,11 @@ import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
-import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
 import com.navercorp.pinpoint.plugin.spring.tx.SpringTxConfig;
 import com.navercorp.pinpoint.plugin.spring.tx.SpringTxConstants;
-
-import java.util.Objects;
 
 /**
  * Wrapping variant of {@link ReactiveTransactionSupportInterceptor} (config-gated by
@@ -37,75 +32,45 @@ import java.util.Objects;
  * wrapped one instead of relying on the accessor field the reactor plugin injects into
  * reactor.core.publisher types; any other async result keeps the original injection.
  */
-public class WrappingReactiveTransactionSupportInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
+public class WrappingReactiveTransactionSupportInterceptor extends SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin {
     private final boolean markError;
 
     public WrappingReactiveTransactionSupportInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
         final SpringTxConfig config = new SpringTxConfig(traceContext.getProfilerConfig());
         this.markError = config.isMarkError();
     }
 
     @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
-            return;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recorder.recordServiceType(SpringTxConstants.SPRING_TX);
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
-        }
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
+        recorder.recordServiceType(SpringTxConstants.SPRING_TX);
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Trace trace = traceContext.currentTraceObject();
-        if (trace == null) {
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        recorder.recordException(markError, throwable);
+        recorder.recordApi(methodDescriptor);
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null) {
             return result;
         }
 
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-            recorder.recordException(markError, throwable);
-            recorder.recordApi(methodDescriptor);
-
-            if (throwable != null) {
-                return result;
+        if (SeamPublisherWrapper.isWrappable(result)) {
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+            if (isDebug) {
+                logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
             }
-
-            if (SeamPublisherWrapper.isWrappable(result)) {
-                final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-                final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
-                if (isDebug) {
-                    logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
-                }
-                return wrapped;
-            }
-            // non-reactor async result: keep the original injection.
-            if (result instanceof AsyncContextAccessor) {
-                final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-                ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
-            }
-            return result;
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            return result;
-        } finally {
-            trace.traceBlockEnd();
+            return wrapped;
         }
+        // non-reactor async result: keep the original injection.
+        if (result instanceof AsyncContextAccessor) {
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            ((AsyncContextAccessor) result)._$PINPOINT$_setAsyncContext(asyncContext);
+        }
+        return result;
     }
 }

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingBodyInserterRequestBuilderWriteToInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingBodyInserterRequestBuilderWriteToInterceptor.java
@@ -16,16 +16,13 @@
 
 package com.navercorp.pinpoint.plugin.spring.webflux.interceptor;
 
-import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessorUtils;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.context.TraceId;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.AsyncContextSpanEventResultReplaceBlockSimpleAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestAdaptor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
@@ -35,59 +32,26 @@ import com.navercorp.pinpoint.bootstrap.plugin.request.RequestTraceWriter;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieRecorder;
 import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieRecorderFactory;
-import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
 import com.navercorp.pinpoint.common.util.ArrayArgumentUtils;
 import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
 import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxConstants;
 import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxPluginConfig;
 import org.springframework.http.client.reactive.ClientHttpRequest;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.Objects;
-
 /**
  * Wrapping variant of {@link BodyInserterRequestBuilderWriteToInterceptor} (config-gated by
  * {@code profiler.spring.webflux.wrap.publisher}). The returned publisher is replaced with a
  * wrapped one instead of receiving the next AsyncContext through its injected accessor field.
- * The original passes its conditionally-begun TraceBlock from before() to after() through the
- * weaver; a result-replace interceptor has no such channel, so the state travels on a
- * per-thread frame stack (writeTo runs synchronously, so before/after pair up on one thread).
- * <p>
- * The pairing is structural: before() pushes EXACTLY one frame on every invocation — including
- * early returns and failures — and after() polls exactly one, so a frame can never be claimed by
- * the wrong (e.g. an outer recursive) invocation. after() operates on the trace the frame
- * carries, never on the ambient thread-local, so a lost or foreign binding cannot mispair the
- * cleanup either.
+ * The conditionally-begun TraceBlock travels from before() to after() through the weaver, the
+ * same channel the original uses.
  */
-public class WrappingBodyInserterRequestBuilderWriteToInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    // one entry per before() invocation; EMPTY marks "my before() did nothing to undo".
-    static final class Frame {
-        static final Frame EMPTY = new Frame();
-        AsyncContext asyncContext;
-        Trace trace;
-        boolean begun;
-    }
-
-    private static final ThreadLocal<Deque<Frame>> FRAMES = new ThreadLocal<Deque<Frame>>() {
-        @Override
-        protected Deque<Frame> initialValue() {
-            return new ArrayDeque<>();
-        }
-    };
-
-    private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
+public class WrappingBodyInserterRequestBuilderWriteToInterceptor extends AsyncContextSpanEventResultReplaceBlockSimpleAroundInterceptor {
     private final ClientRequestRecorder<ClientRequestWrapper> clientRequestRecorder;
     private final CookieRecorder<ClientHttpRequest> cookieRecorder;
     private final RequestTraceWriter<ClientHttpRequest> requestTraceWriter;
 
     public WrappingBodyInserterRequestBuilderWriteToInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
 
         final SpringWebFluxPluginConfig config = new SpringWebFluxPluginConfig(traceContext.getProfilerConfig());
         final ClientRequestAdaptor<ClientRequestWrapper> clientRequestAdaptor = ClientRequestWrapperAdaptor.INSTANCE;
@@ -101,50 +65,7 @@ public class WrappingBodyInserterRequestBuilderWriteToInterceptor implements Res
     }
 
     @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        Frame frame = Frame.EMPTY;
-        try {
-            final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(target);
-            if (asyncContext == null) {
-                return;
-            }
-            final Trace trace = asyncContext.continueAsyncTraceObject(true);
-            if (trace == null) {
-                return;
-            }
-
-            ScopeUtils.entryAsyncTraceScope(trace);
-            // the frame records exactly how far this invocation got, so after() unwinds no more
-            // and no less than what actually happened.
-            frame = new Frame();
-            frame.asyncContext = asyncContext;
-            frame.trace = trace;
-
-            if (checkBeforeTraceBlockBegin(trace, args)) {
-                final SpanEventRecorder recorder = trace.traceBlockBegin();
-                frame.begun = true;
-
-                final ClientHttpRequest request = ArrayArgumentUtils.getArgument(args, 0, ClientHttpRequest.class);
-                final TraceId nextId = trace.getTraceId().getNextTraceId();
-                recorder.recordNextSpanId(nextId.getSpanId());
-                final ClientRequestWrapper clientRequestWrapper = new WebClientRequestWrapper(request);
-                requestTraceWriter.write(request, nextId, clientRequestWrapper.getDestinationId());
-
-                recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX_CLIENT);
-            }
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
-        } finally {
-            // structural pairing: EVERY before() pushes exactly one frame - early returns and
-            // failures push EMPTY - so after() can never claim another invocation's frame.
-            FRAMES.get().push(frame);
-        }
-    }
-
-    // same gate as BodyInserterRequestBuilderWriteToInterceptor.checkBeforeTraceBlockBegin
-    private boolean checkBeforeTraceBlockBegin(Trace trace, Object[] args) {
+    public boolean checkBeforeTraceBlockBegin(AsyncContext asyncContext, Trace trace, Object target, Object[] args) {
         final ClientHttpRequest request = ArrayArgumentUtils.getArgument(args, 0, ClientHttpRequest.class);
         if (request == null) {
             return false;
@@ -163,73 +84,44 @@ public class WrappingBodyInserterRequestBuilderWriteToInterceptor implements Res
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Deque<Frame> frames = FRAMES.get();
-        final Frame frame = frames.poll();
-        if (frames.isEmpty()) {
-            // do not leave an empty deque parked on every pooled thread.
-            FRAMES.remove();
-        }
-        if (frame == null || frame.trace == null) {
-            // frame == null: no paired before() ran (defensive); EMPTY: before() did nothing.
-            return result;
-        }
-        // unwind exactly what the paired before() recorded - never the ambient thread-local,
-        // which may belong to an outer invocation or have been unbound in between.
-        final AsyncContext asyncContext = frame.asyncContext;
-        final Trace trace = frame.trace;
-        final boolean begun = frame.begun;
-
-        if (!ScopeUtils.leaveAsyncTraceScope(trace)) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Failed to leave scope of async trace {}.", trace);
-            }
-            deleteAsyncContext(trace, asyncContext);
-            return result;
+    public void beforeTrace(AsyncContext asyncContext, Trace trace, SpanEventRecorder recorder, Object target, Object[] args) {
+        final ClientHttpRequest request = ArrayArgumentUtils.getArgument(args, 0, ClientHttpRequest.class);
+        if (request == null) {
+            return;
         }
 
-        Object ret = result;
-        try {
-            if (begun) {
-                final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-                recorder.recordApi(methodDescriptor);
-                recorder.recordException(throwable);
-
-                final ClientHttpRequest request = ArrayArgumentUtils.getArgument(args, 0, ClientHttpRequest.class);
-                final ClientRequestWrapper clientRequestWrapper = new WebClientRequestWrapper(request);
-                this.clientRequestRecorder.record(recorder, clientRequestWrapper, throwable);
-                this.cookieRecorder.record(recorder, request, throwable);
-
-                if (throwable == null && SeamPublisherWrapper.isWrappable(result)) {
-                    // make asynchronous trace-id
-                    final AsyncContext nextAsyncContext = recorder.recordNextAsyncContext();
-                    ret = SeamPublisherWrapper.wrap(result, nextAsyncContext);
-                    if (isDebug) {
-                        logger.debug("Wrapped result publisher. asyncContext={}", nextAsyncContext);
-                    }
-                }
-            }
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            ret = result;
-        } finally {
-            if (begun) {
-                trace.traceBlockEnd();
-            }
-            if (ScopeUtils.isAsyncTraceEndScope(trace)) {
-                deleteAsyncContext(trace, asyncContext);
-            }
-        }
-        return ret;
+        final TraceId nextId = trace.getTraceId().getNextTraceId();
+        recorder.recordNextSpanId(nextId.getSpanId());
+        final ClientRequestWrapper clientRequestWrapper = new WebClientRequestWrapper(request);
+        requestTraceWriter.write(request, nextId, clientRequestWrapper.getDestinationId());
     }
 
-    private void deleteAsyncContext(Trace trace, AsyncContext asyncContext) {
-        if (isDebug) {
-            logger.debug("Delete async trace {}.", trace);
+    @Override
+    public void doInBeforeTrace(SpanEventRecorder recorder, AsyncContext asyncContext, Object target, Object[] args) {
+        recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX_CLIENT);
+    }
+
+    @Override
+    public void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        recorder.recordApi(methodDescriptor);
+        recorder.recordException(throwable);
+
+        final ClientHttpRequest request = ArrayArgumentUtils.getArgument(args, 0, ClientHttpRequest.class);
+        final ClientRequestWrapper clientRequestWrapper = new WebClientRequestWrapper(request);
+        this.clientRequestRecorder.record(recorder, clientRequestWrapper, throwable);
+        this.cookieRecorder.record(recorder, request, throwable);
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, AsyncContext asyncContext, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable == null && SeamPublisherWrapper.isWrappable(result)) {
+            // make asynchronous trace-id
+            final AsyncContext nextAsyncContext = recorder.recordNextAsyncContext();
+            if (isDebug) {
+                logger.debug("Wrapped result publisher. asyncContext={}", nextAsyncContext);
+            }
+            return SeamPublisherWrapper.wrap(result, nextAsyncContext);
         }
-        trace.close();
-        asyncContext.close();
+        return result;
     }
 }

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDefaultWebClientExchangeMethodInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDefaultWebClientExchangeMethodInterceptor.java
@@ -21,13 +21,9 @@ import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
 import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxConstants;
-
-import java.util.Objects;
 
 /**
  * Wrapping variant of {@link DefaultWebClientExchangeMethodInterceptor} (config-gated by
@@ -35,67 +31,46 @@ import java.util.Objects;
  * with a wrapped one instead of receiving the AsyncContext through its injected accessor field.
  * As in the original, the next AsyncContext is recorded even for unsampled traces.
  */
-public class WrappingDefaultWebClientExchangeMethodInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
+public class WrappingDefaultWebClientExchangeMethodInterceptor extends SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin {
 
     public WrappingDefaultWebClientExchangeMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
     }
 
     @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final Trace trace = traceContext.currentRawTraceObject();
-        if (trace == null) {
-            return;
-        }
+    protected Trace currentTrace() {
+        return traceContext.currentRawTraceObject();
+    }
 
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
+    @Override
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
+        recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
+    }
+
+    @Override
+    protected void afterTrace(Trace trace, SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        if (trace.canSampled()) {
+            recorder.recordApi(methodDescriptor);
+            recorder.recordException(throwable);
         }
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Trace trace = traceContext.currentRawTraceObject();
-        if (trace == null) {
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
             return result;
         }
 
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-            if (trace.canSampled()) {
-                recorder.recordApi(methodDescriptor);
-                recorder.recordException(throwable);
-            }
-
-            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
-                return result;
-            }
-
-            // make asynchronous trace-id
-            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
-            if (isDebug) {
-                logger.debug("Wrapped response publisher. asyncContext={}", asyncContext);
-            }
-            return wrapped;
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            return result;
-        } finally {
-            trace.traceBlockEnd();
+        // make asynchronous trace-id
+        final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+        final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+        if (isDebug) {
+            logger.debug("Wrapped response publisher. asyncContext={}", asyncContext);
         }
+        return wrapped;
     }
 }

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDispatchHandlerHandleMethodInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDispatchHandlerHandleMethodInterceptor.java
@@ -23,13 +23,9 @@ import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
 import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxConstants;
-
-import java.util.Objects;
 
 /**
  * Wrapping variant of {@link DispatchHandlerHandleMethodInterceptor} (config-gated by
@@ -37,75 +33,50 @@ import java.util.Objects;
  * AsyncContext through its injected accessor field - downstream interceptors read it from
  * there - but the returned publisher is replaced with a wrapped one instead of being injected.
  */
-public class WrappingDispatchHandlerHandleMethodInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
+public class WrappingDispatchHandlerHandleMethodInterceptor extends SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin {
 
     public WrappingDispatchHandlerHandleMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
     }
 
     @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final Trace trace = traceContext.currentRawTraceObject();
-        if (trace == null) {
-            return;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
-            if (args != null && args.length > 0 && args[0] instanceof AsyncContextAccessor) {
-                // make asynchronous trace-id
-                final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-                ((AsyncContextAccessor) args[0])._$PINPOINT$_setAsyncContext(asyncContext);
-                if (isDebug) {
-                    logger.debug("Set AsyncContext {}", asyncContext);
-                }
-            }
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
-        }
+    protected Trace currentTrace() {
+        return traceContext.currentRawTraceObject();
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Trace trace = traceContext.currentRawTraceObject();
-        if (trace == null) {
-            return result;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-            recorder.recordApi(methodDescriptor);
-            recorder.recordException(throwable);
-
-            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
-                return result;
-            }
-
-            final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 0);
-            if (asyncContext == null) {
-                return result;
-            }
-            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
+        recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
+        if (args != null && args.length > 0 && args[0] instanceof AsyncContextAccessor) {
+            // make asynchronous trace-id
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            ((AsyncContextAccessor) args[0])._$PINPOINT$_setAsyncContext(asyncContext);
             if (isDebug) {
-                logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
+                logger.debug("Set AsyncContext {}", asyncContext);
             }
-            return wrapped;
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            return result;
-        } finally {
-            trace.traceBlockEnd();
         }
+    }
+
+    @Override
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        recorder.recordApi(methodDescriptor);
+        recorder.recordException(throwable);
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
+            return result;
+        }
+
+        final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 0);
+        if (asyncContext == null) {
+            return result;
+        }
+        final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+        if (isDebug) {
+            logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
+        }
+        return wrapped;
     }
 }

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDispatchHandlerInvokeHandlerMethodInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDispatchHandlerInvokeHandlerMethodInterceptor.java
@@ -23,10 +23,7 @@ import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.SpanRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
-import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
+import com.navercorp.pinpoint.bootstrap.interceptor.AsyncContextSpanEventResultReplaceBlockSimpleAroundInterceptor;
 import com.navercorp.pinpoint.common.util.ArrayArgumentUtils;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
@@ -34,52 +31,40 @@ import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxConstants;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.pattern.PathPattern;
 
-import java.util.Objects;
-
 /**
  * Wrapping variant of {@link DispatchHandlerInvokeHandlerMethodInterceptor} (config-gated by
  * {@code profiler.spring.webflux.wrap.publisher}). The span event still runs inside the async
- * trace continued from the exchange's AsyncContext, but the returned publisher is replaced with
- * a wrapped one (carrying the same context) instead of being injected.
+ * trace continued from the exchange's AsyncContext (args[0]), but the returned publisher is
+ * replaced with a wrapped one (carrying the same context) instead of being injected.
  */
-public class WrappingDispatchHandlerInvokeHandlerMethodInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
+public class WrappingDispatchHandlerInvokeHandlerMethodInterceptor extends AsyncContextSpanEventResultReplaceBlockSimpleAroundInterceptor {
+    // the async-context base validates but does not keep the trace context.
     private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
     private final Boolean uriStatEnable;
     private final Boolean uriStatUseUserInput;
 
     public WrappingDispatchHandlerInvokeHandlerMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor, Boolean uriStatEnable, Boolean uriStatUseUserInput) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
+        this.traceContext = traceContext;
         this.uriStatEnable = uriStatEnable;
         this.uriStatUseUserInput = uriStatUseUserInput;
     }
 
     @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 0);
-        if (asyncContext == null) {
-            return;
-        }
-        final Trace trace = asyncContext.continueAsyncTraceObject(true);
-        if (trace == null) {
-            return;
-        }
+    protected AsyncContext getAsyncContext(Object target, Object[] args) {
+        return AsyncContextAccessorUtils.getAsyncContext(args, 0);
+    }
 
-        ScopeUtils.entryAsyncTraceScope(trace);
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
-            if (uriStatEnable) {
-                recordUriTemplate(args);
-            }
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
+    @Override
+    protected AsyncContext getAsyncContext(Object target, Object[] args, Object result, Throwable throwable) {
+        return AsyncContextAccessorUtils.getAsyncContext(args, 0);
+    }
+
+    @Override
+    public void doInBeforeTrace(SpanEventRecorder recorder, AsyncContext asyncContext, Object target, Object[] args) {
+        recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
+        if (uriStatEnable) {
+            recordUriTemplate(args);
         }
     }
 
@@ -121,56 +106,22 @@ public class WrappingDispatchHandlerInvokeHandlerMethodInterceptor implements Re
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 0);
-        if (asyncContext == null) {
-            return result;
-        }
-        final Trace trace = asyncContext.currentAsyncTraceObject();
-        if (trace == null) {
-            return result;
-        }
-
-        if (!ScopeUtils.leaveAsyncTraceScope(trace)) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Failed to leave scope of async trace {}.", trace);
-            }
-            deleteAsyncContext(trace, asyncContext);
-            return result;
-        }
-
-        Object ret = result;
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-            recorder.recordApi(methodDescriptor);
-            recorder.recordException(throwable);
-
-            if (throwable == null && SeamPublisherWrapper.isWrappable(result)) {
-                // hand the exchange's AsyncContext to the wrapped publisher.
-                ret = SeamPublisherWrapper.wrap(result, asyncContext);
-                if (isDebug) {
-                    logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
-                }
-            }
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            ret = result;
-        } finally {
-            trace.traceBlockEnd();
-            if (ScopeUtils.isAsyncTraceEndScope(trace)) {
-                deleteAsyncContext(trace, asyncContext);
-            }
-        }
-        return ret;
+    public void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        recorder.recordApi(methodDescriptor);
+        recorder.recordException(throwable);
     }
 
-    private void deleteAsyncContext(Trace trace, AsyncContext asyncContext) {
-        if (isDebug) {
-            logger.debug("Delete async trace {}.", trace);
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, AsyncContext asyncContext, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
+            return result;
         }
-        trace.close();
-        asyncContext.close();
+
+        // hand the exchange's AsyncContext to the wrapped publisher.
+        final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+        if (isDebug) {
+            logger.debug("Wrapped result publisher. asyncContext={}", asyncContext);
+        }
+        return wrapped;
     }
 }

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingExchangeFunctionMethodInterceptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingExchangeFunctionMethodInterceptor.java
@@ -23,13 +23,9 @@ import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
-import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
-import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
+import com.navercorp.pinpoint.bootstrap.interceptor.SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin;
 import com.navercorp.pinpoint.plugin.reactorsupport.SeamPublisherWrapper;
 import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxConstants;
-
-import java.util.Objects;
 
 /**
  * Wrapping variant of {@link ExchangeFunctionMethodInterceptor} (config-gated by
@@ -37,75 +33,50 @@ import java.util.Objects;
  * AsyncContext through its injected accessor field, but the returned response publisher is
  * replaced with a wrapped one instead of being injected.
  */
-public class WrappingExchangeFunctionMethodInterceptor implements ResultReplaceAroundInterceptor {
-    private final PluginLogger logger = PluginLogManager.getLogger(getClass());
-    private final boolean isDebug = logger.isDebugEnabled();
-
-    private final TraceContext traceContext;
-    private final MethodDescriptor methodDescriptor;
+public class WrappingExchangeFunctionMethodInterceptor extends SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin {
 
     public WrappingExchangeFunctionMethodInterceptor(TraceContext traceContext, MethodDescriptor methodDescriptor) {
-        this.traceContext = Objects.requireNonNull(traceContext, "traceContext");
-        this.methodDescriptor = Objects.requireNonNull(methodDescriptor, "methodDescriptor");
+        super(traceContext, methodDescriptor);
     }
 
     @Override
-    public void before(Object target, Class<?> returnType, Object[] args) {
-        final Trace trace = traceContext.currentRawTraceObject();
-        if (trace == null) {
-            return;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.traceBlockBegin();
-            recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
-            if (args != null && args.length > 0 && args[0] instanceof AsyncContextAccessor) {
-                // make asynchronous trace-id
-                final AsyncContext asyncContext = recorder.recordNextAsyncContext();
-                ((AsyncContextAccessor) args[0])._$PINPOINT$_setAsyncContext(asyncContext);
-                if (isDebug) {
-                    logger.debug("Set closeable-AsyncContext {}", asyncContext);
-                }
-            }
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("BEFORE. Caused:{}", th.getMessage(), th);
-            }
-        }
+    protected Trace currentTrace() {
+        return traceContext.currentRawTraceObject();
     }
 
     @Override
-    public Object after(Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
-        final Trace trace = traceContext.currentRawTraceObject();
-        if (trace == null) {
-            return result;
-        }
-
-        try {
-            final SpanEventRecorder recorder = trace.currentSpanEventRecorder();
-            recorder.recordApi(methodDescriptor);
-            recorder.recordException(throwable);
-
-            if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
-                return result;
-            }
-
-            final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 0);
-            if (asyncContext == null) {
-                return result;
-            }
-            final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+    protected void doInBeforeTrace(SpanEventRecorder recorder, Object target, Object[] args) {
+        recorder.recordServiceType(SpringWebFluxConstants.SPRING_WEBFLUX);
+        if (args != null && args.length > 0 && args[0] instanceof AsyncContextAccessor) {
+            // make asynchronous trace-id
+            final AsyncContext asyncContext = recorder.recordNextAsyncContext();
+            ((AsyncContextAccessor) args[0])._$PINPOINT$_setAsyncContext(asyncContext);
             if (isDebug) {
-                logger.debug("Wrapped response publisher. asyncContext={}", asyncContext);
+                logger.debug("Set closeable-AsyncContext {}", asyncContext);
             }
-            return wrapped;
-        } catch (Throwable th) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("AFTER error. Caused:{}", th.getMessage(), th);
-            }
-            return result;
-        } finally {
-            trace.traceBlockEnd();
         }
+    }
+
+    @Override
+    protected void doInAfterTrace(SpanEventRecorder recorder, Object target, Object[] args, Object result, Throwable throwable) {
+        recorder.recordApi(methodDescriptor);
+        recorder.recordException(throwable);
+    }
+
+    @Override
+    protected Object replaceResult(SpanEventRecorder recorder, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        if (throwable != null || !SeamPublisherWrapper.isWrappable(result)) {
+            return result;
+        }
+
+        final AsyncContext asyncContext = AsyncContextAccessorUtils.getAsyncContext(args, 0);
+        if (asyncContext == null) {
+            return result;
+        }
+        final Object wrapped = SeamPublisherWrapper.wrap(result, asyncContext);
+        if (isDebug) {
+            logger.debug("Wrapped response publisher. asyncContext={}", asyncContext);
+        }
+        return wrapped;
     }
 }

--- a/agent-module/plugins/spring-webflux/src/test/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingBodyInserterRequestBuilderWriteToInterceptorTest.java
+++ b/agent-module/plugins/spring-webflux/src/test/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingBodyInserterRequestBuilderWriteToInterceptorTest.java
@@ -19,13 +19,20 @@ import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
 import com.navercorp.pinpoint.bootstrap.config.ProfilerConfig;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
 import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
 import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,11 +43,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Frame-stack pairing of the wrapping BodyInserter interceptor (W4): every before() pushes
- * exactly one frame — early return and failure push EMPTY — and after() polls exactly one and
- * unwinds only what its own paired before() recorded. The cases that used to mispair under the
- * old boolean stack (an inner no-op invocation stealing the outer frame; a before() failure
- * leaving a stale flag) are pinned here.
+ * Weaver-carried block pairing of the wrapping BodyInserter interceptor: before() hands its
+ * conditionally-begun TraceBlock to the weaver and after() unwinds exactly the trace that block
+ * carries, so a cross-invocation mispair is structurally impossible (this replaces the frame
+ * stack the ResultReplace-only variant needed). The replace hook wraps the returned publisher
+ * only when the paired block was begun.
  */
 public class WrappingBodyInserterRequestBuilderWriteToInterceptorTest {
 
@@ -50,6 +57,7 @@ public class WrappingBodyInserterRequestBuilderWriteToInterceptorTest {
     private AsyncContext outerContext;
     private Trace outerTrace;
     private TraceScope outerScope;
+    private TraceBlock outerBlock;
 
     @BeforeEach
     public void setUp() {
@@ -69,9 +77,12 @@ public class WrappingBodyInserterRequestBuilderWriteToInterceptorTest {
         outerContext = mock(AsyncContext.class);
         outerTrace = mock(Trace.class);
         outerScope = mock(TraceScope.class);
+        outerBlock = mock(TraceBlock.class);
         when(outerContext.continueAsyncTraceObject(true)).thenReturn(outerTrace);
         when(outerTrace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(outerScope);
         when(outerTrace.isAsync()).thenReturn(true);
+        when(outerTrace.getTraceBlock()).thenReturn(outerBlock);
+        when(outerBlock.getTrace()).thenReturn(outerTrace);
         when(outerScope.tryEnter()).thenReturn(true);
         when(outerScope.canLeave()).thenReturn(true);
         when(outerScope.isActive()).thenReturn(false);
@@ -84,46 +95,35 @@ public class WrappingBodyInserterRequestBuilderWriteToInterceptorTest {
     }
 
     @Test
-    public void innerNoopInvocation_cannotStealOuterFrame() {
-        final Object outerTarget = accessorTarget(outerContext);
-        final Object innerTarget = new MockAccessor(); // no context: inner before() is a no-op
+    public void before_returnsTraceBlockForTheWeaverChannel() {
+        final Object target = accessorTarget(outerContext);
 
-        interceptor.before(outerTarget, Object.class, NO_REQUEST_ARGS);   // pushes real frame
-        interceptor.before(innerTarget, Object.class, NO_REQUEST_ARGS);   // pushes EMPTY
-        interceptor.after(innerTarget, Object.class, NO_REQUEST_ARGS, null, null);
+        final TraceBlock block = interceptor.before(target, Object.class, NO_REQUEST_ARGS);
 
-        // the inner after() consumed only its own EMPTY frame - the outer trace is untouched.
-        verify(outerScope, never()).leave();
-        verify(outerTrace, never()).close();
-
-        interceptor.after(outerTarget, Object.class, NO_REQUEST_ARGS, null, null);
-
-        // the outer after() unwinds its own frame exactly once (scope leave + end-scope cleanup).
-        verify(outerScope, times(1)).leave();
-        verify(outerTrace, times(1)).close();
-        verify(outerContext, times(1)).close();
+        assertSame(outerBlock, block);
+        // no request argument: the block travels un-begun.
+        verify(outerBlock, never()).begin();
     }
 
     @Test
-    public void beforeFailure_pushesEmptyFrame_afterIsHarmless() {
-        final AsyncContext failing = mock(AsyncContext.class);
-        when(failing.continueAsyncTraceObject(true)).thenThrow(new IllegalStateException("continue failed"));
-        final Object target = accessorTarget(failing);
+    public void beforeWithoutContext_returnsNull() {
+        final TraceBlock block = interceptor.before(new MockAccessor(), Object.class, NO_REQUEST_ARGS);
 
-        interceptor.before(target, Object.class, NO_REQUEST_ARGS);
-        interceptor.after(target, Object.class, NO_REQUEST_ARGS, null, null);
-
-        verify(failing, never()).close();
+        assertNull(block);
+        verify(outerTrace, never()).getTraceBlock();
     }
 
     @Test
-    public void recursion_unwindsInLifoOrder_eachFrameOnce() {
+    public void nestedInvocations_afterUnwindsExactlyItsOwnBlock() {
         final AsyncContext innerContext = mock(AsyncContext.class);
         final Trace innerTrace = mock(Trace.class);
         final TraceScope innerScope = mock(TraceScope.class);
+        final TraceBlock innerBlock = mock(TraceBlock.class);
         when(innerContext.continueAsyncTraceObject(true)).thenReturn(innerTrace);
         when(innerTrace.getScope(ScopeUtils.ASYNC_TRACE_SCOPE)).thenReturn(innerScope);
         when(innerTrace.isAsync()).thenReturn(true);
+        when(innerTrace.getTraceBlock()).thenReturn(innerBlock);
+        when(innerBlock.getTrace()).thenReturn(innerTrace);
         when(innerScope.tryEnter()).thenReturn(true);
         when(innerScope.canLeave()).thenReturn(true);
         when(innerScope.isActive()).thenReturn(false);
@@ -131,37 +131,104 @@ public class WrappingBodyInserterRequestBuilderWriteToInterceptorTest {
         final Object outerTarget = accessorTarget(outerContext);
         final Object innerTarget = accessorTarget(innerContext);
 
-        interceptor.before(outerTarget, Object.class, NO_REQUEST_ARGS);
-        interceptor.before(innerTarget, Object.class, NO_REQUEST_ARGS);
-        interceptor.after(innerTarget, Object.class, NO_REQUEST_ARGS, null, null);
-        interceptor.after(outerTarget, Object.class, NO_REQUEST_ARGS, null, null);
+        final TraceBlock outer = interceptor.before(outerTarget, Object.class, NO_REQUEST_ARGS);
+        final TraceBlock inner = interceptor.before(innerTarget, Object.class, NO_REQUEST_ARGS);
 
+        interceptor.after(inner, innerTarget, Object.class, NO_REQUEST_ARGS, null, null);
+        // the inner after() unwound only the trace its own block carries.
         verify(innerTrace, times(1)).close();
+        verify(outerTrace, never()).close();
+
+        interceptor.after(outer, outerTarget, Object.class, NO_REQUEST_ARGS, null, null);
+        verify(outerScope, times(1)).leave();
         verify(outerTrace, times(1)).close();
-        verify(innerContext, times(1)).close();
         verify(outerContext, times(1)).close();
     }
 
     @Test
-    public void afterWithoutPairedBefore_isHarmless() {
+    public void afterWithNullBlock_keepsResultAndTouchesNothing() {
         final Object target = accessorTarget(outerContext);
+        final Object result = new Object();
 
-        interceptor.after(target, Object.class, NO_REQUEST_ARGS, null, null);
+        final Object returned = interceptor.after(null, target, Object.class, NO_REQUEST_ARGS, result, null);
 
+        assertSame(result, returned);
         verify(outerTrace, never()).close();
         verify(outerContext, never()).close();
     }
 
     @Test
-    public void unbalancedScope_deletesUnstableTraceFromOwnFrame() {
+    public void afterNotBegun_keepsResult() {
+        final Object target = accessorTarget(outerContext);
+        final Object result = new Object();
+
+        final TraceBlock block = interceptor.before(target, Object.class, NO_REQUEST_ARGS);
+        final Object returned = interceptor.after(block, target, Object.class, NO_REQUEST_ARGS, result, null);
+
+        assertSame(result, returned);
+    }
+
+    @Test
+    public void unbalancedScope_deletesUnstableTraceFromTheBlock() {
         when(outerScope.canLeave()).thenReturn(false);
         final Object target = accessorTarget(outerContext);
 
-        interceptor.before(target, Object.class, NO_REQUEST_ARGS);
-        interceptor.after(target, Object.class, NO_REQUEST_ARGS, null, null);
+        final TraceBlock block = interceptor.before(target, Object.class, NO_REQUEST_ARGS);
+        final Object result = new Object();
+        final Object returned = interceptor.after(block, target, Object.class, NO_REQUEST_ARGS, result, null);
 
+        assertSame(result, returned);
         verify(outerTrace, times(1)).close();
         verify(outerContext, times(1)).close();
+    }
+
+    @Test
+    public void replaceResult_wrapsWrappablePublisher() {
+        final SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        final AsyncContext nextContext = mock(AsyncContext.class);
+        when(recorder.recordNextAsyncContext()).thenReturn(nextContext);
+        final Mono<String> source = Mono.defer(() -> Mono.just("body"));
+
+        final Object returned = interceptor.replaceResult(recorder, outerContext, new Object(), Object.class, NO_REQUEST_ARGS, source, null);
+
+        assertNotSame(source, returned);
+        assertTrue(returned instanceof Mono);
+        verify(recorder, times(1)).recordNextAsyncContext();
+    }
+
+    @Test
+    public void replaceResult_keepsScalarPublisher_noDanglingAsyncLink() {
+        final SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        // Mono.just is Fuseable.ScalarCallable: wrapping would destroy the scalar fast path,
+        // so the wrapper skips it and no async link may be minted for it.
+        final Mono<String> source = Mono.just("body");
+
+        final Object returned = interceptor.replaceResult(recorder, outerContext, new Object(), Object.class, NO_REQUEST_ARGS, source, null);
+
+        assertSame(source, returned);
+        verify(recorder, never()).recordNextAsyncContext();
+    }
+
+    @Test
+    public void replaceResult_keepsResultOnThrowable() {
+        final SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        final Mono<String> source = Mono.just("body");
+
+        final Object returned = interceptor.replaceResult(recorder, outerContext, new Object(), Object.class, NO_REQUEST_ARGS, source, new RuntimeException("fail"));
+
+        assertSame(source, returned);
+        verify(recorder, never()).recordNextAsyncContext();
+    }
+
+    @Test
+    public void replaceResult_keepsNonWrappableResult() {
+        final SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+        final Object source = new Object();
+
+        final Object returned = interceptor.replaceResult(recorder, outerContext, new Object(), Object.class, NO_REQUEST_ARGS, source, null);
+
+        assertSame(source, returned);
+        verify(recorder, never()).recordNextAsyncContext();
     }
 
     private static class MockAccessor implements AsyncContextAccessor {

--- a/agent-module/plugins/spring-webflux/src/test/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDefaultWebClientExchangeMethodInterceptorTest.java
+++ b/agent-module/plugins/spring-webflux/src/test/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/WrappingDefaultWebClientExchangeMethodInterceptorTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.plugin.spring.webflux.interceptor;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Weaver-carried block pairing of the wrapping WebClient exchange interceptor on the
+ * synchronous-trace base: before() begins a TraceBlock on the ambient raw trace and hands it to
+ * the weaver; after() unwinds exactly that block instead of re-resolving the ambient trace. The
+ * replace hook wraps the response publisher, minting the next AsyncContext even for unsampled
+ * traces as the original did.
+ */
+public class WrappingDefaultWebClientExchangeMethodInterceptorTest {
+
+    private static final Object[] ARGS = new Object[]{null};
+
+    private WrappingDefaultWebClientExchangeMethodInterceptor interceptor;
+    private TraceContext traceContext;
+    private Trace trace;
+    private TraceBlock block;
+
+    @BeforeEach
+    public void setUp() {
+        traceContext = mock(TraceContext.class);
+        trace = mock(Trace.class);
+        block = mock(TraceBlock.class);
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
+        when(trace.getTraceBlock()).thenReturn(block);
+        when(block.getTrace()).thenReturn(trace);
+
+        interceptor = new WrappingDefaultWebClientExchangeMethodInterceptor(traceContext, mock(MethodDescriptor.class));
+    }
+
+    @Test
+    public void before_beginsBlockAndHandsItToTheWeaver() {
+        final TraceBlock returned = interceptor.before(new Object(), Object.class, ARGS);
+
+        assertSame(block, returned);
+        verify(block, times(1)).begin();
+    }
+
+    @Test
+    public void beforeWithoutTrace_returnsNull() {
+        when(traceContext.currentRawTraceObject()).thenReturn(null);
+
+        assertNull(interceptor.before(new Object(), Object.class, ARGS));
+    }
+
+    @Test
+    public void afterWithNullBlock_keepsResultAndTouchesNothing() {
+        final Object result = new Object();
+
+        final Object returned = interceptor.after(null, new Object(), Object.class, ARGS, result, null);
+
+        assertSame(result, returned);
+        verify(block, never()).close();
+    }
+
+    @Test
+    public void afterBegun_wrapsAndClosesTheBlock() {
+        when(block.isBegin()).thenReturn(true);
+        when(trace.canSampled()).thenReturn(true);
+        final AsyncContext nextContext = mock(AsyncContext.class);
+        when(block.recordNextAsyncContext()).thenReturn(nextContext);
+        final Mono<String> source = Mono.defer(() -> Mono.just("body"));
+
+        final Object returned = interceptor.after(block, new Object(), Object.class, ARGS, source, null);
+
+        assertNotSame(source, returned);
+        assertTrue(returned instanceof Mono);
+        verify(block, times(1)).recordApi(org.mockito.ArgumentMatchers.any(MethodDescriptor.class));
+        verify(block, times(1)).close();
+    }
+
+    @Test
+    public void afterUnsampled_skipsApiRecordingButStillWraps() {
+        // as in the original: the next AsyncContext is recorded even for unsampled traces.
+        when(block.isBegin()).thenReturn(true);
+        when(trace.canSampled()).thenReturn(false);
+        final AsyncContext nextContext = mock(AsyncContext.class);
+        when(block.recordNextAsyncContext()).thenReturn(nextContext);
+        final Mono<String> source = Mono.defer(() -> Mono.just("body"));
+
+        final Object returned = interceptor.after(block, new Object(), Object.class, ARGS, source, null);
+
+        assertNotSame(source, returned);
+        verify(block, never()).recordApi(org.mockito.ArgumentMatchers.any(MethodDescriptor.class));
+        verify(block, times(1)).recordNextAsyncContext();
+        verify(block, times(1)).close();
+    }
+
+    @Test
+    public void afterWithThrowable_keepsResult() {
+        when(block.isBegin()).thenReturn(true);
+        when(trace.canSampled()).thenReturn(true);
+        final Mono<String> source = Mono.defer(() -> Mono.just("body"));
+
+        final Object returned = interceptor.after(block, new Object(), Object.class, ARGS, source, new RuntimeException("fail"));
+
+        assertSame(source, returned);
+        verify(block, never()).recordNextAsyncContext();
+        verify(block, times(1)).close();
+    }
+
+    @Test
+    public void afterNotBegun_keepsResultAndClosesQuietly() {
+        when(block.isBegin()).thenReturn(false);
+        final Mono<String> source = Mono.defer(() -> Mono.just("body"));
+
+        final Object returned = interceptor.after(block, new Object(), Object.class, ARGS, source, null);
+
+        assertSame(source, returned);
+        verify(block, never()).recordNextAsyncContext();
+        // close() is a no-op end when not begun - the block owns that decision.
+        verify(block, times(1)).close();
+    }
+}

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/interceptor/InterceptorDefinitionFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/interceptor/InterceptorDefinitionFactory.java
@@ -37,6 +37,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.BlockAroundInterceptor5;
 import com.navercorp.pinpoint.bootstrap.interceptor.BlockStaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceBlockAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.StaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.annotation.IgnoreMethod;
 import org.apache.logging.log4j.LogManager;
@@ -87,6 +88,8 @@ public class InterceptorDefinitionFactory {
         addTypeHandler(typeHandlerList, ApiIdAwareAroundInterceptor.class, InterceptorType.API_ID_AWARE);
         addTypeHandler(typeHandlerList, InjectedAsyncContextApiIdAwareAroundInterceptor.class, InterceptorType.ASYNC_CONTEXT_API_ID_AWARE);
         addTypeHandler(typeHandlerList, ResultReplaceAroundInterceptor.class, InterceptorType.RESULT_REPLACE);
+        // block variant: before() returning TraceBlock switches the capture type to BLOCK_AROUND.
+        addTypeHandler(typeHandlerList, ResultReplaceBlockAroundInterceptor.class, InterceptorType.RESULT_REPLACE);
         // block
         addTypeHandler(typeHandlerList, BlockAroundInterceptor.class, InterceptorType.ARRAY_ARGS);
         addTypeHandler(typeHandlerList, BlockAroundInterceptor0.class, InterceptorType.BASIC);

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/interceptor/factory/AnnotatedInterceptorFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/interceptor/factory/AnnotatedInterceptorFactory.java
@@ -58,9 +58,11 @@ import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandleBlockAroundIn
 import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandleBlockStaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandleStaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandleResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandleResultReplaceBlockAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.ExceptionHandler;
 import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceBlockAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.StaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedApiIdAwareAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInjectedAsyncContextApiIdAwareAroundInterceptor;
@@ -81,6 +83,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedI
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor4;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedInterceptor5;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedResultReplaceBlockAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExceptionHandleScopedStaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ExecutionPolicy;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.InterceptorScope;
@@ -103,6 +106,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedInterceptor3;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedInterceptor4;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedInterceptor5;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedResultReplaceAroundInterceptor;
+import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedResultReplaceBlockAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.scope.ScopedStaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.plugin.RequestRecorderFactory;
 import com.navercorp.pinpoint.bootstrap.plugin.monitor.DataSourceMonitorRegistry;
@@ -218,6 +222,8 @@ public class AnnotatedInterceptorFactory implements InterceptorFactory {
             return new ScopedInjectedAsyncContextApiIdAwareAroundInterceptor((InjectedAsyncContextApiIdAwareAroundInterceptor) interceptor, scope, policy);
         } else if (interceptor instanceof ResultReplaceAroundInterceptor) {
             return new ScopedResultReplaceAroundInterceptor((ResultReplaceAroundInterceptor) interceptor, scope, policy);
+        } else if (interceptor instanceof ResultReplaceBlockAroundInterceptor) {
+            return new ScopedResultReplaceBlockAroundInterceptor((ResultReplaceBlockAroundInterceptor) interceptor, scope, policy);
         } else if (interceptor instanceof BlockAroundInterceptor) {
             return new ScopedBlockInterceptor((BlockAroundInterceptor) interceptor, scope, policy);
         } else if (interceptor instanceof BlockStaticAroundInterceptor) {
@@ -274,6 +280,8 @@ public class AnnotatedInterceptorFactory implements InterceptorFactory {
             return new ExceptionHandleScopedInjectedAsyncContextApiIdAwareAroundInterceptor((InjectedAsyncContextApiIdAwareAroundInterceptor) interceptor, scope, policy, exceptionHandler);
         } else if (interceptor instanceof ResultReplaceAroundInterceptor) {
             return new ExceptionHandleScopedResultReplaceAroundInterceptor((ResultReplaceAroundInterceptor) interceptor, scope, policy, exceptionHandler);
+        } else if (interceptor instanceof ResultReplaceBlockAroundInterceptor) {
+            return new ExceptionHandleScopedResultReplaceBlockAroundInterceptor((ResultReplaceBlockAroundInterceptor) interceptor, scope, policy, exceptionHandler);
         } else if (interceptor instanceof BlockAroundInterceptor) {
             return new ExceptionHandleScopedBlockInterceptor((BlockAroundInterceptor) interceptor, scope, policy, exceptionHandler);
         } else if (interceptor instanceof BlockStaticAroundInterceptor) {
@@ -331,6 +339,8 @@ public class AnnotatedInterceptorFactory implements InterceptorFactory {
             return new ExceptionHandleInjectedAsyncContextApiIdAwareAroundInterceptor((InjectedAsyncContextApiIdAwareAroundInterceptor) interceptor, exceptionHandler);
         } else if (interceptor instanceof ResultReplaceAroundInterceptor) {
             return new ExceptionHandleResultReplaceAroundInterceptor((ResultReplaceAroundInterceptor) interceptor, exceptionHandler);
+        } else if (interceptor instanceof ResultReplaceBlockAroundInterceptor) {
+            return new ExceptionHandleResultReplaceBlockAroundInterceptor((ResultReplaceBlockAroundInterceptor) interceptor, exceptionHandler);
         } else if (interceptor instanceof BlockAroundInterceptor) {
             return new ExceptionHandleBlockAroundInterceptor((BlockAroundInterceptor) interceptor, exceptionHandler);
         } else if (interceptor instanceof BlockStaticAroundInterceptor) {

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMMethodNodeAdapterAddInterceptorTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/ASMMethodNodeAdapterAddInterceptorTest.java
@@ -27,6 +27,8 @@ import com.navercorp.pinpoint.profiler.instrument.mock.ArgsArrayInterceptor;
 import com.navercorp.pinpoint.profiler.instrument.mock.BaseEnum;
 import com.navercorp.pinpoint.profiler.instrument.mock.BasicInterceptor;
 import com.navercorp.pinpoint.profiler.instrument.mock.ExceptionInterceptor;
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
+import com.navercorp.pinpoint.profiler.instrument.mock.ResultReplaceBlockInterceptor;
 import com.navercorp.pinpoint.profiler.instrument.mock.ResultReplaceInterceptor;
 import com.navercorp.pinpoint.profiler.instrument.mock.StaticInterceptor;
 import com.navercorp.pinpoint.profiler.interceptor.factory.ExceptionHandlerFactory;
@@ -51,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -153,6 +156,73 @@ public class ASMMethodNodeAdapterAddInterceptorTest {
         assertNull(voidType.invoke(instance));
         assertTrue(ResultReplaceInterceptor.after);
         assertEquals(Void.class, ResultReplaceInterceptor.afterReturnType);
+    }
+
+    @Test
+    public void addResultReplaceBlockInterceptor() throws Exception {
+        // the shared suite runs with a null block and no replacement, so the block variant must
+        // behave exactly like the plain result-replace interceptor across every method shape.
+        addInterceptor(new ResultReplaceBlockInterceptor());
+    }
+
+    @Test
+    public void resultReplaceBlockChannel() throws Exception {
+        ResultReplaceBlockInterceptor interceptor = new ResultReplaceBlockInterceptor();
+        Class<?> clazz = addInterceptor0("com.navercorp.pinpoint.profiler.instrument.mock.ReturnClass", interceptor);
+        Object instance = clazz.newInstance();
+        Method returnString = clazz.getDeclaredMethod("returnString");
+
+        // the weaver hands after() exactly the block before() returned.
+        ResultReplaceBlockInterceptor.clear();
+        ResultReplaceBlockInterceptor.blockToReturn = org.mockito.Mockito.mock(TraceBlock.class);
+        assertEquals("s", returnString.invoke(instance));
+        assertSame(ResultReplaceBlockInterceptor.blockToReturn, ResultReplaceBlockInterceptor.afterBlock);
+
+        // a null block travels as null.
+        ResultReplaceBlockInterceptor.clear();
+        assertEquals("s", returnString.invoke(instance));
+        assertTrue(ResultReplaceBlockInterceptor.after);
+        assertNull(ResultReplaceBlockInterceptor.afterBlock);
+
+        // replacement works alongside the block channel.
+        ResultReplaceBlockInterceptor.clear();
+        ResultReplaceBlockInterceptor.blockToReturn = org.mockito.Mockito.mock(TraceBlock.class);
+        ResultReplaceBlockInterceptor.useReplacement = true;
+        ResultReplaceBlockInterceptor.replacement = "replaced";
+        assertEquals("replaced", returnString.invoke(instance));
+        assertSame(ResultReplaceBlockInterceptor.blockToReturn, ResultReplaceBlockInterceptor.afterBlock);
+        assertEquals("s", ResultReplaceBlockInterceptor.result);
+        assertEquals(String.class, ResultReplaceBlockInterceptor.beforeReturnType);
+        assertEquals(String.class, ResultReplaceBlockInterceptor.afterReturnType);
+
+        // a type-incompatible replacement keeps the original.
+        ResultReplaceBlockInterceptor.clear();
+        ResultReplaceBlockInterceptor.useReplacement = true;
+        ResultReplaceBlockInterceptor.replacement = Integer.valueOf(1);
+        assertEquals("s", returnString.invoke(instance));
+    }
+
+    @Test
+    public void resultReplaceBlockExceptionPath() throws Exception {
+        ResultReplaceBlockInterceptor interceptor = new ResultReplaceBlockInterceptor();
+        Class<?> clazz = addInterceptor0("com.navercorp.pinpoint.profiler.instrument.mock.ExceptionClass", interceptor);
+
+        // exiting exceptionally: the block still arrives, the replacement is discarded and the
+        // original exception propagates.
+        ResultReplaceBlockInterceptor.clear();
+        ResultReplaceBlockInterceptor.blockToReturn = org.mockito.Mockito.mock(TraceBlock.class);
+        ResultReplaceBlockInterceptor.useReplacement = true;
+        ResultReplaceBlockInterceptor.replacement = "ignored";
+        Method method = clazz.getDeclaredMethod("throwable");
+        try {
+            method.invoke(clazz.newInstance());
+            fail("expected an exception");
+        } catch (Throwable expected) {
+        }
+        assertTrue(ResultReplaceBlockInterceptor.after);
+        assertSame(ResultReplaceBlockInterceptor.blockToReturn, ResultReplaceBlockInterceptor.afterBlock);
+        assertNotNull(ResultReplaceBlockInterceptor.throwable);
+        assertNull(ResultReplaceBlockInterceptor.result);
     }
 
     @Test
@@ -381,6 +451,7 @@ public class ASMMethodNodeAdapterAddInterceptorTest {
         BasicInterceptor.clear();
         ExceptionInterceptor.clear();
         ResultReplaceInterceptor.clear();
+        ResultReplaceBlockInterceptor.clear();
 
         Constructor<?> constructor;
         Method method = null;
@@ -546,6 +617,35 @@ public class ASMMethodNodeAdapterAddInterceptorTest {
             assertEquals(returnValue, ResultReplaceInterceptor.result, name);
             if (throwable) {
                 assertNotNull(ResultReplaceInterceptor.throwable, name);
+            }
+        } else if (interceptorClass == ResultReplaceBlockInterceptor.class) {
+            assertTrue(ResultReplaceBlockInterceptor.before, name);
+            assertTrue(ResultReplaceBlockInterceptor.after, name);
+
+            if (method != null && Modifier.isStatic(method.getModifiers())) {
+                assertNull(ResultReplaceBlockInterceptor.beforeTarget, name);
+                assertNull(ResultReplaceBlockInterceptor.afterTarget, name);
+            } else if (method != null) {
+                assertNotNull(ResultReplaceBlockInterceptor.beforeTarget, name);
+                assertNotNull(ResultReplaceBlockInterceptor.afterTarget, name);
+            }
+            assertEquals(ResultReplaceBlockInterceptor.beforeTarget, ResultReplaceBlockInterceptor.afterTarget, name);
+
+            assertNotNull(ResultReplaceBlockInterceptor.beforeReturnType, name);
+            assertNotNull(ResultReplaceBlockInterceptor.afterReturnType, name);
+            // the weaver hands after() exactly the block before() returned (null in this suite).
+            assertSame(ResultReplaceBlockInterceptor.blockToReturn, ResultReplaceBlockInterceptor.afterBlock, name);
+
+            if (ResultReplaceBlockInterceptor.beforeArgs != null) {
+                assertThat(args).as(name).containsExactly(ResultReplaceBlockInterceptor.beforeArgs);
+            }
+
+            if (ResultReplaceBlockInterceptor.afterArgs != null) {
+                assertThat(args).as(name).containsExactly(ResultReplaceBlockInterceptor.afterArgs);
+            }
+            assertEquals(returnValue, ResultReplaceBlockInterceptor.result, name);
+            if (throwable) {
+                assertNotNull(ResultReplaceBlockInterceptor.throwable, name);
             }
         } else if (interceptorClass == BasicInterceptor.class) {
             assertTrue(BasicInterceptor.before, name);

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/interceptor/InterceptorDefinitionFactoryTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/interceptor/InterceptorDefinitionFactoryTest.java
@@ -28,6 +28,7 @@ import com.navercorp.pinpoint.bootstrap.interceptor.Interceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.StaticAroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.interceptor.annotation.IgnoreMethod;
+import com.navercorp.pinpoint.profiler.instrument.mock.ResultReplaceBlockInterceptor;
 import com.navercorp.pinpoint.profiler.instrument.mock.ResultReplaceInterceptor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -87,6 +88,18 @@ public class InterceptorDefinitionFactoryTest {
         final InterceptorDefinition definition = typeDetector.createInterceptorDefinition(ResultReplaceInterceptor.class);
         Assertions.assertSame(InterceptorType.RESULT_REPLACE, definition.getInterceptorType());
         Assertions.assertSame(CaptureType.AROUND, definition.getCaptureType());
+        Assertions.assertEquals(Object.class, definition.getAfterMethod().getReturnType());
+    }
+
+    @Test
+    public void testGetInterceptorType_ResultReplaceBlock() {
+        InterceptorDefinitionFactory typeDetector = new InterceptorDefinitionFactory();
+
+        final InterceptorDefinition definition = typeDetector.createInterceptorDefinition(ResultReplaceBlockInterceptor.class);
+        Assertions.assertSame(InterceptorType.RESULT_REPLACE, definition.getInterceptorType());
+        // before() returning TraceBlock switches the capture type, composing the block channel
+        // with the result-replace calling convention.
+        Assertions.assertSame(CaptureType.BLOCK_AROUND, definition.getCaptureType());
         Assertions.assertEquals(Object.class, definition.getAfterMethod().getReturnType());
     }
 

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/mock/ResultReplaceBlockInterceptor.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/instrument/mock/ResultReplaceBlockInterceptor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.profiler.instrument.mock;
+
+import com.navercorp.pinpoint.bootstrap.context.TraceBlock;
+import com.navercorp.pinpoint.bootstrap.interceptor.ResultReplaceBlockAroundInterceptor;
+
+public class ResultReplaceBlockInterceptor implements ResultReplaceBlockAroundInterceptor {
+
+    public static boolean before;
+    public static boolean after;
+    public static Object beforeTarget;
+    public static Class<?> beforeReturnType;
+    public static Object[] beforeArgs;
+    public static Object afterTarget;
+    public static Class<?> afterReturnType;
+    public static Object[] afterArgs;
+    public static Object result;
+    public static Throwable throwable;
+
+    /** what before() hands to the weaver; after() must receive exactly this instance back. */
+    public static TraceBlock blockToReturn;
+    public static TraceBlock afterBlock;
+
+    public static boolean useReplacement;
+    public static Object replacement;
+
+    public static void clear() {
+        before = false;
+        after = false;
+        beforeTarget = null;
+        beforeReturnType = null;
+        beforeArgs = null;
+        afterTarget = null;
+        afterReturnType = null;
+        afterArgs = null;
+        result = null;
+        throwable = null;
+        blockToReturn = null;
+        afterBlock = null;
+        useReplacement = false;
+        replacement = null;
+    }
+
+    @Override
+    public TraceBlock before(Object target, Class<?> returnType, Object[] args) {
+        before = true;
+        beforeTarget = target;
+        beforeReturnType = returnType;
+        beforeArgs = args;
+        return blockToReturn;
+    }
+
+    @Override
+    public Object after(TraceBlock block, Object target, Class<?> returnType, Object[] args, Object result, Throwable throwable) {
+        after = true;
+        afterBlock = block;
+        afterTarget = target;
+        afterReturnType = returnType;
+        afterArgs = args;
+        ResultReplaceBlockInterceptor.result = result;
+        ResultReplaceBlockInterceptor.throwable = throwable;
+        if (useReplacement) {
+            return replacement;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
…ace block through the weaver

Every wrapping (result-replace) interceptor needs before/after pairing state for its span-event lifecycle, but ResultReplaceAroundInterceptor has no channel from before() to after(). Each implementor worked around that on its own: the BodyInserter variant with a per-thread frame stack - sixty lines of careful structural pairing - and the other ten by re-resolving the ambient trace in after(), where a trace bound or unbound between the two calls ends a block that was never begun (corrupting the caller's block stack) or leaks one that was. The block interceptors already have the missing channel: the weaver stores the TraceBlock before() returns and passes it to after().

ResultReplaceBlockAroundInterceptor combines the two contracts: TraceBlock before(target, returnType, args) and Object after(block, target, returnType, args, result, throwable) whose return value replaces the intercepted method's return value. The two behaviors are orthogonal axes in the weaver - the result-replace calling convention is keyed on InterceptorType.RESULT_REPLACE and the block channel on CaptureType.BLOCK_AROUND, which the definition factory derives from before()'s return type - so registering the interface is the only weaving change. The ExceptionHandle / Scoped / ExceptionHandleScoped wrappers keep the original return value when the delegate fails or the scope skips. EmptyInterceptor/LoggingInterceptor cannot implement the interface - before() differs from the ResultReplace one only by return type - the same reason they skip the Block family.

Two abstract bases carry the lifecycles:
- AsyncContextSpanEventResultReplaceBlockSimpleAroundInterceptor mirrors the async-context block base for interceptors that continue a trace from an injected AsyncContext.
- SpanEventResultReplaceBlockSimpleAroundInterceptorForPlugin mirrors SpanEventSimpleAroundInterceptorForPlugin (same hook surface, currentTrace() override point, unconditional begin) for the ambient-trace ones; after() unwinds via try-with-resources, so close() ends the block only if it was begun. Both expose a replaceResult() hook, called only when the paired block was begun, that carries the declared return type - the publishOn seam's returnType.isInstance(wrapped) pre-check needs it to validate a candidate before minting an async link that a discarded replacement would strand.

All twelve wrapping interceptors move onto the bases with their recording semantics intact: the five webflux ones (the DispatchHandlerInvokeHandler onto the async-context base, reading the exchange's context from args[0]; WebClientExchange keeps minting the next AsyncContext for unsampled traces), the reactor publishOn seam with its minting gate and injection fallback, lettuce/redisson with the injection-if-absent fallback for non-reactor async results, spring-tx with its unconditional injection and markError flag, and the three r2dbc execute/create interceptors with their bind-variable recording. The frame stack, its ThreadLocal and eleven inlined lifecycle copies are gone. WrappingDefaultFetchSpecInterceptor stays on the plain ResultReplace shape deliberately: it is a pure relay with no span-event lifecycle, so there is no block to carry.

Verified: unit tests pin the definition-factory composition (RESULT_REPLACE type + BLOCK_AROUND capture), the weaving suite runs the new shape across every method form with the block channel asserted end to end (JDK 17 and a forked JDK 8 VM), and the interceptor suites pin the weaver-channel pairing, the replace policies (non-scalar wrapped, scalar/throwable/non-publisher kept, unsampled still mints the async link) and the classpath-negative containment - the block now provably closes on the Error path too. An e2e smoke on the packaged agent (webflux testweb, JDK 25, wrap.publisher=true) served the WebClient self-call clean, with the shaded SeamPublisherWrapper lambda loaded as proof the wrap path ran.