### PR TITLE
[#noissue] Map OTel Span.Link on child spans

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -56,6 +56,7 @@ import java.util.function.Predicate;
 public class OtlpTraceSpanEventMapper {
 
     private final OtlpTraceEventMapper eventMapper;
+    private final OtlpTraceLinkMapper linkMapper;
     private final OtlpDbSystemTypeResolver dbSystemTypeResolver;
     private final OtlpMessagingTypeResolver messagingTypeResolver;
     private final OtlpClientTypeResolver clientTypeResolver;
@@ -65,6 +66,7 @@ public class OtlpTraceSpanEventMapper {
     private final int sqlMaxBytes;
 
     public OtlpTraceSpanEventMapper(OtlpTraceEventMapper eventMapper,
+                                    OtlpTraceLinkMapper linkMapper,
                                     ServiceTypeRegistryService serviceTypeRegistryService,
                                     OtlpMessagingTypeResolver messagingTypeResolver,
                                     OtlpClientTypeResolver clientTypeResolver,
@@ -73,6 +75,7 @@ public class OtlpTraceSpanEventMapper {
                                     OtlpAttributeBoMapper attributeBoMapper,
                                     @Value("${pinpoint.collector.otlptrace.sql.max-bytes:8192}") int sqlMaxBytes) {
         this.eventMapper = Objects.requireNonNull(eventMapper, "eventMapper");
+        this.linkMapper = Objects.requireNonNull(linkMapper, "linkMapper");
         this.dbSystemTypeResolver = new OtlpDbSystemTypeResolver(
                 Objects.requireNonNull(serviceTypeRegistryService, "serviceTypeRegistryService"));
         this.messagingTypeResolver = Objects.requireNonNull(messagingTypeResolver, "messagingTypeResolver");
@@ -215,6 +218,13 @@ public class OtlpTraceSpanEventMapper {
             final AnnotationBo eventAnnotation = eventMapper.toAnnotation(event, truncatedCounts::event);
             if (eventAnnotation != null) {
                 spanEventBo.addAnnotation(eventAnnotation);
+            }
+        }
+        // link
+        for (Span.Link link : span.getLinksList()) {
+            final AnnotationBo linkAnnotation = linkMapper.toAnnotation(link, truncatedCounts::link);
+            if (linkAnnotation != null) {
+                spanEventBo.addAnnotation(linkAnnotation);
             }
         }
         // SDK-side data-loss hints (Span proto fields 10/12/14). Only emit when > 0.

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -102,6 +102,7 @@ class OtlpTraceMapperTest {
                 new OtlpAttributeBoMapper(8192));
         OtlpTraceSpanEventMapper spanEventMapper = new OtlpTraceSpanEventMapper(
                 eventMapper,
+                new OtlpTraceLinkMapper(json, 8192),
                 REGISTRY,
                 new OtlpMessagingTypeResolver(REGISTRY),
                 new OtlpClientTypeResolver(REGISTRY),
@@ -425,6 +426,74 @@ class OtlpTraceMapperTest {
             assertThat(scopeAnnotation(spanBo.getAnnotationBoList()))
                     .isEqualTo("io.opentelemetry.kafka-clients-2.6");
         }
+    }
+
+    // =======================================================================
+    // Span.Link on child spans → OPENTELEMETRY_LINK annotation (end-to-end)
+    // =======================================================================
+
+    private static final byte[] LINK_TRACE_ID = {9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9};
+    private static final byte[] LINK_SPAN_ID = {8, 7, 6, 5, 4, 3, 2, 1};
+
+    private static Object linkAnnotation(List<AnnotationBo> annotations) {
+        return annotations.stream()
+                .filter(a -> a.getKey() == AnnotationKey.OPENTELEMETRY_LINK.getCode())
+                .map(AnnotationBo::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    // kind=0 span shape as exported by non-SDK tracers (e.g. Claude Code): every span is
+    // SPAN_KIND_UNSPECIFIED and cross-trace links ride on child spans, never on the root.
+    private static Span unspecifiedSpan(byte[] spanId, byte[] parentSpanId, Span.Link link) {
+        Span.Builder builder = Span.newBuilder()
+                .setName("claude_code.op")
+                .setTraceId(ByteString.copyFrom(TRACE_ID))
+                .setSpanId(ByteString.copyFrom(spanId))
+                .setKindValue(Span.SpanKind.SPAN_KIND_UNSPECIFIED_VALUE)
+                .setStartTimeUnixNano(1_000_000_000L)
+                .setEndTimeUnixNano(2_000_000_000L);
+        if (parentSpanId != null) {
+            builder.setParentSpanId(ByteString.copyFrom(parentSpanId));
+        }
+        if (link != null) {
+            builder.addLinks(link);
+        }
+        return builder.build();
+    }
+
+    private static Span.Link crossTraceLink() {
+        return Span.Link.newBuilder()
+                .setTraceId(ByteString.copyFrom(LINK_TRACE_ID))
+                .setSpanId(ByteString.copyFrom(LINK_SPAN_ID))
+                .addAttributes(kv("link.type", strVal("parent_of")))
+                .build();
+    }
+
+    @Test
+    void childLink_survivesOnRootLinkedSpanEvent() {
+        Span root = unspecifiedSpan(ROOT_A, null, null);
+        Span child = unspecifiedSpan(CHILD, ROOT_A, crossTraceLink());
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(root, child));
+
+        assertThat(data.getSpanBoList()).hasSize(1);
+        SpanEventBo childEvent = data.getSpanBoList().get(0).getSpanEventBoList().get(0);
+        Object value = linkAnnotation(childEvent.getAnnotationBoList());
+        assertThat(value).isNotNull();
+        assertThat((String) value).contains("09090909090909090909090909090909");
+    }
+
+    @Test
+    void childLink_survivesOnOrphanSpanChunk() {
+        // Split arrival: the link-bearing child lands in a batch without its root and is
+        // stored as an orphan SpanChunk — the link must survive on that path too.
+        Span orphan = unspecifiedSpan(ORPHAN, ABSENT_PARENT, crossTraceLink());
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(orphan));
+
+        SpanEventBo orphanEvent = data.getSpanChunkBoList().get(0).getSpanEventBoList().get(0);
+        assertThat(linkAnnotation(orphanEvent.getAnnotationBoList())).isNotNull();
     }
 
     // =======================================================================

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -65,6 +65,7 @@ class OtlpTraceSpanEventMapperTest {
     void setUp() {
         mapper = new OtlpTraceSpanEventMapper(
                 new OtlpTraceEventMapper(new ObjectMapper(), 8192),
+                new OtlpTraceLinkMapper(new ObjectMapper(), 8192),
                 TEST_REGISTRY,
                 new OtlpMessagingTypeResolver(TEST_REGISTRY),
                 new OtlpClientTypeResolver(TEST_REGISTRY),
@@ -914,6 +915,88 @@ class OtlpTraceSpanEventMapperTest {
         assertThat(event.getAnnotationBoList())
                 .extracting(com.navercorp.pinpoint.common.server.bo.AnnotationBo::getKey)
                 .doesNotContain(com.navercorp.pinpoint.common.trace.AnnotationKey.OPENTELEMETRY_DROPPED.getCode());
+    }
+
+    // =======================================================================
+    // map() — Span.Link → OPENTELEMETRY_LINK annotation on SpanEvent
+    // =======================================================================
+
+    private static final byte[] LINK_TRACE_ID = {
+            9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9
+    };
+    private static final byte[] LINK_SPAN_ID = {8, 7, 6, 5, 4, 3, 2, 1};
+
+    private static Object findLinkAnnotation(SpanEventBo event) {
+        return findAnnotation(event, AnnotationKey.OPENTELEMETRY_LINK.getCode());
+    }
+
+    @Test
+    void map_link_recordsLinkAnnotation() throws Exception {
+        // Mirrors the root-span path: a child span's Span.Link must survive as an
+        // OPENTELEMETRY_LINK annotation instead of being silently lost.
+        Span span = Span.newBuilder()
+                .setName("op")
+                .setTraceId(ByteString.copyFrom(TRACE_ID))
+                .setSpanId(ByteString.copyFrom(SPAN_ID))
+                .setKindValue(Span.SpanKind.SPAN_KIND_UNSPECIFIED_VALUE)
+                .addLinks(Span.Link.newBuilder()
+                        .setTraceId(ByteString.copyFrom(LINK_TRACE_ID))
+                        .setSpanId(ByteString.copyFrom(LINK_SPAN_ID))
+                        .addAttributes(kv("link.type", strVal("parent_of"))))
+                .build();
+
+        SpanEventBo event = mapSingle(span);
+        Object value = findLinkAnnotation(event);
+        assertThat(value).isNotNull();
+
+        ObjectMapper om = new ObjectMapper();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> root = om.readValue((String) value, Map.class);
+        assertThat(root).containsEntry("traceId", "09090909090909090909090909090909");
+        assertThat(root).containsEntry("spanId", String.valueOf(
+                com.navercorp.pinpoint.common.server.util.ByteStringUtils.parseLong(ByteString.copyFrom(LINK_SPAN_ID))));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> linkAttrs = (Map<String, Object>) root.get("attributes");
+        assertThat(linkAttrs).containsEntry("link.type", "parent_of");
+    }
+
+    @Test
+    void map_link_invalidLink_dropped() {
+        // All-zero SpanContext cannot reference a real span — only the link is dropped,
+        // the owning SpanEvent maps normally (same rule as the root path).
+        Span span = Span.newBuilder()
+                .setName("op")
+                .setTraceId(ByteString.copyFrom(TRACE_ID))
+                .setSpanId(ByteString.copyFrom(SPAN_ID))
+                .setKindValue(Span.SpanKind.SPAN_KIND_CLIENT_VALUE)
+                .addLinks(Span.Link.newBuilder()
+                        .setTraceId(ByteString.copyFrom(new byte[16]))
+                        .setSpanId(ByteString.copyFrom(new byte[8])))
+                .build();
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findLinkAnnotation(event)).isNull();
+    }
+
+    @Test
+    void map_link_truncatedTraceState_countsInTruncatedAnnotation() {
+        // Over-long link traceState is capped by the link mapper; the truncation must
+        // surface in the SpanEvent's OPENTELEMETRY_TRUNCATED annotation.
+        Span span = Span.newBuilder()
+                .setName("op")
+                .setTraceId(ByteString.copyFrom(TRACE_ID))
+                .setSpanId(ByteString.copyFrom(SPAN_ID))
+                .setKindValue(Span.SpanKind.SPAN_KIND_CLIENT_VALUE)
+                .addLinks(Span.Link.newBuilder()
+                        .setTraceId(ByteString.copyFrom(LINK_TRACE_ID))
+                        .setSpanId(ByteString.copyFrom(LINK_SPAN_ID))
+                        .setTraceState("x".repeat(9000)))
+                .build();
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findLinkAnnotation(event)).isNotNull();
+        assertThat(findAnnotation(event, AnnotationKey.OPENTELEMETRY_TRUNCATED.getCode()))
+                .isEqualTo("links=1");
     }
 
     // =======================================================================

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java
@@ -113,23 +113,43 @@ public class FilteredMapBuilder {
                 if (host.getTraceSourceType() != TraceSourceType.OPENTELEMETRY) {
                     continue;
                 }
-                final List<AnnotationBo> annotationBoList = host.getAnnotationBoList();
-                if (annotationBoList == null || annotationBoList.isEmpty()) {
-                    continue;
-                }
-                for (AnnotationBo annotation : annotationBoList) {
-                    if (annotation.getKey() != AnnotationKey.OPENTELEMETRY_LINK.getCode()) {
-                        continue;
-                    }
-                    final OtelLinkValue value = OtelLinkValueSerde.parse(annotation.getValue());
-                    if (value == null || value.traceId() == null || value.spanId() == null) {
-                        continue;
-                    }
-                    index.add(new TraceSpanKey(value.traceId(), value.spanId()), host);
+                // 1) Top-level OTel span carrying the Link annotation
+                indexOtelLinks(host, host.getAnnotationBoList(), index);
+
+                // 2) OTel sub-span(s) inside SpanEvents can carry links too — attribute them to
+                //    the owning SpanBo, mirroring the upstream-side matchSpanEvents.
+                indexSpanEventLinks(host, host.getSpanEventBoList(), index);
+                for (SpanChunkBo chunk : host.getSpanChunkBoList()) {
+                    indexSpanEventLinks(host, chunk.getSpanEventBoList(), index);
                 }
             }
         }
         return index;
+    }
+
+    private void indexSpanEventLinks(SpanBo host, List<SpanEventBo> events, MultiValueMap<TraceSpanKey, SpanBo> index) {
+        if (events == null || events.isEmpty()) {
+            return;
+        }
+        for (SpanEventBo event : events) {
+            indexOtelLinks(host, event.getAnnotationBoList(), index);
+        }
+    }
+
+    private void indexOtelLinks(SpanBo host, List<AnnotationBo> annotationBoList, MultiValueMap<TraceSpanKey, SpanBo> index) {
+        if (annotationBoList == null || annotationBoList.isEmpty()) {
+            return;
+        }
+        for (AnnotationBo annotation : annotationBoList) {
+            if (annotation.getKey() != AnnotationKey.OPENTELEMETRY_LINK.getCode()) {
+                continue;
+            }
+            final OtelLinkValue value = OtelLinkValueSerde.parse(annotation.getValue());
+            if (value == null || value.traceId() == null || value.spanId() == null) {
+                continue;
+            }
+            index.add(new TraceSpanKey(value.traceId(), value.spanId()), host);
+        }
     }
 
     private void addOtelLinksByUpstream(List<SpanBo> transaction, MultiValueMap<TraceSpanKey, SpanBo> otelLinkIndex) {

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilderTest.java
@@ -17,11 +17,17 @@
 
 package com.navercorp.pinpoint.web.applicationmap.map;
 
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.server.bo.SpanOwner;
+import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
+import com.navercorp.pinpoint.common.server.trace.OtelServerTraceId;
 import com.navercorp.pinpoint.common.server.util.UserNodeUtils;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.TestTraceUtils;
@@ -32,6 +38,7 @@ import com.navercorp.pinpoint.web.applicationmap.rawdata.LinkDataMap;
 import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.component.DefaultApplicationFactory;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
+import com.navercorp.pinpoint.web.util.ServiceTypeRegistryMockFactory;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseHistograms;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
@@ -161,5 +168,100 @@ public class FilteredMapBuilderTest {
         LinkData targetLinkData = targetLinkDataMap.getLinkData(linkKey);
         String assertMessage = String.format("%s[%s] from %s[%s] target link data does not exist", toApplicationName, toServiceType.getName(), fromApplicationName, fromServiceType.getName());
         Assertions.assertNotNull(targetLinkData, assertMessage);
+    }
+
+    // =======================================================================
+    // OTel Span.Link → upstream/downstream link data across transactions
+    // =======================================================================
+
+    private static final String UPSTREAM_TRACE_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String DOWNSTREAM_TRACE_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final long UPSTREAM_SPAN_ID = 100L;
+
+    private static ServiceTypeRegistryService otelRegistry() {
+        ServiceTypeRegistryMockFactory mockFactory = new ServiceTypeRegistryMockFactory();
+        mockFactory.addServiceTypeMock(ServiceType.UNKNOWN);
+        mockFactory.addServiceTypeMock(ServiceType.USER);
+        mockFactory.addServiceTypeMock(ServiceType.OPENTELEMETRY_SERVER);
+        mockFactory.addServiceTypeMock(ServiceType.OPENTELEMETRY_INTERNAL);
+        return mockFactory.createMockServiceTypeRegistryService();
+    }
+
+    private static SpanBo otelRootSpan(String applicationName, String agentId, String traceIdHex, long spanId) {
+        SpanOwner owner = new SpanOwner();
+        owner.setAgentId(agentId);
+        owner.setApplicationName(applicationName);
+        SpanBo span = new SpanBo(TraceSourceType.OPENTELEMETRY, owner);
+        span.setApplicationServiceType(ServiceType.OPENTELEMETRY_SERVER.getCode());
+        span.setServiceType(ServiceType.OPENTELEMETRY_SERVER.getCode());
+        span.setTransactionId(OtelServerTraceId.of(traceIdHex));
+        span.setSpanId(spanId);
+        span.setParentSpanId(-1);
+        span.setTraceTime(0, 1000L, 100);
+        span.setCollectorAcceptTime(1100L);
+        return span;
+    }
+
+    // Raw collector wire shape of the OPENTELEMETRY_LINK annotation (spanId as decimal string)
+    private static AnnotationBo linkAnnotation(String targetTraceIdHex, long targetSpanId) {
+        return AnnotationBo.of(AnnotationKey.OPENTELEMETRY_LINK.getCode(),
+                "{\"traceId\":\"" + targetTraceIdHex + "\",\"spanId\":\"" + targetSpanId + "\"}");
+    }
+
+    private static SpanEventBo linkSpanEvent(String targetTraceIdHex, long targetSpanId) {
+        SpanEventBo event = new SpanEventBo();
+        event.setServiceType(ServiceType.OPENTELEMETRY_INTERNAL.getCode());
+        event.addAnnotation(linkAnnotation(targetTraceIdHex, targetSpanId));
+        return event;
+    }
+
+    private void assertOtelLinkData(FilteredMap filteredMap) {
+        LinkDataDuplexMap linkDataDuplexMap = filteredMap.getLinkDataDuplexMap();
+        LinkKey linkKey = LinkKey.of("APP_UP", ServiceType.OPENTELEMETRY_SERVER, "APP_DOWN", ServiceType.OPENTELEMETRY_SERVER);
+        Assertions.assertNotNull(linkDataDuplexMap.getSourceLinkDataMap().getLinkData(linkKey),
+                "APP_UP -> APP_DOWN OTel link source data does not exist");
+        Assertions.assertNotNull(linkDataDuplexMap.getTargetLinkDataMap().getLinkData(linkKey),
+                "APP_UP -> APP_DOWN OTel link target data does not exist");
+    }
+
+    private FilteredMap buildOtelLinkMap(SpanBo upstream, SpanBo downstream) {
+        TimeWindow timeWindow = new TimeWindow(Range.between(1, 200000));
+        ServiceTypeRegistryService otelRegistry = otelRegistry();
+        ApplicationFactory otelApplicationFactory = new DefaultApplicationFactory(otelRegistry, mock(ServiceModelResolver.class));
+        FilteredMapBuilder builder = new FilteredMapBuilder(otelApplicationFactory, otelRegistry, timeWindow);
+        builder.addTransactions(List.of(List.of(upstream), List.of(downstream)));
+        return builder.build();
+    }
+
+    @Test
+    public void otelLink_onDownstreamSpan() {
+        SpanBo upstream = otelRootSpan("APP_UP", "agent-up", UPSTREAM_TRACE_ID, UPSTREAM_SPAN_ID);
+        SpanBo downstream = otelRootSpan("APP_DOWN", "agent-down", DOWNSTREAM_TRACE_ID, 200L);
+        downstream.addAnnotation(linkAnnotation(UPSTREAM_TRACE_ID, UPSTREAM_SPAN_ID));
+
+        assertOtelLinkData(buildOtelLinkMap(upstream, downstream));
+    }
+
+    @Test
+    public void otelLink_onDownstreamSpanEvent() {
+        // link carried by an OTel sub-span (child SpanEvent) — e.g. exporters that attach
+        // cross-trace links to child spans only; must index to the owning SpanBo
+        SpanBo upstream = otelRootSpan("APP_UP", "agent-up", UPSTREAM_TRACE_ID, UPSTREAM_SPAN_ID);
+        SpanBo downstream = otelRootSpan("APP_DOWN", "agent-down", DOWNSTREAM_TRACE_ID, 200L);
+        downstream.addSpanEvent(linkSpanEvent(UPSTREAM_TRACE_ID, UPSTREAM_SPAN_ID));
+
+        assertOtelLinkData(buildOtelLinkMap(upstream, downstream));
+    }
+
+    @Test
+    public void otelLink_onDownstreamSpanChunkEvent() {
+        // split arrival: the link-bearing sub-span was stored as an orphan SpanChunk
+        SpanBo upstream = otelRootSpan("APP_UP", "agent-up", UPSTREAM_TRACE_ID, UPSTREAM_SPAN_ID);
+        SpanBo downstream = otelRootSpan("APP_DOWN", "agent-down", DOWNSTREAM_TRACE_ID, 200L);
+        SpanChunkBo chunk = new SpanChunkBo(TraceSourceType.OPENTELEMETRY);
+        chunk.addSpanEventBoList(List.of(linkSpanEvent(UPSTREAM_TRACE_ID, UPSTREAM_SPAN_ID)));
+        downstream.addSpanChunkBo(chunk);
+
+        assertOtelLinkData(buildOtelLinkMap(upstream, downstream));
     }
 }


### PR DESCRIPTION
The SpanEvent mapper dropped Span.Link entirely (only the root-span path had linkMapper wired), so cross-trace links carried by child spans never reached storage. Inject OtlpTraceLinkMapper and emit the OPENTELEMETRY_LINK annotation the same way the root path does; this covers root-linked children, orphan-chunk local roots and their descendants, since all three funnel through OtlpTraceSpanEventMapper.

On the web side, FilteredMapBuilder.buildOtelLinkIndex only scanned SpanBo-level annotations for the downstream side of an OTel link, while the upstream-side matching (matchSpanEvents) already handled sub-spans inside SpanEvents and SpanChunks. Scan SpanEvent/SpanChunk annotations too and attribute them to the owning SpanBo, so child-carried links produce filtered-map edges. No additional storage reads: the lists are already in memory.