### PR TITLE
[#noissue] Keep well-known serviceUids out of the DEFAULT fallback

### DIFF
--- a/batch/src/main/java/com/navercorp/pinpoint/batch/job/ApplicationCleanupTasklet.java
+++ b/batch/src/main/java/com/navercorp/pinpoint/batch/job/ApplicationCleanupTasklet.java
@@ -105,7 +105,7 @@ public class ApplicationCleanupTasklet implements Tasklet {
     }
 
     private void processApplication(Application application, long baseTimestamp) {
-        int serviceUid = application.getService().getServiceUid().getUid();
+        int serviceUid = application.getService().getServiceUid();
         String applicationName = application.getApplicationName();
         int serviceTypeCode = application.getServiceTypeCode();
         int agentCount = agentIdDao.countAgentIdEntry(serviceUid, applicationName, serviceTypeCode);
@@ -266,7 +266,7 @@ public class ApplicationCleanupTasklet implements Tasklet {
         }
         logger.info("delete application. application={}", application);
         applicationDao.deleteApplication(
-                application.getService().getServiceUid().getUid(),
+                application.getService().getServiceUid(),
                 application.getApplicationName(),
                 application.getServiceTypeCode(),
                 baseTimestamp - Duration.ofHours(1).toMillis()

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceUid.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/ServiceUid.java
@@ -10,6 +10,7 @@ public class ServiceUid {
 
     public static final int DEFAULT_SERVICE_UID_CODE = 0;
     public static final String DEFAULT_SERVICE_UID_NAME = "DEFAULT";
+    public static final String ERROR_SERVICE_UID_NAME = "ERROR";
     public static final String UNKNOWN_SERVICE_UID_NAME = "UNKNOWN";
 
     // serviceUid
@@ -25,12 +26,28 @@ public class ServiceUid {
         return (-RESERVED_NEGATIVE_UID_COUNT <= uid && uid <= RESERVED_POSITIVE_UID_COUNT);
     }
 
-    public static ServiceUid of(int uid) {
+    /**
+     * Resolves a reserved uid to its well-known constant.
+     * Returns null for uids outside the well-known set.
+     * NULL(-3) is an in-memory cache sentinel and is deliberately excluded.
+     */
+    public static ServiceUid wellKnownServiceUid(int uid) {
         if (uid == DEFAULT.getUid()) {
             return DEFAULT;
         }
         if (uid == ERROR.getUid()) {
             return ERROR;
+        }
+        if (uid == UNKNOWN.getUid()) {
+            return UNKNOWN;
+        }
+        return null;
+    }
+
+    public static ServiceUid of(int uid) {
+        final ServiceUid wellKnown = wellKnownServiceUid(uid);
+        if (wellKnown != null) {
+            return wellKnown;
         }
         if (isReservedUid(uid)) {
             throw new IllegalArgumentException("Range check failed: " + uid + " is invalid");

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapAgentResponseTimeDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapAgentResponseTimeDao.java
@@ -86,7 +86,7 @@ public class HbaseMapAgentResponseTimeDao implements MapAgentResponseDao {
         }
 
         Range windowRange = timeWindow.getWindowRange();
-        Scan scan = scanFactory.createScan("MAgeRes", application.getService().getServiceUid().getUid(), application, windowRange, table.getName());
+        Scan scan = scanFactory.createScan("MAgeRes", application.getService().getServiceUid(), application, windowRange, table.getName());
 
         ResultsExtractor<List<ResponseTime>> resultsExtractor = resultExtractFactory.newMapper(timeWindow, application);
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapInLinkDao.java
@@ -88,7 +88,7 @@ public class HbaseMapInLinkDao implements MapInLinkDao {
         RowMapper<LinkDataMap> rowMapper = this.inLinkMapperFactory.newMapper(mapperWindow, inApplication);
         ResultsExtractor<LinkDataMap> resultExtractor = new RowMapReduceResultExtractor<>(rowMapper, new LinkTimeWindowReducer(timeWindow));
 
-        final Scan scan = scanFactory.createScan("MInLink", inApplication.getService().getServiceUid().getUid(), inApplication, timeWindow.getWindowRange(), table.getName());
+        final Scan scan = scanFactory.createScan("MInLink", inApplication.getService().getServiceUid(), inApplication, timeWindow.getWindowRange(), table.getName());
 
         final LinkDataMap linkDataMap = selectInLink(scan, table.getTable(), resultExtractor, NUM_PARTITIONS);
         if (logger.isDebugEnabled()) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapOutLinkDao.java
@@ -87,7 +87,7 @@ public class HbaseMapOutLinkDao implements MapOutLinkDao {
 
         ResultsExtractor<LinkDataMap> resultExtractor = new RowMapReduceResultExtractor<>(rowMapper, new LinkTimeWindowReducer(timeWindow));
 
-        final Scan scan = scanFactory.createScan("MOutLink", outApplication.getService().getServiceUid().getUid(), outApplication, timeWindow.getWindowRange(), table.getName());
+        final Scan scan = scanFactory.createScan("MOutLink", outApplication.getService().getServiceUid(), outApplication, timeWindow.getWindowRange(), table.getName());
         final LinkDataMap linkDataMap = selectOutLink(scan, table.getTable(), resultExtractor, NUM_PARTITIONS);
         if (logger.isDebugEnabled()) {
             logger.debug("selectOutLink {} {}", outApplication, linkDataMap.getLinkDataSize());

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapResponseDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/hbase/HbaseMapResponseDao.java
@@ -80,7 +80,7 @@ public class HbaseMapResponseDao implements MapResponseDao {
         }
 
         Range windowRange = timeWindow.getWindowRange();
-        Scan scan = scanFactory.createScan("MAppRes", application.getService().getServiceUid().getUid(), application, windowRange, table.getName());
+        Scan scan = scanFactory.createScan("MAppRes", application.getService().getServiceUid(), application, windowRange, table.getName());
 
         ResultsExtractor<ApplicationResponse> mapper = resultExtractor.newMapper(timeWindow, application);
         TableName mapStatisticsSelfTableName = tableNameProvider.getTableName(table.getTable());

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostScanKeyFactoryV3.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/HostScanKeyFactoryV3.java
@@ -27,7 +27,7 @@ public class HostScanKeyFactoryV3 implements HostScanKeyFactory {
     @Override
     public byte[] scanKey(Application parentApplication, long timestamp) {
         return UidAppRowKey.makeRowKey(saltKeySize,
-                parentApplication.getService().getServiceUid().getUid(),
+                parentApplication.getService().getServiceUid(),
                 parentApplication.getApplicationName(),
                 parentApplication.getServiceTypeCode(),
                 timestamp);

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/RowFilter.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/dao/v3/RowFilter.java
@@ -31,7 +31,7 @@ public class RowFilter<T extends UidRowKey> implements Predicate<T> {
     }
 
     public boolean test(UidRowKey row) {
-        return this.application.getService().getServiceUid().getUid() == row.getServiceUid()
+        return this.application.getService().getServiceUid() == row.getServiceUid()
                 &&  application.getApplicationName().equals(row.getApplicationName())
                 && application.getServiceTypeCode() == row.getServiceType();
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentIdDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/dao/hbase/HbaseAgentIdDao.java
@@ -116,7 +116,7 @@ public class HbaseAgentIdDao implements AgentIdDao {
     public void delete(List<AgentIdEntry> agentIdEntryList) {
         List<Delete> deletes = new ArrayList<>(agentIdEntryList.size());
         for (AgentIdEntry agentIdEntry : agentIdEntryList) {
-            byte[] rowKey = AgentIdRowKeyUtils.createRow(agentIdEntry.getService().getServiceUid().getUid(), agentIdEntry.getApplicationName(), agentIdEntry.getServiceTypeCode(), agentIdEntry.getAgentId(), agentIdEntry.getAgentStartTime());
+            byte[] rowKey = AgentIdRowKeyUtils.createRow(agentIdEntry.getService().getServiceUid(), agentIdEntry.getApplicationName(), agentIdEntry.getServiceTypeCode(), agentIdEntry.getAgentId(), agentIdEntry.getAgentStartTime());
             deletes.add(new Delete(rowKey));
         }
         TableName agentListTableName = tableNameProvider.getTableName(DESCRIPTOR.getTable());
@@ -188,7 +188,7 @@ public class HbaseAgentIdDao implements AgentIdDao {
         Scan scan = new Scan();
         if (lastAgentIdEntry != null) {
             byte[] startRow = AgentIdRowKeyUtils.createRow(
-                    lastAgentIdEntry.getService().getServiceUid().getUid(),
+                    lastAgentIdEntry.getService().getServiceUid(),
                     lastAgentIdEntry.getApplicationName(),
                     lastAgentIdEntry.getServiceTypeCode(),
                     lastAgentIdEntry.getAgentId(),

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java
@@ -118,7 +118,7 @@ public class HbaseTraceIndexDao implements TraceIndexDao {
             throw new IllegalArgumentException("negative limitWithTies:" + limitWithTies);
         }
         logger.debug("scanTraceScatterDataMadeOfDotGroup");
-        final int serviceUid = service.getServiceUid().getUid();
+        final int serviceUid = service.getServiceUid();
         Scan scan = createScan(serviceUid, applicationName, serviceTypeCode, range);
 
         RowMapper<List<Dot>> dotMapper = new TraceIndexDotMapper(TraceIndexRowKeyUtils.createApplicationNamePredicate(applicationName));
@@ -143,7 +143,7 @@ public class HbaseTraceIndexDao implements TraceIndexDao {
         DragArea dragArea = dragAreaQuery.getDragArea();
         Range range = Range.unchecked(dragArea.getXLow(), dragArea.getXHigh());
         logger.debug("scanTraceScatterData-range:{}", range);
-        final int serviceUid = service.getServiceUid().getUid();
+        final int serviceUid = service.getServiceUid();
         Scan scan = createScan(serviceUid, applicationName, serviceTypeCode, range);
         setHbaseFilter(scan, dragAreaQuery, rpcRegex);
         scan.addFamily(META.getName());

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentListV2ServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentListV2ServiceImpl.java
@@ -50,7 +50,7 @@ public class AgentListV2ServiceImpl implements AgentListV2Service {
 
     @Override
     public List<AgentIdEntry> getAllAgentList(Service service, String applicationName, ServiceType serviceType) {
-        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntry(service.getServiceUid().getUid(), applicationName, serviceType.getCode());
+        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntry(service.getServiceUid(), applicationName, serviceType.getCode());
         return dedupeConsecutiveAgentId(agentIdEntryList);
     }
 
@@ -66,7 +66,7 @@ public class AgentListV2ServiceImpl implements AgentListV2Service {
      * For service types that may not send steady pings — fetch all entries, then filter by span statistics.
      */
     private List<AgentIdEntry> getActiveAgentListByStatistics(Service service, String applicationName, ServiceType serviceType, Range range) {
-        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntry(service.getServiceUid().getUid(), applicationName, serviceType.getCode());
+        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntry(service.getServiceUid(), applicationName, serviceType.getCode());
         agentIdEntryList = filterByAgentStartTime(agentIdEntryList, range);
         agentIdEntryList = dedupeConsecutiveAgentId(agentIdEntryList);
 
@@ -81,7 +81,7 @@ public class AgentListV2ServiceImpl implements AgentListV2Service {
      * For service types that send pings — filter by status timestamp.
      */
     private List<AgentIdEntry> getActiveAgentListByStatus(Service service, String applicationName, ServiceType serviceType, Range range) {
-        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntryByMinStateTimestamp(service.getServiceUid().getUid(), applicationName, serviceType.getCode(), range.getFrom());
+        List<AgentIdEntry> agentIdEntryList = agentIdDao.getAgentIdEntryByMinStateTimestamp(service.getServiceUid(), applicationName, serviceType.getCode(), range.getFrom());
         agentIdEntryList = filterByAgentStartTime(agentIdEntryList, range);
         agentIdEntryList = dedupeConsecutiveAgentId(agentIdEntryList);
         return agentIdEntryList;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexServiceImpl.java
@@ -50,12 +50,12 @@ public class ApplicationIndexServiceImpl implements ApplicationIndexService {
 
     @Override
     public List<Application> selectAllApplications(Service service) {
-        return this.applicationDao.getApplications(service.getServiceUid().getUid());
+        return this.applicationDao.getApplications(service.getServiceUid());
     }
 
     @Override
     public List<Application> selectApplication(Service service, String applicationName) {
-        return this.applicationDao.getApplications(service.getServiceUid().getUid(), applicationName);
+        return this.applicationDao.getApplications(service.getServiceUid(), applicationName);
     }
 
     @Deprecated
@@ -69,7 +69,7 @@ public class ApplicationIndexServiceImpl implements ApplicationIndexService {
 
     @Override
     public void deleteApplication(Service service, String applicationName, int serviceTypeCode) {
-        deleteApplication(service.getServiceUid().getUid(), applicationName, serviceTypeCode);
+        deleteApplication(service.getServiceUid(), applicationName, serviceTypeCode);
     }
 
     private void deleteApplication(int serviceUid, String applicationName, int serviceTypeCode) {
@@ -81,12 +81,12 @@ public class ApplicationIndexServiceImpl implements ApplicationIndexService {
         if (applicationName == null) {
             return false;
         }
-        return !applicationDao.getApplications(service.getServiceUid().getUid(), applicationName).isEmpty();
+        return !applicationDao.getApplications(service.getServiceUid(), applicationName).isEmpty();
     }
 
     @Override
     public List<String> selectAgentIds(Service service, String applicationName) {
-        return this.agentIdDao.getAgentIdEntry(service.getServiceUid().getUid(), applicationName).stream()
+        return this.agentIdDao.getAgentIdEntry(service.getServiceUid(), applicationName).stream()
                 .map(AgentIdEntry::getAgentId)
                 .distinct()
                 .sorted()
@@ -95,7 +95,7 @@ public class ApplicationIndexServiceImpl implements ApplicationIndexService {
 
     @Override
     public List<String> selectAgentIds(Service service, String applicationName, int serviceTypeCode) {
-        return agentIdDao.getAgentIdEntry(service.getServiceUid().getUid(), applicationName, serviceTypeCode).stream()
+        return agentIdDao.getAgentIdEntry(service.getServiceUid(), applicationName, serviceTypeCode).stream()
                 .map(AgentIdEntry::getAgentId)
                 .distinct()
                 .sorted()
@@ -105,16 +105,16 @@ public class ApplicationIndexServiceImpl implements ApplicationIndexService {
     @Override
     public void deleteAgentIds(Service service, String applicationName, List<String> agentIds) {
         logger.info("delete AgentIds. applicationName:{}, agentIds:{}", applicationName, agentIds);
-        List<Application> applicationList = this.applicationDao.getApplications(service.getServiceUid().getUid(), applicationName);
+        List<Application> applicationList = this.applicationDao.getApplications(service.getServiceUid(), applicationName);
         for (Application application : applicationList) {
-            deleteAgentIds(service.getServiceUid().getUid(), application.getApplicationName(), application.getServiceTypeCode(), agentIds);
+            deleteAgentIds(service.getServiceUid(), application.getApplicationName(), application.getServiceTypeCode(), agentIds);
         }
     }
 
     @Override
     public void deleteAgentIds(Service service, String applicationName, int serviceTypeCode, List<String> agentIds) {
         logger.info("delete AgentIds. applicationName:{}, serviceTypeCode:{}, agentIds:{}", applicationName, serviceTypeCode, agentIds);
-        deleteAgentIds(service.getServiceUid().getUid(), applicationName, serviceTypeCode, agentIds);
+        deleteAgentIds(service.getServiceUid(), applicationName, serviceTypeCode, agentIds);
     }
 
     @Override
@@ -126,7 +126,7 @@ public class ApplicationIndexServiceImpl implements ApplicationIndexService {
     @Override
     public void deleteAgentId(Service service, String applicationName, int serviceTypeCode, String agentId) {
         logger.info("delete AgentId. applicationName:{}, serviceTypeCode:{}, agentId:{}", applicationName, serviceTypeCode, agentId);
-        deleteAgentId(service.getServiceUid().getUid(), applicationName, serviceTypeCode, agentId);
+        deleteAgentId(service.getServiceUid(), applicationName, serviceTypeCode, agentId);
     }
 
     private void deleteAgentId(int serviceUid, String applicationName, int serviceTypeCode, String agentId) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolver.java
@@ -108,7 +108,7 @@ public class CachingServiceModelResolver extends ServiceModelResolver implements
             for (ServiceEntity entity : serviceList) {
                 Service service = toService(entity);
                 serviceByNameCache.put(service.getServiceName(), service);
-                serviceByUidCache.put(service.getServiceUid().getUid(), service);
+                serviceByUidCache.put(service.getServiceUid(), service);
             }
             return serviceList.size();
         } catch (Exception e) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
@@ -15,8 +15,9 @@ public class ServiceModelResolver {
     }
 
     public Service getService(int serviceUid) {
-        if (Service.DEFAULT.getServiceUid().getUid() == serviceUid) {
-            return Service.DEFAULT;
+        final Service wellKnown = Service.wellKnownService(serviceUid);
+        if (wellKnown != null) {
+            return wellKnown;
         }
         Service service = resolveService(serviceUid);
         if (service == null) {
@@ -26,8 +27,9 @@ public class ServiceModelResolver {
     }
 
     public Service getService(String serviceName) {
-        if (Service.DEFAULT.getServiceName().equals(serviceName)) {
-            return Service.DEFAULT;
+        final Service wellKnown = Service.wellKnownService(serviceName);
+        if (wellKnown != null) {
+            return wellKnown;
         }
         Service service = resolveService(serviceName);
         if (service == null) {

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/Application.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/Application.java
@@ -89,7 +89,7 @@ public final class Application {
 
     @Override
     public String toString() {
-        return service.getServiceName() + "(" + service.getServiceUid().getUid() + ")/"
+        return service.getServiceName() + "(" + service.getServiceUid() + ")/"
                 + applicationName + "(" + serviceType.getDesc() + ":" + serviceType.getCode() + ")";
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/Service.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/Service.java
@@ -8,25 +8,62 @@ import java.util.Objects;
 public class Service {
 
     public static final Service DEFAULT = new Service(ServiceUid.DEFAULT_SERVICE_UID_NAME, ServiceUid.DEFAULT);
+    public static final Service ERROR = new Service(ServiceUid.ERROR_SERVICE_UID_NAME, ServiceUid.ERROR);
+    public static final Service UNKNOWN = new Service(ServiceUid.UNKNOWN_SERVICE_UID_NAME, ServiceUid.UNKNOWN);
+
+    /**
+     * Resolves a reserved serviceUid to its well-known Service without touching the registry.
+     * Returns null for uids that require a registry lookup.
+     */
+    public static Service wellKnownService(int serviceUid) {
+        if (serviceUid == ServiceUid.DEFAULT.getUid()) {
+            return DEFAULT;
+        }
+        if (serviceUid == ServiceUid.ERROR.getUid()) {
+            return ERROR;
+        }
+        if (serviceUid == ServiceUid.UNKNOWN.getUid()) {
+            return UNKNOWN;
+        }
+        return null;
+    }
+
+    /**
+     * Resolves a reserved serviceName to its well-known Service without touching the registry.
+     * Returns null for names that require a registry lookup.
+     */
+    public static Service wellKnownService(String serviceName) {
+        if (DEFAULT.getServiceName().equals(serviceName)) {
+            return DEFAULT;
+        }
+        if (ERROR.getServiceName().equals(serviceName)) {
+            return ERROR;
+        }
+        if (UNKNOWN.getServiceName().equals(serviceName)) {
+            return UNKNOWN;
+        }
+        return null;
+    }
 
     private final String serviceName;
-    private final ServiceUid serviceUid;
+    private final int serviceUid;
 
     public Service(String serviceName, int serviceUid) {
         this.serviceName = StringPrecondition.requireHasLength(serviceName, "name");
-        this.serviceUid = ServiceUid.of(serviceUid);
+        this.serviceUid = serviceUid;
     }
 
     public Service(String serviceName, ServiceUid serviceUid) {
         this.serviceName = StringPrecondition.requireHasLength(serviceName, "name");
-        this.serviceUid = serviceUid;
+        Objects.requireNonNull(serviceUid, "serviceUid");
+        this.serviceUid = serviceUid.getUid();
     }
 
     public String getServiceName() {
         return serviceName;
     }
 
-    public ServiceUid getServiceUid() {
+    public int getServiceUid() {
         return serviceUid;
     }
 
@@ -35,13 +72,13 @@ public class Service {
         if (o == null || getClass() != o.getClass()) return false;
 
         Service service = (Service) o;
-        return serviceUid.equals(service.serviceUid) && serviceName.equals(service.serviceName);
+        return serviceUid == service.serviceUid && serviceName.equals(service.serviceName);
     }
 
     @Override
     public int hashCode() {
         int result = serviceName.hashCode();
-        result = 31 * result + serviceUid.hashCode();
+        result = 31 * result + serviceUid;
         return result;
     }
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/component/DefaultApplicationFactoryTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/component/DefaultApplicationFactoryTest.java
@@ -31,7 +31,7 @@ class DefaultApplicationFactoryTest {
     @BeforeEach
     void setUp() {
         lenient().when(mockRegistry.findServiceType(ServiceType.TEST.getCode())).thenReturn(ServiceType.TEST);
-        lenient().when(mockServiceModelResolver.getService(Service.DEFAULT.getServiceUid().getUid())).thenReturn(Service.DEFAULT);
+        lenient().when(mockServiceModelResolver.getService(Service.DEFAULT.getServiceUid())).thenReturn(Service.DEFAULT);
 
         defaultApplicationFactory = new DefaultApplicationFactory(mockRegistry, mockServiceModelResolver);
     }
@@ -63,7 +63,7 @@ class DefaultApplicationFactoryTest {
         int serviceType = ServiceType.TEST.getCode();
 
         // When
-        Application application = defaultApplicationFactory.createApplication(service.getServiceUid().getUid(), applicationName, serviceType);
+        Application application = defaultApplicationFactory.createApplication(service.getServiceUid(), applicationName, serviceType);
 
         // Then
         assertNotNull(application);

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
@@ -65,7 +65,7 @@ class CachingServiceModelResolverTest {
         CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
 
         assertThat(resolver.getService(Service.DEFAULT.getServiceName())).isEqualTo(Service.DEFAULT);
-        assertThat(resolver.getService(Service.DEFAULT.getServiceUid().getUid())).isEqualTo(Service.DEFAULT);
+        assertThat(resolver.getService(Service.DEFAULT.getServiceUid())).isEqualTo(Service.DEFAULT);
 
         Mockito.verifyNoInteractions(serviceRegistryService);
     }

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
@@ -32,7 +32,7 @@ class ServiceModelResolverTest {
         ServiceModelResolver resolver = new ServiceModelResolver(serviceRegistryService);
 
         assertThat(resolver.getService(Service.DEFAULT.getServiceName())).isEqualTo(Service.DEFAULT);
-        assertThat(resolver.getService(Service.DEFAULT.getServiceUid().getUid())).isEqualTo(Service.DEFAULT);
+        assertThat(resolver.getService(Service.DEFAULT.getServiceUid())).isEqualTo(Service.DEFAULT);
 
         Mockito.verifyNoInteractions(serviceRegistryService);
     }


### PR DESCRIPTION
ServiceModelResolver collapsed every unresolved serviceUid to
Service.DEFAULT, so the ERROR(-1) and UNKNOWN(-2) uids the collector
writes into application map rows lost their identity on read and were
merged into the DEFAULT node instead of appearing as their own nodes.

Introduce a well-known set, DEFAULT/ERROR/UNKNOWN, resolved before the
registry on both resolver entry points: Service.wellKnownService(int)
for uids decoded from storage and wellKnownService(String) so the map
UI can query the ERROR/UNKNOWN nodes it now renders without a
ServiceNotFoundException. ServiceUid gains the matching
wellKnownServiceUid(int), and of() now accepts UNKNOWN(-2), a value
that legitimately exists in storage, while still rejecting the
in-memory NULL(-3) sentinel and the rest of the reserved range.

Service now stores the uid as a plain int with a single
getServiceUid() accessor, matching the int-based rowkey APIs; every
consumer previously unwrapped the ServiceUid object on the spot. This
also frees Service construction from ServiceUid.of() validation, which
would have rejected the UNKNOWN constant.
