### PR TITLE
[#noissue] Add OTel-SDK sample testwebs that export spans to Pinpoint…

### DIFF
--- a/agent-module/agent-testweb/micronaut-opentelemetry-testweb/README.md
+++ b/agent-module/agent-testweb/micronaut-opentelemetry-testweb/README.md
@@ -1,0 +1,47 @@
+## micronaut-opentelemetry-testweb
+
+Micronaut app instrumented with **`micronaut-tracing-opentelemetry-http`** (OTel SDK autoconfigure driven by
+`otel.*` properties, HTTP server/client filters, `@NewSpan`). Spans go to Pinpoint through the SDK's own OTLP
+exporter (`otel.exporter.otlp.*`).
+
+- Do **not** attach the Pinpoint agent or the OpenTelemetry Java Agent (duplicate instrumentation).
+- The module is in the **`otel-framework-testweb`** profile (off by default).
+- **Micronaut 5.x is compiled for Java 25**: the app, the compiler and the Maven JVM itself must run on JDK 25
+  (`micronaut-maven-plugin` / `micronaut-core` are class file version 69.0). This module therefore uses
+  `jdk.home=${java.home}` and must be built with `JAVA_HOME=<jdk25>`.
+- `application.yml` is silently ignored (snakeyaml is not on the classpath); use `application.properties`.
+
+### Run (JDK 25, also for Maven)
+
+```
+JAVA_HOME=<jdk25> ./mvnw -Potel-framework-testweb -pl agent-module/agent-testweb/micronaut-opentelemetry-testweb package -Dmaven.test.skip=true -Dspring-boot-build-skip=false
+<jdk25>/bin/java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow \
+  -jar agent-module/agent-testweb/micronaut-opentelemetry-testweb/target/pinpoint-micronaut-opentelemetry-testweb-*-exec.jar \
+  -Dotel.exporter.otlp.endpoint=http://<collector>:9998
+```
+
+`-Dspring-boot-build-skip=false` (the same switch as the other testwebs) builds the shaded exec jar; without it the
+module only compiles.
+
+### Endpoints (port 18085)
+
+| path | spans |
+| --- | --- |
+| `/helloworld` | server span |
+| `/user/{id}` | server span (`http.route` template) |
+| `/observed` | server span + `@NewSpan` INTERNAL span |
+| `/remote` | server span -> HttpClient client span -> server span (`/user/{id}`); needs `@ExecuteOn(BLOCKING)` |
+| `/throw` | server span with error |
+
+### What the collector sees (verified 2026-08-25, Micronaut 5.1.2 / tracing 8.2.0 / SDK 1.64.0)
+
+- scopes `io.micronaut.http.server`, `io.micronaut.http.client`, `io.micronaut.code` (no version); **stable HTTP
+  semconv** (`http.route`, `url.path`, `http.request.method`, `http.response.status_code` as int, `server.address/port`,
+  `error.type`; `url.full` on the client). rpc template / status / method map with no key mapping.
+  Fixture: `otlptrace-collector` `micronaut-5.1-tracing-opentelemetry.pb`.
+- No `client.address`, so remoteAddr stays empty. Unmatched routes have no `http.route`: rpc falls back to `url.path`.
+- Every exception is recorded twice as a span event; the collector still stores one exception record per span.
+- **The default resource is `service.name` + `telemetry.sdk.*` only** (no host/process resource providers, no
+  auto-generated `service.instance.id`). Without `service.instance.id` the collector rejects every span
+  ("no per-instance identifier"), so it is mandatory here. `otel.resource.attributes` is ONE comma-separated string,
+  a nested map is ignored. Fixture of the rejected case: `micronaut-5.1-default-resource-rejected.pb`.

--- a/agent-module/agent-testweb/micronaut-opentelemetry-testweb/pom.xml
+++ b/agent-module/agent-testweb/micronaut-opentelemetry-testweb/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint-agent-testweb</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-micronaut-opentelemetry-testweb</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <!-- Micronaut 5.x is compiled for Java 25 (class file 69.0): compile, run AND the Maven JVM itself must be JDK 25.
+             jdk.home = the JVM running Maven (JAVA_HOME=<jdk25>). -->
+        <jdk.version>25</jdk.version>
+        <jdk.home>${java.home}</jdk.home>
+        <micronaut.platform.version>5.1.2</micronaut.platform.version>
+        <micronaut.core.version>5.1.12</micronaut.core.version>
+        <micronaut.serialization.version>3.1.1</micronaut.serialization.version>
+        <!-- the pinpoint parent pins the netty artifacts with netty4.version (4.1.x); Micronaut 5 needs Netty 4.2 -->
+        <netty4.version>4.2.17.Final</netty4.version>
+
+        <!-- OTel SDK app: the pinpoint agent must NOT be attached (duplicate instrumentation).
+             Reused as the packaging switch: -Dspring-boot-build-skip=false builds the shaded exec jar. -->
+        <spring-boot-build-skip>true</spring-boot-build-skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.micronaut.platform</groupId>
+                <artifactId>micronaut-platform</artifactId>
+                <version>${micronaut.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-http-server-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-http-client</artifactId>
+        </dependency>
+        <!-- the JSON error-response provider of the HTTP server needs a JSON codec at startup -->
+        <dependency>
+            <groupId>io.micronaut.serde</groupId>
+            <artifactId>micronaut-serde-jackson</artifactId>
+        </dependency>
+        <!-- OTel SDK autoconfigure (otel.*) + HTTP server/client filters + @NewSpan/@WithSpan -->
+        <dependency>
+            <groupId>io.micronaut.tracing</groupId>
+            <artifactId>micronaut-tracing-opentelemetry-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-inject-java</artifactId>
+                            <version>${micronaut.core.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.micronaut.serde</groupId>
+                            <artifactId>micronaut-serde-processor</artifactId>
+                            <version>${micronaut.serialization.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-Amicronaut.processing.group=com.pinpoint.test</arg>
+                        <arg>-Amicronaut.processing.module=micronaut-opentelemetry-testweb</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <!-- JDK 25 is required (also for Maven itself):
+                 JAVA_HOME=<jdk25> ./mvnw -Potel-framework-testweb -pl agent-module/agent-testweb/micronaut-opentelemetry-testweb package -Dmaven.test.skip=true -Dspring-boot-build-skip=false -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${spring-boot-build-skip}</skip>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>exec</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.pinpoint.test.micronautotel.MicronautOpenTelemetryTestApplication</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/agent-module/agent-testweb/micronaut-opentelemetry-testweb/src/main/java/com/pinpoint/test/micronautotel/MicronautOpenTelemetryTestApplication.java
+++ b/agent-module/agent-testweb/micronaut-opentelemetry-testweb/src/main/java/com/pinpoint/test/micronautotel/MicronautOpenTelemetryTestApplication.java
@@ -1,0 +1,15 @@
+package com.pinpoint.test.micronautotel;
+
+import io.micronaut.runtime.Micronaut;
+
+/**
+ * Micronaut app instrumented with {@code micronaut-tracing-opentelemetry-http} (OTel SDK autoconfigure, stable HTTP
+ * semconv on the HTTP server and HTTP client spans). Spans go to Pinpoint through {@code otel.exporter.otlp.*}.
+ * Do NOT attach the Pinpoint agent or the OpenTelemetry Java Agent to this app.
+ */
+public class MicronautOpenTelemetryTestApplication {
+
+    public static void main(String[] args) {
+        Micronaut.run(MicronautOpenTelemetryTestApplication.class, args);
+    }
+}

--- a/agent-module/agent-testweb/micronaut-opentelemetry-testweb/src/main/java/com/pinpoint/test/micronautotel/TestController.java
+++ b/agent-module/agent-testweb/micronaut-opentelemetry-testweb/src/main/java/com/pinpoint/test/micronautotel/TestController.java
@@ -1,0 +1,51 @@
+package com.pinpoint.test.micronautotel;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
+
+@Controller("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class TestController {
+
+    private final HttpClient client;
+    private final TestService testService;
+
+    public TestController(@Client("http://localhost:18085") HttpClient client, TestService testService) {
+        this.client = client;
+        this.testService = testService;
+    }
+
+    @Get("/helloworld")
+    public String helloworld() {
+        return "helloworld";
+    }
+
+    @Get("/user/{id}")
+    public String user(@PathVariable String id) {
+        return "user " + id;
+    }
+
+    @Get("/observed")
+    public String observed() {
+        return "observed " + testService.observedHello();
+    }
+
+    @Get("/remote")
+    @ExecuteOn(TaskExecutors.BLOCKING) // a blocking client call is not allowed on the netty event loop
+    public String remote() {
+        // self call: server span -> http client span -> server span (context propagated via W3C traceparent)
+        return "remote " + client.toBlocking().retrieve("/user/42");
+    }
+
+    @Get("/throw")
+    public String error() {
+        throw new IllegalStateException("observed error");
+    }
+}

--- a/agent-module/agent-testweb/micronaut-opentelemetry-testweb/src/main/java/com/pinpoint/test/micronautotel/TestService.java
+++ b/agent-module/agent-testweb/micronaut-opentelemetry-testweb/src/main/java/com/pinpoint/test/micronautotel/TestService.java
@@ -1,0 +1,13 @@
+package com.pinpoint.test.micronautotel;
+
+import io.micronaut.tracing.annotation.NewSpan;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class TestService {
+
+    @NewSpan("observed-hello")
+    public String observedHello() {
+        return "hello";
+    }
+}

--- a/agent-module/agent-testweb/micronaut-opentelemetry-testweb/src/main/resources/application.properties
+++ b/agent-module/agent-testweb/micronaut-opentelemetry-testweb/src/main/resources/application.properties
@@ -1,0 +1,14 @@
+# application.yml needs snakeyaml (not on the classpath by default): use .properties
+micronaut.application.name=micronaut-otel-testweb
+micronaut.server.port=18085
+
+# Micronaut feeds otel.* into the OTel SDK autoconfigure (grpc is the SDK default; set explicitly anyway)
+otel.traces.exporter=otlp
+otel.metrics.exporter=none
+otel.logs.exporter=none
+otel.exporter.otlp.endpoint=http://localhost:9998
+otel.exporter.otlp.protocol=grpc
+# ONE comma-separated string (a nested map otel.resource.attributes.k=v is ignored).
+# The default resource is service.name + telemetry.sdk.* only (no host/process resource providers), so without
+# service.instance.id the collector rejects every span ("no per-instance identifier"). UUID or <= 24 chars.
+otel.resource.attributes=pinpoint.applicationName=micronaut-otel-testweb,pinpoint.agentName=micronaut-otel-testweb-001,service.instance.id=${random.uuid}

--- a/agent-module/agent-testweb/pom.xml
+++ b/agent-module/agent-testweb/pom.xml
@@ -145,9 +145,21 @@
             <modules>
                 <module>spring-boot3-testweb</module>
                 <module>spring-boot3-webflux-plugin-testweb</module>
+                <module>spring-boot3-micrometer-tracing-testweb</module>
+                <module>spring-boot3-otel-starter-testweb</module>
                 <module>jetty12-plugin-testweb</module>
                 <module>spring-boot4-plugin-testweb</module>
                 <module>spring-boot4-webflux-plugin-testweb</module>
+                <module>spring-boot4-opentelemetry-testweb</module>
+            </modules>
+        </profile>
+        <profile>
+            <!-- OTel-SDK sample apps on non-Spring frameworks. Off by default: they pull their own build plugins
+                 (quarkus-maven-plugin, maven-shade) and Micronaut 5 needs JDK 25 for Maven itself. -->
+            <id>otel-framework-testweb</id>
+            <modules>
+                <module>quarkus-opentelemetry-testweb</module>
+                <module>micronaut-opentelemetry-testweb</module>
             </modules>
         </profile>
     </profiles>

--- a/agent-module/agent-testweb/quarkus-opentelemetry-testweb/README.md
+++ b/agent-module/agent-testweb/quarkus-opentelemetry-testweb/README.md
@@ -1,0 +1,42 @@
+## quarkus-opentelemetry-testweb
+
+Quarkus app instrumented with **`quarkus-opentelemetry`** (OTel SDK embedded in the framework). Spans go to Pinpoint
+through the framework's own OTLP exporter (`quarkus.otel.exporter.otlp.*`); a second exporter is not needed for the
+sample, fan-out to another backend is a Collector concern (guide section D).
+
+- Do **not** attach the Pinpoint agent or the OpenTelemetry Java Agent (duplicate instrumentation).
+- The module is in the **`otel-framework-testweb`** profile (off by default): it pulls `quarkus-maven-plugin` into the reactor.
+- `quarkus.otel.exporter.otlp.protocol` defaults to `grpc` already.
+
+### Run (JDK 17)
+
+```
+./mvnw -Potel-framework-testweb -pl agent-module/agent-testweb/quarkus-opentelemetry-testweb package -Dmaven.test.skip=true -Dspring-boot-build-skip=false
+java -jar agent-module/agent-testweb/quarkus-opentelemetry-testweb/target/quarkus-app/quarkus-run.jar \
+  -Dquarkus.otel.exporter.otlp.endpoint=http://<collector>:9998
+```
+
+`-Dspring-boot-build-skip=false` (the same switch as the other testwebs) enables the Quarkus build; without it the
+module only compiles.
+
+### Endpoints (port 18084)
+
+| path | spans |
+| --- | --- |
+| `/helloworld` | server span |
+| `/user/{id}` | server span (`http.route` template) |
+| `/observed` | server span + `@WithSpan` INTERNAL span |
+| `/remote` | server span -> REST client span -> server span (`/user/{id}`) |
+| `/throw` | server span with error |
+
+### What the collector sees (verified 2026-08-25, Quarkus 3.38.3)
+
+- scope `io.quarkus.opentelemetry`; **stable HTTP semconv** on server and REST client spans (`http.route`, `url.path`,
+  `http.request.method`, `http.response.status_code` as int, `server.address/port`, `client.address`, `error.type`,
+  `url.full` on the client). rpc template / endPoint / remoteAddr / status / method all map with no key mapping.
+  Fixture: `otlptrace-collector` `quarkus-3.38-opentelemetry.pb`.
+- Unmatched routes are reported with `http.route=/`.
+- The resource has `host.name`, `service.name`, `service.version`, `webengine.*` but **no `service.instance.id`
+  and no `process.*`**: the collector falls back to `host.name` as the agentId, which collides when several
+  instances run on one host. Set `service.instance.id` in `quarkus.otel.resource.attributes` (done above with
+  `${quarkus.uuid}`).

--- a/agent-module/agent-testweb/quarkus-opentelemetry-testweb/pom.xml
+++ b/agent-module/agent-testweb/quarkus-opentelemetry-testweb/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint-agent-testweb</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-quarkus-opentelemetry-testweb</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <jdk.version>17</jdk.version>
+        <jdk.home>${env.JAVA_17_HOME}</jdk.home>
+        <quarkus.platform.version>3.38.3</quarkus.platform.version>
+
+        <!-- OTel SDK app: the pinpoint agent must NOT be attached (duplicate instrumentation).
+             Reused as the packaging switch: -Dspring-boot-build-skip=false runs the quarkus build (target/quarkus-app). -->
+        <spring-boot-build-skip>true</spring-boot-build-skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- the pinpoint parent pins jakarta.transaction-api 1.3.3 (javax package); Quarkus needs the jakarta.* API -->
+            <dependency>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+                <version>2.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
+        </dependency>
+        <!-- OTel SDK + OTLP exporter + REST server/client instrumentation (quarkus.otel.*) -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <!-- jdk 17 is required: ./mvnw -Potel-framework-testweb -pl agent-module/agent-testweb/quarkus-opentelemetry-testweb package -Dmaven.test.skip=true -Dspring-boot-build-skip=false -->
+            <plugin>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${spring-boot-build-skip}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/agent-module/agent-testweb/quarkus-opentelemetry-testweb/src/main/java/com/pinpoint/test/quarkusotel/TestResource.java
+++ b/agent-module/agent-testweb/quarkus-opentelemetry-testweb/src/main/java/com/pinpoint/test/quarkusotel/TestResource.java
@@ -1,0 +1,68 @@
+package com.pinpoint.test.quarkusotel;
+
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import java.net.URI;
+
+/**
+ * Quarkus app instrumented with {@code quarkus-opentelemetry} (OTel SDK embedded, stable HTTP semconv on the REST
+ * server and REST client spans). Spans go to Pinpoint through {@code quarkus.otel.exporter.otlp.*}.
+ * Do NOT attach the Pinpoint agent or the OpenTelemetry Java Agent to this app.
+ */
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class TestResource {
+
+    @Path("/")
+    public interface SelfClient {
+        @GET
+        @Path("/user/{id}")
+        String user(@PathParam("id") String id);
+    }
+
+    private final SelfClient self = RestClientBuilder.newBuilder()
+            .baseUri(URI.create("http://localhost:18084"))
+            .build(SelfClient.class);
+
+    @GET
+    @Path("/helloworld")
+    public String helloworld() {
+        return "helloworld";
+    }
+
+    @GET
+    @Path("/user/{id}")
+    public String user(@PathParam("id") String id) {
+        return "user " + id;
+    }
+
+    @GET
+    @Path("/observed")
+    public String observed() {
+        return "observed " + observedHello();
+    }
+
+    @WithSpan("observed-hello")
+    String observedHello() {
+        return "hello";
+    }
+
+    @GET
+    @Path("/remote")
+    public String remote() {
+        // self call: server span -> REST client span -> server span (context propagated via W3C traceparent)
+        return "remote " + self.user("42");
+    }
+
+    @GET
+    @Path("/throw")
+    public String error() {
+        throw new IllegalStateException("observed error");
+    }
+}

--- a/agent-module/agent-testweb/quarkus-opentelemetry-testweb/src/main/resources/application.properties
+++ b/agent-module/agent-testweb/quarkus-opentelemetry-testweb/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+quarkus.application.name=quarkus-otel-testweb
+quarkus.http.port=18084
+
+# OTLP -> Pinpoint. Quarkus default protocol is grpc; set explicitly anyway.
+quarkus.otel.exporter.otlp.endpoint=http://localhost:9998
+quarkus.otel.exporter.otlp.protocol=grpc
+quarkus.otel.traces.sampler=always_on
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false
+# Quarkus resource = host.name + service.name/version + webengine.* only: no service.instance.id, no process.*.
+# The collector then falls back to host.name as the agentId, which collides when several instances share a host.
+# Set service.instance.id explicitly (UUID or <= 24 chars):
+quarkus.otel.resource.attributes=pinpoint.applicationName=quarkus-otel-testweb,pinpoint.agentName=quarkus-otel-testweb-001,service.instance.id=${quarkus.uuid}

--- a/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/README.md
+++ b/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/README.md
@@ -1,0 +1,46 @@
+## spring-boot3-micrometer-tracing-testweb
+
+Spring Boot 3 app that is **already instrumented with micrometer-tracing (`micrometer-tracing-bridge-otel`)**
+and sends its spans to Pinpoint by adding a second `SpanExporter` bean.
+
+- Do **not** attach the Pinpoint agent or the OpenTelemetry Java Agent (duplicate instrumentation).
+- Spring Boot collects every `SpanExporter` bean into one `BatchSpanProcessor`, so the existing backend
+  (`management.otlp.tracing.endpoint`) and Pinpoint (`pinpoint.otel.trace.endpoint`) receive the same spans.
+- The Pinpoint bean is declared as `SpanExporter`, not `OtlpGrpcSpanExporter`; otherwise Boot's
+  auto-configured OTLP exporter (`@ConditionalOnMissingBean(OtlpGrpcSpanExporter, OtlpHttpSpanExporter)`) backs off.
+- To turn off Boot's own OTLP export while keeping tracing: `management.otlp.tracing.export.enabled=false` (Boot 3.4+).
+
+### Run (JDK 17)
+
+```
+./mvnw -Pjdk17 -pl agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb package -Dmaven.test.skip=true -Dspring-boot-build-skip=false
+java -jar agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/target/pinpoint-spring-boot3-micrometer-tracing-testweb-*-exec.jar \
+  --pinpoint.otel.trace.endpoint=http://<collector>:9998 \
+  --management.otlp.tracing.endpoint=http://<existing-backend>:4317   # optional: simulates the app's existing OTLP backend
+```
+
+or run `MicrometerTracingTestApplication` in the IDE. Unlike the other testwebs the exec jar does not attach the pinpoint agent.
+
+Verified combinations (Boot 3.5.14):
+
+| flags | SpanExporter beans | export targets |
+| --- | --- | --- |
+| (default) | `pinpointSpanExporter` | 9998 |
+| `--management.otlp.tracing.endpoint=http://localhost:4317` | `otlpGrpcSpanExporter`, `pinpointSpanExporter` | 4317, 9998 |
+| `--management.otlp.tracing.endpoint=... --management.otlp.tracing.export.enabled=false` | `pinpointSpanExporter` | 9998 |
+| `--pinpoint.otel.trace.enabled=false --management.otlp.tracing.endpoint=http://localhost:9998` (property only, no code) | `otlpGrpcSpanExporter` | 9998 |
+
+### Endpoints (port 18080)
+
+| path | spans |
+| --- | --- |
+| `/helloworld` | server span |
+| `/observed` | server span + `@Observed` span |
+| `/remote` | server span -> RestClient client span -> server span (`/helloworld`) |
+| `/sleep` | server span (1s) |
+| `/throw` | server span + `@Observed` span with error (not `/error`: that path is Boot's BasicErrorController) |
+| `/actuator/beans` | check that both `otlpGrpcSpanExporter` (when an endpoint is set) and `pinpointSpanExporter` exist |
+
+If the collector is unreachable the app logs `Failed to export spans`; no such log means export succeeded.
+
+`--pinpoint.otel.trace.debug=true` additionally logs every exported span as OTLP JSON (`OtlpJsonLoggingSpanExporter`) — exactly what the collector receives.

--- a/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint-agent-testweb</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-spring-boot3-micrometer-tracing-testweb</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <jdk.version>17</jdk.version>
+        <jdk.home>${env.JAVA_17_HOME}</jdk.home>
+        <spring.version>${spring6.version}</spring.version>
+        <spring-boot.version>${spring-boot3.version}</spring-boot.version>
+        <jakarta.annotation-api.version>${jakarta.annotation-api2.version}</jakarta.annotation-api.version>
+        <jaxb.version>${jaxb4.version}</jaxb.version>
+
+        <!-- OTel SDK app: the pinpoint agent must NOT be attached (duplicate instrumentation) -->
+        <spring-boot-build-skip>true</spring-boot-build-skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- pinpoint-plugins-bom pins okhttp 3.8.1 (plugin target); the OTel OTLP sender needs okhttp 4.x -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>4.12.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+        <!-- @Observed -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+
+        <!-- Spring Boot micrometer-tracing (OpenTelemetry bridge) + OTLP exporter -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <!-- pinpoint.otel.trace.debug=true: dump exported spans as OTLP JSON to the log -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging-otlp</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- jdk 17 is required: ./mvnw -Pjdk17 -pl agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb package -Dspring-boot-build-skip=false -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>${spring-boot-build-skip}</skip>
+                    <!-- this app is instrumented by its own OTel SDK: never attach the pinpoint agent -->
+                    <agents combine.self="override"/>
+                    <jvmArguments combine.self="override"/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/MicrometerTracingTestApplication.java
+++ b/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/MicrometerTracingTestApplication.java
@@ -1,0 +1,18 @@
+package com.pinpoint.test.micrometertracing;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Spring Boot app that is already instrumented with micrometer-tracing (OpenTelemetry bridge).
+ * <p>
+ * Spans are produced by Spring Boot's own OTel SDK and exported to Pinpoint through an additional
+ * {@code SpanExporter} bean. Do NOT attach the Pinpoint agent or the OpenTelemetry Java Agent to this app.
+ */
+@SpringBootApplication
+public class MicrometerTracingTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MicrometerTracingTestApplication.class, args);
+    }
+}

--- a/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/config/ObservationConfiguration.java
+++ b/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/config/ObservationConfiguration.java
@@ -1,0 +1,19 @@
+package com.pinpoint.test.micrometertracing.config;
+
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.aop.ObservedAspect;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Enables {@code @Observed}. These spans exist only in the Observation-based SDK path,
+ * which is why the OTel bridge cannot simply be replaced by the OpenTelemetry Java Agent.
+ */
+@Configuration(proxyBeanMethods = false)
+public class ObservationConfiguration {
+
+    @Bean
+    public ObservedAspect observedAspect(ObservationRegistry observationRegistry) {
+        return new ObservedAspect(observationRegistry);
+    }
+}

--- a/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/config/PinpointSpanExporterConfiguration.java
+++ b/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/config/PinpointSpanExporterConfiguration.java
@@ -1,0 +1,43 @@
+package com.pinpoint.test.micrometertracing.config;
+
+import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingSpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Adds a second OTLP/gRPC exporter that points to the Pinpoint collector.
+ * <p>
+ * Spring Boot collects every {@link SpanExporter} bean and wires them into one BatchSpanProcessor
+ * (CompositeSpanExporter), so the existing backend keeps receiving the same spans.
+ * <p>
+ * The bean method deliberately returns {@link SpanExporter}, not {@link OtlpGrpcSpanExporter}:
+ * Boot's auto-configured OTLP exporter is {@code @ConditionalOnMissingBean(OtlpGrpcSpanExporter, OtlpHttpSpanExporter)}
+ * and would back off if this bean were declared with the concrete type.
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(PinpointTraceProperties.class)
+@ConditionalOnProperty(prefix = "pinpoint.otel.trace", name = "enabled", havingValue = "true")
+public class PinpointSpanExporterConfiguration {
+
+    @Bean
+    public SpanExporter pinpointSpanExporter(PinpointTraceProperties properties) {
+        return OtlpGrpcSpanExporter.builder()
+                .setEndpoint(properties.getEndpoint())
+                .setTimeout(properties.getTimeout())
+                .build();
+    }
+
+    /**
+     * Debug aid: logs every exported span as OTLP JSON (logger io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingSpanExporter),
+     * i.e. exactly what the Pinpoint collector receives.
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "pinpoint.otel.trace", name = "debug", havingValue = "true")
+    public SpanExporter otlpJsonLoggingSpanExporter() {
+        return OtlpJsonLoggingSpanExporter.create();
+    }
+}

--- a/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/config/PinpointTraceProperties.java
+++ b/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/config/PinpointTraceProperties.java
@@ -1,0 +1,46 @@
+package com.pinpoint.test.micrometertracing.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "pinpoint.otel.trace")
+public class PinpointTraceProperties {
+
+    /**
+     * Switch for the Pinpoint exporter. Exporters share one batch queue, so an unreachable backend
+     * delays the others as well; keep the exporter switchable.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Pinpoint collector OTLP/gRPC endpoint.
+     */
+    private String endpoint = "http://localhost:9998";
+
+    private Duration timeout = Duration.ofSeconds(10);
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Duration timeout) {
+        this.timeout = timeout;
+    }
+}

--- a/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/controller/TestController.java
+++ b/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/controller/TestController.java
@@ -1,0 +1,50 @@
+package com.pinpoint.test.micrometertracing.controller;
+
+import com.pinpoint.test.micrometertracing.service.TestService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClient;
+
+@RestController
+public class TestController {
+
+    private final TestService testService;
+    private final RestClient restClient;
+
+    public TestController(TestService testService, RestClient.Builder restClientBuilder) {
+        this.testService = testService;
+        // RestClient.Builder provided by Boot is observation-instrumented -> HTTP client span
+        this.restClient = restClientBuilder.build();
+    }
+
+    @GetMapping("/helloworld")
+    public String helloworld() {
+        return "helloworld";
+    }
+
+    @GetMapping("/observed")
+    public String observed() {
+        return "observed " + testService.observedHello();
+    }
+
+    @GetMapping("/remote")
+    public String remote() {
+        // self call: server span -> http client span -> server span (context propagated via W3C traceparent)
+        String body = restClient.get()
+                .uri("http://localhost:18080/helloworld")
+                .retrieve()
+                .body(String.class);
+        return "remote " + body;
+    }
+
+    @GetMapping("/sleep")
+    public String sleep() throws InterruptedException {
+        Thread.sleep(1000);
+        return "sleep 1000ms";
+    }
+
+    @GetMapping("/throw")
+    public String error() {
+        return testService.observedError();
+    }
+}

--- a/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/service/TestService.java
+++ b/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/java/com/pinpoint/test/micrometertracing/service/TestService.java
@@ -1,0 +1,18 @@
+package com.pinpoint.test.micrometertracing.service;
+
+import io.micrometer.observation.annotation.Observed;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestService {
+
+    @Observed(name = "test.observed", contextualName = "observed-hello")
+    public String observedHello() {
+        return "hello";
+    }
+
+    @Observed(name = "test.observed.error", contextualName = "observed-error")
+    public String observedError() {
+        throw new IllegalStateException("observed error");
+    }
+}

--- a/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/resources/application.yml
+++ b/agent-module/agent-testweb/spring-boot3-micrometer-tracing-testweb/src/main/resources/application.yml
@@ -1,0 +1,37 @@
+server:
+  port: 18080
+
+logging:
+  level:
+    root: info
+    # exporters log only on failure ("Failed to export spans"); no such log means export succeeded
+    io.opentelemetry.exporter: info
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  opentelemetry:
+    # keys contain '.' and upper-case letters -> bracket notation is mandatory
+    resource-attributes:
+      "[service.name]": micrometer-tracing-testweb
+      "[pinpoint.applicationName]": micrometer-tracing-testweb
+      "[pinpoint.agentName]": micrometer-tracing-testweb-001
+      "[service.instance.id]": ${random.uuid}
+  otlp:
+    tracing:
+      # Boot's own OTLP exporter = the "existing backend". It is created only when an endpoint is set
+      # (an empty value is NOT "unset" and breaks startup), e.g. --management.otlp.tracing.endpoint=http://localhost:4317
+      # To switch it off while keeping tracing: management.otlp.tracing.export.enabled=false (Boot 3.4+).
+      transport: grpc
+  endpoints:
+    web:
+      exposure:
+        include: health,beans
+
+# Pinpoint exporter (additional SpanExporter bean)
+pinpoint:
+  otel:
+    trace:
+      enabled: true
+      endpoint: http://localhost:9998

--- a/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/README.md
+++ b/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/README.md
@@ -1,0 +1,38 @@
+## spring-boot3-otel-starter-testweb
+
+Spring Boot 3 app instrumented with the **OpenTelemetry Spring Boot Starter** (`opentelemetry-spring-boot-starter`,
+OTel SDK autoconfigure, no javaagent). Pinpoint is added as a second exporter through an
+`AutoConfigurationCustomizerProvider` bean (guide section B).
+
+- Do **not** attach the Pinpoint agent or the OpenTelemetry Java Agent (duplicate instrumentation).
+- The starter's own exporter is configured by `otel.exporter.otlp.*`; its **default protocol is `http/protobuf`**, so
+  `otel.exporter.otlp.protocol=grpc` must be set explicitly when it points at a gRPC-only collector.
+- `RestClient.create()` is not instrumented; inject `RestClient.Builder` and build the client from it.
+
+### Run (JDK 17)
+
+```
+./mvnw -Pjdk17 -pl agent-module/agent-testweb/spring-boot3-otel-starter-testweb package -Dmaven.test.skip=true -Dspring-boot-build-skip=false
+java -jar agent-module/agent-testweb/spring-boot3-otel-starter-testweb/target/pinpoint-spring-boot3-otel-starter-testweb-*-exec.jar \
+  --pinpoint.otel.trace.endpoint=http://<collector>:9998 \
+  --otel.exporter.otlp.endpoint=http://<existing-backend>:4317
+```
+
+Unlike the other testwebs the exec jar does not attach the pinpoint agent.
+
+### Endpoints (port 18081)
+
+| path | spans |
+| --- | --- |
+| `/helloworld` | server span |
+| `/user/{id}` | server span (`http.route` template) |
+| `/observed` | server span + `@WithSpan` INTERNAL span |
+| `/remote` | server span -> RestClient client span -> server span (`/user/{id}`) |
+| `/throw` | server span + `@WithSpan` span with error |
+
+### What the collector sees (verified 2026-08-25, starter 2.28.1 / SDK 1.62 / Boot 3.5.14)
+
+- spans carry stable HTTP semconv (`http.route`, `url.path`, `http.request.method`, `http.response.status_code`),
+  so rpc template / status / method map without any key mapping.
+- the resource includes `host.*`, `os.*`, `process.*` and an auto-generated `service.instance.id` (UUID); unlike
+  Spring Boot Actuator's micrometer-tracing nothing has to be set for the agentId.

--- a/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint-agent-testweb</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-spring-boot3-otel-starter-testweb</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <jdk.version>17</jdk.version>
+        <jdk.home>${env.JAVA_17_HOME}</jdk.home>
+        <spring.version>${spring6.version}</spring.version>
+        <spring-boot.version>${spring-boot3.version}</spring-boot.version>
+        <jakarta.annotation-api.version>${jakarta.annotation-api2.version}</jakarta.annotation-api.version>
+        <jaxb.version>${jaxb4.version}</jaxb.version>
+        <opentelemetry-instrumentation.version>2.28.1</opentelemetry-instrumentation.version>
+
+        <!-- OTel SDK app: the pinpoint agent must NOT be attached (duplicate instrumentation) -->
+        <spring-boot-build-skip>true</spring-boot-build-skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- pinpoint-plugins-bom pins okhttp 3.8.1 (plugin target); the OTel OTLP sender needs okhttp 4.x -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>4.12.0</version>
+            </dependency>
+            <!-- the OTel instrumentation BOM must come before spring-boot-dependencies -->
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom</artifactId>
+                <version>${opentelemetry-instrumentation.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+
+        <!-- OpenTelemetry Spring Boot Starter (OTel SDK autoconfigure + Spring instrumentation, no javaagent) -->
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-spring-boot-starter</artifactId>
+        </dependency>
+        <!-- otel.traces.exporter=otlp,logging-otlp -> additionally dump spans as OTLP JSON -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging-otlp</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- jdk 17 is required: ./mvnw -Pjdk17 -pl agent-module/agent-testweb/spring-boot3-otel-starter-testweb package -Dspring-boot-build-skip=false -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>${spring-boot-build-skip}</skip>
+                    <!-- this app is instrumented by its own OTel SDK: never attach the pinpoint agent -->
+                    <agents combine.self="override"/>
+                    <jvmArguments combine.self="override"/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/src/main/java/com/pinpoint/test/otelstarter/OtelStarterTestApplication.java
+++ b/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/src/main/java/com/pinpoint/test/otelstarter/OtelStarterTestApplication.java
@@ -1,0 +1,19 @@
+package com.pinpoint.test.otelstarter;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Spring Boot 3 app instrumented with the OpenTelemetry Spring Boot Starter (OTel SDK autoconfigure, no javaagent).
+ * <p>
+ * The starter's own exporter is configured with {@code otel.exporter.otlp.*}; Pinpoint is added as a second exporter
+ * through an {@code AutoConfigurationCustomizerProvider} bean. Do NOT attach the Pinpoint agent or the
+ * OpenTelemetry Java Agent to this app.
+ */
+@SpringBootApplication
+public class OtelStarterTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OtelStarterTestApplication.class, args);
+    }
+}

--- a/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/src/main/java/com/pinpoint/test/otelstarter/config/PinpointExporterConfiguration.java
+++ b/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/src/main/java/com/pinpoint/test/otelstarter/config/PinpointExporterConfiguration.java
@@ -1,0 +1,26 @@
+package com.pinpoint.test.otelstarter.config;
+
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Adds a Pinpoint OTLP/gRPC exporter next to the exporter configured by {@code otel.exporter.otlp.*}.
+ * The starter picks up every {@link AutoConfigurationCustomizerProvider} bean, so both backends receive the same spans.
+ */
+@Configuration
+public class PinpointExporterConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(name = "pinpoint.otel.trace.enabled", havingValue = "true", matchIfMissing = true)
+    public AutoConfigurationCustomizerProvider pinpointExporterCustomizer() {
+        return customizer -> customizer.addTracerProviderCustomizer((builder, config) -> {
+            String endpoint = config.getString("pinpoint.otel.trace.endpoint", "http://localhost:9998");
+            OtlpGrpcSpanExporter exporter = OtlpGrpcSpanExporter.builder().setEndpoint(endpoint).build();
+            return builder.addSpanProcessor(BatchSpanProcessor.builder(exporter).build());
+        });
+    }
+}

--- a/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/src/main/java/com/pinpoint/test/otelstarter/controller/TestController.java
+++ b/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/src/main/java/com/pinpoint/test/otelstarter/controller/TestController.java
@@ -1,0 +1,50 @@
+package com.pinpoint.test.otelstarter.controller;
+
+import com.pinpoint.test.otelstarter.service.TestService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClient;
+
+@RestController
+public class TestController {
+
+    private final TestService testService;
+    private final RestClient restClient;
+
+    // RestClient.create() is NOT instrumented by the starter; the client must come from the RestClient.Builder bean
+    public TestController(TestService testService, RestClient.Builder restClientBuilder) {
+        this.testService = testService;
+        this.restClient = restClientBuilder.build();
+    }
+
+    @GetMapping("/helloworld")
+    public String helloworld() {
+        return "helloworld";
+    }
+
+    @GetMapping("/user/{id}")
+    public String user(@PathVariable("id") String id) {
+        return "user " + id;
+    }
+
+    @GetMapping("/observed")
+    public String observed() {
+        return "observed " + testService.observedHello();
+    }
+
+    @GetMapping("/remote")
+    public String remote() {
+        // self call: server span -> http client span -> server span (context propagated via W3C traceparent)
+        String body = restClient.get()
+                .uri("http://localhost:18081/user/{id}", 42)
+                .retrieve()
+                .body(String.class);
+        return "remote " + body;
+    }
+
+    @GetMapping("/throw")
+    public String error() {
+        return testService.observedError();
+    }
+}

--- a/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/src/main/java/com/pinpoint/test/otelstarter/service/TestService.java
+++ b/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/src/main/java/com/pinpoint/test/otelstarter/service/TestService.java
@@ -1,0 +1,18 @@
+package com.pinpoint.test.otelstarter.service;
+
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestService {
+
+    @WithSpan("observed-hello")
+    public String observedHello() {
+        return "hello";
+    }
+
+    @WithSpan("observed-error")
+    public String observedError() {
+        throw new IllegalStateException("observed error");
+    }
+}

--- a/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/src/main/resources/application.yml
+++ b/agent-module/agent-testweb/spring-boot3-otel-starter-testweb/src/main/resources/application.yml
@@ -1,0 +1,35 @@
+server:
+  port: 18081
+
+logging:
+  level:
+    root: info
+    # exporters log only on failure ("Failed to export spans"); no such log means export succeeded
+    io.opentelemetry.exporter: info
+
+# OpenTelemetry Spring Boot Starter (otel.* = SDK autoconfigure keys)
+otel:
+  traces:
+    # add ",logging-otlp" to also dump every exported span as OTLP JSON
+    exporter: otlp
+  metrics:
+    exporter: none
+  logs:
+    exporter: none
+  exporter:
+    otlp:
+      # the app's existing OTLP backend. Default protocol is http/protobuf (NOT grpc).
+      endpoint: http://localhost:4317
+      protocol: grpc
+  resource:
+    attributes:
+      # the starter auto-generates service.instance.id (UUID) and host/os/process resource attributes
+      pinpoint.applicationName: otel-starter-testweb
+      pinpoint.agentName: otel-starter-testweb-001
+
+# Pinpoint exporter (additional AutoConfigurationCustomizerProvider bean)
+pinpoint:
+  otel:
+    trace:
+      enabled: true
+      endpoint: http://localhost:9998

--- a/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/README.md
+++ b/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/README.md
@@ -1,0 +1,44 @@
+## spring-boot4-opentelemetry-testweb
+
+Spring Boot 4 app that is **already instrumented with `spring-boot-starter-opentelemetry`** (Micrometer Observation ->
+OTel SDK; the Boot 4 successor of `micrometer-tracing-bridge-otel` + `opentelemetry-exporter-otlp`) and sends its
+spans to Pinpoint by adding a second `SpanExporter` bean. Boot 3 counterpart: `spring-boot3-micrometer-tracing-testweb`.
+
+- Do **not** attach the Pinpoint agent or the OpenTelemetry Java Agent (duplicate instrumentation).
+- Boot 4 splits the starters: `spring-boot-starter-webmvc` / `-aspectj` (`@Observed`) / `-restclient` (`RestClient.Builder` bean).
+- OTLP keys moved to `management.opentelemetry.tracing.export.otlp.*` (Boot 3: `management.otlp.tracing.*`).
+- The Pinpoint bean is declared as `SpanExporter`, not `OtlpGrpcSpanExporter`; otherwise the OTLP exporter
+  auto-configured by Boot backs off (`@ConditionalOnMissingBean`).
+
+### Run (JDK 17)
+
+```
+./mvnw -Pjdk17 -pl agent-module/agent-testweb/spring-boot4-opentelemetry-testweb package -Dmaven.test.skip=true -Dspring-boot-build-skip=false
+java -jar agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/target/pinpoint-spring-boot4-opentelemetry-testweb-*-exec.jar \
+  --pinpoint.otel.trace.endpoint=http://<collector>:9998 \
+  --management.opentelemetry.tracing.export.otlp.endpoint=http://<existing-backend>:4317
+```
+
+Unlike the other testwebs the exec jar does not attach the pinpoint agent.
+
+### Endpoints (port 18083)
+
+| path | spans |
+| --- | --- |
+| `/helloworld` | server span |
+| `/user/{id}` | server span (`uri` template) |
+| `/observed` | server span + `@Observed` span |
+| `/remote` | server span -> RestClient client span -> server span (`/user/{id}`) |
+| `/throw` | server span + `@Observed` span with error |
+| `/actuator/beans` | check the `SpanExporter` beans |
+
+`--pinpoint.otel.trace.debug=true` additionally logs every exported span as OTLP JSON, exactly what the collector receives.
+
+### What the collector sees (verified 2026-08-25, Boot 4.1.0)
+
+- scope `org.springframework.boot` (same name as Boot 3.5) and the same **Micrometer keys** instead of OTel semconv:
+  `uri` (template), `http.url` (raw path), `method`, `status` (string), `outcome`, `exception`, client `client.name`.
+- The collector maps those keys (`OtlpMicrometerAttributes`, gated on that scope) to rpc = `uri` template and the
+  HTTP status / method annotations. Fixture: `otlptrace-collector` `spring-boot-4.1-starter-opentelemetry.pb`.
+- The resource has no `service.instance.id` / `process.*`: set `service.instance.id` yourself (`${random.uuid}` above)
+  or the collector rejects the spans.

--- a/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/pom.xml
+++ b/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.navercorp.pinpoint</groupId>
+        <artifactId>pinpoint-agent-testweb</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pinpoint-spring-boot4-opentelemetry-testweb</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <jdk.version>17</jdk.version>
+        <jdk.home>${env.JAVA_17_HOME}</jdk.home>
+        <spring.version>${spring7.version}</spring.version>
+        <spring-boot.version>${spring-boot4.version}</spring-boot.version>
+        <jakarta.annotation-api.version>${jakarta.annotation-api2.version}</jakarta.annotation-api.version>
+        <jaxb.version>${jaxb4.version}</jaxb.version>
+
+        <!-- OTel SDK app: the pinpoint agent must NOT be attached (duplicate instrumentation) -->
+        <spring-boot-build-skip>true</spring-boot-build-skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- pinpoint-plugins-bom pins okhttp 3.8.1 (plugin target); the OTel OTLP sender needs okhttp 4.x -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>4.12.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Spring Boot 4 splits the starters: webmvc / aspectj (@Observed) / restclient (RestClient.Builder bean) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aspectj</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-restclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <!-- Spring 7 logs through commons-logging (no spring-jcl any more) -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+        <!-- Boot 4: Micrometer Observation -> OTel SDK + OTLP exporter in one starter (replaces micrometer-tracing-bridge-otel + exporter) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-opentelemetry</artifactId>
+        </dependency>
+        <!-- the starter configures the exporter but does not ship the OTLP exporter jar (Boot 4.1.0) -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <!-- pinpoint.otel.trace.debug=true: dump exported spans as OTLP JSON to the log -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging-otlp</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- jdk 17 is required: ./mvnw -Pjdk17 -pl agent-module/agent-testweb/spring-boot4-opentelemetry-testweb package -Dspring-boot-build-skip=false -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+                <configuration>
+                    <skip>${spring-boot-build-skip}</skip>
+                    <!-- this app is instrumented by its own OTel SDK: never attach the pinpoint agent -->
+                    <agents combine.self="override"/>
+                    <jvmArguments combine.self="override"/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/Boot4OpenTelemetryTestApplication.java
+++ b/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/Boot4OpenTelemetryTestApplication.java
@@ -1,0 +1,18 @@
+package com.pinpoint.test.boot4otel;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Spring Boot 4 app instrumented with {@code spring-boot-starter-opentelemetry} (Micrometer Observation -> OTel SDK).
+ * <p>
+ * Spans are produced by the OTel SDK that Spring Boot configures and exported to Pinpoint through an additional
+ * {@code SpanExporter} bean. Do NOT attach the Pinpoint agent or the OpenTelemetry Java Agent to this app.
+ */
+@SpringBootApplication
+public class Boot4OpenTelemetryTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Boot4OpenTelemetryTestApplication.class, args);
+    }
+}

--- a/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/config/ObservationConfiguration.java
+++ b/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/config/ObservationConfiguration.java
@@ -1,0 +1,15 @@
+package com.pinpoint.test.boot4otel.config;
+
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.aop.ObservedAspect;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObservationConfiguration {
+
+    @Bean
+    public ObservedAspect observedAspect(ObservationRegistry observationRegistry) {
+        return new ObservedAspect(observationRegistry);
+    }
+}

--- a/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/config/PinpointSpanExporterConfiguration.java
+++ b/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/config/PinpointSpanExporterConfiguration.java
@@ -1,0 +1,35 @@
+package com.pinpoint.test.boot4otel.config;
+
+import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingSpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Additional Pinpoint exporter. Boot collects every {@link SpanExporter} bean into one BatchSpanProcessor, so the
+ * existing backend ({@code management.opentelemetry.tracing.export.otlp.endpoint}) and Pinpoint receive the same spans.
+ * <p>
+ * The bean type must be {@link SpanExporter}, not {@code OtlpGrpcSpanExporter}: the OTLP exporter auto-configured
+ * by Boot is {@code @ConditionalOnMissingBean(OtlpGrpcSpanExporter, OtlpHttpSpanExporter)} and would back off otherwise.
+ */
+@Configuration
+@EnableConfigurationProperties(PinpointTraceProperties.class)
+public class PinpointSpanExporterConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(name = "pinpoint.otel.trace.enabled", havingValue = "true", matchIfMissing = true)
+    public SpanExporter pinpointSpanExporter(PinpointTraceProperties properties) {
+        return OtlpGrpcSpanExporter.builder()
+                .setEndpoint(properties.getEndpoint())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "pinpoint.otel.trace.debug", havingValue = "true")
+    public SpanExporter otlpJsonLoggingSpanExporter() {
+        return OtlpJsonLoggingSpanExporter.create();
+    }
+}

--- a/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/config/PinpointTraceProperties.java
+++ b/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/config/PinpointTraceProperties.java
@@ -1,0 +1,35 @@
+package com.pinpoint.test.boot4otel.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "pinpoint.otel.trace")
+public class PinpointTraceProperties {
+
+    private boolean enabled = true;
+    private String endpoint = "http://localhost:9998";
+    private boolean debug = false;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public boolean isDebug() {
+        return debug;
+    }
+
+    public void setDebug(boolean debug) {
+        this.debug = debug;
+    }
+}

--- a/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/controller/TestController.java
+++ b/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/controller/TestController.java
@@ -1,0 +1,49 @@
+package com.pinpoint.test.boot4otel.controller;
+
+import com.pinpoint.test.boot4otel.service.TestService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClient;
+
+@RestController
+public class TestController {
+
+    private final TestService testService;
+    private final RestClient restClient;
+
+    public TestController(TestService testService, RestClient.Builder restClientBuilder) {
+        this.testService = testService;
+        this.restClient = restClientBuilder.build();
+    }
+
+    @GetMapping("/helloworld")
+    public String helloworld() {
+        return "helloworld";
+    }
+
+    @GetMapping("/user/{id}")
+    public String user(@PathVariable("id") String id) {
+        return "user " + id;
+    }
+
+    @GetMapping("/observed")
+    public String observed() {
+        return "observed " + testService.observedHello();
+    }
+
+    @GetMapping("/remote")
+    public String remote() {
+        // self call: server span -> http client span -> server span (context propagated via W3C traceparent)
+        String body = restClient.get()
+                .uri("http://localhost:18083/user/{id}", 42)
+                .retrieve()
+                .body(String.class);
+        return "remote " + body;
+    }
+
+    @GetMapping("/throw")
+    public String error() {
+        return testService.observedError();
+    }
+}

--- a/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/service/TestService.java
+++ b/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/java/com/pinpoint/test/boot4otel/service/TestService.java
@@ -1,0 +1,18 @@
+package com.pinpoint.test.boot4otel.service;
+
+import io.micrometer.observation.annotation.Observed;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestService {
+
+    @Observed(name = "test.observed", contextualName = "observed-hello")
+    public String observedHello() {
+        return "hello";
+    }
+
+    @Observed(name = "test.observed.error", contextualName = "observed-error")
+    public String observedError() {
+        throw new IllegalStateException("observed error");
+    }
+}

--- a/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/resources/application.yml
+++ b/agent-module/agent-testweb/spring-boot4-opentelemetry-testweb/src/main/resources/application.yml
@@ -1,0 +1,39 @@
+server:
+  port: 18083
+
+logging:
+  level:
+    root: info
+    # exporters log only on failure ("Failed to export spans"); no such log means export succeeded
+    io.opentelemetry.exporter: info
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  opentelemetry:
+    # keys contain '.' and upper-case letters -> bracket notation is mandatory
+    resource-attributes:
+      "[service.name]": boot4-otel-testweb
+      "[pinpoint.applicationName]": boot4-otel-testweb
+      "[pinpoint.agentName]": boot4-otel-testweb-001
+      # Boot does not generate service.instance.id; without it the collector rejects the spans
+      "[service.instance.id]": ${random.uuid}
+    tracing:
+      export:
+        otlp:
+          # Boot 4 moved the OTLP keys here (Boot 3: management.otlp.tracing.*). The exporter auto-configured by Boot is
+          # created only when an endpoint is set, e.g. --management.opentelemetry.tracing.export.otlp.endpoint=http://localhost:4317
+          transport: grpc
+  endpoints:
+    web:
+      exposure:
+        include: health,beans
+
+# Pinpoint exporter (additional SpanExporter bean)
+pinpoint:
+  otel:
+    trace:
+      enabled: true
+      endpoint: http://localhost:9998
+      debug: false


### PR DESCRIPTION
… without the agent

Sample apps that are instrumented by their framework's own OpenTelemetry SDK and send spans to the Pinpoint OTLP trace collector. The exec jars do not attach the pinpoint agent (duplicate instrumentation). They are the apps the OTLP key-mapping work in otlptrace-collector was verified against, and each README records what the collector sees.

- spring-boot3-micrometer-tracing-testweb: Boot 3 actuator + micrometer-tracing-bridge-otel, Pinpoint added as a second SpanExporter bean (declared as SpanExporter so Boot's own OTLP exporter is not backed off); pinpoint.otel.trace.{enabled,endpoint,debug} properties
- spring-boot3-otel-starter-testweb: OpenTelemetry Spring Boot Starter, Pinpoint added through an AutoConfigurationCustomizerProvider bean
- spring-boot4-opentelemetry-testweb: spring-boot-starter-opentelemetry (Micrometer keys, scope org.springframework.boot), extra SpanExporter bean
- quarkus-opentelemetry-testweb: quarkus-opentelemetry, stable semconv; service.instance.id set explicitly (Quarkus resource has none)
- micronaut-opentelemetry-testweb: micronaut-tracing-opentelemetry-http, stable semconv; service.instance.id is mandatory (default resource has no per-instance identifier, the collector rejects the spans otherwise)

The Boot modules join the jdk17 profile. Quarkus and Micronaut are in a new otel-framework-testweb profile (off by default): they bring their own build plugins and Micronaut 5 needs JDK 25 for Maven itself. Parent BOM pins overridden per module: okhttp 4.x (Boot, plugins-bom pins 3.8.1), jakarta.transaction-api 2.0.1 (Quarkus), netty4.version 4.2.x (Micronaut).