### PR TITLE
Query servicemap charts with the selected node's own service

### DIFF
--- a/web-frontend/src/main/v3/.claude/rules/service-map.md
+++ b/web-frontend/src/main/v3/.claude/rules/service-map.md
@@ -111,6 +111,66 @@ service 전체를 대상으로 필터를 걸 수 있게 할지 정해지면 경�
 - 첫 세그먼트가 `{app}@{type}`으로 파싱되면 serviceName이 아니다. serviceName 세그먼트가 생기기
   전 형태(`/serviceMap/myApp@TOMCAT`)의 링크·북마크를 살리기 위한 가드다.
 
+## 화면의 service ≠ 조회 대상의 service
+
+경로의 serviceName은 **map을 그리는 service**다. 그런데 map에는 다른 service의 application도
+함께 그려진다(service group을 펼쳐 고른 자식 노드). 그런 노드를 고르면 우측 패널의 조회는
+경로의 service가 아니라 **그 노드의 service**로 나가야 한다.
+
+```
+(A service) -> (B service)
+```
+A의 servicemap에서 B의 `b-1`을 고르면 chartBoard 조회는 `pServiceName: B`로 나간다.
+A로 나가면 백엔드가 A service에서 `b-1`을 찾으므로 데이터가 비어서 온다. (이슈 #10497)
+
+### 전달은 prop으로 한다
+
+`useServerMapTargetServiceName`이 고른 대상의 service를 읽고, 우측 패널의 컴포넌트들에
+`serviceName` prop으로 내려준다. 받은 컴포넌트는 조회 훅과 링크 생성에 그 값을 쓴다.
+**prop을 받지 않으면 화면의 service로 조회한다**(`serviceName ?? useServiceNameForLink()`).
+그래서 filteredMap·inspector처럼 이 값을 넘기지 않는 화면은 동작이 그대로다.
+
+- 값의 출처는 백엔드가 노드마다 내려주는 `serviceName`(= `application.getService()`)이다.
+  링크는 자기 service가 없어 출발지 노드의 service를 쓴다(링크 통계의 기준 application과 같다).
+- `enableServiceMap`이 꺼져 있으면 `useServerMapTargetServiceName`이 undefined를 반환한다.
+  설정이 꺼진 저장소로 헤더가 새어 나가지 않도록 **그 한 곳에서** 막는다.
+- **prop을 내려주는 곳을 빠뜨리면 그 차트만 조용히 화면의 service로 조회한다.** 화면은 멀쩡히
+  그려지고 숫자만 비어서, 타입 검사로도 잡히지 않는다. 우측 패널에 조회하는 컴포넌트를 새로
+  추가하면 `serviceName`도 함께 내려야 한다.
+  → 지금 내려주는 곳: `ServerMapChartsBoardFetcher`, `Realtime`
+
+### 헤더와 캐시 키는 같은 값에서 나온다
+
+- 조회 훅은 `queryFn(url, { serviceName })`으로 헤더를 직접 싣고, **queryKey에도 같은 값을 넣는다.**
+  헤더만 갈리고 캐시 키가 같으면 이름이 같은 다른 service의 application끼리 캐시가 섞인다.
+- fetch 인터셉터는 **이미 실린 헤더를 덮어쓰지 않는다.** 인터셉터는 경로/전역 선택값만 보므로
+  "고른 노드가 다른 service 소속"이라는 사실을 알 수 없다.
+
+### serviceName은 기준 application과 같은 commit에 바뀌어야 한다
+
+조회 훅 상당수가 파라미터를 state에 담고 `useEffect`로 동기화한다(그 자리에서 계산하지 않는다).
+그래서 대상이 바뀌는 렌더에서는 파라미터가 한 박자 뒤처진다. serviceName을 prop 그대로 쓰면
+그 한 렌더 동안 **(이전 application, 새 service)** 짝의 queryKey가 만들어지고, 캐시에 없는 키라
+React Query가 곧바로 요청을 날린다 — 그 service에 없는 application을 묻는 요청이라 400이 온다.
+
+그래서 serviceName도 **파라미터를 갱신하는 그 effect 안에서** 함께 state로 옮긴다(두 setState가
+같은 commit에 배치되므로 짝이 어긋나지 않는다). queryKey와 헤더에는 prop이 아니라 그 state
+(`requestServiceName`)를 쓴다. deferred를 쓰는 스캐터는 serviceName도 같이 deferred로 넘긴다.
+
+→ `useGetApdexScore`, `useGetHistogramStatistics`, `useGetScatterData`,
+`useGetScatterRealtimeData`, `HeatmapFetcher`, `HeatmapRealtimeFetcher`
+
+파라미터를 그 자리에서 계산하는 훅(`useGetAgentOverview`)은 이 처리가 필요 없다.
+링크 생성에 쓰는 값은 요청이 아니므로 최신 prop을 그대로 쓴다(`HeatmapChartCore`).
+
+### 통계 API는 기준 application도 함께 갈아야 한다
+
+경로의 application은 화면 service 소속이라, 대상의 service로 나가는 요청의 기준이 될 수 없다
+(백엔드가 그 이름을 대상의 service에서 찾는다). 대상이 다른 service면 노드 자신을 기준으로 삼는다.
+→ `useGetHistogramStatistics`의 `ignorePathApplication`
+
+액티브 스레드(실시간)는 WebSocket이라 헤더가 없다. 지금도 service를 싣지 않는다.
+
 ## map 노드/링크 id 형식이 API마다 다르다
 
 | API | render | node key |
@@ -191,6 +251,7 @@ servermap/filteredMap 응답에는 이 필드가 없어 그 화면들의 동작�
 | 경로에 실린 serviceName 읽기 | `utils/helper/application.ts` (`getServiceNameFromPath`) |
 | 경로 분해 (로더용) | `utils/helper/application.ts` (`parseServiceScopedPath`) |
 | 경로 만들기 | `utils/helper/route.ts` (`getServiceMapPath`, `getServiceMapRealtimePath`, `getFilteredMapPath`, `getTransactionListPath`) |
+| 조회 대상의 service | `hooks/serverMap/useServerMapTargetServiceName.ts` |
 | 요청 헤더 주입 | `hooks/api/serviceNameFetchInterceptor.ts` |
 | service 단위 캐시 키 | `hooks/api/reactQueryHelper.tsx` (`serviceScopedQueryKeyHashFn`) |
 | service 변경 시 초기화 | `hooks/utility/useClearApplicationOnServiceChange.ts` |

--- a/web-frontend/src/main/v3/apps/web/dev-mock/README.md
+++ b/web-frontend/src/main/v3/apps/web/dev-mock/README.md
@@ -1,0 +1,72 @@
+# dev-mock — 로컬 확인용 임시 mock (#10497)
+
+> **이 디렉터리는 임시입니다.** 사내 이슈(#10497)
+> 확인이 끝나면 아래 "삭제 방법"대로 지우면 됩니다. 프로덕션 번들에는 들어가지 않습니다
+> (`apply: 'serve'`라 vite dev 서버에서만 동작합니다).
+
+## 왜 필요한가
+
+#10497은 **service가 둘 이상이고 서로 호출하는** 저장소에서만 재현됩니다.
+
+```
+(A service) -> (B service)
+```
+
+A service의 servicemap에는 B service가 group 노드로 함께 그려지고, 그 group을 펼쳐 `b-1`을 고르면
+우측 ChartsBoard 조회가 `pServiceName: B`로 나가야 합니다(고치기 전에는 화면의 service인 `A`로 나감).
+로컬 저장소에는 보통 service가 하나뿐이라 이 상황 자체를 만들 수 없어, dev 서버가 map 응답을
+대신 내려줍니다.
+
+## 사용 방법
+
+```bash
+yarn dev:mock          # = MOCK_SERVICE_MAP=1 yarn dev
+```
+
+그 다음 브라우저에서:
+
+```
+http://localhost:3000/serviceMap/A
+```
+
+1. map에 `a-1`, `a-2` (service **A**) 와 `B` group 노드가 그려집니다.
+2. `B` group 노드를 클릭하면 팝업에 `b-1`, `b-2`가 나옵니다. `b-1`을 고릅니다.
+3. 우측 ChartsBoard에서 **VIEW SERVERS**를 눌러 서버 목록의 agent 이름을 봅니다.
+   - `b-1-agent / pServiceName=B` → 정상 (고쳐진 동작)
+   - `b-1-agent / pServiceName=A` → 이슈 재현 (화면의 service로 나감)
+4. 터미널에도 `/api` 요청마다 실려 나간 헤더가 찍힙니다.
+   ```
+   [mock #10497] MOCK  /api/histogram/statistics pServiceName=B
+   [mock #10497] pass  /api/applications pServiceName=A
+   ```
+   `MOCK`은 mock이 대신 응답한 것, `pass`는 실제 백엔드로 넘긴 것입니다.
+
+`a-1`을 골랐을 때는 `pServiceName=A`로 나가야 합니다. 같이 확인하세요.
+
+## 무엇을 가로채는가
+
+| 경로 | 동작 |
+|---|---|
+| `/api/configuration` | 실제 백엔드 응답에 `experimental.enableServiceMap.value: true`만 강제로 켜서 내려줍니다. 백엔드가 안 떠 있으면 최소 설정으로 폴백합니다. |
+| `/api/v2/services` | 실제 목록에 mock service `A`, `B`를 덧붙입니다. |
+| `/api/servermap/serviceMap` | `pServiceName`이 `A`/`B`일 때만 mock map을 내려줍니다. |
+| `/api/histogram/statistics`(`/links`), `/api/getApdexScore`, `/api/agents/overview`, `/api/getScatterData`, `/api/heatmap/applicationData` | 조회 대상이 mock application(`a-1`, `a-2`, `b-1`, `b-2`)이거나 service group 노드(`A`, `B`)일 때만 가로챕니다. 응답에 **요청에 실려 온 `pServiceName`을 그대로 박아** 내려줍니다. |
+| 그 외 `/api/*` | 실제 백엔드로 그대로 넘어갑니다(로그만 남김). |
+
+그래서 mock을 켜 둔 채로도 나머지 화면은 평소대로 쓸 수 있습니다.
+실제 백엔드 주소는 `MOCK_UPSTREAM` 환경변수로 바꿀 수 있습니다(기본값 `http://localhost:8080`).
+
+## 삭제 방법
+
+`MOCK #10497` 로 grep하면 손댄 곳이 전부 나옵니다.
+
+```bash
+cd web-frontend/src/main/v3
+grep -rn "MOCK #10497\|dev-mock\|dev:mock" apps/web --exclude-dir=node_modules --exclude-dir=dist
+```
+
+1. `apps/web/dev-mock/` 디렉터리 삭제
+2. `apps/web/vite.config.ts` — `serviceMapMockPlugin` import 1줄과 `plugins`의 호출 1줄 삭제 (`// [MOCK #10497]` 주석 포함)
+3. `apps/web/package.json` — `"dev:mock"` 스크립트 삭제
+4. `package.json`(v3 루트) — `"dev:mock"` 스크립트 삭제
+5. `apps/web/tsconfig.node.json` — `include`의 `"dev-mock/**/*.ts"` 삭제

--- a/web-frontend/src/main/v3/apps/web/dev-mock/index.ts
+++ b/web-frontend/src/main/v3/apps/web/dev-mock/index.ts
@@ -1,0 +1,279 @@
+/**
+ * [MOCK #10497] 로컬 개발 서버(vite dev)에서만 동작하는 임시 mock API.
+ *
+ * 이슈 #10497("servicemap에서 다른 service의 application을 고르면 그 service로 조회해야 한다")을
+ * 로컬에서 확인하려면 service가 둘 이상이고 서로 호출하는 저장소가 필요하다. 그런 저장소를
+ * 준비하는 대신 dev 서버가 그 응답을 대신 내려준다.
+ *
+ * 기본값은 꺼져 있고, `MOCK_SERVICE_MAP=1`일 때만 붙는다(= `yarn dev:mock`).
+ * 가로채지 않는 `/api` 요청은 그대로 실제 백엔드로 프록시되므로, 켜 두어도 나머지 화면은 평소대로 쓸 수 있다.
+ *
+ * 이 디렉터리는 통째로 지울 수 있다. 지우는 방법은 README.md 참고.
+ */
+
+/* eslint-disable no-console */
+
+import type { Plugin } from 'vite';
+import {
+  MOCK_APPLICATIONS,
+  MOCK_SERVICES,
+  OTHER_SERVICE,
+  VIEWING_SERVICE,
+  makeAgentOverviewResponse,
+  makeApdexScoreResponse,
+  makeHeatmapResponse,
+  makeHistogramStatisticsResponse,
+  makeScatterResponse,
+  makeServiceMapResponse,
+} from './mockData';
+
+/** 가로채지 않고 실제 백엔드로 넘긴다는 표시. */
+const PASS_THROUGH = Symbol('pass-through');
+
+/** 실제 백엔드. vite proxy의 target과 같아야 한다. */
+const UPSTREAM = process.env.MOCK_UPSTREAM || 'http://localhost:8080';
+const UPSTREAM_TIMEOUT = 2000;
+
+const LOG_PREFIX = '[mock #10497]';
+const SERVICE_NAME_HEADER = 'pservicename';
+
+interface MockContext {
+  url: URL;
+  /** 이 요청에 실려 온 pServiceName. 비어 있으면 헤더가 붙지 않은 것이다. */
+  requestedServiceName: string;
+}
+
+type MockHandler = (context: MockContext) => Promise<unknown> | unknown;
+
+const BASIC_ISO = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(\.\d+)?Z$/;
+
+/** 프론트가 보내는 basic ISO(`20260821T031500Z`)와 epoch ms를 모두 받는다. */
+const parseTime = (value: string | null, fallback: number) => {
+  if (!value) {
+    return fallback;
+  }
+
+  const matched = BASIC_ISO.exec(value);
+  if (matched) {
+    const [, year, month, day, hour, minute, second, ms = ''] = matched;
+    return Date.parse(`${year}-${month}-${day}T${hour}:${minute}:${second}${ms}Z`);
+  }
+
+  const parsed = /^\d+$/.test(value) ? Number(value) : Date.parse(value);
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+const getRange = (url: URL) => {
+  const now = Date.now();
+  const from = parseTime(url.searchParams.get('from'), now - 5 * 60 * 1000);
+  const to = parseTime(url.searchParams.get('to'), now);
+  return { from, to };
+};
+
+/** 조회 대상 application. 파라미터 이름이 API마다 다르다. */
+const getApplicationName = (url: URL) =>
+  url.searchParams.get('applicationName') || url.searchParams.get('application') || '';
+
+const fetchUpstream = async <T>(path: string): Promise<T | undefined> => {
+  try {
+    const response = await fetch(`${UPSTREAM}${path}`, {
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT),
+    });
+    return response.ok ? ((await response.json()) as T) : undefined;
+  } catch {
+    // 백엔드가 안 떠 있어도 mock 화면은 볼 수 있어야 하므로 조용히 폴백한다.
+    return undefined;
+  }
+};
+
+/**
+ * 백엔드가 안 떠 있을 때 쓰는 최소 configuration.
+ * 실제 백엔드가 떠 있으면 그 응답에 `enableServiceMap`만 켜서 내려준다.
+ */
+const FALLBACK_CONFIGURATION = {
+  webhookEnable: false,
+  showActiveThread: true,
+  showActiveThreadDump: false,
+  sendUsage: false,
+  editUserInfo: false,
+  enableServerMapRealTime: true,
+  showApplicationStat: true,
+  showStackTraceOnError: true,
+  showSystemMetric: false,
+  showUrlStat: false,
+  showExceptionTrace: false,
+  showOtlpMetric: false,
+  showInspector: true,
+  showHeatmap: true,
+  openSource: true,
+  version: 'mock',
+  'experimental.enableHeatmap.value': true,
+  'experimental.enableHeatmap.description': 'mock',
+  'experimental.enableServerMapRealTime.value': true,
+  'experimental.enableServerMapRealTime.description': 'mock',
+  'experimental.enableServerSideScanForScatter.value': false,
+  'experimental.enableServerSideScanForScatter.description': 'mock',
+  'experimental.useStatisticsAgentState.value': true,
+  'experimental.useStatisticsAgentState.description': 'mock',
+  'experimental.sampleScatter.value': false,
+  'experimental.sampleScatter.description': 'mock',
+  'experimental.enableServiceMap.value': true,
+  'periodMax.exceptionTrace': 28,
+  'periodInterval.exceptionTrace': ['5m', '20m', '1h', '3h', '6h', '12h', '1d', '2d'],
+  'periodMax.inspector': 28,
+  'periodInterval.inspector': ['5m', '20m', '1h', '3h', '6h', '12h', '1d', '2d'],
+  'periodMax.otlpMetric': 28,
+  'periodInterval.otlpMetric': ['5m', '20m', '1h', '3h', '6h', '12h', '1d', '2d'],
+  'periodMax.serverMap': 2,
+  'periodInterval.serverMap': ['5m', '20m', '1h', '3h', '6h', '12h', '1d', '2d'],
+  'periodMax.systemMetric': 28,
+  'periodInterval.systemMetric': ['5m', '20m', '1h', '3h', '6h', '12h', '1d', '2d'],
+  'periodMax.uriStat': 28,
+  'periodInterval.uriStat': ['5m', '20m', '1h', '3h', '6h', '12h', '1d', '2d'],
+};
+
+/**
+ * mock이 응답할 조회 대상 이름.
+ *
+ * service group 노드(접힌 service)를 그대로 고르면 그 노드의 applicationName이 serviceName이라
+ * `B`로 조회가 나간다. 그것까지 받아 주지 않으면 실제 백엔드가 400을 돌려주고 화면에 에러 토스트가
+ * 떠서, 정작 확인하려는 흐름이 가려진다.
+ */
+const MOCK_TARGET_NAMES = [...MOCK_APPLICATIONS, ...MOCK_SERVICES];
+
+/**
+ * application 단위 조회는 mock 대상일 때만 가로챈다.
+ * 그 외에는 실제 백엔드로 넘겨서, mock을 켜 둔 채로도 평소 화면을 그대로 볼 수 있게 한다.
+ */
+const forMockApplication =
+  (build: (applicationName: string, context: MockContext) => unknown): MockHandler =>
+  (context) => {
+    const applicationName = getApplicationName(context.url);
+    return MOCK_TARGET_NAMES.includes(applicationName)
+      ? build(applicationName, context)
+      : PASS_THROUGH;
+  };
+
+const handlers: Record<string, MockHandler> = {
+  // 설정이 꺼져 있으면 화면에 service 개념 자체가 없으므로 여기서 강제로 켠다.
+  '/api/configuration': async () => {
+    const upstream = await fetchUpstream<Record<string, unknown>>('/api/configuration');
+    return {
+      ...(upstream ?? FALLBACK_CONFIGURATION),
+      'experimental.enableServiceMap.value': true,
+    };
+  },
+
+  // service 선택 박스에 mock service가 보이도록 실제 목록에 덧붙인다.
+  '/api/v2/services': async () => {
+    const upstream = (await fetchUpstream<string[]>('/api/v2/services')) ?? ['DEFAULT'];
+    const merged = [...upstream];
+    MOCK_SERVICES.forEach((service) => {
+      if (!merged.includes(service)) {
+        merged.push(service);
+      }
+    });
+    return merged;
+  },
+
+  // mock service를 보고 있을 때만 map을 대신 내려준다.
+  '/api/servermap/serviceMap': ({ url, requestedServiceName }) => {
+    if (!MOCK_SERVICES.includes(requestedServiceName)) {
+      return PASS_THROUGH;
+    }
+    const { from, to } = getRange(url);
+    return makeServiceMapResponse(from, to);
+  },
+
+  '/api/histogram/statistics': forMockApplication(
+    (applicationName, { url, requestedServiceName }) => {
+      const { from, to } = getRange(url);
+      return makeHistogramStatisticsResponse(applicationName, requestedServiceName, from, to);
+    },
+  ),
+
+  '/api/histogram/statistics/links': forMockApplication(
+    (applicationName, { url, requestedServiceName }) => {
+      const { from, to } = getRange(url);
+      return makeHistogramStatisticsResponse(applicationName, requestedServiceName, from, to);
+    },
+  ),
+
+  '/api/getApdexScore': forMockApplication((applicationName, { requestedServiceName }) =>
+    makeApdexScoreResponse(applicationName, requestedServiceName),
+  ),
+
+  '/api/agents/overview': forMockApplication((applicationName, { url, requestedServiceName }) => {
+    const { to } = getRange(url);
+    return makeAgentOverviewResponse(applicationName, requestedServiceName, to);
+  }),
+
+  '/api/getScatterData': forMockApplication((applicationName, { url, requestedServiceName }) => {
+    const { from, to } = getRange(url);
+    return makeScatterResponse(applicationName, requestedServiceName, from, to);
+  }),
+
+  '/api/heatmap/applicationData': forMockApplication(
+    (applicationName, { url, requestedServiceName }) => {
+      const { from, to } = getRange(url);
+      return makeHeatmapResponse(applicationName, requestedServiceName, from, to);
+    },
+  ),
+};
+
+const isEnabled = () =>
+  ['1', 'true', 'on'].includes(String(process.env.MOCK_SERVICE_MAP ?? '').toLowerCase());
+
+export const serviceMapMockPlugin = (): Plugin => ({
+  name: 'pinpoint-dev-mock-service-map',
+  apply: 'serve',
+  configureServer(server) {
+    if (!isEnabled()) {
+      return;
+    }
+
+    console.log(
+      `${LOG_PREFIX} mock API 활성화. service "${VIEWING_SERVICE}"의 servicemap에 service ` +
+        `"${OTHER_SERVICE}"가 group 노드로 그려집니다. → /serviceMap/${VIEWING_SERVICE}`,
+    );
+
+    server.middlewares.use(async (req, res, next) => {
+      const path = req.url ?? '/';
+      if (!path.startsWith('/api')) {
+        next();
+        return;
+      }
+
+      const url = new URL(path, 'http://localhost');
+      const requestedServiceName = String(req.headers[SERVICE_NAME_HEADER] ?? '');
+      const handler = handlers[url.pathname];
+
+      // 가로채지 않는 요청도 어떤 service로 나갔는지는 남긴다. 헤더 확인이 이 이슈의 핵심이다.
+      const logSuffix = `pServiceName=${requestedServiceName || '(none)'}`;
+
+      if (!handler) {
+        console.log(`${LOG_PREFIX} pass  ${url.pathname} ${logSuffix}`);
+        next();
+        return;
+      }
+
+      try {
+        const body = await handler({ url, requestedServiceName });
+
+        if (body === PASS_THROUGH) {
+          console.log(`${LOG_PREFIX} pass  ${url.pathname} ${logSuffix}`);
+          next();
+          return;
+        }
+
+        console.log(`${LOG_PREFIX} MOCK  ${url.pathname} ${logSuffix}`);
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        res.end(JSON.stringify(body));
+      } catch (error) {
+        console.error(`${LOG_PREFIX} handler error on ${url.pathname}`, error);
+        next();
+      }
+    });
+  },
+});

--- a/web-frontend/src/main/v3/apps/web/dev-mock/mockData.ts
+++ b/web-frontend/src/main/v3/apps/web/dev-mock/mockData.ts
@@ -1,0 +1,370 @@
+/**
+ * [MOCK #10497] 로컬에서 cross-service servicemap을 재현하기 위한 임시 mock 데이터.
+ *
+ * 이슈 #10497의 상황을 로컬 저장소에 만들어 두기 위한 것이다.
+ *
+ *   (A service) -> (B service)
+ *
+ * A service의 servicemap에 B service가 group 노드로 함께 그려지고, group을 펼쳐 `b-1`을 고르면
+ * 우측 ChartsBoard의 조회가 `pServiceName: B`로 나가야 한다. 로컬 저장소에는 보통 service가
+ * 하나뿐이라 이 상황 자체를 만들 수 없어서 map 응답을 통째로 mock한다.
+ *
+ * 조회 응답에는 **요청에 실려 온 pServiceName을 그대로 박아서** 내려준다(서버 목록의 agent 이름).
+ * 화면만 보고도 어떤 service로 요청이 나갔는지 알 수 있게 하기 위한 것이다.
+ * 고친 뒤: `b-1`을 고르면 `pServiceName=B`. 고치기 전: 화면의 service인 `pServiceName=A`.
+ *
+ * 이 파일이 있는 `dev-mock/` 디렉터리는 통째로 지울 수 있다. 지우는 방법은 README.md 참고.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** map을 그리는(= 화면에서 보고 있는) service */
+export const VIEWING_SERVICE = 'A';
+/** map에 group 노드로 함께 그려지는 다른 service */
+export const OTHER_SERVICE = 'B';
+
+export const MOCK_SERVICES = [VIEWING_SERVICE, OTHER_SERVICE];
+
+const VIEWING_APPS = ['a-1', 'a-2'];
+const OTHER_APPS = ['b-1', 'b-2'];
+
+/** mock이 가로챌 application. 그 외 application 조회는 실제 백엔드로 그대로 넘긴다. */
+export const MOCK_APPLICATIONS = [...VIEWING_APPS, ...OTHER_APPS];
+
+const TOMCAT = { serviceType: 'TOMCAT', serviceTypeCode: 1010, nodeCategory: 'SERVER' };
+const USER = { serviceType: 'USER', serviceTypeCode: 2, nodeCategory: 'USER' };
+
+type NodeType = typeof TOMCAT;
+
+/** 같은 입력이면 항상 같은 수치가 나오도록 하는 결정적 seed. service마다 수치가 달라 보이게 한다. */
+const seedOf = (...parts: string[]) =>
+  parts
+    .join('^')
+    .split('')
+    .reduce((acc, char) => (acc * 31 + char.charCodeAt(0)) % 89, 7) + 5;
+
+const makeHistogram = (seed: number) => ({
+  '1s': seed * 12,
+  '3s': seed * 4,
+  '5s': seed * 2,
+  Slow: seed,
+  Error: Math.floor(seed / 3),
+});
+
+const sumOf = (histogram: Record<string, number>) =>
+  Object.values(histogram).reduce((acc, value) => acc + value, 0);
+
+const makeResponseStatistics = (seed: number) => ({
+  Tot: seed * 19,
+  Sum: seed * 19 * (80 + seed),
+  Avg: 80 + seed,
+  Max: 300 + seed * 7,
+});
+
+const HISTOGRAM_KEYS = ['1s', '3s', '5s', 'Slow', 'Error'];
+
+const makeTimeSeriesHistogram = (seed: number, timestamps: number[]) =>
+  HISTOGRAM_KEYS.map((key, keyIndex) => ({
+    key,
+    values: timestamps.map(
+      (_, index) => Math.round(seed / (keyIndex + 1)) + ((index * (seed + keyIndex)) % 5),
+    ),
+  }));
+
+const makeApdex = (seed: number) => {
+  const totalSamples = seed * 19;
+  const satisfiedCount = Math.round(totalSamples * 0.8);
+  const toleratingCount = Math.round(totalSamples * 0.1);
+
+  return {
+    apdexScore: Number(((satisfiedCount + toleratingCount / 2) / totalSamples).toFixed(2)),
+    apdexFormula: { satisfiedCount, toleratingCount, totalSamples },
+  };
+};
+
+/** 지정한 구간을 균등하게 나눈 timestamp. timeSeries 값 배열의 길이 기준이 된다. */
+export const makeTimestamps = (from: number, to: number, count = 20) => {
+  const step = Math.max(1, Math.floor((to - from) / count));
+  return Array.from({ length: count }, (_, index) => from + step * index);
+};
+
+const makeAppNode = (
+  serviceName: string,
+  applicationName: string,
+  nodeType: NodeType,
+  timestamps: number[],
+) => {
+  const seed = seedOf(serviceName, applicationName);
+  const histogram = makeHistogram(seed);
+  const agentId = `${applicationName}-agent`;
+
+  return {
+    type: 'app',
+    // servicemap의 노드 key는 3단이다: serviceName^applicationName^serviceType
+    key: `${serviceName}^${applicationName}^${nodeType.serviceType}`,
+    // 통계 API가 쓰는 2단 key.
+    nodeKey: `${applicationName}^${nodeType.serviceType}`,
+    serviceKey: serviceName,
+    serviceName,
+    applicationName,
+    serviceType: nodeType.serviceType,
+    serviceTypeCode: nodeType.serviceTypeCode,
+    nodeCategory: nodeType.nodeCategory,
+    isQueue: false,
+    isAuthorized: true,
+    totalCount: sumOf(histogram),
+    errorCount: histogram.Error,
+    slowCount: histogram.Slow,
+    hasAlert: false,
+    responseStatistics: makeResponseStatistics(seed),
+    histogram,
+    apdex: makeApdex(seed),
+    timeSeriesHistogram: makeTimeSeriesHistogram(seed, timestamps),
+    instanceCount: 1,
+    instanceErrorCount: 0,
+    agents: [{ id: agentId, name: agentId }],
+  };
+};
+
+const infoOf = (node: any) => ({
+  serviceName: node.serviceName,
+  applicationName: node.applicationName,
+  serviceType: node.serviceType,
+  serviceTypeCode: node.serviceTypeCode,
+  nodeCategory: node.nodeCategory,
+});
+
+const makeAppLink = (source: any, target: any, timestamps: number[]) => {
+  const seed = seedOf(source.applicationName, target.applicationName);
+  const histogram = makeHistogram(seed);
+
+  return {
+    type: 'app',
+    key: `${source.key}~${target.key}`,
+    linkKey: `${source.nodeKey}~${target.nodeKey}`,
+    from: source.key,
+    to: target.key,
+    fromAgents: source.agents,
+    toAgents: target.agents,
+    sourceInfo: infoOf(source),
+    targetInfo: infoOf(target),
+    filter: {
+      serviceName: source.serviceName,
+      applicationName: source.applicationName,
+      serviceTypeCode: source.serviceTypeCode,
+      serviceTypeName: source.serviceType,
+    },
+    totalCount: sumOf(histogram),
+    errorCount: histogram.Error,
+    slowCount: histogram.Slow,
+    responseStatistics: makeResponseStatistics(seed),
+    histogram,
+    timeSeriesHistogram: makeTimeSeriesHistogram(seed, timestamps),
+    hasAlert: false,
+  };
+};
+
+/**
+ * `/api/servermap/serviceMap` 응답.
+ *
+ * A service는 보고 있는 service라 펼쳐진 app 노드로, B service는 group 노드 하나로 내려온다.
+ * (백엔드 `ServiceMapViewBuilder`의 `expandedServiceNames`와 같은 규칙)
+ */
+export const makeServiceMapResponse = (from: number, to: number) => {
+  const timestamps = makeTimestamps(from, to);
+
+  const user = makeAppNode(VIEWING_SERVICE, VIEWING_APPS[0], USER, timestamps);
+  const a1 = makeAppNode(VIEWING_SERVICE, VIEWING_APPS[0], TOMCAT, timestamps);
+  const a2 = makeAppNode(VIEWING_SERVICE, VIEWING_APPS[1], TOMCAT, timestamps);
+  const b1 = makeAppNode(OTHER_SERVICE, OTHER_APPS[0], TOMCAT, timestamps);
+  const b2 = makeAppNode(OTHER_SERVICE, OTHER_APPS[1], TOMCAT, timestamps);
+
+  const groupLinks = [makeAppLink(a1, b1, timestamps), makeAppLink(a1, b2, timestamps)];
+  const groupTotal = groupLinks.reduce((acc, link) => acc + link.totalCount, 0);
+
+  return {
+    applicationMapData: {
+      range: {
+        from,
+        to,
+        fromDateTime: new Date(from).toISOString(),
+        toDateTime: new Date(to).toISOString(),
+      },
+      timestamp: timestamps,
+      nodeDataArray: [
+        user,
+        a1,
+        a2,
+        // 다른 service는 group 노드 하나로 접혀서 온다. key가 serviceName 하나뿐이고
+        // 자식 노드는 nodes에 담겨 온다(ServiceGroupNodeView).
+        { key: OTHER_SERVICE, type: 'service', serviceName: OTHER_SERVICE, nodes: [b1, b2] },
+      ],
+      linkDataArray: [
+        makeAppLink(user, a1, timestamps),
+        makeAppLink(a1, a2, timestamps),
+        // 한쪽 끝이 접힌 service라 group 링크로 온다. 자식 링크는 links에 담겨 온다.
+        {
+          key: `${a1.key}~${OTHER_SERVICE}`,
+          from: a1.key,
+          to: OTHER_SERVICE,
+          type: 'service',
+          totalCount: groupTotal,
+          links: groupLinks,
+        },
+      ],
+    },
+  };
+};
+
+/** 요청에 실려 온 pServiceName을 화면에서 바로 읽을 수 있도록 만드는 표식. */
+const receivedServiceLabel = (requestedServiceName: string) =>
+  `pServiceName=${requestedServiceName || '(none)'}`;
+
+/** `/api/histogram/statistics`, `/api/histogram/statistics/links` 응답. */
+export const makeHistogramStatisticsResponse = (
+  applicationName: string,
+  requestedServiceName: string,
+  from: number,
+  to: number,
+) => {
+  const timestamps = makeTimestamps(from, to);
+  // 응답 수치도 요청에 실려 온 service에 따라 달라지게 한다. 헤더가 잘못 나가면 숫자도 달라진다.
+  const seed = seedOf(requestedServiceName, applicationName);
+  const histogram = makeHistogram(seed);
+  const agentId = `${applicationName}-agent`;
+  const agentName = `${agentId} / ${receivedServiceLabel(requestedServiceName)}`;
+
+  return {
+    currentServerTime: to,
+    histogram,
+    responseStatistics: makeResponseStatistics(seed),
+    timeSeriesHistogram: makeTimeSeriesHistogram(seed, timestamps),
+    timestamp: timestamps,
+    instanceCount: 1,
+    instanceErrorCount: 0,
+    agentHistogram: { [agentId]: histogram },
+    agentResponseStatistics: { [agentId]: makeResponseStatistics(seed) },
+    agentTimeSeriesHistogram: { [agentId]: makeTimeSeriesHistogram(seed, timestamps) },
+    serverList: {
+      [`${applicationName}-host`]: {
+        name: `${applicationName}-host`,
+        status: null,
+        linkList: [],
+        instanceList: {
+          [agentId]: {
+            hasInspector: false,
+            name: agentId,
+            agentName,
+            serviceType: TOMCAT.serviceType,
+            status: { code: 200, desc: 'Running' },
+          },
+        },
+      },
+    },
+  };
+};
+
+/** `/api/agents/overview` 응답. */
+export const makeAgentOverviewResponse = (
+  applicationName: string,
+  requestedServiceName: string,
+  to: number,
+) => {
+  const agentId = `${applicationName}-agent`;
+
+  return [
+    {
+      agentId,
+      agentName: `${agentId} / ${receivedServiceLabel(requestedServiceName)}`,
+      agentVersion: '3.0.0-MOCK',
+      applicationName,
+      container: false,
+      hasInspector: false,
+      hostName: `${applicationName}-host`,
+      ip: '127.0.0.1',
+      linkList: [],
+      pid: 10000 + seedOf(applicationName),
+      ports: '',
+      serviceType: TOMCAT.serviceType,
+      serviceTypeCode: TOMCAT.serviceTypeCode,
+      startTimestamp: to - 60 * 60 * 1000,
+      status: { agentId, eventTimestamp: to, state: { code: 200, desc: 'Running' } },
+      vmVersion: '17',
+    },
+  ];
+};
+
+/** `/api/getApdexScore` 응답. */
+export const makeApdexScoreResponse = (applicationName: string, requestedServiceName: string) =>
+  makeApdex(seedOf(requestedServiceName, applicationName));
+
+/** `/api/getScatterData` 응답. */
+export const makeScatterResponse = (
+  applicationName: string,
+  requestedServiceName: string,
+  from: number,
+  to: number,
+) => {
+  const seed = seedOf(requestedServiceName, applicationName);
+  const agentId = `${applicationName}-agent`;
+  const dotCount = 60 + seed;
+  // [x(timestamp), y(응답시간), agentIndex, transactionIndex, ?, type(0:success, 1:failed)]
+  const dotList = Array.from({ length: dotCount }, (_, index) => {
+    const x = from + Math.floor(((to - from) * index) / dotCount);
+    const y = 30 + ((index * (seed + 7)) % (seed * 20));
+    return [x, y, 1, index, 1, index % 9 === 0 ? 1 : 0];
+  });
+
+  return {
+    currentServerTime: to,
+    from,
+    to,
+    scatter: {
+      metadata: { 1: [agentId, agentId, from] },
+      dotList,
+    },
+    complete: true,
+    resultFrom: from,
+    resultTo: to,
+  };
+};
+
+/** `/api/heatmap/applicationData` 응답. */
+export const makeHeatmapResponse = (
+  applicationName: string,
+  requestedServiceName: string,
+  from: number,
+  to: number,
+) => {
+  const seed = seedOf(requestedServiceName, applicationName);
+  const columns = makeTimestamps(from, to, 20);
+  const rows = 10;
+  const elapsedStep = 1000;
+
+  let totalSuccessCount = 0;
+  let totalFailCount = 0;
+
+  const heatmapData = columns.map((timestamp, column) => ({
+    column,
+    timestamp,
+    cellDataList: Array.from({ length: rows }, (_, row) => {
+      const successCount = (seed + column * (row + 1)) % 40;
+      const failCount = (seed + column + row) % 5;
+      totalSuccessCount += successCount;
+      totalFailCount += failCount;
+
+      return {
+        row,
+        elapsedTime: (row + 1) * elapsedStep,
+        successCount,
+        failCount,
+      };
+    }),
+  }));
+
+  return {
+    size: { width: columns.length, height: rows },
+    summary: { totalSuccessCount, totalFailCount },
+    heatmapData,
+  };
+};

--- a/web-frontend/src/main/v3/apps/web/package.json
+++ b/web-frontend/src/main/v3/apps/web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
+    "dev:mock": "MOCK_SERVICE_MAP=1 vite --host",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "format": "prettier --write \"./src/**/*.{js,jsx,ts,tsx}\"",

--- a/web-frontend/src/main/v3/apps/web/tsconfig.node.json
+++ b/web-frontend/src/main/v3/apps/web/tsconfig.node.json
@@ -6,5 +6,6 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  // [MOCK #10497] dev-mock 은 임시입니다. 삭제 방법은 dev-mock/README.md 참고.
+  "include": ["vite.config.ts", "dev-mock/**/*.ts"]
 }

--- a/web-frontend/src/main/v3/apps/web/vite.config.ts
+++ b/web-frontend/src/main/v3/apps/web/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite';
 import { compression } from 'vite-plugin-compression2';
 import svgr from 'vite-plugin-svgr';
+// [MOCK #10497] 로컬 확인용 임시 mock. 삭제 방법은 ./dev-mock/README.md 참고.
+import { serviceMapMockPlugin } from './dev-mock';
 // import { visualizer } from 'rollup-plugin-visualizer';
 // import react from '@vitejs/plugin-react';
 
@@ -34,6 +36,8 @@ export default defineConfig({
   },
   plugins: [
     svgr(),
+    // [MOCK #10497] MOCK_SERVICE_MAP=1 일 때만 동작한다(= yarn dev:mock).
+    serviceMapMockPlugin(),
     compression(),
     compression({
       algorithm: 'brotliCompress',

--- a/web-frontend/src/main/v3/package.json
+++ b/web-frontend/src/main/v3/package.json
@@ -10,6 +10,7 @@
     "prepare": "cd ../../../.. && husky web-frontend/src/main/v3/.husky",
     "build": "yarn workspace @pinpoint-fe/web build",
     "dev": "yarn workspace @pinpoint-fe/web dev",
+    "dev:mock": "yarn workspace @pinpoint-fe/web dev:mock",
     "lint": "yarn workspaces run lint",
     "test": "yarn workspaces run test",
     "test:e2e": "yarn workspace @pinpoint-fe/web test:e2e",

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapFetcher.tsx
@@ -13,9 +13,14 @@ const DefaultAxisY = [0, 10000];
 
 export type HeatmapFetcherProps = {
   agentId?: string;
-} & Pick<HeatmapChartCoreProps, 'toolbarOption' | 'nodeData'>;
+} & Pick<HeatmapChartCoreProps, 'toolbarOption' | 'nodeData' | 'serviceName'>;
 
-export const HeatmapFetcher = ({ nodeData, agentId, ...props }: HeatmapFetcherProps) => {
+export const HeatmapFetcher = ({
+  nodeData,
+  agentId,
+  serviceName,
+  ...props
+}: HeatmapFetcherProps) => {
   const { t } = useTranslation();
   const { dateRange } = useServerMapSearchParameters();
   const [setting] = useStoragedSetting(APP_SETTING_KEYS.HEATMAP_SETTING);
@@ -29,7 +34,12 @@ export const HeatmapFetcher = ({ nodeData, agentId, ...props }: HeatmapFetcherPr
     maxElapsedTime: Number(setting?.yMax) || DefaultAxisY[1],
     agentId: agentId,
   });
-  const { data, isLoading, error } = useGetHeatmapAppData(parameters);
+  // 조회 파라미터가 effect로 한 박자 늦게 따라오므로 serviceName도 같은 effect에서 함께 갱신한다.
+  // 그러지 않으면 대상이 바뀌는 렌더에서 (이전 application, 새 service) 짝의 queryKey가 한 번
+  // 만들어져, 그 service에 없는 application을 조회하는 요청이 나간다.
+  // (아래 HeatmapChartCore에 넘기는 값은 링크 생성용이라 최신값 그대로 쓴다.)
+  const [requestServiceName, setRequestServiceName] = React.useState(serviceName);
+  const { data, isLoading, error } = useGetHeatmapAppData(parameters, requestServiceName);
 
   React.useEffect(() => {
     setParameters({
@@ -41,6 +51,7 @@ export const HeatmapFetcher = ({ nodeData, agentId, ...props }: HeatmapFetcherPr
       maxElapsedTime: Number(setting?.yMax) || DefaultAxisY[1],
       agentId: agentId,
     });
+    setRequestServiceName(serviceName);
   }, [
     dateRange.from.getTime(),
     dateRange.to.getTime(),
@@ -49,6 +60,7 @@ export const HeatmapFetcher = ({ nodeData, agentId, ...props }: HeatmapFetcherPr
     nodeData?.applicationName,
     nodeData?.serviceType,
     agentId,
+    serviceName,
   ]);
 
   return (
@@ -69,6 +81,7 @@ export const HeatmapFetcher = ({ nodeData, agentId, ...props }: HeatmapFetcherPr
         isLoading={isLoading}
         data={data || ({} as GetHeatmapAppData.Response)}
         nodeData={nodeData}
+        serviceName={serviceName}
         {...props}
       />
     </div>

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapRealtimeFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapRealtimeFetcher.tsx
@@ -29,11 +29,12 @@ function ceilTo10SecAndSubtract30(date: Date): Date {
 export type HeatmapRealtimeFetcherProps = {
   nodeData: GetServerMap.NodeData | ApplicationType;
   agentId?: string;
-} & Pick<HeatmapChartCoreProps, 'toolbarOption'>;
+} & Pick<HeatmapChartCoreProps, 'toolbarOption' | 'serviceName'>;
 
 export const HeatmapRealtimeFetcher = ({
   nodeData,
   agentId,
+  serviceName,
   ...props
 }: HeatmapRealtimeFetcherProps) => {
   const now = new Date();
@@ -77,7 +78,12 @@ export const HeatmapRealtimeFetcher = ({
     maxElapsedTime: Number(setting?.yMax) || DefaultAxisY[1],
     agentId: agentId,
   });
-  const { data, isLoading } = useGetHeatmapAppData(parameters);
+  // 조회 파라미터가 effect로 한 박자 늦게 따라오므로 serviceName도 같은 effect에서 함께 갱신한다.
+  // 그러지 않으면 대상이 바뀌는 렌더에서 (이전 application, 새 service) 짝의 queryKey가 한 번
+  // 만들어져, 그 service에 없는 application을 조회하는 요청이 나간다.
+  // (아래 HeatmapChartCore에 넘기는 값은 링크 생성용이라 최신값 그대로 쓴다.)
+  const [requestServiceName, setRequestServiceName] = React.useState(serviceName);
+  const { data, isLoading } = useGetHeatmapAppData(parameters, requestServiceName);
 
   React.useEffect(() => {
     setParameters({
@@ -92,6 +98,7 @@ export const HeatmapRealtimeFetcher = ({
       maxElapsedTime: Number(setting?.yMax) || DefaultAxisY[1],
       agentId: agentId,
     });
+    setRequestServiceName(serviceName);
   }, [
     realtimeDateRange.from.getTime(),
     realtimeDateRange.to.getTime(),
@@ -100,6 +107,7 @@ export const HeatmapRealtimeFetcher = ({
     nodeData?.applicationName,
     nodeData?.serviceType,
     agentId,
+    serviceName,
   ]);
 
   React.useEffect(() => {
@@ -164,6 +172,7 @@ export const HeatmapRealtimeFetcher = ({
       isLoading={isLoading && !realtimeData}
       nodeData={nodeData}
       data={realtimeData}
+      serviceName={serviceName}
       {...props}
     />
   );

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/core/HeatmapChartCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/core/HeatmapChartCore.tsx
@@ -37,6 +37,11 @@ export type HeatmapChartCoreProps = {
       hide?: boolean;
     };
   };
+  /**
+   * 조회 대상이 소속된 service. 화면의 service와 다를 때만 넘긴다(map에서 다른 service의 노드를
+   * 고른 경우). 넘기지 않으면 화면의 service로 조회한다.
+   */
+  serviceName?: string;
 };
 
 const HeatmapChartCore = ({
@@ -46,11 +51,14 @@ const HeatmapChartCore = ({
   data,
   agentId,
   toolbarOption,
+  serviceName,
 }: HeatmapChartCoreProps) => {
   const chartContainerRef = React.useRef<HTMLDivElement>(null);
 
   const { dateRange, searchParameters } = useServerMapSearchParameters();
-  const serviceNameForLink = useServiceNameForLink();
+  // 넘어온 값이 없으면 화면의 service로 조회한다(map 밖에서 쓰이는 경우).
+  const screenServiceName = useServiceNameForLink();
+  const requestServiceName = serviceName ?? screenServiceName;
   const [showSetting, setShowSetting] = React.useState(false);
   const [isCapturingImage, setIsCapturingImage] = React.useState(false);
 
@@ -111,7 +119,7 @@ const HeatmapChartCore = ({
       `${BASE_PATH}${getTransactionListPath(
         nodeData,
         isRealtime ? getFormattedDateRange(dateRange) : searchParameters,
-        serviceNameForLink,
+        requestServiceName,
       )}&${getTransactionListQueryString({
         ...data,
         checkedLegends,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
@@ -20,7 +20,11 @@ import {
   Heatmap,
   ChartTypeButtons,
 } from '..';
-import { useServerMapSearchParameters, useTabFocus } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useServerMapSearchParameters,
+  useServerMapTargetServiceName,
+  useTabFocus,
+} from '@pinpoint-fe/ui/src/hooks';
 import {
   CurrentTarget,
   serverMapCurrentTargetAtom,
@@ -111,6 +115,9 @@ export const Realtime = ({ MapView = ServerMap, requiresApplication = true }: Re
   };
 
   const { currentPanelWidth, resizeHandleWidth } = useLayoutWithHorizontalResizable();
+  // servicemap 실시간 보기에서는 다른 service의 노드도 고를 수 있다. 우측 패널의 조회는
+  // 화면의 service가 아니라 고른 노드의 service로 나가야 한다. 차트들에 prop으로 내려준다.
+  const targetServiceName = useServerMapTargetServiceName();
 
   return (
     <div ref={containerRef} className="relative flex flex-1 h-full overflow-x-hidden">
@@ -199,18 +206,21 @@ export const Realtime = ({ MapView = ServerMap, requiresApplication = true }: Re
                       <ApdexScore
                         shouldPoll={true}
                         nodeData={currentTargetData || application}
+                        serviceName={targetServiceName}
                       ></ApdexScore>
                     </div>
                     {chartType === 'scatter' ? (
                       <ScatterChart
                         node={serverMapCurrentTarget || (application as ApplicationType)}
                         realtime={true}
+                        serviceName={targetServiceName}
                       />
                     ) : (
                       // <div className="w-full pl-3 pt-5 pr-10 pb-8 aspect-[1.3]">
                       <Heatmap
                         nodeData={currentTargetData || (application as ApplicationType)}
                         realtime={true}
+                        serviceName={targetServiceName}
                       />
                       // </div>
                     )}

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartFetcher.tsx
@@ -21,23 +21,35 @@ export interface ScatterChartFetcherProps {
   node: CurrentTarget;
   agentId?: string;
   toolbarOption?: ScatterChartCoreProps['toolbarOption'];
+  /**
+   * 조회 대상이 소속된 service. 화면의 service와 다를 때만 넘긴다(map에서 다른 service의 노드를
+   * 고른 경우). 넘기지 않으면 화면의 service로 조회한다.
+   */
+  serviceName?: string;
 }
 
 export const ScatterChartFetcher = ({
   node,
   agentId = SCATTER_DATA_TOTAL_KEY,
   toolbarOption,
+  serviceName,
 }: ScatterChartFetcherProps) => {
   const scatterRef = React.useRef<ScatterChartHandle>(null);
   const { dateRange, searchParameters } = useServerMapSearchParameters();
-  const serviceNameForLink = useServiceNameForLink();
+  // 넘어온 값이 없으면 화면의 service로 조회한다(map 밖에서 쓰이는 경우).
+  const screenServiceName = useServiceNameForLink();
+  const requestServiceName = serviceName ?? screenServiceName;
   const from = dateRange.from.getTime();
   const to = dateRange.to.getTime();
   const currentNode = `${node.applicationName}^${node.serviceType}`;
   const [x, setX] = React.useState<[number, number]>([from, to]);
   const [y, setY] = useStoragedAxisY();
   const isScatterMounted = scatterRef.current?.isMounted();
-  const { data, isLoading, setQueryParams } = useGetScatterData(node, dateRange);
+  const { data, isLoading, setQueryParams } = useGetScatterData(
+    node,
+    dateRange,
+    requestServiceName,
+  );
   const [scatterData, setScatterData] = useAtom(scatterDataAtom);
 
   React.useEffect(() => {
@@ -106,7 +118,7 @@ export const ScatterChartFetcher = ({
           `${BASE_PATH}${getTransactionListPath(
             node,
             searchParameters,
-            serviceNameForLink,
+            requestServiceName,
           )}&${getTransactionListQueryString({
             ...data,
             checkedLegends,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartRealtimeFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartRealtimeFetcher.tsx
@@ -31,16 +31,24 @@ export interface ScatterChartRealtimeFetcherProps {
   node: CurrentTarget;
   agentId?: string;
   toolbarOption?: ScatterChartCoreProps['toolbarOption'];
+  /**
+   * 조회 대상이 소속된 service. 화면의 service와 다를 때만 넘긴다(map에서 다른 service의 노드를
+   * 고른 경우). 넘기지 않으면 화면의 service로 조회한다.
+   */
+  serviceName?: string;
 }
 
 export const ScatterChartRealtimeFetcher = ({
   node,
   agentId = SCATTER_DATA_TOTAL_KEY,
   toolbarOption,
+  serviceName,
 }: ScatterChartRealtimeFetcherProps) => {
   const scatterRef = React.useRef<ScatterChartHandle>(null);
   const { dateRange } = useServerMapSearchParameters();
-  const serviceNameForLink = useServiceNameForLink();
+  // 넘어온 값이 없으면 화면의 service로 조회한다(map 밖에서 쓰이는 경우).
+  const screenServiceName = useServiceNameForLink();
+  const requestServiceName = serviceName ?? screenServiceName;
   const from = dateRange.from.getTime();
   const to = dateRange.to.getTime();
   const currentNode = `${node.applicationName}^${node.serviceType}`;
@@ -49,7 +57,11 @@ export const ScatterChartRealtimeFetcher = ({
 
   // 5분 전 ~ 현재까지의 데이터
   const [defaultDateRange, setDefaultDateRange] = React.useState(dateRange);
-  const { data, isLoading, setQueryParams } = useGetScatterData(node, defaultDateRange);
+  const { data, isLoading, setQueryParams } = useGetScatterData(
+    node,
+    defaultDateRange,
+    requestServiceName,
+  );
 
   // 5분 밑그림이 덮은 끝 시각. 마운트 직후의 2초 구간은 이미 이 안에 들어 있어서, 그대로 요청하면
   // 같은 구간을 한 번 더 받는다. 시계가 이 시각을 지난 다음부터 꼬리를 물기 시작한다.
@@ -63,6 +75,7 @@ export const ScatterChartRealtimeFetcher = ({
   } = useGetScatterRealtimeData(
     node,
     hasTailToFetch ? { ...dateRange, from: subSeconds(dateRange.to, 2) } : EMPTY_RANGE,
+    requestServiceName,
   );
   const sc = scatterRef.current;
   const isScatterMounted = scatterRef.current?.isMounted();
@@ -161,7 +174,7 @@ export const ScatterChartRealtimeFetcher = ({
           `${getTransactionListPath(
             node,
             getFormattedDateRange(dateRange),
-            serviceNameForLink,
+            requestServiceName,
           )}&${getTransactionListQueryString({
             ...data,
             checkedLegends,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartStatic.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartStatic.tsx
@@ -33,6 +33,11 @@ export interface ScatterChartStaticProps extends Pick<
   data?: ScatterDataType[];
   range: [number, number];
   selectedAgentId?: string;
+  /**
+   * 조회 대상이 소속된 service. 화면의 service와 다를 때만 넘긴다(map에서 다른 service의 노드를
+   * 고른 경우). 넘기지 않으면 화면의 service로 조회한다.
+   */
+  serviceName?: string;
 }
 
 export const ScatterChartStatic = ({
@@ -40,10 +45,13 @@ export const ScatterChartStatic = ({
   data = [],
   range,
   selectedAgentId,
+  serviceName,
   ...props
 }: ScatterChartStaticProps) => {
   const { searchParameters } = useServerMapSearchParameters();
-  const serviceNameForLink = useServiceNameForLink();
+  // 넘어온 값이 없으면 화면의 service로 조회한다(map 밖에서 쓰이는 경우).
+  const screenServiceName = useServiceNameForLink();
+  const requestServiceName = serviceName ?? screenServiceName;
   const [timezone] = useTimezone();
   const scatterRef = React.useRef<ScatterChartHandle>(null);
   const [x, setX] = React.useState<[number, number]>([range[0], range[1]]);
@@ -117,7 +125,7 @@ export const ScatterChartStatic = ({
             `${BASE_PATH}${getTransactionListPath(
               application,
               searchParameters,
-              serviceNameForLink,
+              requestServiceName,
             )}&${getTransactionListQueryString({
               ...data,
               checkedLegends,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerList/ServerListFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerList/ServerListFetcher.tsx
@@ -19,9 +19,14 @@ import { upperCase } from 'lodash';
 
 export interface ServerListFetcherProps extends ServerListProps {
   nodeStatistics?: GetHistogramStatistics.Response;
+  /**
+   * 조회 대상이 소속된 service. 화면의 service와 다를 때만 넘긴다(map에서 다른 service의 노드를
+   * 고른 경우). 넘기지 않으면 화면의 service로 조회한다.
+   */
+  serviceName?: string;
 }
 
-export const ServerListFetcher = ({ nodeStatistics }: ServerListFetcherProps) => {
+export const ServerListFetcher = ({ nodeStatistics, serviceName }: ServerListFetcherProps) => {
   const { searchParameters } = useSearchParameters();
   // 값은 쓰지 않지만 atom 구독은 유지해야 하므로 호출은 남긴다.
   useAtomValue(serverMapCurrentTargetAtom);
@@ -44,14 +49,17 @@ export const ServerListFetcher = ({ nodeStatistics }: ServerListFetcherProps) =>
     ]),
   };
 
-  const { data, isLoading } = useGetAgentOverview({
-    application: currentTargetData?.applicationName,
-    serviceTypeName: currentTargetData?.serviceType,
-    serviceTypeCode: currentTargetData?.serviceTypeCode,
-    applicationPairs: JSON.stringify(applicationPairs),
-    from: toBasicISOString(getParsedDate(searchParameters.from)),
-    to: toBasicISOString(getParsedDate(searchParameters.to)),
-  });
+  const { data, isLoading } = useGetAgentOverview(
+    {
+      application: currentTargetData?.applicationName,
+      serviceTypeName: currentTargetData?.serviceType,
+      serviceTypeCode: currentTargetData?.serviceTypeCode,
+      applicationPairs: JSON.stringify(applicationPairs),
+      from: toBasicISOString(getParsedDate(searchParameters.from)),
+      to: toBasicISOString(getParsedDate(searchParameters.to)),
+    },
+    serviceName,
+  );
 
   React.useEffect(() => {
     if (data) {

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
@@ -19,7 +19,11 @@ import {
   ChartsBoardHeader,
 } from '@pinpoint-fe/ui/src/components';
 import { ApplicationType, GetServerMap } from '@pinpoint-fe/ui/src/constants';
-import { useExperimentals, useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useExperimentals,
+  useServerMapSearchParameters,
+  useServiceNameForLink,
+} from '@pinpoint-fe/ui/src/hooks';
 import { MdArrowBackIosNew, MdArrowForwardIos } from 'react-icons/md';
 import { PiArrowSquareOut } from 'react-icons/pi';
 import {
@@ -37,6 +41,7 @@ import { cn } from '@pinpoint-fe/ui/src/lib';
 import { RxChevronRight } from 'react-icons/rx';
 import { ServerListForCommon } from '@pinpoint-fe/ui/src/components/ServerList/ServerListForCommon';
 import { useGetHistogramStatistics } from '@pinpoint-fe/ui/src/hooks/api/useGetHistogramStatistics';
+import { useServerMapTargetServiceName } from '@pinpoint-fe/ui/src/hooks/serverMap/useServerMapTargetServiceName';
 
 export interface ServerMapChartsBoardProps extends ServerMapChartsBoardFetcherProps {}
 
@@ -107,7 +112,20 @@ export const ServerMapChartsBoardFetcher = ({
       : undefined;
   }, [serverMapCurrentTarget, currentTargetData]);
 
-  const baseApplication = application ?? selectedTargetApplication;
+  // servicemap은 다른 service의 application도 함께 그린다. 그런 노드를 고르면 이 패널의 조회는
+  // 화면의 service가 아니라 그 노드의 service로 나가야 한다. 아래 차트/목록에 prop으로 내려준다.
+  //
+  // 대상이 다른 service면 경로의 application(화면 service 소속)은 통계 조회의 기준이 될 수 없다.
+  // 요청이 노드의 service로 나가므로 백엔드가 그 이름을 노드의 service에서 찾게 되기 때문이다.
+  // 그때는 노드 자신을 기준으로 삼는다 — 그 application을 직접 열어 본 것과 같은 결과가 된다.
+  const targetServiceName = useServerMapTargetServiceName();
+  const screenServiceName = useServiceNameForLink();
+  const isCrossServiceTarget =
+    !!targetServiceName && !!screenServiceName && targetServiceName !== screenServiceName;
+
+  const baseApplication = isCrossServiceTarget
+    ? selectedTargetApplication
+    : (application ?? selectedTargetApplication);
 
   const { data, isLoading } = useGetHistogramStatistics({
     useStatisticsAgentState,
@@ -116,6 +134,8 @@ export const ServerMapChartsBoardFetcher = ({
       (baseApplication ? getApplicationKey(baseApplication) : undefined), // 원래 optional인데 첫 페이지 로딩 시 currentTargetData가 없을 때, currentTargetData가 application으로 잡힐 때 두번 중복 call 방지를 위해 required 처럼 사용
     linkKey: (currentTargetData as GetServerMap.LinkData)?.linkKey,
     fallbackApplication: selectedTargetApplication,
+    ignorePathApplication: isCrossServiceTarget,
+    serviceName: targetServiceName,
   });
 
   React.useEffect(() => {
@@ -296,15 +316,18 @@ export const ServerMapChartsBoardFetcher = ({
                       <div className="h-7">
                         <ApdexScore
                           nodeData={(currentTargetData as GetServerMap.NodeData) || application}
+                          serviceName={targetServiceName}
                         />
                       </div>
                       {chartType === 'scatter' ? (
                         <ScatterChart
                           node={(serverMapCurrentTarget || application) as CurrentTarget}
+                          serviceName={targetServiceName}
                         />
                       ) : (
                         <Heatmap
                           nodeData={(currentTargetData as GetServerMap.NodeData) || application}
+                          serviceName={targetServiceName}
                         />
                       )}
                     </div>
@@ -340,7 +363,7 @@ export const ServerMapChartsBoardFetcher = ({
             <img src={serverMapCurrentTarget?.imgPath} width={52} />
             <div className="truncate">{serverMapCurrentTarget?.applicationName}</div>
           </div>
-          <ServerListForCommon nodeStatistics={data} />
+          <ServerListForCommon nodeStatistics={data} serviceName={targetServiceName} />
         </div>
         <div style={{ width: currentPanelWidth }}>
           <ChartsBoard
@@ -365,6 +388,7 @@ export const ServerMapChartsBoardFetcher = ({
                       <ApdexScore
                         nodeData={currentTargetData as GetServerMap.NodeData}
                         agentId={currentServer?.agentId}
+                        serviceName={targetServiceName}
                       />
                     )}
                   </div>
@@ -375,6 +399,7 @@ export const ServerMapChartsBoardFetcher = ({
                     }
                     range={[dateRange.from.getTime(), dateRange.to.getTime()]}
                     selectedAgentId={currentServer?.agentId || ''}
+                    serviceName={targetServiceName}
                   />
                   {isScatterDataOutdated && (
                     <div className="absolute top-0 left-0 z-[1000] flex flex-col items-center justify-center w-full h-[calc(100%+48px)] bg-background/50 text-center">

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
@@ -116,11 +116,11 @@ export const ServerMapCore = ({
   const serviceGroupLinkTargetRef = React.useRef<GetServerMap.LinkData | undefined>(undefined);
   const [serviceGroupSearch, setServiceGroupSearch] = React.useState('');
   const serviceGroupSearchRef = React.useRef<HTMLInputElement>(null);
-  // 팝업이 map 영역을 넘치지 않도록 접어 넣은 좌표. ServerMapMenu에는 이 값을 넘긴다.
-  const [menuPosition, setMenuPosition] = React.useState<Partial<{ x: number; y: number }>>({
-    x: 0,
-    y: 0,
-  });
+  // 팝업이 map 영역을 넘칠 때만 채워지는 대체 좌표. 넘치지 않으면 undefined로 두고
+  // popperPosition을 그대로 쓴다 — 팝업이 열려 있는 동안 pan/zoom마다 좌표가 갱신되는데,
+  // 그때마다 상태를 새로 쓰면 이동 한 번에 렌더가 두 번씩 돈다.
+  const [clampedPosition, setClampedPosition] = React.useState<{ x: number; y: number }>();
+  const menuPosition = clampedPosition ?? popperPosition;
   // cytoscape 이벤트 핸들러는 한 번 등록되어 popperContentType의 최신값을 stale closure로 놓친다.
   // 가드는 ref를 통해 항상 최신 상태를 본다.
   const popperContentTypeRef = React.useRef<SERVERMAP_MENU_CONTENT_TYPE | undefined>(undefined);
@@ -150,8 +150,17 @@ export const ServerMapCore = ({
     // popperContentRef는 테두리를 그리는 래퍼 안에 있으므로, 실제 팝업 크기는 부모에서 잰다.
     const content = popperContentRef.current?.parentElement ?? popperContentRef.current;
 
+    // 값이 그대로면 이전 참조를 돌려줘 리렌더를 만들지 않는다.
+    const update = (next?: { x: number; y: number }) =>
+      setClampedPosition((prev) => {
+        if (!next) {
+          return undefined;
+        }
+        return prev && prev.x === next.x && prev.y === next.y ? prev : next;
+      });
+
     if (!popperContentType || !container || !content) {
-      setMenuPosition(popperPosition);
+      update();
       return;
     }
 
@@ -162,10 +171,11 @@ export const ServerMapCore = ({
       return Math.min(Math.max(flipped, POPPER_EDGE_GAP), max);
     };
 
-    setMenuPosition({
-      x: fit(popperPosition.x ?? 0, width, container.clientWidth),
-      y: fit(popperPosition.y ?? 0, height, container.clientHeight),
-    });
+    const x = fit(popperPosition.x ?? 0, width, container.clientWidth);
+    const y = fit(popperPosition.y ?? 0, height, container.clientHeight);
+
+    // 넘치지 않으면 popperPosition을 그대로 쓰면 되므로 대체 좌표를 두지 않는다.
+    update(x === popperPosition.x && y === popperPosition.y ? undefined : { x, y });
   }, [popperContentType, popperPosition.x, popperPosition.y]);
 
   // service group 팝업의 검색 입력에 포커스를 준다. autoFocus를 쓰지 않는 이유는 위 클램프 주석과

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
@@ -44,6 +44,9 @@ import cytoscape from 'cytoscape';
 import { cn } from '../../lib';
 import { Input } from '../ui/input';
 
+/** 팝업이 map 영역 가장자리에 닿지 않도록 두는 여백(px) */
+const POPPER_EDGE_GAP = 8;
+
 export interface ServerMapCoreProps extends Omit<ServerMapComponentProps, 'data'> {
   data?: GetServerMap.Response | FilteredMap.Response;
   isLoading?: boolean;
@@ -112,6 +115,12 @@ export const ServerMapCore = ({
   const serviceGroupTargetRef = React.useRef<GetServerMap.NodeData | undefined>(undefined);
   const serviceGroupLinkTargetRef = React.useRef<GetServerMap.LinkData | undefined>(undefined);
   const [serviceGroupSearch, setServiceGroupSearch] = React.useState('');
+  const serviceGroupSearchRef = React.useRef<HTMLInputElement>(null);
+  // 팝업이 map 영역을 넘치지 않도록 접어 넣은 좌표. ServerMapMenu에는 이 값을 넘긴다.
+  const [menuPosition, setMenuPosition] = React.useState<Partial<{ x: number; y: number }>>({
+    x: 0,
+    y: 0,
+  });
   // cytoscape 이벤트 핸들러는 한 번 등록되어 popperContentType의 최신값을 stale closure로 놓친다.
   // 가드는 ref를 통해 항상 최신 상태를 본다.
   const popperContentTypeRef = React.useRef<SERVERMAP_MENU_CONTENT_TYPE | undefined>(undefined);
@@ -122,6 +131,51 @@ export const ServerMapCore = ({
       popperContentType !== SERVERMAP_MENU_CONTENT_TYPE.SERVICE_GROUP_LINK_LIST
     ) {
       setServiceGroupSearch('');
+    }
+  }, [popperContentType]);
+
+  /**
+   * 팝업을 map 영역 안쪽으로 접어 넣는다.
+   *
+   * 팝업은 노드의 렌더 좌표에 절대 위치로 그려지므로, 오른쪽/아래 가장자리의 노드에서 열면 map
+   * 컨테이너를 넘친다. 넘치면 조상(overflow hidden)의 scrollWidth가 늘어나고, 그 상태에서 검색
+   * 입력에 포커스가 가면 브라우저가 입력을 보이게 하려고 scrollLeft를 옮긴다. 그러면 map 전체가
+   * 왼쪽으로 밀려 사이드 네비게이션 아래로 들어간다.
+   *
+   * 넘칠 때만 기준점 반대편으로 뒤집고(popper의 flip), 그래도 모자라면 가장자리에 맞춘다.
+   * 넘치지 않는 경우에는 기존 위치 그대로다.
+   */
+  React.useLayoutEffect(() => {
+    const container = containerRef.current;
+    // popperContentRef는 테두리를 그리는 래퍼 안에 있으므로, 실제 팝업 크기는 부모에서 잰다.
+    const content = popperContentRef.current?.parentElement ?? popperContentRef.current;
+
+    if (!popperContentType || !container || !content) {
+      setMenuPosition(popperPosition);
+      return;
+    }
+
+    const { width, height } = content.getBoundingClientRect();
+    const fit = (start: number, size: number, limit: number) => {
+      const flipped = start + size + POPPER_EDGE_GAP > limit ? start - size : start;
+      const max = Math.max(POPPER_EDGE_GAP, limit - size - POPPER_EDGE_GAP);
+      return Math.min(Math.max(flipped, POPPER_EDGE_GAP), max);
+    };
+
+    setMenuPosition({
+      x: fit(popperPosition.x ?? 0, width, container.clientWidth),
+      y: fit(popperPosition.y ?? 0, height, container.clientHeight),
+    });
+  }, [popperContentType, popperPosition.x, popperPosition.y]);
+
+  // service group 팝업의 검색 입력에 포커스를 준다. autoFocus를 쓰지 않는 이유는 위 클램프 주석과
+  // 같다 — 팝업이 조금이라도 넘친 순간에 포커스가 가면 브라우저가 화면을 스크롤해 버린다.
+  React.useEffect(() => {
+    if (
+      popperContentType === SERVERMAP_MENU_CONTENT_TYPE.SERVICE_GROUP_LIST ||
+      popperContentType === SERVERMAP_MENU_CONTENT_TYPE.SERVICE_GROUP_LINK_LIST
+    ) {
+      serviceGroupSearchRef.current?.focus({ preventScroll: true });
     }
   }, [popperContentType]);
 
@@ -463,7 +517,7 @@ export const ServerMapCore = ({
             </TooltipProvider>
           </div>
           {!disableMenu && (
-            <ServerMapMenu contentType={popperContentType} position={popperPosition}>
+            <ServerMapMenu contentType={popperContentType} position={menuPosition}>
               <div ref={popperContentRef}>
                 {popperContentType === SERVERMAP_MENU_CONTENT_TYPE.BACKGROUND && (
                   <ServerMapMenuContent title="Merge">
@@ -570,7 +624,7 @@ export const ServerMapCore = ({
                           <div className="relative">
                             <FaSearch className="absolute -translate-y-1/2 pointer-events-none left-2 top-1/2 text-muted-foreground" />
                             <Input
-                              autoFocus
+                              ref={serviceGroupSearchRef}
                               placeholder={t('COMMON.SEARCH_INPUT')}
                               value={serviceGroupSearch}
                               onChange={(e) => setServiceGroupSearch(e.target.value)}
@@ -635,7 +689,7 @@ export const ServerMapCore = ({
                           <div className="relative">
                             <FaSearch className="absolute -translate-y-1/2 pointer-events-none left-2 top-1/2 text-muted-foreground" />
                             <Input
-                              autoFocus
+                              ref={serviceGroupSearchRef}
                               placeholder={t('COMMON.SEARCH_INPUT')}
                               value={serviceGroupSearch}
                               onChange={(e) => setServiceGroupSearch(e.target.value)}

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.test.tsx
@@ -20,8 +20,10 @@ import { getDefaultStore } from 'jotai';
 import { QueryClient } from '@tanstack/react-query';
 import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
 import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
+import { SERVICE_NAME_HEADER } from './serviceNameFetchInterceptor';
 import {
   handleGlobalQueryError,
+  queryFn,
   serviceScopedQueryKeyHashFn,
   showGlobalErrorToast,
 } from './reactQueryHelper';
@@ -65,6 +67,32 @@ describe('reactQueryHelper global query error handling', () => {
     showGlobalErrorToast(new Error('x'), { toastId: 'abc' });
 
     expect((toast.error as jest.Mock).mock.calls[0][1].toastId).toBe('abc');
+  });
+});
+
+describe('queryFn', () => {
+  const fetchMock = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response),
+  );
+
+  beforeEach(() => {
+    fetchMock.mockClear();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  // 헤더를 붙이는 것은 fetch 인터셉터의 몫이다. 여기서 빈 init을 넘기면 그 판단을 흐린다.
+  test('requests without an init when no service is given', async () => {
+    await queryFn('/api/getApdexScore')();
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/getApdexScore');
+  });
+
+  // 조회 대상이 화면과 다른 service에 속할 때 그 service로 나가야 한다.
+  test('carries the given service in the request header', async () => {
+    await queryFn('/api/getApdexScore', { serviceName: 'other-service' })();
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(new Headers(init.headers).get(SERVICE_NAME_HEADER)).toBe('other-service');
   });
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/reactQueryHelper.tsx
@@ -11,7 +11,7 @@ import { toast } from 'react-toastify';
 import { getDefaultStore } from 'jotai';
 import { toastCountAtom } from '@pinpoint-fe/ui/src/atoms';
 import { ErrorToast } from '../../components/Error/ErrorToast';
-import { getRequestService } from './serviceNameFetchInterceptor';
+import { getRequestService, SERVICE_NAME_HEADER } from './serviceNameFetchInterceptor';
 
 declare module '@tanstack/react-query' {
   interface Register {
@@ -65,8 +65,24 @@ export async function parseResponseError(response: Response): Promise<never> {
   throw new Error((detail as string) || 'An error occurred while fetching the data.');
 }
 
-export const queryFn = (url: string) => async () => {
-  const response = await fetch(url);
+export interface QueryFnOptions {
+  /**
+   * 이 요청이 조회할 service. 지정하면 `pServiceName` 헤더를 여기서 직접 싣고,
+   * fetch 인터셉터는 이미 실린 헤더를 덮어쓰지 않는다.
+   *
+   * 화면의 service와 조회 대상의 service가 다를 때 쓴다(`useServerMapTargetServiceName`).
+   * 인터셉터는 경로/전역 선택값만 보므로 "고른 노드가 다른 service 소속"이라는 사실을 알 수 없다.
+   *
+   * 이 값을 싣는 훅은 queryKey에도 같은 값을 넣어야 한다. 헤더만 갈리고 캐시 키가 같으면
+   * 이름이 같은 다른 service의 application끼리 캐시가 섞인다.
+   */
+  serviceName?: string;
+}
+
+export const queryFn = (url: string, options?: QueryFnOptions) => async () => {
+  const response = options?.serviceName
+    ? await fetch(url, { headers: { [SERVICE_NAME_HEADER]: options.serviceName } })
+    : await fetch(url);
 
   if (!response.ok) {
     await parseResponseError(response);

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
@@ -89,6 +89,19 @@ describe('serviceNameFetchInterceptor', () => {
     expect(init?.method).toBe('POST');
   });
 
+  // 조회 대상이 화면과 다른 service에 속할 때 호출자가 직접 헤더를 싣는다.
+  // 인터셉터는 경로/전역 선택값만 보므로 그 사실을 알 수 없어, 실린 값을 덮어쓰면 안 된다.
+  test('keeps the service header the caller already set', async () => {
+    store.set(configurationAtom, configWithServiceMap(true));
+    store.set(selectedServiceAtom, 'my-service');
+
+    await window.fetch('/api/getApdexScore', {
+      headers: { [SERVICE_NAME_HEADER]: 'other-service' },
+    });
+
+    expect(headerOfLastCall()).toBe('other-service');
+  });
+
   test.each([
     ['/serverMap/app-name@TOMCAT?from=1&to=2'],
     ['/serverMap/realtime/app-name@TOMCAT'],

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
@@ -93,7 +93,12 @@ export const installServiceNameFetchInterceptor = () => {
           const headers = new Headers(
             init?.headers ?? (isRequestObject(input) ? input.headers : undefined),
           );
-          headers.set(SERVICE_NAME_HEADER, selectedService);
+
+          // 호출자가 직접 실은 값이 우선이다. 인터셉터는 경로/전역 선택값만 보므로, 조회 대상이
+          // 화면과 다른 service에 속한다는 사실(`useServerMapTargetServiceName`)을 알 수 없다.
+          if (!headers.has(SERVICE_NAME_HEADER)) {
+            headers.set(SERVICE_NAME_HEADER, selectedService);
+          }
           return originalFetch(input, { ...init, headers });
         }
       }

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetAgentOverview.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetAgentOverview.ts
@@ -11,14 +11,23 @@ const getQueryString = (queryParams: Partial<AgentOverview.Parameters>) => {
   return '';
 };
 
-export const useGetAgentOverview = ({
-  application,
-  serviceTypeName,
-  serviceTypeCode,
-  from,
-  to,
-  applicationPairs,
-}: AgentOverview.Parameters) => {
+/**
+ * @param serviceName 이 조회가 나갈 service. 지정하면 `pServiceName` 헤더를 직접 싣고 캐시도 그
+ * 단위로 갈린다. 화면의 service와 조회 대상의 service가 다를 때 넘긴다 — servicemap은 다른
+ * service의 application도 함께 그리기 때문이다(`useServerMapTargetServiceName`). 넘기지 않으면
+ * 기존대로 fetch 인터셉터가 경로/전역 선택값으로 결정한다.
+ */
+export const useGetAgentOverview = (
+  {
+    application,
+    serviceTypeName,
+    serviceTypeCode,
+    from,
+    to,
+    applicationPairs,
+  }: AgentOverview.Parameters,
+  serviceName?: string,
+) => {
   const queryString = getQueryString({
     from,
     to,
@@ -29,8 +38,10 @@ export const useGetAgentOverview = ({
   });
 
   const { data, isLoading, refetch } = useSuspenseQuery<AgentOverview.Response | null>({
-    queryKey: [END_POINTS.AGENT_OVERVIEW, queryString],
-    queryFn: !!queryString ? queryFn(`${END_POINTS.AGENT_OVERVIEW}${queryString}`) : () => null,
+    queryKey: [END_POINTS.AGENT_OVERVIEW, queryString, serviceName],
+    queryFn: !!queryString
+      ? queryFn(`${END_POINTS.AGENT_OVERVIEW}${queryString}`, { serviceName })
+      : () => null,
   });
 
   return {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApdexScore.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApdexScore.ts
@@ -23,9 +23,22 @@ export type UseGetApdexScoreProps = {
   disableFetch?: boolean;
   shouldPoll?: boolean;
   agentId?: string;
+  /**
+   * 이 조회가 나갈 service. 지정하면 `pServiceName` 헤더를 직접 싣고 캐시도 그 단위로 갈린다.
+   *
+   * 화면의 service와 조회 대상의 service가 다를 때 넘긴다 — servicemap은 다른 service의
+   * application도 함께 그리기 때문이다(`useServerMapTargetServiceName`). 넘기지 않으면 기존대로
+   * fetch 인터셉터가 경로/전역 선택값으로 결정한다.
+   */
+  serviceName?: string;
 };
 
-export const useGetApdexScore = ({ nodeData, shouldPoll, agentId }: UseGetApdexScoreProps) => {
+export const useGetApdexScore = ({
+  nodeData,
+  shouldPoll,
+  agentId,
+  serviceName,
+}: UseGetApdexScoreProps) => {
   const { dateRange } = useServerMapSearchParameters();
   const from = toBasicISOString(dateRange.from);
   const to = toBasicISOString(dateRange.to);
@@ -36,6 +49,10 @@ export const useGetApdexScore = ({ nodeData, shouldPoll, agentId }: UseGetApdexS
     serviceTypeName: nodeData?.serviceType,
     agentId: agentId,
   });
+  // 조회 파라미터가 effect로 한 박자 늦게 따라오므로 serviceName도 같은 effect에서 함께 갱신한다.
+  // 그러지 않으면 대상이 바뀌는 렌더에서 (이전 application, 새 service) 짝의 queryKey가 한 번
+  // 만들어져, 그 service에 없는 application을 조회하는 요청이 나간다.
+  const [requestServiceName, setRequestServiceName] = React.useState(serviceName);
 
   React.useEffect(() => {
     if (nodeData) {
@@ -47,15 +64,18 @@ export const useGetApdexScore = ({ nodeData, shouldPoll, agentId }: UseGetApdexS
         to: to,
         agentId,
       }));
+      setRequestServiceName(serviceName);
     }
-  }, [nodeData, from, to, agentId]);
+  }, [nodeData, from, to, agentId, serviceName]);
 
   const queryString = getQueryString(queryParams);
 
   const query = shouldPoll ? useQuery : useSuspenseQuery;
   const { data, isLoading } = query({
-    queryKey: [END_POINTS.APDEX_SCORE, queryString],
-    queryFn: queryFn(`${END_POINTS.APDEX_SCORE}${queryString}`),
+    queryKey: [END_POINTS.APDEX_SCORE, queryString, requestServiceName],
+    queryFn: queryFn(`${END_POINTS.APDEX_SCORE}${queryString}`, {
+      serviceName: requestServiceName,
+    }),
     gcTime: shouldPoll ? 0 : 30000,
     staleTime: shouldPoll ? 0 : 30000,
     placeholderData: shouldPoll ? keepPreviousData : undefined,

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHeatmapAppData.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHeatmapAppData.ts
@@ -3,11 +3,20 @@ import { convertParamsToQueryString } from '@pinpoint-fe/ui/src/utils';
 import { useQuery } from '@tanstack/react-query';
 import { queryFn } from './reactQueryHelper';
 
-export const useGetHeatmapAppData = (parameters: GetHeatmapAppData.Parameters) => {
+/**
+ * @param serviceName 이 조회가 나갈 service. 지정하면 `pServiceName` 헤더를 직접 싣고 캐시도 그
+ * 단위로 갈린다. 화면의 service와 조회 대상의 service가 다를 때 넘긴다 — servicemap은 다른
+ * service의 application도 함께 그리기 때문이다(`useServerMapTargetServiceName`). 넘기지 않으면
+ * 기존대로 fetch 인터셉터가 경로/전역 선택값으로 결정한다.
+ */
+export const useGetHeatmapAppData = (
+  parameters: GetHeatmapAppData.Parameters,
+  serviceName?: string,
+) => {
   const queryString = `?${convertParamsToQueryString(parameters)}`;
   const { data, isLoading, refetch, error } = useQuery<GetHeatmapAppData.Response>({
-    queryKey: [END_POINTS.HEATMAP_APP_DATA, parameters],
-    queryFn: queryFn(`${END_POINTS.HEATMAP_APP_DATA}${queryString}`),
+    queryKey: [END_POINTS.HEATMAP_APP_DATA, parameters, serviceName],
+    queryFn: queryFn(`${END_POINTS.HEATMAP_APP_DATA}${queryString}`, { serviceName }),
     enabled: !!queryString,
     // HeatmapFetcher renders a full inline error overlay for this failure — suppress the
     // redundant global error toast so the user sees a single error signal.

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHistogramStatistics.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHistogramStatistics.ts
@@ -25,6 +25,8 @@ export const useGetHistogramStatistics = ({
   nodeKey,
   linkKey,
   fallbackApplication,
+  ignorePathApplication,
+  serviceName,
 }: {
   useStatisticsAgentState?: boolean;
   nodeKey?: string;
@@ -35,6 +37,22 @@ export const useGetHistogramStatistics = ({
    * 통계 API는 기준 application이 필수라 선택된 노드/링크에서 끌어와야 한다.
    */
   fallbackApplication?: ApplicationType;
+  /**
+   * true면 경로의 application을 무시하고 `fallbackApplication`을 기준으로 쓴다.
+   *
+   * 다른 service의 노드를 고른 경우가 여기에 해당한다. 이 요청은 그 노드의 service로 나가는데
+   * (`serviceName`) 경로의 application은 지금 화면의 service 소속이라, 백엔드가 그 이름을
+   * 노드의 service에서 찾게 되어 기준이 성립하지 않는다.
+   */
+  ignorePathApplication?: boolean;
+  /**
+   * 이 조회가 나갈 service. 지정하면 `pServiceName` 헤더를 직접 싣고 캐시도 그 단위로 갈린다.
+   *
+   * 화면의 service와 조회 대상의 service가 다를 때 넘긴다 — servicemap은 다른 service의
+   * application도 함께 그리기 때문이다(`useServerMapTargetServiceName`). 넘기지 않으면 기존대로
+   * fetch 인터셉터가 경로/전역 선택값으로 결정한다.
+   */
+  serviceName?: string;
 }) => {
   const {
     dateRange,
@@ -42,7 +60,8 @@ export const useGetHistogramStatistics = ({
     application: applicationFromPath,
     queryOption,
   } = useServerMapSearchParameters();
-  const application = applicationFromPath ?? fallbackApplication;
+  const application =
+    (ignorePathApplication ? undefined : applicationFromPath) ?? fallbackApplication;
   const from = toBasicISOString(dateRange.from);
   const to = toBasicISOString(dateRange.to);
 
@@ -59,6 +78,10 @@ export const useGetHistogramStatistics = ({
     nodeKey,
     linkKey,
   });
+  // 조회 파라미터가 effect로 한 박자 늦게 따라오므로 serviceName도 같은 effect에서 함께 갱신한다.
+  // 그러지 않으면 대상이 바뀌는 렌더에서 (이전 application, 새 service) 짝의 queryKey가 한 번
+  // 만들어져, 그 service에 없는 application을 조회하는 요청이 나간다.
+  const [requestServiceName, setRequestServiceName] = React.useState(serviceName);
   const queryString = getQueryString(queryParams);
 
   React.useEffect(() => {
@@ -76,6 +99,7 @@ export const useGetHistogramStatistics = ({
       from,
       to,
     }));
+    setRequestServiceName(serviceName);
   }, [
     application?.applicationName,
     application?.serviceType,
@@ -85,14 +109,16 @@ export const useGetHistogramStatistics = ({
     useStatisticsAgentState,
     nodeKey,
     linkKey,
+    serviceName,
   ]);
 
   const { data, isLoading } = useQuery<GetHistogramStatistics.Response>({
-    queryKey: [END_POINTS.HISTOGRAM_STATISTICS, queryString],
+    queryKey: [END_POINTS.HISTOGRAM_STATISTICS, queryString, requestServiceName],
     queryFn: queryFn(
       linkKey
         ? `${END_POINTS.HISTOGRAM_STATISTICS_LINKS}${queryString}`
         : `${END_POINTS.HISTOGRAM_STATISTICS}${queryString}`,
+      { serviceName: requestServiceName },
     ),
     enabled: !!queryString,
   });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetScatterData.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetScatterData.test.tsx
@@ -6,11 +6,9 @@ import { END_POINTS, ApplicationType } from '@pinpoint-fe/ui/src/constants';
 // reactQueryHelper transitively imports the ECharts (ESM) chart stack via ErrorToast,
 // which babel-jest does not transform. Mock queryFn with an equivalent fetch-based
 // implementation so this test can focus on the hook's URL/enabled logic.
+const mockQueryFn = jest.fn();
 jest.mock('./reactQueryHelper', () => ({
-  queryFn: (url: string) => async () => {
-    const response = await fetch(url);
-    return response.json();
-  },
+  queryFn: (url: string, options?: { serviceName?: string }) => mockQueryFn(url, options),
 }));
 
 import { useGetScatterData } from './useGetScatterData';
@@ -38,6 +36,11 @@ const dateRange = {
 describe('useGetScatterData', () => {
   beforeEach(() => {
     global.fetch = jest.fn();
+    // afterEach의 resetAllMocks가 구현까지 지우므로 매번 다시 심는다.
+    mockQueryFn.mockImplementation((url: string) => async () => {
+      const response = await fetch(url);
+      return response.json();
+    });
   });
 
   afterEach(() => {
@@ -80,6 +83,26 @@ describe('useGetScatterData', () => {
     expect(calledUrl).toContain('serviceTypeName=SPRING_BOOT');
     expect(calledUrl).toContain('xGroupUnit=10');
     expect(calledUrl).toContain('yGroupUnit=100');
+  });
+
+  // 다른 service의 노드를 골랐을 때 그 service로 조회해야 한다. 헤더는 queryFn이 싣는다.
+  test('passes the given service down to queryFn', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ complete: true }),
+    });
+
+    const { result } = renderHook(() => useGetScatterData(application, dateRange, 'bService'), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.setQueryParams((prev) => ({ ...prev, xGroupUnit: 10, yGroupUnit: 100 }));
+    });
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+    expect(mockQueryFn).toHaveBeenCalledWith(expect.any(String), { serviceName: 'bService' });
   });
 
   test('does not fetch when the application is missing even if group units are set', async () => {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetScatterData.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetScatterData.ts
@@ -26,6 +26,12 @@ const getQueryString = (queryParams: GetScatter.Parameters & { timestamp?: numbe
   return '';
 };
 
+/**
+ * @param serviceName 이 조회가 나갈 service. 지정하면 `pServiceName` 헤더를 직접 싣고 캐시도 그
+ * 단위로 갈린다. 화면의 service와 조회 대상의 service가 다를 때 넘긴다 — servicemap은 다른
+ * service의 application도 함께 그리기 때문이다(`useServerMapTargetServiceName`). 넘기지 않으면
+ * 기존대로 fetch 인터셉터가 경로/전역 선택값으로 결정한다.
+ */
 export const useGetScatterData = (
   application: ApplicationType,
   dateRange: {
@@ -33,6 +39,7 @@ export const useGetScatterData = (
     from: Date;
     to: Date;
   },
+  serviceName?: string,
 ) => {
   const from = dateRange.from.getTime();
   const to = dateRange.to.getTime();
@@ -49,7 +56,12 @@ export const useGetScatterData = (
     backwardDirection: true,
     timestamp: undefined,
   });
+  // 조회 파라미터가 effect로 한 박자 늦게 따라오므로 serviceName도 같은 effect에서 함께 갱신하고,
+  // 파라미터와 같이 deferred로 넘긴다. 그러지 않으면 대상이 바뀌는 렌더에서 (이전 application,
+  // 새 service) 짝의 queryKey가 한 번 만들어져, 그 service에 없는 application을 조회하게 된다.
+  const [requestService, setRequestService] = React.useState(serviceName);
   const queryParams = React.useDeferredValue(query);
+  const requestServiceName = React.useDeferredValue(requestService);
   const queryString = getQueryString(queryParams);
 
   React.useEffect(() => {
@@ -60,11 +72,14 @@ export const useGetScatterData = (
       application: application?.applicationName,
       serviceTypeName: application?.serviceType,
     }));
-  }, [application?.applicationName, application?.serviceType, from, to]);
+    setRequestService(serviceName);
+  }, [application?.applicationName, application?.serviceType, from, to, serviceName]);
 
   const { data, isLoading } = useQuery({
-    queryKey: [END_POINTS.SCATTER_DATA, queryString],
-    queryFn: queryFn(`${END_POINTS.SCATTER_DATA}${queryString}`),
+    queryKey: [END_POINTS.SCATTER_DATA, queryString, requestServiceName],
+    queryFn: queryFn(`${END_POINTS.SCATTER_DATA}${queryString}`, {
+      serviceName: requestServiceName,
+    }),
     enabled: !!queryString,
     gcTime: 0,
   });

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetScatterRealtimeData.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetScatterRealtimeData.ts
@@ -26,6 +26,12 @@ const getQueryString = (queryParams: GetScatter.Parameters, application?: Applic
   return '';
 };
 
+/**
+ * @param serviceName 이 조회가 나갈 service. 지정하면 `pServiceName` 헤더를 직접 싣고 캐시도 그
+ * 단위로 갈린다. 화면의 service와 조회 대상의 service가 다를 때 넘긴다 — servicemap은 다른
+ * service의 application도 함께 그리기 때문이다(`useServerMapTargetServiceName`). 넘기지 않으면
+ * 기존대로 fetch 인터셉터가 경로/전역 선택값으로 결정한다.
+ */
 export const useGetScatterRealtimeData = (
   application: ApplicationType,
   dateRange: {
@@ -33,6 +39,7 @@ export const useGetScatterRealtimeData = (
     to: Date;
     isRealtime: boolean;
   },
+  serviceName?: string,
 ) => {
   const from = dateRange.from.getTime();
   const to = dateRange.to.getTime();
@@ -52,11 +59,17 @@ export const useGetScatterRealtimeData = (
     backwardDirection: true,
     timestamp: undefined,
   });
+  // 조회 파라미터가 effect로 한 박자 늦게 따라오므로 serviceName도 같은 effect에서 함께 갱신한다.
+  // 그러지 않으면 대상이 바뀌는 렌더에서 (이전 application, 새 service) 짝의 queryKey가 한 번
+  // 만들어져, 그 service에 없는 application을 조회하는 요청이 나간다.
+  const [requestServiceName, setRequestServiceName] = React.useState(serviceName);
   const queryString = getQueryString(queryParams, application);
 
   const { data, isLoading } = useQuery({
-    queryKey: [END_POINTS.SCATTER_DATA, queryString],
-    queryFn: queryFn(`${END_POINTS.SCATTER_DATA}${queryString}`),
+    queryKey: [END_POINTS.SCATTER_DATA, queryString, requestServiceName],
+    queryFn: queryFn(`${END_POINTS.SCATTER_DATA}${queryString}`, {
+      serviceName: requestServiceName,
+    }),
     enabled: !!queryString,
     gcTime: 0,
   });
@@ -69,7 +82,8 @@ export const useGetScatterRealtimeData = (
       application: application.applicationName,
       serviceTypeName: application.serviceType,
     }));
-  }, [application.applicationName, application.serviceType, from, to]);
+    setRequestServiceName(serviceName);
+  }, [application.applicationName, application.serviceType, from, to, serviceName]);
 
   React.useEffect(() => {
     if (!isLoading && data) {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/index.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/index.tsx
@@ -1,2 +1,3 @@
 export * from './useFilterWizardOnClickApply';
 export * from './useServerMapOnClickMenuItem';
+export * from './useServerMapTargetServiceName';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapTargetServiceName.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapTargetServiceName.test.tsx
@@ -1,0 +1,108 @@
+import { renderHook, act } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import {
+  configurationAtom,
+  CurrentTarget,
+  serverMapCurrentTargetAtom,
+  serverMapDataAtom,
+} from '@pinpoint-fe/ui/src/atoms';
+import { Configuration, GetServerMap } from '@pinpoint-fe/ui/src/constants';
+import { useServerMapTargetServiceName } from './useServerMapTargetServiceName';
+
+const store = getDefaultStore();
+
+const configWithServiceMap = (enable: boolean) =>
+  ({ 'experimental.enableServiceMap.value': enable }) as unknown as Configuration;
+
+const setEnableServiceMap = (enable: boolean) => {
+  act(() => {
+    store.set(configurationAtom, configWithServiceMap(enable));
+  });
+};
+
+const node = (serviceName: string, applicationName: string) =>
+  ({
+    key: `${serviceName}^${applicationName}^SPRING_BOOT`,
+    serviceName,
+    applicationName,
+    serviceType: 'SPRING_BOOT',
+  }) as GetServerMap.NodeData;
+
+const setMap = (
+  nodeDataArray: GetServerMap.NodeData[],
+  linkDataArray: GetServerMap.LinkData[] = [],
+) => {
+  act(() => {
+    store.set(serverMapDataAtom, {
+      applicationMapData: { nodeDataArray, linkDataArray },
+    } as GetServerMap.Response);
+  });
+};
+
+const setTarget = (target?: CurrentTarget) => {
+  act(() => {
+    store.set(serverMapCurrentTargetAtom, target);
+  });
+};
+
+const render = () => renderHook(() => useServerMapTargetServiceName()).result.current;
+
+describe('useServerMapTargetServiceName', () => {
+  beforeEach(() => {
+    setEnableServiceMap(true);
+  });
+
+  test('is undefined while nothing is picked, so the screen service keeps being used', () => {
+    setMap([node('aService', 'a-1')]);
+    setTarget(undefined);
+
+    expect(render()).toBeUndefined();
+  });
+
+  test('is the service of the picked node', () => {
+    setMap([node('aService', 'a-1')]);
+    setTarget({ id: 'aService^a-1^SPRING_BOOT', type: 'node' });
+
+    expect(render()).toBe('aService');
+  });
+
+  // service group을 펼쳐 고른 자식 노드. 이 화면(aService)과 다른 service에 속한다.
+  test('is the service of a child node picked inside a collapsed service group', () => {
+    setMap([
+      node('aService', 'a-1'),
+      {
+        ...node('bService', 'bService'),
+        key: 'bService',
+        subNodes: [node('bService', 'b-1')],
+      } as GetServerMap.NodeData,
+    ]);
+    setTarget({ id: 'bService^b-1^SPRING_BOOT', type: 'node' });
+
+    expect(render()).toBe('bService');
+  });
+
+  // 설정이 꺼져 있으면 백엔드가 모든 요청을 기본 service로 해석하므로 실을 값이 없다.
+  test('is undefined when enableServiceMap is off', () => {
+    setEnableServiceMap(false);
+    setMap([node('aService', 'a-1')]);
+    setTarget({ id: 'aService^a-1^SPRING_BOOT', type: 'node' });
+
+    expect(render()).toBeUndefined();
+  });
+
+  test('is the service of the source node for a link', () => {
+    setMap(
+      [node('aService', 'a-1')],
+      [
+        {
+          key: 'aService^a-1^SPRING_BOOT~bService^b-1^SPRING_BOOT',
+          sourceInfo: { serviceName: 'aService', applicationName: 'a-1' },
+          targetInfo: { serviceName: 'bService', applicationName: 'b-1' },
+        } as GetServerMap.LinkData,
+      ],
+    );
+    setTarget({ id: 'aService^a-1^SPRING_BOOT~bService^b-1^SPRING_BOOT', type: 'edge' });
+
+    expect(render()).toBe('aService');
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapTargetServiceName.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapTargetServiceName.ts
@@ -1,0 +1,37 @@
+import { useAtomValue } from 'jotai';
+import { serverMapCurrentTargetDataAtom } from '@pinpoint-fe/ui/src/atoms';
+import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
+import { useConfiguration } from '../utility/useConfiguration';
+
+/**
+ * map에서 고른 노드/링크가 소속된 service. 고른 것이 없으면 undefined다.
+ *
+ * servicemap은 다른 service를 묶은 group 노드까지 함께 그리고, group을 펼쳐 그 안의
+ * application을 고를 수 있다. 그렇게 고른 대상은 화면의 service와 다른 service에 속하므로,
+ * 그 대상을 조회하는 요청은 화면의 service가 아니라 이 값으로 나가야 한다.
+ *
+ * 이 값은 우측 패널의 컴포넌트들에 `serviceName` prop으로 내려간다. 받은 컴포넌트는 조회 훅과
+ * 다른 화면으로 넘기는 링크에 그대로 쓰고, 받지 않은 화면(filteredMap, inspector 등)은 기존대로
+ * 화면의 service로 조회한다.
+ *
+ * 값은 백엔드가 노드마다 내려주는 `serviceName`(= `application.getService()`)이다.
+ * 링크는 자기 service가 없으므로 출발지 노드의 service를 쓴다. 링크 통계의 기준 application도
+ * 출발지 노드이므로(`ServerMapChartsBoardFetcher`) 같은 기준이다.
+ *
+ * `enableServiceMap`이 꺼져 있으면 service 개념 자체가 없으므로(백엔드가 모든 요청을 기본
+ * service로 해석한다) 항상 undefined다. 이 값이 그대로 요청 헤더가 되므로, 설정이 꺼진 저장소에
+ * 헤더가 새어 나가지 않도록 여기 한 곳에서 막는다.
+ */
+export const useServerMapTargetServiceName = () => {
+  const configuration = useConfiguration();
+  const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom);
+
+  if (!configuration?.['experimental.enableServiceMap.value'] || !currentTargetData) {
+    return undefined;
+  }
+
+  return (
+    (currentTargetData as GetServerMap.NodeData).serviceName ??
+    (currentTargetData as GetServerMap.LinkData).sourceInfo?.serviceName
+  );
+};


### PR DESCRIPTION
## Summary
- Servicemap draws applications of other services as service groups. Expanding a group and picking a child queried the right panel with the screen's service, so the backend looked the application up in a service it does not belong to and the charts came back empty (internal issue: servicemap cross-service `pServiceName`).
- The target's service now comes from the node the map returns and is passed to the charts, which put it on the `pServiceName` header **and** in the query key, so caches of same-named applications in different services cannot mix. The path application belongs to the screen's service, so statistics fall back to the selected node when the target is from another service.
- `serviceName` is committed together with the query parameters it belongs to. Those hooks keep parameters in state and sync them in an effect, so reading `serviceName` straight from props fired one request pairing the *previous* application with the *new* service on every target switch.
- Also keeps the service group popup inside the map. It overflowed the pane, and focusing its search input then scrolled the whole map under the side navigation.
- The second commit adds a dev-only mock (`yarn dev:mock`) that reproduces a two-service repository locally, since the case needs two services calling each other. **It is temporary and will be dropped before merge** - `apps/web/dev-mock/README.md` lists every touch point.

## Test plan
- [x] `yarn build`
- [x] `yarn test` (968 tests / 114 suites)
- [x] Servicemap of a non-DEFAULT service: expand another service's group, pick a child, and confirm the right panel requests carry that child's service in `pServiceName`
- [x] Same on `/serviceMap/realtime`
- [x] Switch back to a node of the screen's service and confirm no request pairs the previous application with the new service
- [x] Open the service group popup on a node near the right edge and confirm the map no longer shifts under the side navigation
- [ ] Servermap and filteredMap are unchanged (they pass no `serviceName`, so the popup clamp is the only shared change)
