### PR TITLE
[#14187] Replace exceptionChainId with errorKey in call tree exception rows

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/error-detail/ErrorAnalysisErrorDetail.stories.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/error-detail/ErrorAnalysisErrorDetail.stories.tsx
@@ -18,9 +18,9 @@ export const Default: Story = {
     errorInfo: {
       applicationName: '',
       agentId: '',
-      spanId: 0,
+      spanId: '',
       transactionId: '',
-      exceptionId: 0,
+      exceptionId: '',
     },
   },
 };

--- a/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/error-detail/ErrorAnalysisErrorDetailFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/error-detail/ErrorAnalysisErrorDetailFetcher.tsx
@@ -1,4 +1,8 @@
-import { useGetErrorAnalysisTransactionInfoData, useTimezone } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useGetErrorAnalysisTransactionInfoData,
+  useServiceNameForLink,
+  useTimezone,
+} from '@pinpoint-fe/ui/src/hooks';
 import { ErrorAnalysisTransactionInfo } from '@pinpoint-fe/ui/src/constants';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '../../ui';
 import { ClipboardCopyButton } from '../../Button';
@@ -13,7 +17,13 @@ export const ErrorAnalysisErrorDetailFetcher = ({
   errorInfo,
 }: ErrorAnalysisErrorDetailFetcherProps) => {
   const [timezone] = useTimezone();
-  const { data } = useGetErrorAnalysisTransactionInfoData(errorInfo);
+  // TODO #14196: drop the screen-service fallback once list responses carry serviceName
+  const screenServiceName = useServiceNameForLink();
+  const requestServiceName = errorInfo.serviceName ?? screenServiceName;
+  const { data } = useGetErrorAnalysisTransactionInfoData({
+    ...errorInfo,
+    serviceName: requestServiceName,
+  });
 
   return (
     <div className="p-5 space-y-5 overflow-auto">

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
@@ -569,7 +569,8 @@ const MethodCell = (props: {
   if (rowData.hasException) {
     Icon = <FaFire className="fill-status-fail" />;
 
-    if (rowData.exceptionChainId) {
+    const errorKey: TransactionInfo.ErrorKey | null = rowData.errorKey;
+    if (errorKey) {
       // The call stack's begin/end can be empty (0) for many nodes, which would
       // produce a window around epoch 0 and a negative `from` that the backend
       // (Timestamp) rejects. Center the window on the transaction's focus
@@ -583,11 +584,7 @@ const MethodCell = (props: {
         from,
         to,
         transactionInfo: JSON.stringify({
-          applicationName: rowData.applicationName,
-          agentId: rowData.agent,
-          spanId: transactionInfo.spanId,
-          transactionId: metaData.transactionId,
-          exceptionId: rowData.exceptionChainId,
+          ...errorKey,
           timestamp: transactionInfo.focusTimestamp,
           uriTemplate: metaData.uri,
         }),

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/timeline.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/timeline.test.ts
@@ -16,7 +16,7 @@ const row = (r: {
   excludeFromTimeline?: boolean;
   isMethod?: boolean;
   hasException?: boolean;
-  exceptionChainId?: string;
+  errorKey?: TransactionInfo.ErrorKey;
 }): Row => {
   const beginOffsetNanos = r.beginOffsetNanos === undefined ? (r.begin ?? 0) : r.beginOffsetNanos;
   const endOffsetNanos = r.endOffsetNanos === undefined ? (r.end ?? 0) : r.endOffsetNanos;
@@ -118,7 +118,14 @@ describe('computeParallelGroups', () => {
         end: 1010,
         isMethod: false,
         hasException: true,
-        exceptionChainId: '4',
+        errorKey: {
+          serviceName: 'DEFAULT',
+          applicationName: 'app',
+          agentId: 'agent',
+          transactionId: 'agent^0^1',
+          spanId: '4',
+          exceptionId: '4',
+        },
       }),
       row({ id: 3, parentId: 1, begin: 1005, end: 1015 }),
     ];

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/ErrorAnalysisErrorList.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/ErrorAnalysisErrorList.ts
@@ -13,8 +13,8 @@ export namespace ErrorAnalysisErrorList {
   export interface ErrorData {
     timestamp: number;
     transactionId: string;
-    spanId: number;
-    exceptionId: number;
+    spanId: string;
+    exceptionId: string;
     applicationServiceType: string;
     applicationName: string;
     agentId: string;

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/ErrorAnalysisTransactionInfo.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/ErrorAnalysisTransactionInfo.ts
@@ -1,18 +1,20 @@
 export namespace ErrorAnalysisTransactionInfo {
   export interface Parameters {
+    // TODO #14196: make required (missing values default to DEFAULT)
+    serviceName?: string;
     applicationName: string;
     agentId: string;
     transactionId: string;
-    spanId: number;
-    exceptionId: number;
+    spanId: string;
+    exceptionId: string;
   }
 
   export type Response = ErrorData[];
   export interface ErrorData {
     timestamp: number;
     transactionId: string;
-    spanId: number;
-    exceptionId: number;
+    spanId: string;
+    exceptionId: string;
     applicationServiceType: string;
     applicationName: string;
     agentId: string;

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/TransactionInfo.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/TransactionInfo.ts
@@ -22,7 +22,7 @@ export namespace TransactionInfoType {
     callTreeTimelineEnd: number;
     callTreeTimelineDurationNanos: number;
     callStackIndex: CallStackIndex;
-    callStack: any[][]; // ['begin', 'end', 'excludeFromTimeline', 'applicationName', 'tab', 'id', 'parentId', 'isMethod', 'hasChild', 'title', 'arguments', 'executeTime', 'gap', 'elapsedTime', 'barWidth', 'executionMilliseconds', 'simpleClassName', 'methodType', 'apiType', 'agent', 'hasException', 'isAuthorized', 'agentName', 'lineNumber', 'location', 'applicationServiceType', 'exceptionChainId', 'serviceName', 'gapNanos', 'elapsedTimeNanos', 'executionNanos', 'beginOffsetNanos', 'endOffsetNanos']
+    callStack: any[][]; // ['begin', 'end', 'excludeFromTimeline', 'applicationName', 'tab', 'id', 'parentId', 'isMethod', 'hasChild', 'title', 'arguments', 'executeTime', 'gap', 'elapsedTime', 'barWidth', 'executionMilliseconds', 'simpleClassName', 'methodType', 'apiType', 'agent', 'hasException', 'isAuthorized', 'agentName', 'lineNumber', 'location', 'applicationServiceType', 'errorKey', 'serviceName', 'gapNanos', 'elapsedTimeNanos', 'executionNanos', 'beginOffsetNanos', 'endOffsetNanos']
     loggingTransactionInfo: boolean;
     agentId: string;
     agentName: string;
@@ -59,13 +59,22 @@ export namespace TransactionInfoType {
     lineNumber: number;
     location: number;
     applicationServiceType: number;
-    exceptionChainId: number;
+    errorKey: number;
     serviceName: number;
     gapNanos: number;
     elapsedTimeNanos: number;
     executionNanos: number;
     beginOffsetNanos: number;
     endOffsetNanos: number;
+  }
+
+  export interface ErrorKey {
+    serviceName: string;
+    applicationName: string;
+    agentId: string;
+    transactionId: string;
+    spanId: string;
+    exceptionId: string;
   }
 
   export type CallStackKeyValueMap = {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetErrorAnalysisTransactionInfoData.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetErrorAnalysisTransactionInfoData.ts
@@ -17,18 +17,13 @@ const getQueryString = (queryParams: Partial<ErrorAnalysisTransactionInfo.Parame
 };
 
 export const useGetErrorAnalysisTransactionInfoData = ({
+  serviceName,
   applicationName,
   agentId,
   transactionId,
   spanId,
   exceptionId,
-}: {
-  applicationName: string;
-  agentId: string;
-  transactionId: string;
-  spanId: number;
-  exceptionId: number;
-}) => {
+}: ErrorAnalysisTransactionInfo.Parameters) => {
   const queryString = getQueryString({
     applicationName,
     agentId,
@@ -39,9 +34,9 @@ export const useGetErrorAnalysisTransactionInfoData = ({
 
   const { data, isLoading, isFetching } =
     useSuspenseQuery<ErrorAnalysisTransactionInfo.Response | null>({
-      queryKey: [END_POINTS.ERROR_ANALYSIS_TRANSACTION_INFO, queryString],
+      queryKey: [END_POINTS.ERROR_ANALYSIS_TRANSACTION_INFO, queryString, serviceName],
       queryFn: queryString
-        ? queryFn(`${END_POINTS.ERROR_ANALYSIS_TRANSACTION_INFO}${queryString}`)
+        ? queryFn(`${END_POINTS.ERROR_ANALYSIS_TRANSACTION_INFO}${queryString}`, { serviceName })
         : () => null,
     });
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/BaseRecord.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/BaseRecord.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.trace.callstacks;
 
 import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.TimeUnit;
 
@@ -48,7 +49,7 @@ public abstract class BaseRecord implements Record {
     protected String destinationId;
     protected boolean hasChild;
     protected boolean hasException;
-    protected long exceptionChainId;
+    protected ErrorKey errorKey;
     protected String transactionId;
     protected long spanId;
     protected long executionMilliseconds;
@@ -197,8 +198,9 @@ public abstract class BaseRecord implements Record {
         return hasException;
     }
 
-    public long getExceptionChainId() {
-        return exceptionChainId;
+    @Nullable
+    public ErrorKey getErrorKey() {
+        return errorKey;
     }
 
     public String getTransactionId() {
@@ -260,7 +262,7 @@ public abstract class BaseRecord implements Record {
                 ", destinationId='" + destinationId + '\'' +
                 ", hasChild=" + hasChild +
                 ", hasException=" + hasException +
-                ", exceptionChainId=" + exceptionChainId +
+                ", errorKey=" + errorKey +
                 ", transactionId='" + transactionId + '\'' +
                 ", spanId=" + spanId +
                 ", executionMilliseconds=" + executionMilliseconds +

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/ErrorKey.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/ErrorKey.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.trace.callstacks;
+
+public record ErrorKey(
+        String serviceName,
+        String applicationName,
+        String agentId,
+        String transactionId,
+        long spanId,
+        long exceptionId
+) {
+}

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/ExceptionRecord.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/ExceptionRecord.java
@@ -21,8 +21,8 @@ import com.navercorp.pinpoint.common.server.bo.ExceptionInfo;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.trace.span.Align;
+import org.jspecify.annotations.Nullable;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -57,7 +57,9 @@ public class ExceptionRecord extends BaseRecord {
         this.applicationName = align.getApplicationName();
         this.serviceName = align.getServiceName();
         this.applicationServiceType = applicationServiceType;
-        this.exceptionChainId = toExceptionChainId(align.getAnnotationBoList());
+        this.transactionId = align.getTransactionId();
+        this.spanId = align.getSpanId();
+        this.errorKey = toErrorKey(align);
     }
 
     String toSimpleExceptionName(String exceptionClass) {
@@ -71,16 +73,6 @@ public class ExceptionRecord extends BaseRecord {
         return exceptionClass;
     }
 
-    long toExceptionChainId(List<AnnotationBo> annotationBoList) {
-        for (AnnotationBo annotationBo : annotationBoList) {
-            if (annotationBo.getKey() == AnnotationKey.EXCEPTION_CHAIN_ID.getCode()
-                    && annotationBo.getValue() instanceof Long longValue) {
-                return longValue;
-            }
-        }
-        return -1;
-    }
-
     String buildArgument(Align align) {
         final ExceptionInfo exceptionInfo = align.getExceptionInfo();
         if (exceptionInfo == null) {
@@ -92,5 +84,23 @@ public class ExceptionRecord extends BaseRecord {
             return Objects.toString(ExceptionInfo.otelMessageBody(exceptionInfo.message()), "");
         }
         return Objects.toString(exceptionInfo.message(), "");
+    }
+
+    @Nullable
+    static ErrorKey toErrorKey(Align align) {
+        for (AnnotationBo annotationBo : align.getAnnotationBoList()) {
+            if (annotationBo.getKey() == AnnotationKey.EXCEPTION_CHAIN_ID.getCode()
+                    && annotationBo.getValue() instanceof Long exceptionId) {
+                return new ErrorKey(
+                        align.getServiceName(),
+                        align.getApplicationName(),
+                        align.getAgentId(),
+                        align.getTransactionId(),
+                        align.getSpanId(),
+                        exceptionId
+                );
+            }
+        }
+        return null;
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/Record.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/callstacks/Record.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.web.trace.callstacks;
 
 import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
+import org.jspecify.annotations.Nullable;
 
 /**
  * each stack
@@ -81,7 +82,8 @@ public interface Record {
 
     boolean getHasException();
 
-    long getExceptionChainId();
+    @Nullable
+    ErrorKey getErrorKey();
 
     String getTransactionId();
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/view/TransactionCallTreeCallStackSerializer.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/view/TransactionCallTreeCallStackSerializer.java
@@ -18,13 +18,15 @@ package com.navercorp.pinpoint.web.trace.view;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.navercorp.pinpoint.web.trace.callstacks.ErrorKey;
 
 import java.io.IOException;
 
 public class TransactionCallTreeCallStackSerializer extends JsonSerializer<TransactionCallTreeViewModel.CallStack> {
 
     @Override
-    public void serialize(TransactionCallTreeViewModel.CallStack value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+    public void serialize(TransactionCallTreeViewModel.CallStack value, JsonGenerator jgen, SerializerProvider provider)
+            throws IOException {
         jgen.writeStartArray();
         jgen.writeNumber(value.getBegin());
         jgen.writeNumber(value.getEnd());
@@ -54,8 +56,7 @@ public class TransactionCallTreeCallStackSerializer extends JsonSerializer<Trans
         jgen.writeNumber(value.getLineNumber());
         jgen.writeString(value.getLocation());
         jgen.writeString(value.getApplicationServiceType());
-        // json number overflow
-        jgen.writeString(String.valueOf(value.getExceptionChainId()));
+        writeErrorKey(jgen, value.getErrorKey());
         jgen.writeString(value.getServiceName());
         writeLong(jgen, value.getGapNanos());
         writeLong(jgen, value.getElapsedTimeNanos());
@@ -79,5 +80,21 @@ public class TransactionCallTreeCallStackSerializer extends JsonSerializer<Trans
         } else {
             jgen.writeNumber(value);
         }
+    }
+
+    void writeErrorKey(JsonGenerator jgen, ErrorKey errorKey) throws IOException {
+        if (errorKey == null) {
+            jgen.writeNull();
+            return;
+        }
+        jgen.writeStartObject();
+        jgen.writeStringField("serviceName", errorKey.serviceName());
+        jgen.writeStringField("applicationName", errorKey.applicationName());
+        jgen.writeStringField("agentId", errorKey.agentId());
+        jgen.writeStringField("transactionId", errorKey.transactionId());
+        // json number overflow
+        jgen.writeStringField("spanId", String.valueOf(errorKey.spanId()));
+        jgen.writeStringField("exceptionId", String.valueOf(errorKey.exceptionId()));
+        jgen.writeEndObject();
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/trace/view/TransactionCallTreeViewModel.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/trace/view/TransactionCallTreeViewModel.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.navercorp.pinpoint.common.server.util.DateTimeFormatUtils;
+import com.navercorp.pinpoint.web.trace.callstacks.ErrorKey;
 import com.navercorp.pinpoint.web.trace.callstacks.Record;
 import com.navercorp.pinpoint.web.trace.callstacks.RecordSet;
 import com.navercorp.pinpoint.web.trace.span.TraceState;
@@ -193,7 +194,7 @@ public class TransactionCallTreeViewModel {
         lineNumber,
         location,
         applicationServiceType,
-        exceptionChainId,
+        errorKey,
         serviceName,
         gapNanos,
         elapsedTimeNanos,
@@ -268,7 +269,8 @@ public class TransactionCallTreeViewModel {
         private final String serviceName;
 
         private final boolean hasException;
-        private final long exceptionChainId;
+        @Nullable
+        private final ErrorKey errorKey;
         private final boolean isAuthorized;
         private final int lineNumber;
         private final String location;
@@ -318,7 +320,7 @@ public class TransactionCallTreeViewModel {
             serviceName = record.getServiceName();
 
             hasException = record.getHasException();
-            exceptionChainId = record.getExceptionChainId();
+            errorKey = record.getErrorKey();
             isAuthorized = record.isAuthorized();
             lineNumber = record.getLineNumber();
             location = record.getLocation();
@@ -468,8 +470,9 @@ public class TransactionCallTreeViewModel {
             return hasException;
         }
 
-        public String getExceptionChainId() {
-            return exceptionChainId  >= 0 ? String.valueOf(exceptionChainId) : "";
+        @Nullable
+        public ErrorKey getErrorKey() {
+            return errorKey;
         }
 
         public boolean isAuthorized() {

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/callstacks/RecordFactoryTest.java
@@ -140,6 +140,53 @@ public class RecordFactoryTest {
     }
 
     @Test
+    public void getException_withExceptionChainId_buildsErrorKey() {
+        final RecordFactory factory = newRecordFactory();
+
+        SpanBo spanBo = new SpanBo();
+        spanBo.getSpanOwner().setApplicationName("app-name");
+        spanBo.getSpanOwner().setAgentId("agent-id");
+        spanBo.setTransactionId(new PinpointServerTraceId("test", 0, 30));
+        spanBo.setSpanId(100L);
+        spanBo.setExceptionInfo(new ExceptionInfo(1, "error"));
+        spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.EXCEPTION_CHAIN_ID.getCode(), 1400L));
+        Align align = new SpanAlign(spanBo);
+
+        Record exceptionRecord = factory.getException(0, 0, align);
+
+        ErrorKey errorKey = exceptionRecord.getErrorKey();
+        assertThat(errorKey).isNotNull();
+        assertThat(errorKey.serviceName()).isEqualTo(ServiceUid.DEFAULT_SERVICE_UID_NAME);
+        assertThat(errorKey.applicationName()).isEqualTo("app-name");
+        assertThat(errorKey.agentId()).isEqualTo("agent-id");
+        assertThat(errorKey.transactionId()).isEqualTo(align.getTransactionId());
+        assertThat(errorKey.spanId()).isEqualTo(100L);
+        assertThat(errorKey.exceptionId()).isEqualTo(1400L);
+    }
+
+    @Test
+    public void getException_withoutExceptionChainId_hasNoErrorKey() {
+        final RecordFactory factory = newRecordFactory();
+
+        SpanBo spanBo = new SpanBo();
+        spanBo.setTransactionId(new PinpointServerTraceId("test", 0, 0));
+        spanBo.setExceptionInfo(new ExceptionInfo(1, "error"));
+        Align align = new SpanAlign(spanBo);
+
+        Record exceptionRecord = factory.getException(0, 0, align);
+
+        assertThat(exceptionRecord.getErrorKey()).isNull();
+    }
+
+    @Test
+    public void errorCategoryRecord_hasNoErrorKey() {
+        Record errorCategoryRecord = ParameterRecord.errorRecord(0, 1, 0, "HTTP_STATUS(500)");
+
+        assertThat(errorCategoryRecord.getHasException()).isTrue();
+        assertThat(errorCategoryRecord.getErrorKey()).isNull();
+    }
+
+    @Test
     public void getParameter_check_argument() {
 
         final RecordFactory factory = newRecordFactory();

--- a/web/src/test/java/com/navercorp/pinpoint/web/trace/view/TransactionCallTreeCallStackSerializerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/trace/view/TransactionCallTreeCallStackSerializerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.web.trace.view;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.pinpoint.common.server.bo.MethodTypeEnum;
+import com.navercorp.pinpoint.common.server.uid.ServiceUid;
+import com.navercorp.pinpoint.web.trace.callstacks.ErrorKey;
+import com.navercorp.pinpoint.web.trace.callstacks.Record;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransactionCallTreeCallStackSerializerTest {
+
+    private static final int ERROR_KEY_INDEX = TransactionCallTreeViewModel.Field.errorKey.ordinal();
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private Record mockRecord() {
+        Record record = mock(Record.class);
+        when(record.getMethodTypeEnum()).thenReturn(MethodTypeEnum.DEFAULT);
+        return record;
+    }
+
+    @Test
+    public void serialize_errorKey_asObject() throws Exception {
+        Record record = mockRecord();
+        when(record.getErrorKey()).thenReturn(new ErrorKey(ServiceUid.DEFAULT_SERVICE_UID_NAME, "app-name", "agent-id", "agent-id^0^30", 100L, 1400L));
+
+        TransactionCallTreeViewModel.CallStack callStack = new TransactionCallTreeViewModel.CallStack(record, 0, -1);
+        JsonNode row = mapper.readTree(mapper.writeValueAsString(callStack));
+
+        JsonNode errorKey = row.get(ERROR_KEY_INDEX);
+        assertThat(errorKey.isObject()).isTrue();
+        assertThat(errorKey.get("serviceName").asText()).isEqualTo(ServiceUid.DEFAULT_SERVICE_UID_NAME);
+        assertThat(errorKey.get("applicationName").asText()).isEqualTo("app-name");
+        assertThat(errorKey.get("agentId").asText()).isEqualTo("agent-id");
+        assertThat(errorKey.get("transactionId").asText()).isEqualTo("agent-id^0^30");
+        assertThat(errorKey.get("spanId").isTextual()).isTrue();
+        assertThat(errorKey.get("spanId").asText()).isEqualTo("100");
+        assertThat(errorKey.get("exceptionId").isTextual()).isTrue();
+        assertThat(errorKey.get("exceptionId").asText()).isEqualTo("1400");
+    }
+
+    @Test
+    public void serialize_withoutErrorKey_writesNull() throws Exception {
+        Record record = mockRecord();
+
+        TransactionCallTreeViewModel.CallStack callStack = new TransactionCallTreeViewModel.CallStack(record, 0, -1);
+        JsonNode row = mapper.readTree(mapper.writeValueAsString(callStack));
+
+        assertThat(row.get(ERROR_KEY_INDEX).isNull()).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Call tree exception rows whose chain was collected now carry an `errorKey` (`applicationName`, `agentId`, `transactionId`, `spanId`, `exceptionId`) — the exact Error Analysis query parameters — replacing `exceptionChainId`. The web UI builds the Error Analysis link by passing it through, so exceptions thrown in downstream applications resolve to the correct span.
- Rows without a collected chain (ERROR_CATEGORY rows, exception rows missing the chain annotation) carry no `errorKey`, so no dead link is rendered. Previously the serialized default `"0"` was treated as truthy and activated a link that queried `exceptionId=0` and returned nothing.
- `errorKey.spanId`/`exceptionId` are serialized as strings, matching the Error Analysis APIs (d8aa8c69d4) and surviving JS number precision. The frontend types that declared them as numbers (`ErrorAnalysisErrorList`, `ErrorAnalysisTransactionInfo`) are corrected to string, fixing an empty error detail screen.

- `errorKey` also carries the throwing span's `serviceName`, sent as the service name header when querying Error Analysis; rows opened from the error list keep the screen-service fallback until #14196 exposes serviceName in list responses.

Closes #14187

## Test plan
- [x] `RecordFactoryTest` — errorKey built from the throwing span's align; absent without the chain annotation; absent on ERROR_CATEGORY rows
- [x] `TransactionCallTreeCallStackSerializerTest` — errorKey serialized as an object with string spanId/exceptionId; null when the chain was not collected
- [x] Frontend — ui package tests and `tsc --noEmit` pass
- [x] `RecordFactoryTest` — errorKey.serviceName defaults to DEFAULT when the span carries none
- [x] Manual — on a distributed trace, an exception row of a non-entry application links to Error Analysis and shows that exception; HTTP_STATUS/SQL-only rows render no link
