### PR TITLE
[#noissue] Promote time to first token to the gen_ai.ttft annotation

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/trace/AnnotationKey.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/trace/AnnotationKey.java
@@ -281,4 +281,8 @@ public interface AnnotationKey {
     // Token usage summary composed from the gen_ai.usage.* attributes (bare nonstandard token
     // keys as fallback), e.g. "in:1200 out:340 cache_r:5000 cache_w:0" — present parts only.
     AnnotationKey GEN_AI_USAGE = AnnotationKeyFactory.of(410, "gen_ai.usage", VIEW_IN_RECORD_SET);
+    // Time to first token, e.g. "2659 ms". Kept separate from GEN_AI_USAGE: usage is the token
+    // namespace and a time value inside it would read as a token count. Source is the bare
+    // ttft_ms key (Claude Code) — OTel semconv defines TTFT only as a metric, not a span attribute.
+    AnnotationKey GEN_AI_TTFT = AnnotationKeyFactory.of(411, "gen_ai.ttft", VIEW_IN_RECORD_SET);
 }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorder.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorder.java
@@ -38,6 +38,9 @@ import java.util.function.Consumer;
  *   <li>{@code gen_ai.usage} (410): a composed summary such as
  *       {@code "in:1200 out:340 cache_r:5000 cache_w:0"}. Only the parts present on the span
  *       are included; when no token attribute is present the annotation is omitted entirely.</li>
+ *   <li>{@code gen_ai.ttft} (411): time to first token, e.g. {@code "2659 ms"} — the streaming
+ *       latency half of the span duration (the rest is token generation). Sourced from the bare
+ *       {@code ttft_ms} key; OTel semconv defines TTFT only as a metric, not a span attribute.</li>
  * </ul>
  *
  * <p>Each token part resolves through a key ladder, mirroring {@link OtlpGrpcStatusResolver}:
@@ -73,6 +76,9 @@ public final class OtlpGenAiRecorder {
     private static final String[] CACHE_CREATION_TOKEN_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS,
     };
+    private static final String[] TTFT_KEYS = {
+            OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS,
+    };
 
     private static final long ABSENT = -1;
 
@@ -91,6 +97,12 @@ public final class OtlpGenAiRecorder {
         final String usage = composeUsage(attributes, consumedKeys);
         if (usage != null) {
             sink.accept(AnnotationBo.of(AnnotationKey.GEN_AI_USAGE.getCode(), usage));
+        }
+        // Kept out of the usage line: usage is the token namespace and a time value inside it
+        // would read as a token count.
+        final long ttftMillis = firstLong(attributes, consumedKeys, TTFT_KEYS);
+        if (ttftMillis != ABSENT) {
+            sink.accept(AnnotationBo.of(AnnotationKey.GEN_AI_TTFT.getCode(), ttftMillis + " ms"));
         }
     }
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -139,6 +139,10 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_OUTPUT_TOKENS = "output_tokens";
     public static final String ATTRIBUTE_KEY_CACHE_READ_TOKENS = "cache_read_tokens";
     public static final String ATTRIBUTE_KEY_CACHE_CREATION_TOKENS = "cache_creation_tokens";
+    // Time to first token in milliseconds — bare nonstandard key emitted by Claude Code. OTel
+    // semconv has no span-attribute counterpart (only the gen_ai.server.time_to_first_token
+    // metric), so the ladder is this single key until one is standardized.
+    public static final String ATTRIBUTE_KEY_TTFT_MS = "ttft_ms";
     // OTel HTTP server semconv: the matched route template (low-cardinality, e.g. "/users/{id}").
     // Takes precedence over url.path/http.url/http.target so the rpc field groups by endpoint
     // pattern instead of the raw, high-cardinality request path. This is the OTel equivalent of

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorderTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorderTest.java
@@ -140,6 +140,46 @@ class OtlpGenAiRecorderTest {
     }
 
     // =======================================================================
+    // ttft — time to first token (bare ttft_ms only; no semconv span attribute exists)
+    // =======================================================================
+
+    @Test
+    void ttft_promotedWithMillisUnit() {
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS, AttributeValue.of(2659L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_TTFT)).isEqualTo("2659 ms");
+        assertThat(consumedKeys).containsExactly(OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS);
+    }
+
+    @Test
+    void ttft_zeroIsPromoted() {
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS, AttributeValue.of(0L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_TTFT)).isEqualTo("0 ms");
+    }
+
+    @Test
+    void ttft_stringTypedNotPromoted() {
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS, AttributeValue.of("2659")));
+
+        assertThat(annotations).isEmpty();
+        assertThat(consumedKeys).isEmpty();
+    }
+
+    @Test
+    void ttft_keptOutOfUsageLine() {
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of(3L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS, AttributeValue.of(2659L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:3");
+        assertThat(annotationValue(AnnotationKey.GEN_AI_TTFT)).isEqualTo("2659 ms");
+    }
+
+    // =======================================================================
     // no-op on non-GenAI spans
     // =======================================================================
 


### PR DESCRIPTION
An LLM span's duration conflates two phases with different bottlenecks: time to first token (context processing, cache misses, server queueing) and token generation (output length). Claude Code reports the boundary as the bare ttft_ms attribute, but it was only visible by expanding the raw Attribute list -- on real traces TTFT can be 95% of the span duration, which changes the interpretation of a slow call entirely.

Promote it to a GEN_AI_TTFT (411, "gen_ai.ttft") annotation, e.g. "2659 ms", next to gen_ai.model/usage. Kept out of the usage line: usage is the token namespace and a time value inside it would read as a token count. The key ladder is the single bare key -- OTel semconv defines TTFT only as a metric (gen_ai.server.time_to_first_token), not a span attribute -- and follows the recorder's existing rules: the consumed key is filtered from the raw attributes, and a string-typed value is not promoted and survives raw.