### PR TITLE
[#14103] Require jwt secret key for basic login

### DIFF
--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/config/BasicLoginProperties.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/config/BasicLoginProperties.java
@@ -35,6 +35,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class BasicLoginProperties implements InitializingBean {
 
+    // shipped as the example value until 4.0.0, so it is publicly known - see git history
+    private static final String LEAKED_JWT_SECRET_KEY = "__PINPOINT_JWT_SECRET__";
+
     private static final long DEFAULT_EXPIRATION_TIME_SECONDS = TimeUnit.HOURS.toSeconds(12);
 
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
@@ -95,7 +98,10 @@ public class BasicLoginProperties implements InitializingBean {
 
         this.adminList = createAdmin(adminIdAndPasswordPairList);
 
-        Assert.hasLength(jwtSecretKey, "jwtSecretKey must not be empty");
+        Assert.hasLength(jwtSecretKey, "web.security.auth.jwt.secretkey must not be empty. " +
+                "Set it in pinpoint-web.properties to a random string of 24 characters or more");
+        Assert.isTrue(!LEAKED_JWT_SECRET_KEY.equals(jwtSecretKey), "web.security.auth.jwt.secretkey must not be " +
+                LEAKED_JWT_SECRET_KEY + ". It was shipped as an example value and is publicly known - rotate it");
     }
 
     private List<UserDetails> createUser(List<String> idAndPasswordList) {

--- a/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/BasicLoginService.java
+++ b/basic-login/src/main/java/com/navercorp/pinpoint/login/basic/service/BasicLoginService.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.login.basic.service;
 
 import com.navercorp.pinpoint.login.basic.config.BasicLoginProperties;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.Cookie;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -66,6 +67,9 @@ public class BasicLoginService {
 
             if (BasicLoginConstants.PINPOINT_JWT_COOKIE_NAME.equals(name)) {
                 String pinpointJwtToken = cookie.getValue();
+                if (pinpointJwtToken == null || pinpointJwtToken.isBlank()) {
+                    continue;
+                }
 
                 try {
                     Date expirationDate = jwtService.getExpirationDate(pinpointJwtToken);
@@ -78,6 +82,8 @@ public class BasicLoginService {
                     }
                 } catch (ExpiredJwtException e) {
                     logger.warn("This token already expired. message:{}", e.getMessage(), e);
+                } catch (JwtException e) {
+                    logger.warn("Invalid JWT token. message:{}", e.getMessage());
                 } catch (UsernameNotFoundException e) {
                     logger.warn("Could not find user for JWT token. message:{}", e.getMessage());
                 }

--- a/basic-login/src/test/java/com/navercorp/pinpoint/login/basic/service/BasicLoginServiceTest.java
+++ b/basic-login/src/test/java/com/navercorp/pinpoint/login/basic/service/BasicLoginServiceTest.java
@@ -110,8 +110,43 @@ class BasicLoginServiceTest {
         }
     }
 
+    @Test
+    void getUserDetailsShouldIgnoreInvalidJwt() {
+        try (AnnotationConfigApplicationContext context = newContext(Map.of(
+                "web.security.auth.user", "user:password"
+        ))) {
+            BasicLoginService service = context.getBean(BasicLoginService.class);
+            Cookie cookie = new Cookie(BasicLoginConstants.PINPOINT_JWT_COOKIE_NAME, "not-a-jwt");
+
+            assertThat(service.getUserDetails(new Cookie[]{cookie})).isNull();
+        }
+    }
+
+    @Test
+    void getUserDetailsShouldIgnoreEmptyJwt() {
+        try (AnnotationConfigApplicationContext context = newContext(Map.of(
+                "web.security.auth.user", "user:password"
+        ))) {
+            BasicLoginService service = context.getBean(BasicLoginService.class);
+            Cookie cookie = new Cookie(BasicLoginConstants.PINPOINT_JWT_COOKIE_NAME, "");
+
+            assertThat(service.getUserDetails(new Cookie[]{cookie})).isNull();
+        }
+    }
+
+    @Test
+    void leakedSecretKeyShouldFailStartup() {
+        assertThatThrownBy(() -> newContext(Map.of(
+                "web.security.auth.jwt.secretkey", "__PINPOINT_JWT_SECRET__"
+        ))).hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .rootCause()
+                .hasMessageContaining("publicly known");
+    }
+
     private AnnotationConfigApplicationContext newContext(Map<String, Object> properties) {
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.getEnvironment().getPropertySources().addLast(new MapPropertySource("test-default",
+                Map.of("web.security.auth.jwt.secretkey", "test-jwt-secret-key-for-unit-test")));
         context.getEnvironment().getPropertySources().addFirst(new MapPropertySource("test", properties));
         context.register(BasicLoginConfiguration.class);
         context.refresh();

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -81,6 +81,7 @@ web.installation.downloadUrl=
 # Role (User : Can use whole function except for admin rest api, Admin : Can use whole function)
 #web.security.auth.user=alice:foo,bob:bar
 #web.security.auth.admin=eve:baz
+# Required when pinpoint.modules.web.login=basicLogin. Web fails to start if unset.
 #web.security.auth.jwt.secretkey=<generate-a-random-secret>
 #web.security.auth.jwt.cookie.http-only=true
 #web.security.auth.jwt.cookie.secure=false


### PR DESCRIPTION
The field initializer removed in 826e8c9f09 was the actual fallback, not dead code. A deployment that did not set web.security.auth.jwt.secretkey signed JWT cookies with a constant compiled into the source tree. Keep the startup failure, but name the property and the length requirement in the message so an upgrading user can act on it, and fix the tests that the removal broke.

Also ignore invalid JWT cookies instead of letting JwtException escape JwtRequestFilter, which turned a malformed or stale cookie into a 500 that the browser kept re-triggering.