### PR TITLE
[#14184] Bump mybatis from 3.0.3 to 3.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,8 +258,8 @@
         <guice.version>7.0.0</guice.version>
         <gson.version>2.13.2</gson.version>
 
-        <mybatis.spring.version>3.0.3</mybatis.spring.version>
-        <mybatis.version>3.5.16</mybatis.version>
+        <mybatis.spring.version>3.0.5</mybatis.spring.version>
+        <mybatis.version>3.5.19</mybatis.version>
 
         <jjwt.version>0.12.3</jjwt.version>
 


### PR DESCRIPTION
This pull request updates dependency versions in the `pom.xml` file to ensure the project uses the latest bug fixes and improvements for MyBatis.

Dependency version updates:

* Upgraded `mybatis-spring` from version 3.0.3 to 3.0.5.
* Upgraded `mybatis` from version 3.5.16 to 3.5.19.