### PR TITLE
[#noissue] Gate bare GenAI keys on gen_ai context and consume total_t…

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorder.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorder.java
@@ -37,7 +37,9 @@ import java.util.function.Consumer;
  *       {@code gen_ai.request.model}.</li>
  *   <li>{@code gen_ai.usage} (410): a composed summary such as
  *       {@code "in:1200 out:340 cache_r:5000 cache_w:0"}. Only the parts present on the span
- *       are included; when no token attribute is present the annotation is omitted entirely.</li>
+ *       are included; when no token attribute is present the annotation is omitted entirely.
+ *       When only {@code gen_ai.usage.total_tokens} is present (neither the input nor the
+ *       output half resolved) the summary degrades to {@code "tot:410"}.</li>
  *   <li>{@code gen_ai.ttft} (411): time to first token, e.g. {@code "2659 ms"} — the streaming
  *       latency half of the span duration (the rest is token generation). Sourced from the bare
  *       {@code ttft_ms} key; OTel semconv defines TTFT only as a metric, not a span attribute.</li>
@@ -50,33 +52,49 @@ import java.util.function.Consumer;
  * The cache pair ({@code cache_read_tokens} / {@code cache_creation_tokens}) exists only in the
  * bare form — there is no semconv equivalent.</p>
  *
+ * <p>Bare keys are short, generic names ({@code input_tokens}, {@code ttft_ms}) that a non-LLM
+ * instrumentation could coincidentally use, so the bare ladder steps apply only when the span
+ * carries GenAI context — any {@code gen_ai.}-prefixed attribute. The namespaced semconv keys
+ * are their own proof of context and resolve unconditionally. (Claude Code always carries
+ * {@code gen_ai.system}, so its bare-token spans keep resolving.)</p>
+ *
  * <p>Only the key actually consumed by a promotion is added to {@code consumedKeys} (and thereby
  * excluded from the raw attribute list); a non-promoted variant — e.g. a request.model that lost
- * to response.model, or a token carried as a string value — survives as a raw attribute.</p>
+ * to response.model, a total next to a resolved input/output, or a token carried as a string
+ * value — survives as a raw attribute.</p>
  */
 public final class OtlpGenAiRecorder {
+
+    private static final String GEN_AI_KEY_PREFIX = "gen_ai.";
 
     private static final String[] MODEL_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_RESPONSE_MODEL,
             OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL,
     };
-    private static final String[] INPUT_TOKEN_KEYS = {
+    private static final String[] INPUT_SEMCONV_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS,
             OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_PROMPT_TOKENS,
+    };
+    private static final String[] INPUT_BARE_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS,
     };
-    private static final String[] OUTPUT_TOKEN_KEYS = {
+    private static final String[] OUTPUT_SEMCONV_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_OUTPUT_TOKENS,
             OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_COMPLETION_TOKENS,
+    };
+    private static final String[] OUTPUT_BARE_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS,
     };
-    private static final String[] CACHE_READ_TOKEN_KEYS = {
+    private static final String[] TOTAL_SEMCONV_KEYS = {
+            OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_TOTAL_TOKENS,
+    };
+    private static final String[] CACHE_READ_BARE_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS,
     };
-    private static final String[] CACHE_CREATION_TOKEN_KEYS = {
+    private static final String[] CACHE_CREATION_BARE_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS,
     };
-    private static final String[] TTFT_KEYS = {
+    private static final String[] TTFT_BARE_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS,
     };
 
@@ -86,40 +104,71 @@ public final class OtlpGenAiRecorder {
     }
 
     /**
-     * Records the gen_ai.model / gen_ai.usage annotations when the corresponding attributes are
-     * present; a span without GenAI attributes is a no-op.
+     * Records the gen_ai.model / gen_ai.usage / gen_ai.ttft annotations when the corresponding
+     * attributes are present; a span without GenAI attributes is a no-op.
      */
     public static void record(Consumer<AnnotationBo> sink, Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
         final String model = firstString(attributes, consumedKeys, MODEL_KEYS);
         if (model != null) {
             sink.accept(AnnotationBo.of(AnnotationKey.GEN_AI_MODEL.getCode(), model));
         }
-        final String usage = composeUsage(attributes, consumedKeys);
+        final boolean genAiContext = hasGenAiContext(attributes);
+        final String usage = composeUsage(attributes, consumedKeys, genAiContext);
         if (usage != null) {
             sink.accept(AnnotationBo.of(AnnotationKey.GEN_AI_USAGE.getCode(), usage));
         }
         // Kept out of the usage line: usage is the token namespace and a time value inside it
         // would read as a token count.
-        final long ttftMillis = firstLong(attributes, consumedKeys, TTFT_KEYS);
-        if (ttftMillis != ABSENT) {
-            sink.accept(AnnotationBo.of(AnnotationKey.GEN_AI_TTFT.getCode(), ttftMillis + " ms"));
+        if (genAiContext) {
+            final long ttftMillis = firstLong(attributes, consumedKeys, TTFT_BARE_KEYS);
+            if (ttftMillis != ABSENT) {
+                sink.accept(AnnotationBo.of(AnnotationKey.GEN_AI_TTFT.getCode(), ttftMillis + " ms"));
+            }
         }
     }
 
-    private static String composeUsage(Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
-        final long input = firstLong(attributes, consumedKeys, INPUT_TOKEN_KEYS);
-        final long output = firstLong(attributes, consumedKeys, OUTPUT_TOKEN_KEYS);
-        final long cacheRead = firstLong(attributes, consumedKeys, CACHE_READ_TOKEN_KEYS);
-        final long cacheCreation = firstLong(attributes, consumedKeys, CACHE_CREATION_TOKEN_KEYS);
-        if (input == ABSENT && output == ABSENT && cacheRead == ABSENT && cacheCreation == ABSENT) {
+    private static boolean hasGenAiContext(Map<String, AttributeValue> attributes) {
+        for (String key : attributes.keySet()) {
+            if (key.startsWith(GEN_AI_KEY_PREFIX)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String composeUsage(Map<String, AttributeValue> attributes, Set<String> consumedKeys, boolean genAiContext) {
+        final long input = resolveToken(attributes, consumedKeys, INPUT_SEMCONV_KEYS, INPUT_BARE_KEYS, genAiContext);
+        final long output = resolveToken(attributes, consumedKeys, OUTPUT_SEMCONV_KEYS, OUTPUT_BARE_KEYS, genAiContext);
+        final long cacheRead = genAiContext ? firstLong(attributes, consumedKeys, CACHE_READ_BARE_KEYS) : ABSENT;
+        final long cacheCreation = genAiContext ? firstLong(attributes, consumedKeys, CACHE_CREATION_BARE_KEYS) : ABSENT;
+        // Next to a resolved input/output a total is a derived duplicate (and may disagree — the
+        // raw value is the evidence), so it is consumed only when neither half resolved.
+        final long total = (input == ABSENT && output == ABSENT)
+                ? firstLong(attributes, consumedKeys, TOTAL_SEMCONV_KEYS)
+                : ABSENT;
+        if (input == ABSENT && output == ABSENT && total == ABSENT
+                && cacheRead == ABSENT && cacheCreation == ABSENT) {
             return null;
         }
         final StringJoiner joiner = new StringJoiner(" ");
         appendPart(joiner, "in", input);
         appendPart(joiner, "out", output);
+        appendPart(joiner, "tot", total);
         appendPart(joiner, "cache_r", cacheRead);
         appendPart(joiner, "cache_w", cacheCreation);
         return joiner.toString();
+    }
+
+    private static long resolveToken(Map<String, AttributeValue> attributes, Set<String> consumedKeys,
+                                     String[] semconvKeys, String[] bareKeys, boolean genAiContext) {
+        final long semconv = firstLong(attributes, consumedKeys, semconvKeys);
+        if (semconv != ABSENT) {
+            return semconv;
+        }
+        if (!genAiContext) {
+            return ABSENT;
+        }
+        return firstLong(attributes, consumedKeys, bareKeys);
     }
 
     private static void appendPart(StringJoiner joiner, String label, long value) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -137,6 +137,9 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens";
     public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens";
     public static final String ATTRIBUTE_KEY_OUTPUT_TOKENS = "output_tokens";
+    // Some SDKs report only the total; consumed only when neither the input nor the output half
+    // resolved — next to them a total is a derived duplicate and survives raw.
+    public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens";
     public static final String ATTRIBUTE_KEY_CACHE_READ_TOKENS = "cache_read_tokens";
     public static final String ATTRIBUTE_KEY_CACHE_CREATION_TOKENS = "cache_creation_tokens";
     // Time to first token in milliseconds — bare nonstandard key emitted by Claude Code. OTel

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorderTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorderTest.java
@@ -34,6 +34,9 @@ class OtlpGenAiRecorderTest {
     private final List<AnnotationBo> annotations = new ArrayList<>();
     private final Set<String> consumedKeys = new HashSet<>();
 
+    // GenAI context marker for bare-key fixtures — Claude Code always carries it
+    private static final String GEN_AI_SYSTEM = "gen_ai.system";
+
     private void record(Map<String, AttributeValue> attributes) {
         OtlpGenAiRecorder.record(annotations::add, attributes, consumedKeys);
     }
@@ -85,8 +88,10 @@ class OtlpGenAiRecorderTest {
 
     @Test
     void usage_claudeCodeBareKeys() {
-        // Claude Code shape: bare nonstandard token keys (kind=0 llm_request span)
+        // Claude Code shape: bare nonstandard token keys on a span that always carries
+        // gen_ai.system (the GenAI context that admits the bare ladder steps)
         record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of(1200L),
                 OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS, AttributeValue.of(340L),
                 OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS, AttributeValue.of(5000L),
@@ -124,6 +129,7 @@ class OtlpGenAiRecorderTest {
     @Test
     void usage_partialPartsOnly() {
         record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS, AttributeValue.of(42L)));
 
         assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("out:42");
@@ -133,10 +139,45 @@ class OtlpGenAiRecorderTest {
     void usage_stringTypedTokenNotPromoted() {
         // a token carried as a string value cannot be promoted and must survive as a raw attribute
         record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of("1200")));
 
         assertThat(annotations).isEmpty();
         assertThat(consumedKeys).isEmpty();
+    }
+
+    @Test
+    void usage_bareKeysWithoutGenAiContextNotPromoted() {
+        // bare names are generic — without any gen_ai.* attribute they are not LLM evidence
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of(1200L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS, AttributeValue.of(5000L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS, AttributeValue.of(2659L)));
+
+        assertThat(annotations).isEmpty();
+        assertThat(consumedKeys).isEmpty();
+    }
+
+    @Test
+    void usage_totalOnlyFallback() {
+        // some SDKs report only the total — without it the whole usage line would be lost
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_TOTAL_TOKENS, AttributeValue.of(410L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("tot:410");
+        assertThat(consumedKeys).containsExactly(OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_TOTAL_TOKENS);
+    }
+
+    @Test
+    void usage_totalNextToInputOutputStaysRaw() {
+        // next to a resolved half the total is a derived duplicate — not consumed, survives raw
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS, AttributeValue.of(100L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_OUTPUT_TOKENS, AttributeValue.of(50L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_TOTAL_TOKENS, AttributeValue.of(150L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:100 out:50");
+        assertThat(consumedKeys).doesNotContain(OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_TOTAL_TOKENS);
     }
 
     // =======================================================================
@@ -146,6 +187,7 @@ class OtlpGenAiRecorderTest {
     @Test
     void ttft_promotedWithMillisUnit() {
         record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS, AttributeValue.of(2659L)));
 
         assertThat(annotationValue(AnnotationKey.GEN_AI_TTFT)).isEqualTo("2659 ms");
@@ -155,6 +197,7 @@ class OtlpGenAiRecorderTest {
     @Test
     void ttft_zeroIsPromoted() {
         record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS, AttributeValue.of(0L)));
 
         assertThat(annotationValue(AnnotationKey.GEN_AI_TTFT)).isEqualTo("0 ms");
@@ -163,6 +206,7 @@ class OtlpGenAiRecorderTest {
     @Test
     void ttft_stringTypedNotPromoted() {
         record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS, AttributeValue.of("2659")));
 
         assertThat(annotations).isEmpty();
@@ -172,6 +216,7 @@ class OtlpGenAiRecorderTest {
     @Test
     void ttft_keptOutOfUsageLine() {
         record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
                 OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of(3L),
                 OtlpTraceConstants.ATTRIBUTE_KEY_TTFT_MS, AttributeValue.of(2659L)));
 


### PR DESCRIPTION
…okens

The GenAI recorder runs on every span and promoted on key presence alone. The namespaced gen_ai.* keys are their own proof of an LLM call, but the bare fallback keys (input_tokens, output_tokens, cache_*, ttft_ms) are short, generic names that a non-LLM instrumentation could coincidentally use -- such a span would grow a misleading gen_ai.usage/ gen_ai.ttft annotation. Apply the bare ladder steps only when the span carries GenAI context (any gen_ai.-prefixed attribute). Claude Code -- the only known bare-key emitter -- always carries gen_ai.system, so its spans resolve unchanged.

Also consume gen_ai.usage.total_tokens: SDKs that report only the total previously lost the whole usage line. It resolves only when neither the input nor the output half did ("tot:410"); next to a resolved half a total is a derived duplicate and survives as a raw attribute.