### PR TITLE
[#noissue] Manage async-http-client plugin versions as agent-module properties

### DIFF
--- a/agent-module/agent-testweb/ning-asynchttpclient-plugin-testweb/pom.xml
+++ b/agent-module/agent-testweb/ning-asynchttpclient-plugin-testweb/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.asynchttpclient</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.13</version>
         </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>

--- a/agent-module/plugins-bom/pom.xml
+++ b/agent-module/plugins-bom/pom.xml
@@ -171,19 +171,6 @@
                 <version>${jedis.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>com.ning</groupId>
-                <artifactId>async-http-client</artifactId>
-                <version>1.8.3</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.asynchttpclient</groupId>
-                <artifactId>async-http-client</artifactId>
-                <version>2.0.32</version>
-            </dependency>
-
-
 
             <dependency>
                 <groupId>org.apache.activemq</groupId>

--- a/agent-module/plugins-it/ning-asyncclient-it/pom.xml
+++ b/agent-module/plugins-it/ning-asyncclient-it/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.ning</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>1.8.3</version>
+            <version>${plugins-ning-asynchttpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>

--- a/agent-module/plugins-it/ning-asyncclient-it/src/test/java/com/navercorp/pinpoint/it/plugin/ning/asynchttpclient/NingAsyncHttpClientIT.java
+++ b/agent-module/plugins-it/ning-asyncclient-it/src/test/java/com/navercorp/pinpoint/it/plugin/ning/asynchttpclient/NingAsyncHttpClientIT.java
@@ -58,13 +58,9 @@ public class NingAsyncHttpClientIT {
 
     @Test
     public void test() throws Exception {
-        AsyncHttpClient client = new AsyncHttpClient();
-        
-        try {
+        try (AsyncHttpClient client = new AsyncHttpClient()) {
             Future<Response> f = client.preparePost(webServer.getCallHttpUrl()).addParameter("param1", "value1").execute();
             Response response = f.get();
-        } finally {
-            client.close();
         }
         
         PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();

--- a/agent-module/plugins/ning-asynchttpclient/pom.xml
+++ b/agent-module/plugins/ning-asynchttpclient/pom.xml
@@ -26,11 +26,13 @@
         <dependency>
             <groupId>com.ning</groupId>
             <artifactId>async-http-client</artifactId>
+            <version>${plugins-ning-asynchttpclient.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.asynchttpclient</groupId>
             <artifactId>async-http-client</artifactId>
+            <version>${plugins-org-asynchttpclient.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/agent-module/pom.xml
+++ b/agent-module/pom.xml
@@ -52,6 +52,12 @@
     <properties>
         <jetty9-version>9.4.57.v20241219</jetty9-version>
         <postgresql-jdbc-version>42.3.10</postgresql-jdbc-version>
+
+        <!-- START : plugins-it, agent-testweb dependency -->
+        <plugins-ning-asynchttpclient.version>1.8.17</plugins-ning-asynchttpclient.version>
+        <plugins-org-asynchttpclient.version>2.0.40</plugins-org-asynchttpclient.version>
+
+        <!-- END : plugins-it, agent-testweb dependency -->
     </properties>
 
 


### PR DESCRIPTION
Remove the com.ning and org.asynchttpclient entries from plugins-bom
and declare the versions as plugins- prefixed properties in the
agent-module parent, referenced directly where they are used. BOM
dependencyManagement overrides transitive versions across every
importing module, which is unwanted for per-plugin target libraries;
properties apply only at the point of declaration.

The ning IT now compiles against the same 1.9.40 as the plugin
(previously 1.8.3); the versions it actually tests stay pinned by its
@Dependency ranges. Also bump org.asynchttpclient to 2.0.40 and the
testweb to 3.0.13.
