### PR TITLE
[#noissue] Redact Claude Code sensitive attributes at storage

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpAttributeBoMapper.java
@@ -64,7 +64,8 @@ public class OtlpAttributeBoMapper {
             if (excludeFilter.test(key) || OtlpSensitiveAttributeFilter.isSensitive(key)) {
                 continue;
             }
-            // Strip query/fragment/userinfo from URL values before truncation.
+            // Strip query/fragment/userinfo from URL values and reduce shell command content
+            // to its presence marker before truncation.
             final AttributeValue sanitized = sanitizeValue(key, entry.getValue());
             final AttributeValue value = truncateValue(sanitized, onTruncated);
             result.add(new AttributeBo(key, value));
@@ -77,7 +78,8 @@ public class OtlpAttributeBoMapper {
             return value;
         }
         final String original = (String) value.getValue();
-        final String sanitized = OtlpSensitiveAttributeFilter.sanitizeUrl(key, original);
+        String sanitized = OtlpSensitiveAttributeFilter.sanitizeUrl(key, original);
+        sanitized = OtlpSensitiveAttributeFilter.sanitizeCommand(key, sanitized);
         if (sanitized == null || sanitized.equals(original)) {
             return value;
         }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpSensitiveAttributeFilter.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpSensitiveAttributeFilter.java
@@ -33,6 +33,8 @@ import java.util.Set;
  *   <li>{@link #sanitizeUrl(String, String)} — URL-valued attributes ({@code url.full} /
  *       {@code http.url} / {@code http.target}) are kept but reduced to {@code scheme://host[:port]/path}
  *       (query, fragment and userinfo removed).</li>
+ *   <li>{@link #sanitizeCommand(String, String)} — shell command content ({@code full_command})
+ *       is kept but reduced to its first character + {@code "..."} as a presence marker.</li>
  * </ul>
  *
  * <p>Only Span and SpanEvent attributes pass through {@code toAttributeBoList}; Span Event and
@@ -59,7 +61,19 @@ final class OtlpSensitiveAttributeFilter {
             "http.response.body",
             "messaging.message.body",
             "rpc.request.body",
-            "rpc.response.body"
+            "rpc.response.body",
+            // Free-form prompt text, emitted by Claude Code on its interaction root span. The
+            // content can carry anything the user typed (secrets, PII) and has no safe partial
+            // form; the separately-emitted user_prompt_length stays as the size signal.
+            "user_prompt"
+    );
+
+    // Shell command content, emitted by Claude Code on tool spans. Kept as a presence marker
+    // only — see sanitizeCommand: arguments routinely carry secrets (tokens in curl headers)
+    // and even the leading word can leak via VAR=secret assignment prefixes, so the value is
+    // reduced to its first character.
+    private static final Set<String> COMMAND_KEYS = Set.of(
+            "full_command"
     );
 
     private static final Set<String> END_USER_KEYS = Set.of(
@@ -70,8 +84,18 @@ final class OtlpSensitiveAttributeFilter {
             "enduser.email",
             "user.id",
             "user.email",
+            // Anthropic account identifiers, emitted by Claude Code on every span. Same
+            // end-user-identity category as user.id/user.email — only the key names differ.
+            "user.account_id",
+            "user.account_uuid",
             "tenant.id",
-            "tenant.name"
+            "tenant.name",
+            // Anthropic organization identifier, emitted by Claude Code on every span. A
+            // tenant-like external identifier: near-constant in a single-org deployment (no
+            // observability value) and useful only as social-engineering material if exposed.
+            // session.id is deliberately NOT dropped — it is the only explicit key correlating
+            // the transactions of one session and adds little linkability beyond the agentId.
+            "organization.id"
     );
 
     private static final Set<String> CREDENTIAL_KEYS = Set.of(
@@ -201,6 +225,24 @@ final class OtlpSensitiveAttributeFilter {
             return sanitized;
         }
         return sanitized.substring(0, authorityStart) + sanitized.substring(userInfoEnd + 1);
+    }
+
+    /**
+     * For shell-command-valued attributes, keeps only the first character of the command followed
+     * by {@code "..."} (e.g. {@code "curl -H ..."} → {@code "c..."}) — a presence marker that
+     * structurally cannot leak arguments, assignment prefixes or paths. Every other key returns
+     * its value unchanged.
+     */
+    static String sanitizeCommand(String key, String value) {
+        if (value == null || value.isEmpty() || !COMMAND_KEYS.contains(normalize(key))) {
+            return value;
+        }
+        final String trimmed = value.strip();
+        if (trimmed.isEmpty()) {
+            return "...";
+        }
+        final int firstCodePoint = trimmed.codePointAt(0);
+        return new StringBuilder(5).appendCodePoint(firstCodePoint).append("...").toString();
     }
 
     private static String normalize(String key) {

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpSensitiveAttributeFilterTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpSensitiveAttributeFilterTest.java
@@ -66,6 +66,11 @@ class OtlpSensitiveAttributeFilterTest {
             "enduser.scope",
             "enduser.scopes",
             "user.email",
+            "user.account_id",
+            "user.account_uuid",
+            "organization.id",
+            // free-form prompt content (Claude Code interaction span) — no safe partial form
+            "user_prompt",
             "tenant.id",
             // case / dash insensitivity
             "URL.QUERY",
@@ -82,7 +87,14 @@ class OtlpSensitiveAttributeFilterTest {
             "db.statement",
             "http.response.status_code",
             "service.name",
-            "safe.custom"
+            "safe.custom",
+            // Claude Code keys deliberately kept (policy decision, 2026-08-18): session.id is
+            // the only explicit session-correlation key and adds little linkability beyond the
+            // agentId; user_prompt_length is the safe size signal for the dropped user_prompt;
+            // full_command is kept as a key but its VALUE is reduced — see sanitizeCommand tests.
+            "session.id",
+            "user_prompt_length",
+            "full_command"
     );
 
     @Test
@@ -114,6 +126,37 @@ class OtlpSensitiveAttributeFilterTest {
     void sanitizeUrlHandlesNullAndEmpty() {
         assertThat(OtlpSensitiveAttributeFilter.sanitizeUrl("url.full", null)).isNull();
         assertThat(OtlpSensitiveAttributeFilter.sanitizeUrl("url.full", "")).isEmpty();
+    }
+
+    @Test
+    void sanitizeCommandKeepsFirstCharacterOnly() {
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("full_command", "echo pinpoint-otel-probe"))
+                .isEqualTo("e...");
+        // worst cases that defeated word-level extraction: assignment prefix / secret in args
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("full_command", "API_KEY=sk-live-123 node app.js"))
+                .isEqualTo("A...");
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("full_command", "curl -H \"Authorization: Bearer x\""))
+                .isEqualTo("c...");
+        // leading whitespace is not the marker character
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("full_command", "  git push"))
+                .isEqualTo("g...");
+        // single-character and non-BMP-safe handling
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("full_command", "a")).isEqualTo("a...");
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("full_command", "실행 스크립트")).isEqualTo("실...");
+        // supplementary-plane leading character (surrogate pair, 2 Java chars): the whole code
+        // point survives — a charAt-based cut would emit a lone surrogate (broken glyph)
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("full_command", "🚀 launch.sh"))
+                .isEqualTo("🚀...");
+    }
+
+    @Test
+    void sanitizeCommandLeavesOtherKeysAndBlanksAlone() {
+        // non-command keys keep their value verbatim
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("db.statement", "select 1"))
+                .isEqualTo("select 1");
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("full_command", null)).isNull();
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("full_command", "")).isEmpty();
+        assertThat(OtlpSensitiveAttributeFilter.sanitizeCommand("full_command", "   ")).isEqualTo("...");
     }
 
     @Test


### PR DESCRIPTION
Claude Code stamps end-user identity and content attributes on the spans it exports; the corporate telemetry policy forces OTEL_LOG_TOOL_DETAILS=1, so client-side suppression is not available and the storage-side filter is the only control point.

Identity keys, dropped via END_USER_KEYS:

- user.account_id / user.account_uuid: Anthropic account identifiers, stamped on every span. Same end-user-identity category as user.id/user.email, which the list already drops - only the key names differ, so they passed the exact-match filter.
- organization.id: a tenant-like external identifier, near-constant in a single-org deployment - no observability value.
- session.id is deliberately kept and pinned in the kept-keys fixture: the only explicit session-correlation key, adding little linkability beyond the agentId.

Content keys, decided per value shape:

- user_prompt: dropped. Free-form text routinely carries pasted secrets and PII and has no safe partial form; the separately emitted user_prompt_length stays as the size signal.
- full_command: value reduced to its first character + "..." (e.g. "curl -H ..." -> "c...") via sanitizeCommand, next to the existing sanitizeUrl value rule. A single leading code point is a presence marker that structurally cannot leak arguments, assignment prefixes or paths - word-level extraction was rejected because the first token itself leaks on VAR=secret command lines. Code-point based, so a multibyte or supplementary-plane leading character survives intact.