### PR TITLE
[#noissue] Add unit tests for Ktor client tracing instrumentation

### DIFF
--- a/agent-module/plugins/ktor/pom.xml
+++ b/agent-module/plugins/ktor/pom.xml
@@ -27,6 +27,11 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-commons-profiler</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.ktor</groupId>

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/KtorConstantsTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/KtorConstantsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class KtorConstantsTest {
+
+    @BeforeAll
+    static void registerServiceTypes() {
+        // registrations come from this plugin's own type-provider.yml
+        KtorTestServiceTypes.register();
+    }
+
+    @Test
+    void serviceTypesMatchShippedTypeRegistry() {
+        assertEquals("KTOR", KtorConstants.KTOR.getName());
+        assertEquals(1160, KtorConstants.KTOR.getCode());
+        assertEquals("KTOR_INTERNAL", KtorConstants.KTOR_INTERNAL.getName());
+        assertEquals(1161, KtorConstants.KTOR_INTERNAL.getCode());
+        assertEquals("KTOR_CLIENT", KtorConstants.KTOR_CLIENT.getName());
+        assertEquals(9068, KtorConstants.KTOR_CLIENT.getCode());
+        assertEquals("KTOR_CLIENT_INTERNAL", KtorConstants.KTOR_CLIENT_INTERNAL.getName());
+        assertEquals(9069, KtorConstants.KTOR_CLIENT_INTERNAL.getCode());
+    }
+
+    @Test
+    void serviceTypesAreDistinct() {
+        assertNotEquals(KtorConstants.KTOR, KtorConstants.KTOR_INTERNAL);
+        assertNotEquals(KtorConstants.KTOR, KtorConstants.KTOR_CLIENT);
+        assertNotEquals(KtorConstants.KTOR_CLIENT, KtorConstants.KTOR_CLIENT_INTERNAL);
+        assertNotEquals(KtorConstants.KTOR.getCode(), KtorConstants.KTOR_INTERNAL.getCode());
+        assertNotEquals(KtorConstants.KTOR.getCode(), KtorConstants.KTOR_CLIENT.getCode());
+        assertNotEquals(KtorConstants.KTOR_CLIENT.getCode(), KtorConstants.KTOR_CLIENT_INTERNAL.getCode());
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/KtorPluginTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/KtorPluginTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor;
+
+import com.navercorp.pinpoint.bootstrap.async.AsyncContextAccessor;
+import com.navercorp.pinpoint.bootstrap.config.DefaultProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentClass;
+import com.navercorp.pinpoint.bootstrap.instrument.InstrumentMethod;
+import com.navercorp.pinpoint.bootstrap.instrument.Instrumentor;
+import com.navercorp.pinpoint.bootstrap.instrument.MethodFilter;
+import com.navercorp.pinpoint.bootstrap.instrument.transformer.MatchableTransformTemplate;
+import com.navercorp.pinpoint.bootstrap.plugin.ProfilerPluginSetupContext;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.plugin.ktor.client.KtorClientContinuationConstructorInterceptor;
+import com.navercorp.pinpoint.plugin.ktor.client.KtorClientContinuationInterceptor;
+import com.navercorp.pinpoint.plugin.ktor.client.KtorClientSendInterceptor;
+import com.navercorp.pinpoint.plugin.ktor.client.KtorClientTraceAccessor;
+import com.navercorp.pinpoint.plugin.ktor.interceptor.ConfigureRoutingFactoryInterceptor;
+import com.navercorp.pinpoint.plugin.ktor.interceptor.NettyApplicationCallHandlerInterceptor;
+import com.navercorp.pinpoint.plugin.ktor.interceptor.NettyHttp1HandlerHandleRequestInterceptor;
+import com.navercorp.pinpoint.plugin.ktor.interceptor.NettyHttp1HandlerPrepareCallFromRequestInterceptor;
+import com.navercorp.pinpoint.plugin.ktor.interceptor.SuspendFunctionGunInterceptor;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class KtorPluginTest {
+    @BeforeAll
+    static void registerServiceTypes() {
+        // registrations come from this plugin's own type-provider.yml
+        KtorTestServiceTypes.register();
+    }
+
+    private static final String DEFAULT_SENDER = "io.ktor.client.plugins.HttpSend$DefaultSender";
+    private static final String DEFAULT_SENDER_CONTINUATION = "io.ktor.client.plugins.HttpSend$DefaultSender$execute$1";
+
+    private final MatchableTransformTemplate transformTemplate = mock(MatchableTransformTemplate.class);
+    private final ProfilerPluginSetupContext setupContext = mock(ProfilerPluginSetupContext.class);
+
+    @Test
+    void setupDisabledDoesNothing() {
+        DefaultProfilerConfig profilerConfig = new DefaultProfilerConfig();
+        profilerConfig.getProperties().setProperty("profiler.ktor.enable", "false");
+        when(setupContext.getConfig()).thenReturn(profilerConfig);
+
+        newKtorPlugin().setup(setupContext);
+
+        verifyNoInteractions(transformTemplate);
+    }
+
+    @Test
+    void setupRegistersServerAndClientTransforms() {
+        when(setupContext.getConfig()).thenReturn(new DefaultProfilerConfig());
+        when(setupContext.getConfiguredApplicationType()).thenReturn(ServiceType.UNDEFINED);
+
+        newKtorPlugin().setup(setupContext);
+
+        verify(transformTemplate).transform("io.ktor.server.netty.http1.NettyHttp1Handler", KtorPlugin.NettyHttp1HandlerTransform.class);
+        verify(transformTemplate).transform("io.ktor.server.netty.http1.NettyHttp1ApplicationCall", KtorPlugin.NettyHttp1ApplicationCallTransform.class);
+        verify(transformTemplate).transform("io.ktor.server.netty.NettyApplicationCallHandler", KtorPlugin.NettyApplicationCallHandlerTransform.class);
+        verify(transformTemplate).transform("io.ktor.util.pipeline.SuspendFunctionGun", KtorPlugin.SuspendFunctionGunTransform.class);
+        verify(transformTemplate).transform("io.ktor.server.routing.Route", KtorPlugin.RouteTransform.class);
+        verify(transformTemplate).transform(DEFAULT_SENDER, KtorPlugin.KtorClientDefaultSenderTransform.class);
+        verify(transformTemplate).transform(DEFAULT_SENDER_CONTINUATION, KtorPlugin.KtorClientDefaultSenderContinuationTransform.class);
+    }
+
+    @Test
+    void setupSkipsClientTransformsWhenClientDisabled() {
+        DefaultProfilerConfig profilerConfig = new DefaultProfilerConfig();
+        profilerConfig.getProperties().setProperty("profiler.ktor.client.enable", "false");
+        when(setupContext.getConfig()).thenReturn(profilerConfig);
+        when(setupContext.getConfiguredApplicationType()).thenReturn(KtorConstants.KTOR);
+
+        newKtorPlugin().setup(setupContext);
+
+        verify(transformTemplate).transform("io.ktor.server.netty.http1.NettyHttp1Handler", KtorPlugin.NettyHttp1HandlerTransform.class);
+        verify(transformTemplate, never()).transform(DEFAULT_SENDER, KtorPlugin.KtorClientDefaultSenderTransform.class);
+        verify(transformTemplate, never()).transform(DEFAULT_SENDER_CONTINUATION, KtorPlugin.KtorClientDefaultSenderContinuationTransform.class);
+    }
+
+    @Test
+    void setupSkipsRouteTransformWhenRetransformDisabled() {
+        DefaultProfilerConfig profilerConfig = new DefaultProfilerConfig();
+        profilerConfig.getProperties().setProperty("profiler.ktor.http.server.retransform.configure-routing", "false");
+        when(setupContext.getConfig()).thenReturn(profilerConfig);
+        when(setupContext.getConfiguredApplicationType()).thenReturn(KtorConstants.KTOR);
+
+        newKtorPlugin().setup(setupContext);
+
+        verify(transformTemplate, never()).transform("io.ktor.server.routing.Route", KtorPlugin.RouteTransform.class);
+    }
+
+    @Test
+    void defaultSenderTransformAddsSendInterceptor() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        InstrumentMethod execute = mock(InstrumentMethod.class);
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), DEFAULT_SENDER, bytecode)).thenReturn(target);
+        when(target.getDeclaredMethod("execute", "io.ktor.client.request.HttpRequestBuilder", "kotlin.coroutines.Continuation")).thenReturn(execute);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.KtorClientDefaultSenderTransform().doInTransform(instrumentor, getClass().getClassLoader(), DEFAULT_SENDER, null, null, bytecode);
+
+        verify(execute).addInterceptor(KtorClientSendInterceptor.class);
+        assertSame(bytecode, transformed);
+    }
+
+    @Test
+    void defaultSenderTransformSkipsMissingExecute() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), DEFAULT_SENDER, bytecode)).thenReturn(target);
+        when(target.getDeclaredMethod("execute", "io.ktor.client.request.HttpRequestBuilder", "kotlin.coroutines.Continuation")).thenReturn(null);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.KtorClientDefaultSenderTransform().doInTransform(instrumentor, getClass().getClassLoader(), DEFAULT_SENDER, null, null, bytecode);
+
+        verify(target, never()).getDeclaredMethods(any());
+        assertSame(bytecode, transformed);
+    }
+
+    @Test
+    void continuationTransformAddsFieldAndInterceptors() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        InstrumentMethod constructor = mock(InstrumentMethod.class);
+        InstrumentMethod invokeSuspend = mock(InstrumentMethod.class);
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), DEFAULT_SENDER_CONTINUATION, bytecode)).thenReturn(target);
+        when(target.getConstructor("io.ktor.client.plugins.HttpSend$DefaultSender", "kotlin.coroutines.Continuation")).thenReturn(constructor);
+        when(target.getDeclaredMethod("invokeSuspend", "java.lang.Object")).thenReturn(invokeSuspend);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.KtorClientDefaultSenderContinuationTransform().doInTransform(instrumentor, getClass().getClassLoader(), DEFAULT_SENDER_CONTINUATION, null, null, bytecode);
+
+        verify(target).addField(KtorClientTraceAccessor.class);
+        verify(constructor).addInterceptor(KtorClientContinuationConstructorInterceptor.class);
+        verify(invokeSuspend).addInterceptor(KtorClientContinuationInterceptor.class);
+        assertSame(bytecode, transformed);
+    }
+
+    @Test
+    void continuationTransformSkipsMissingMembers() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), DEFAULT_SENDER_CONTINUATION, bytecode)).thenReturn(target);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.KtorClientDefaultSenderContinuationTransform().doInTransform(instrumentor, getClass().getClassLoader(), DEFAULT_SENDER_CONTINUATION, null, null, bytecode);
+
+        verify(target).addField(KtorClientTraceAccessor.class);
+        assertSame(bytecode, transformed);
+    }
+
+    @Test
+    void nettyHttp1HandlerTransformAddsInterceptors() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        InstrumentMethod handleRequest = mock(InstrumentMethod.class);
+        InstrumentMethod prepareCall = mock(InstrumentMethod.class);
+        String className = "io.ktor.server.netty.http1.NettyHttp1Handler";
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), className, bytecode)).thenReturn(target);
+        when(target.getDeclaredMethod("handleRequest", "io.netty.channel.ChannelHandlerContext", "io.netty.handler.codec.http.HttpRequest")).thenReturn(handleRequest);
+        when(target.getDeclaredMethod("prepareCallFromRequest", "io.netty.channel.ChannelHandlerContext", "io.netty.handler.codec.http.HttpRequest")).thenReturn(prepareCall);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.NettyHttp1HandlerTransform().doInTransform(instrumentor, getClass().getClassLoader(), className, null, null, bytecode);
+
+        verify(target).addField(AsyncContextAccessor.class);
+        verify(handleRequest).addInterceptor(NettyHttp1HandlerHandleRequestInterceptor.class);
+        verify(prepareCall).addInterceptor(NettyHttp1HandlerPrepareCallFromRequestInterceptor.class);
+        assertSame(bytecode, transformed);
+    }
+
+    @Test
+    void nettyHttp1ApplicationCallTransformAddsAccessorField() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        String className = "io.ktor.server.netty.http1.NettyHttp1ApplicationCall";
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), className, bytecode)).thenReturn(target);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.NettyHttp1ApplicationCallTransform().doInTransform(instrumentor, getClass().getClassLoader(), className, null, null, bytecode);
+
+        verify(target).addField(AsyncContextAccessor.class);
+        assertSame(bytecode, transformed);
+    }
+
+    @Test
+    void nettyApplicationCallHandlerTransformAddsGetterAndInterceptor() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        InstrumentMethod handleRequest = mock(InstrumentMethod.class);
+        String className = "io.ktor.server.netty.NettyApplicationCallHandler";
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), className, bytecode)).thenReturn(target);
+        List<InstrumentMethod> methods = Collections.singletonList(handleRequest);
+        when(target.getDeclaredMethods(any(MethodFilter.class))).thenReturn(methods);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.NettyApplicationCallHandlerTransform().doInTransform(instrumentor, getClass().getClassLoader(), className, null, null, bytecode);
+
+        verify(target).addGetter(CoroutineContextGetter.class, "coroutineContext");
+        verify(handleRequest).addInterceptor(NettyApplicationCallHandlerInterceptor.class);
+        assertSame(bytecode, transformed);
+    }
+
+    @Test
+    void suspendFunctionGunTransformAddsLoopInterceptors() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        InstrumentMethod loopOne = mock(InstrumentMethod.class);
+        InstrumentMethod loopTwo = mock(InstrumentMethod.class);
+        String className = "io.ktor.util.pipeline.SuspendFunctionGun";
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), className, bytecode)).thenReturn(target);
+        List<InstrumentMethod> methods = Arrays.asList(loopOne, loopTwo);
+        when(target.getDeclaredMethods(any(MethodFilter.class))).thenReturn(methods);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.SuspendFunctionGunTransform().doInTransform(instrumentor, getClass().getClassLoader(), className, null, null, bytecode);
+
+        verify(loopOne).addInterceptor(SuspendFunctionGunInterceptor.class);
+        verify(loopTwo).addInterceptor(SuspendFunctionGunInterceptor.class);
+        assertSame(bytecode, transformed);
+    }
+
+    @Test
+    void routeTransformAddsHandleInterceptorWithTransformer() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        InstrumentMethod handle = mock(InstrumentMethod.class);
+        String className = "io.ktor.server.routing.Route";
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), className, bytecode)).thenReturn(target);
+        List<InstrumentMethod> methods = Collections.singletonList(handle);
+        when(target.getDeclaredMethods(any(MethodFilter.class))).thenReturn(methods);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.RouteTransform().doInTransform(instrumentor, getClass().getClassLoader(), className, null, null, bytecode);
+
+        verify(handle).addInterceptor(eq(ConfigureRoutingFactoryInterceptor.class), any(Object[].class));
+        assertSame(bytecode, transformed);
+    }
+
+    @Test
+    void nettyHttp1HandlerTransformSkipsMissingMethods() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        String className = "io.ktor.server.netty.http1.NettyHttp1Handler";
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), className, bytecode)).thenReturn(target);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.NettyHttp1HandlerTransform().doInTransform(instrumentor, getClass().getClassLoader(), className, null, null, bytecode);
+
+        verify(target).addField(AsyncContextAccessor.class);
+        assertSame(bytecode, transformed);
+    }
+
+    @Test
+    void nettyApplicationCallHandlerTransformIgnoresNullMethodEntry() throws Exception {
+        Instrumentor instrumentor = mock(Instrumentor.class);
+        InstrumentClass target = mock(InstrumentClass.class);
+        String className = "io.ktor.server.netty.NettyApplicationCallHandler";
+        byte[] bytecode = new byte[0];
+        when(instrumentor.getInstrumentClass(getClass().getClassLoader(), className, bytecode)).thenReturn(target);
+        List<InstrumentMethod> methods = Collections.singletonList(null);
+        when(target.getDeclaredMethods(any(MethodFilter.class))).thenReturn(methods);
+        when(target.toBytecode()).thenReturn(bytecode);
+
+        byte[] transformed = new KtorPlugin.NettyApplicationCallHandlerTransform().doInTransform(instrumentor, getClass().getClassLoader(), className, null, null, bytecode);
+
+        verify(target).addGetter(CoroutineContextGetter.class, "coroutineContext");
+        assertSame(bytecode, transformed);
+    }
+
+    private KtorPlugin newKtorPlugin() {
+        KtorPlugin plugin = new KtorPlugin();
+        plugin.setTransformTemplate(transformTemplate);
+        return plugin;
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/KtorTestServiceTypes.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/KtorTestServiceTypes.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor;
+
+import com.navercorp.pinpoint.common.profiler.trace.TraceMetadataRegistrar;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
+import com.navercorp.pinpoint.common.trace.ServiceTypeLocator;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Registers the service types declared in this plugin's own
+ * META-INF/pinpoint/type-provider.yml into ServiceTypeProvider, so unit tests
+ * exercise KtorConstants against the same metadata the agent will ship.
+ * Static initialisation is the single point of registration: regardless of
+ * which test class loads first, the values always come from the yml file.
+ */
+public final class KtorTestServiceTypes {
+    private static final String TYPE_PROVIDER_RESOURCE = "META-INF/pinpoint/type-provider.yml";
+    private static final Pattern CODE_PATTERN = Pattern.compile("^\\s*-\\s+code:\\s*(\\d+)\\s*$");
+    private static final Pattern NAME_PATTERN = Pattern.compile("^\\s+name:\\s*'?([A-Za-z0-9_]+)'?\\s*$");
+
+    static {
+        Map<String, ServiceType> byName = parseServiceTypes();
+        TraceMetadataRegistrar.registerServiceTypes(new TypeProviderServiceTypeLocator(byName));
+        // resolve now, outside any Mockito stubbing/verification window, so a
+        // failed KtorConstants.<clinit> can never poison later test classes
+        KtorConstants.KTOR.getName();
+        KtorConstants.KTOR_INTERNAL.getName();
+        KtorConstants.KTOR_CLIENT.getName();
+        KtorConstants.KTOR_CLIENT_INTERNAL.getName();
+    }
+
+    private KtorTestServiceTypes() {
+    }
+
+    public static void register() {
+        // trigger the static block; later calls are no-ops
+    }
+
+    private static Map<String, ServiceType> parseServiceTypes() {
+        InputStream inputStream = KtorTestServiceTypes.class.getClassLoader().getResourceAsStream(TYPE_PROVIDER_RESOURCE);
+        if (inputStream == null) {
+            throw new IllegalStateException(TYPE_PROVIDER_RESOURCE + " not found on the test classpath");
+        }
+
+        Map<String, ServiceType> byName = new LinkedHashMap<>();
+        Integer pendingCode = null;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+                Matcher codeMatcher = CODE_PATTERN.matcher(line);
+                if (codeMatcher.matches()) {
+                    pendingCode = Integer.valueOf(codeMatcher.group(1));
+                    continue;
+                }
+                if (pendingCode == null) {
+                    continue;
+                }
+                Matcher nameMatcher = NAME_PATTERN.matcher(line);
+                if (nameMatcher.matches()) {
+                    byName.put(nameMatcher.group(1), ServiceTypeFactory.of(pendingCode, nameMatcher.group(1)));
+                    pendingCode = null;
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse " + TYPE_PROVIDER_RESOURCE, e);
+        }
+        if (byName.isEmpty()) {
+            throw new IllegalStateException("No serviceTypes parsed from " + TYPE_PROVIDER_RESOURCE);
+        }
+        return byName;
+    }
+
+    private static final class TypeProviderServiceTypeLocator implements ServiceTypeLocator {
+        private final Map<String, ServiceType> byName;
+        private final Map<Integer, ServiceType> byCode;
+
+        TypeProviderServiceTypeLocator(Map<String, ServiceType> byName) {
+            this.byName = byName;
+            Map<Integer, ServiceType> codes = new LinkedHashMap<>();
+            for (ServiceType serviceType : byName.values()) {
+                codes.put((int) serviceType.getCode(), serviceType);
+            }
+            this.byCode = codes;
+        }
+
+        @Override
+        public ServiceType findServiceType(int code) {
+            ServiceType serviceType = byCode.get(code);
+            return serviceType != null ? serviceType : ServiceType.UNDEFINED;
+        }
+
+        @Override
+        public ServiceType findServiceTypeByName(String name) {
+            ServiceType serviceType = byName.get(Objects.requireNonNull(name, "name"));
+            return serviceType != null ? serviceType : ServiceType.UNDEFINED;
+        }
+
+        @Override
+        public List<ServiceType> findDesc(String name) {
+            return Collections.unmodifiableList(new ArrayList<>(byName.values()));
+        }
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientSendInterceptorTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientSendInterceptorTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import com.navercorp.pinpoint.bootstrap.config.DefaultProfilerConfig;
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.Header;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
+import com.navercorp.pinpoint.bootstrap.context.TraceId;
+import com.navercorp.pinpoint.bootstrap.sampler.SamplingFlagUtils;
+import com.navercorp.pinpoint.plugin.ktor.KtorConstants;
+import com.navercorp.pinpoint.plugin.ktor.KtorTestServiceTypes;
+import io.ktor.client.request.HttpRequestBuilder;
+import io.ktor.http.URLProtocol;
+import kotlin.coroutines.intrinsics.IntrinsicsKt;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class KtorClientSendInterceptorTest {
+    @BeforeAll
+    static void registerServiceTypes() {
+        // registrations come from this plugin's own type-provider.yml
+        KtorTestServiceTypes.register();
+    }
+
+    private final TraceContext traceContext = mock(TraceContext.class);
+    private final Trace trace = mock(Trace.class);
+    private final TraceId traceId = mock(TraceId.class);
+    private final TraceId nextId = mock(TraceId.class);
+    private final SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+    private final AsyncContext asyncContext = mock(AsyncContext.class);
+    private final MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+
+    private KtorClientSendInterceptor newInterceptor() {
+        short serverTypeCode = KtorConstants.KTOR.getCode();
+        when(traceContext.getProfilerConfig()).thenReturn(new DefaultProfilerConfig());
+        when(traceContext.getApplicationName()).thenReturn("test-app");
+        when(traceContext.getServerTypeCode()).thenReturn(serverTypeCode);
+        return new KtorClientSendInterceptor(traceContext, methodDescriptor);
+    }
+
+    @AfterEach
+    void cleanup() {
+        KtorClientTraceStorage.clearPending();
+    }
+
+    @Test
+    void tracedCallWritesHeadersAndClosesOnReturn() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        startBlock();
+        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+        HttpRequestBuilder request = newRequest();
+
+        interceptor.before(this, new Object[]{request});
+        interceptor.after(this, new Object[]{request}, new Object(), null);
+
+        verify(recorder, times(1)).recordNextSpanId(100L);
+        verify(recorder, times(1)).recordServiceType(KtorConstants.KTOR_CLIENT);
+        verify(recorder, times(1)).recordNextAsyncContext(true);
+        verify(recorder, times(1)).recordDestinationId("api.example.com:8443");
+        verify(recorder, times(1)).recordApi(methodDescriptor);
+        verify(recorder, times(1)).recordException(true, null);
+        verify(trace, times(1)).traceBlockEnd();
+        // synchronous completion cancels the async span
+        verify(asyncContext, times(1)).finish();
+        assertHeader(request, Header.HTTP_TRACE_ID, "ktor-app^1710000000000^7");
+        assertHeader(request, Header.HTTP_SPAN_ID, "100");
+        assertHeader(request, Header.HTTP_PARENT_SPAN_ID, "99");
+        assertHeader(request, Header.HTTP_FLAGS, "0");
+        assertHeader(request, Header.HTTP_PARENT_APPLICATION_NAME, "test-app");
+        assertHeader(request, Header.HTTP_PARENT_APPLICATION_TYPE, "1160");
+        assertHeader(request, Header.HTTP_HOST, "api.example.com:8443");
+        assertNull(KtorClientTraceStorage.getPending());
+    }
+
+    @Test
+    void thrownErrorIsRecordedOnCompletion() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        startBlock();
+        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+        HttpRequestBuilder request = newRequest();
+        Throwable throwable = new IllegalStateException("send boom");
+
+        interceptor.before(this, new Object[]{request});
+        interceptor.after(this, new Object[]{request}, null, throwable);
+
+        verify(recorder, times(1)).recordException(true, throwable);
+        verify(trace, times(1)).traceBlockEnd();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void suspendedCallKeepsAsyncTraceOpen() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        startBlock();
+        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+        HttpRequestBuilder request = newRequest();
+
+        interceptor.before(this, new Object[]{request});
+        // the continuation constructor binds the pending holder to the continuation
+        KtorClientTraceHolder holder = KtorClientTraceStorage.getPending();
+        holder.markAttached();
+
+        interceptor.after(this, new Object[]{request}, IntrinsicsKt.getCOROUTINE_SUSPENDED(), null);
+
+        verify(trace, times(1)).traceBlockEnd();
+        verify(recorder, times(1)).recordException(true, null);
+        // the suspended continuation finishes the async trace later
+        verify(asyncContext, never()).finish();
+        assertNull(KtorClientTraceStorage.getPending());
+
+        holder.cancelAsync();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void unsampledCallWritesSamplingHeaderOnly() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
+        when(trace.canSampled()).thenReturn(false);
+        HttpRequestBuilder request = newRequest();
+
+        interceptor.before(this, new Object[]{request});
+        interceptor.after(this, new Object[]{request}, new Object(), null);
+
+        assertHeader(request, Header.HTTP_SAMPLED, SamplingFlagUtils.SAMPLING_RATE_FALSE);
+        verify(trace, never()).traceBlockBegin();
+        verify(trace, never()).traceBlockEnd();
+    }
+
+    @Test
+    void noActiveTraceSkipsInstrumentation() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        when(traceContext.currentRawTraceObject()).thenReturn(null);
+        HttpRequestBuilder request = newRequest();
+
+        interceptor.before(this, new Object[]{request});
+        interceptor.after(this, new Object[]{request}, new Object(), null);
+
+        assertNull(KtorClientTraceStorage.getPending());
+        assertHeader(request, Header.HTTP_TRACE_ID, null);
+        assertHeader(request, Header.HTTP_SAMPLED, null);
+    }
+
+    @Test
+    void nonRequestArgumentSkipsInstrumentation() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
+
+        interceptor.before(this, null);
+        interceptor.before(this, new Object[0]);
+        interceptor.before(this, new Object[]{new Object()});
+
+        verify(trace, never()).traceBlockBegin();
+        assertNull(KtorClientTraceStorage.getPending());
+    }
+
+    @Test
+    void headerWriteFailureClosesTraceBlock() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
+        when(trace.canSampled()).thenReturn(true);
+        when(trace.traceBlockBegin()).thenReturn(recorder);
+        when(trace.getTraceId()).thenReturn(traceId);
+        // a null next id fails the span id recording after the block has started
+        when(traceId.getNextTraceId()).thenReturn(null);
+        HttpRequestBuilder request = newRequest();
+
+        interceptor.before(this, new Object[]{request});
+        interceptor.after(this, new Object[]{request}, new Object(), null);
+
+        verify(trace, times(1)).traceBlockEnd();
+        verify(recorder, never()).recordNextAsyncContext(true);
+        assertNull(KtorClientTraceStorage.getPending());
+    }
+
+    @Test
+    void afterWithoutBeforeIsNoOp() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+
+        interceptor.after(this, new Object[]{newRequest()}, new Object(), null);
+
+        verify(trace, never()).traceBlockEnd();
+    }
+
+    @Test
+    void nullRequestArgumentSkipsInstrumentation() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
+
+        interceptor.before(this, new Object[]{null});
+
+        verify(trace, never()).traceBlockBegin();
+        assertNull(KtorClientTraceStorage.getPending());
+    }
+
+    @Test
+    void suspendedWithoutAttachedContinuationFinishesSynchronously() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        startBlock();
+        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+        HttpRequestBuilder request = newRequest();
+
+        interceptor.before(this, new Object[]{request});
+        // no continuation constructor ran, so the holder is not attached
+        interceptor.after(this, new Object[]{request}, IntrinsicsKt.getCOROUTINE_SUSPENDED(), null);
+
+        verify(trace, times(1)).traceBlockEnd();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void headerWriteFailureSwallowsBrokenBlockEnd() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
+        when(trace.canSampled()).thenReturn(true);
+        when(trace.traceBlockBegin()).thenReturn(recorder);
+        when(trace.getTraceId()).thenReturn(traceId);
+        when(traceId.getNextTraceId()).thenReturn(null);
+        doThrow(new IllegalStateException("traceBlockEnd boom")).when(trace).traceBlockEnd();
+        HttpRequestBuilder request = newRequest();
+
+        interceptor.before(this, new Object[]{request});
+        interceptor.after(this, new Object[]{request}, new Object(), null);
+
+        verify(trace, times(1)).traceBlockEnd();
+        assertNull(KtorClientTraceStorage.getPending());
+    }
+
+    @Test
+    void reentrantBeforeDropsPreviousState() {
+        KtorClientSendInterceptor interceptor = newInterceptor();
+        startBlock();
+        when(trace.currentSpanEventRecorder()).thenReturn(recorder);
+        HttpRequestBuilder first = newRequest();
+        HttpRequestBuilder second = newRequest();
+
+        interceptor.before(this, new Object[]{first});
+        // a nested send invocation on the same thread starts without the previous after()
+        interceptor.before(this, new Object[]{second});
+        interceptor.after(this, new Object[]{second}, new Object(), null);
+
+        verify(trace, times(2)).traceBlockBegin();
+        // only the latest state is finished; the dropped one must not double-close the trace
+        verify(trace, times(1)).traceBlockEnd();
+        verify(asyncContext, times(1)).finish();
+        assertNull(KtorClientTraceStorage.getPending());
+    }
+
+    private void startBlock() {
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
+        when(trace.canSampled()).thenReturn(true);
+        when(trace.traceBlockBegin()).thenReturn(recorder);
+        when(trace.getTraceId()).thenReturn(traceId);
+        when(traceId.getNextTraceId()).thenReturn(nextId);
+        when(nextId.getSpanId()).thenReturn(100L);
+        when(nextId.getParentSpanId()).thenReturn(99L);
+        when(nextId.getFlags()).thenReturn((short) 0);
+        when(nextId.getTransactionId()).thenReturn("ktor-app^1710000000000^7");
+        when(recorder.recordNextAsyncContext(true)).thenReturn(asyncContext);
+    }
+
+    private HttpRequestBuilder newRequest() {
+        HttpRequestBuilder request = new HttpRequestBuilder();
+        request.getUrl().setProtocol(URLProtocol.Companion.getHTTPS());
+        request.getUrl().setHost("api.example.com");
+        request.getUrl().setPort(8443);
+        request.getUrl().setPathSegments(java.util.Arrays.asList("v1", "images"));
+        return request;
+    }
+
+    private void assertHeader(HttpRequestBuilder request, Header header, String expected) {
+        assertEquals(expected, request.getHeaders().get(header.toString()), header.toString());
+    }
+}

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceHolderTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceHolderTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.ktor.client;
+
+import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
+import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
+import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
+import com.navercorp.pinpoint.plugin.ktor.KtorConstants;
+import com.navercorp.pinpoint.plugin.ktor.KtorPluginConfig;
+import com.navercorp.pinpoint.plugin.ktor.KtorTestServiceTypes;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class KtorClientTraceHolderTest {
+    @BeforeAll
+    static void registerServiceTypes() {
+        // registrations come from this plugin's own type-provider.yml
+        KtorTestServiceTypes.register();
+    }
+
+    private final AsyncContext asyncContext = mock(AsyncContext.class);
+    private final Object request = new Object();
+    private final MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+    private final KtorPluginConfig config = mock(KtorPluginConfig.class);
+    @SuppressWarnings("unchecked")
+    private final ClientRequestRecorder<Object> requestRecorder = mock(ClientRequestRecorder.class);
+    private final SpanEventRecorder recorder = mock(SpanEventRecorder.class);
+    private final Trace asyncTrace = mock(Trace.class);
+    private final TraceScope asyncScope = mock(TraceScope.class);
+
+    private KtorClientTraceHolder newHolder() {
+        return new KtorClientTraceHolder(asyncContext, request, methodDescriptor, config, requestRecorder);
+    }
+
+    @Test
+    void attachedState() {
+        KtorClientTraceHolder holder = newHolder();
+
+        assertFalse(holder.isAttached());
+        holder.markAttached();
+        assertTrue(holder.isAttached());
+    }
+
+    @Test
+    void recordWithNullRecorderSkipsRecording() {
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.record(null, null);
+
+        verifyNoInteractions(requestRecorder);
+    }
+
+    @Test
+    void recordWritesRequestApiAndException() {
+        when(config.isClientMarkError()).thenReturn(true);
+        KtorClientTraceHolder holder = newHolder();
+        Throwable throwable = new IllegalStateException("boom");
+
+        holder.record(recorder, throwable);
+
+        verify(requestRecorder, times(1)).record(recorder, request, throwable);
+        verify(recorder, times(1)).recordApi(methodDescriptor);
+        verify(recorder, times(1)).recordException(true, throwable);
+    }
+
+    @Test
+    void recordHonoursMarkErrorFlag() {
+        when(config.isClientMarkError()).thenReturn(false);
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.record(recorder, null);
+
+        verify(recorder, times(1)).recordException(false, null);
+    }
+
+    @Test
+    void recordFailureIsSwallowed() {
+        KtorClientTraceHolder holder = newHolder();
+        doThrow(new IllegalStateException("record boom")).when(requestRecorder).record(recorder, request, null);
+
+        holder.record(recorder, null);
+
+        verify(recorder, never()).recordApi(methodDescriptor);
+    }
+
+    @Test
+    void finishAsyncRecordsAndClosesOwnedTrace() {
+        startAsyncTrace();
+        KtorClientTraceHolder holder = newHolder();
+        Throwable throwable = new IllegalStateException("boom");
+
+        holder.finishAsync(throwable);
+
+        verify(recorder, times(1)).recordServiceType(KtorConstants.KTOR_CLIENT_INTERNAL);
+        verify(requestRecorder, times(1)).record(recorder, request, throwable);
+        verify(recorder, times(1)).recordApi(methodDescriptor);
+        verify(asyncScope, times(1)).tryEnter();
+        verify(asyncScope, times(1)).leave();
+        verify(asyncTrace, times(1)).traceBlockEnd();
+        verify(asyncTrace, times(1)).close();
+        verify(asyncContext, times(1)).close();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void secondFinishAsyncIsNoOp() {
+        startAsyncTrace();
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.finishAsync(null);
+        holder.finishAsync(null);
+
+        verify(asyncTrace, times(1)).traceBlockEnd();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void finishAsyncWithoutAsyncTraceOnlyFinishesState() {
+        when(asyncContext.continueAsyncTraceObject(true)).thenReturn(null);
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.finishAsync(null);
+
+        verifyNoInteractions(requestRecorder);
+        verify(asyncContext, times(1)).finish();
+        verify(asyncContext, never()).close();
+    }
+
+    @Test
+    void nestedAsyncScopeIsLeftButNotClosed() {
+        startAsyncTrace();
+        // another plugin owns the shared coroutine binder, so the scope cannot be left
+        when(asyncScope.canLeave()).thenReturn(false);
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.finishAsync(null);
+
+        verify(asyncScope, never()).leave();
+        verify(asyncTrace, times(1)).traceBlockEnd();
+        verify(asyncTrace, never()).close();
+        verify(asyncContext, never()).close();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void activeAsyncScopeBlocksClose() {
+        startAsyncTrace();
+        // the scope was left by us but the owner has not finished yet
+        when(asyncScope.isActive()).thenReturn(true);
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.finishAsync(null);
+
+        verify(asyncTrace, times(1)).traceBlockEnd();
+        verify(asyncTrace, never()).close();
+        verify(asyncContext, never()).close();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void continuationFailureIsSwallowed() {
+        when(asyncContext.continueAsyncTraceObject(true)).thenThrow(new IllegalStateException("continuation boom"));
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.finishAsync(null);
+
+        verify(asyncContext, times(1)).finish();
+        verify(asyncContext, never()).close();
+    }
+
+    @Test
+    void closeFailureDoesNotSkipFinish() {
+        startAsyncTrace();
+        doThrow(new IllegalStateException("close boom")).when(asyncTrace).close();
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.finishAsync(null);
+
+        verify(asyncTrace, times(1)).traceBlockEnd();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void cancelAsyncOnlyFinishesStateAndBlocksFinish() {
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.cancelAsync();
+        holder.finishAsync(null);
+
+        verify(asyncContext, times(1)).finish();
+        verify(asyncContext, never()).continueAsyncTraceObject(true);
+    }
+
+    @Test
+    void cancelAsyncAfterFinishIsNoOp() {
+        startAsyncTrace();
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.finishAsync(null);
+        holder.cancelAsync();
+
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void cancelAsyncSwallowsFinishFailure() {
+        doThrow(new IllegalStateException("finish boom")).when(asyncContext).finish();
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.cancelAsync();
+
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void leaveScopeFailureIsSwallowed() {
+        startAsyncTrace();
+        when(asyncScope.canLeave()).thenThrow(new IllegalStateException("leave boom"));
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.finishAsync(null);
+
+        verify(asyncTrace, times(1)).traceBlockEnd();
+        verify(asyncTrace, never()).close();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void blockEndFailureStillClosesOwnedTrace() {
+        startAsyncTrace();
+        doThrow(new IllegalStateException("end boom")).when(asyncTrace).traceBlockEnd();
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.finishAsync(null);
+
+        verify(asyncTrace, times(1)).close();
+        verify(asyncContext, times(1)).close();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void blockBeginFailureLeavesScopeWithoutEnd() {
+        when(asyncContext.continueAsyncTraceObject(true)).thenReturn(asyncTrace);
+        when(asyncTrace.traceBlockBegin()).thenThrow(new IllegalStateException("begin boom"));
+        when(asyncTrace.getScope(AsyncContext.ASYNC_TRACE_SCOPE)).thenReturn(asyncScope);
+        when(asyncTrace.isAsync()).thenReturn(true);
+        when(asyncScope.canLeave()).thenReturn(true);
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.finishAsync(null);
+
+        verify(asyncTrace, never()).traceBlockEnd();
+        verify(asyncTrace, times(1)).close();
+        verify(asyncContext, times(1)).close();
+        verify(asyncContext, times(1)).finish();
+    }
+
+    private void startAsyncTrace() {
+        when(asyncContext.continueAsyncTraceObject(true)).thenReturn(asyncTrace);
+        when(asyncTrace.traceBlockBegin()).thenReturn(recorder);
+        when(asyncTrace.getScope(AsyncContext.ASYNC_TRACE_SCOPE)).thenReturn(asyncScope);
+        when(asyncTrace.isAsync()).thenReturn(true);
+        when(asyncScope.canLeave()).thenReturn(true);
+    }
+}


### PR DESCRIPTION
## Summary

Supplements unit test coverage for the Ktor client tracing instrumentation merged in 24f56ef (#14090). I missed verifying the test coverage before merging that PR — codecov reported 34.6% patch coverage there — so this PR adds the missing tests.

**Why the coverage was low**: the three largest new classes had no unit tests at all, accounting for 169 of the 202 uncovered patch lines. The 28 tests that did ship covered only the surrounding adaptors/storages.

Local JaCoCo measurement (`mvn test jacoco:report` for `agent-module/plugins/ktor`, `code.coverage` semantics):

| class | before | after |
|---|---|---|
| `KtorClientSendInterceptor` | 0% (77 lines missed) | **94.8%** (73/77) |
| `KtorClientTraceHolder` | 0% (71) | **100%** (71/71) |
| `KtorPlugin` | 0% (76) | **96.1%** (73/76) |
| `KtorClientParentTraceState` | 95% | 100% |
| `KtorConstants` | 0% | 80% |

Combined: **91.5%** line coverage for the Ktor client package (258/282), **92.3%** including `KtorPlugin`/`KtorConstants` (335/363).

## What was added (4 test classes + 1 test helper, no production changes)

- `KtorClientSendInterceptorTest`: traced calls (header injection verified against a real `HttpRequestBuilder`), unsampled/untraced calls, suspended continuation handling (span finishes but the async context stays open), reentrant sends, recording failures.
- `KtorClientTraceHolderTest`: async finish/cancel CAS semantics, scope ownership (leave-only-when-nested, close-only-when-owner), every failure-swallowing path.
- `KtorPluginTest`: setup transform registrations (enabled/disabled/client-disabled/retransform-disabled) and every transform callback including the two client sender transforms.
- `KtorConstantsTest`: shipped `type-provider.yml` registry consistency.
- `KtorTestServiceTypes`: single test-only `ServiceTypeLocator` populated from the plugin's own `META-INF/pinpoint/type-provider.yml`, so all test classes share one yml-grounded `ServiceTypeProvider` registration instead of duplicating mock registrations. `pinpoint-commons-profiler` is added as a test-scope dependency for `TraceMetadataRegistrar` (same pattern as mssql-jdbc / db2-jdbc).

The lines left uncovered are intentionally defensive: `isDebug` log blocks, a `catch` around code that cannot throw by construction, and the application-type detection branch that needs a real main class.

## Observation worth a follow-up

While covering the reentrant path I noticed `KtorClientSendInterceptor.before()` silently drops a previous `activeState`/`pending` entry without finishing it. With the unit harness I can only verify the documented behavior (`reentrantBeforeDropsPreviousState`); whether the Ktor retry/redirect flow can actually re-enter `execute` on the same thread before `after()` runs is better answered with an agent-level integration test — happy to follow up if it looks worth pinning down.

## Validation

- `./mvnw -pl agent-module/plugins/ktor test` — 75 tests, 0 failures.
- Local JaCoCo numbers above; Codecov/SonarCloud on this PR should show the same classes covered.
