### PR TITLE
Scope the realtime active thread panel to the node's own service

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/atoms/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/serverMap.ts
@@ -88,6 +88,28 @@ export const currentNodeStatisticsAtom = atom<GetHistogramStatistics.Response | 
   undefined,
 );
 
+/**
+ * 실시간 activeThreadCount(WebSocket)의 조회 대상.
+ *
+ * 핀(잠금)이 걸려 있으면 map에서 다른 노드를 골라도 이 대상은 그대로다. 컴포넌트 안에 두면
+ * 다른 화면에 다녀오는 것만으로 사라져(브라우저 탭 전환도 포함된다 — `useTabFocus`가 패널을
+ * 통째로 내린다), 돌아왔을 때 핀은 그대로 꽂혀 있는데 대상만 지금 고른 노드로 바뀐다.
+ * 소켓이 다시 연결되면 떠나기 전에 보고 있던 application을 그대로 이어 보라고 아톰에 둔다.
+ *
+ * `path`는 이 대상을 고른 화면의 경로다. 경로에는 service와 기준 application이 실려 있으므로,
+ * 경로가 다르면 다른 화면을 보고 있는 것이라 고정해 둔 대상도 무효다. (아톰은 전역이라
+ * 화면 remount로 지워지지 않는다. 이 비교가 없으면 다른 application의 실시간 화면에 들어가도
+ * 이전 application의 수치를 보여준다.)
+ */
+export type ActiveThreadTarget = {
+  path: string;
+  applicationName: string;
+  serviceName?: string;
+  serviceType?: string;
+};
+
+export const activeThreadTargetAtom = atom<ActiveThreadTarget | undefined>(undefined);
+
 // server-list 선택시
 export const currentServerAtom = atom<AgentOverview.Instance | undefined>(undefined);
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { AgentActiveThread, GetServerMap } from '@pinpoint-fe/ui/src/constants';
+import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { AgentActiveThreadView } from './AgentActiveThreadView';
 import { useLocation } from 'react-router-dom';
 import { useAtom, useAtomValue } from 'jotai';
@@ -10,6 +10,7 @@ import {
   serverMapCurrentTargetDataAtom,
 } from '@pinpoint-fe/ui/src/atoms';
 import { AgentActiveThreadSkeleton } from './AgentActiveThreadSkeleton';
+import { useActiveThreadSocket } from './useActiveThreadSocket';
 import {
   Tooltip,
   TooltipContent,
@@ -38,37 +39,17 @@ export interface AgentActiveThreadFetcherProps {
   serviceName?: string;
 }
 
-/**
- * 끊긴 소켓을 다시 붙이기까지 기다리는 시간(ms). 시도할수록 늘리고 마지막 값에서 멈춘다.
- *
- * 서버가 요청을 거절하며 곧바로 끊는 경우가 있다(모르는 serviceName이면
- * `ActiveThreadCountHandler`가 BAD_DATA로 세션을 닫는다). 이때 지체 없이 다시 붙으면
- * 연결→요청→끊김이 쉼 없이 반복되며 서버와 브라우저를 함께 태운다.
- *
- * 간격을 되돌리는 기준은 "연결됐다"가 아니라 "응답이 왔다"이다. 거절당하는 세션도 open까지는
- * 정상으로 열리므로, open에서 되돌리면 간격이 1초에 묶인 채 영원히 반복된다.
- */
-const RECONNECT_DELAYS_MS = [1000, 2000, 5000, 10000, 30000];
-
 export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetcherProps) => {
   const { t } = useTranslation();
-  const wsRef = React.useRef<WebSocket | undefined>(undefined);
-  const reconnectTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const reconnectCountRef = React.useRef(0);
-  // 화면을 떠났는지 여부. 떠날 때 부르는 close()도 close 이벤트를 일으키므로, 이 표시가 없으면
-  // 사라진 화면이 소켓을 다시 열고 그 소켓은 아무도 닫지 않는다.
-  const isUnmountedRef = React.useRef(false);
   const [timezone] = useTimezone();
-  const [webSocketState, setWebSocketState] = React.useState<number>(WebSocket.CLOSED);
   const currentServerMapTarget = useAtomValue(serverMapCurrentTargetAtom);
   const { pathname } = useLocation();
   const [storedTarget, setStoredTarget] = useAtom(activeThreadTargetAtom);
   // 다른 화면에서 고정해 둔 대상은 이 화면의 것이 아니다. 경로가 같을 때만 이어 쓴다.
   const target = storedTarget?.path === pathname ? storedTarget : undefined;
+  const { webSocketState, activeThreadCounts } = useActiveThreadSocket(target);
   const applicationName = currentServerMapTarget?.applicationName || '';
   const serviceType = currentServerMapTarget?.serviceType;
-  // const { activeThreadCountsWithTotal, setActiveThreadCounts } = useActiveThread();
-  const [activeThreadCounts, setActiveThreadCounts] = React.useState<AgentActiveThread.Response>();
   const [isApplicationLocked, setApplicationLock] = React.useState(true);
   const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom) as GetServerMap.NodeData;
   const [showSetting, setShowSetting] = React.useState(false);
@@ -84,17 +65,6 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
   const hasTarget = !!(applicationName || target?.applicationName);
 
   React.useEffect(() => {
-    isUnmountedRef.current = false;
-    initWebSocket();
-
-    return () => {
-      isUnmountedRef.current = true;
-      clearTimeout(reconnectTimerRef.current);
-      close();
-    };
-  }, []);
-
-  React.useEffect(() => {
     if (!applicationName) {
       return;
     }
@@ -103,8 +73,8 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
     if (isApplicationLocked && target) {
       return;
     }
-    // 값이 그대로면 새로 담지 않는다. 담으면 참조가 바뀌어 아래 effect가 다시 돌고, 같은
-    // application에 같은 요청을 한 번 더 보내게 된다(핀만 껐다 켠 경우).
+    // 값이 그대로면 새로 담지 않는다. 담으면 참조가 바뀌어 소켓 훅이 대상이 바뀐 것으로 보고,
+    // 같은 application에 같은 요청을 한 번 더 보내게 된다(핀만 껐다 켠 경우).
     if (
       target?.applicationName === applicationName &&
       target?.serviceName === serviceName &&
@@ -123,107 +93,6 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
     target,
     setStoredTarget,
   ]);
-
-  React.useEffect(() => {
-    const isSocketOpen = wsRef.current?.readyState === WebSocket.OPEN;
-
-    if (target?.applicationName && isSocketOpen) {
-      sendMessage({
-        type: 'REQUEST',
-        command: 'activeThreadCount',
-        parameters: {
-          applicationName: target.applicationName,
-          // 키 이름은 백엔드가 정한 것을 그대로 쓴다
-          // (ActiveThreadCountHandler의 SERVICE_NAME_KEY / SERVICE_TYPE_NAME_KEY).
-          // enableServiceMap이 꺼져 있으면 serviceName이 undefined로 들어오므로
-          // (useServerMapTargetServiceName이 한 곳에서 막는다) 파라미터도 붙지 않는다.
-          // 설정이 꺼진 저장소에는 지금까지와 똑같은 요청이 나간다(백엔드도 DEFAULT로 해석한다).
-          ...(target.serviceName
-            ? { serviceName: target.serviceName, serviceTypeName: target.serviceType }
-            : {}),
-        },
-      });
-    }
-  }, [target, wsRef.current?.readyState]);
-
-  const initWebSocket = () => {
-    const location = window.location;
-    const protocol = location.protocol.indexOf('https') === -1 ? 'ws' : 'wss';
-    const url = `${protocol}://${location.host}/api/agent/activeThread`;
-    const eventController = new AbortController();
-    const { signal } = eventController;
-    const ws = new WebSocket(url);
-    wsRef.current = ws;
-
-    ws.addEventListener(
-      'open',
-      () => {
-        setWebSocketState(WebSocket.CONNECTING);
-        // setSocketOpen(true);
-      },
-      { signal },
-    );
-    ws.addEventListener(
-      'message',
-      (message) => {
-        const parsedMessage = parseMessage(message.data);
-        // 응답이 왔다는 것은 이 세션이 실제로 살아 있다는 뜻이다. 다음에 끊기면 처음 간격부터.
-        reconnectCountRef.current = 0;
-        if (parsedMessage?.type === 'PING') {
-          sendMessage({ type: 'PONG' });
-        } else if (parsedMessage?.result) {
-          setWebSocketState(WebSocket.OPEN);
-          setActiveThreadCounts(parsedMessage);
-        }
-      },
-      { signal },
-    );
-    ws.addEventListener(
-      'close',
-      () => {
-        eventController.abort();
-        // 화면을 떠나며 부른 close()도 여기로 온다. 그때 다시 붙으면 사라진 화면의 소켓이
-        // 남아 아무도 닫지 못한 채 재연결을 반복한다.
-        if (isUnmountedRef.current) {
-          return;
-        }
-
-        setWebSocketState(WebSocket.CLOSED);
-        scheduleReconnect();
-        // wsRef.current = undefined;
-      },
-      { signal },
-    );
-  };
-
-  const scheduleReconnect = () => {
-    const delay =
-      RECONNECT_DELAYS_MS[Math.min(reconnectCountRef.current, RECONNECT_DELAYS_MS.length - 1)];
-    reconnectCountRef.current += 1;
-    reconnectTimerRef.current = setTimeout(() => {
-      if (isUnmountedRef.current) {
-        return;
-      }
-      initWebSocket();
-    }, delay);
-  };
-
-  const parseMessage = (message: string): AgentActiveThread.Response => {
-    try {
-      return JSON.parse(message);
-    } catch (error) {
-      console.error('Error parsing message:', error);
-      return {};
-    }
-  };
-
-  const sendMessage = (message: AgentActiveThread.Request) => {
-    wsRef.current?.send(JSON.stringify(message));
-  };
-
-  const close = () => {
-    wsRef.current?.close();
-  };
 
   return (
     <div className="w-full h-full">

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
@@ -24,14 +24,39 @@ import { useTimezone } from '@pinpoint-fe/ui/src/hooks';
 
 export interface ActiveRequestProps {}
 
-export const AgentActiveThreadFetcher = () => {
+export interface AgentActiveThreadFetcherProps {
+  /**
+   * 조회 대상 노드가 소속된 service.
+   *
+   * servicemap은 다른 service의 노드도 함께 그리므로, 조회는 화면의 service가 아니라 고른
+   * 노드의 service로 나가야 한다. 값은 `useServerMapTargetServiceName`에서 오고, 그 훅이
+   * `enableServiceMap`이 꺼져 있으면 undefined를 돌려주므로 설정이 꺼진 저장소에서는 항상
+   * undefined다.
+   */
+  serviceName?: string;
+}
+
+/**
+ * activeThreadCount 요청의 조회 대상.
+ *
+ * 세 값을 한 객체로 묶어 둔다. applicationName만 따로 고정하면 잠금(lock) 상태에서 이름은
+ * 그대로인데 service만 새로 고른 노드를 따라가, 그 service에 없는 application을 묻게 된다.
+ */
+type ActiveThreadTarget = {
+  applicationName: string;
+  serviceName?: string;
+  serviceType?: string;
+};
+
+export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetcherProps) => {
   const { t } = useTranslation();
   const wsRef = React.useRef<WebSocket | undefined>(undefined);
   const [timezone] = useTimezone();
   const [webSocketState, setWebSocketState] = React.useState<number>(WebSocket.CLOSED);
   const currentServerMapTarget = useAtomValue(serverMapCurrentTargetAtom);
-  const applicationNameRef = React.useRef('');
+  const targetRef = React.useRef<ActiveThreadTarget>({ applicationName: '' });
   const applicationName = currentServerMapTarget?.applicationName || '';
+  const serviceType = currentServerMapTarget?.serviceType;
   // const { activeThreadCountsWithTotal, setActiveThreadCounts } = useActiveThread();
   const [activeThreadCounts, setActiveThreadCounts] = React.useState<AgentActiveThread.Response>();
   const [isApplicationLocked, setApplicationLock] = React.useState(true);
@@ -46,7 +71,7 @@ export const AgentActiveThreadFetcher = () => {
    * 하는지 알려준다. (기준 application이 없는 servicemap 실시간 보기에서 아직 노드를 고르지
    * 않은 상태가 여기에 해당한다.)
    */
-  const hasTarget = !!(applicationName || applicationNameRef.current);
+  const hasTarget = !!(applicationName || targetRef.current.applicationName);
 
   React.useEffect(() => {
     initWebSocket();
@@ -57,24 +82,40 @@ export const AgentActiveThreadFetcher = () => {
   }, []);
 
   React.useEffect(() => {
-    if ((applicationName && !isApplicationLocked) || applicationNameRef.current === '') {
-      applicationNameRef.current = applicationName;
+    if ((applicationName && !isApplicationLocked) || targetRef.current.applicationName === '') {
+      // 세 값을 한 번에 갈아 끼운다. 아래 effect는 객체가 아니라 값 하나하나를 비교하므로,
+      // 핀만 껐다 켠 경우처럼 내용이 그대로면 요청을 다시 보내지 않는다.
+      targetRef.current = { applicationName, serviceName, serviceType };
     }
-  }, [applicationName, isApplicationLocked]);
+  }, [applicationName, serviceName, serviceType, isApplicationLocked]);
 
   React.useEffect(() => {
     const isSocketOpen = wsRef.current?.readyState === WebSocket.OPEN;
+    const target = targetRef.current;
 
-    if (applicationNameRef.current && isSocketOpen) {
+    if (target.applicationName && isSocketOpen) {
       sendMessage({
         type: 'REQUEST',
         command: 'activeThreadCount',
         parameters: {
-          applicationName: applicationNameRef.current,
+          applicationName: target.applicationName,
+          // 키 이름은 백엔드가 정한 것을 그대로 쓴다
+          // (ActiveThreadCountHandler의 SERVICE_NAME_KEY / SERVICE_TYPE_NAME_KEY).
+          // enableServiceMap이 꺼져 있으면 serviceName이 undefined로 들어오므로
+          // (useServerMapTargetServiceName이 한 곳에서 막는다) 파라미터도 붙지 않는다.
+          // 설정이 꺼진 저장소에는 지금까지와 똑같은 요청이 나간다(백엔드도 DEFAULT로 해석한다).
+          ...(target.serviceName
+            ? { serviceName: target.serviceName, serviceTypeName: target.serviceType }
+            : {}),
         },
       });
     }
-  }, [applicationNameRef.current, wsRef.current?.readyState]);
+  }, [
+    targetRef.current.applicationName,
+    targetRef.current.serviceName,
+    targetRef.current.serviceType,
+    wsRef.current?.readyState,
+  ]);
 
   const initWebSocket = () => {
     const location = window.location;
@@ -167,7 +208,7 @@ export const AgentActiveThreadFetcher = () => {
                 </Tooltip>
               </TooltipProvider>
               <div className="flex flex-row gap-1 w-full truncate">
-                {applicationNameRef.current}
+                {targetRef.current.applicationName}
                 <HelpPopover helpKey="HELP_VIEWER.REAL_TIME" />
               </div>
               <div className="flex gap-1 items-center font-normal text-gray-400">
@@ -186,7 +227,7 @@ export const AgentActiveThreadFetcher = () => {
             </div>
             <div className="flex flex-grow w-full h-[-webkit-fill-available] overflow-hidden">
               <AgentActiveThreadView
-                applicationName={applicationNameRef.current}
+                applicationName={targetRef.current.applicationName}
                 activeThreadCounts={activeThreadCounts?.result}
                 setting={setting}
               />

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { AgentActiveThread, GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { AgentActiveThreadView } from './AgentActiveThreadView';
-import { useAtomValue } from 'jotai';
+import { useLocation } from 'react-router-dom';
+import { useAtom, useAtomValue } from 'jotai';
 import {
+  activeThreadTargetAtom,
   serverMapCurrentTargetAtom,
   serverMapCurrentTargetDataAtom,
 } from '@pinpoint-fe/ui/src/atoms';
@@ -36,25 +38,16 @@ export interface AgentActiveThreadFetcherProps {
   serviceName?: string;
 }
 
-/**
- * activeThreadCount 요청의 조회 대상.
- *
- * 세 값을 한 객체로 묶어 둔다. applicationName만 따로 고정하면 잠금(lock) 상태에서 이름은
- * 그대로인데 service만 새로 고른 노드를 따라가, 그 service에 없는 application을 묻게 된다.
- */
-type ActiveThreadTarget = {
-  applicationName: string;
-  serviceName?: string;
-  serviceType?: string;
-};
-
 export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetcherProps) => {
   const { t } = useTranslation();
   const wsRef = React.useRef<WebSocket | undefined>(undefined);
   const [timezone] = useTimezone();
   const [webSocketState, setWebSocketState] = React.useState<number>(WebSocket.CLOSED);
   const currentServerMapTarget = useAtomValue(serverMapCurrentTargetAtom);
-  const targetRef = React.useRef<ActiveThreadTarget>({ applicationName: '' });
+  const { pathname } = useLocation();
+  const [storedTarget, setStoredTarget] = useAtom(activeThreadTargetAtom);
+  // 다른 화면에서 고정해 둔 대상은 이 화면의 것이 아니다. 경로가 같을 때만 이어 쓴다.
+  const target = storedTarget?.path === pathname ? storedTarget : undefined;
   const applicationName = currentServerMapTarget?.applicationName || '';
   const serviceType = currentServerMapTarget?.serviceType;
   // const { activeThreadCountsWithTotal, setActiveThreadCounts } = useActiveThread();
@@ -71,7 +64,7 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
    * 하는지 알려준다. (기준 application이 없는 servicemap 실시간 보기에서 아직 노드를 고르지
    * 않은 상태가 여기에 해당한다.)
    */
-  const hasTarget = !!(applicationName || targetRef.current.applicationName);
+  const hasTarget = !!(applicationName || target?.applicationName);
 
   React.useEffect(() => {
     initWebSocket();
@@ -82,18 +75,39 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
   }, []);
 
   React.useEffect(() => {
-    if ((applicationName && !isApplicationLocked) || targetRef.current.applicationName === '') {
-      // 세 값을 한 번에 갈아 끼운다. 아래 effect는 객체가 아니라 값 하나하나를 비교하므로,
-      // 핀만 껐다 켠 경우처럼 내용이 그대로면 요청을 다시 보내지 않는다.
-      targetRef.current = { applicationName, serviceName, serviceType };
+    if (!applicationName) {
+      return;
     }
-  }, [applicationName, serviceName, serviceType, isApplicationLocked]);
+    // 핀이 걸려 있으면 map에서 다른 노드를 골라도 조회 대상은 그대로다. 아직 대상이 없을 때
+    // (이 화면에 처음 들어왔거나 다른 화면의 대상만 남아 있을 때)만 지금 고른 노드로 정한다.
+    if (isApplicationLocked && target) {
+      return;
+    }
+    // 값이 그대로면 새로 담지 않는다. 담으면 참조가 바뀌어 아래 effect가 다시 돌고, 같은
+    // application에 같은 요청을 한 번 더 보내게 된다(핀만 껐다 켠 경우).
+    if (
+      target?.applicationName === applicationName &&
+      target?.serviceName === serviceName &&
+      target?.serviceType === serviceType
+    ) {
+      return;
+    }
+
+    setStoredTarget({ path: pathname, applicationName, serviceName, serviceType });
+  }, [
+    pathname,
+    applicationName,
+    serviceName,
+    serviceType,
+    isApplicationLocked,
+    target,
+    setStoredTarget,
+  ]);
 
   React.useEffect(() => {
     const isSocketOpen = wsRef.current?.readyState === WebSocket.OPEN;
-    const target = targetRef.current;
 
-    if (target.applicationName && isSocketOpen) {
+    if (target?.applicationName && isSocketOpen) {
       sendMessage({
         type: 'REQUEST',
         command: 'activeThreadCount',
@@ -110,12 +124,7 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
         },
       });
     }
-  }, [
-    targetRef.current.applicationName,
-    targetRef.current.serviceName,
-    targetRef.current.serviceType,
-    wsRef.current?.readyState,
-  ]);
+  }, [target, wsRef.current?.readyState]);
 
   const initWebSocket = () => {
     const location = window.location;
@@ -208,7 +217,7 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
                 </Tooltip>
               </TooltipProvider>
               <div className="flex flex-row gap-1 w-full truncate">
-                {targetRef.current.applicationName}
+                {target?.applicationName}
                 <HelpPopover helpKey="HELP_VIEWER.REAL_TIME" />
               </div>
               <div className="flex gap-1 items-center font-normal text-gray-400">
@@ -227,7 +236,7 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
             </div>
             <div className="flex flex-grow w-full h-[-webkit-fill-available] overflow-hidden">
               <AgentActiveThreadView
-                applicationName={targetRef.current.applicationName}
+                applicationName={target?.applicationName}
                 activeThreadCounts={activeThreadCounts?.result}
                 setting={setting}
               />

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
@@ -38,9 +38,26 @@ export interface AgentActiveThreadFetcherProps {
   serviceName?: string;
 }
 
+/**
+ * 끊긴 소켓을 다시 붙이기까지 기다리는 시간(ms). 시도할수록 늘리고 마지막 값에서 멈춘다.
+ *
+ * 서버가 요청을 거절하며 곧바로 끊는 경우가 있다(모르는 serviceName이면
+ * `ActiveThreadCountHandler`가 BAD_DATA로 세션을 닫는다). 이때 지체 없이 다시 붙으면
+ * 연결→요청→끊김이 쉼 없이 반복되며 서버와 브라우저를 함께 태운다.
+ *
+ * 간격을 되돌리는 기준은 "연결됐다"가 아니라 "응답이 왔다"이다. 거절당하는 세션도 open까지는
+ * 정상으로 열리므로, open에서 되돌리면 간격이 1초에 묶인 채 영원히 반복된다.
+ */
+const RECONNECT_DELAYS_MS = [1000, 2000, 5000, 10000, 30000];
+
 export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetcherProps) => {
   const { t } = useTranslation();
   const wsRef = React.useRef<WebSocket | undefined>(undefined);
+  const reconnectTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const reconnectCountRef = React.useRef(0);
+  // 화면을 떠났는지 여부. 떠날 때 부르는 close()도 close 이벤트를 일으키므로, 이 표시가 없으면
+  // 사라진 화면이 소켓을 다시 열고 그 소켓은 아무도 닫지 않는다.
+  const isUnmountedRef = React.useRef(false);
   const [timezone] = useTimezone();
   const [webSocketState, setWebSocketState] = React.useState<number>(WebSocket.CLOSED);
   const currentServerMapTarget = useAtomValue(serverMapCurrentTargetAtom);
@@ -67,9 +84,12 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
   const hasTarget = !!(applicationName || target?.applicationName);
 
   React.useEffect(() => {
+    isUnmountedRef.current = false;
     initWebSocket();
 
     return () => {
+      isUnmountedRef.current = true;
+      clearTimeout(reconnectTimerRef.current);
       close();
     };
   }, []);
@@ -147,6 +167,8 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
       'message',
       (message) => {
         const parsedMessage = parseMessage(message.data);
+        // 응답이 왔다는 것은 이 세션이 실제로 살아 있다는 뜻이다. 다음에 끊기면 처음 간격부터.
+        reconnectCountRef.current = 0;
         if (parsedMessage?.type === 'PING') {
           sendMessage({ type: 'PONG' });
         } else if (parsedMessage?.result) {
@@ -159,13 +181,31 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
     ws.addEventListener(
       'close',
       () => {
-        setWebSocketState(WebSocket.CLOSED);
         eventController.abort();
-        initWebSocket();
+        // 화면을 떠나며 부른 close()도 여기로 온다. 그때 다시 붙으면 사라진 화면의 소켓이
+        // 남아 아무도 닫지 못한 채 재연결을 반복한다.
+        if (isUnmountedRef.current) {
+          return;
+        }
+
+        setWebSocketState(WebSocket.CLOSED);
+        scheduleReconnect();
         // wsRef.current = undefined;
       },
       { signal },
     );
+  };
+
+  const scheduleReconnect = () => {
+    const delay =
+      RECONNECT_DELAYS_MS[Math.min(reconnectCountRef.current, RECONNECT_DELAYS_MS.length - 1)];
+    reconnectCountRef.current += 1;
+    reconnectTimerRef.current = setTimeout(() => {
+      if (isUnmountedRef.current) {
+        return;
+      }
+      initWebSocket();
+    }, delay);
   };
 
   const parseMessage = (message: string): AgentActiveThread.Response => {

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/useActiveThreadSocket.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/useActiveThreadSocket.ts
@@ -1,0 +1,145 @@
+import React from 'react';
+import { AgentActiveThread } from '@pinpoint-fe/ui/src/constants';
+import { ActiveThreadTarget } from '@pinpoint-fe/ui/src/atoms';
+
+/**
+ * 끊긴 소켓을 다시 붙이기까지 기다리는 시간(ms). 시도할수록 늘리고 마지막 값에서 멈춘다.
+ *
+ * 서버가 요청을 거절하며 곧바로 끊는 경우가 있다(모르는 serviceName이면
+ * `ActiveThreadCountHandler`가 BAD_DATA로 세션을 닫는다). 이때 지체 없이 다시 붙으면
+ * 연결→요청→끊김이 쉼 없이 반복되며 서버와 브라우저를 함께 태운다.
+ *
+ * 간격을 되돌리는 기준은 "연결됐다"가 아니라 "응답이 왔다"이다. 거절당하는 세션도 open까지는
+ * 정상으로 열리므로, open에서 되돌리면 간격이 1초에 묶인 채 영원히 반복된다.
+ */
+const RECONNECT_DELAYS_MS = [1000, 2000, 5000, 10000, 30000];
+
+/**
+ * activeThreadCount WebSocket 하나를 열고 대상의 수치를 받아 온다.
+ *
+ * 대상(`target`)이 바뀌면 그 대상으로 다시 요청하고, 끊기면 간격을 늘려 가며 다시 붙는다.
+ * 화면(`AgentActiveThreadFetcher`)은 무엇을 조회할지만 정하고, 소켓의 생애는 여기서 끝난다.
+ */
+export const useActiveThreadSocket = (target?: ActiveThreadTarget) => {
+  const wsRef = React.useRef<WebSocket | undefined>(undefined);
+  const reconnectTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const reconnectCountRef = React.useRef(0);
+  // 화면을 떠났는지 여부. 떠날 때 부르는 close()도 close 이벤트를 일으키므로, 이 표시가 없으면
+  // 사라진 화면이 소켓을 다시 열고 그 소켓은 아무도 닫지 않는다.
+  const isUnmountedRef = React.useRef(false);
+  const [webSocketState, setWebSocketState] = React.useState<number>(WebSocket.CLOSED);
+  const [activeThreadCounts, setActiveThreadCounts] = React.useState<AgentActiveThread.Response>();
+
+  React.useEffect(() => {
+    isUnmountedRef.current = false;
+    initWebSocket();
+
+    return () => {
+      isUnmountedRef.current = true;
+      clearTimeout(reconnectTimerRef.current);
+      close();
+    };
+  }, []);
+
+  React.useEffect(() => {
+    const isSocketOpen = wsRef.current?.readyState === WebSocket.OPEN;
+
+    if (target?.applicationName && isSocketOpen) {
+      sendMessage({
+        type: 'REQUEST',
+        command: 'activeThreadCount',
+        parameters: {
+          applicationName: target.applicationName,
+          // 키 이름은 백엔드가 정한 것을 그대로 쓴다
+          // (ActiveThreadCountHandler의 SERVICE_NAME_KEY / SERVICE_TYPE_NAME_KEY).
+          // enableServiceMap이 꺼져 있으면 serviceName이 undefined로 들어오므로
+          // (useServerMapTargetServiceName이 한 곳에서 막는다) 파라미터도 붙지 않는다.
+          // 설정이 꺼진 저장소에는 지금까지와 똑같은 요청이 나간다(백엔드도 DEFAULT로 해석한다).
+          ...(target.serviceName
+            ? { serviceName: target.serviceName, serviceTypeName: target.serviceType }
+            : {}),
+        },
+      });
+    }
+  }, [target, wsRef.current?.readyState]);
+
+  function initWebSocket() {
+    const location = window.location;
+    const protocol = location.protocol.indexOf('https') === -1 ? 'ws' : 'wss';
+    const url = `${protocol}://${location.host}/api/agent/activeThread`;
+    const eventController = new AbortController();
+    const { signal } = eventController;
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+
+    ws.addEventListener(
+      'open',
+      () => {
+        setWebSocketState(WebSocket.CONNECTING);
+      },
+      { signal },
+    );
+    ws.addEventListener('message', (message) => handleMessage(message.data), { signal });
+    ws.addEventListener(
+      'close',
+      () => {
+        eventController.abort();
+        // 화면을 떠나며 부른 close()도 여기로 온다. 그때 다시 붙으면 사라진 화면의 소켓이
+        // 남아 아무도 닫지 못한 채 재연결을 반복한다.
+        if (isUnmountedRef.current) {
+          return;
+        }
+
+        setWebSocketState(WebSocket.CLOSED);
+        scheduleReconnect();
+      },
+      { signal },
+    );
+  }
+
+  function handleMessage(data: string) {
+    const parsedMessage = parseMessage(data);
+    // 응답이 왔다는 것은 이 세션이 실제로 살아 있다는 뜻이다. 다음에 끊기면 처음 간격부터.
+    reconnectCountRef.current = 0;
+
+    if (parsedMessage?.type === 'PING') {
+      sendMessage({ type: 'PONG' });
+      return;
+    }
+    if (parsedMessage?.result) {
+      setWebSocketState(WebSocket.OPEN);
+      setActiveThreadCounts(parsedMessage);
+    }
+  }
+
+  function scheduleReconnect() {
+    const delay =
+      RECONNECT_DELAYS_MS[Math.min(reconnectCountRef.current, RECONNECT_DELAYS_MS.length - 1)];
+    reconnectCountRef.current += 1;
+    reconnectTimerRef.current = setTimeout(() => {
+      if (isUnmountedRef.current) {
+        return;
+      }
+      initWebSocket();
+    }, delay);
+  }
+
+  function parseMessage(message: string): AgentActiveThread.Response {
+    try {
+      return JSON.parse(message);
+    } catch (error) {
+      console.error('Error parsing message:', error);
+      return {};
+    }
+  }
+
+  function sendMessage(message: AgentActiveThread.Request) {
+    wsRef.current?.send(JSON.stringify(message));
+  }
+
+  function close() {
+    wsRef.current?.close();
+  }
+
+  return { webSocketState, activeThreadCounts };
+};

--- a/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
@@ -137,7 +137,7 @@ export const Realtime = ({ MapView = ServerMap, requiresApplication = true }: Re
             <ResizablePanel minSize={10} maxSize={90} className="!overflow-auto">
               {isFocus && (
                 <ErrorBoundary>
-                  <AgentActiveThreadFetcher />
+                  <AgentActiveThreadFetcher serviceName={targetServiceName} />
                 </ErrorBoundary>
               )}
             </ResizablePanel>

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
@@ -15,6 +15,8 @@ import {
 } from '@pinpoint-fe/ui/src/hooks';
 import { useTranslation } from 'react-i18next';
 import {
+  findServiceGroupLink,
+  findServiceGroupNode,
   flattenServiceMapResponse,
   getBaseNodeId,
   getServerImagePath,
@@ -72,9 +74,17 @@ export const ServiceMapFetcher = ({ shouldPoll, ...props }: ServiceMapFetcherPro
     setDataAtom(data);
   }, [data]);
 
-  const handleClickNode: ServerMapCoreProps['onClickNode'] = ({ data, eventType }) => {
-    const { label, type, imgPath, id, nodes } = data as MergedNode;
+  const handleClickNode: ServerMapCoreProps['onClickNode'] = ({ data: clickedData, eventType }) => {
+    const { label, type, imgPath, id, nodes } = clickedData as MergedNode;
     if (eventType === 'left' || eventType === 'programmatic') {
+      // service group(접힌 service) 노드는 그 자체로 조회 대상이 될 수 없다. 좌클릭은 자식
+      // application 목록 팝업을 열 뿐이고, 목록에서 b-1 같은 application을 골라야 비로소
+      // 선택이다(→ handleClickSubNode). group을 선택으로 만들면 우측 패널이 열리면서
+      // 고르지도 않은 service가 선택된 것처럼 보인다(패널에 그릴 것은 없어 비어 있다).
+      if (findServiceGroupNode(data?.applicationMapData?.nodeDataArray, id)) {
+        return;
+      }
+
       setServerMapCurrentTarget({
         id,
         applicationName: label,
@@ -87,9 +97,15 @@ export const ServiceMapFetcher = ({ shouldPoll, ...props }: ServiceMapFetcherPro
     }
   };
 
-  const handleClickEdge: ServerMapCoreProps['onClickEdge'] = ({ data, eventType }) => {
-    const { id, source, target, edges } = data as MergedEdge;
+  const handleClickEdge: ServerMapCoreProps['onClickEdge'] = ({ data: clickedData, eventType }) => {
+    const { id, source, target, edges } = clickedData as MergedEdge;
     if (eventType === 'left') {
+      // 한쪽 끝이 service group인 링크도 마찬가지다. 팝업에서 자식 링크를 골라야 선택이다.
+      // (→ handleClickSubLink)
+      if (findServiceGroupLink(data?.applicationMapData?.linkDataArray, id)) {
+        return;
+      }
+
       setServerMapCurrentTarget({
         id,
         source,


### PR DESCRIPTION
## Summary

- **Send the selected node's service on activeThreadCount.** The servicemap draws nodes belonging to other services, so the realtime active thread panel has to ask the node's own service rather than the screen's one. A WebSocket request carries no header, so the service rides in the request parameters (`serviceName` / `serviceTypeName`, matching `ActiveThreadCountHandler`'s keys). Nothing is sent when `experimental.enableServiceMap` is off, so those installations send the exact same request as before.
- **Keep the pinned active thread target across page moves.** The pinned target lived in a ref while the selected map node lives in a global atom, so leaving the page and coming back left the pin engaged but silently re-pinned to whatever node happened to be selected. The target moved to an atom that remembers the path it was pinned on, so a reconnect resumes the application it was watching and another application's realtime view is unaffected.
- **Select an application, not the service group it sits in.** Left-clicking a collapsed service opened its application list but also marked the group as the current target, sliding open a side panel that draws nothing for a group. Selection now happens only when an application (or a link between two of them) is picked from that popup.
- **Back off before reopening the active thread socket.** The socket reopened the instant it closed, and the backend closes the session when it cannot resolve the `serviceName` this PR starts sending, so connect - request - close could run back to back with nothing in between. Retries now wait 1s, 2s, 5s, 10s, then 30s, resetting on a received message rather than on `open` (a session about to be rejected still opens normally). Leaving the page also fires `close`, which used to reopen a socket from a screen that was already gone.

## Test plan

- [ ] `yarn build` and `yarn test` pass (948 tests).
- [ ] With `experimental.enableServiceMap` **off**: the realtime `activeThreadCount` frame is byte-for-byte what it was before - `{ applicationName }` only.
- [ ] With it **on**: pick a node belonging to another service in the servicemap realtime view; the frame carries that node's `serviceName` / `serviceTypeName`, not the screen's service.
- [ ] Pin on, select a WAS node, move to another page and back: the panel keeps watching the application it was watching before, and the reconnected socket requests that one.
- [ ] Pin off and on again without changing the selection: no duplicate request goes out.
- [ ] Open a different application's realtime view: it starts from that view's own selection instead of the previously pinned one.
- [ ] Servicemap: left-click a collapsed service - the application list opens and the side panel stays as it was; picking `b-1` from the list is what selects it. Same for a link whose end is a collapsed service.
- [ ] Servermap and filteredMap are unchanged (neither response carries `subNodes`/`subLinks`).
- [ ] Kill the backend while the realtime view is open: retries space out instead of hammering, and the panel recovers on its own once it is back.
- [ ] Leave the realtime view: no socket is left reconnecting in the background (DevTools -> Network -> WS).
