### PR TITLE
[#noissue] Add TraceIndexScanKey for trace index scan start/end keys

### DIFF
--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/scatter/TraceIndexRowKeyUtils.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/scatter/TraceIndexRowKeyUtils.java
@@ -5,7 +5,6 @@ import com.google.common.hash.Hashing;
 import com.navercorp.pinpoint.common.buffer.AutomaticBuffer;
 import com.navercorp.pinpoint.common.buffer.Buffer;
 import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
-import com.navercorp.pinpoint.common.buffer.FixedBuffer;
 import com.navercorp.pinpoint.common.buffer.OffsetFixedBuffer;
 import com.navercorp.pinpoint.common.timeseries.util.LongInverter;
 import com.navercorp.pinpoint.common.util.BytesUtils;
@@ -46,20 +45,6 @@ public class TraceIndexRowKeyUtils {
         buffer.putShort(toAgentIdHash(agentId));
 
         buffer.putPrefixedBytes(applicationNameBytes);
-        return buffer.getBuffer();
-    }
-
-    public static byte[] createScanRowKey(int serviceUid, String applicationName, int serviceTypeCode, long timestamp) {
-        long reverseTimestamp = LongInverter.invert(timestamp);
-        Buffer buffer = new FixedBuffer(4 + 4 + 4 + 8 +
-                12
-        );
-        buffer.putInt(toApplicationNameHash(applicationName));
-        buffer.putInt(serviceUid);
-        buffer.putInt(serviceTypeCode);
-        buffer.putLong(reverseTimestamp);
-
-        buffer.putPadBytes(null, 12);  // pad 12 bytes to Prevent ArrayIndexOutOfBoundsException
         return buffer.getBuffer();
     }
 

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/scatter/TraceIndexScanKey.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/scatter/TraceIndexScanKey.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.scatter;
+
+import com.navercorp.pinpoint.common.buffer.Buffer;
+import com.navercorp.pinpoint.common.buffer.ByteArrayUtils;
+import com.navercorp.pinpoint.common.buffer.FixedBuffer;
+import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.timeseries.util.LongInverter;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Scan start/end row keys of the trace index table for one (application, range) query.
+ * <p>
+ * The row timestamp is stored reversed, so the scan start key is built from {@code range.getTo()}
+ * and the scan end key from {@code range.getFrom()}.
+ * <p>
+ * The salt key is not written; it is applied per partition by the {@code RowKeyDistributor}.
+ */
+public class TraceIndexScanKey {
+    // applicationNameHash(4) + serviceUid(4) + serviceType(4)
+    private static final int TIMESTAMP_OFFSET = 4 + 4 + 4;
+    // pad spanId(8) + elapsed(1) + error(1) + agentIdHash(2) to prevent ArrayIndexOutOfBoundsException
+    private static final int PAD_SIZE = 8 + 1 + 1 + 2;
+
+    private final byte[] startKey;
+    private final byte[] endKey;
+
+    public TraceIndexScanKey(int serviceUid, String applicationName, int serviceTypeCode, Range range) {
+        Objects.requireNonNull(applicationName, "applicationName");
+        Objects.requireNonNull(range, "range");
+
+        // start key uses the end of the range and end key uses the start of the range
+        // because the row timestamp is reversed
+        this.startKey = encodeScanKey(serviceUid, applicationName, serviceTypeCode, range.getTo());
+        this.endKey = copyWithTimestamp(this.startKey, range.getFrom());
+    }
+
+    private static byte[] encodeScanKey(int serviceUid, String applicationName, int serviceTypeCode, long timestamp) {
+        long reverseTimestamp = LongInverter.invert(timestamp);
+        Buffer buffer = new FixedBuffer(TIMESTAMP_OFFSET + 8 + PAD_SIZE);
+        buffer.putInt(TraceIndexRowKeyUtils.toApplicationNameHash(applicationName));
+        buffer.putInt(serviceUid);
+        buffer.putInt(serviceTypeCode);
+        buffer.putLong(reverseTimestamp);
+
+        buffer.putPadBytes(null, PAD_SIZE);
+        return buffer.getBuffer();
+    }
+
+    /**
+     * the two keys differ only in the timestamp, so copy the start key and overwrite the timestamp
+     */
+    private static byte[] copyWithTimestamp(byte[] scanKey, long timestamp) {
+        byte[] copy = Arrays.copyOf(scanKey, scanKey.length);
+        ByteArrayUtils.writeLong(LongInverter.invert(timestamp), copy, TIMESTAMP_OFFSET);
+        return copy;
+    }
+
+    public byte[] startKey() {
+        return startKey;
+    }
+
+    public byte[] endKey() {
+        return endKey;
+    }
+}

--- a/commons-server/src/test/java/com/navercorp/pinpoint/common/server/scatter/TraceIndexScanKeyTest.java
+++ b/commons-server/src/test/java/com/navercorp/pinpoint/common/server/scatter/TraceIndexScanKeyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.common.server.scatter;
+
+import com.navercorp.pinpoint.common.timeseries.time.Range;
+import com.navercorp.pinpoint.common.trace.ServiceType;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class TraceIndexScanKeyTest {
+
+    private static final int SALT_KEY_SIZE = 0;
+    // applicationNameHash(4) + serviceUid(4) + serviceType(4) + reverseTimestamp(8)
+    private static final int PREFIX_SIZE = 4 + 4 + 4 + 8;
+
+    private static final String APPLICATION_NAME = "testApp";
+    private static final int SERVICE_UID = 7;
+    private static final int SERVICE_TYPE_CODE = ServiceType.TEST.getCode();
+
+    private static byte[] rowKey(long timestamp) {
+        return TraceIndexRowKeyUtils.createRowKeyWithSaltSize(
+                SALT_KEY_SIZE, SERVICE_UID, APPLICATION_NAME, SERVICE_TYPE_CODE, timestamp,
+                1L, 100, 0, "agentId"
+        );
+    }
+
+    @Test
+    public void scanKey_prefix_matches_rowKey() {
+        Range range = Range.between(1000L, 2000L);
+        TraceIndexScanKey scanKey = new TraceIndexScanKey(SERVICE_UID, APPLICATION_NAME, SERVICE_TYPE_CODE, range);
+
+        Assertions.assertThat(Arrays.copyOf(scanKey.startKey(), PREFIX_SIZE))
+                .isEqualTo(Arrays.copyOf(rowKey(range.getTo()), PREFIX_SIZE));
+        Assertions.assertThat(Arrays.copyOf(scanKey.endKey(), PREFIX_SIZE))
+                .isEqualTo(Arrays.copyOf(rowKey(range.getFrom()), PREFIX_SIZE));
+    }
+
+    @Test
+    public void startKey_is_lower_than_endKey() {
+        Range range = Range.between(1000L, 2000L);
+        TraceIndexScanKey scanKey = new TraceIndexScanKey(SERVICE_UID, APPLICATION_NAME, SERVICE_TYPE_CODE, range);
+
+        // reversed timestamp: the later time produces the smaller row key
+        Assertions.assertThat(Bytes.compareTo(scanKey.startKey(), scanKey.endKey())).isNegative();
+    }
+
+    @Test
+    public void rowKey_is_within_scan_range() {
+        Range range = Range.between(1000L, 2000L);
+        TraceIndexScanKey scanKey = new TraceIndexScanKey(SERVICE_UID, APPLICATION_NAME, SERVICE_TYPE_CODE, range);
+        byte[] startKey = scanKey.startKey();
+        byte[] endKey = scanKey.endKey();
+
+        byte[] inside = rowKey(1500L);
+        byte[] before = rowKey(999L);
+        byte[] after = rowKey(2001L);
+
+        Assertions.assertThat(Bytes.compareTo(startKey, inside)).isNegative();
+        Assertions.assertThat(Bytes.compareTo(inside, endKey)).isNegative();
+        // 999 < from : reversed timestamp is larger than endKey -> excluded
+        Assertions.assertThat(Bytes.compareTo(before, endKey)).isPositive();
+        // 2001 > to : reversed timestamp is smaller than startKey -> excluded
+        Assertions.assertThat(Bytes.compareTo(after, startKey)).isNegative();
+    }
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java
@@ -28,6 +28,7 @@ import com.navercorp.pinpoint.common.hbase.TableNameProvider;
 import com.navercorp.pinpoint.common.hbase.wd.RowKeyDistributor;
 import com.navercorp.pinpoint.common.server.scatter.TraceIndexFilterBuilder;
 import com.navercorp.pinpoint.common.server.scatter.TraceIndexRowKeyUtils;
+import com.navercorp.pinpoint.common.server.scatter.TraceIndexScanKey;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.config.ScatterChartProperties;
 import com.navercorp.pinpoint.web.scatter.DragArea;
@@ -173,11 +174,10 @@ public class HbaseTraceIndexDao implements TraceIndexDao {
         Scan scan = new Scan();
         scan.setCaching(this.scanCacheSize);
 
-        byte[] traceIndexStartKey = TraceIndexRowKeyUtils.createScanRowKey(serviceUid, applicationName, serviceTypeCode, range.getFrom());
-        byte[] traceIndexEndKey = TraceIndexRowKeyUtils.createScanRowKey(serviceUid, applicationName, serviceTypeCode, range.getTo());
-        // start key is replaced by end key because row timestamp has been reversed
-        scan.withStartRow(traceIndexEndKey);
-        scan.withStopRow(traceIndexStartKey);
+        // reversed row timestamp is handled by TraceIndexScanKey: startKey <- range.to, endKey <- range.from
+        TraceIndexScanKey scanKey = new TraceIndexScanKey(serviceUid, applicationName, serviceTypeCode, range);
+        scan.withStartRow(scanKey.startKey());
+        scan.withStopRow(scanKey.endKey());
 
         scan.addColumn(INDEX.getName(), INDEX.getName());
         scan.setId(INDEX.getTable().getName() + "scan");


### PR DESCRIPTION
This pull request refactors how scan keys are generated and used for trace index queries, improving code clarity and testability. It introduces a new `TraceIndexScanKey` class to encapsulate scan key logic, removes the now-redundant `createScanRowKey` method, and updates the DAO to use the new class. Unit tests are also added for the new scan key logic.

**Scan key refactoring and encapsulation:**

* Added the new `TraceIndexScanKey` class to encapsulate the logic for generating scan start and end keys for trace index table scans, handling reversed timestamps and padding internally.
* Removed the old `createScanRowKey` method from `TraceIndexRowKeyUtils`, as its logic is now encapsulated in `TraceIndexScanKey`.
* Updated `HbaseTraceIndexDao` to use `TraceIndexScanKey` for setting scan start and stop rows, improving readability and correctness. [[1]](diffhunk://#diff-7d3c22915938d4dea4f29dc1b0152dd194c95ff29258857ec72b6ac88c6210e1R31) [[2]](diffhunk://#diff-7d3c22915938d4dea4f29dc1b0152dd194c95ff29258857ec72b6ac88c6210e1L176-R180)

**Testing improvements:**

* Added `TraceIndexScanKeyTest` to verify that the scan keys are generated correctly and that the scan range logic is correct.

**Minor cleanup:**

* Removed an unused import (`FixedBuffer`) from `TraceIndexRowKeyUtils.java`.