### PR TITLE
[#noissue] Register ServiceLookup configurations in the OTLPTRACE col…

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
@@ -24,6 +24,8 @@ import com.navercorp.pinpoint.collector.heatmap.HeatmapCollectorModule;
 import com.navercorp.pinpoint.collector.receiver.grpc.GrpcReceiver;
 import com.navercorp.pinpoint.collector.receiver.grpc.monitor.BasicMonitor;
 import com.navercorp.pinpoint.collector.receiver.grpc.monitor.Monitor;
+import com.navercorp.pinpoint.collector.uid.ServiceLookupConfiguration;
+import com.navercorp.pinpoint.collector.uid.StaticServiceLookupConfiguration;
 import com.navercorp.pinpoint.common.server.config.TypeLoaderConfiguration;
 import com.navercorp.pinpoint.common.server.uid.ObjectNameVersion;
 import com.navercorp.pinpoint.common.server.util.IgnoreAddressFilter;
@@ -56,6 +58,8 @@ import java.util.concurrent.Executor;
         ApplicationMapModule.class,
         TypeLoaderConfiguration.class,
 
+        ServiceLookupConfiguration.class,
+        StaticServiceLookupConfiguration.class,
         HeatmapCollectorModule.class,
 
         OtlpTraceCollectorPropertySources.class,


### PR DESCRIPTION
…lector module

09324f1263 made ApplicationMapModule's applicationMapBuilder require a ServiceLookupService bean, and 6ac4a517b1 registered the static DEFAULT fallback only in PinpointCollectorModule. OtlpTraceCollectorModule imports ApplicationMapModule directly, so the standalone OTLPTRACE collector failed to boot with 'required a bean of type ServiceLookupService that could not be found'. Import the same ServiceLookupConfiguration / StaticServiceLookupConfiguration pair so exactly one ServiceLookupService exists whether service lookup is enabled or not.