### PR TITLE
[#14103] Remove dead codes

### DIFF
--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/config/BasicLoginProperties.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/config/BasicLoginProperties.java
@@ -35,8 +35,6 @@ import java.util.concurrent.TimeUnit;
  */
 public class BasicLoginProperties implements InitializingBean {
 
-    private static final String DEFAULT_JWT_SECRET_KEY = "__PINPOINT_JWT_SECRET__";
-
     private static final long DEFAULT_EXPIRATION_TIME_SECONDS = TimeUnit.HOURS.toSeconds(12);
 
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
@@ -48,7 +46,7 @@ public class BasicLoginProperties implements InitializingBean {
     private List<String> adminIdAndPasswordPairList;
 
     @Value("${web.security.auth.jwt.secretkey:#{null}}")
-    private String jwtSecretKey = DEFAULT_JWT_SECRET_KEY;
+    private String jwtSecretKey;
 
     @Value("${web.security.auth.jwt.cookie.http-only:true}")
     private boolean jwtCookieHttpOnly;

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -81,7 +81,7 @@ web.installation.downloadUrl=
 # Role (User : Can use whole function except for admin rest api, Admin : Can use whole function)
 #web.security.auth.user=alice:foo,bob:bar
 #web.security.auth.admin=eve:baz
-#web.security.auth.jwt.secretkey=__PINPOINT_JWT_SECRET__
+#web.security.auth.jwt.secretkey=<generate-a-random-secret>
 #web.security.auth.jwt.cookie.http-only=true
 #web.security.auth.jwt.cookie.secure=false
 #web.security.auth.jwt.cookie.same-site=Lax


### PR DESCRIPTION
DEFAULT_JWT_SECRET_KEY was dead code - the @Value default of #{null} always overwrote the field initializer, so a missing web.security.auth.jwt.secretkey has always failed startup at afterPropertiesSet(). Removing it and the matching example value in pinpoint-web-root.properties keeps the literal out of the source tree.