### PR TITLE
[#14197] Resolve serviceName in the realtime active thread count path

### DIFF
--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/service/ActiveThreadCountService.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/service/ActiveThreadCountService.java
@@ -25,7 +25,7 @@ import java.time.Duration;
  */
 public interface ActiveThreadCountService {
 
-    Flux<ActiveThreadCountResponse> getResponses(String applicationName) throws Exception;
+    Flux<ActiveThreadCountResponse> getResponses(String serviceName, String applicationName) throws Exception;
 
     class ATCPeriods {
         private final Duration periodEmit;

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/service/ActiveThreadCountServiceImpl.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/service/ActiveThreadCountServiceImpl.java
@@ -69,14 +69,14 @@ public class ActiveThreadCountServiceImpl implements ActiveThreadCountService {
     }
 
     @Override
-    public Flux<ActiveThreadCountResponse> getResponses(String applicationName) {
+    public Flux<ActiveThreadCountResponse> getResponses(String serviceName, String applicationName) {
         TaskDecorator taskDecorator = taskDecoratorFactory.createDecorator();
         SupplyCollector collector = new SupplyCollector(applicationName, emitPeriod.toMillis() * 2);
 
         Map<ClusterKey, Disposable> disposableMap = new ConcurrentHashMap<>();
 
         Disposable updateDisposable = this.scheduler.schedulePeriodically(() -> {
-            getAgents(taskDecorator, applicationName).subscribe(agents -> {
+            getAgents(taskDecorator, serviceName, applicationName).subscribe(agents -> {
                 for (ClusterKeyAndMetadata agentMetadata : agents) {
                     ClusterKey agent = agentMetadata.key();
                     Flux<ATCSupply> supplies = this.atcDao.getSupplies(agent);
@@ -106,12 +106,12 @@ public class ActiveThreadCountServiceImpl implements ActiveThreadCountService {
         return new ClusterKey(supply.getServiceName(), supply.getApplicationName(), supply.getAgentId(), supply.getStartTimestamp());
     }
 
-    private Mono<List<ClusterKeyAndMetadata>> getAgents(TaskDecorator taskDecorator, String applicationName) {
+    private Mono<List<ClusterKeyAndMetadata>> getAgents(TaskDecorator taskDecorator, String serviceName, String applicationName) {
         return Mono.create(sink -> {
             taskDecorator.decorate(new Runnable() {
                 @Override
                 public void run() {
-                    sink.success(agentLookupService.getRecentAgents(applicationName));
+                    sink.success(agentLookupService.getRecentAgents(serviceName, applicationName));
                 }
             }).run();
         });

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/websocket/RedisActiveThreadCountWebSocketHandler.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/activethread/count/websocket/RedisActiveThreadCountWebSocketHandler.java
@@ -58,16 +58,17 @@ public class RedisActiveThreadCountWebSocketHandler {
         HandlerSession.dispose(session);
     }
 
-    public void handleActiveThreadCount(WebSocketSession wsSession, String applicationName) {
+    public void handleActiveThreadCount(WebSocketSession wsSession, String serviceName, String applicationName) {
+        Objects.requireNonNull(serviceName, "serviceName");
         Objects.requireNonNull(applicationName, "applicationName");
 
-        logger.info("ATC Requested. session: {}, applicationName: {}", wsSession, applicationName);
+        logger.info("ATC Requested. session: {}, serviceName: {}, applicationName: {}", wsSession, serviceName, applicationName);
         HandlerSession handlerSession = HandlerSession.get(wsSession);
         if (handlerSession == null) {
             logger.error("CustomSession is not initialized");
             return;
         }
-        handlerSession.start(applicationName);
+        handlerSession.start(serviceName, applicationName);
     }
 
     private static class HandlerSession implements Disposable {
@@ -77,6 +78,7 @@ public class RedisActiveThreadCountWebSocketHandler {
         private final WebSocketSession wsSession;
         private final ActiveThreadCountService atcService;
         private final Serializer<ActiveThreadCountResponse> responseSerializer;
+        private String serviceName;
         private String applicationName;
         private Disposable disposable;
 
@@ -120,21 +122,23 @@ public class RedisActiveThreadCountWebSocketHandler {
             }
         }
 
-        void start(String applicationName) {
+        void start(String serviceName, String applicationName) {
             synchronized (lock) {
-                if (this.applicationName != null && this.applicationName.equals(applicationName)) {
-                    logger.error("Already started with application {}", this.applicationName);
+                if (this.applicationName != null && this.applicationName.equals(applicationName)
+                        && Objects.equals(this.serviceName, serviceName)) {
+                    logger.error("Already started with service {}, application {}", this.serviceName, this.applicationName);
                     return;
                 }
                 dispose();
-                start0(applicationName);
+                start0(serviceName, applicationName);
             }
         }
 
-        private void start0(String applicationName) {
+        private void start0(String serviceName, String applicationName) {
             try {
+                this.serviceName = serviceName;
                 this.applicationName = applicationName;
-                Flux<ActiveThreadCountResponse> responses = this.atcService.getResponses(applicationName);
+                Flux<ActiveThreadCountResponse> responses = this.atcService.getResponses(serviceName, applicationName);
                 this.disposable = responses.subscribe(this::sendMessage);
             } catch (Exception e) {
                 logger.error("Failed to start atc session");
@@ -148,6 +152,7 @@ public class RedisActiveThreadCountWebSocketHandler {
                 if (this.disposable != null) {
                     this.disposable.dispose();
                 }
+                this.serviceName = null;
                 this.applicationName = null;
                 this.disposable = null;
             }

--- a/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/service/AgentLookupService.java
+++ b/realtime/realtime-web/src/main/java/com/navercorp/pinpoint/web/realtime/service/AgentLookupService.java
@@ -24,6 +24,6 @@ import java.util.List;
  */
 public interface AgentLookupService {
 
-    List<ClusterKeyAndMetadata> getRecentAgents(String applicationName);
+    List<ClusterKeyAndMetadata> getRecentAgents(String serviceName, String applicationName);
 
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/realtime/AgentLookupServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/realtime/AgentLookupServiceImpl.java
@@ -16,15 +16,18 @@
 package com.navercorp.pinpoint.web.realtime;
 
 import com.navercorp.pinpoint.common.server.cluster.ClusterKey;
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.web.realtime.activethread.count.dto.ClusterKeyAndMetadata;
 import com.navercorp.pinpoint.web.realtime.service.AgentLookupService;
 import com.navercorp.pinpoint.web.service.ApplicationAgentListService;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
+import com.navercorp.pinpoint.web.service.ServiceNotFoundException;
 import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.time.Duration;
 import java.util.List;
@@ -38,37 +41,52 @@ import static com.navercorp.pinpoint.web.service.ApplicationAgentListService.ACT
  */
 class AgentLookupServiceImpl implements AgentLookupService {
 
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
     private final ApplicationAgentListService applicationAgentListService;
+    private final ServiceModelResolver serviceModelResolver;
     private final Duration recentness;
 
-    AgentLookupServiceImpl(ApplicationAgentListService applicationAgentListService, Duration recentness) {
+    AgentLookupServiceImpl(ApplicationAgentListService applicationAgentListService,
+                           ServiceModelResolver serviceModelResolver,
+                           Duration recentness) {
         this.applicationAgentListService = Objects.requireNonNull(applicationAgentListService, "applicationAgentListService");
+        this.serviceModelResolver = Objects.requireNonNull(serviceModelResolver, "serviceModelResolver");
         this.recentness = Objects.requireNonNullElse(recentness, Duration.ZERO);
     }
 
     @Override
-    public List<ClusterKeyAndMetadata> getRecentAgents(String applicationName) {
+    public List<ClusterKeyAndMetadata> getRecentAgents(String serviceName, String applicationName) {
+        final Service service;
+        try {
+            service = serviceModelResolver.getService(serviceName);
+        } catch (ServiceNotFoundException e) {
+            logger.warn("Service not found. serviceName: {}, applicationName: {}", serviceName, applicationName);
+            return List.of();
+        }
+
         long now = System.currentTimeMillis();
         long from = now - recentness.toMillis();
         Range between = Range.between(from, now);
         TimeWindow timeWindow = new TimeWindow(between);
 
-        return intoClusterKeyAndMetadataList(this.applicationAgentListService.activeStatisticsAgentList(Service.DEFAULT, applicationName, null,
-                timeWindow,
-                ACTUAL_AGENT_INFO_PREDICATE
-        ));
+        return intoClusterKeyAndMetadataList(service.getServiceName(),
+                this.applicationAgentListService.activeStatisticsAgentList(service, applicationName, null,
+                        timeWindow,
+                        ACTUAL_AGENT_INFO_PREDICATE
+                ));
     }
 
-    private static List<ClusterKeyAndMetadata> intoClusterKeyAndMetadataList(List<AgentAndStatus> agentAndStatusList) {
+    private static List<ClusterKeyAndMetadata> intoClusterKeyAndMetadataList(String serviceName, List<AgentAndStatus> agentAndStatusList) {
         return agentAndStatusList.stream()
                 .map(AgentAndStatus::getAgentInfo)
-                .map(AgentLookupServiceImpl::intoClusterKeyAndMetadata)
+                .map(agentInfo -> intoClusterKeyAndMetadata(serviceName, agentInfo))
                 .collect(Collectors.toList());
     }
 
-    private static ClusterKeyAndMetadata intoClusterKeyAndMetadata(AgentInfo src) {
+    private static ClusterKeyAndMetadata intoClusterKeyAndMetadata(String serviceName, AgentInfo src) {
         return new ClusterKeyAndMetadata(
-                new ClusterKey(ServiceUid.DEFAULT_SERVICE_UID_NAME, src.getApplicationName(), src.getAgentId(), src.getStartTimestamp()),
+                new ClusterKey(serviceName, src.getApplicationName(), src.getAgentId(), src.getStartTimestamp()),
                 src.getAgentName()
         );
     }

--- a/web/src/main/java/com/navercorp/pinpoint/web/realtime/RealtimeConfig.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/realtime/RealtimeConfig.java
@@ -29,6 +29,7 @@ import com.navercorp.pinpoint.web.service.ActiveThreadDumpService;
 import com.navercorp.pinpoint.web.service.AgentService;
 import com.navercorp.pinpoint.web.service.ApplicationAgentListService;
 import com.navercorp.pinpoint.web.service.EchoService;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.websocket.PinpointWebSocketHandler;
 import com.navercorp.pinpoint.web.websocket.WebSocketTaskDecoratorFactory;
 import com.navercorp.pinpoint.web.websocket.message.PinpointWebSocketMessageConverter;
@@ -68,17 +69,19 @@ public class RealtimeConfig {
         Duration agentRecentness;
 
         @Bean
-        AgentLookupService agentLookupService(ApplicationAgentListService applicationAgentListService) {
-            return new AgentLookupServiceImpl(applicationAgentListService, agentRecentness);
+        AgentLookupService agentLookupService(ApplicationAgentListService applicationAgentListService,
+                                              ServiceModelResolver serviceModelResolver) {
+            return new AgentLookupServiceImpl(applicationAgentListService, serviceModelResolver, agentRecentness);
         }
 
         @Bean
         PinpointWebSocketHandler redisActiveThreadCountHandler(
                 RedisActiveThreadCountWebSocketHandler delegate,
                 PinpointWebSocketMessageConverter converter,
-                @Autowired(required = false) ServerMapDataFilter serverMapDataFilter
+                @Autowired(required = false) ServerMapDataFilter serverMapDataFilter,
+                ServiceModelResolver serviceModelResolver
         ) {
-            return new RedisActiveThreadCountHandlerAdaptor(delegate, converter, serverMapDataFilter, null);
+            return new RedisActiveThreadCountHandlerAdaptor(delegate, converter, serverMapDataFilter, serviceModelResolver, null);
         }
 
         @Bean

--- a/web/src/main/java/com/navercorp/pinpoint/web/realtime/RedisActiveThreadCountHandlerAdaptor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/realtime/RedisActiveThreadCountHandlerAdaptor.java
@@ -17,6 +17,7 @@ package com.navercorp.pinpoint.web.realtime;
 
 import com.navercorp.pinpoint.web.realtime.activethread.count.websocket.RedisActiveThreadCountWebSocketHandler;
 import com.navercorp.pinpoint.web.security.ServerMapDataFilter;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.websocket.ActiveThreadCountHandler;
 import com.navercorp.pinpoint.web.websocket.message.PinpointWebSocketMessageConverter;
 import org.apache.logging.log4j.LogManager;
@@ -39,9 +40,10 @@ public class RedisActiveThreadCountHandlerAdaptor extends ActiveThreadCountHandl
             RedisActiveThreadCountWebSocketHandler delegate,
             PinpointWebSocketMessageConverter converter,
             ServerMapDataFilter serverMapDataFilter,
+            ServiceModelResolver serviceModelResolver,
             String requestMapping
     ) {
-        super(converter, serverMapDataFilter, requestMapping);
+        super(converter, serverMapDataFilter, serviceModelResolver, requestMapping);
         this.delegate = Objects.requireNonNull(delegate, "delegate");
     }
 
@@ -68,8 +70,8 @@ public class RedisActiveThreadCountHandlerAdaptor extends ActiveThreadCountHandl
     }
 
     @Override
-    protected void handleActiveThreadCount(WebSocketSession session, String applicationName) {
-        this.delegate.handleActiveThreadCount(session, applicationName);
+    protected void handleActiveThreadCount(WebSocketSession session, String serviceName, String applicationName) {
+        this.delegate.handleActiveThreadCount(session, serviceName, applicationName);
     }
 
     @Override

--- a/web/src/main/java/com/navercorp/pinpoint/web/websocket/ActiveThreadCountHandler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/websocket/ActiveThreadCountHandler.java
@@ -16,7 +16,11 @@
 
 package com.navercorp.pinpoint.web.websocket;
 
+import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.web.security.ServerMapDataFilter;
+import com.navercorp.pinpoint.web.service.ServiceModelResolver;
+import com.navercorp.pinpoint.web.service.ServiceNotFoundException;
+import com.navercorp.pinpoint.web.vo.Service;
 import com.navercorp.pinpoint.web.websocket.message.PinpointWebSocketMessage;
 import com.navercorp.pinpoint.web.websocket.message.PinpointWebSocketMessageConverter;
 import com.navercorp.pinpoint.web.websocket.message.PinpointWebSocketMessageType;
@@ -38,6 +42,8 @@ import java.util.Objects;
  */
 public abstract class ActiveThreadCountHandler extends TextWebSocketHandler implements PinpointWebSocketHandler {
 
+    public static final String SERVICE_NAME_KEY = "serviceName";
+    public static final String SERVICE_TYPE_NAME_KEY = "serviceTypeName";
     public static final String APPLICATION_NAME_KEY = "applicationName";
     public static final String DEFAULT_REQUEST_MAPPING = "/api/agent/activeThread";
 
@@ -47,14 +53,17 @@ public abstract class ActiveThreadCountHandler extends TextWebSocketHandler impl
     private final PinpointWebSocketMessageConverter messageConverter;
     private final String requestMapping;
     private final ServerMapDataFilter serverMapDataFilter;
+    private final ServiceModelResolver serviceModelResolver;
 
     public ActiveThreadCountHandler(
             PinpointWebSocketMessageConverter converter,
             ServerMapDataFilter serverMapDataFilter,
+            ServiceModelResolver serviceModelResolver,
             String requestMapping
     ) {
         this.messageConverter = Objects.requireNonNull(converter, "converter");
         this.serverMapDataFilter = serverMapDataFilter;
+        this.serviceModelResolver = Objects.requireNonNull(serviceModelResolver, "serviceModelResolver");
         this.requestMapping = Objects.requireNonNullElse(requestMapping, DEFAULT_REQUEST_MAPPING);
     }
 
@@ -105,15 +114,32 @@ public abstract class ActiveThreadCountHandler extends TextWebSocketHandler impl
 
     private void handleActiveThreadCount(WebSocketSession webSocketSession, RequestMessage requestMessage) {
         final String applicationName = MapUtils.getString(requestMessage.getParameters(), APPLICATION_NAME_KEY);
-        if (applicationName != null) {
-            handleActiveThreadCount(webSocketSession, applicationName);
-        } else {
+        if (applicationName == null) {
             CloseStatus status = CloseStatus.BAD_DATA.withReason("applicationName not found");
             closeSession(webSocketSession, status);
+            return;
         }
+
+        final String serviceName = MapUtils.getString(requestMessage.getParameters(), SERVICE_NAME_KEY);
+        final Service service;
+        try {
+            service = resolveService(serviceName);
+        } catch (ServiceNotFoundException e) {
+            CloseStatus status = CloseStatus.BAD_DATA.withReason("Unknown serviceName " + serviceName);
+            closeSession(webSocketSession, status);
+            return;
+        }
+        handleActiveThreadCount(webSocketSession, service.getServiceName(), applicationName);
     }
 
-    protected abstract void handleActiveThreadCount(WebSocketSession webSocketSession, String applicationName);
+    private Service resolveService(String serviceName) {
+        if (StringUtils.isEmpty(serviceName)) {
+            return Service.DEFAULT;
+        }
+        return serviceModelResolver.getService(serviceName);
+    }
+
+    protected abstract void handleActiveThreadCount(WebSocketSession webSocketSession, String serviceName, String applicationName);
 
     private void closeSession(WebSocketSession session, CloseStatus status) {
         try {


### PR DESCRIPTION
Closes #14197

## Summary
- Resolve the requested service in the active thread count websocket path instead of hardcoding `Service.DEFAULT` on the web side. The collector already registers agent command streams with service-scoped ClusterKeys, so demand keys now match for agents under a non-default service.
- `ActiveThreadCountHandler` accepts optional `serviceName` / `serviceTypeName` message parameters (missing values fall back to DEFAULT for backward compatibility) and closes the session with BAD_DATA for an unknown serviceName.
- `AgentLookupServiceImpl` looks up agents for the requested service and builds service-scoped ClusterKeys.

## Test plan
- [x] Local E2E: agents under a non-default service and the DEFAULT service both stream active thread counts; a non-default application queried as DEFAULT returns no agents (isolation); an unknown serviceName closes the session.
- [x] Backward compatibility: a request without serviceName behaves as before (DEFAULT).