### PR TITLE
Carry service info on the active thread socket in ServiceMap realtime

### DIFF
--- a/web-frontend/src/main/v3/.claude/rules/service-map.md
+++ b/web-frontend/src/main/v3/.claude/rules/service-map.md
@@ -137,7 +137,7 @@ A로 나가면 백엔드가 A service에서 `b-1`을 찾으므로 데이터가 �
 - **prop을 내려주는 곳을 빠뜨리면 그 차트만 조용히 화면의 service로 조회한다.** 화면은 멀쩡히
   그려지고 숫자만 비어서, 타입 검사로도 잡히지 않는다. 우측 패널에 조회하는 컴포넌트를 새로
   추가하면 `serviceName`도 함께 내려야 한다.
-  → 지금 내려주는 곳: `ServerMapChartsBoardFetcher`, `Realtime`
+  → 지금 내려주는 곳: `ServerMapChartsBoardFetcher`, `Realtime`(차트들 + `AgentActiveThreadFetcher`)
 
 ### 헤더와 캐시 키는 같은 값에서 나온다
 
@@ -169,7 +169,51 @@ React Query가 곧바로 요청을 날린다 — 그 service에 없는 applicati
 (백엔드가 그 이름을 대상의 service에서 찾는다). 대상이 다른 service면 노드 자신을 기준으로 삼는다.
 → `useGetHistogramStatistics`의 `ignorePathApplication`
 
-액티브 스레드(실시간)는 WebSocket이라 헤더가 없다. 지금도 service를 싣지 않는다.
+### 액티브 스레드(실시간)는 헤더가 아니라 메시지에 싣는다
+
+WebSocket이라 요청 헤더를 붙일 수 없다. 그래서 `activeThreadCount` 요청 메시지의 `parameters`에
+`serviceName`·`serviceType`을 함께 담아 보낸다(`AgentActiveThreadFetcher`).
+
+- **세 값(`applicationName`/`serviceType`/`serviceName`)은 한 벌로 움직인다.** 하나만 새 노드의
+  값으로 갈리면 그 service에 없는 application을 묻는 요청이 된다. 그래서 값 셋을 담은 객체를 두고
+  통째로 갈아 끼운다. 그 객체는 ref가 아니라 **state**다 — 값이 바뀌는 렌더에서 곧바로 요청이
+  나가야 한다(ref로 두면 다른 이유로 렌더가 일어날 때까지 밀려, 대상을 바꿔도 다음 응답이 올
+  때까지 최대 1초를 기다린다).
+- **핀(📌)은 클릭을 막지 않는다.** 노드를 고르면 핀과 무관하게 그 노드로 조회한다 — 클릭한 노드의
+  액티브 스레드를 보여주는 것이 이 패널의 목적이다.
+  > 예전에는 핀이 걸려 있으면(기본값) 클릭을 통째로 무시해서, 다른 노드를 눌러도 **이전 노드의
+  > 응답만 계속 오는** 상태가 됐다. WAS가 아닌 노드를 눌렀을 때 안내 문구가 뜨지 않는 것도
+  > 같은 원인이었다.
+  >
+  > 그래서 지금 핀은 조회 대상에 영향을 주지 않는다. 링크(엣지)처럼 applicationName이 없는 것을
+  > 골랐을 때 직전 대상을 유지하는 데만 쓰인다. **버튼의 역할을 다시 정하거나 없애야 한다.**
+- **service 정보는 경로에 serviceName을 싣는 화면에서만 싣는다.** servermap 실시간 보기
+  (`/serverMap/realtime`)는 예전과 **완전히 같은 메시지**(`applicationName` 하나)를 보내야 하므로,
+  `useServiceNameForLink`의 전역 선택값 폴백을 쓰지 않고 `getServiceNameFromPath`로 경로를 본다.
+  폴백을 그대로 쓰면 servermap에서도 실려 나간다(`useFilteredMapParameters`가 같은 이유로
+  폴백하지 않는다). `serviceType`도 같은 판단을 따른다 — 한 벌로 싣거나 아예 안 싣는다.
+- `enableServiceMap`이 꺼져 있으면 `useServiceNameForLink`가 undefined를 반환해 servicemap
+  경로에서도 빠진다. 그러면 JSON 직렬화에서 두 필드가 함께 빠지므로 예전 형태로 나간다.
+- **요청은 고른 노드로 그대로 보낸다.** WAS가 아닌 노드(USER·DB·캐시·큐)도 보낸다 — 예전 동작이다.
+  요청을 막는 것은 **service group**(접힌 service) 하나뿐이다. group은 기준 application이 없는데도
+  `applicationName` 자리에 serviceName이 들어 있어(`flattenServiceMapResponse`), 보내면 service를
+  application인 것처럼 묻는 요청이 된다.
+- **"WAS가 아니다"(`NOT_WAS`)는 화면 표시만의 판단이고, 핀과 무관하다.** 액티브 스레드는 agent가
+  붙은 WAS만 가지므로 차트 대신 안내 문구를 띄운다. 판단은 고른 노드의 `nodeCategory`로 한다
+  (`SERVER`가 아니면 안내). 핀이 걸려 있을 때 이 판단을 건너뛰면 **WAS가 아닌 노드를 고른 채
+  직전 WAS의 액티브 스레드가 그려진다** — USER 노드는 진입점 WAS와 이름이 같을 수 있어 특히
+  헷갈린다. map 응답이 아직 없어 노드를 모를 때는 판단을 보류한다(안내가 잠깐 스치지 않게).
+- **조회할 수 없는 대상(group)을 거쳐 같은 노드로 돌아왔을 때는 값이 그대로여도 요청을 다시
+  보낸다.** 그 사이 구독이 끊겼을 수 있고, "값이 같으니 보낼 필요 없다"고 건너뛰면 WAS가 하나뿐인
+  map에서는(진입 시 이미 그 WAS가 대상) 클릭해도 요청이 한 번도 나가지 않는다. 반대로 핀을
+  눌렀을 때는 보내지 않는다 — 같은 요청을 또 받으면 서버가 `Already started` 에러를 남긴다.
+- **조회 대상이 없어져도 소켓은 닫지 않는다.** 연결은 화면이 열려 있는 동안 유지한다(기존 동작).
+  > 서버는 소켓 하나에 구독 하나이고(`RedisActiveThreadCountWebSocketHandler`의 `HandlerSession`)
+  > **구독을 취소하는 명령이 없다**(`activeThreadCount` 하나뿐이다). 그래서 WAS가 아닌 노드를
+  > 골라 대상이 없어져도 **직전 대상의 응답은 계속 온다.** 멈추려면 소켓을 닫는 수밖에 없는데,
+  > 그러면 예전에 없던 동작이 된다. 그래서 새 요청을 보내지 않고 화면에도 쓰지 않은 채 흘려보낸다.
+- **자동 재연결은 예기치 않게 끊긴 경우에만 한다**(`shouldConnectRef`). 구분하지 않으면 언마운트
+  때 닫은 소켓이 곧바로 다시 붙어, 화면을 떠난 뒤에도(탭 포커스를 잃어도) 소켓이 살아남는다.
 
 ## map 노드/링크 id 형식이 API마다 다르다
 
@@ -239,6 +283,16 @@ servermap/filteredMap 응답에는 이 필드가 없어 그 화면들의 동작�
 - **통계 API는 기준 application이 필수다.** service 전체 map에는 URL에 application이 없으므로,
   선택된 노드(링크는 출발지 노드)를 기준으로 삼는다. → `useGetHistogramStatistics`의
   `fallbackApplication`
+- **service group 노드는 겉보기로 application 노드와 구별되지 않는다.** `flattenServiceMapResponse`가
+  화면에 이름을 그리려고 `applicationName` 자리에 serviceName을 넣고 `serviceType`도 자식 노드에서
+  합성해 채운다. 그래서 그 대상을 그대로 조회에 쓰면 **service를 application인 것처럼 묻는 요청**이
+  나간다(예: `applicationName: "B", serviceType: "TOMCAT"`). 그 이름의 application은 없으니 데이터가
+  비어서 오거나 400이 온다. 조회하는 컴포넌트는 `isServiceGroupTarget`으로 걸러 내고, 자식 노드를
+  고를 때까지 조회를 시작하지 않는다(안내 문구를 띄운다).
+  → 지금 걸러 내는 곳: `ServerMapChartsBoardFetcher`(통계 조회 + ChartsBoard),
+  `Realtime`(우측 패널), `AgentActiveThreadFetcher`(소켓)
+  > 조회하는 컴포넌트를 새로 추가하면 이 판별도 함께 넣어야 한다. `serviceName` prop과 마찬가지로
+  > 빠뜨려도 화면은 멀쩡히 그려지고 숫자만 비어서, 타입 검사로 잡히지 않는다.
 - **`useSuspenseQuery`는 `enabled`를 지원하지 않는다.** `useGetApdexScore`처럼 `shouldPoll`에 따라
   suspense를 쓰는 훅은 `enabled`로 막을 수 없다. `skipToken`을 쓰면 영원히 suspend 되므로,
   컴포넌트에서 조회 대상이 없을 때 fetcher를 마운트하지 않는 쪽으로 막는다.
@@ -257,4 +311,5 @@ servermap/filteredMap 응답에는 이 필드가 없어 그 화면들의 동작�
 | service 변경 시 초기화 | `hooks/utility/useClearApplicationOnServiceChange.ts` |
 | 라우트 로더 | `loader/serviceMap.ts`, `loader/serviceMapRealtime.ts`, `loader/filteredMap.ts` |
 | 로더의 날짜 정규화 (공유) | `loader/mapDateRange.ts` |
+| service group(접힌 service) 판별 | `utils/helper/serviceMap.ts` (`isServiceGroupTarget`) |
 | filteredMap 경로 읽기 | `hooks/searchParameters/useFilteredMapParameters.ts` |

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.test.tsx
@@ -1,0 +1,426 @@
+import { render, act, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider, createStore } from 'jotai';
+import { serverMapCurrentTargetAtom, serverMapDataAtom } from '@pinpoint-fe/ui/src/atoms';
+import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
+
+// 이 테스트의 관심사는 소켓에 무엇이 실려 나가는지, 그리고 소켓을 언제 열고 닫는지다. 차트/표/설정
+// 폼은 그와 무관하므로 모킹해 두고 렌더 트리를 가볍게 유지한다.
+jest.mock('./AgentActiveThreadView', () => ({ AgentActiveThreadView: () => null }));
+jest.mock('./AgentActiveThreadSkeleton', () => ({ AgentActiveThreadSkeleton: () => null }));
+jest.mock('./AgentActiveSetting', () => ({
+  AgentActiveSetting: () => null,
+  DefaultValue: {},
+}));
+jest.mock('@pinpoint-fe/ui/src/components/HelpPopover', () => ({ HelpPopover: () => null }));
+jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+// jest.mock 팩토리는 `mock` 접두사가 붙은 변수만 참조할 수 있다.
+let mockScreenServiceName: string | undefined;
+jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
+  useTimezone: () => ['UTC'],
+  useServiceNameForLink: () => mockScreenServiceName,
+}));
+
+import { AgentActiveThreadFetcher } from './AgentActiveThreadFetcher';
+
+type Listener = (event: unknown) => void;
+
+const sockets: MockWebSocket[] = [];
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  send = jest.fn();
+  close = jest.fn();
+  private listeners: Record<string, Listener[]> = {};
+
+  constructor() {
+    sockets.push(this);
+  }
+
+  addEventListener(type: string, listener: Listener) {
+    (this.listeners[type] ||= []).push(listener);
+  }
+
+  dispatch(type: string, event: unknown = {}) {
+    (this.listeners[type] || []).forEach((listener) => listener(event));
+  }
+}
+
+const latestSocket = () => sockets[sockets.length - 1];
+
+/** 소켓이 1초마다 밀어 주는 응답. */
+const pushResponse = (socket: MockWebSocket, timeStamp: number) => {
+  act(() => {
+    socket.dispatch('message', {
+      data: JSON.stringify({ type: 'RESPONSE', result: { timeStamp } }),
+    });
+  });
+};
+
+/**
+ * 소켓이 열리고 첫 응답이 도착한 상태를 만든다.
+ *
+ * `readyState`를 먼저 OPEN으로 바꾼다 — 실제 브라우저도 open 이벤트가 불릴 때 이미 OPEN이고,
+ * 컴포넌트는 그 시점에 첫 요청을 보낸다.
+ */
+const openSocket = (socket = latestSocket()) => {
+  act(() => {
+    socket.readyState = MockWebSocket.OPEN;
+    socket.dispatch('open');
+  });
+  pushResponse(socket, 0);
+};
+
+const activeThreadCountRequests = (socket = latestSocket()) =>
+  socket.send.mock.calls
+    .map(([payload]) => JSON.parse(payload as string))
+    .filter((message) => message.command === 'activeThreadCount');
+
+const sentParameters = (socket = latestSocket()) => {
+  const requests = activeThreadCountRequests(socket);
+  return requests[requests.length - 1]?.parameters;
+};
+
+type MapNode = { key: string; applicationName: string; serviceType: string };
+
+const APP_NODE = {
+  key: 'A^a-1^TOMCAT',
+  applicationName: 'a-1',
+  serviceType: 'TOMCAT',
+  nodeCategory: GetServerMap.NodeCategory.SERVER,
+};
+
+/**
+ * USER 노드. **applicationName이 진입점 WAS와 같다**(`a-1`) — mock(`dev-mock/mockData.ts`)과
+ * 실제 응답이 모두 이 형태다. 그래서 이름만으로는 WAS와 구별되지 않는다.
+ */
+const USER_NODE = {
+  key: 'A^a-1^USER',
+  applicationName: 'a-1',
+  serviceType: 'USER',
+  nodeCategory: GetServerMap.NodeCategory.USER,
+};
+
+/** servicemap 실시간 보기 경로. 로더가 serviceName 세그먼트를 항상 채워 넣는다. */
+const SERVICE_MAP_REALTIME_PATH = '/serviceMap/realtime/A/a-1@TOMCAT';
+/** servermap 실시간 보기 경로. 이 화면은 serviceName을 경로에 싣지 않는다. */
+const SERVER_MAP_REALTIME_PATH = '/serverMap/realtime/a-1@TOMCAT';
+
+const mount = ({
+  nodes = [APP_NODE],
+  selected = APP_NODE as MapNode | undefined,
+  serviceName,
+  path = SERVICE_MAP_REALTIME_PATH,
+}: {
+  nodes?: Partial<GetServerMap.NodeData>[];
+  selected?: MapNode;
+  serviceName?: string;
+  path?: string;
+} = {}) => {
+  const store = createStore();
+  store.set(serverMapDataAtom, {
+    applicationMapData: { nodeDataArray: nodes, linkDataArray: [] },
+  } as unknown as GetServerMap.Response);
+  if (selected) {
+    store.set(serverMapCurrentTargetAtom, { id: selected.key, ...selected, type: 'node' });
+  }
+
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Provider store={store}>
+        <AgentActiveThreadFetcher serviceName={serviceName} />
+      </Provider>
+    </MemoryRouter>,
+  );
+
+  /** map에서 노드를 클릭한 것과 같은 상태를 만든다. */
+  const clickNode = (node: MapNode) =>
+    act(() => {
+      store.set(serverMapCurrentTargetAtom, { id: node.key, ...node, type: 'node' });
+    });
+
+  /** 헤더의 핀 버튼을 눌러 고정을 푼다. */
+  const unpin = () =>
+    act(() => {
+      fireEvent.click(screen.getAllByRole('button')[0]);
+    });
+
+  return { store, clickNode, unpin };
+};
+
+describe('AgentActiveThreadFetcher', () => {
+  const originalWebSocket = global.WebSocket;
+
+  beforeAll(() => {
+    global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterAll(() => {
+    global.WebSocket = originalWebSocket;
+  });
+
+  beforeEach(() => {
+    sockets.length = 0;
+    mockScreenServiceName = undefined;
+  });
+
+  it('조회 대상의 applicationName과 serviceType을 실어 보낸다', () => {
+    mockScreenServiceName = 'A';
+    mount();
+    openSocket();
+
+    expect(sentParameters()).toMatchObject({ applicationName: 'a-1', serviceType: 'TOMCAT' });
+  });
+
+  it('넘어온 serviceName이 있으면 그것으로 조회한다', () => {
+    mockScreenServiceName = 'screen-service';
+    mount({ serviceName: 'target-service' });
+    openSocket();
+
+    expect(sentParameters()).toEqual({
+      applicationName: 'a-1',
+      serviceType: 'TOMCAT',
+      serviceName: 'target-service',
+    });
+  });
+
+  it('넘어온 serviceName이 없으면 화면의 service로 조회한다', () => {
+    mockScreenServiceName = 'screen-service';
+    mount();
+    openSocket();
+
+    expect(sentParameters()).toMatchObject({ serviceName: 'screen-service' });
+  });
+
+  // enableServiceMap이 꺼져 있으면 useServiceNameForLink가 undefined를 반환한다. 그때는 예전과
+  // 같은 형태로 나가야 한다 — service 개념이 없는 저장소에 service 이름이 새어 나가지 않도록.
+  it('service를 알 수 없으면 예전과 같은 메시지를 보낸다', () => {
+    mount();
+    openSocket();
+
+    expect(sentParameters()).toEqual({ applicationName: 'a-1' });
+  });
+
+  /**
+   * servermap 실시간 보기는 경로에 serviceName을 싣지 않는 화면이다. 이 화면의 메시지는 예전과
+   * 완전히 같아야 한다 — `useServiceNameForLink`의 전역 선택값 폴백을 그대로 쓰면 여기서도
+   * service 정보가 실려 나간다.
+   */
+  it('servermap 실시간 보기는 applicationName만 보낸다', () => {
+    mockScreenServiceName = 'screen-service';
+    mount({ serviceName: 'target-service', path: SERVER_MAP_REALTIME_PATH });
+    openSocket();
+
+    expect(sentParameters()).toEqual({ applicationName: 'a-1' });
+  });
+
+  it('servicemap 실시간 보기는 service 정보를 함께 보낸다', () => {
+    mockScreenServiceName = 'A';
+    mount({ serviceName: 'A', path: SERVICE_MAP_REALTIME_PATH });
+    openSocket();
+
+    expect(sentParameters()).toEqual({
+      applicationName: 'a-1',
+      serviceType: 'TOMCAT',
+      serviceName: 'A',
+    });
+  });
+
+  // service group 노드는 기준 application이 없는데도 applicationName에 serviceName이 들어 있다
+  // (flattenServiceMapResponse). 그대로 보내면 service를 application인 것처럼 묻게 된다.
+  it('service group 노드를 골랐으면 요청을 보내지 않는다', () => {
+    const groupNode = {
+      key: 'B',
+      serviceName: 'B',
+      applicationName: 'B',
+      serviceType: 'TOMCAT',
+      nodeCategory: GetServerMap.NodeCategory.SERVER,
+      subNodes: [{ key: 'B^b-1^TOMCAT', applicationName: 'b-1', serviceType: 'TOMCAT' }],
+    } as unknown as GetServerMap.NodeData;
+
+    mount({
+      nodes: [groupNode],
+      selected: { key: 'B', applicationName: 'B', serviceType: 'TOMCAT' },
+      serviceName: 'B',
+    });
+    openSocket();
+
+    expect(sentParameters()).toBeUndefined();
+  });
+
+  /**
+   * WAS가 아닌 노드도 **고른 노드로 요청은 보낸다**(예전 동작). 액티브 스레드는 WAS만 가지므로
+   * 차트 대신 안내 문구를 띄우는 것이 이 판단의 몫이다.
+   *
+   * USER 노드는 진입점 WAS와 applicationName이 같을 수 있어, 안내 없이 차트를 그리면 WAS의
+   * 액티브 스레드를 그 노드의 것으로 착각하게 된다.
+   */
+  it('WAS가 아닌 노드(USER)도 그 노드로 요청하고 WAS가 아니라고 알려준다', () => {
+    mockScreenServiceName = 'A';
+    mount({ nodes: [USER_NODE, APP_NODE], selected: USER_NODE, serviceName: 'A' });
+    openSocket();
+
+    expect(sentParameters()).toMatchObject({ applicationName: 'a-1', serviceType: 'USER' });
+    expect(screen.getByText('SERVER_MAP.REAL_TIME.NOT_WAS')).toBeTruthy();
+  });
+
+  // 핀을 풀지 않고도 그 다음에 고른 WAS가 대상이 되어야 한다. WAS가 아닌 노드를 대상으로
+  // 삼아 버리면 핀이 걸린 채로 고정되어, 핀을 해제할 때까지 이 패널이 멈춘다.
+  it('WAS가 아닌 노드를 거쳐도 그 다음에 고른 WAS가 대상이 된다', () => {
+    mockScreenServiceName = 'A';
+    const { clickNode } = mount({
+      nodes: [USER_NODE, APP_NODE],
+      selected: USER_NODE,
+      serviceName: 'A',
+    });
+
+    clickNode(APP_NODE);
+    openSocket();
+
+    expect(sentParameters()).toEqual({
+      applicationName: 'a-1',
+      serviceType: 'TOMCAT',
+      serviceName: 'A',
+    });
+  });
+
+  /**
+   * 핀을 풀면 조회 대상도 고른 것을 따라간다. 대상이 없어져도 **소켓은 그대로 열어 둔다** —
+   * 연결을 화면이 열려 있는 동안 유지하는 것이 기존 동작이다. 구독을 취소하는 명령이 없어서
+   * 직전 WAS의 응답은 계속 오지만, 새 요청을 보내지 않고 화면에도 쓰지 않는다.
+   */
+  it('핀을 푼 뒤 WAS가 아닌 노드를 골라도 소켓을 닫지 않는다', () => {
+    const { clickNode, unpin } = mount({
+      nodes: [USER_NODE, APP_NODE],
+      selected: APP_NODE,
+      serviceName: 'A',
+    });
+    const socket = latestSocket();
+    openSocket(socket);
+
+    unpin();
+    clickNode(USER_NODE);
+    pushResponse(socket, 2);
+
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(screen.getByText('SERVER_MAP.REAL_TIME.NOT_WAS')).toBeTruthy();
+  });
+
+  /**
+   * 핀이 걸려 있어도 WAS를 고르면 그 노드로 조회한다. 클릭한 노드의 액티브 스레드를 보여주는
+   * 것이 이 패널의 목적이라, 핀 때문에 이전 노드의 응답만 계속 오면 안 된다.
+   *
+   * 이때 세 값은 한 벌로 갈려야 한다 — 하나만 새 노드의 값이 되면 그 service에 없는
+   * application을 묻는 요청이 된다.
+   */
+  it('핀이 걸려 있어도 WAS를 고르면 그 노드로 조회한다', () => {
+    mockScreenServiceName = 'service-a';
+    const otherWas = {
+      key: 'A^a-2^SPRING_BOOT',
+      applicationName: 'a-2',
+      serviceType: 'SPRING_BOOT',
+      nodeCategory: GetServerMap.NodeCategory.SERVER,
+    };
+    const { clickNode } = mount({
+      nodes: [APP_NODE, otherWas],
+      selected: APP_NODE,
+      serviceName: 'service-a',
+    });
+    const socket = latestSocket();
+    openSocket(socket);
+
+    clickNode(otherWas);
+
+    expect(sentParameters(socket)).toEqual({
+      applicationName: 'a-2',
+      serviceType: 'SPRING_BOOT',
+      serviceName: 'service-a',
+    });
+  });
+
+  // 안내 문구는 핀과 무관하다. 핀이 걸려 있을 때 이 판단을 건너뛰면, WAS가 아닌 노드를 고른 채
+  // 직전 WAS의 액티브 스레드가 그려진다.
+  it('핀이 걸려 있어도 WAS가 아닌 노드를 고르면 WAS가 아니라고 알려준다', () => {
+    mockScreenServiceName = 'A';
+    const { clickNode } = mount({
+      nodes: [APP_NODE, USER_NODE],
+      selected: APP_NODE,
+      serviceName: 'A',
+    });
+    const socket = latestSocket();
+    openSocket(socket);
+
+    clickNode(USER_NODE);
+
+    expect(screen.getByText('SERVER_MAP.REAL_TIME.NOT_WAS')).toBeTruthy();
+  });
+
+  /**
+   * 조회 대상이 될 수 없는 것(service group)을 거쳐 **같은 노드로 돌아왔을 때**도 요청이 다시
+   * 나가야 한다. 대상 값이 그대로라 "보낼 필요 없다"고 건너뛰면 그 사이 구독이 끊겼을 때 되살릴
+   * 방법이 없고, WAS가 하나뿐인 map에서는(진입 시 이미 그 WAS가 대상) 클릭해도 요청이 한 번도
+   * 나가지 않는 상태가 된다.
+   */
+  it('조회할 수 없는 대상을 거쳐 같은 노드로 돌아오면 요청을 다시 보낸다', () => {
+    mockScreenServiceName = 'A';
+    const groupNode = {
+      key: 'B',
+      serviceName: 'B',
+      applicationName: 'B',
+      serviceType: 'TOMCAT',
+      nodeCategory: GetServerMap.NodeCategory.SERVER,
+      subNodes: [{ key: 'B^b-1^TOMCAT', applicationName: 'b-1', serviceType: 'TOMCAT' }],
+    } as unknown as GetServerMap.NodeData;
+    const { clickNode } = mount({
+      nodes: [APP_NODE, groupNode],
+      selected: APP_NODE,
+      serviceName: 'A',
+    });
+    const socket = latestSocket();
+    openSocket(socket);
+    const requestsBefore = activeThreadCountRequests(socket).length;
+
+    clickNode({ key: 'B', applicationName: 'B', serviceType: 'TOMCAT' });
+    clickNode(APP_NODE);
+
+    expect(activeThreadCountRequests(socket).length).toBe(requestsBefore + 1);
+    expect(sentParameters(socket)).toMatchObject({ applicationName: 'a-1' });
+  });
+
+  // 반대로 핀을 눌렀을 뿐인데 같은 요청을 또 보내면, 서버가 'Already started' 에러를 남긴다.
+  it('핀만 눌렀을 때는 같은 요청을 다시 보내지 않는다', () => {
+    mockScreenServiceName = 'A';
+    const { unpin } = mount({ serviceName: 'A' });
+    const socket = latestSocket();
+    openSocket(socket);
+    const requestsBefore = activeThreadCountRequests(socket).length;
+
+    unpin();
+
+    expect(activeThreadCountRequests(socket).length).toBe(requestsBefore);
+  });
+
+  // 예기치 않게 끊기면(서버 재시작 등) 다시 붙고, 붙자마자 같은 대상으로 다시 구독한다.
+  it('소켓이 끊기면 다시 붙어 같은 대상으로 조회한다', () => {
+    mockScreenServiceName = 'A';
+    mount({ serviceName: 'A' });
+    const firstSocket = latestSocket();
+    openSocket(firstSocket);
+
+    act(() => {
+      firstSocket.readyState = MockWebSocket.CLOSED;
+      firstSocket.dispatch('close');
+    });
+
+    const reconnected = latestSocket();
+    expect(reconnected).not.toBe(firstSocket);
+    openSocket(reconnected);
+    expect(sentParameters(reconnected)).toMatchObject({ applicationName: 'a-1' });
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
@@ -20,61 +20,192 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { BsGearFill } from 'react-icons/bs';
 import { AgentActiveSetting, AgentActiveSettingType, DefaultValue } from './AgentActiveSetting';
 import { HelpPopover } from '@pinpoint-fe/ui/src/components/HelpPopover';
-import { useTimezone } from '@pinpoint-fe/ui/src/hooks';
+import { useLocation } from 'react-router-dom';
+import { useServiceNameForLink, useTimezone } from '@pinpoint-fe/ui/src/hooks';
+import { getServiceNameFromPath, isServiceGroupTarget } from '@pinpoint-fe/ui/src/utils';
 
-export interface ActiveRequestProps {}
+export interface ActiveRequestProps {
+  /**
+   * 조회 대상 노드가 소속된 service.
+   *
+   * servicemap 실시간 보기에서는 다른 service의 노드도 고를 수 있으므로, 조회는 화면의 service가
+   * 아니라 고른 노드의 service로 나가야 한다. 넘기지 않으면 화면의 service로 조회한다.
+   */
+  serviceName?: string;
+}
 
-export const AgentActiveThreadFetcher = () => {
+export const AgentActiveThreadFetcher = ({ serviceName }: ActiveRequestProps) => {
   const { t } = useTranslation();
   const wsRef = React.useRef<WebSocket | undefined>(undefined);
+  /** 소켓을 유지해야 하는지. 의도적으로 닫을 때 자동 재연결을 막는다. */
+  const shouldConnectRef = React.useRef(false);
   const [timezone] = useTimezone();
-  const [webSocketState, setWebSocketState] = React.useState<number>(WebSocket.CLOSED);
+  // 대상이 정해진 뒤에 소켓을 열기 때문에, 첫 화면은 "연결 중"이 맞다. CLOSED로 두면 연결되기
+  // 전 한 프레임 동안 "연결이 종료되었습니다"가 스친다.
+  const [webSocketState, setWebSocketState] = React.useState<number>(WebSocket.CONNECTING);
   const currentServerMapTarget = useAtomValue(serverMapCurrentTargetAtom);
-  const applicationNameRef = React.useRef('');
-  const applicationName = currentServerMapTarget?.applicationName || '';
+  /**
+   * 소켓에 실어 보낼 조회 대상. 없으면 `applicationName`이 빈 문자열이다.
+   *
+   * 세 값을 한 객체에 모아 두는 이유는 applicationName·serviceType·serviceName이 반드시 한 벌로
+   * 갈려야 하기 때문이다. 하나만 새 노드의 값으로 바뀌면 그 service에 없는 application을 묻는
+   * 요청이 된다.
+   *
+   * ref가 아니라 state다. 소켓을 열고 닫는 것이 이 값에 달려 있어서, 값이 바뀌면 렌더가 반드시
+   * 일어나야 한다. (ref로 두면 다른 이유로 렌더가 일어날 때까지 반영이 밀린다)
+   */
+  const [requestTarget, setRequestTarget] = React.useState<AgentActiveThread.RequestParameters>({
+    applicationName: '',
+  });
+  // 소켓 이벤트 핸들러에서 최신 대상을 읽기 위한 거울.
+  const requestTargetRef = React.useRef(requestTarget);
+  requestTargetRef.current = requestTarget;
+  /**
+   * 직전에 고른 것이 조회할 수 있는 대상이었는지.
+   *
+   * 조회할 수 없는 노드(USER·DB·service group 등)를 거쳐 **같은 노드로 돌아왔을 때** 요청을 다시
+   * 보내야 하는지 판단하는 데 쓴다. 대상 값이 그대로라 그것만으로는 구별할 수 없다.
+   */
+  const hadQueryableSelectionRef = React.useRef(true);
+  const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom) as GetServerMap.NodeData;
+  /**
+   * service group(접힌 service) 노드는 조회 대상으로 삼지 않는다.
+   *
+   * group 노드에는 기준 application이 없는데도 `applicationName`에 serviceName이 들어 있어
+   * (`flattenServiceMapResponse`), 그대로 보내면 service를 application인 것처럼 묻게 된다.
+   * 팝업에서 자식 노드를 고르면 대상이 그 application으로 바뀌어 그때 조회가 시작된다.
+   */
+  const isGroupTarget = isServiceGroupTarget(currentTargetData);
+  /**
+   * 고른 것이 WAS가 아닌 상태(USER·DB·캐시·메시지 큐·UNKNOWN 노드, 그리고 링크).
+   *
+   * 액티브 스레드는 agent가 붙은 WAS만 가지므로 **차트 대신 안내 문구를 띄운다.** 요청은 그대로
+   * 보낸다(예전 동작) — 화면 표시만 갈리는 판단이다.
+   *
+   * 핀과 무관하게 본다. 핀이 걸려 있을 때 이 판단을 건너뛰면, WAS가 아닌 노드를 고른 채 직전 WAS의
+   * 액티브 스레드가 그려진다(USER 노드는 진입점 WAS와 이름이 같을 수 있어 특히 헷갈린다).
+   *
+   * map 응답이 아직 없어 노드 정보를 모를 때(`currentTargetData`가 undefined)는 판단을 보류한다.
+   * 그러지 않으면 화면에 처음 들어왔을 때 안내 문구가 잠깐 스친다.
+   */
+  const isNotWasTarget =
+    !!currentTargetData &&
+    (currentTargetData as GetServerMap.NodeData).nodeCategory !== GetServerMap.NodeCategory.SERVER;
+  // service group(접힌 service)만 조회 대상에서 뺀다. 그 외에는 고른 노드로 그대로 요청한다.
+  const applicationName = isGroupTarget ? '' : currentServerMapTarget?.applicationName || '';
+  const serviceType = isGroupTarget ? undefined : currentServerMapTarget?.serviceType;
+  const screenServiceName = useServiceNameForLink();
+  const { pathname } = useLocation();
+  /**
+   * 메시지에 service 정보를 실을 화면인지.
+   *
+   * **경로에 serviceName 세그먼트를 싣는 화면(servicemap 계열)에서만 싣는다.** 전역 선택값으로
+   * 폴백하지 않는 것이 핵심이다 — `useServiceNameForLink`는 경로에 없으면 전역 선택값을 주므로,
+   * 그것을 그대로 쓰면 servermap 실시간 보기에서도 실려 나가 예전과 다른 메시지가 된다. 그 화면은
+   * 기존과 완전히 같은 메시지(`applicationName` 하나)를 보내야 한다.
+   * (`useFilteredMapParameters`의 serviceName도 같은 이유로 폴백하지 않는다)
+   *
+   * `enableServiceMap`이 꺼져 있으면 `useServiceNameForLink`가 undefined를 반환하므로 servicemap
+   * 경로에서도 빠진다 — service 개념이 없는 저장소로 새어 나가지 않게 하는 것은 그 훅 한 곳이다.
+   */
+  const carriesServiceInfo = !!screenServiceName && !!getServiceNameFromPath(pathname);
+  // 고른 노드의 service가 화면의 service와 다를 수 있다(servicemap의 다른 service 노드).
+  const requestServiceName = carriesServiceInfo ? (serviceName ?? screenServiceName) : undefined;
+  const requestServiceType = carriesServiceInfo ? serviceType : undefined;
   // const { activeThreadCountsWithTotal, setActiveThreadCounts } = useActiveThread();
   const [activeThreadCounts, setActiveThreadCounts] = React.useState<AgentActiveThread.Response>();
   const [isApplicationLocked, setApplicationLock] = React.useState(true);
-  const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom) as GetServerMap.NodeData;
   const [showSetting, setShowSetting] = React.useState(false);
   const [setting, setSetting] = React.useState<AgentActiveSettingType>(DefaultValue);
   /**
    * 조회할 대상이 정해졌는지 여부.
    *
-   * 대상이 없으면 activeThreadCount 요청을 보내지 않으므로 응답도 오지 않는다. 그러면 연결
-   * 상태가 CONNECTING에 머물러 로딩 스켈레톤이 영영 떠 있게 되므로, 로딩 대신 무엇을 해야
-   * 하는지 알려준다. (기준 application이 없는 servicemap 실시간 보기에서 아직 노드를 고르지
-   * 않은 상태가 여기에 해당한다.)
+   * 대상이 없으면 activeThreadCount 요청을 보내지 않으므로 보여줄 응답도 없다. 그대로 두면 로딩
+   * 스켈레톤이 영영 떠 있게 되므로, 로딩 대신 무엇을 해야 하는지 알려준다. (기준 application이
+   * 없는 servicemap 실시간 보기에서 아직 노드를 고르지 않은 상태, WAS가 아닌 노드나 service
+   * group을 고른 상태가 여기에 해당한다.)
    */
-  const hasTarget = !!(applicationName || applicationNameRef.current);
+  const hasTarget = !!(applicationName || requestTarget.applicationName);
 
   React.useEffect(() => {
-    initWebSocket();
+    connect();
 
     return () => {
-      close();
+      // 언마운트: 자동 재연결까지 막고 닫는다. 막지 않으면 close 이벤트가 다시 붙어서
+      // 화면을 떠난 뒤에도 소켓이 살아남는다.
+      disconnect();
     };
   }, []);
 
+  /**
+   * 고른 대상을 조회 대상으로 옮긴다.
+   *
+   * - **조회할 수 있는 대상(WAS)을 고르면 핀과 무관하게 그 대상으로 옮긴다.** 클릭한 노드의
+   *   액티브 스레드를 보여주는 것이 이 패널의 목적이다. (핀이 걸려 있으면 클릭을 무시하던 예전
+   *   동작에서 달라진 부분이다 — 다른 WAS를 눌러도 이전 노드의 응답만 계속 오는 상태가 된다)
+   * - 조회할 수 없는 대상(WAS가 아닌 노드·service group·링크)을 골랐을 때는 **핀이 지금 보고 있는
+   *   대상을 지켜 준다.** 핀이 풀려 있으면 대상을 비워 "WAS가 아니다"를 알린다.
+   */
   React.useEffect(() => {
-    if ((applicationName && !isApplicationLocked) || applicationNameRef.current === '') {
-      applicationNameRef.current = applicationName;
-    }
-  }, [applicationName, isApplicationLocked]);
+    const previousTarget = requestTargetRef.current;
+    const hadQueryableSelection = hadQueryableSelectionRef.current;
+    const shouldFollowTarget = !!applicationName || !isApplicationLocked;
 
+    hadQueryableSelectionRef.current = !!applicationName;
+
+    if (!shouldFollowTarget) {
+      return;
+    }
+    if (
+      previousTarget.applicationName === applicationName &&
+      previousTarget.serviceType === requestServiceType &&
+      previousTarget.serviceName === requestServiceName
+    ) {
+      if (!hadQueryableSelection) {
+        // 조회할 수 없는 노드를 거쳐 같은 노드로 돌아왔다. 값이 그대로라 state는 두고 요청만 다시
+        // 보낸다 — 그 사이 구독이 끊겼을 수 있고, 서버는 같은 이름이면 기존 구독을 유지한다.
+        requestActiveThreadCount();
+      }
+      // 값도 그대로고 직전 선택도 그대로면 보낼 이유가 없다. (핀을 눌렀을 때가 여기에 해당한다.
+      // 같은 요청을 또 보내면 서버가 'Already started' 에러를 남긴다)
+      return;
+    }
+    // 세 값을 한 번에 갈아 끼운다. 따로 대입하면 중간 렌더에서 짝이 어긋난 요청이 나간다.
+    setRequestTarget({
+      applicationName,
+      serviceType: requestServiceType,
+      serviceName: requestServiceName,
+    });
+  }, [applicationName, requestServiceType, requestServiceName, isApplicationLocked]);
+
+  /**
+   * 조회 대상이 정해지면 그 대상으로 요청한다. (이미 열려 있을 때. 열리는 중이면 open 핸들러가 보낸다)
+   *
+   * **대상이 없어져도 소켓은 닫지 않는다.** 서버는 소켓 하나에 구독 하나이고 구독을 취소하는
+   * 명령이 없어서(`activeThreadCount` 하나뿐이다), 닫는 것 말고는 직전 대상의 스트림을 멈출
+   * 방법이 없다. 그래서 WAS가 아닌 노드를 골랐을 때는 직전 대상의 응답이 계속 오는데, 화면에
+   * 쓰지 않고 흘려보낸다 — 연결은 화면이 열려 있는 동안 유지하는 것이 기존 동작이다.
+   */
   React.useEffect(() => {
-    const isSocketOpen = wsRef.current?.readyState === WebSocket.OPEN;
+    requestActiveThreadCount();
+  }, [requestTarget]);
 
-    if (applicationNameRef.current && isSocketOpen) {
-      sendMessage({
-        type: 'REQUEST',
-        command: 'activeThreadCount',
-        parameters: {
-          applicationName: applicationNameRef.current,
-        },
-      });
+  const connect = () => {
+    shouldConnectRef.current = true;
+    if (wsRef.current) {
+      return; // 이미 열려 있거나 연결 중이다
     }
-  }, [applicationNameRef.current, wsRef.current?.readyState]);
+    initWebSocket();
+  };
+
+  const disconnect = () => {
+    shouldConnectRef.current = false;
+    wsRef.current?.close();
+    wsRef.current = undefined;
+    // 다음에 열릴 때를 위한 초기 상태로 되돌린다. CLOSED로 두면 다시 대상이 정해져 연결되는
+    // 사이에 "연결이 종료되었습니다"가 스친다.
+    setWebSocketState(WebSocket.CONNECTING);
+  };
 
   const initWebSocket = () => {
     const location = window.location;
@@ -89,7 +220,8 @@ export const AgentActiveThreadFetcher = () => {
       'open',
       () => {
         setWebSocketState(WebSocket.CONNECTING);
-        // setSocketOpen(true);
+        // 대상이 정해진 뒤에 열기 때문에, 열리는 즉시 요청하면 첫 조회가 늦지 않는다.
+        requestActiveThreadCount();
       },
       { signal },
     );
@@ -109,13 +241,27 @@ export const AgentActiveThreadFetcher = () => {
     ws.addEventListener(
       'close',
       () => {
-        setWebSocketState(WebSocket.CLOSED);
         eventController.abort();
-        initWebSocket();
-        // wsRef.current = undefined;
+        if (wsRef.current === ws) {
+          wsRef.current = undefined;
+        }
+        if (!shouldConnectRef.current) {
+          return; // 의도적으로 닫은 것이다
+        }
+        setWebSocketState(WebSocket.CLOSED);
+        initWebSocket(); // 예기치 않게 끊긴 경우에만 다시 붙는다
       },
       { signal },
     );
+  };
+
+  const requestActiveThreadCount = () => {
+    const target = requestTargetRef.current;
+
+    if (!target.applicationName || wsRef.current?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    sendMessage({ type: 'REQUEST', command: 'activeThreadCount', parameters: target });
   };
 
   const parseMessage = (message: string): AgentActiveThread.Response => {
@@ -131,10 +277,6 @@ export const AgentActiveThreadFetcher = () => {
     wsRef.current?.send(JSON.stringify(message));
   };
 
-  const close = () => {
-    wsRef.current?.close();
-  };
-
   return (
     <div className="w-full h-full">
       {!hasTarget ? (
@@ -142,8 +284,8 @@ export const AgentActiveThreadFetcher = () => {
           {t('SERVER_MAP.REAL_TIME.SELECT_NODE')}
         </div>
       ) : webSocketState === WebSocket.OPEN ? (
-        isApplicationLocked ||
-        currentTargetData?.nodeCategory === GetServerMap.NodeCategory.SERVER ? (
+        // 핀은 이 판단에 끼어들지 않는다. 고른 것이 WAS가 아니면 그 사실을 알려준다.
+        !isNotWasTarget ? (
           <div className="flex flex-col items-center p-4 h-full">
             <div className="flex flex-row gap-1 justify-between items-center p-1 w-full text-sm font-semibold truncate">
               <TooltipProvider>
@@ -167,7 +309,7 @@ export const AgentActiveThreadFetcher = () => {
                 </Tooltip>
               </TooltipProvider>
               <div className="flex flex-row gap-1 w-full truncate">
-                {applicationNameRef.current}
+                {requestTarget.applicationName}
                 <HelpPopover helpKey="HELP_VIEWER.REAL_TIME" />
               </div>
               <div className="flex gap-1 items-center font-normal text-gray-400">
@@ -186,7 +328,7 @@ export const AgentActiveThreadFetcher = () => {
             </div>
             <div className="flex flex-grow w-full h-[-webkit-fill-available] overflow-hidden">
               <AgentActiveThreadView
-                applicationName={applicationNameRef.current}
+                applicationName={requestTarget.applicationName}
                 activeThreadCounts={activeThreadCounts?.result}
                 setting={setting}
               />

--- a/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
@@ -33,7 +33,7 @@ import {
   serverMapChartTypeAtom,
 } from '@pinpoint-fe/ui/src/atoms';
 import { APP_SETTING_KEYS, ApplicationType, GetServerMap } from '@pinpoint-fe/ui/src/constants';
-import { getServerImagePath } from '@pinpoint-fe/ui/src/utils';
+import { getServerImagePath, isServiceGroupTarget } from '@pinpoint-fe/ui/src/utils';
 import { cn } from '@pinpoint-fe/ui/src/lib';
 
 export interface RealtimeProps {
@@ -62,6 +62,15 @@ export const Realtime = ({ MapView = ServerMap, requiresApplication = true }: Re
   const { t } = useTranslation();
   // 기준 application이 필요 없는 map은 고를 대상이 없으므로 곧바로 그린다.
   const showMap = !requiresApplication || !!application;
+  /**
+   * service group(접힌 service)을 고른 상태.
+   *
+   * group 노드/링크에는 기준 application이 없는데도 `applicationName`에 serviceName이 들어 있어
+   * (`flattenServiceMapResponse`), 그대로 조회하면 service를 application인 것처럼 묻게 된다.
+   * 그래서 우측 패널은 조회를 시작하지 않고, 팝업에서 자식 노드를 고르라고 알려준다.
+   * (servicemap이 아닌 화면에서는 group이 없으므로 항상 false다.)
+   */
+  const isGroupTarget = isServiceGroupTarget(currentTargetData);
 
   React.useEffect(() => {
     if (application) {
@@ -137,7 +146,7 @@ export const Realtime = ({ MapView = ServerMap, requiresApplication = true }: Re
             <ResizablePanel minSize={10} maxSize={90} className="!overflow-auto">
               {isFocus && (
                 <ErrorBoundary>
-                  <AgentActiveThreadFetcher />
+                  <AgentActiveThreadFetcher serviceName={targetServiceName} />
                 </ErrorBoundary>
               )}
             </ResizablePanel>
@@ -157,7 +166,11 @@ export const Realtime = ({ MapView = ServerMap, requiresApplication = true }: Re
             serverMapData?.applicationMapData
               ?.timestamp as GetServerMap.ApplicationMapData['timestamp']
           }
-          nodeData={currentTargetData?.isAuthorized === false ? undefined : currentTargetData}
+          nodeData={
+            currentTargetData?.isAuthorized === false || isGroupTarget
+              ? undefined
+              : currentTargetData
+          }
           emptyMessage={t('COMMON.NO_DATA')}
           header={
             <ChartsBoardHeader
@@ -175,9 +188,11 @@ export const Realtime = ({ MapView = ServerMap, requiresApplication = true }: Re
             />
           }
         >
-          {!serverMapCurrentTarget ? (
-            // 고른 대상이 없으면 헤더도 차트도 그릴 것이 없어 패널이 통째로 비어 보인다.
-            // 무엇을 해야 하는지 알려준다. (기준 application이 없는 map에서만 생기는 상태)
+          {!serverMapCurrentTarget || isGroupTarget ? (
+            // 조회할 application이 정해지지 않은 상태다 — 아무것도 고르지 않았거나(기준
+            // application이 없는 map), service group을 골랐거나. 억지로 차트를 그리면 빈 차트만
+            // 남으므로 무엇을 해야 하는지 알려준다.
+            // (group을 좌클릭하면 자식 노드 목록 팝업이 열리므로, 그중 하나를 고르면 된다.)
             <div className="flex justify-center items-center w-full h-full text-muted-foreground">
               {t('SERVER_MAP.SELECT_NODE_FOR_CHART')}
             </div>

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
@@ -36,7 +36,11 @@ import {
   serverMapDataAtom,
 } from '@pinpoint-fe/ui/src/atoms';
 import { useAtom, useAtomValue } from 'jotai';
-import { getApplicationKey, getServerImagePath } from '@pinpoint-fe/ui/src/utils';
+import {
+  getApplicationKey,
+  getServerImagePath,
+  isServiceGroupTarget,
+} from '@pinpoint-fe/ui/src/utils';
 import { cn } from '@pinpoint-fe/ui/src/lib';
 import { RxChevronRight } from 'react-icons/rx';
 import { ServerListForCommon } from '@pinpoint-fe/ui/src/components/ServerList/ServerListForCommon';
@@ -127,12 +131,19 @@ export const ServerMapChartsBoardFetcher = ({
     ? selectedTargetApplication
     : (application ?? selectedTargetApplication);
 
+  // service group(접힌 service) 대상은 기준 application이 없다 — applicationName 자리에
+  // serviceName이 들어 있어(`flattenServiceMapResponse`) 그대로 조회하면 service를 application인
+  // 것처럼 묻는 요청이 된다. key를 둘 다 비우면 훅이 조회를 시작하지 않는다(`enabled`).
+  // 아래에서 ChartsBoard도 그리지 않으므로 보여줄 데이터도 없다.
+  const isGroupTarget = isServiceGroupTarget(currentTargetData);
+
   const { data, isLoading } = useGetHistogramStatistics({
     useStatisticsAgentState,
-    nodeKey:
-      (currentTargetData as GetServerMap.NodeData)?.nodeKey ||
-      (baseApplication ? getApplicationKey(baseApplication) : undefined), // 원래 optional인데 첫 페이지 로딩 시 currentTargetData가 없을 때, currentTargetData가 application으로 잡힐 때 두번 중복 call 방지를 위해 required 처럼 사용
-    linkKey: (currentTargetData as GetServerMap.LinkData)?.linkKey,
+    nodeKey: isGroupTarget
+      ? undefined
+      : (currentTargetData as GetServerMap.NodeData)?.nodeKey ||
+        (baseApplication ? getApplicationKey(baseApplication) : undefined), // 원래 optional인데 첫 페이지 로딩 시 currentTargetData가 없을 때, currentTargetData가 application으로 잡힐 때 두번 중복 call 방지를 위해 required 처럼 사용
+    linkKey: isGroupTarget ? undefined : (currentTargetData as GetServerMap.LinkData)?.linkKey,
     fallbackApplication: selectedTargetApplication,
     ignorePathApplication: isCrossServiceTarget,
     serviceName: targetServiceName,
@@ -238,12 +249,9 @@ export const ServerMapChartsBoardFetcher = ({
     );
   }
 
-  // service group 노드/링크가 선택된 경우(subNodes/subLinks 보유) ChartsBoard를 그리지 않는다.
+  // service group 노드/링크가 선택된 경우 ChartsBoard를 그리지 않는다.
   // 팝업에서 자식 노드/링크를 선택하면 currentTarget이 자식 key로 바뀌어 다시 렌더된다.
-  if (
-    ((currentTargetData as GetServerMap.NodeData)?.subNodes?.length ?? 0) > 0 ||
-    ((currentTargetData as GetServerMap.LinkData)?.subLinks?.length ?? 0) > 0
-  ) {
+  if (isGroupTarget) {
     return null;
   }
 

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/AgentActiveThread.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/AgentActiveThread.ts
@@ -1,11 +1,24 @@
-/* eslint-disable  @typescript-eslint/no-explicit-any */
 export namespace AgentActiveThread {
   export type AgentActiveThreadType = 'PING' | 'PONG' | 'REQUEST' | 'RESPONSE';
 
   export interface Request {
     type: AgentActiveThreadType;
     command?: string;
-    parameters?: any;
+    parameters?: RequestParameters;
+  }
+
+  /**
+   * activeThreadCount 요청 파라미터.
+   *
+   * 소켓은 요청 헤더가 없으므로 service 정보를 메시지에 실어 보낸다. 세 값은 한 벌로 움직여야
+   * 한다 - applicationName만 그대로 두고 serviceName/serviceType이 다른 노드의 값으로 바뀌면
+   * 그 service에 없는 application을 묻는 요청이 된다.
+   */
+  export interface RequestParameters {
+    applicationName: string;
+    serviceType?: string;
+    /** enableServiceMap이 꺼져 있으면 undefined - JSON 직렬화에서 빠지므로 예전 형태로 나간다. */
+    serviceName?: string;
   }
 
   export interface Response {

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.test.ts
@@ -1,6 +1,7 @@
 import {
   findServiceGroupLink,
   findServiceGroupNode,
+  isServiceGroupTarget,
   flattenServiceMapResponse,
 } from './serviceMap';
 import { GetServerMap, GetServiceMap } from '@pinpoint-fe/ui/src/constants';
@@ -228,5 +229,39 @@ describe('findServiceGroupNode / findServiceGroupLink', () => {
     expect(findServiceGroupLink([appLink], 'svcA^a^TOMCAT~svcA^b^TOMCAT')).toBeUndefined();
     expect(findServiceGroupNode(undefined, 'svcA')).toBeUndefined();
     expect(findServiceGroupLink(undefined, 'svcA~svcB')).toBeUndefined();
+  });
+});
+
+describe('isServiceGroupTarget', () => {
+  // group 노드는 applicationName에 serviceName이 들어 있어(flattenServiceMapResponse) 겉보기로는
+  // application 노드와 구별되지 않는다. 조회 대상으로 삼으면 service를 application인 것처럼
+  // 묻게 되므로, 조회하는 화면들은 이 판별로 걸러 낸다.
+  test('service group 노드를 걸러 낸다', () => {
+    const groupNode = {
+      key: 'svcB',
+      serviceName: 'svcB',
+      applicationName: 'svcB',
+      serviceType: 'TOMCAT',
+      subNodes: [makeAppNode()],
+    } as unknown as GetServerMap.NodeData;
+
+    expect(isServiceGroupTarget(groupNode)).toBe(true);
+  });
+
+  test('service group 링크를 걸러 낸다', () => {
+    const groupLink = {
+      key: 'svcA~svcB',
+      subLinks: [makeAppLink()],
+    } as unknown as GetServerMap.LinkData;
+
+    expect(isServiceGroupTarget(groupLink)).toBe(true);
+  });
+
+  // servermap/filteredMap 응답에는 subNodes/subLinks가 없다 — 그 화면들의 동작은 그대로여야 한다.
+  test('application 노드·링크와 빈 값은 group이 아니다', () => {
+    expect(isServiceGroupTarget(makeAppNode())).toBe(false);
+    expect(isServiceGroupTarget(makeAppLink())).toBe(false);
+    expect(isServiceGroupTarget({ key: 'svcA', subNodes: [] })).toBe(false);
+    expect(isServiceGroupTarget(undefined)).toBe(false);
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.ts
@@ -95,12 +95,36 @@ export const flattenServiceMapResponse = (
   };
 };
 
+// 고른 대상은 servermap/servicemap/filteredMap 노드·링크 중 무엇이든 될 수 있다. 타입 유니온을
+// 늘리는 대신 판별에 쓰는 두 필드만 구조로 본다.
+type ServiceGroupCandidate = { subNodes?: unknown[]; subLinks?: unknown[] };
+
 /**
- * service group(접힌 service) 노드인지 찾는다. 아니면 undefined다.
+ * 고른 대상이 service group(접힌 service)인지.
  *
- * 판별은 `subNodes`로 한다 — `flattenServiceMapResponse`가 `type:'service'` 응답에만 담아 두는
- * 필드라, 이 필드의 유무가 곧 "접힌 service인가"다. servermap/filteredMap 응답에는 없으므로
- * 그 화면들에서는 항상 undefined가 되어 동작이 달라지지 않는다.
+ * 판별은 `subNodes`/`subLinks`로 한다 — `flattenServiceMapResponse`가 `type:'service'` 응답에만
+ * 담아 두는 필드라, 이 필드의 유무가 곧 "접힌 service인가"다. servermap/filteredMap 응답에는
+ * 없으므로 그 화면들에서는 항상 false가 되어 동작이 달라지지 않는다.
+ *
+ * group 노드는 **기준 application이 없다.** 그런데 `flattenServiceMapResponse`가 화면에 이름을
+ * 그리려고 `applicationName`에 serviceName을 넣어 두기 때문에, 그대로 조회에 쓰면 service를
+ * application인 것처럼 묻게 된다(그 이름의 application은 없으니 데이터가 비어서 온다).
+ * 그래서 **조회하는 컴포넌트는 group 대상을 조회 대상으로 삼지 않는다.**
+ */
+export const isServiceGroupNode = (node?: unknown): boolean =>
+  ((node as ServiceGroupCandidate)?.subNodes?.length ?? 0) > 0;
+
+/** 고른 대상이 service group 링크인지. 판별 근거는 {@link isServiceGroupNode}와 같다. */
+export const isServiceGroupLink = (link?: unknown): boolean =>
+  ((link as ServiceGroupCandidate)?.subLinks?.length ?? 0) > 0;
+
+/** 고른 대상(노드 또는 링크)이 service group인지. */
+export const isServiceGroupTarget = (data?: unknown): boolean =>
+  isServiceGroupNode(data) || isServiceGroupLink(data);
+
+/**
+ * 주어진 key의 노드가 service group(접힌 service)인지 찾는다. 아니면 undefined다.
+ * 판별 근거는 {@link isServiceGroupNode} 참고.
  *
  * 두 곳에서 쓴다.
  * 1. 좌클릭 — 자식 노드 목록 팝업을 연다.
@@ -112,13 +136,10 @@ export const flattenServiceMapResponse = (
 export const findServiceGroupNode = <T extends GetServerMap.NodeData>(
   nodes: T[] | undefined,
   key?: string,
-): T | undefined =>
-  nodes?.find(
-    (node) => node.key === key && Array.isArray(node.subNodes) && node.subNodes.length > 0,
-  );
+): T | undefined => nodes?.find((node) => node.key === key && isServiceGroupNode(node));
 
 /**
- * service group 링크인지 찾는다. 아니면 undefined다.
+ * 주어진 key의 링크가 service group 링크인지 찾는다. 아니면 undefined다.
  *
  * 백엔드는 **양쪽 끝이 모두 펼쳐진 service일 때만** 평범한 링크로 내려준다
  * (`ServiceMapViewBuilder#buildLinks`의 `fromExpanded && toExpanded`). 한쪽이라도 접혀 있으면
@@ -131,7 +152,4 @@ export const findServiceGroupNode = <T extends GetServerMap.NodeData>(
 export const findServiceGroupLink = <T extends GetServerMap.LinkData>(
   links: T[] | undefined,
   key?: string,
-): T | undefined =>
-  links?.find(
-    (link) => link.key === key && Array.isArray(link.subLinks) && link.subLinks.length > 0,
-  );
+): T | undefined => links?.find((link) => link.key === key && isServiceGroupLink(link));


### PR DESCRIPTION
## Summary

- Send `serviceName` and `serviceType` along with `applicationName` in the `activeThreadCount` socket message, so the active thread panel can be resolved per service in ServiceMap realtime. The socket has no request headers, so the values ride in the message; they are kept in one object and swapped together, since changing one alone would ask for an application that does not exist in that service.
- **Only screens that carry a serviceName segment in the path do this.** ServerMap realtime sends the exact same message as before (`applicationName` alone): the screen-level fallback in `useServiceNameForLink` (which falls back to the globally selected service) is deliberately not used here, the same reason `useFilteredMapParameters` does not fall back. With `enableServiceMap` off, both fields drop out on every screen.
- **Clicking a node now always queries that node.** The pin used to swallow the click, so selecting another node left the panel receiving the previous node's responses - and on a map whose only WAS is already the target on entry, no request was ever sent no matter what was clicked. Coming back to the same node after a target that cannot be queried re-sends the request as well, since the subscription may have been lost meanwhile.
- **"Selected target is not a WAS" is now purely a display decision**, taken from the selected node's category and no longer skipped while the pin is held. Holding the pin used to draw the previous WAS's active threads under a non-WAS node, which is easy to misread when the USER node shares its name with the entry point WAS. Non-WAS nodes are still requested, exactly as before.
- Only a service group (collapsed service) node is kept out of the request: it has no base application, its `applicationName` holds the serviceName (synthesized by `flattenServiceMapResponse`), so querying it asks for a service as if it were an application. The same guard skips the histogram statistics request for group targets in `ServerMapChartsBoardFetcher`.
- The socket is left open for the lifetime of the panel, as before. Reconnecting is now limited to unexpected closes - the close handler used to reconnect unconditionally, so a new socket was opened right after the panel unmounted and outlived the screen.

## Test plan

- [x] `yarn build`
- [x] `yarn test` (966 passed, 15 new)
- [x] `yarn lint`
- [ ] **ServerMap > Realtime (`enableServiceMap` off): the socket message is `{applicationName}` only, and every clicked node - WAS, USER, database, cache, queue - sends a request for that node**
- [ ] ServerMap > Realtime: a non-WAS node shows "Selected target is not a WAS" whether the pin is held or released; a WAS node shows the charts
- [ ] ServiceMap > Realtime, non-DEFAULT service: the message carries `applicationName`, `serviceType` and the node's `serviceName`
- [ ] ServiceMap > Realtime: click a collapsed service node - no request goes out; picking a child application from the popup starts the query
- [ ] Leave the realtime page (or switch browser tabs) - no socket is left connected

## Notes

The web backend does not read the new parameters yet (`ActiveThreadCountHandler` only reads `applicationName`), so this change is inert on its own and safe for existing installations.

The pin no longer affects which node is queried, so it now only holds the previous target when something without an application (a link) is selected. Its role should be redefined or the button dropped in a follow-up.
