### PR TITLE
[#noissue] Promote GenAI model and token usage to annotations

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/AnnotationKey.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/AnnotationKey.java
@@ -274,4 +274,11 @@ public interface AnnotationKey {
     // carries one, so a call-tree child row per span would be pure noise. The web surfaces it as
     // a dedicated Scope row (RecordFactory.getScope) that the frontend lifts into a row icon.
     AnnotationKey OPENTELEMETRY_SCOPE = AnnotationKeyFactory.of(408, "Scope");
+    // GenAI (LLM call) semconv promotion, attached by the otlptrace collector's OtlpGenAiRecorder.
+    // The model that served the call: gen_ai.response.model (the model that actually responded,
+    // which may differ from the requested alias) wins over gen_ai.request.model.
+    AnnotationKey GEN_AI_MODEL = AnnotationKeyFactory.of(409, "gen_ai.model", VIEW_IN_RECORD_SET);
+    // Token usage summary composed from the gen_ai.usage.* attributes (bare nonstandard token
+    // keys as fallback), e.g. "in:1200 out:340 cache_r:5000 cache_w:0" — present parts only.
+    AnnotationKey GEN_AI_USAGE = AnnotationKeyFactory.of(410, "gen_ai.usage", VIEW_IN_RECORD_SET);
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorder.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorder.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.function.Consumer;
+
+/**
+ * Promotes the GenAI (LLM call) semconv attributes of a span to first-class annotations,
+ * so the model and token usage are readable on the call-tree row without opening the raw
+ * attribute list.
+ *
+ * <ul>
+ *   <li>{@code gen_ai.model} (409): {@code gen_ai.response.model} — the model that actually
+ *       served the call, which may differ from the requested alias — over
+ *       {@code gen_ai.request.model}.</li>
+ *   <li>{@code gen_ai.usage} (410): a composed summary such as
+ *       {@code "in:1200 out:340 cache_r:5000 cache_w:0"}. Only the parts present on the span
+ *       are included; when no token attribute is present the annotation is omitted entirely.</li>
+ * </ul>
+ *
+ * <p>Each token part resolves through a key ladder, mirroring {@link OtlpGrpcStatusResolver}:
+ * the current semconv key ({@code gen_ai.usage.input_tokens} / {@code ...output_tokens}), then
+ * the pre-rename semconv key ({@code ...prompt_tokens} / {@code ...completion_tokens}), then the
+ * bare nonstandard key emitted by Claude Code ({@code input_tokens} / {@code output_tokens}).
+ * The cache pair ({@code cache_read_tokens} / {@code cache_creation_tokens}) exists only in the
+ * bare form — there is no semconv equivalent.</p>
+ *
+ * <p>Only the key actually consumed by a promotion is added to {@code consumedKeys} (and thereby
+ * excluded from the raw attribute list); a non-promoted variant — e.g. a request.model that lost
+ * to response.model, or a token carried as a string value — survives as a raw attribute.</p>
+ */
+public final class OtlpGenAiRecorder {
+
+    private static final String[] MODEL_KEYS = {
+            OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_RESPONSE_MODEL,
+            OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL,
+    };
+    private static final String[] INPUT_TOKEN_KEYS = {
+            OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS,
+            OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_PROMPT_TOKENS,
+            OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS,
+    };
+    private static final String[] OUTPUT_TOKEN_KEYS = {
+            OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_OUTPUT_TOKENS,
+            OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_COMPLETION_TOKENS,
+            OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS,
+    };
+    private static final String[] CACHE_READ_TOKEN_KEYS = {
+            OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS,
+    };
+    private static final String[] CACHE_CREATION_TOKEN_KEYS = {
+            OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS,
+    };
+
+    private static final long ABSENT = -1;
+
+    private OtlpGenAiRecorder() {
+    }
+
+    /**
+     * Records the gen_ai.model / gen_ai.usage annotations when the corresponding attributes are
+     * present; a span without GenAI attributes is a no-op.
+     */
+    public static void record(Consumer<AnnotationBo> sink, Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
+        final String model = firstString(attributes, consumedKeys, MODEL_KEYS);
+        if (model != null) {
+            sink.accept(AnnotationBo.of(AnnotationKey.GEN_AI_MODEL.getCode(), model));
+        }
+        final String usage = composeUsage(attributes, consumedKeys);
+        if (usage != null) {
+            sink.accept(AnnotationBo.of(AnnotationKey.GEN_AI_USAGE.getCode(), usage));
+        }
+    }
+
+    private static String composeUsage(Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
+        final long input = firstLong(attributes, consumedKeys, INPUT_TOKEN_KEYS);
+        final long output = firstLong(attributes, consumedKeys, OUTPUT_TOKEN_KEYS);
+        final long cacheRead = firstLong(attributes, consumedKeys, CACHE_READ_TOKEN_KEYS);
+        final long cacheCreation = firstLong(attributes, consumedKeys, CACHE_CREATION_TOKEN_KEYS);
+        if (input == ABSENT && output == ABSENT && cacheRead == ABSENT && cacheCreation == ABSENT) {
+            return null;
+        }
+        final StringJoiner joiner = new StringJoiner(" ");
+        appendPart(joiner, "in", input);
+        appendPart(joiner, "out", output);
+        appendPart(joiner, "cache_r", cacheRead);
+        appendPart(joiner, "cache_w", cacheCreation);
+        return joiner.toString();
+    }
+
+    private static void appendPart(StringJoiner joiner, String label, long value) {
+        if (value != ABSENT) {
+            joiner.add(label + ':' + value);
+        }
+    }
+
+    private static String firstString(Map<String, AttributeValue> attributes, Set<String> consumedKeys, String[] keys) {
+        for (String key : keys) {
+            final String value = AttributeUtils.getAttributeStringValue(attributes, key, null);
+            if (value != null && !value.isEmpty()) {
+                consumedKeys.add(key);
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static long firstLong(Map<String, AttributeValue> attributes, Set<String> consumedKeys, String[] keys) {
+        for (String key : keys) {
+            final long value = AttributeUtils.getAttributeIntValue(attributes, key, ABSENT);
+            if (value >= 0) {
+                consumedKeys.add(key);
+                return value;
+            }
+        }
+        return ABSENT;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -122,6 +122,23 @@ public class OtlpTraceConstants {
     // NAME (io.grpc Status.getCode().name()); the OTel numeric code is translated accordingly
     // by OtlpGrpcStatusResolver.
     public static final int ANNOTATION_KEY_GRPC_STATUS = 160;
+    // GenAI (LLM) semconv, promoted to the gen_ai.model (409) / gen_ai.usage (410) annotations
+    // by OtlpGenAiRecorder. Model: response.model is the model that actually served the call
+    // (may differ from the requested alias) and wins over request.model. Tokens: current semconv
+    // names input_tokens/output_tokens, the pre-rename semconv used prompt_tokens/completion_tokens,
+    // and Claude Code emits bare nonstandard keys (input_tokens/output_tokens/cache_read_tokens/
+    // cache_creation_tokens); the cache pair has no semconv equivalent. Only the key actually
+    // consumed is filtered from the raw attributes — non-promoted variants survive.
+    public static final String ATTRIBUTE_KEY_GEN_AI_RESPONSE_MODEL = "gen_ai.response.model";
+    public static final String ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
+    public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens";
+    public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens";
+    public static final String ATTRIBUTE_KEY_INPUT_TOKENS = "input_tokens";
+    public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens";
+    public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens";
+    public static final String ATTRIBUTE_KEY_OUTPUT_TOKENS = "output_tokens";
+    public static final String ATTRIBUTE_KEY_CACHE_READ_TOKENS = "cache_read_tokens";
+    public static final String ATTRIBUTE_KEY_CACHE_CREATION_TOKENS = "cache_creation_tokens";
     // OTel HTTP server semconv: the matched route template (low-cardinality, e.g. "/users/{id}").
     // Takes precedence over url.path/http.url/http.target so the rpc field groups by endpoint
     // pattern instead of the raw, high-cardinality request path. This is the OTel equivalent of

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -201,6 +201,11 @@ public class OtlpTraceSpanEventMapper {
             spanEventBo.addAnnotation(AnnotationBo.of(OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS, grpcStatus.name()));
             consumedKeys.add(grpcStatus.sourceKey());
         }
+        // GenAI (LLM call) → gen_ai.model (409) / gen_ai.usage (410) annotations. Claude Code
+        // carries these on kind=0 child spans (claude_code.llm_request), so the SpanEvent path
+        // is the primary consumer; the root-span path is wired symmetrically for SDKs that
+        // emit an LLM call as a root/local-root span.
+        OtlpGenAiRecorder.record(spanEventBo::addAnnotation, attributes, consumedKeys);
         // attributes
         if (!attributes.isEmpty()) {
             final Predicate<String> attributeFilter = OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY.or(consumedKeys::contains);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -167,6 +167,8 @@ public class OtlpTraceSpanMapper {
             spanBo.addAnnotation(AnnotationBo.of(OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS, grpcStatus.name()));
             consumedKeys.add(grpcStatus.sourceKey());
         }
+        // GenAI (LLM call) → gen_ai.model (409) / gen_ai.usage (410) annotations
+        OtlpGenAiRecorder.record(spanBo::addAnnotation, attributes, consumedKeys);
         final Predicate<String> attributeFilter = OtlpTraceConstants.FILTERED_ATTRIBUTE_KEY.or(consumedKeys::contains);
         final TruncatedCounts truncatedCounts = new TruncatedCounts();
         // attributes

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorderTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorderTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpGenAiRecorderTest {
+
+    private final List<AnnotationBo> annotations = new ArrayList<>();
+    private final Set<String> consumedKeys = new HashSet<>();
+
+    private void record(Map<String, AttributeValue> attributes) {
+        OtlpGenAiRecorder.record(annotations::add, attributes, consumedKeys);
+    }
+
+    private String annotationValue(AnnotationKey key) {
+        return annotations.stream()
+                .filter(a -> a.getKey() == key.getCode())
+                .map(a -> String.valueOf(a.getValue()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    // =======================================================================
+    // model — response.model over request.model
+    // =======================================================================
+
+    @Test
+    void model_semconvResponseModelWins() {
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_RESPONSE_MODEL, AttributeValue.of("claude-sonnet-4-5-20250929"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL, AttributeValue.of("claude-sonnet-4-5")));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_MODEL)).isEqualTo("claude-sonnet-4-5-20250929");
+        // only the winning key is consumed — the losing request.model survives as a raw attribute
+        assertThat(consumedKeys).containsExactly(OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_RESPONSE_MODEL);
+    }
+
+    @Test
+    void model_requestModelFallback() {
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL, AttributeValue.of("claude-sonnet-4-5")));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_MODEL)).isEqualTo("claude-sonnet-4-5");
+        assertThat(consumedKeys).containsExactly(OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL);
+    }
+
+    @Test
+    void model_emptyStringNotPromoted() {
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL, AttributeValue.of("")));
+
+        assertThat(annotations).isEmpty();
+        assertThat(consumedKeys).isEmpty();
+    }
+
+    // =======================================================================
+    // usage — key ladder and composition
+    // =======================================================================
+
+    @Test
+    void usage_claudeCodeBareKeys() {
+        // Claude Code shape: bare nonstandard token keys (kind=0 llm_request span)
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of(1200L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS, AttributeValue.of(340L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS, AttributeValue.of(5000L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS, AttributeValue.of(0L)));
+
+        // zero is a legitimate value and stays visible
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:1200 out:340 cache_r:5000 cache_w:0");
+        assertThat(consumedKeys).containsExactlyInAnyOrder(
+                OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS,
+                OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS,
+                OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS,
+                OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS);
+    }
+
+    @Test
+    void usage_semconvKeysWinOverBare() {
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS, AttributeValue.of(100L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of(999L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:100");
+        assertThat(consumedKeys).containsExactly(OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS);
+    }
+
+    @Test
+    void usage_preRenameSemconvLadder() {
+        // gen_ai.usage.prompt_tokens / completion_tokens — semconv names before the input/output rename
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_PROMPT_TOKENS, AttributeValue.of(70L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_COMPLETION_TOKENS, AttributeValue.of(30L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:70 out:30");
+    }
+
+    @Test
+    void usage_partialPartsOnly() {
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS, AttributeValue.of(42L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("out:42");
+    }
+
+    @Test
+    void usage_stringTypedTokenNotPromoted() {
+        // a token carried as a string value cannot be promoted and must survive as a raw attribute
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of("1200")));
+
+        assertThat(annotations).isEmpty();
+        assertThat(consumedKeys).isEmpty();
+    }
+
+    // =======================================================================
+    // no-op on non-GenAI spans
+    // =======================================================================
+
+    @Test
+    void noOp_whenNoGenAiAttributes() {
+        record(Map.of(
+                "http.method", AttributeValue.of("GET")));
+
+        assertThat(annotations).isEmpty();
+        assertThat(consumedKeys).isEmpty();
+    }
+
+    @Test
+    void modelAndUsageTogether() {
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL, AttributeValue.of("claude-sonnet-4-5"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of(3L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS, AttributeValue.of(7L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_MODEL)).isEqualTo("claude-sonnet-4-5");
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:3 out:7");
+        assertThat(annotations).hasSize(2);
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -1075,4 +1075,66 @@ class OtlpTraceSpanEventMapperTest {
         assertThat(event.hasException()).isFalse();
         assertThat(countEventAnnotations(event)).isEqualTo(1);
     }
+
+    // =======================================================================
+    // map() — GenAI annotation promotion (gen_ai.model / gen_ai.usage)
+    // =======================================================================
+
+    private static final int GEN_AI_MODEL =
+            com.navercorp.pinpoint.common.trace.AnnotationKey.GEN_AI_MODEL.getCode();
+
+    private static final int GEN_AI_USAGE =
+            com.navercorp.pinpoint.common.trace.AnnotationKey.GEN_AI_USAGE.getCode();
+
+    @Test
+    void map_genAi_claudeCodeShape_kindUnspecified() {
+        // Claude Code fixture: an llm_request child span — kind=0 (UNSPECIFIED), semconv model
+        // key, bare nonstandard token keys (see the otel-console dump this mirrors).
+        Span span = span(Span.SpanKind.SPAN_KIND_UNSPECIFIED,
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL, strVal("claude-sonnet-4-5")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, intVal(1200)),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS, intVal(340)),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS, intVal(5000)),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS, intVal(0)),
+                kv("gen_ai.response.finish_reasons", strVal("end_turn")));
+
+        SpanEventBo event = mapSingle(span);
+
+        // unclassified kind keeps the INTERNAL_METHOD fallback — the promotion is annotation-only
+        assertThat(event.getServiceType()).isEqualTo(ServiceType.INTERNAL_METHOD.getCode());
+        assertThat(findAnnotation(event, GEN_AI_MODEL)).isEqualTo("claude-sonnet-4-5");
+        assertThat(findAnnotation(event, GEN_AI_USAGE)).isEqualTo("in:1200 out:340 cache_r:5000 cache_w:0");
+        // consumed keys leave the raw attribute list; non-promoted gen_ai keys survive
+        assertThat(attributeKeys(event))
+                .doesNotContain(
+                        OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL,
+                        OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS,
+                        OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS,
+                        OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS,
+                        OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS)
+                .contains("gen_ai.response.finish_reasons");
+    }
+
+    @Test
+    void map_genAi_absent_noAnnotations() {
+        SpanEventBo event = mapSingle(span(Span.SpanKind.SPAN_KIND_UNSPECIFIED));
+
+        assertThat(findAnnotation(event, GEN_AI_MODEL)).isNull();
+        assertThat(findAnnotation(event, GEN_AI_USAGE)).isNull();
+    }
+
+    @Test
+    void map_genAi_clientKind_annotationsStillRecorded() {
+        // a semconv-conformant LLM SDK emits the call as a CLIENT span — the promotion is
+        // kind-independent and must not disturb the CLIENT classification
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_RESPONSE_MODEL, strVal("gpt-oss-120b")),
+                kv(OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS, intVal(10)));
+
+        SpanEventBo event = mapSingle(span);
+
+        assertThat(findAnnotation(event, GEN_AI_MODEL)).isEqualTo("gpt-oss-120b");
+        assertThat(findAnnotation(event, GEN_AI_USAGE)).isEqualTo("in:10");
+        assertThat(event.getServiceType()).isEqualTo(ServiceType.OPENTELEMETRY_CLIENT.getCode());
+    }
 }


### PR DESCRIPTION
The gen_ai.* semconv attributes of LLM-call spans were stored only as generic raw attributes, so the model and token usage were invisible on the call-tree row and unreadable without opening the attribute list.

Add OtlpGenAiRecorder, which promotes two first-class annotations on both the root-span and SpanEvent paths (mirroring the HTTP_METHOD / grpc.status promotions):

- gen_ai.model (409, viewInRecordSet): gen_ai.response.model - the model that actually served the call - over gen_ai.request.model.
- gen_ai.usage (410, viewInRecordSet): a composed summary such as "in:1200 out:340 cache_r:5000 cache_w:0", present parts only.

Each token part resolves through a key ladder: the current semconv key (gen_ai.usage.input_tokens/output_tokens), the pre-rename semconv key (prompt_tokens/completion_tokens), then the bare nonstandard keys that Claude Code emits (input_tokens/output_tokens/cache_read_tokens/ cache_creation_tokens - the cache pair has no semconv equivalent). Only the key actually consumed is filtered from the raw attribute list; non-promoted variants survive.

Deliberately annotation-only: the kind classification is untouched (kind=0 spans keep the INTERNAL_METHOD fallback, CLIENT spans keep OPENTELEMETRY_CLIENT), and no new ServiceType is registered - a GenAI type only becomes meaningful as an aggregation dimension, which is a separate track.

Tests: OtlpGenAiRecorderTest (ladders, precedence, partial/zero/string values, consumedKeys) plus SpanEvent mapper fixtures including the kind=0 Claude Code shape that previously had no test coverage.