### PR TITLE
[#noissue] Provide a static DEFAULT ServiceLookupService when service lookup is disabled

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/PinpointCollectorModule.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/PinpointCollectorModule.java
@@ -27,6 +27,7 @@ import com.navercorp.pinpoint.collector.grpc.ssl.GrpcSslModule;
 import com.navercorp.pinpoint.collector.heatmap.HeatmapCollectorModule;
 import com.navercorp.pinpoint.collector.manage.CollectorAdminConfiguration;
 import com.navercorp.pinpoint.collector.uid.ServiceLookupConfiguration;
+import com.navercorp.pinpoint.collector.uid.StaticServiceLookupConfiguration;
 import com.navercorp.pinpoint.common.server.CommonsServerConfiguration;
 import com.navercorp.pinpoint.common.server.config.TypeLoaderConfiguration;
 import com.navercorp.pinpoint.common.server.uid.ObjectNameVersion;
@@ -62,6 +63,7 @@ import org.springframework.context.annotation.Import;
         ApplicationMapModule.class,
 
         ServiceLookupConfiguration.class,
+        StaticServiceLookupConfiguration.class,
         HeatmapCollectorModule.class,
 
         CollectorEventConfiguration.class

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/grpc/config/GrpcComponentConfiguration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/grpc/config/GrpcComponentConfiguration.java
@@ -27,12 +27,11 @@ import com.navercorp.pinpoint.collector.uid.service.ServiceLookupService;
 import com.navercorp.pinpoint.common.server.bo.filter.SpanEventFilter;
 import com.navercorp.pinpoint.common.server.io.CollectorGrpcSpanFactory;
 import com.navercorp.pinpoint.common.server.io.GrpcSpanBinder;
-import com.navercorp.pinpoint.io.request.UidFetcher;
 import com.navercorp.pinpoint.io.request.UidFetcherService;
 import com.navercorp.pinpoint.io.request.UidFetcherStreamService;
-import com.navercorp.pinpoint.io.request.UidFetchers;
 import io.grpc.ServerTransportFilter;
-import org.springframework.beans.factory.ObjectProvider;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
@@ -47,25 +46,20 @@ import java.util.List;
 @Configuration
 public class GrpcComponentConfiguration {
 
+    private static final Logger logger = LogManager.getLogger(GrpcComponentConfiguration.class);
+
     public GrpcComponentConfiguration() {
+        logger.info("Install GrpcComponentConfiguration");
     }
 
     @Bean
-    public UidFetcherService uidFetcherService(ObjectProvider<ServiceLookupService> serviceLookupServiceProvider) {
-        return () -> newUidFetcher(serviceLookupServiceProvider);
+    public UidFetcherService uidFetcherService(ServiceLookupService serviceLookupService) {
+        return () -> serviceLookupService::getServiceUid;
     }
 
     @Bean
-    public UidFetcherStreamService uidFetcherStreamService(ObjectProvider<ServiceLookupService> serviceLookupServiceProvider) {
-        return () -> newUidFetcher(serviceLookupServiceProvider);
-    }
-
-    private UidFetcher newUidFetcher(ObjectProvider<ServiceLookupService> serviceLookupServiceProvider) {
-        ServiceLookupService serviceLookupService = serviceLookupServiceProvider.getIfAvailable();
-        if (serviceLookupService == null) {
-            return UidFetchers.defaultUidFetcher();
-        }
-        return serviceLookupService::getServiceUid;
+    public UidFetcherStreamService uidFetcherStreamService(ServiceLookupService serviceLookupService) {
+        return () -> serviceLookupService::getServiceUid;
     }
 
     @Bean

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/uid/ServiceLookupConfiguration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/uid/ServiceLookupConfiguration.java
@@ -9,6 +9,8 @@ import com.navercorp.pinpoint.common.server.executor.ExecutorProperties;
 import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
 import com.navercorp.pinpoint.service.config.ServiceMysqlConfiguration;
 import com.navercorp.pinpoint.service.dao.ServiceRegistryDao;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -25,14 +27,23 @@ import java.util.concurrent.ExecutorService;
 
 @Configuration
 //@ConditionalOnProperty(name = ObjectNameVersion.KEY, havingValue = "v4")
-@ConditionalOnProperty(name = "pinpoint.collector.service.lookup.enabled", havingValue = "true")
+@ConditionalOnProperty(name = ServiceLookupConfiguration.ENABLED_KEY, havingValue = "true")
 @Import({
         ServiceMysqlConfiguration.class,
         ServiceLookupCacheConfiguration.class,
 })
 public class ServiceLookupConfiguration {
 
+    // Service lookup becomes mandatory in 4.0.0, remove StaticServiceLookupConfiguration then
+    public static final String ENABLED_KEY = "pinpoint.collector.service.lookup.enabled";
+
     public static final String EXECUTOR_NAME = "collectorServiceLookupExecutor";
+
+    private static final Logger logger = LogManager.getLogger(ServiceLookupConfiguration.class);
+
+    public ServiceLookupConfiguration() {
+        logger.info("Install ServiceLookupConfiguration");
+    }
 
     @Bean
     @Validated

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/uid/StaticServiceLookupConfiguration.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/uid/StaticServiceLookupConfiguration.java
@@ -1,0 +1,39 @@
+package com.navercorp.pinpoint.collector.uid;
+
+import com.navercorp.pinpoint.collector.uid.service.ServiceLookupService;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.common.server.uid.ServiceUidService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Fallback for the disabled case, mirroring the condition of {@link ServiceLookupConfiguration}.
+ * Registers a static {@link ServiceLookupService} that resolves every serviceName to
+ * {@link ServiceUid#DEFAULT} without touching storage.
+ * Service lookup becomes mandatory in 4.0.0, remove this configuration then.
+ */
+@Configuration
+@ConditionalOnProperty(name = ServiceLookupConfiguration.ENABLED_KEY, havingValue = "false", matchIfMissing = true)
+public class StaticServiceLookupConfiguration {
+
+    private static final Logger logger = LogManager.getLogger(StaticServiceLookupConfiguration.class);
+
+    public StaticServiceLookupConfiguration() {
+        logger.info("Install StaticServiceLookupConfiguration");
+    }
+
+    @Bean
+    public ServiceLookupService staticServiceLookupService() {
+        logger.warn("Service lookup is disabled, falling back to static DEFAULT serviceUid resolution. " +
+                "Set `{}=true`, it will be mandatory in 4.0.0", ServiceLookupConfiguration.ENABLED_KEY);
+        return serviceName -> {
+            ServiceUid serviceUid = ServiceUidService.getServiceUid(serviceName);
+            return CompletableFuture.completedFuture(serviceUid);
+        };
+    }
+}

--- a/collector/src/main/java/com/navercorp/pinpoint/collector/uid/service/ServiceLookupService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/uid/service/ServiceLookupService.java
@@ -8,7 +8,8 @@ public interface ServiceLookupService {
 
     /**
      * Resolve a single serviceName to its serviceUid. The future completes with null when the serviceName is not
-     * registered.
+     * registered. When service lookup is disabled, the static fallback registered by
+     * {@code StaticServiceLookupConfiguration} completes with {@link ServiceUid#DEFAULT} instead.
      */
     CompletableFuture<ServiceUid> getServiceUid(String serviceName);
 }


### PR DESCRIPTION
Service lookup becomes mandatory in 4.0.0. Until then, register a fallback
ServiceLookupService that resolves every serviceName to ServiceUid.DEFAULT
via StaticServiceLookupConfiguration, mirroring the condition of
ServiceLookupConfiguration. Consumers now inject ServiceLookupService
directly instead of falling back through ObjectProvider/UidFetchers.


This pull request introduces a fallback mechanism for service UID lookup in the Pinpoint collector, ensuring the system can operate even when service lookup is disabled. It adds a new `StaticServiceLookupConfiguration` that provides a static UID resolver when the main service lookup is turned off, and refactors configuration and bean wiring for clarity and maintainability. Logging has also been improved for better visibility into configuration activation.

Key changes:

**Service Lookup Fallback Mechanism:**
* Added `StaticServiceLookupConfiguration`, which registers a static `ServiceLookupService` that always returns the default service UID when service lookup is disabled. This avoids storage access and ensures the collector can still function. The configuration is conditionally activated based on the `pinpoint.collector.service.lookup.enabled` property.
* Updated the documentation for `ServiceLookupService#getServiceUid` to clarify that the static fallback returns `ServiceUid.DEFAULT` when service lookup is disabled.

**Configuration and Bean Wiring Improvements:**
* Updated `PinpointCollectorModule` to import and register `StaticServiceLookupConfiguration` alongside the existing `ServiceLookupConfiguration`, ensuring the correct configuration is loaded based on the property. [[1]](diffhunk://#diff-2c08c4a8c9f96f190cf1af7029a45ff421f6d0ea7c49ecb74e1d631ce1b1dba0R30) [[2]](diffhunk://#diff-2c08c4a8c9f96f190cf1af7029a45ff421f6d0ea7c49ecb74e1d631ce1b1dba0R66)
* Refactored `GrpcComponentConfiguration` to simplify bean creation for `UidFetcherService` and `UidFetcherStreamService`, removing unnecessary indirection and ensuring they always use the correct `ServiceLookupService` bean. [[1]](diffhunk://#diff-3c328bf9e071b1dd543cf7830e8df5472de2eac8766602e93301d65fb5ec92b3L30-R34) [[2]](diffhunk://#diff-3c328bf9e071b1dd543cf7830e8df5472de2eac8766602e93301d65fb5ec92b3R49-R62)
* Refactored `ServiceLookupConfiguration` to use a shared constant for the enable property key, improving maintainability and consistency. [[1]](diffhunk://#diff-dfd24d457ac95961fef017599ab5c7f2ad305cbc3ccccd83ea81b8ae423dc655R12-R13) [[2]](diffhunk://#diff-dfd24d457ac95961fef017599ab5c7f2ad305cbc3ccccd83ea81b8ae423dc655L28-R47)

**Logging and Observability:**
* Added logger initialization and informative log messages to both `ServiceLookupConfiguration` and `StaticServiceLookupConfiguration` constructors, making it easier to trace which configuration is active at runtime. [[1]](diffhunk://#diff-dfd24d457ac95961fef017599ab5c7f2ad305cbc3ccccd83ea81b8ae423dc655L28-R47) [[2]](diffhunk://#diff-9047aebba47372d5b1612b9a094cfb55f3cec0b83d54a86b787b463a262a0f8fR1-R39)