### PR TITLE
[#noissue] Inject the ApplicationMapBuilder instead of constructing i…

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/ApplicationMapModule.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/config/ApplicationMapModule.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.collector.applicationmap.dao.MapAgentResponseDao;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapApplicationResponseDao;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapInLinkDao;
 import com.navercorp.pinpoint.collector.applicationmap.dao.MapOutLinkDao;
+import com.navercorp.pinpoint.collector.applicationmap.model.ApplicationMapBuilder;
 import com.navercorp.pinpoint.collector.applicationmap.service.ApplicationMapService;
 import com.navercorp.pinpoint.collector.applicationmap.service.HbaseApplicationMapService;
 import com.navercorp.pinpoint.collector.applicationmap.service.LinkService;
@@ -63,11 +64,16 @@ public class ApplicationMapModule {
     }
 
     @Bean
+    public ApplicationMapBuilder applicationMapBuilder(ServiceTypeRegistryService registry) {
+        return new ApplicationMapBuilder(registry);
+    }
+
+    @Bean
     public ApplicationMapService applicationMapService(HostApplicationMapDao[] hostApplicationMapDaos,
                                                        LinkService linkService,
-                                                       ServiceTypeRegistryService registry) {
+                                                       ApplicationMapBuilder applicationMapBuilder) {
         HostApplicationMapDao hostApplicationMapDao = deleageHostApplicationMapDao(hostApplicationMapDaos);
-        return new HbaseApplicationMapService(hostApplicationMapDao, linkService, registry);
+        return new HbaseApplicationMapService(hostApplicationMapDao, linkService, applicationMapBuilder);
     }
 
     private HostApplicationMapDao deleageHostApplicationMapDao(HostApplicationMapDao[] hostApplicationMapDaos) {

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/applicationmap/service/HbaseApplicationMapService.java
@@ -25,7 +25,6 @@ import com.navercorp.pinpoint.collector.applicationmap.model.OutLinkRow;
 import com.navercorp.pinpoint.collector.applicationmap.model.ResponseTimeRow;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
 import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
-import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -48,11 +47,10 @@ public class HbaseApplicationMapService implements ApplicationMapService {
 
     public HbaseApplicationMapService(HostApplicationMapDao hostApplicationMapDao,
                                       LinkService linkService,
-                                      ServiceTypeRegistryService registry) {
+                                      ApplicationMapBuilder applicationMapBuilder) {
         this.hostApplicationMapDao = Objects.requireNonNull(hostApplicationMapDao, "hostApplicationMapDao");
         this.linkService = Objects.requireNonNull(linkService, "linkService");
-        Objects.requireNonNull(registry, "registry");
-        this.applicationMapBuilder = new ApplicationMapBuilder(registry);
+        this.applicationMapBuilder = Objects.requireNonNull(applicationMapBuilder, "applicationMapBuilder");
     }
 
     @Override


### PR DESCRIPTION
…t in the service

This pull request refactors the way `ApplicationMapBuilder` is instantiated and injected into the application map service. Instead of creating a new `ApplicationMapBuilder` within the `HbaseApplicationMapService`, it is now defined as a Spring bean and injected through the configuration. This change improves dependency management and testability.

Dependency injection improvements:

* `ApplicationMapBuilder` is now defined as a Spring bean in `ApplicationMapModule`, allowing it to be shared and managed by the Spring container. [[1]](diffhunk://#diff-6edc73dc7af5e7a1152068f7725370dce85925678160f12ac0700d20e4f28509R25) [[2]](diffhunk://#diff-6edc73dc7af5e7a1152068f7725370dce85925678160f12ac0700d20e4f28509R66-R76)
* The `applicationMapService` bean in `ApplicationMapModule` is updated to receive an `ApplicationMapBuilder` bean instead of a `ServiceTypeRegistryService`, reflecting the new dependency injection approach.
* The constructor of `HbaseApplicationMapService` is changed to accept an `ApplicationMapBuilder` instance instead of a `ServiceTypeRegistryService`, and uses the injected builder directly.
* The direct instantiation of `ApplicationMapBuilder` inside `HbaseApplicationMapService` is removed, ensuring the builder is only created and managed by the Spring context.
* The unused import of `ServiceTypeRegistryService` is removed from `HbaseApplicationMapService.java`, cleaning up the code.