### PR TITLE
[#noissue] Fix heatmap crash when adjusting the visual map

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/core/HeatmapChart.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/core/HeatmapChart.tsx
@@ -424,7 +424,7 @@ const HeatmapChart = ({
 
     function getDragRect() {
       if (!startCell || !endCell) {
-        return [];
+        return undefined;
       }
 
       const startX = startCell.event?.target?.shape?.x;
@@ -469,13 +469,20 @@ const HeatmapChart = ({
       }
     }
 
+    const dragRect = getDragRect();
+
+    // 선택 영역이 없을 때는 엘리먼트를 지우지 않고 숨긴다.
+    // $action: 'remove'로 지우면, 이미 지워진 상태에서 다시 remove가 나갈 때
+    // echarts가 없는 엘리먼트를 참조해 에러가 난다(예: visualMap을 조작하면
+    // 셀 선택 없이 mouseup만 발생해 remove가 반복된다).
     chartInstanceRef.current.setOption({
       graphic: [
         {
           type: 'rect',
           id: 'drag-rect',
           z: 10,
-          shape: getDragRect(),
+          ignore: !dragRect,
+          shape: dragRect || { x: 0, y: 0, width: 0, height: 0 },
           style: {
             fill: 'rgba(225,225,225,0.4)',
             stroke: '#469ae4',
@@ -566,23 +573,11 @@ const HeatmapChart = ({
       }}
       onMouseUp={() => {
         setIsMouseDown(false);
+        // 선택 영역 표시는 startCell/endCell에서 파생되므로, 비우면 dragRect가 숨겨진다.
         setStartCell(undefined);
         setEndCell(undefined);
 
         handleDragEnd();
-
-        try {
-          chartInstanceRef.current?.setOption({
-            graphic: [
-              {
-                id: 'drag-rect',
-                $action: 'remove',
-              },
-            ],
-          });
-        } catch (err) {
-          console.error('Error onMouseUp', err);
-        }
       }}
     >
       <div ref={chartRef} style={{ width: '100%', height: '100%' }} />


### PR DESCRIPTION
## Summary

- Adjusting the heatmap visual map threw `TypeError: Cannot read properties of undefined (reading '__ec_inner_NN')` on mouse up. Mouse up always sent `$action: 'remove'` for the drag rect, but the element is only re-created when `startCell`/`endCell` change. Pressing the visual map raises no chart-level `mousedown` (ECharts only dispatches for targets carrying `ecData`/`eventData`, which visualMap views do not set), so those cells stay `undefined`, the rect is never re-created, and the next mouse up removes an element that is already gone — ECharts 6 dereferences it in `updateLeaveTo`.
- Keep the drag rect element alive and derive its visibility from the selection (`ignore`) instead of removing and re-creating it, so no removal is needed and the same crash cannot happen for an empty selection either.
- Drop the `try/catch` that was swallowing the error into `console.error`.
<img width="1208" height="375" alt="스크린샷 2026-08-12 오후 3 25 15" src="https://github.com/user-attachments/assets/35177d27-5f0b-46c2-91a7-ed6d2a999449" />


## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (101 suites / 799 tests)
- [x] Reproduced the crash and verified the fix against ECharts 6 directly: repeated `remove` throws, the `ignore`-based hide does not; legend graphics and the drag rect stay correct across repeated option updates
- [ ] Open the server map, select a node, and drag the heatmap success/fail visual map handles several times — no console error
- [ ] Drag-select cells on the heatmap — the selection rectangle appears while dragging, disappears on release, and still opens the transaction list
- [ ] Repeat both on the realtime heatmap and on the full-screen heatmap