### PR TITLE
Add step in/out to the Call Tree and Flame Graph

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/atoms/transaction.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/transaction.test.ts
@@ -5,6 +5,7 @@ import {
   transactionInfoDatasAtom,
   transactionInfoCurrentTabId,
   transactionInfoCallTreeFocusId,
+  transactionInfoSteppedInSpanId,
 } from './transaction';
 import { Transaction, TransactionInfoType as TransactionInfo } from '@pinpoint-fe/ui/src/constants';
 
@@ -179,6 +180,45 @@ describe('Test transaction atoms', () => {
 
       act(() => {
         result.current[1]('focus-1');
+        result.current[1]('');
+      });
+
+      expect(result.current[0]).toBe('');
+    });
+  });
+
+  describe('Test "transactionInfoSteppedInSpanId"', () => {
+    test('should initialize unfocused', () => {
+      const { result } = renderHook(() => useAtom(transactionInfoSteppedInSpanId));
+      expect(result.current[0]).toBe('');
+    });
+
+    test('should hold the focused call stack id', () => {
+      const { result } = renderHook(() => useAtom(transactionInfoSteppedInSpanId));
+
+      act(() => {
+        result.current[1]('12');
+      });
+
+      expect(result.current[0]).toBe('12');
+    });
+
+    test('should move the focus to another span', () => {
+      const { result } = renderHook(() => useAtom(transactionInfoSteppedInSpanId));
+
+      act(() => {
+        result.current[1]('12');
+        result.current[1]('34');
+      });
+
+      expect(result.current[0]).toBe('34');
+    });
+
+    test('should clear the focus with an empty string', () => {
+      const { result } = renderHook(() => useAtom(transactionInfoSteppedInSpanId));
+
+      act(() => {
+        result.current[1]('12');
         result.current[1]('');
       });
 

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/transaction.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/transaction.ts
@@ -12,3 +12,8 @@ export const transactionListDatasAtom = atom<
 export const transactionInfoDatasAtom = atom<TransactionInfo.Response | null>(null);
 export const transactionInfoCurrentTabId = atom<string>('');
 export const transactionInfoCallTreeFocusId = atom<string>('');
+// "Step in": the Call Tree and the Flame Graph are re-rooted at this call stack id so that only
+// that span and its descendants are drawn. Shared by both tabs because the trace viewer's
+// `args.id` is the very same call stack record id as the Call Tree row's `id` (the backend puts
+// `record.getId()` in both). Empty string means "stepped out" — showing the whole trace.
+export const transactionInfoSteppedInSpanId = atom<string>('');

--- a/web-frontend/src/main/v3/packages/ui/src/components/DataTable/VirtualizedDataTable.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/DataTable/VirtualizedDataTable.tsx
@@ -14,7 +14,7 @@ import {
 } from '@tanstack/react-table';
 import { LuArrowUp, LuArrowDown } from 'react-icons/lu';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useUpdateEffect } from 'usehooks-ts';
+import { useUpdateEffect } from '../../hooks/utility/useUpdateEffect';
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import { cn } from '../../lib';
@@ -112,6 +112,13 @@ export function VirtualizedDataTable<TData, TValue>({
         ? (element) => element?.getBoundingClientRect().height
         : undefined,
     overscan: 5,
+    // `measureElement` above runs from each row's ref callback, i.e. during commit. Rows measure
+    // taller than the estimate, so when the list is scrolled the virtualizer corrects the scroll
+    // offset and, by default, re-renders through `flushSync` — which React rejects mid-commit
+    // ("flushSync was called from inside a lifecycle method"). Letting that re-render batch
+    // normally is the library's own escape hatch and is enough here: React still commits it
+    // before paint, and rows are near-uniform in height so the correction is a few pixels.
+    useFlushSync: false,
   });
 
   React.useEffect(() => {

--- a/web-frontend/src/main/v3/packages/ui/src/components/FlameGraph/FlameGraph.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/FlameGraph/FlameGraph.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { throttle } from 'lodash';
 import cloneDeep from 'lodash.clonedeep';
 import { FlameNode, FlameNodeType, FlameNodeProps } from './FlameNode';
@@ -23,6 +24,12 @@ export interface FlameGraphProps<T> extends Pick<
     selected?: string;
     next: string[];
   };
+  // Optional DOM node to portal the graph controls into, so they share one row with the host's
+  // own toolbar instead of floating above the graph and overlapping it.
+  toolbarSlot?: HTMLElement | null;
+  // Host-supplied controls sharing the toolbar row, placed before / after the zoom buttons.
+  toolbarStart?: React.ReactNode;
+  toolbarEnd?: React.ReactNode;
 }
 
 export const FlameGraph = <T,>({
@@ -33,6 +40,9 @@ export const FlameGraph = <T,>({
   onClickNode,
   customNodeStyle,
   customTextStyle,
+  toolbarSlot,
+  toolbarStart,
+  toolbarEnd,
 }: FlameGraphProps<T>) => {
   const widthOffset = end - start || 1;
   const [config] = React.useState(flameGraphDefaultConfig);
@@ -250,12 +260,13 @@ export const FlameGraph = <T,>({
     });
   }
 
-  return (
-    <FlameGraphConfigContext.Provider value={{ config }}>
+  const toolbar = (
+    <div className="flex flex-wrap items-center justify-end gap-1">
+      {toolbarStart}
       <TooltipProvider>
         <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>
-            <div className="absolute space-x-1 right-[275px] -top-10">
+            <div className="space-x-1">
               <Button
                 variant={'outline'}
                 size="sm"
@@ -277,6 +288,17 @@ export const FlameGraph = <T,>({
           <TooltipContent>Zoom In/Out: Command + Scroll</TooltipContent>
         </Tooltip>
       </TooltipProvider>
+      {toolbarEnd}
+    </div>
+  );
+
+  return (
+    <FlameGraphConfigContext.Provider value={{ config }}>
+      {toolbarSlot ? (
+        createPortal(toolbar, toolbarSlot)
+      ) : (
+        <div className="absolute right-4 -top-10">{toolbar}</div>
+      )}
       <div className="relative w-full h-full overflow-x-auto" ref={containerRef}>
         <svg width={containerWidth} height={config.height.timeline} className="shadow-md">
           <FlameTimeline width={containerWidth} start={start} end={end} zoom={zoom} />

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/CallTree.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/CallTree.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { formatInTimeZone } from 'date-fns-tz';
-import { usePostBind, useTimezone } from '@pinpoint-fe/ui/src/hooks';
-import { useUpdateEffect } from 'usehooks-ts';
+import { usePostBind, useTimezone, useUpdateEffect } from '@pinpoint-fe/ui/src/hooks';
 import { IoMdClose } from 'react-icons/io';
 import { LuMoveUp, LuMoveDown } from 'react-icons/lu';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '../../ui/sheet';
@@ -28,9 +27,19 @@ import { TransactionInfoType as TransactionInfo } from '@pinpoint-fe/ui/src/cons
 import { addCommas } from '@pinpoint-fe/ui/src/utils';
 import { RxMagnifyingGlass } from 'react-icons/rx';
 import { HighLightCode } from '../../HighLightCode';
-import { useAtomValue } from 'jotai';
-import { transactionInfoCallTreeFocusId } from '@pinpoint-fe/ui/src/atoms';
+import { useAtom, useAtomValue } from 'jotai';
+import {
+  transactionInfoCallTreeFocusId,
+  transactionInfoSteppedInSpanId,
+} from '@pinpoint-fe/ui/src/atoms';
 import { CallTreeTableColumnsSetting } from './CallTreeTableColumnsSetting';
+import {
+  collectSteppedInSpanIds,
+  findSteppedInTreeNode,
+  flattenTreeRowIds,
+  rebaseTreeIndent,
+} from '../stepInSpan';
+import { getSteppedInTimelineAxis } from './timeline';
 
 export interface CallTreeProps {
   data: TransactionInfo.CallStackKeyValueMap[];
@@ -119,10 +128,42 @@ export const CallTree = ({ data, mapData, metaData, toolbarSlot }: CallTreeProps
     0,
   );
   const hasFilteredList = Boolean(filteredListIds?.length);
+
+  // "Step in": re-root the tree at one row so only that row and its descendants show.
+  const [steppedInSpanId, setSteppedInSpanId] = useAtom(transactionInfoSteppedInSpanId);
+  const steppedInSpanIds = React.useMemo(
+    () => collectSteppedInSpanIds(mapData, steppedInSpanId),
+    [mapData, steppedInSpanId],
+  );
+  const steppedInData = React.useMemo(() => {
+    if (!steppedInSpanIds) {
+      return data;
+    }
+    const steppedInRoot = findSteppedInTreeNode(data, steppedInSpanId);
+    // The stepped-into row can be one the tree does not render (Attribute/Scope rows are lifted
+    // onto their parent). Falling back to the whole tree beats showing nothing.
+    return steppedInRoot ? [rebaseTreeIndent(steppedInRoot)] : data;
+  }, [data, steppedInSpanId, steppedInSpanIds]);
+  const steppedInTimelineAxis = React.useMemo(
+    () => getSteppedInTimelineAxis(mapData, steppedInSpanIds),
+    [mapData, steppedInSpanIds],
+  );
+  // Searching stays inside what is on screen, so the "n of m" counter matches the visible rows.
+  const searchScope = React.useMemo(
+    () => (steppedInSpanIds ? mapData.filter((d) => steppedInSpanIds.has(String(d.id))) : mapData),
+    [mapData, steppedInSpanIds],
+  );
+  // Row order of the fully expanded table; a stepped-into tree no longer lines up with row ids.
+  const visibleRowIds = React.useMemo(() => flattenTreeRowIds(steppedInData), [steppedInData]);
+  const scrollRowIndex = focusRowId === undefined ? -1 : visibleRowIds.indexOf(String(focusRowId));
+
   const { defaultColumns, columns, updateColumns } = useCallTreeTableColumns({
     metaData,
     mapData,
     onClickDetailView,
+    onStepSpan: setSteppedInSpanId,
+    steppedInSpanId,
+    steppedInTimelineAxis,
   });
   const focusIdFromTimeline = useAtomValue(transactionInfoCallTreeFocusId);
   const [timezone] = useTimezone();
@@ -146,32 +187,43 @@ export const CallTree = ({ data, mapData, metaData, toolbarSlot }: CallTreeProps
   useUpdateEffect(() => {
     let filteredList: TransactionInfo.CallStackKeyValueMap[] = [];
     if (filter === 'hasException') {
-      filteredList = mapData.filter((d) => d[filter]);
-      const indexLists = filteredList.map((item) => item.id);
+      filteredList = searchScope.filter((d) => d[filter]);
+      const indexLists = filteredList.map((item) => String(item.id));
       setFilteredListIds(indexLists);
       setFocusRowId(indexLists[0]);
     } else if (filterInput) {
       let filteredList: TransactionInfo.CallStackKeyValueMap[] = [];
 
       if (filter === 'all') {
-        filteredList = mapData.filter((d) =>
+        filteredList = searchScope.filter((d) =>
           Object.values(d).some((value) => `${value}`.toLowerCase().includes(filterInput)),
         );
       } else if (filter === 'executionMilliseconds') {
-        filteredList = mapData.filter((d) => getExecutionMilliseconds(d) >= Number(filterInput));
+        filteredList = searchScope.filter(
+          (d) => getExecutionMilliseconds(d) >= Number(filterInput),
+        );
       } else if (filter === 'arguments') {
-        filteredList = mapData.filter((d) =>
+        filteredList = searchScope.filter((d) =>
           d[filter as keyof typeof d].toLowerCase().includes(filterInput),
         );
       }
-      const indexLists = filteredList.map((item) => item.id);
+      const indexLists = filteredList.map((item) => String(item.id));
       setFilteredListIds(indexLists);
       setFocusRowId(indexLists[0]);
     } else {
       setFilteredListIds(undefined);
       setFocusRowId(undefined);
     }
-  }, [filterInput]);
+    // Re-runs on a step in/out so the match list never points outside the visible rows.
+  }, [filterInput, searchScope]);
+
+  // Stepping into a span marks it, the same way loading the page marks `focusCallStackId`. From
+  // then on the mark belongs to the search: it moves with the hits and clears when the search is
+  // cancelled, exactly as it does with nothing stepped into. Declared after the search effect so
+  // it wins on the render where both fire (a step in/out also re-runs the search).
+  useUpdateEffect(() => {
+    setFocusRowId(steppedInSpanId || undefined);
+  }, [steppedInSpanId]);
 
   const goToNextSearchIndex = () => {
     if ((filteredListIds?.length || 0) > focusRowIdIndex + 1) {
@@ -193,7 +245,7 @@ export const CallTree = ({ data, mapData, metaData, toolbarSlot }: CallTreeProps
     <div className="flex flex-wrap items-center justify-end gap-1 gap-y-1">
       <CallTreeTableColumnsSetting defaultColumns={defaultColumns} updateColumns={updateColumns} />
       <Select value={filter} onValueChange={(value) => setFilter(value)}>
-        <SelectTrigger className="w-24 h-7 text-xs">
+        <SelectTrigger className="w-24 text-xs h-7">
           <SelectValue placeholder={t('TRANSACTION_LIST.CALL_TREE_FILTER')} />
         </SelectTrigger>
         <SelectContent>
@@ -273,10 +325,12 @@ export const CallTree = ({ data, mapData, metaData, toolbarSlot }: CallTreeProps
       <div className="flex-1 min-h-0">
         <CallTreeTable
           columns={columns || defaultColumns || []}
-          data={data}
+          data={steppedInData}
           metaData={metaData}
-          // scrollToIndex={(row) => row.findIndex((r) => r.original.id === callTreeFocusId)}
-          focusRowIndex={Number(focusRowId) - 1}
+          // Index within the rendered rows: the row ids no longer equal their position once the
+          // tree is re-rooted (and Attribute/Scope rows consume ids without taking a row).
+          focusRowIndex={scrollRowIndex}
+          highlightRowId={focusRowId}
           filteredRowIds={filteredListIds}
           onDoubleClickCell={(cell) => {
             const originalData = cell.getContext().row.original;

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/CallTree.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/CallTree.tsx
@@ -36,7 +36,7 @@ import { CallTreeTableColumnsSetting } from './CallTreeTableColumnsSetting';
 import {
   collectSteppedInSpanIds,
   findSteppedInTreeNode,
-  flattenTreeRowIds,
+  flattenTreeRows,
   rebaseTreeIndent,
 } from '../stepInSpan';
 import { getSteppedInTimelineAxis } from './timeline';
@@ -148,13 +148,17 @@ export const CallTree = ({ data, mapData, metaData, toolbarSlot }: CallTreeProps
     () => getSteppedInTimelineAxis(mapData, steppedInSpanIds),
     [mapData, steppedInSpanIds],
   );
-  // Searching stays inside what is on screen, so the "n of m" counter matches the visible rows.
-  const searchScope = React.useMemo(
-    () => (steppedInSpanIds ? mapData.filter((d) => steppedInSpanIds.has(String(d.id))) : mapData),
-    [mapData, steppedInSpanIds],
+  // The rows the table actually draws, in render order. Everything that has to agree with what
+  // the user sees is derived from this one list: which rows the search may match (so the "n of m"
+  // counter cannot count rows that are not there), and which position to scroll to. Reading it
+  // from the rendered tree rather than the flat call stack also drops the Attribute/Scope rows,
+  // which the tree lifts onto their parent instead of drawing.
+  const visibleRows = React.useMemo(() => flattenTreeRows(steppedInData), [steppedInData]);
+  const visibleRowIds = React.useMemo(
+    () => visibleRows.map((row) => String(row.id)),
+    [visibleRows],
   );
-  // Row order of the fully expanded table; a stepped-into tree no longer lines up with row ids.
-  const visibleRowIds = React.useMemo(() => flattenTreeRowIds(steppedInData), [steppedInData]);
+  const searchScope = visibleRows;
   const scrollRowIndex = focusRowId === undefined ? -1 : visibleRowIds.indexOf(String(focusRowId));
 
   const { defaultColumns, columns, updateColumns } = useCallTreeTableColumns({
@@ -196,7 +200,11 @@ export const CallTree = ({ data, mapData, metaData, toolbarSlot }: CallTreeProps
 
       if (filter === 'all') {
         filteredList = searchScope.filter((d) =>
-          Object.values(d).some((value) => `${value}`.toLowerCase().includes(filterInput)),
+          // `subRows` holds the children themselves; stringifying them would match on nothing
+          // meaningful. Every other field, including the lifted `attributes`/`scope`, is fair game.
+          Object.entries(d).some(
+            ([key, value]) => key !== 'subRows' && `${value}`.toLowerCase().includes(filterInput),
+          ),
         );
       } else if (filter === 'executionMilliseconds') {
         filteredList = searchScope.filter(

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/CallTreeTable.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/CallTreeTable.tsx
@@ -1,5 +1,6 @@
 import { TransactionInfoType as TransactionInfo } from '@pinpoint-fe/ui/src/constants';
 import { VirtualizedDataTable, VirtualizedDataTableProps } from '../../DataTable';
+import { getCallTreeRowClasses } from './rowClasses';
 
 export interface CallTreeTableProps extends VirtualizedDataTableProps<
   TransactionInfo.CallStackKeyValueMap,
@@ -8,6 +9,9 @@ export interface CallTreeTableProps extends VirtualizedDataTableProps<
   data: TransactionInfo.CallStackKeyValueMap[];
   metaData: TransactionInfo.Response;
   filteredRowIds?: string[];
+  // Row to highlight. Kept separate from `focusRowIndex` (which only scrolls) because the two
+  // diverge as soon as the tree is re-rooted by "Step in".
+  highlightRowId?: string;
 }
 
 export const CallTreeTable = ({
@@ -15,27 +19,16 @@ export const CallTreeTable = ({
   metaData,
   data,
   filteredRowIds,
+  highlightRowId,
   ...props
 }: CallTreeTableProps) => {
   return (
     <VirtualizedDataTable
       enableColumnResizing
       tableClassName="text-xs [&_td]:p-1.5"
-      rowClassName={(row) => {
-        const classes = [];
-
-        if (row.original.hasException) {
-          classes.push('bg-rose-50');
-        }
-        if (filteredRowIds?.some((id) => id === row.original.id)) {
-          classes.push('bg-yellow-100');
-        }
-        if (Number(row.original.id) - 1 === props.focusRowIndex) {
-          classes.push('bg-yellow-200');
-        }
-
-        return classes;
-      }}
+      rowClassName={(row) =>
+        getCallTreeRowClasses(row.original, { filteredRowIds, highlightRowId })
+      }
       data={data || []}
       columns={columns || []}
       {...props}

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
@@ -18,10 +18,19 @@ import {
   FaListUl,
 } from 'react-icons/fa';
 import { LuChevronRight, LuChevronDown } from 'react-icons/lu';
+import { VscDebugStepInto, VscDebugStepOut } from 'react-icons/vsc';
 import { PiStackDuotone } from 'react-icons/pi';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { Button } from '../..';
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../..';
+import { cn } from '@pinpoint-fe/ui/src/lib';
 import {
   addCommas,
   convertParamsToQueryString,
@@ -54,6 +63,11 @@ export interface CallTreeTableColumnsProps {
   // The Attribute/SQL icons trigger the detail view; the handler infers the type from the row data.
   onClickDetailView?: (data: TransactionInfo.CallStackKeyValueMap) => void;
   mapData?: TransactionInfo.CallStackKeyValueMap[];
+  // "Step in": re-roots the tree at the given row, or steps back out when given ''.
+  // Omitted -> no step in/out affordance.
+  onStepSpan?: (id: string) => void;
+  // The row that has been stepped into; its button stays filled in as the way back out.
+  steppedInSpanId?: string;
 }
 
 export type CallTreeTableColumnId =
@@ -75,30 +89,50 @@ export const useCallTreeTableColumns = ({
   metaData,
   onClickDetailView,
   mapData,
-}: CallTreeTableColumnsProps) => {
-  const timelineAxis = React.useMemo<TimelineAxis>(
+  onStepSpan,
+  steppedInSpanId,
+  steppedInTimelineAxis,
+}: CallTreeTableColumnsProps & { steppedInTimelineAxis?: TimelineAxis }) => {
+  const transactionTimelineAxis = React.useMemo<TimelineAxis>(
     () => ({
       durationNanos: metaData.callTreeTimelineDurationNanos,
     }),
     [metaData.callTreeTimelineDurationNanos],
   );
+  // After stepping in, the bars are drawn on that span's window instead, so the subtree fills
+  // the column the same way the Flame Graph rescales.
+  const timelineAxis = steppedInTimelineAxis ?? transactionTimelineAxis;
   const parallelGroups = React.useMemo(() => computeParallelGroups(mapData), [mapData]);
   const defaultColumns = React.useMemo(
-    () => callTreeTableColumns({ metaData, onClickDetailView, timelineAxis, parallelGroups }),
-    [metaData, onClickDetailView, timelineAxis, parallelGroups],
+    () =>
+      callTreeTableColumns({
+        metaData,
+        onClickDetailView,
+        timelineAxis,
+        parallelGroups,
+        onStepSpan,
+        steppedInSpanId,
+      }),
+    [metaData, onClickDetailView, timelineAxis, parallelGroups, onStepSpan, steppedInSpanId],
   );
 
-  const [columns, setColumns] =
-    React.useState<ColumnDef<TransactionInfo.CallStackKeyValueMap>[]>(defaultColumns);
-
-  const updateColumns = React.useCallback(
-    (columnIds: CallTreeTableColumnId[]) => {
-      setColumns(
-        defaultColumns.filter((column) => columnIds.includes(column.id as CallTreeTableColumnId)),
-      );
-    },
-    [defaultColumns],
+  // Only the *selection* is state; the column definitions are always derived from the current
+  // `defaultColumns`. Holding built columns in state would freeze the closures they were created
+  // with, so a new transaction (or a changed timeline axis) would keep rendering with stale data.
+  const [visibleColumnIds, setVisibleColumnIds] = React.useState<CallTreeTableColumnId[]>();
+  const columns = React.useMemo(
+    () =>
+      visibleColumnIds
+        ? defaultColumns.filter((column) =>
+            visibleColumnIds.includes(column.id as CallTreeTableColumnId),
+          )
+        : defaultColumns,
+    [defaultColumns, visibleColumnIds],
   );
+
+  const updateColumns = React.useCallback((columnIds: CallTreeTableColumnId[]) => {
+    setVisibleColumnIds(columnIds);
+  }, []);
 
   return { defaultColumns, columns, updateColumns };
 };
@@ -108,6 +142,8 @@ export const callTreeTableColumns = ({
   onClickDetailView,
   timelineAxis,
   parallelGroups,
+  onStepSpan,
+  steppedInSpanId,
 }: CallTreeTableColumnsProps & {
   timelineAxis: TimelineAxis;
   parallelGroups: ParallelInfo;
@@ -136,6 +172,7 @@ export const callTreeTableColumns = ({
     header: 'Method',
     cell: (props) => {
       const rowData = props.row.original;
+      const isSteppedIn = String(rowData.id) === steppedInSpanId;
       return (
         <div className="flex items-center" style={{ paddingLeft: `${props.row.original.tab}rem` }}>
           {props.row.getCanExpand() && (
@@ -150,6 +187,20 @@ export const callTreeTableColumns = ({
               onClickDetailView,
             }}
           />
+          {/* Pinned to the right edge of the Method column (`ml-auto`) so it always sits in the
+              same place instead of drifting with the method name's length.
+
+              Only method rows can be stepped into — leaves included, since a leaf here can still
+              be the parent of async work in another thread. The rest (SQL, annotations, exception
+              details) describe the method above them rather than being spans of their own.
+              The row already stepped into keeps its button whatever it is, so a root that somehow
+              is not a method row still offers the way back out instead of a dead end. */}
+          {onStepSpan && (rowData.isMethod || isSteppedIn) && (
+            <StepSpanButton
+              steppedIn={isSteppedIn}
+              onClick={() => onStepSpan(isSteppedIn ? '' : String(rowData.id))}
+            />
+          )}
         </div>
       );
     },
@@ -237,8 +288,10 @@ export const callTreeTableColumns = ({
       const end = getRowEndOffsetNanos(rowData);
       const elapsed = Math.max(end - start, 0);
 
-      // Each row is positioned on the Call Tree timeline axis supplied by the server.
+      // Each row is positioned on the Call Tree timeline axis supplied by the server, or on the
+      // stepped-into span's window once the user has stepped in.
       const total = timelineAxis.durationNanos;
+      const axisStart = timelineAxis.startNanos ?? 0;
       if (!Number.isFinite(total) || total <= 0) {
         return null;
       }
@@ -246,7 +299,7 @@ export const callTreeTableColumns = ({
       // gaps (empty space) and overlaps (vertically overlapping bars) become visible.
       // A zero-duration row keeps elapsed 0; the `max(width, 2px)` floor below still draws a
       // minimum-width bar so the event's position stays visible instead of vanishing.
-      const rawOffset = (start / total) * 100;
+      const rawOffset = ((start - axisStart) / total) * 100;
       const rawWidth = (elapsed / total) * 100;
       const offset = Math.min(Math.max(rawOffset, 0), 100); // keep the bar start within the axis
       const width = Math.max(rawWidth, 0);
@@ -263,7 +316,7 @@ export const callTreeTableColumns = ({
       // form one continuous band, making the parallel block explicit.
       const parallel = parallelGroups.get(String(rowData.id));
       const laneLeft = parallel
-        ? Math.min(Math.max((parallel.group.start / total) * 100, 0), 100)
+        ? Math.min(Math.max(((parallel.group.start - axisStart) / total) * 100, 0), 100)
         : 0;
       const laneWidth = parallel
         ? Math.max(((parallel.group.end - parallel.group.start) / total) * 100, 0)
@@ -459,6 +512,45 @@ const addDurationCommas = (value: string) => {
     return `${addCommas(integer)}.${fraction}`;
   }
   return addCommas(integer);
+};
+
+/**
+ * Steps into this row's span (redrawing the tree from it) or, on the row already stepped into,
+ * back out. Revealed on row hover (and on keyboard focus) so it adds no permanent noise, except
+ * on the stepped-into row, where it stays filled in and visible as the way back out.
+ */
+const StepSpanButton = ({ steppedIn, onClick }: { steppedIn: boolean; onClick: () => void }) => {
+  const { t } = useTranslation();
+  const label = steppedIn
+    ? t('TRANSACTION_LIST.STEP_OUT_SPAN')
+    : t('TRANSACTION_LIST.STEP_IN_SPAN');
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={steppedIn ? 'default' : 'outline'}
+            className={cn('flex-none w-5 h-5 p-0 ml-auto rounded', {
+              'opacity-0 text-muted-foreground group-hover:opacity-100 focus-visible:opacity-100 hover:text-foreground':
+                !steppedIn,
+            })}
+            aria-label={label}
+            onClick={(e) => {
+              e.stopPropagation();
+              onClick();
+            }}
+          >
+            {steppedIn ? <VscDebugStepOut /> : <VscDebugStepInto />}
+          </Button>
+        </TooltipTrigger>
+        {/* Portalled: the Method cell clips its overflow, so an inline tooltip would be cut off. */}
+        <TooltipPortal>
+          <TooltipContent>{label}</TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </TooltipProvider>
+  );
 };
 
 const MethodCell = (props: {

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/rowClasses.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/rowClasses.test.ts
@@ -1,0 +1,53 @@
+import { TransactionInfoType as TransactionInfo } from '@pinpoint-fe/ui/src/constants';
+import { getCallTreeRowClasses } from './rowClasses';
+
+// The backend sends `id` as a number inside the raw call stack arrays, so the row data carries a
+// number while every prop that points at a row carries a string. The tests below keep it that way
+// on purpose — matching only when the types happen to line up is the bug this file guards.
+const row = (r: { id: number | string; hasException?: boolean }) =>
+  ({ hasException: false, ...r }) as unknown as TransactionInfo.CallStackKeyValueMap;
+
+// The component hands the result to `cn()`, so assert on the joined string the row ends up with.
+const classesOf = (...args: Parameters<typeof getCallTreeRowClasses>) =>
+  getCallTreeRowClasses(...args).join(' ');
+
+describe('getCallTreeRowClasses', () => {
+  test('marks a plain row with nothing but the hover group', () => {
+    expect(getCallTreeRowClasses(row({ id: 9 }), {})).toEqual(['group']);
+  });
+
+  test('marks every search match', () => {
+    expect(classesOf(row({ id: 9 }), { filteredRowIds: ['8', '9'] })).toContain('bg-yellow-100');
+    expect(classesOf(row({ id: 7 }), { filteredRowIds: ['8', '9'] })).not.toContain(
+      'bg-yellow-100',
+    );
+  });
+
+  test('marks the search hit the user is standing on, with a numeric row id', () => {
+    expect(
+      classesOf(row({ id: 9 }), { filteredRowIds: ['8', '9'], highlightRowId: '9' }),
+    ).toContain('bg-yellow-200');
+  });
+
+  test('marks only the row the caller picked', () => {
+    const marks = { filteredRowIds: ['8', '9'], highlightRowId: '8' };
+    expect(classesOf(row({ id: 8 }), marks)).toContain('bg-yellow-200');
+    expect(classesOf(row({ id: 9 }), marks)).not.toContain('bg-yellow-200');
+  });
+
+  test('leaves the mark to plain hover styling, with no hover override', () => {
+    expect(classesOf(row({ id: 9 }), { highlightRowId: '9' })).not.toContain('hover:');
+  });
+
+  test('marks nothing once the search is cancelled', () => {
+    expect(getCallTreeRowClasses(row({ id: 9 }), { highlightRowId: undefined })).toEqual(['group']);
+  });
+
+  test('marks an exception row', () => {
+    expect(classesOf(row({ id: 9, hasException: true }), {})).toContain('bg-rose-50');
+  });
+
+  test('marks nothing when no row was picked', () => {
+    expect(getCallTreeRowClasses(row({ id: '' }), {})).toEqual(['group']);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/rowClasses.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/rowClasses.ts
@@ -1,0 +1,39 @@
+import { TransactionInfoType as TransactionInfo } from '@pinpoint-fe/ui/src/constants';
+
+/**
+ * Row background marks for the Call Tree, as a pure function so the rules between them can be
+ * unit-tested. Kept free of React / component imports for the same reason as `timeline.ts`.
+ */
+export interface CallTreeRowMarks {
+  /** Every row the current search matched. */
+  filteredRowIds?: string[];
+  /**
+   * The single "you are here" row: the initial `focusCallStackId` row, the row just stepped into,
+   * or the search hit the user is standing on. Cleared with the search.
+   */
+  highlightRowId?: string;
+}
+
+export const getCallTreeRowClasses = (
+  row: TransactionInfo.CallStackKeyValueMap,
+  { filteredRowIds, highlightRowId }: CallTreeRowMarks,
+): string[] => {
+  // `group` lets row-hover reveal the per-row actions rendered inside the cells.
+  const classes = ['group'];
+
+  // `id` is typed `any` and arrives from the backend as a number, so every comparison here goes
+  // through String() on both sides — `"9" === 9` is false and silently drops the mark.
+  const rowId = String(row.id);
+
+  if (row.hasException) {
+    classes.push('bg-rose-50');
+  }
+  if (filteredRowIds?.some((id) => String(id) === rowId)) {
+    classes.push('bg-yellow-100');
+  }
+  if (highlightRowId !== undefined && rowId === String(highlightRowId)) {
+    classes.push('bg-yellow-200');
+  }
+
+  return classes;
+};

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/timeline.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/timeline.test.ts
@@ -1,4 +1,4 @@
-import { computeParallelGroups, isTimelineWorkRow } from './timeline';
+import { computeParallelGroups, getSteppedInTimelineAxis, isTimelineWorkRow } from './timeline';
 import { TransactionInfoType as TransactionInfo } from '@pinpoint-fe/ui/src/constants';
 
 type Row = TransactionInfo.CallStackKeyValueMap;
@@ -132,5 +132,55 @@ describe('computeParallelGroups', () => {
       row({ id: 3, parentId: 2, begin: 1000, end: 1010 }), // child of id2, not a sibling
     ];
     expect(computeParallelGroups(rows).size).toBe(0);
+  });
+});
+
+describe('getSteppedInTimelineAxis', () => {
+  // 1 (0..1000) ─ 2 (200..600) ─ 4 (300..500)
+  //             └ 3 (700..900)
+  const rows = [
+    row({ id: 1, parentId: null, begin: 0, end: 1000 }),
+    row({ id: 2, parentId: 1, begin: 200, end: 600 }),
+    row({ id: 4, parentId: 2, begin: 300, end: 500 }),
+    row({ id: 3, parentId: 1, begin: 700, end: 900 }),
+  ];
+
+  test('spans exactly the stepped-into subtree so it fills the column', () => {
+    expect(getSteppedInTimelineAxis(rows, new Set(['2', '4']))).toEqual({
+      startNanos: 200,
+      durationNanos: 400,
+    });
+  });
+
+  test('covers a descendant that outlives its parent (async work)', () => {
+    const asyncRows = [
+      row({ id: 1, parentId: null, begin: 0, end: 100 }),
+      row({ id: 2, parentId: 1, begin: 50, end: 400 }),
+    ];
+    expect(getSteppedInTimelineAxis(asyncRows, new Set(['1', '2']))).toEqual({
+      startNanos: 0,
+      durationNanos: 400,
+    });
+  });
+
+  test('falls back (undefined) with nothing stepped into, no rows, or no measurable window', () => {
+    expect(getSteppedInTimelineAxis(rows, undefined)).toBeUndefined();
+    expect(getSteppedInTimelineAxis(rows, new Set())).toBeUndefined();
+    expect(getSteppedInTimelineAxis(undefined, new Set(['2']))).toBeUndefined();
+    // a single zero-duration row leaves nothing to scale to
+    expect(
+      getSteppedInTimelineAxis([row({ id: 9, begin: 500, end: 500 })], new Set(['9'])),
+    ).toBeUndefined();
+  });
+
+  test('ignores rows that are not timeline work', () => {
+    const withMetadata = [
+      row({ id: 1, parentId: null, begin: 100, end: 300 }),
+      row({ id: 2, parentId: 1, begin: 0, end: 900, isMethod: false }), // annotation row
+    ];
+    expect(getSteppedInTimelineAxis(withMetadata, new Set(['1', '2']))).toEqual({
+      startNanos: 100,
+      durationNanos: 200,
+    });
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/timeline.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/timeline.ts
@@ -15,7 +15,9 @@ export const getRowStartOffsetNanos = (r: TransactionInfo.CallStackKeyValueMap):
 export const getRowEndOffsetNanos = (r: TransactionInfo.CallStackKeyValueMap): number =>
   toTimelineNumber(r.endOffsetNanos);
 
-export type TimelineAxis = { durationNanos: number };
+// `startNanos` is the offset the axis begins at. It is 0 for the whole transaction and moves to
+// the stepped-into span's start, so that subtree fills the column.
+export type TimelineAxis = { durationNanos: number; startNanos?: number };
 
 export const isTimelineWorkRow = (r: TransactionInfo.CallStackKeyValueMap): boolean => {
   // excludeFromTimeline is deliberately ignored here: the server sets it on INTERNAL_METHOD
@@ -32,6 +34,36 @@ export const isTimelineWorkRow = (r: TransactionInfo.CallStackKeyValueMap): bool
   const start = getRowStartOffsetNanos(r);
   const end = getRowEndOffsetNanos(r);
   return Number.isFinite(start) && Number.isFinite(end);
+};
+
+/**
+ * Timeline axis covering only the stepped-into span and its descendants. Spans the whole subtree
+ * rather than just its root, because an async descendant can outlive its parent and would
+ * otherwise be drawn past the right edge. Returns `undefined` when the subtree has no measurable
+ * window, so callers fall back to the transaction-wide axis.
+ */
+export const getSteppedInTimelineAxis = (
+  rows: TransactionInfo.CallStackKeyValueMap[] | undefined,
+  steppedInIds: Set<string> | undefined,
+): TimelineAxis | undefined => {
+  if (!steppedInIds?.size || !rows?.length) {
+    return undefined;
+  }
+
+  let start = Number.POSITIVE_INFINITY;
+  let end = Number.NEGATIVE_INFINITY;
+  rows.forEach((row) => {
+    if (!steppedInIds.has(String(row.id)) || !isTimelineWorkRow(row)) {
+      return;
+    }
+    start = Math.min(start, getRowStartOffsetNanos(row));
+    end = Math.max(end, getRowEndOffsetNanos(row));
+  });
+
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    return undefined;
+  }
+  return { startNanos: start, durationNanos: end - start };
 };
 
 export type ParallelGroup = { start: number; end: number; size: number };

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/stepInSpan.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/stepInSpan.test.ts
@@ -2,7 +2,7 @@ import { TransactionInfoType as TransactionInfo } from '@pinpoint-fe/ui/src/cons
 import {
   collectSteppedInSpanIds,
   findSteppedInTreeNode,
-  flattenTreeRowIds,
+  flattenTreeRows,
   getFlameGroupsTimeRange,
   pruneFlameGroupsToSteppedIn,
   rebaseTreeIndent,
@@ -90,8 +90,15 @@ describe('findSteppedInTreeNode / rebaseTreeIndent', () => {
     expect(steppedInRoot.subRows?.[0].tab).toBe(2);
   });
 
-  test('lists row ids in rendered order', () => {
-    expect(flattenTreeRowIds(tree)).toEqual(['1', '2', '4', '3']);
+  test('lists the rendered rows in render order', () => {
+    expect(flattenTreeRows(tree).map((r) => String(r.id))).toEqual(['1', '2', '4', '3']);
+  });
+
+  test('lists only what the tree draws, so search cannot match a row that is not there', () => {
+    // `convertToTree` drops the backend's Attribute/Scope rows, lifting their values onto the
+    // parent, so they must not appear here either.
+    const withLifted = [row({ id: 1, title: 'method', subRows: [row({ id: 2, title: 'child' })] })];
+    expect(flattenTreeRows(withLifted).map((r) => String(r.id))).toEqual(['1', '2']);
   });
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/stepInSpan.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/stepInSpan.test.ts
@@ -1,0 +1,142 @@
+import { TransactionInfoType as TransactionInfo } from '@pinpoint-fe/ui/src/constants';
+import {
+  collectSteppedInSpanIds,
+  findSteppedInTreeNode,
+  flattenTreeRowIds,
+  getFlameGroupsTimeRange,
+  pruneFlameGroupsToSteppedIn,
+  rebaseTreeIndent,
+} from './stepInSpan';
+import { FlameNodeType } from '../FlameGraph/FlameNode';
+
+type Row = TransactionInfo.CallStackKeyValueMap;
+
+const row = (r: {
+  id: number | string;
+  parentId?: number | string | null;
+  tab?: number;
+  title?: string;
+  subRows?: Row[];
+}): Row => ({ parentId: null, tab: 0, title: '', ...r }) as unknown as Row;
+
+// 1 ─ 2 ─ 4
+//   └ 3
+// 5 (unrelated sibling of 1)
+const flatRows: Row[] = [
+  row({ id: 1, parentId: null }),
+  row({ id: 2, parentId: 1 }),
+  row({ id: 3, parentId: 1 }),
+  row({ id: 4, parentId: 2 }),
+  row({ id: 5, parentId: null }),
+];
+
+describe('collectSteppedInSpanIds', () => {
+  test('returns the stepped-into row plus every descendant', () => {
+    expect(collectSteppedInSpanIds(flatRows, '2')).toEqual(new Set(['2', '4']));
+  });
+
+  test('returns the whole subtree when the trace root is stepped into', () => {
+    expect(collectSteppedInSpanIds(flatRows, '1')).toEqual(new Set(['1', '2', '3', '4']));
+  });
+
+  test('returns only the row itself for a leaf', () => {
+    expect(collectSteppedInSpanIds(flatRows, '4')).toEqual(new Set(['4']));
+  });
+
+  test('returns undefined when nothing is stepped into', () => {
+    expect(collectSteppedInSpanIds(flatRows, '')).toBeUndefined();
+    expect(collectSteppedInSpanIds(flatRows, undefined)).toBeUndefined();
+  });
+
+  test('returns undefined for an id that is not part of this trace, so the view is not blanked', () => {
+    expect(collectSteppedInSpanIds(flatRows, '999')).toBeUndefined();
+  });
+
+  test('matches ids across number/string representations', () => {
+    const numericIdRows = [row({ id: 1, parentId: null }), row({ id: 2, parentId: 1 })];
+    expect(collectSteppedInSpanIds(numericIdRows, '1')).toEqual(new Set(['1', '2']));
+  });
+});
+
+describe('findSteppedInTreeNode / rebaseTreeIndent', () => {
+  const tree: Row[] = [
+    row({
+      id: 1,
+      tab: 0,
+      title: 'root',
+      subRows: [
+        row({ id: 2, tab: 1, title: 'child', subRows: [row({ id: 4, tab: 2, title: 'leaf' })] }),
+        row({ id: 3, tab: 1, title: 'sibling' }),
+      ],
+    }),
+  ];
+
+  test('finds a nested node', () => {
+    expect(findSteppedInTreeNode(tree, '4')?.title).toBe('leaf');
+  });
+
+  test('returns undefined for a row the tree does not render', () => {
+    expect(findSteppedInTreeNode(tree, '99')).toBeUndefined();
+  });
+
+  test('re-bases indentation on the new root so it starts at the left edge', () => {
+    const steppedInRoot = findSteppedInTreeNode(tree, '2') as Row;
+    const rebased = rebaseTreeIndent(steppedInRoot);
+
+    expect(rebased.tab).toBe(0);
+    expect(rebased.subRows?.[0].tab).toBe(1);
+    // the original tree is left untouched
+    expect(steppedInRoot.tab).toBe(1);
+    expect(steppedInRoot.subRows?.[0].tab).toBe(2);
+  });
+
+  test('lists row ids in rendered order', () => {
+    expect(flattenTreeRowIds(tree)).toEqual(['1', '2', '4', '3']);
+  });
+});
+
+describe('pruneFlameGroupsToSteppedIn', () => {
+  const node = (
+    id: string,
+    start: number,
+    duration: number,
+    children: FlameNodeType<unknown>[] = [],
+  ): FlameNodeType<unknown> => ({ id, name: id, start, duration, detail: {}, children });
+
+  // group 0: 1 ─ 2 ─ 4      group 1 (async): 10
+  const groups: FlameNodeType<unknown>[][] = [
+    [node('1', 0, 100, [node('2', 10, 50, [node('4', 20, 10)]), node('3', 70, 20)])],
+    [node('10', 30, 40)],
+  ];
+
+  test('re-roots the group at the stepped-into node and keeps async groups underneath it', () => {
+    const pruned = pruneFlameGroupsToSteppedIn(groups, new Set(['2', '4', '10']));
+
+    expect(pruned).toHaveLength(2);
+    expect(pruned[0].map((n) => n.id)).toEqual(['2']);
+    expect(pruned[0][0].children.map((n) => n.id)).toEqual(['4']);
+    expect(pruned[1].map((n) => n.id)).toEqual(['10']);
+  });
+
+  test('drops groups that hold nothing stepped into', () => {
+    const pruned = pruneFlameGroupsToSteppedIn(groups, new Set(['2', '4']));
+
+    expect(pruned).toHaveLength(1);
+    expect(pruned[0].map((n) => n.id)).toEqual(['2']);
+  });
+
+  test('returns no groups when the stepped-into span is not drawn here', () => {
+    expect(pruneFlameGroupsToSteppedIn(groups, new Set(['999']))).toEqual([]);
+  });
+
+  test('spans the whole subtree, including a descendant that outlives its parent', () => {
+    const pruned = pruneFlameGroupsToSteppedIn(groups, new Set(['2', '4', '10']));
+
+    // node 2 ends at 60, but the async group's node 10 runs to 70
+    expect(getFlameGroupsTimeRange(pruned)).toEqual({ start: 10, end: 70 });
+  });
+
+  test('has no time range without nodes', () => {
+    expect(getFlameGroupsTimeRange([])).toBeUndefined();
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/stepInSpan.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/stepInSpan.ts
@@ -96,19 +96,23 @@ export const rebaseTreeIndent = (
   subRows: node.subRows?.map((subRow) => rebaseTreeIndent(subRow, indentOffset)),
 });
 
-/** Row ids in the order the fully expanded table renders them, used to scroll to a row. */
-export const flattenTreeRowIds = (
+/**
+ * The rows the fully expanded table draws, in render order. This is the authoritative "what is on
+ * screen" list: it excludes the flat call stack's Attribute/Scope rows (the tree lifts those onto
+ * their parent) as well as anything outside the stepped-into subtree.
+ */
+export const flattenTreeRows = (
   rows: TransactionInfo.CallStackKeyValueMap[] | undefined,
-): string[] => {
-  const ids: string[] = [];
+): TransactionInfo.CallStackKeyValueMap[] => {
+  const flat: TransactionInfo.CallStackKeyValueMap[] = [];
   const walk = (nodes: TransactionInfo.CallStackKeyValueMap[] | undefined) => {
     nodes?.forEach((node) => {
-      ids.push(String(node.id));
+      flat.push(node);
       walk(node.subRows);
     });
   };
   walk(rows);
-  return ids;
+  return flat;
 };
 
 /**

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/stepInSpan.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/stepInSpan.ts
@@ -1,0 +1,154 @@
+import { TransactionInfoType as TransactionInfo } from '@pinpoint-fe/ui/src/constants';
+import { FlameNodeType } from '../FlameGraph/FlameNode';
+
+/**
+ * Helpers for "Step in": re-root the Call Tree / Flame Graph at one span so only that span and
+ * its descendants are drawn. Stepping in only changes what is displayed — it neither refetches
+ * nor alters the underlying trace.
+ *
+ * The two tabs share one stepped-into id: the trace viewer's `args.id` is the same call stack
+ * record id as the Call Tree row's `id` (the backend writes `record.getId()` into both). The
+ * descendant set is therefore always derived from the flat call stack (`mapData`), which is the
+ * only view that holds the complete parent/child relation — the flame graph splits async work
+ * into separate `tid` groups and would otherwise lose those descendants.
+ *
+ * Kept free of React imports so it can be unit-tested in isolation.
+ */
+
+/** Ids of the stepped-into row plus every descendant. `undefined` when nothing is stepped into. */
+export const collectSteppedInSpanIds = (
+  rows: TransactionInfo.CallStackKeyValueMap[] | undefined,
+  steppedInSpanId: string | undefined,
+): Set<string> | undefined => {
+  if (!steppedInSpanId || !rows?.length) {
+    return undefined;
+  }
+
+  const childIdsByParentId = new Map<string, string[]>();
+  let steppedInExists = false;
+  rows.forEach((row) => {
+    const id = String(row.id);
+    if (id === steppedInSpanId) {
+      steppedInExists = true;
+    }
+    const parentId = String(row.parentId);
+    const siblings = childIdsByParentId.get(parentId);
+    if (siblings) {
+      siblings.push(id);
+    } else {
+      childIdsByParentId.set(parentId, [id]);
+    }
+  });
+
+  // An id that is not part of this trace (e.g. left over from another transaction) must not
+  // blank out the view.
+  if (!steppedInExists) {
+    return undefined;
+  }
+
+  const steppedInIds = new Set<string>([steppedInSpanId]);
+  const queue = [steppedInSpanId];
+  while (queue.length) {
+    const id = queue.pop() as string;
+    for (const childId of childIdsByParentId.get(id) ?? []) {
+      if (!steppedInIds.has(childId)) {
+        steppedInIds.add(childId);
+        queue.push(childId);
+      }
+    }
+  }
+
+  return steppedInIds;
+};
+
+/** The stepped-into node inside the Call Tree row tree, or `undefined` when it is not rendered. */
+export const findSteppedInTreeNode = (
+  rows: TransactionInfo.CallStackKeyValueMap[] | undefined,
+  steppedInSpanId: string | undefined,
+): TransactionInfo.CallStackKeyValueMap | undefined => {
+  if (!steppedInSpanId || !rows?.length) {
+    return undefined;
+  }
+
+  for (const row of rows) {
+    if (String(row.id) === steppedInSpanId) {
+      return row;
+    }
+    const found = findSteppedInTreeNode(row.subRows, steppedInSpanId);
+    if (found) {
+      return found;
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Copies a subtree with its indentation re-based on the new root, so a deeply nested row starts
+ * at the left edge instead of being pushed off-screen (`tab` drives the row's padding).
+ */
+export const rebaseTreeIndent = (
+  node: TransactionInfo.CallStackKeyValueMap,
+  indentOffset = Number(node.tab) || 0,
+): TransactionInfo.CallStackKeyValueMap => ({
+  ...node,
+  tab: Math.max((Number(node.tab) || 0) - indentOffset, 0),
+  subRows: node.subRows?.map((subRow) => rebaseTreeIndent(subRow, indentOffset)),
+});
+
+/** Row ids in the order the fully expanded table renders them, used to scroll to a row. */
+export const flattenTreeRowIds = (
+  rows: TransactionInfo.CallStackKeyValueMap[] | undefined,
+): string[] => {
+  const ids: string[] = [];
+  const walk = (nodes: TransactionInfo.CallStackKeyValueMap[] | undefined) => {
+    nodes?.forEach((node) => {
+      ids.push(String(node.id));
+      walk(node.subRows);
+    });
+  };
+  walk(rows);
+  return ids;
+};
+
+/**
+ * Keeps only the stepped-into part of the flame graph. For every `tid` group the topmost nodes
+ * that belong to the set become the group's new roots, so the stepped-into span heads its own
+ * group while async groups spawned underneath it survive as their own groups. Groups left with
+ * nothing are dropped.
+ */
+export const pruneFlameGroupsToSteppedIn = <T>(
+  groups: FlameNodeType<T>[][],
+  steppedInIds: Set<string>,
+): FlameNodeType<T>[][] => {
+  const collect = (node: FlameNodeType<T>): FlameNodeType<T>[] =>
+    steppedInIds.has(String(node.id)) ? [node] : (node.children ?? []).flatMap(collect);
+
+  return groups.map((roots) => roots.flatMap(collect)).filter((roots) => roots.length > 0);
+};
+
+/**
+ * Time window covered by the given flame nodes, so the stepped-into subtree fills the timeline.
+ * Spans the whole subtree rather than only its root: an async descendant may outlive its parent
+ * and would otherwise be drawn past the right edge.
+ */
+export const getFlameGroupsTimeRange = <T>(
+  groups: FlameNodeType<T>[][],
+): { start: number; end: number } | undefined => {
+  let start = Number.POSITIVE_INFINITY;
+  let end = Number.NEGATIVE_INFINITY;
+
+  const walk = (node: FlameNodeType<T>) => {
+    if (Number.isFinite(node.start)) {
+      start = Math.min(start, node.start);
+      end = Math.max(end, node.start + (Number.isFinite(node.duration) ? node.duration : 0));
+    }
+    (node.children ?? []).forEach(walk);
+  };
+  groups.forEach((roots) => roots.forEach(walk));
+
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    return undefined;
+  }
+  return { start, end };
+};

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/timeline/TimelineFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/timeline/TimelineFetcher.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import Fuse from 'fuse.js';
+import { useAtom } from 'jotai';
+import { useTranslation } from 'react-i18next';
+import { VscDebugStepInto, VscDebugStepOut } from 'react-icons/vsc';
 import { RxMagnifyingGlass } from 'react-icons/rx';
+import { transactionInfoSteppedInSpanId } from '@pinpoint-fe/ui/src/atoms';
 import { useGetTraceViewerData, useTransactionSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import {
   TraceViewerData,
@@ -15,16 +19,40 @@ import {
 import { FlameGraph } from '../../FlameGraph';
 import { cn } from '../../../lib';
 import { TimelineDetail } from './TimelineDetail';
-import { FlameNodeType } from '../../FlameGraph/FlameNode';
 import { LuMoveDown, LuMoveUp } from 'react-icons/lu';
-import { Button, Input } from '../..';
+import {
+  Button,
+  Input,
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../..';
 import { TimelineInfo } from './TimelineInfo';
+import {
+  collectSteppedInSpanIds,
+  getFlameGroupsTimeRange,
+  pruneFlameGroupsToSteppedIn,
+} from '../stepInSpan';
+import { genFlameGraphData } from './flameGraphData';
 
 export interface TimelineFetcherProps {
   transactionInfo?: TransactionInfo.Response;
+  // Flat call stack, the only view that holds the complete parent/child relation. "Step in"
+  // needs it because async descendants live in their own flame graph groups.
+  mapData?: TransactionInfo.CallStackKeyValueMap[];
+  // Optional DOM node in the tab header to portal the toolbar into, so the tabs and the toolbar
+  // share one flex-wrap row and never overlap when the panel narrows.
+  toolbarSlot?: HTMLElement | null;
 }
 
-export const TimelineFetcher = ({ transactionInfo }: TimelineFetcherProps) => {
+export const TimelineFetcher = ({
+  transactionInfo,
+  mapData,
+  toolbarSlot,
+}: TimelineFetcherProps) => {
+  const { t } = useTranslation();
   const { transactionInfo: transactionSearchParams } = useTransactionSearchParameters();
   const [selectedTrace, setSelectedTrace] = React.useState<TraceViewerData.TraceEvent>();
   const [input, setInput] = React.useState('');
@@ -45,7 +73,26 @@ export const TimelineFetcher = ({ transactionInfo }: TimelineFetcherProps) => {
     linkTraceId: transactionSearchParams?.linkTraceId,
     linkSpanId: transactionSearchParams?.linkSpanId,
   });
-  const flameGraphData = genFlameGraphData(data);
+  // "Step in" is shared with the Call Tree through the atom, and this tab can set it too.
+  // `undefined` when nothing is stepped into, or when the id does not belong to this trace.
+  const [steppedInSpanId, setSteppedInSpanId] = useAtom(transactionInfoSteppedInSpanId);
+  const steppedInSpanIds = React.useMemo(
+    () => collectSteppedInSpanIds(mapData, steppedInSpanId),
+    [mapData, steppedInSpanId],
+  );
+  const allFlameGraphData = React.useMemo(() => genFlameGraphData(data), [data]);
+  const flameGraphData = React.useMemo(
+    () =>
+      steppedInSpanIds
+        ? pruneFlameGroupsToSteppedIn(allFlameGraphData, steppedInSpanIds)
+        : allFlameGraphData,
+    [allFlameGraphData, steppedInSpanIds],
+  );
+  const steppedInTimeRange = React.useMemo(
+    () => (steppedInSpanIds ? getFlameGroupsTimeRange(flameGraphData) : undefined),
+    [steppedInSpanIds, flameGraphData],
+  );
+  const isSteppedIn = Boolean(steppedInSpanIds);
 
   React.useEffect(() => {
     setInput('');
@@ -54,13 +101,21 @@ export const TimelineFetcher = ({ transactionInfo }: TimelineFetcherProps) => {
     setSelectedTrace(undefined);
   }, [transactionInfo]);
 
+  // Searching stays inside what is on screen, so the "n of m" counter matches the visible nodes.
+  const searchTargets = React.useMemo(() => {
+    const traceEvents = data?.traceEvents || [];
+    return steppedInSpanIds
+      ? traceEvents.filter((ev) => steppedInSpanIds.has(String(ev.args.id)))
+      : traceEvents;
+  }, [data?.traceEvents, steppedInSpanIds]);
+
   const fuzzySearch = React.useMemo(() => {
-    return new Fuse(data?.traceEvents || [], {
+    return new Fuse(searchTargets, {
       keys: ['name'],
       threshold: 0.3,
       shouldSort: false,
     });
-  }, [data?.traceEvents]);
+  }, [searchTargets]);
 
   const searchedList = searchInput
     ? fuzzySearch.search(searchInput).map(({ item }) => item)
@@ -131,74 +186,147 @@ export const TimelineFetcher = ({ transactionInfo }: TimelineFetcherProps) => {
     });
   };
 
+  const clearSelection = () => {
+    setNodeFlows({
+      prev: [],
+      selected: undefined,
+      next: [],
+    });
+    setSelectedTrace(undefined);
+    setFocusedNodeId(undefined);
+  };
+
+  // Stepping in from the Call Tree can exclude whatever was selected here; keeping it would
+  // leave the detail panel describing a node that is no longer drawn.
+  React.useEffect(() => {
+    if (selectedTrace && steppedInSpanIds && !steppedInSpanIds.has(String(selectedTrace.args.id))) {
+      clearSelection();
+    }
+  }, [steppedInSpanIds, selectedTrace]);
+
+  // Always present, and its direction follows what the click would do:
+  //   stepped in, and either nothing selected or the root selected -> step back out
+  //   a span selected that is not the current root                 -> step into it (drill deeper)
+  //   nothing stepped into and nothing selected                    -> nothing to do, disabled
+  const selectedSpanId = selectedTrace?.args?.id ? String(selectedTrace.args.id) : undefined;
+  const canStepOut =
+    Boolean(steppedInSpanIds) && (!selectedSpanId || selectedSpanId === steppedInSpanId);
+  const canStepIn = !canStepOut && Boolean(selectedSpanId) && selectedSpanId !== steppedInSpanId;
+  const stepDisabled = !canStepOut && !canStepIn;
+  const stepLabel = canStepOut
+    ? t('TRANSACTION_LIST.STEP_OUT_SPAN')
+    : stepDisabled
+      ? t('TRANSACTION_LIST.STEP_IN_SELECT_SPAN')
+      : t('TRANSACTION_LIST.STEP_IN_SPAN');
+  const stepButton = (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        {/* The span keeps the trigger hoverable while the button is disabled: a disabled button
+            emits no pointer events, so the tooltip explaining *why* would never show. */}
+        <TooltipTrigger asChild>
+          <span className="inline-flex">
+            <Button
+              variant={canStepOut ? 'default' : 'outline'}
+              size="sm"
+              className="w-7 h-7 p-0"
+              disabled={stepDisabled}
+              aria-label={stepLabel}
+              onClick={() => {
+                if (canStepOut) {
+                  setSteppedInSpanId('');
+                } else if (selectedSpanId) {
+                  setSteppedInSpanId(selectedSpanId);
+                }
+              }}
+            >
+              {canStepOut ? <VscDebugStepOut size={14} /> : <VscDebugStepInto size={14} />}
+            </Button>
+          </span>
+        </TooltipTrigger>
+        {/* Portalled like the Call Tree's button: the toolbar is portalled into the tab header,
+            so an inline tooltip would be laid out inside that row instead of over the graph. */}
+        <TooltipPortal>
+          <TooltipContent>{stepLabel}</TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </TooltipProvider>
+  );
+
+  const searchBox = (
+    <div className="flex border rounded h-7 pr-0.5 w-64">
+      <Input
+        className="h-full text-xs border-none shadow-none focus-visible:ring-0 placeholder:text-xs"
+        placeholder="Search trace events..."
+        value={input}
+        onChange={(e) => setInput(e.currentTarget.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            if (e.shiftKey) {
+              setSearchInput((prev) => {
+                if (prev === input) {
+                  backToPrevSearchIndex();
+                }
+                return input;
+              });
+            } else {
+              setSearchInput((prev) => {
+                if (prev === input) {
+                  goToNextSearchIndex();
+                }
+                return input;
+              });
+            }
+          } else if (e.key === 'Escape') {
+            if (input) {
+              setInput('');
+              setSearchInput('');
+            } else {
+              clearSelection();
+            }
+          }
+        }}
+      />
+      <div className="flex items-center opacity-50">
+        {searchedListIds && (
+          <>
+            <span className="whitespace-nowrap text-xxs">
+              {searchedListIds?.findIndex((id) => id === focusedNodeId) + 1} of{' '}
+              {searchedListIds?.length}
+            </span>
+            <Button
+              variant="ghost"
+              className="h-full p-0.5"
+              onClick={() => backToPrevSearchIndex()}
+            >
+              <LuMoveUp />
+            </Button>
+            <Button variant="ghost" className="h-full p-0.5" onClick={() => goToNextSearchIndex()}>
+              <LuMoveDown />
+            </Button>
+          </>
+        )}
+        <Button variant="ghost" className="h-full p-0.5" onClick={() => setSearchInput(input)}>
+          <RxMagnifyingGlass />
+        </Button>
+      </div>
+    </div>
+  );
+
   return (
     <div className={cn('h-full flex relative')}>
-      <div className="absolute -top-10 right-4 h-7 border flex rounded pr-0.5 w-64 placeholder">
-        <Input
-          className="h-full text-xs border-none shadow-none focus-visible:ring-0 placeholder:text-xs"
-          placeholder="Search trace events..."
-          value={input}
-          onChange={(e) => setInput(e.currentTarget.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              if (e.shiftKey) {
-                setSearchInput((prev) => {
-                  if (prev === input) {
-                    backToPrevSearchIndex();
-                  }
-                  return input;
-                });
-              } else {
-                setSearchInput((prev) => {
-                  if (prev === input) {
-                    goToNextSearchIndex();
-                  }
-                  return input;
-                });
-              }
-            } else if (e.key === 'Escape') {
-              if (input) {
-                setInput('');
-                setSearchInput('');
-              } else {
-                setSelectedTrace(undefined);
-                setFocusedNodeId(undefined);
-              }
-            }
-          }}
-        />
-        <div className="flex items-center opacity-50">
-          {searchedListIds && (
-            <>
-              <span className="whitespace-nowrap text-xxs">
-                {searchedListIds?.findIndex((id) => id === focusedNodeId) + 1} of{' '}
-                {searchedListIds?.length}
-              </span>
-              <Button
-                variant="ghost"
-                className="h-full p-0.5"
-                onClick={() => backToPrevSearchIndex()}
-              >
-                <LuMoveUp />
-              </Button>
-              <Button
-                variant="ghost"
-                className="h-full p-0.5"
-                onClick={() => goToNextSearchIndex()}
-              >
-                <LuMoveDown />
-              </Button>
-            </>
-          )}
-          <Button variant="ghost" className="h-full p-0.5" onClick={() => setSearchInput(input)}>
-            <RxMagnifyingGlass />
-          </Button>
+      {isSteppedIn && flameGraphData.length === 0 && (
+        <div className="absolute inset-x-0 top-16 z-[1] text-sm text-center text-muted-foreground">
+          {t('TRANSACTION_LIST.STEP_IN_NO_SPANS')}
         </div>
-      </div>
+      )}
       <FlameGraph<TraceViewerData.TraceEvent>
         data={flameGraphData}
-        start={transactionInfo?.callStackStart}
-        end={transactionInfo?.callStackEnd}
+        // After stepping in, the graph is rescaled to that subtree's own window.
+        start={steppedInTimeRange?.start ?? transactionInfo?.callStackStart}
+        end={steppedInTimeRange?.end ?? transactionInfo?.callStackEnd}
+        toolbarSlot={toolbarSlot}
+        toolbarStart={stepButton}
+        toolbarEnd={searchBox}
         nodeFlows={nodeFlows}
         customNodeStyle={(node, _color) => {
           const nodeApplicationName = node?.detail?.args?.['Application Name'] || '';
@@ -246,76 +374,10 @@ export const TimelineFetcher = ({ transactionInfo }: TimelineFetcherProps) => {
         <TimelineDetail
           start={transactionInfo?.callStackStart || 0}
           data={selectedTrace}
-          onClose={() => {
-            setNodeFlows({
-              prev: [],
-              selected: undefined,
-              next: [],
-            });
-            setSelectedTrace(undefined);
-            setFocusedNodeId(undefined);
-          }}
+          onClose={clearSelection}
         />
       )}
       <TimelineInfo data={data?.traceEvents} selectedTrace={selectedTrace} />
     </div>
   );
-};
-
-const genFlameGraphData = (data?: TraceViewerData.Response | null) => {
-  let result: FlameNodeType<TraceViewerData.TraceEvent>[][] = [];
-  if (data) {
-    const traceEvents = data?.traceEvents || [];
-    const mapByTid: { [key: number]: TraceViewerData.TraceEvent[] } = {};
-
-    traceEvents.forEach((item) => {
-      const { tid } = item;
-
-      if (mapByTid[tid]) {
-        mapByTid[tid].push(item);
-      } else {
-        mapByTid[tid] = [];
-        mapByTid[tid].push(item);
-      }
-    });
-
-    result = Object.values(mapByTid).map((traceEventsByTid) => {
-      const roots: FlameNodeType<TraceViewerData.TraceEvent>[] = [];
-      const map: { [key: string]: FlameNodeType<TraceViewerData.TraceEvent> } = {};
-
-      traceEventsByTid.forEach((item) => {
-        const { name } = item;
-
-        if (name !== 'Async Trace') {
-          const { id } = item.args;
-          map[id] = {
-            id,
-            children: [],
-            start: item.ts / 1000,
-            duration: item.dur / 1000,
-            detail: item,
-            name,
-          };
-        }
-      });
-
-      // find Roots
-      Object.values(map).forEach((item) => {
-        const { parentId } = item.detail.args;
-        if (!map[parentId]) {
-          roots.push(item);
-        }
-      });
-
-      traceEventsByTid.forEach((item) => {
-        const { id, parentId } = item.args;
-        const node = map[id];
-
-        map[parentId]?.children.push(node);
-      });
-      return roots;
-    });
-  }
-
-  return result;
 };

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/timeline/TimelineFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/timeline/TimelineFetcher.tsx
@@ -94,13 +94,6 @@ export const TimelineFetcher = ({
   );
   const isSteppedIn = Boolean(steppedInSpanIds);
 
-  React.useEffect(() => {
-    setInput('');
-    setSearchInput('');
-    setFocusedNodeId(undefined);
-    setSelectedTrace(undefined);
-  }, [transactionInfo]);
-
   // Searching stays inside what is on screen, so the "n of m" counter matches the visible nodes.
   const searchTargets = React.useMemo(() => {
     const traceEvents = data?.traceEvents || [];
@@ -195,6 +188,15 @@ export const TimelineFetcher = ({
     setSelectedTrace(undefined);
     setFocusedNodeId(undefined);
   };
+
+  // A new transaction starts with nothing selected. `nodeFlows` has to go with it: the ids in it
+  // are per-trace record indices, so they would match unrelated nodes in the next trace and draw
+  // arrows between them. Placed after `clearSelection` so it can reuse it.
+  React.useEffect(() => {
+    setInput('');
+    setSearchInput('');
+    clearSelection();
+  }, [transactionInfo]);
 
   // Stepping in from the Call Tree can exclude whatever was selected here; keeping it would
   // leave the detail panel describing a node that is no longer drawn.

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/timeline/flameGraphData.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/timeline/flameGraphData.test.ts
@@ -1,0 +1,108 @@
+import { TraceViewerData } from '@pinpoint-fe/ui/src/constants';
+import { genFlameGraphData } from './flameGraphData';
+
+const MS = 1000; // the trace viewer reports microseconds
+
+const traceEvent = (e: {
+  id: string;
+  parentId: string;
+  tid?: number;
+  name?: string;
+  ph?: string;
+  start?: number;
+  duration?: number;
+}): TraceViewerData.TraceEvent =>
+  ({
+    cat: 'Trace',
+    tid: e.tid ?? 1,
+    id: '0',
+    ts: (e.start ?? 0) * MS,
+    ph: e.ph ?? 'X',
+    dur: (e.duration ?? 10) * MS,
+    s: 't',
+    name: e.name ?? `span-${e.id}`,
+    cname: '',
+    pid: 'app',
+    args: { id: e.id, parentId: e.parentId, 'API Type': '', 'Application Name': 'app' },
+  }) as TraceViewerData.TraceEvent;
+
+const ids = (nodes: { id: string; children: { id: string }[] }[]) =>
+  nodes.map((n) => `${n.id}(${n.children.map((c) => c.id).join(',')})`);
+
+describe('genFlameGraphData', () => {
+  test('returns nothing without data', () => {
+    expect(genFlameGraphData(null)).toEqual([]);
+    expect(genFlameGraphData(undefined)).toEqual([]);
+    expect(genFlameGraphData({ traceEvents: [] })).toEqual([]);
+  });
+
+  test('nests children under their parent and keeps the parentless node as the root', () => {
+    const groups = genFlameGraphData({
+      traceEvents: [
+        traceEvent({ id: '1', parentId: '-1' }),
+        traceEvent({ id: '2', parentId: '1' }),
+        traceEvent({ id: '3', parentId: '2' }),
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(ids(groups[0])).toEqual(['1(2)']);
+    expect(ids(groups[0][0].children)).toEqual(['2(3)']);
+  });
+
+  test('splits threads into their own groups', () => {
+    const groups = genFlameGraphData({
+      traceEvents: [
+        traceEvent({ id: '1', parentId: '-1', tid: 1 }),
+        traceEvent({ id: '2', parentId: '1', tid: 1 }),
+        // async work: its parent lives in the other thread, so it heads its own group
+        traceEvent({ id: '3', parentId: '2', tid: 2 }),
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(ids(groups[0])).toEqual(['1(2)']);
+    expect(ids(groups[1])).toEqual(['3()']);
+  });
+
+  test('attaches a node once even when other events reuse its record', () => {
+    // The backend emits "Async Trace" arrow events around async work: the start carries the
+    // *parent* record's args, the end the child's. Attaching per raw event drew those nodes twice
+    // and made two siblings share a React key.
+    const groups = genFlameGraphData({
+      traceEvents: [
+        traceEvent({ id: '1', parentId: '-1', tid: 1 }),
+        traceEvent({ id: '2', parentId: '1', tid: 1 }),
+        traceEvent({ id: '2', parentId: '1', tid: 1, name: 'Async Trace', ph: 's' }),
+        traceEvent({ id: '3', parentId: '2', tid: 2 }),
+        traceEvent({ id: '3', parentId: '2', tid: 2, name: 'Async Trace', ph: 'f' }),
+      ],
+    });
+
+    expect(ids(groups[0])).toEqual(['1(2)']);
+    expect(ids(groups[1])).toEqual(['3()']);
+  });
+
+  test('never lists the same node twice among siblings', () => {
+    const groups = genFlameGraphData({
+      traceEvents: [
+        traceEvent({ id: '1', parentId: '-1' }),
+        traceEvent({ id: '2', parentId: '1' }),
+        // an exception row reuses the record of the method it belongs to
+        traceEvent({ id: '2', parentId: '1', name: 'exception' }),
+      ],
+    });
+
+    const childIds = groups[0][0].children.map((c) => c.id);
+    expect(childIds).toEqual([...new Set(childIds)]);
+    expect(childIds).toEqual(['2']);
+  });
+
+  test('converts microseconds to milliseconds', () => {
+    const groups = genFlameGraphData({
+      traceEvents: [traceEvent({ id: '1', parentId: '-1', start: 1500, duration: 250 })],
+    });
+
+    expect(groups[0][0]).toMatchObject({ start: 1500, duration: 250 });
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/timeline/flameGraphData.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/timeline/flameGraphData.ts
@@ -1,0 +1,65 @@
+import { TraceViewerData } from '@pinpoint-fe/ui/src/constants';
+import { FlameNodeType } from '../../FlameGraph/FlameNode';
+
+/**
+ * Turns the trace viewer's flat event list into the flame graph's forest: one group per `tid`, so
+ * async work drawn on its own thread becomes its own band of rows. Pure, so it can be unit-tested
+ * in isolation — same reason as the Call Tree's `timeline.ts`.
+ */
+export const genFlameGraphData = (data?: TraceViewerData.Response | null) => {
+  let result: FlameNodeType<TraceViewerData.TraceEvent>[][] = [];
+  if (data) {
+    const traceEvents = data?.traceEvents || [];
+    const mapByTid: { [key: number]: TraceViewerData.TraceEvent[] } = {};
+
+    traceEvents.forEach((item) => {
+      const { tid } = item;
+
+      if (mapByTid[tid]) {
+        mapByTid[tid].push(item);
+      } else {
+        mapByTid[tid] = [];
+        mapByTid[tid].push(item);
+      }
+    });
+
+    result = Object.values(mapByTid).map((traceEventsByTid) => {
+      const roots: FlameNodeType<TraceViewerData.TraceEvent>[] = [];
+      const map: { [key: string]: FlameNodeType<TraceViewerData.TraceEvent> } = {};
+
+      traceEventsByTid.forEach((item) => {
+        const { name } = item;
+
+        if (name !== 'Async Trace') {
+          const { id } = item.args;
+          map[id] = {
+            id,
+            children: [],
+            start: item.ts / 1000,
+            duration: item.dur / 1000,
+            detail: item,
+            name,
+          };
+        }
+      });
+
+      // Each node lands in exactly one place: under its parent, or in the roots when the parent
+      // is not part of this tid group. Walking the raw events instead would attach a node again
+      // for every extra event that reuses its record's args — the backend emits "Async Trace"
+      // arrow events (the start carries the *parent* record's args, the end the child's) and
+      // exception events, so those nodes were drawn twice and collided on their React key.
+      Object.values(map).forEach((item) => {
+        const { parentId } = item.detail.args;
+        const parent = map[parentId];
+        if (parent) {
+          parent.children.push(item);
+        } else {
+          roots.push(item);
+        }
+      });
+      return roots;
+    });
+  }
+
+  return result;
+};

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-info/TransactionInfoFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-info/TransactionInfoFetcher.tsx
@@ -13,7 +13,11 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { useTransactionSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { RxExternalLink } from 'react-icons/rx';
-import { transactionInfoCurrentTabId, transactionInfoDatasAtom } from '@pinpoint-fe/ui/src/atoms';
+import {
+  transactionInfoCurrentTabId,
+  transactionInfoDatasAtom,
+  transactionInfoSteppedInSpanId,
+} from '@pinpoint-fe/ui/src/atoms';
 import { Popover, PopoverContent, PopoverTrigger } from '../../ui';
 import { Timeline } from '../timeline/Timeline';
 import { ServerIcon } from '../../Application/ServerIcon';
@@ -37,8 +41,17 @@ export const TransactionInfoFetcher = ({ disableHeader }: TransactionInfoFetcher
   const { data, tableData, mapData } = useGetTransactionInfo();
   const setTransactionInfo = useSetAtom(transactionInfoDatasAtom);
   const [currentTab, setCurrentTab] = useAtom(transactionInfoCurrentTabId);
+  const setSteppedInSpanId = useSetAtom(transactionInfoSteppedInSpanId);
   const [toolbarSlot, setToolbarSlot] = React.useState<HTMLDivElement | null>(null);
   const { t } = useTranslation();
+
+  const currentTabId = currentTab || tabList[0].id;
+
+  // Stepping in is a view state on one trace; a different transaction must start stepped out.
+  // Atoms survive remounts, so this has to be cleared explicitly.
+  React.useEffect(() => {
+    setSteppedInSpanId('');
+  }, [data?.transactionId, data?.spanId, setSteppedInSpanId]);
 
   React.useEffect(() => {
     setTransactionInfo(data);
@@ -72,7 +85,7 @@ export const TransactionInfoFetcher = ({ disableHeader }: TransactionInfoFetcher
 
   return (
     <Tabs
-      value={currentTab || tabList[0].id}
+      value={currentTabId}
       className="flex flex-col h-full"
       onValueChange={(id) => setCurrentTab(id)}
     >
@@ -140,8 +153,9 @@ export const TransactionInfoFetcher = ({ disableHeader }: TransactionInfoFetcher
             ></PopoverContent>
           </Popover>
 
-          {/* Toolbar slot: CallTree portals its column/filter controls here so the tabs and the
-              toolbar share one flex-wrap row and wrap instead of overlapping when space is tight. */}
+          {/* Toolbar slot: the Call Tree and the Flame Graph portal their own controls here so the
+              tabs and the toolbar share one flex-wrap row and wrap instead of overlapping when
+              space is tight. */}
           <div ref={setToolbarSlot} className="flex items-center ml-auto" />
         </div>
       </div>
@@ -159,7 +173,7 @@ export const TransactionInfoFetcher = ({ disableHeader }: TransactionInfoFetcher
         } else if (tab.id === 'serverMap' && data) {
           Content = <TraceServerMap />;
         } else if (tab.id === 'flameGraph') {
-          Content = <Timeline transactionInfo={data} />;
+          Content = <Timeline transactionInfo={data} mapData={mapData} toolbarSlot={toolbarSlot} />;
         }
         return (
           <TabsContent

--- a/web-frontend/src/main/v3/packages/ui/src/constants/locales/en.json
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/locales/en.json
@@ -89,7 +89,11 @@
     "TRANSACTION_RETRIEVE_ERROR": "Transaction information is missing.",
     "TRANSACTION_RETRIEVE_ERROR_DESC": "Please start it over from the Servermap/Filtered page.  (If you close this dialog, you will be redirected to the Servermap page.)",
     "CALL_TREE_FILTER": "Filter",
-    "CALL_TREE_FILTER_PLACEHOLDER": "Filter call tree..."
+    "CALL_TREE_FILTER_PLACEHOLDER": "Filter call tree...",
+    "STEP_IN_SPAN": "Step in",
+    "STEP_OUT_SPAN": "Step out",
+    "STEP_IN_SELECT_SPAN": "Select a span to step into",
+    "STEP_IN_NO_SPANS": "The span you stepped into has nothing to draw here."
   },
   "METRIC": {
     "HOST_GROUP_LIST": "Host-Group List",

--- a/web-frontend/src/main/v3/packages/ui/src/constants/locales/ko.json
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/locales/ko.json
@@ -89,7 +89,11 @@
     "TRANSACTION_RETRIEVE_ERROR": "Transaction 정보가 없습니다.",
     "TRANSACTION_RETRIEVE_ERROR_DESC": "Servermap/Filtered 페이지에서 다시 시도해 주세요. (이 창을 닫으면 Servermap 페이지로 이동합니다)",
     "CALL_TREE_FILTER": "필터",
-    "CALL_TREE_FILTER_PLACEHOLDER": "콜 트리 필터..."
+    "CALL_TREE_FILTER_PLACEHOLDER": "콜 트리 필터...",
+    "STEP_IN_SPAN": "Step In",
+    "STEP_OUT_SPAN": "Step Out",
+    "STEP_IN_SELECT_SPAN": "Step In 할 span을 선택하세요.",
+    "STEP_IN_NO_SPANS": "들어간 span은 이 화면에 그릴 내용이 없습니다."
   },
   "METRIC": {
     "HOST_GROUP_LIST": "호스트 그룹 목록",

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetTransactionInfo.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetTransactionInfo.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { END_POINTS, TransactionInfoType as TransactionInfo } from '@pinpoint-fe/ui/src/constants';
 import { convertParamsToQueryString } from '@pinpoint-fe/ui/src/utils';
@@ -41,8 +42,11 @@ export const useGetTransactionInfo = () => {
     queryKey: [endpoint, queryString],
     queryFn: queryString ? queryFn(`${endpoint}${queryString}`) : async () => null,
   });
-  const mapData = getMapData(data);
-  const tableData = convertToTree(mapData, null);
+  // Memoized so consumers can use these as effect/memo dependencies. Rebuilding them on every
+  // render would give every derived value (columns, parallel groups, focus subtree) a fresh
+  // identity each time and defeat the memoization downstream.
+  const mapData = React.useMemo(() => getMapData(data), [data]);
+  const tableData = React.useMemo(() => convertToTree(mapData, null), [mapData]);
 
   return { data, tableData, isLoading, isValidating: isFetching, mapData };
 };

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
@@ -15,4 +15,5 @@ export * from './useStoragedSetting';
 export * from './useSyncSelectedServiceWithPath';
 export * from './useTabFocus';
 export * from './useTimezone';
+export * from './useUpdateEffect';
 // export * from './useSearchParameters';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useUpdateEffect.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useUpdateEffect.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react';
+import { useUpdateEffect } from './useUpdateEffect';
+
+describe('useUpdateEffect', () => {
+  test('does not run on mount', () => {
+    const effect = jest.fn();
+    renderHook(({ dep }) => useUpdateEffect(effect, [dep]), { initialProps: { dep: 1 } });
+
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  test('runs when a dependency changes', () => {
+    const effect = jest.fn();
+    const { rerender } = renderHook(({ dep }) => useUpdateEffect(effect, [dep]), {
+      initialProps: { dep: 1 },
+    });
+
+    rerender({ dep: 2 });
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender({ dep: 3 });
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not run when the dependencies are unchanged', () => {
+    const effect = jest.fn();
+    const { rerender } = renderHook(({ dep }) => useUpdateEffect(effect, [dep]), {
+      initialProps: { dep: 1 },
+    });
+
+    rerender({ dep: 1 });
+    rerender({ dep: 1 });
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  test('runs the cleanup returned by the effect before the next run', () => {
+    const cleanup = jest.fn();
+    const effect = jest.fn(() => cleanup);
+    const { rerender, unmount } = renderHook(({ dep }) => useUpdateEffect(effect, [dep]), {
+      initialProps: { dep: 1 },
+    });
+
+    rerender({ dep: 2 });
+    expect(cleanup).not.toHaveBeenCalled();
+
+    rerender({ dep: 3 });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(cleanup).toHaveBeenCalledTimes(2);
+  });
+
+  test('skips the mount run again after a remount', () => {
+    const effect = jest.fn();
+    const { unmount } = renderHook(({ dep }) => useUpdateEffect(effect, [dep]), {
+      initialProps: { dep: 1 },
+    });
+    unmount();
+
+    renderHook(({ dep }) => useUpdateEffect(effect, [dep]), { initialProps: { dep: 1 } });
+    expect(effect).not.toHaveBeenCalled();
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useUpdateEffect.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useUpdateEffect.ts
@@ -1,0 +1,33 @@
+import React from 'react';
+
+/**
+ * Runs an effect on updates only, skipping the mount run.
+ *
+ * Replaces `usehooks-ts`' `useUpdateEffect`, which that library deprecated ("don't use this hook,
+ * it's an anti-pattern") — importing it now raises a TS deprecation on every call site. The
+ * behaviour is the same, so existing callers can migrate by swapping the import.
+ *
+ * The deprecation has a point: reacting to a state change in an effect is usually worse than
+ * doing the work in the event handler that caused it. Prefer that for new code. This hook is for
+ * the cases where an effect genuinely has to run after another effect that writes the same state,
+ * which an event handler cannot express.
+ */
+export const useUpdateEffect = (effect: React.EffectCallback, deps?: React.DependencyList) => {
+  const isMounted = React.useRef(false);
+
+  React.useEffect(() => {
+    return () => {
+      // Reset for StrictMode's double-invoked mount, so the first *real* update is not skipped.
+      isMounted.current = false;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true;
+      return;
+    }
+    return effect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+};


### PR DESCRIPTION
## Summary

- Both the Call Tree and the Flame Graph can now **step into** a span: the view re-roots at it so only that span and its descendants are drawn, and the time axis rescales to that subtree so it fills the width. Stepping back out restores the whole trace.
- The Call Tree offers it per method row (hover reveals the button; the row stepped into keeps a filled one as the way back). The Flame Graph steps into whatever span is selected, and back out when the selection is the current root or there is no selection.
- Both tabs share one stepped-into span, because the trace viewer's `args.id` is the same call stack record id as the Call Tree row's `id`. The descendant set is always derived from the flat call stack — the only view that holds the complete parent/child relation, since the flame graph splits async work into separate `tid` groups and would otherwise lose those descendants.

Fixes made along the way, in code this feature leans on:

- The call stack derived from the transaction response was rebuilt on every render, so it could not be used as an effect dependency.
- The Call Tree froze its built columns in state, so a newly selected transaction kept rendering through the previous one's closures.
- Flame graph nodes were attached to their parent once per trace event instead of once per node. Async-trace and exception events reuse a record's args, so those nodes were drawn twice and collided on their React key.
- The Flame Graph toolbar floated over the tab header and overlapped the tabs on a narrow panel; it is now portalled into the header like the Call Tree's.
- Rows measure taller than the virtualizer's estimate, so a scrolled list re-rendered through `flushSync` during commit and React rejected it.
- `usehooks-ts` deprecated `useUpdateEffect`; a local replacement is added and the two files touched here migrate to it.

## Test plan

- [ ] Call Tree: hover a method row, **Step in** — only that span and its children remain, indentation restarts at the left edge, and the Exec(%) bars rescale to the subtree.
- [ ] Call Tree: the row stepped into keeps a filled button; pressing it steps back out.
- [ ] Call Tree: only method rows offer the button (SQL / annotation / exception rows do not).
- [ ] Call Tree: exactly one row carries the highlight at a time — the row stepped into, then the current search hit; cancelling the search with `Esc` clears it, the same as with nothing stepped into.
- [ ] Call Tree: search stays inside the stepped-into subtree, so the "n of m" counter matches what is on screen.
- [ ] Flame Graph: the button is always present; it is disabled with a "select a span" tooltip until a span is selected.
- [ ] Flame Graph: select a span → **Step in**; select a different span while stepped in → steps deeper; select the root or nothing → **Step out**.
- [ ] Switching tabs keeps the same span stepped into; async work spawned under it survives as its own group.
- [ ] Selecting a different transaction clears the step-in.
- [ ] No `Encountered two children with the same key` or `flushSync was called from inside a lifecycle method` in the console.
- [ ] Other virtualized tables (Transaction List, Error Analysis, Thread Dump) still scroll and select normally.