### PR TITLE
[#noissue] Map Spring Boot micrometer-tracing keys in the OTLP trace …

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpMicrometerAttributes.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpMicrometerAttributes.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Spring Boot Actuator's micrometer-tracing (OTel bridge) does not emit OpenTelemetry semantic-convention
+ * keys. Its HTTP observations copy the Micrometer {@code KeyValue}s onto the span as plain string tags:
+ * <ul>
+ *   <li>server: {@code method}, {@code uri} (route template), {@code status}, {@code outcome}, {@code exception},
+ *       {@code http.url} (raw request path)</li>
+ *   <li>client: the same plus {@code client.name}; {@code http.url} is the full URL</li>
+ * </ul>
+ * Without this mapping such spans get no HTTP status / method annotation and their rpc is the raw
+ * {@code http.url} path instead of the route template (high cardinality).
+ *
+ * <p>These generic key names ({@code method}, {@code status}, {@code uri}) may legitimately mean something else in
+ * other SDKs, so the mapping is gated on the instrumentation scope Spring Boot uses for its bridge
+ * ({@value #SCOPE_SPRING_BOOT}, exact match) and only complements the semantic-convention keys: it is consulted
+ * after them, never instead of them.</p>
+ *
+ * <p>Micrometer's {@code method} on {@code @Observed} (INTERNAL) spans is the Java method name, so callers must
+ * restrict {@link #getHttpMethod} to SERVER / CLIENT spans.</p>
+ */
+public final class OtlpMicrometerAttributes {
+
+    /** Instrumentation scope name of Spring Boot's micrometer-tracing OTel bridge. */
+    public static final String SCOPE_SPRING_BOOT = "org.springframework.boot";
+
+    public static final String KEY_URI = "uri";
+    public static final String KEY_METHOD = "method";
+    public static final String KEY_STATUS = "status";
+
+    /**
+     * Values Spring's {@code DefaultServerRequestObservationConvention} puts in {@code uri} when no handler route
+     * matched. They carry no path information, so the rpc falls back to the {@code http.url} path instead.
+     */
+    static final Set<String> URI_PLACEHOLDERS = Set.of("/**", "UNKNOWN", "REDIRECTION", "NOT_FOUND", "root");
+
+    private OtlpMicrometerAttributes() {
+    }
+
+    public static boolean isMicrometerScope(@Nullable InstrumentationScope scope) {
+        return scope != null && SCOPE_SPRING_BOOT.equals(scope.getName());
+    }
+
+    /**
+     * Route template from {@code uri}, or {@code null} when absent or a no-route placeholder (the caller then
+     * continues with its own fallback chain). The key is consumed only when a template is returned.
+     */
+    @Nullable
+    public static String getUriTemplate(Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
+        final String uri = AttributeUtils.getAttributeStringValue(attributes, KEY_URI, null);
+        if (uri == null || uri.isEmpty() || URI_PLACEHOLDERS.contains(uri)) {
+            return null;
+        }
+        consumedKeys.add(KEY_URI);
+        return uri;
+    }
+
+    /**
+     * HTTP status from the string-typed {@code status} tag ("200"). Non-numeric values such as the client-side
+     * {@code IO_ERROR} / {@code CLIENT_ERROR} are not promoted and stay in the raw attribute list.
+     */
+    public static OtlpHttpStatusResolver.@Nullable ResponseStatus getResponseStatus(Map<String, AttributeValue> attributes) {
+        final long code = OtlpHttpStatusResolver.resolveStatusCode(attributes, KEY_STATUS);
+        if (code == -1) {
+            return null;
+        }
+        return new OtlpHttpStatusResolver.ResponseStatus((int) code, KEY_STATUS);
+    }
+
+    /** HTTP request method from {@code method}; Micrometer uses {@code "none"} for unknown methods → not promoted. */
+    @Nullable
+    public static String getHttpMethod(Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
+        final String method = AttributeUtils.getAttributeStringValue(attributes, KEY_METHOD, null);
+        if (method == null || method.isEmpty() || "none".equals(method)) {
+            return null;
+        }
+        consumedKeys.add(KEY_METHOD);
+        return method;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
@@ -116,7 +116,7 @@ public class OtlpTraceMapper {
                         // the stored transaction (root SpanBo) via (transactionId, rootSpanId).
                         final Map<String, AttributeValue> rootAttributes =
                                 OtlpTraceMapperUtils.getAttributeValueMap(rootSpan.getAttributesList());
-                        final String rootUriTemplate = spanMapper.getServerSpanToRpc(rootSpan, rootAttributes);
+                        final String rootUriTemplate = spanMapper.getServerSpanToRpc(rootSpan, rootAttributes, rootScopedSpan.scope());
                         final long rootSpanId = OtlpTraceMapperUtils.getSpanId(rootSpan.getSpanId());
 
                         final SpanBo spanBo = spanMapper.map(idAndName, rootSpan, rootScopedSpan.scope(), agentStartTime);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapper.java
@@ -197,13 +197,23 @@ public class OtlpTraceSpanEventMapper {
         // SpanEventRecorder.recordAttribute(AnnotationKey.HTTP_STATUS_CODE, ...). Only the consumed
         // raw key is excluded below, so a non-promoted variant survives. Fires only when an HTTP
         // status attribute is present (gRPC clients carry rpc.grpc.status_code instead → no-op).
-        final OtlpHttpStatusResolver.ResponseStatus responseStatus = OtlpHttpStatusResolver.resolve(attributes);
+        // Spring Boot micrometer-tracing bridge (Micrometer key names, see OtlpMicrometerAttributes): its
+        // string-typed `status` / `method` complement the semconv keys on HTTP client spans only — on
+        // @Observed (INTERNAL) spans `method` is the Java method name.
+        final boolean micrometerHttpClient = isClient(span) && OtlpMicrometerAttributes.isMicrometerScope(scope);
+        OtlpHttpStatusResolver.ResponseStatus responseStatus = OtlpHttpStatusResolver.resolve(attributes);
+        if (responseStatus == null && micrometerHttpClient) {
+            responseStatus = OtlpMicrometerAttributes.getResponseStatus(attributes);
+        }
         if (responseStatus != null) {
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatus.code()));
             consumedKeys.add(responseStatus.sourceKey());
         }
         // http method → HTTP_METHOD annotation (e.g. an HTTP client SpanEvent's request method)
-        final String httpMethod = OtlpTraceSpanMapper.getHttpMethod(attributes, consumedKeys);
+        String httpMethod = OtlpTraceSpanMapper.getHttpMethod(attributes, consumedKeys);
+        if (httpMethod == null && micrometerHttpClient) {
+            httpMethod = OtlpMicrometerAttributes.getHttpMethod(attributes, consumedKeys);
+        }
         if (httpMethod != null) {
             spanEventBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_METHOD.getCode(), httpMethod));
         }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -119,12 +119,20 @@ public class OtlpTraceSpanMapper {
         // raw attribute list below — "filter only what was actually consumed". Keys consumed by
         // the messaging/db collaborators are covered by the static FILTERED_ATTRIBUTE_KEY_SET.
         final Set<String> consumedKeys = new HashSet<>();
+        // Spring Boot micrometer-tracing bridge: Micrometer key names instead of semconv (see OtlpMicrometerAttributes).
+        final boolean micrometer = OtlpMicrometerAttributes.isMicrometerScope(scope);
+        final boolean isServerKind = span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE;
+        // Micrometer `status` / `method` are HTTP-typed only on the HTTP observations (SERVER, and a
+        // CLIENT root when the app has no inbound span, e.g. a batch job) — on @Observed (INTERNAL)
+        // roots `method` is the Java method name. Same rule as the SpanEvent path.
+        final boolean micrometerHttp = micrometer
+                && (isServerKind || span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_CLIENT_VALUE);
         final String messagingSystem = isConsumer(span) ? MessagingAttributeUtils.getSystem(attributes) : null;
         final MessageConsumerRecorder messageConsumerRecorder = messagingConsumerResolver.resolve(messagingSystem);
         if (messageConsumerRecorder != null) {
             messageConsumerRecorder.recordMessagingConsumer(spanBo, attributes);
         } else {
-            recordServer(spanBo, span, attributes, consumedKeys);
+            recordServer(spanBo, span, attributes, consumedKeys, micrometer);
         }
 
         // Apply Pinpoint context propagated via tracestate from an upstream OTel-traced service.
@@ -149,13 +157,19 @@ public class OtlpTraceSpanMapper {
         // response — promote the HTTP status code (int, or Envoy's numeric string) to an annotation.
         // Only the raw attribute key actually consumed here is excluded from the attribute list below,
         // so a non-promoted status variant (or a non-numeric value that could not be promoted) survives.
-        final OtlpHttpStatusResolver.ResponseStatus responseStatus = OtlpHttpStatusResolver.resolve(attributes);
+        OtlpHttpStatusResolver.ResponseStatus responseStatus = OtlpHttpStatusResolver.resolve(attributes);
+        if (responseStatus == null && micrometerHttp) {
+            responseStatus = OtlpMicrometerAttributes.getResponseStatus(attributes);
+        }
         if (responseStatus != null) {
             spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_STATUS_CODE.getCode(), responseStatus.code()));
             consumedKeys.add(responseStatus.sourceKey());
         }
         // http method → HTTP_METHOD annotation (surfaced as a 1st-class field in the web UI)
-        final String httpMethod = getHttpMethod(attributes, consumedKeys);
+        String httpMethod = getHttpMethod(attributes, consumedKeys);
+        if (httpMethod == null && micrometerHttp) {
+            httpMethod = OtlpMicrometerAttributes.getHttpMethod(attributes, consumedKeys);
+        }
         if (httpMethod != null) {
             spanBo.addAnnotation(AnnotationBo.of(AnnotationKey.HTTP_METHOD.getCode(), httpMethod));
         }
@@ -289,8 +303,8 @@ public class OtlpTraceSpanMapper {
      * to the server-style mapping). acceptorHost is only set when the span has a parent
      * (i.e. is not a trace root), since a root server span has no upstream caller.
      */
-    private void recordServer(SpanBo spanBo, Span span, Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
-        spanBo.setRpc(getServerSpanToRpc(span, attributes, consumedKeys));
+    private void recordServer(SpanBo spanBo, Span span, Map<String, AttributeValue> attributes, Set<String> consumedKeys, boolean micrometer) {
+        spanBo.setRpc(getServerSpanToRpc(span, attributes, consumedKeys, micrometer));
         spanBo.setEndPoint(getServerSpanToEndPoint(span, attributes, consumedKeys));
         spanBo.setRemoteAddr(getServerSpanToRemoteAddress(span, attributes, consumedKeys));
 
@@ -383,10 +397,19 @@ public class OtlpTraceSpanMapper {
      * uriTemplate in {@link OtlpTraceMapper}) — consumed keys are collected into a throwaway set.
      */
     String getServerSpanToRpc(Span span, Map<String, AttributeValue> attributes) {
-        return getServerSpanToRpc(span, attributes, new HashSet<>());
+        return getServerSpanToRpc(span, attributes, new HashSet<>(), false);
+    }
+
+    /** rpc as {@link #map} computes it for this span — used for the exception-trace uriTemplate of a root span. */
+    String getServerSpanToRpc(Span span, Map<String, AttributeValue> attributes, InstrumentationScope scope) {
+        return getServerSpanToRpc(span, attributes, new HashSet<>(), OtlpMicrometerAttributes.isMicrometerScope(scope));
     }
 
     String getServerSpanToRpc(Span span, Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
+        return getServerSpanToRpc(span, attributes, consumedKeys, false);
+    }
+
+    String getServerSpanToRpc(Span span, Map<String, AttributeValue> attributes, Set<String> consumedKeys, boolean micrometer) {
         if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE || span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_INTERNAL_VALUE) {
             // http.route is the matched route template ("/users/{id}") — prefer it over the raw
             // url.path ("/users/12345") so the rpc field stays low-cardinality, matching the agent's
@@ -403,6 +426,14 @@ public class OtlpTraceSpanMapper {
             if (nextRoute != null) {
                 consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NEXT_ROUTE);
                 return nextRoute;
+            }
+            // Spring Boot micrometer-tracing: `uri` is the route template ("/user/{id}"). Prefer it over the raw
+            // path below; no-route placeholders ("/**", "NOT_FOUND", ...) return null and fall through to http.url.
+            if (micrometer && span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_SERVER_VALUE) {
+                final String uriTemplate = OtlpMicrometerAttributes.getUriTemplate(attributes, consumedKeys);
+                if (uriTemplate != null) {
+                    return uriTemplate;
+                }
             }
             final String urlPath = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_URL_PATH, null);
             if (urlPath != null) {

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpMicrometerAttributesTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpMicrometerAttributesTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpMicrometerAttributesTest {
+
+    private static InstrumentationScope scope(String name, String version) {
+        InstrumentationScope.Builder builder = InstrumentationScope.newBuilder().setName(name);
+        if (version != null) {
+            builder.setVersion(version);
+        }
+        return builder.build();
+    }
+
+    @Test
+    void isMicrometerScope_exactNameMatch_versionAgnostic() {
+        assertThat(OtlpMicrometerAttributes.isMicrometerScope(scope("org.springframework.boot", "3.5.14"))).isTrue();
+        assertThat(OtlpMicrometerAttributes.isMicrometerScope(scope("org.springframework.boot", "4.1.0"))).isTrue();
+        assertThat(OtlpMicrometerAttributes.isMicrometerScope(scope("org.springframework.boot", null))).isTrue();
+    }
+
+    @Test
+    void isMicrometerScope_rejectsNullPrefixAndOtherScopes() {
+        assertThat(OtlpMicrometerAttributes.isMicrometerScope(null)).isFalse();
+        assertThat(OtlpMicrometerAttributes.isMicrometerScope(InstrumentationScope.getDefaultInstance())).isFalse();
+        // the gate is an exact match — neither a sub-package nor a parent package qualifies
+        assertThat(OtlpMicrometerAttributes.isMicrometerScope(scope("org.springframework.boot.actuate", null))).isFalse();
+        assertThat(OtlpMicrometerAttributes.isMicrometerScope(scope("org.springframework", null))).isFalse();
+        assertThat(OtlpMicrometerAttributes.isMicrometerScope(scope("io.opentelemetry.spring-webmvc-6.0", "2.28.1-alpha"))).isFalse();
+        assertThat(OtlpMicrometerAttributes.isMicrometerScope(scope("ORG.SPRINGFRAMEWORK.BOOT", null))).isFalse();
+    }
+
+    @Test
+    void getUriTemplate_returnsTemplateAndConsumesKey() {
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpMicrometerAttributes.getUriTemplate(Map.of("uri", AttributeValue.of("/user/{id}")), consumed))
+                .isEqualTo("/user/{id}");
+        assertThat(consumed).containsExactly("uri");
+    }
+
+    @Test
+    void getUriTemplate_placeholdersAbsentAndEmpty_returnNullWithoutConsuming() {
+        for (String placeholder : List.of("/**", "UNKNOWN", "REDIRECTION", "NOT_FOUND", "root", "")) {
+            Set<String> consumed = new HashSet<>();
+            assertThat(OtlpMicrometerAttributes.getUriTemplate(Map.of("uri", AttributeValue.of(placeholder)), consumed))
+                    .as("uri=%s", placeholder).isNull();
+            assertThat(consumed).as("uri=%s", placeholder).isEmpty();
+        }
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpMicrometerAttributes.getUriTemplate(Map.of(), consumed)).isNull();
+        assertThat(consumed).isEmpty();
+    }
+
+    @Test
+    void getUriTemplate_placeholderSetIsExactlyTheSpringConventionValues() {
+        // DefaultServerRequestObservationConvention: "/**" (no handler), "UNKNOWN", "REDIRECTION",
+        // "NOT_FOUND", "root" — a change here must be deliberate
+        assertThat(OtlpMicrometerAttributes.URI_PLACEHOLDERS).containsExactlyInAnyOrder("/**", "UNKNOWN", "REDIRECTION", "NOT_FOUND", "root");
+    }
+
+    @Test
+    void getResponseStatus_numericString_promoted_withSourceKey() {
+        OtlpHttpStatusResolver.ResponseStatus status = OtlpMicrometerAttributes.getResponseStatus(Map.of("status", AttributeValue.of("404")));
+        assertThat(status).isNotNull();
+        assertThat(status.code()).isEqualTo(404);
+        assertThat(status.sourceKey()).isEqualTo("status");
+    }
+
+    @Test
+    void getResponseStatus_nonNumericOrAbsent_returnsNull() {
+        for (String value : List.of("IO_ERROR", "CLIENT_ERROR", "UNKNOWN", "")) {
+            assertThat(OtlpMicrometerAttributes.getResponseStatus(Map.of("status", AttributeValue.of(value))))
+                    .as("status=%s", value).isNull();
+        }
+        assertThat(OtlpMicrometerAttributes.getResponseStatus(Map.of())).isNull();
+    }
+
+    @Test
+    void getHttpMethod_returnsMethodAndConsumesKey() {
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpMicrometerAttributes.getHttpMethod(Map.of("method", AttributeValue.of("POST")), consumed)).isEqualTo("POST");
+        assertThat(consumed).containsExactly("method");
+    }
+
+    @Test
+    void getHttpMethod_noneEmptyAbsent_returnNullWithoutConsuming() {
+        for (String value : List.of("none", "")) {
+            Set<String> consumed = new HashSet<>();
+            assertThat(OtlpMicrometerAttributes.getHttpMethod(Map.of("method", AttributeValue.of(value)), consumed))
+                    .as("method=%s", value).isNull();
+            assertThat(consumed).as("method=%s", value).isEmpty();
+        }
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpMicrometerAttributes.getHttpMethod(Map.of(), consumed)).isNull();
+        assertThat(consumed).isEmpty();
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpMicrometerKeyMappingTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpMicrometerKeyMappingTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.google.protobuf.ByteString;
+import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
+import com.navercorp.pinpoint.common.server.bo.AttributeBo;
+import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
+import com.navercorp.pinpoint.common.trace.AnnotationKey;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.kv;
+import static com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpAnyValueFactory.strVal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Spring Boot micrometer-tracing (OTel bridge) emits Micrometer key names ({@code uri}, {@code method},
+ * {@code status}, {@code http.url}) instead of OTel semconv. Verifies the scope-gated mapping in
+ * {@link OtlpMicrometerAttributes}.
+ */
+class OtlpMicrometerKeyMappingTest {
+
+    private static final byte[] TRACE_ID = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    private static final byte[] ROOT = {1, 1, 1, 1, 1, 1, 1, 1};
+    private static final byte[] CHILD = {2, 2, 2, 2, 2, 2, 2, 2};
+
+    private static final InstrumentationScope SPRING_BOOT = InstrumentationScope.newBuilder().setName("org.springframework.boot").setVersion("3.5.14").build();
+    private static final InstrumentationScope OTHER = InstrumentationScope.newBuilder().setName("io.opentelemetry.spring-webmvc-6.0").build();
+
+    private static Span.Builder span(String name, byte[] id, byte[] parent, int kind) {
+        Span.Builder b = Span.newBuilder().setName(name).setTraceId(ByteString.copyFrom(TRACE_ID)).setSpanId(ByteString.copyFrom(id))
+                .setKindValue(kind).setStartTimeUnixNano(1_000_000_000L).setEndTimeUnixNano(2_000_000_000L);
+        if (parent != null) {
+            b.setParentSpanId(ByteString.copyFrom(parent));
+        }
+        return b;
+    }
+
+    /** Exactly what Spring MVC's DefaultServerRequestObservationConvention puts on a server span. */
+    private static Span.Builder micrometerServer(String uri, String httpUrl, String status) {
+        return span("http get " + uri, ROOT, null, Span.SpanKind.SPAN_KIND_SERVER_VALUE)
+                .addAttributes(kv("exception", strVal("none")))
+                .addAttributes(kv("http.url", strVal(httpUrl)))
+                .addAttributes(kv("method", strVal("GET")))
+                .addAttributes(kv("outcome", strVal("SUCCESS")))
+                .addAttributes(kv("status", strVal(status)))
+                .addAttributes(kv("uri", strVal(uri)));
+    }
+
+    private static OtlpTraceMapperData map(InstrumentationScope scope, Span... spans) {
+        Resource resource = Resource.newBuilder()
+                .addAttributes(kv("pinpoint.applicationName", strVal("boot-app")))
+                .addAttributes(kv("service.instance.id", strVal("56d7dd8f-f1c8-4b81-a424-736421b7f530")))
+                .build();
+        ScopeSpans.Builder scopeSpans = ScopeSpans.newBuilder().setScope(scope);
+        for (Span s : spans) {
+            scopeSpans.addSpans(s);
+        }
+        return OtlpTraceMapperTest.newMapper().map(List.of(ResourceSpans.newBuilder().setResource(resource).addScopeSpans(scopeSpans).build()));
+    }
+
+    private static Optional<AnnotationBo> annotation(List<AnnotationBo> list, AnnotationKey key) {
+        return list.stream().filter(a -> a.getKey() == key.getCode()).findFirst();
+    }
+
+    private static List<String> attributeKeys(List<AttributeBo> list) {
+        return list == null ? List.of() : list.stream().map(AttributeBo::getKey).toList();
+    }
+
+    @Test
+    void server_uriTemplateBecomesRpc_statusAndMethodPromoted() {
+        OtlpTraceMapperData data = map(SPRING_BOOT, micrometerServer("/user/{id}", "/user/123", "200").build());
+
+        SpanBo root = data.getSpanBoList().get(0);
+        assertThat(root.getRpc()).isEqualTo("/user/{id}");
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_STATUS_CODE)).map(AnnotationBo::getValue).contains(200);
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_METHOD)).map(AnnotationBo::getValue).contains("GET");
+        // consumed keys leave the raw attribute list; the rest (and http.url, never consumed) stay
+        assertThat(attributeKeys(root.getAttributeBoList()))
+                .doesNotContain("uri", "status", "method")
+                .contains("http.url", "outcome", "exception");
+        assertThat(data.getExceptionMetaDataBoList()).isEmpty();
+    }
+
+    @Test
+    void server_uriPlaceholder_fallsBackToHttpUrlPath() {
+        for (String placeholder : List.of("/**", "UNKNOWN", "REDIRECTION", "NOT_FOUND", "root")) {
+            OtlpTraceMapperData data = map(SPRING_BOOT, micrometerServer(placeholder, "/no/such/path?x=1", "404").build());
+
+            SpanBo root = data.getSpanBoList().get(0);
+            assertThat(root.getRpc()).as(placeholder).isEqualTo("/no/such/path");
+            // placeholder is not consumed → still visible as a raw attribute
+            assertThat(attributeKeys(root.getAttributeBoList())).as(placeholder).contains("uri");
+            assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_STATUS_CODE)).map(AnnotationBo::getValue).contains(404);
+        }
+    }
+
+    @Test
+    void server_semconvKeysTakePrecedenceOverMicrometerKeys() {
+        Span both = micrometerServer("/micrometer/{id}", "/micrometer/1", "200")
+                .addAttributes(kv("http.route", strVal("/semconv/{id}")))
+                .addAttributes(kv("http.request.method", strVal("POST")))
+                .addAttributes(kv("http.response.status_code", OtlpAnyValueFactory.intVal(201)))
+                .build();
+        OtlpTraceMapperData data = map(SPRING_BOOT, both);
+
+        SpanBo root = data.getSpanBoList().get(0);
+        assertThat(root.getRpc()).isEqualTo("/semconv/{id}");
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_STATUS_CODE)).map(AnnotationBo::getValue).contains(201);
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_METHOD)).map(AnnotationBo::getValue).contains("POST");
+        // the Micrometer twins were not consumed
+        assertThat(attributeKeys(root.getAttributeBoList())).contains("uri", "status", "method");
+    }
+
+    @Test
+    void otherScope_micrometerKeysAreNotInterpreted() {
+        OtlpTraceMapperData data = map(OTHER, micrometerServer("/user/{id}", "/user/123", "200").build());
+
+        SpanBo root = data.getSpanBoList().get(0);
+        assertThat(root.getRpc()).isEqualTo("/user/123");
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_STATUS_CODE)).isEmpty();
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_METHOD)).isEmpty();
+        assertThat(attributeKeys(root.getAttributeBoList())).contains("uri", "status", "method");
+    }
+
+    @Test
+    void exceptionTraceUriTemplate_usesTheSameRpc() {
+        Span failing = micrometerServer("/user/{id}", "/user/123", "500")
+                .setStatus(io.opentelemetry.proto.trace.v1.Status.newBuilder().setCodeValue(io.opentelemetry.proto.trace.v1.Status.StatusCode.STATUS_CODE_ERROR_VALUE))
+                .addEvents(Span.Event.newBuilder().setName("exception").setTimeUnixNano(1_500_000_000L)
+                        .addAttributes(kv("exception.type", strVal("java.lang.IllegalStateException")))
+                        .addAttributes(kv("exception.message", strVal("boom"))))
+                .build();
+        OtlpTraceMapperData data = map(SPRING_BOOT, failing);
+
+        assertThat(data.getSpanBoList().get(0).getRpc()).isEqualTo("/user/{id}");
+        assertThat(data.getExceptionMetaDataBoList()).singleElement()
+                .satisfies(ex -> assertThat(ex.getUriTemplate()).isEqualTo("/user/{id}"));
+    }
+
+    @Test
+    void client_statusAndMethodPromoted_uriNotUsed() {
+        Span root = micrometerServer("/remote", "/remote", "200").build();
+        Span client = span("http get", CHILD, ROOT, Span.SpanKind.SPAN_KIND_CLIENT_VALUE)
+                .addAttributes(kv("client.name", strVal("localhost")))
+                .addAttributes(kv("exception", strVal("none")))
+                .addAttributes(kv("http.url", strVal("http://localhost:18080/helloworld?q=1")))
+                .addAttributes(kv("method", strVal("GET")))
+                .addAttributes(kv("outcome", strVal("SUCCESS")))
+                .addAttributes(kv("status", strVal("200")))
+                .addAttributes(kv("uri", strVal("/helloworld")))
+                .build();
+        OtlpTraceMapperData data = map(SPRING_BOOT, root, client);
+
+        SpanEventBo event = data.getSpanBoList().get(0).getSpanEventBoList().get(0);
+        assertThat(event.getDestinationId()).isEqualTo("localhost:18080");
+        assertThat(annotation(event.getAnnotationBoList(), AnnotationKey.HTTP_STATUS_CODE)).map(AnnotationBo::getValue).contains(200);
+        assertThat(annotation(event.getAnnotationBoList(), AnnotationKey.HTTP_METHOD)).map(AnnotationBo::getValue).contains("GET");
+        assertThat(attributeKeys(event.getAttributeBoList())).doesNotContain("status", "method").contains("uri", "client.name", "http.url");
+    }
+
+    @Test
+    void client_nonNumericStatusIsNotPromoted() {
+        Span root = micrometerServer("/remote", "/remote", "500").build();
+        Span client = span("http get", CHILD, ROOT, Span.SpanKind.SPAN_KIND_CLIENT_VALUE)
+                .addAttributes(kv("method", strVal("GET")))
+                .addAttributes(kv("status", strVal("IO_ERROR")))
+                .addAttributes(kv("http.url", strVal("http://localhost:1/x")))
+                .build();
+        OtlpTraceMapperData data = map(SPRING_BOOT, root, client);
+
+        SpanEventBo event = data.getSpanBoList().get(0).getSpanEventBoList().get(0);
+        assertThat(annotation(event.getAnnotationBoList(), AnnotationKey.HTTP_STATUS_CODE)).isEmpty();
+        assertThat(attributeKeys(event.getAttributeBoList())).contains("status");
+    }
+
+    @Test
+    void observedInternal_methodIsJavaMethod_notPromoted() {
+        Span root = micrometerServer("/observed", "/observed", "200").build();
+        Span observed = span("observed-hello", CHILD, ROOT, Span.SpanKind.SPAN_KIND_INTERNAL_VALUE)
+                .addAttributes(kv("class", strVal("com.example.TestService")))
+                .addAttributes(kv("method", strVal("observedHello")))
+                .build();
+        OtlpTraceMapperData data = map(SPRING_BOOT, root, observed);
+
+        SpanEventBo event = data.getSpanBoList().get(0).getSpanEventBoList().get(0);
+        assertThat(annotation(event.getAnnotationBoList(), AnnotationKey.HTTP_METHOD)).isEmpty();
+        assertThat(attributeKeys(event.getAttributeBoList())).contains("class", "method");
+    }
+
+    @Test
+    void server_specialValues_methodNoneAndNonNumericStatus_notPromoted() {
+        // Micrometer's "none" method and a non-numeric status ("UNKNOWN") carry no HTTP value → stay raw
+        Span server = span("http none", ROOT, null, Span.SpanKind.SPAN_KIND_SERVER_VALUE)
+                .addAttributes(kv("http.url", strVal("/weird")))
+                .addAttributes(kv("method", strVal("none")))
+                .addAttributes(kv("status", strVal("UNKNOWN")))
+                .addAttributes(kv("uri", strVal("/weird")))
+                .build();
+        OtlpTraceMapperData data = map(SPRING_BOOT, server);
+
+        SpanBo root = data.getSpanBoList().get(0);
+        assertThat(root.getRpc()).isEqualTo("/weird");
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_METHOD)).isEmpty();
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_STATUS_CODE)).isEmpty();
+        assertThat(attributeKeys(root.getAttributeBoList())).contains("method", "status").doesNotContain("uri");
+    }
+
+    @Test
+    void server_uriAbsentOrEmpty_fallsBackToHttpUrlPath() {
+        Span noUri = span("http get", ROOT, null, Span.SpanKind.SPAN_KIND_SERVER_VALUE)
+                .addAttributes(kv("http.url", strVal("/no-uri?x=1")))
+                .addAttributes(kv("method", strVal("GET")))
+                .addAttributes(kv("status", strVal("200")))
+                .build();
+        assertThat(map(SPRING_BOOT, noUri).getSpanBoList().get(0).getRpc()).isEqualTo("/no-uri");
+
+        Span emptyUri = micrometerServer("", "/empty-uri", "200").build();
+        SpanBo root = map(SPRING_BOOT, emptyUri).getSpanBoList().get(0);
+        assertThat(root.getRpc()).isEqualTo("/empty-uri");
+        assertThat(attributeKeys(root.getAttributeBoList())).contains("uri"); // not consumed
+    }
+
+    @Test
+    void clientRoot_statusAndMethodPromoted_uriNotUsedForRpc() {
+        // Boot app without an inbound span (batch job): the HTTP client observation is the root span.
+        // Its Micrometer status/method are HTTP-typed and are promoted like on the SpanEvent path;
+        // `uri` (client URI template) is not an rpc source.
+        Span clientRoot = span("http get", ROOT, null, Span.SpanKind.SPAN_KIND_CLIENT_VALUE)
+                .addAttributes(kv("client.name", strVal("api.example.com")))
+                .addAttributes(kv("http.url", strVal("https://api.example.com/items/7")))
+                .addAttributes(kv("method", strVal("GET")))
+                .addAttributes(kv("status", strVal("200")))
+                .addAttributes(kv("uri", strVal("/items/{id}")))
+                .build();
+        OtlpTraceMapperData data = map(SPRING_BOOT, clientRoot);
+
+        SpanBo root = data.getSpanBoList().get(0);
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_STATUS_CODE)).map(AnnotationBo::getValue).contains(200);
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_METHOD)).map(AnnotationBo::getValue).contains("GET");
+        assertThat(root.getRpc()).isNotEqualTo("/items/{id}");
+        assertThat(attributeKeys(root.getAttributeBoList())).contains("uri").doesNotContain("status", "method");
+    }
+
+    @Test
+    void internalRoot_methodIsJavaMethod_notPromoted() {
+        // @Observed root (no HTTP observation at all): `method` is the Java method name
+        Span observedRoot = span("observed-job", ROOT, null, Span.SpanKind.SPAN_KIND_INTERNAL_VALUE)
+                .addAttributes(kv("class", strVal("com.example.JobService")))
+                .addAttributes(kv("method", strVal("runJob")))
+                .build();
+        OtlpTraceMapperData data = map(SPRING_BOOT, observedRoot);
+
+        SpanBo root = data.getSpanBoList().get(0);
+        assertThat(annotation(root.getAnnotationBoList(), AnnotationKey.HTTP_METHOD)).isEmpty();
+        assertThat(attributeKeys(root.getAttributeBoList())).contains("class", "method");
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -82,7 +82,7 @@ class OtlpTraceMapperTest {
         };
     }
 
-    private static OtlpTraceMapper newMapper() {
+    static OtlpTraceMapper newMapper() {
         ObjectMapper json = new ObjectMapper();
         OtlpTraceEventMapper eventMapper = new OtlpTraceEventMapper(json, 8192);
         OtlpExceptionInfoResolver exceptionInfoResolver = new OtlpExceptionInfoResolver();


### PR DESCRIPTION
…collector

Spring Boot's micrometer-tracing bridge (Boot 3.x actuator, Boot 4.x spring-boot-starter-opentelemetry; scope org.springframework.boot) emits Micrometer observation keys instead of OTel HTTP semconv: uri (route template), http.url (raw path), method, status (string), outcome, exception. The collector therefore stored the raw path as rpc (high cardinality in the URI statistics) and promoted no HTTP status / method annotations.

OtlpMicrometerAttributes maps those keys as a fallback after the semconv lookup, gated on the exact scope name:
- uri -> rpc (after next.route); placeholder values (/**, UNKNOWN, REDIRECTION, NOT_FOUND, root) fall back to the http.url path
- status -> HTTP_STATUS_CODE, method -> HTTP_METHOD
- status/method on HTTP observations only: SERVER root spans, CLIENT root spans (batch job without an inbound span) and CLIENT events; INTERNAL (@Observed) spans untouched - there `method` is the Java method name. uri -> rpc is SERVER-only
- exception uriTemplate uses the same rpc

Tests: OtlpMicrometerAttributesTest (helpers and the scope gate) and OtlpMicrometerKeyMappingTest (end-to-end through OtlpTraceMapper, synthetic spans shaped like Spring MVC / RestClient observations).