### PR TITLE
[#noissue] Dump the full application map model when debug logging is enabled

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/ApplicationMapModule.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/ApplicationMapModule.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.collector.applicationmap.dao.MapAgentResponseDao;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapApplicationResponseDao;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapInLinkDao;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapOutLinkDao;
+import com.navercorp.pinpoint.collector.applicationmap.model.ApplicationMapBuilder;
 import com.navercorp.pinpoint.collector.applicationmap.service.ApplicationMapService;
 import com.navercorp.pinpoint.collector.applicationmap.service.HbaseApplicationMapService;
 import com.navercorp.pinpoint.collector.applicationmap.service.LinkService;
@@ -63,11 +64,16 @@ public class ApplicationMapModule {
     }
 
     @Bean
+    public ApplicationMapBuilder applicationMapBuilder(ServiceTypeRegistryService registry) {
+        return new ApplicationMapBuilder(registry);
+    }
+
+    @Bean
     public ApplicationMapService applicationMapService(HostApplicationMapDao[] hostApplicationMapDaos,
                                                        LinkService linkService,
-                                                       ServiceTypeRegistryService registry) {
+                                                       ApplicationMapBuilder applicationMapBuilder) {
         HostApplicationMapDao hostApplicationMapDao = deleageHostApplicationMapDao(hostApplicationMapDaos);
-        return new HbaseApplicationMapService(hostApplicationMapDao, linkService, registry);
+        return new HbaseApplicationMapService(hostApplicationMapDao, linkService, applicationMapBuilder);
     }
 
     private HostApplicationMapDao deleageHostApplicationMapDao(HostApplicationMapDao[] hostApplicationMapDaos) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/model/ApplicationMapModel.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/model/ApplicationMapModel.java
@@ -99,9 +99,9 @@ public class ApplicationMapModel {
         return list;
     }
 
-    public boolean isEmpty() {
-        return CollectionUtils.isEmpty(outLinks) && CollectionUtils.isEmpty(inLinks)
-                && CollectionUtils.isEmpty(responseTimes) && CollectionUtils.isEmpty(acceptorHosts);
+    public boolean hasRows() {
+        return CollectionUtils.hasLength(outLinks) || CollectionUtils.hasLength(inLinks)
+                || CollectionUtils.hasLength(responseTimes) || CollectionUtils.hasLength(acceptorHosts);
     }
 
     @Override
@@ -116,15 +116,31 @@ public class ApplicationMapModel {
     }
 
     /**
-     * Dumps every collected row, unlike {@link #toString()} which only prints the list sizes.
+     * Dumps every collected row as an indented multi-line string, one row per line.
+     * Empty lists are omitted, unlike {@link #toString()} which only prints the list sizes.
      */
     public String dump() {
-        return "ApplicationMapModel{" +
-                "requestTime=" + requestTime +
-                ", outLinks=" + nonNull(outLinks) +
-                ", inLinks=" + nonNull(inLinks) +
-                ", responseTimes=" + nonNull(responseTimes) +
-                ", acceptorHosts=" + nonNull(acceptorHosts) +
-                '}';
+        if (hasRows()) {
+            StringBuilder builder = new StringBuilder(128);
+            builder.append("ApplicationMapModel{");
+            builder.append("\n  requestTime=").append(requestTime);
+            dump(builder, "outLinks", outLinks);
+            dump(builder, "inLinks", inLinks);
+            dump(builder, "responseTimes", responseTimes);
+            dump(builder, "acceptorHosts", acceptorHosts);
+            builder.append("\n}");
+            return builder.toString();
+        }
+        return "ApplicationMapModel{requestTime=" + requestTime + '}';
+    }
+
+    private static void dump(StringBuilder builder, String name, List<?> rows) {
+        if (CollectionUtils.isEmpty(rows)) {
+            return;
+        }
+        builder.append("\n  ").append(name).append('=');
+        for (Object row : rows) {
+            builder.append("\n    ").append(row);
+        }
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -68,25 +68,27 @@ public class HbaseApplicationMapService implements ApplicationMapService {
     }
 
     private void write(ApplicationMapModel model) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("MapModel {}", model.dump());
-        }
+        if (model.hasRows()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("MapModel {}", model.dump());
+            }
 
-        final long requestTime = model.getRequestTime();
+            final long requestTime = model.getRequestTime();
 
-        for (AcceptorHostRow row : model.getAcceptorHosts()) {
-            hostApplicationMapDao.insert(requestTime, row.parentVertex(), row.vertex(), row.host());
-        }
-        for (OutLinkRow row : model.getOutLinks()) {
-            linkService.updateOutLink(requestTime, row.selfVertex(),
-                    row.outVertex(), row.outHost(), row.elapsed(), row.error());
-        }
-        for (InLinkRow row : model.getInLinks()) {
-            linkService.updateInLink(requestTime, row.inVertex(),
-                    row.selfVertex(), row.selfHost(), row.elapsed(), row.error());
-        }
-        for (ResponseTimeRow row : model.getResponseTimes()) {
-            linkService.updateResponseTime(requestTime, row.selfVertex(), row.agentId(), row.elapsed(), row.error());
+            for (AcceptorHostRow row : model.getAcceptorHosts()) {
+                hostApplicationMapDao.insert(requestTime, row.parentVertex(), row.vertex(), row.host());
+            }
+            for (OutLinkRow row : model.getOutLinks()) {
+                linkService.updateOutLink(requestTime, row.selfVertex(),
+                        row.outVertex(), row.outHost(), row.elapsed(), row.error());
+            }
+            for (InLinkRow row : model.getInLinks()) {
+                linkService.updateInLink(requestTime, row.inVertex(),
+                        row.selfVertex(), row.selfHost(), row.elapsed(), row.error());
+            }
+            for (ResponseTimeRow row : model.getResponseTimes()) {
+                linkService.updateResponseTime(requestTime, row.selfVertex(), row.agentId(), row.elapsed(), row.error());
+            }
         }
     }
 }

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.collector.applicationmap.model.OutLinkRow;
 import com.navercorp.pinpoint.collector.applicationmap.model.ResponseTimeRow;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
-import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -48,11 +47,10 @@ public class HbaseApplicationMapService implements ApplicationMapService {
 
     public HbaseApplicationMapService(HostApplicationMapDao hostApplicationMapDao,
                                       LinkService linkService,
-                                      ServiceTypeRegistryService registry) {
+                                      ApplicationMapBuilder applicationMapBuilder) {
         this.hostApplicationMapDao = Objects.requireNonNull(hostApplicationMapDao, "hostApplicationMapDao");
         this.linkService = Objects.requireNonNull(linkService, "linkService");
-        Objects.requireNonNull(registry, "registry");
-        this.applicationMapBuilder = new ApplicationMapBuilder(registry);
+        this.applicationMapBuilder = Objects.requireNonNull(applicationMapBuilder, "applicationMapBuilder");
     }
 
     @Override

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/model/ApplicationMapBuilderTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/applicationmap/model/ApplicationMapBuilderTest.java
@@ -192,7 +192,7 @@ class ApplicationMapBuilderTest {
 
         ApplicationMapModel model = builder.build(spanChunk);
 
-        assertThat(model.isEmpty()).isTrue();
+        assertThat(model.hasRows()).isFalse();
         assertThat(model.getRequestTime()).isEqualTo(ACCEPT_TIME);
     }
 }


### PR DESCRIPTION
This pull request refactors the application map building and writing logic to improve clarity and efficiency in the Pinpoint collector. The changes focus on replacing the `isEmpty()` method with a more intuitive `hasRows()` method, enhancing the `dump()` output for debugging, and updating dependency injection for `ApplicationMapBuilder`. These updates help ensure that only non-empty models are processed and logged, and improve code maintainability.

**Refactoring and API improvements:**

* Replaced `isEmpty()` with `hasRows()` in `ApplicationMapModel`, inverting the logic to clarify when the model contains data. All usages and tests have been updated accordingly. [[1]](diffhunk://#diff-91e64a339ab3ed142aa1bbdff21bbdc1f46a21b707269629968f3b8ea7fec83eL102-R104) [[2]](diffhunk://#diff-72d08685269a93bf56321c69475abb52954b52ed275659f5da16381a4eb4e8d5L195-R195)
* Enhanced the `dump()` method in `ApplicationMapModel` to produce a more readable, indented, multi-line output, and omit empty lists for easier debugging.

**Dependency injection and service construction:**

* Refactored dependency injection in `ApplicationMapModule` and `HbaseApplicationMapService` to inject an `ApplicationMapBuilder` instance directly, rather than constructing it internally, improving testability and separation of concerns. [[1]](diffhunk://#diff-6edc73dc7af5e7a1152068f7725370dce85925678160f12ac0700d20e4f28509R25) [[2]](diffhunk://#diff-6edc73dc7af5e7a1152068f7725370dce85925678160f12ac0700d20e4f28509R66-R76) [[3]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0L28) [[4]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0L51-R53)

**Behavioral changes:**

* Updated the `write()` method in `HbaseApplicationMapService` to only log and process models that have rows, preventing unnecessary operations on empty models. [[1]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0R69) [[2]](diffhunk://#diff-39cdf7e9937d09cf5ff0ee2a2959807dcae6b6fccae360ffb11e123b2ec99cf0R92)