### PR TITLE
[#noissue] Remove cached protobuf builders from grpc mappers

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/AgentStatMapper.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/AgentStatMapper.java
@@ -80,13 +80,6 @@ import java.util.List;
 )
 public interface AgentStatMapper {
 
-    PAgentStatBatch.Builder pAgentStatBatchBuilder = PAgentStatBatch.newBuilder();
-
-    default PAgentStatBatch.Builder newBuilder() {
-        pAgentStatBatchBuilder.clear();
-        return pAgentStatBatchBuilder;
-    }
-
     @Mapping(source = "agentStats", target = "agentStat")
     PAgentStatBatch map(AgentStatMetricSnapshotBatch batch);
 

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/AnnotationValueMapper.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/AnnotationValueMapper.java
@@ -73,63 +73,6 @@ import java.lang.annotation.Target;
 )
 public interface AnnotationValueMapper {
 
-    PAnnotationValue.Builder annotationBuilder = PAnnotationValue.newBuilder();
-    StringValue.Builder stringValueBuilder = StringValue.newBuilder();
-    PIntBooleanIntBooleanValue.Builder intBoolBoolBuilder = PIntBooleanIntBooleanValue.newBuilder();
-    PLongIntIntByteByteStringValue.Builder longIntIntByteByteStringBuilder = PLongIntIntByteByteStringValue.newBuilder();
-    PIntStringStringValue.Builder intStringStringBuilder = PIntStringStringValue.newBuilder();
-    PIntStringValue.Builder intStringBuilder = PIntStringValue.newBuilder();
-    PStringStringValue.Builder stringStringBuilder = PStringStringValue.newBuilder();
-    PBytesStringStringValue.Builder bytesStringStringBuilder = PBytesStringStringValue.newBuilder();
-
-    default PAnnotationValue.Builder getAnnotationBuilder() {
-        final PAnnotationValue.Builder builder = this.annotationBuilder;
-        builder.clear();
-        return builder;
-    }
-
-    default StringValue.Builder getStringValueBuilder() {
-        final StringValue.Builder builder = this.stringValueBuilder;
-        builder.clear();
-        return builder;
-    }
-
-    default PIntBooleanIntBooleanValue.Builder getIntBoolIntBoolBuilder() {
-        final PIntBooleanIntBooleanValue.Builder builder = this.intBoolBoolBuilder;
-        builder.clear();
-        return builder;
-    }
-
-    default PLongIntIntByteByteStringValue.Builder getLongIntIntByteByteStringBuilder() {
-        final PLongIntIntByteByteStringValue.Builder builder = this.longIntIntByteByteStringBuilder;
-        builder.clear();
-        return builder;
-    }
-
-    default PIntStringStringValue.Builder getIntStringStringBuilder() {
-        final PIntStringStringValue.Builder builder = this.intStringStringBuilder;
-        builder.clear();
-        return builder;
-    }
-
-    default PIntStringValue.Builder getIntStringBuilder() {
-        final PIntStringValue.Builder builder = this.intStringBuilder;
-        builder.clear();
-        return builder;
-    }
-
-    default PStringStringValue.Builder getStringStringBuilder() {
-        final PStringStringValue.Builder builder = this.stringStringBuilder;
-        builder.clear();
-        return builder;
-    }
-
-    default PBytesStringStringValue.Builder getBytesStringStringBuilder() {
-        final PBytesStringStringValue.Builder builder = this.bytesStringStringBuilder;
-        builder.clear();
-        return builder;
-    }
-
     @Qualifier
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.CLASS)

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/ExceptionMetaDataMapper.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/grpc/mapper/ExceptionMetaDataMapper.java
@@ -45,28 +45,6 @@ public interface ExceptionMetaDataMapper {
 
     String EMPTY_STRING = "";
 
-    PExceptionMetaData.Builder pExceptionMetaDataBuilder = PExceptionMetaData.newBuilder();
-    PException.Builder pExceptionBuilder = PException.newBuilder();
-    PStackTraceElement.Builder pStackTraceElementBuilder = PStackTraceElement.newBuilder();
-
-    default PExceptionMetaData.Builder getpExceptionMetaDataBuilder() {
-        PExceptionMetaData.Builder builder = pExceptionMetaDataBuilder;
-        builder.clear();
-        return builder;
-    }
-
-    default PException.Builder getpExceptionBuilder() {
-        PException.Builder builder = pExceptionBuilder;
-        builder.clear();
-        return builder;
-    }
-
-    default PStackTraceElement.Builder getpStackTraceElementBuilder() {
-        PStackTraceElement.Builder builder = pStackTraceElementBuilder;
-        builder.clear();
-        return builder;
-    }
-
     @Mapping(source = "exceptionWrappers", target = "exceptions")
     @Mapping(source = "traceRoot.traceId", target = "transactionId", qualifiedBy = TraceIdMapStructUtils.ToTransactionId.class)
     @Mapping(source = "traceRoot.traceId.spanId", target = "spanId")


### PR DESCRIPTION
Interface fields are implicitly static final, so the cached builders were
shared across every mapper instance and thread. Protobuf builders are cheap
to create, and caching them retains the last mapped data until the next
call. Delete the cache so MapStruct calls the static newBuilder() directly.
