### PR TITLE
[#noissue] Move Service to the commons-server uid package

### DIFF
--- a/collector/src/main/java/com/navercorp/pinpoint/collector/uid/service/CachingServiceLookupService.java
+++ b/collector/src/main/java/com/navercorp/pinpoint/collector/uid/service/CachingServiceLookupService.java
@@ -7,7 +7,7 @@ import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.service.dao.ServiceRegistryDao;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.service.dao.dto.ServiceEntity;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.ApplicationArguments;

--- a/collector/src/test/java/com/navercorp/pinpoint/collector/uid/service/CachingServiceLookupServiceTest.java
+++ b/collector/src/test/java/com/navercorp/pinpoint/collector/uid/service/CachingServiceLookupServiceTest.java
@@ -5,7 +5,7 @@ import com.navercorp.pinpoint.collector.uid.config.ServiceLookupLoadProperties;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
 import com.navercorp.pinpoint.service.dao.ServiceRegistryDao;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.service.dao.dto.ServiceEntity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/Service.java
+++ b/commons-server/src/main/java/com/navercorp/pinpoint/common/server/uid/Service.java
@@ -1,6 +1,5 @@
-package com.navercorp.pinpoint.web.vo;
+package com.navercorp.pinpoint.common.server.uid;
 
-import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
 
 import java.util.Objects;

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatController.java
@@ -35,7 +35,7 @@ import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import org.springframework.security.access.prepost.PreAuthorize;

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatController.java
@@ -19,7 +19,7 @@ import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/ApdexStatService.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/ApdexStatService.java
@@ -17,7 +17,7 @@ package com.navercorp.pinpoint.inspector.web.service;
 
 import com.navercorp.pinpoint.inspector.web.model.InspectorMetricData;
 import com.navercorp.pinpoint.inspector.web.model.InspectorMetricGroupData;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.List;
 

--- a/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultApdexStatService.java
+++ b/inspector-module/inspector-web/src/main/java/com/navercorp/pinpoint/inspector/web/service/DefaultApdexStatService.java
@@ -35,7 +35,7 @@ import com.navercorp.pinpoint.metric.common.util.TagUtils;
 import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.service.ApdexScoreService;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.chart.Chart;
 import com.navercorp.pinpoint.web.vo.stat.chart.StatChartGroup;
 import com.navercorp.pinpoint.web.vo.stat.chart.agent.AgentApdexScoreChart;

--- a/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatControllerTest.java
+++ b/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/AgentInspectorStatControllerTest.java
@@ -11,7 +11,7 @@ import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatControllerTest.java
+++ b/inspector-module/inspector-web/src/test/java/com/navercorp/pinpoint/inspector/web/controller/ApplicationInspectorStatControllerTest.java
@@ -11,7 +11,7 @@ import com.navercorp.pinpoint.inspector.web.view.InspectorMetricView;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/config/ServiceCommonMyBatisRegistryHandler.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/config/ServiceCommonMyBatisRegistryHandler.java
@@ -1,7 +1,7 @@
 package com.navercorp.pinpoint.service.config;
 
 import com.navercorp.pinpoint.service.dao.dto.ServiceParam;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.service.dao.dto.ServiceEntity;
 import org.apache.ibatis.type.TypeAliasRegistry;
 import org.apache.ibatis.type.TypeHandlerRegistry;
 

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/dao/ServiceRegistryDao.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/dao/ServiceRegistryDao.java
@@ -1,6 +1,6 @@
 package com.navercorp.pinpoint.service.dao;
 
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.service.dao.dto.ServiceEntity;
 
 import java.util.List;
 

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/dao/dto/ServiceEntity.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/dao/dto/ServiceEntity.java
@@ -1,4 +1,4 @@
-package com.navercorp.pinpoint.service.vo;
+package com.navercorp.pinpoint.service.dao.dto;
 
 public class ServiceEntity {
 

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/dao/mysql/MysqlServiceRegistryDao.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/dao/mysql/MysqlServiceRegistryDao.java
@@ -2,7 +2,7 @@ package com.navercorp.pinpoint.service.dao.mysql;
 
 import com.navercorp.pinpoint.service.dao.ServiceRegistryDao;
 import com.navercorp.pinpoint.service.dao.dto.ServiceParam;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.service.dao.dto.ServiceEntity;
 import org.mybatis.spring.SqlSessionTemplate;
 
 import java.util.List;

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/service/ServiceRegistryService.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/service/ServiceRegistryService.java
@@ -1,20 +1,20 @@
 package com.navercorp.pinpoint.service.service;
 
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.List;
 
 public interface ServiceRegistryService {
 
-    ServiceEntity insertService(String name);
+    Service insertService(String name);
 
     List<String> getServiceNames();
 
-    List<ServiceEntity> getServiceList(int limit);
+    List<Service> getServiceList(int limit);
 
-    ServiceEntity getService(String name);
+    Service getService(String name);
 
-    ServiceEntity getService(int uid);
+    Service getService(int uid);
 
     void deleteService(String name);
 }

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/service/ServiceRegistryServiceImpl.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/service/ServiceRegistryServiceImpl.java
@@ -3,17 +3,18 @@ package com.navercorp.pinpoint.service.service;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.IdGenerator;
 import com.navercorp.pinpoint.service.dao.ServiceRegistryDao;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.common.server.uid.Service;
+import com.navercorp.pinpoint.service.dao.dto.ServiceEntity;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.retry.annotation.Retryable;
-import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-@Service
+@org.springframework.stereotype.Service
 public class ServiceRegistryServiceImpl implements ServiceRegistryService {
 
     private final ServiceRegistryDao serviceRegistryDao;
@@ -28,7 +29,7 @@ public class ServiceRegistryServiceImpl implements ServiceRegistryService {
     @Override
     @Transactional(rollbackFor = {Exception.class})
     @Retryable(retryFor = DuplicateKeyException.class, maxAttempts = 3)
-    public ServiceEntity insertService(String name) {
+    public Service insertService(String name) {
         Objects.requireNonNull(name, "name");
         int uid = serviceUidGenerator.generate().getUid();
         try {
@@ -40,10 +41,7 @@ public class ServiceRegistryServiceImpl implements ServiceRegistryService {
             throw e;
         }
 
-        ServiceEntity entity = new ServiceEntity();
-        entity.setUid(uid);
-        entity.setName(name);
-        return entity;
+        return new Service(name, uid);
     }
 
     @Override
@@ -54,21 +52,26 @@ public class ServiceRegistryServiceImpl implements ServiceRegistryService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ServiceEntity> getServiceList(int limit) {
-        return serviceRegistryDao.selectServiceList(limit);
+    public List<Service> getServiceList(int limit) {
+        List<ServiceEntity> entityList = serviceRegistryDao.selectServiceList(limit);
+        List<Service> serviceList = new ArrayList<>(entityList.size());
+        for (ServiceEntity entity : entityList) {
+            serviceList.add(toService(entity));
+        }
+        return serviceList;
     }
 
     @Override
     @Transactional(readOnly = true)
-    public ServiceEntity getService(String name) {
+    public Service getService(String name) {
         Objects.requireNonNull(name, "name");
-        return serviceRegistryDao.selectService(name);
+        return toService(serviceRegistryDao.selectService(name));
     }
 
     @Override
     @Transactional(readOnly = true)
-    public ServiceEntity getService(int uid) {
-        return serviceRegistryDao.selectService(uid);
+    public Service getService(int uid) {
+        return toService(serviceRegistryDao.selectService(uid));
     }
 
     @Override
@@ -80,5 +83,12 @@ public class ServiceRegistryServiceImpl implements ServiceRegistryService {
             return;
         }
         serviceRegistryDao.deleteService(service.getUid());
+    }
+
+    private static Service toService(ServiceEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new Service(entity.getName(), entity.getUid());
     }
 }

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/web/controller/ServiceRegistryController.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/web/controller/ServiceRegistryController.java
@@ -2,10 +2,11 @@ package com.navercorp.pinpoint.service.web.controller;
 
 import com.navercorp.pinpoint.common.server.response.Response;
 import com.navercorp.pinpoint.common.server.response.SimpleResponse;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.service.component.ReservedServiceRegistry;
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
 import com.navercorp.pinpoint.service.web.controller.vo.ServiceNameRequest;
+import com.navercorp.pinpoint.service.web.controller.vo.ServiceView;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
@@ -54,14 +55,13 @@ public class ServiceRegistryController {
     }
 
     // TODO: (minwoo) 이게 진짜 필요한지 추후 검토 필요함.
-    // TODO: (minwoo) serviceEntity는 dao 개념이 더 맞아서 controller에서 return 타입으로 써도될지 고민필요하고 애초에 이런 메소드가 필요없다면 고민 필요없음.
     @GetMapping("/service")
-    public ResponseEntity<ServiceEntity> getService(@RequestParam("serviceName") @NotBlank String serviceName) {
-        ServiceEntity service = serviceRegistryService.getService(serviceName);
+    public ResponseEntity<ServiceView> getService(@RequestParam("serviceName") @NotBlank String serviceName) {
+        Service service = serviceRegistryService.getService(serviceName);
         if (service == null) {
             return ResponseEntity.noContent().build();
         }
-        return ResponseEntity.ok(service);
+        return ResponseEntity.ok(ServiceView.of(service));
     }
 
     @PreAuthorize("hasPermission(#serviceName, null, T(com.navercorp.pinpoint.web.security.PermissionChecker).PERMISSION_SERVICEAUTHORIZATION_EDIT_AUTHOR_ONLY_MANAGER)")

--- a/service-module/src/main/java/com/navercorp/pinpoint/service/web/controller/vo/ServiceView.java
+++ b/service-module/src/main/java/com/navercorp/pinpoint/service/web/controller/vo/ServiceView.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.service.web.controller.vo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.navercorp.pinpoint.common.server.uid.Service;
+
+import java.util.Objects;
+
+/**
+ * JSON view of a registered {@link Service}.
+ * Keeps the {@code {"uid": .., "name": ..}} shape that the former ServiceEntity response exposed.
+ */
+public class ServiceView {
+
+    private final int uid;
+    private final String name;
+
+    public static ServiceView of(Service service) {
+        Objects.requireNonNull(service, "service");
+        return new ServiceView(service.getServiceUid(), service.getServiceName());
+    }
+
+    public ServiceView(int uid, String name) {
+        this.uid = uid;
+        this.name = Objects.requireNonNull(name, "name");
+    }
+
+    @JsonProperty("uid")
+    public int getUid() {
+        return uid;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceView{" + name + '(' + uid + ")}";
+    }
+}

--- a/service-module/src/test/java/com/navercorp/pinpoint/service/dao/dto/ServiceEntityTest.java
+++ b/service-module/src/test/java/com/navercorp/pinpoint/service/dao/dto/ServiceEntityTest.java
@@ -1,4 +1,4 @@
-package com.navercorp.pinpoint.service.vo;
+package com.navercorp.pinpoint.service.dao.dto;
 
 import org.junit.jupiter.api.Test;
 

--- a/service-module/src/test/java/com/navercorp/pinpoint/service/service/ServiceRegistryServiceImplTest.java
+++ b/service-module/src/test/java/com/navercorp/pinpoint/service/service/ServiceRegistryServiceImplTest.java
@@ -3,7 +3,8 @@ package com.navercorp.pinpoint.service.service;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.server.util.IdGenerator;
 import com.navercorp.pinpoint.service.dao.ServiceRegistryDao;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.common.server.uid.Service;
+import com.navercorp.pinpoint.service.dao.dto.ServiceEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,11 +45,11 @@ class ServiceRegistryServiceImplTest {
         ServiceUid serviceUid = ServiceUid.of(12345);
         when(serviceUidGenerator.generate()).thenReturn(serviceUid);
 
-        ServiceEntity result = serviceRegistryService.insertService("my-service");
+        Service result = serviceRegistryService.insertService("my-service");
 
         verify(serviceRegistryDao).insertService(12345, "my-service");
-        assertThat(result.getUid()).isEqualTo(12345);
-        assertThat(result.getName()).isEqualTo("my-service");
+        assertThat(result.getServiceUid()).isEqualTo(12345);
+        assertThat(result.getServiceName()).isEqualTo("my-service");
     }
 
     @Test
@@ -110,17 +111,18 @@ class ServiceRegistryServiceImplTest {
         expected.setName("test-svc");
         when(serviceRegistryDao.selectService("test-svc")).thenReturn(expected);
 
-        ServiceEntity result = serviceRegistryService.getService("test-svc");
+        Service result = serviceRegistryService.getService("test-svc");
 
         assertThat(result).isNotNull();
-        assertThat(result.getName()).isEqualTo("test-svc");
+        assertThat(result.getServiceName()).isEqualTo("test-svc");
+        assertThat(result.getServiceUid()).isEqualTo(100);
     }
 
     @Test
     void getService_notFound() {
         when(serviceRegistryDao.selectService("no-svc")).thenReturn(null);
 
-        ServiceEntity result = serviceRegistryService.getService("no-svc");
+        Service result = serviceRegistryService.getService("no-svc");
 
         assertThat(result).isNull();
     }

--- a/service-module/src/test/java/com/navercorp/pinpoint/service/web/controller/ServiceRegistryControllerMvcTest.java
+++ b/service-module/src/test/java/com/navercorp/pinpoint/service/web/controller/ServiceRegistryControllerMvcTest.java
@@ -3,7 +3,7 @@ package com.navercorp.pinpoint.service.web.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.pinpoint.service.component.ReservedServiceRegistry;
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.service.web.controller.vo.ServiceNameRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,10 +50,8 @@ class ServiceRegistryControllerMvcTest {
     void insertService_200() throws Exception {
         ServiceNameRequest serviceNameRequest = new ServiceNameRequest("my-service");
 
-        ServiceEntity entity = new ServiceEntity();
-        entity.setUid(100);
-        entity.setName("my-service");
-        when(serviceRegistryService.insertService("my-service")).thenReturn(entity);
+        Service service = new Service("my-service", 100);
+        when(serviceRegistryService.insertService("my-service")).thenReturn(service);
 
         MvcResult result = mockMvc.perform(post("/api/v2/services")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -77,10 +75,8 @@ class ServiceRegistryControllerMvcTest {
 
     @Test
     void getService_found_200() throws Exception {
-        ServiceEntity entity = new ServiceEntity();
-        entity.setUid(100);
-        entity.setName("my-svc");
-        when(serviceRegistryService.getService("my-svc")).thenReturn(entity);
+        Service service = new Service("my-svc", 100);
+        when(serviceRegistryService.getService("my-svc")).thenReturn(service);
 
         MvcResult result = mockMvc.perform(get("/api/v2/services/service").param("serviceName", "my-svc"))
                 .andExpect(status().isOk())

--- a/service-module/src/test/java/com/navercorp/pinpoint/service/web/controller/ServiceRegistryControllerTest.java
+++ b/service-module/src/test/java/com/navercorp/pinpoint/service/web/controller/ServiceRegistryControllerTest.java
@@ -4,8 +4,9 @@ import com.navercorp.pinpoint.common.server.response.Response;
 import com.navercorp.pinpoint.common.server.response.Result;
 import com.navercorp.pinpoint.service.component.ReservedServiceRegistry;
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.service.web.controller.vo.ServiceNameRequest;
+import com.navercorp.pinpoint.service.web.controller.vo.ServiceView;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,10 +46,8 @@ class ServiceRegistryControllerTest {
     void insertService_returnsSuccess() {
         ServiceNameRequest serviceNameRequest = new ServiceNameRequest("my-service");
 
-        ServiceEntity entity = new ServiceEntity();
-        entity.setUid(100);
-        entity.setName("my-service");
-        when(serviceRegistryService.insertService("my-service")).thenReturn(entity);
+        Service service = new Service("my-service", 100);
+        when(serviceRegistryService.insertService("my-service")).thenReturn(service);
 
         Response response = controller.insertService(serviceNameRequest);
 
@@ -90,12 +89,10 @@ class ServiceRegistryControllerTest {
 
     @Test
     void getService_found_returns200() {
-        ServiceEntity entity = new ServiceEntity();
-        entity.setUid(100);
-        entity.setName("my-svc");
-        when(serviceRegistryService.getService("my-svc")).thenReturn(entity);
+        Service service = new Service("my-svc", 100);
+        when(serviceRegistryService.getService("my-svc")).thenReturn(service);
 
-        ResponseEntity<ServiceEntity> response = controller.getService("my-svc");
+        ResponseEntity<ServiceView> response = controller.getService("my-svc");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -107,7 +104,7 @@ class ServiceRegistryControllerTest {
     void getService_notFound_returns204() {
         when(serviceRegistryService.getService("missing")).thenReturn(null);
 
-        ResponseEntity<ServiceEntity> response = controller.getService("missing");
+        ResponseEntity<ServiceView> response = controller.getService("missing");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
         assertThat(response.getBody()).isNull();

--- a/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentNamesController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentNamesController.java
@@ -33,7 +33,7 @@ import com.navercorp.pinpoint.web.service.ApplicationAgentListQueryRule;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ApplicationPair;
 import com.navercorp.pinpoint.web.vo.ApplicationPairs;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilters;
 import com.navercorp.pinpoint.web.vo.agent.AgentNameGroupView;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatusAndLink;

--- a/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentsController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/agentlist/controller/AgentsController.java
@@ -34,7 +34,7 @@ import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ApplicationPair;
 import com.navercorp.pinpoint.web.vo.ApplicationPairs;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilters;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatusAndLink;
 import com.navercorp.pinpoint.service.web.resolver.ServiceParam;

--- a/web/src/main/java/com/navercorp/pinpoint/web/agentlist/service/AgentsServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/agentlist/service/AgentsServiceImpl.java
@@ -23,7 +23,7 @@ import com.navercorp.pinpoint.web.hyperlink.HyperLinkFactory;
 import com.navercorp.pinpoint.web.service.ApplicationAgentListQueryRule;
 import com.navercorp.pinpoint.web.service.ApplicationAgentListService;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilter;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatusAndLink;

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapController.java
@@ -44,7 +44,7 @@ import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.util.ApplicationValidator;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.SearchOption;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import jakarta.validation.Valid;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapHistogramController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/MapHistogramController.java
@@ -41,7 +41,7 @@ import com.navercorp.pinpoint.web.view.ApplicationTimeHistogramViewModel;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ApplicationPair;
 import com.navercorp.pinpoint.web.vo.ApplicationPairs;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import jakarta.validation.Valid;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/ServerMapHistogramController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/ServerMapHistogramController.java
@@ -45,7 +45,7 @@ import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.util.ApplicationValidator;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.SearchOption;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.apache.logging.log4j.LogManager;

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/form/ApplicationForm.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/controller/form/ApplicationForm.java
@@ -1,7 +1,7 @@
 package com.navercorp.pinpoint.web.applicationmap.controller.form;
 
 import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import jakarta.validation.constraints.NotBlank;
 
 public class ApplicationForm {

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/map/FilteredMapBuilder.java
@@ -46,7 +46,7 @@ import com.navercorp.pinpoint.web.util.OtelLinkValue;
 import com.navercorp.pinpoint.web.util.OtelLinkValueSerde;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseHistograms;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.util.LinkedMultiValueMap;

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/ServiceNodeNameParser.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/nodes/ServiceNodeNameParser.java
@@ -2,7 +2,7 @@ package com.navercorp.pinpoint.web.applicationmap.nodes;
 
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.Objects;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/servicemap/LinkNodeKey.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/servicemap/LinkNodeKey.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.web.applicationmap.servicemap;
 
 import com.navercorp.pinpoint.web.applicationmap.nodes.ServiceNodeName;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 public interface LinkNodeKey {
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AdminController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AdminController.java
@@ -23,7 +23,7 @@ import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.service.AdminService;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentListController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentListController.java
@@ -6,7 +6,7 @@ import com.navercorp.pinpoint.common.timeseries.time.RangeValidator;
 import com.navercorp.pinpoint.web.config.ConfigProperties;
 import com.navercorp.pinpoint.web.service.AgentInfoService;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.DetailedAgentAndStatus;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import com.navercorp.pinpoint.service.web.resolver.ServiceParam;

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentV2Controller.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/AgentV2Controller.java
@@ -28,7 +28,7 @@ import com.navercorp.pinpoint.web.config.ConfigProperties;
 import com.navercorp.pinpoint.web.service.AgentListV2Service;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.view.tree.AgentIdView;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatMapController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/HeatMapController.java
@@ -33,7 +33,7 @@ import com.navercorp.pinpoint.web.validation.NullOrNotBlank;
 import com.navercorp.pinpoint.web.view.transactionlist.DotMetaDataView;
 import com.navercorp.pinpoint.web.view.transactionlist.TransactionDotMetaDataViewModel;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import jakarta.validation.constraints.NotBlank;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ResponseTimeController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ResponseTimeController.java
@@ -39,7 +39,7 @@ import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ApplicationPair;
 import com.navercorp.pinpoint.web.vo.ApplicationPairs;
 import com.navercorp.pinpoint.web.vo.ResponseTimeStatics;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.service.web.resolver.ServiceParam;
 import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;

--- a/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ScatterChartController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/authorization/controller/ScatterChartController.java
@@ -33,7 +33,7 @@ import com.navercorp.pinpoint.web.util.LimitUtils;
 import com.navercorp.pinpoint.web.view.transactionlist.TransactionMetaDataViewModel;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.GetTraceInfoParser;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import org.apache.logging.log4j.LogManager;

--- a/web/src/main/java/com/navercorp/pinpoint/web/component/ApplicationFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/component/ApplicationFactory.java
@@ -19,7 +19,7 @@ package com.navercorp.pinpoint.web.component;
 
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 /**
  * @author emeroad

--- a/web/src/main/java/com/navercorp/pinpoint/web/component/DefaultApplicationFactory.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/component/DefaultApplicationFactory.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.Objects;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/ApdexScoreController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/ApdexScoreController.java
@@ -11,7 +11,7 @@ import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.service.ApdexScoreService;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.stat.chart.StatChart;
 import com.navercorp.pinpoint.common.timeseries.time.Timestamp;
 import jakarta.validation.constraints.NotBlank;

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/ApplicationController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/ApplicationController.java
@@ -16,7 +16,7 @@
 package com.navercorp.pinpoint.web.controller;
 
 import com.navercorp.pinpoint.common.PinpointConstants;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
 import com.navercorp.pinpoint.web.response.CodeResult;
 import com.navercorp.pinpoint.web.service.ApplicationAgentHostService;

--- a/web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/controller/MainController.java
@@ -22,7 +22,7 @@ import com.navercorp.pinpoint.service.web.vo.ServiceName;
 import com.navercorp.pinpoint.web.service.CacheService;
 import com.navercorp.pinpoint.web.service.CommonService;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.util.TagApplicationsUtils;
 import com.navercorp.pinpoint.web.util.etag.ETag;
 import com.navercorp.pinpoint.web.util.etag.ETagUtils;

--- a/web/src/main/java/com/navercorp/pinpoint/web/filter/FilterDescriptor.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/filter/FilterDescriptor.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.web.util.JsonNodeUtils;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;

--- a/web/src/main/java/com/navercorp/pinpoint/web/realtime/AgentLookupServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/realtime/AgentLookupServiceImpl.java
@@ -23,7 +23,7 @@ import com.navercorp.pinpoint.web.realtime.service.AgentLookupService;
 import com.navercorp.pinpoint.web.service.ApplicationAgentListService;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.service.ServiceNotFoundException;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
 import org.apache.logging.log4j.LogManager;

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/TraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/TraceIndexDao.java
@@ -19,7 +19,7 @@ package com.navercorp.pinpoint.web.scatter.dao;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDao.java
@@ -41,7 +41,7 @@ import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 import com.navercorp.pinpoint.web.util.ListListUtils;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.FilterList;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AdminService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AdminService.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.List;
 import java.util.Map;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AdminServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AdminServiceImpl.java
@@ -20,7 +20,7 @@ import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.util.CollectionUtils;
 import com.navercorp.pinpoint.web.service.component.ActiveAgentValidator;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoService.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.server.bo.SimpleAgentKey;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatus;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentInfoServiceImpl.java
@@ -26,7 +26,7 @@ import com.navercorp.pinpoint.web.filter.agent.AgentEventFilter;
 import com.navercorp.pinpoint.web.service.stat.AgentWarningStatService;
 import com.navercorp.pinpoint.web.vo.AgentEvent;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
 import com.navercorp.pinpoint.web.vo.agent.AgentStatus;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentListV2Service.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentListV2Service.java
@@ -2,7 +2,7 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentIdEntry;
 
 import java.util.List;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AgentListV2ServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AgentListV2ServiceImpl.java
@@ -23,7 +23,7 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapAgentResponseDao;
 import com.navercorp.pinpoint.web.dao.AgentIdDao;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentIdEntry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentListService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentListService.java
@@ -2,7 +2,7 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.timeseries.window.TimeWindow;
 import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
 import org.jspecify.annotations.Nullable;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentListServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationAgentListServiceImpl.java
@@ -24,7 +24,7 @@ import com.navercorp.pinpoint.web.applicationmap.dao.MapAgentResponseDao;
 import com.navercorp.pinpoint.web.dao.AgentInfoDao;
 import com.navercorp.pinpoint.web.dao.AgentLifeCycleDao;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilters;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexService.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.List;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ApplicationIndexServiceImpl.java
@@ -20,7 +20,7 @@ import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.web.dao.AgentIdDao;
 import com.navercorp.pinpoint.web.dao.ApplicationDao;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentIdEntry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolver.java
@@ -2,7 +2,6 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
 import com.navercorp.pinpoint.common.server.uid.Service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -104,9 +103,8 @@ public class CachingServiceModelResolver extends ServiceModelResolver implements
         }
 
         try {
-            List<ServiceEntity> serviceList = serviceRegistryService.getServiceList(limit);
-            for (ServiceEntity entity : serviceList) {
-                Service service = toService(entity);
+            List<Service> serviceList = serviceRegistryService.getServiceList(limit);
+            for (Service service : serviceList) {
                 serviceByNameCache.put(service.getServiceName(), service);
                 serviceByUidCache.put(service.getServiceUid(), service);
             }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolver.java
@@ -3,7 +3,7 @@ package com.navercorp.pinpoint.web.service;
 import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
 import com.navercorp.pinpoint.service.vo.ServiceEntity;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.ApplicationArguments;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CommonService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CommonService.java
@@ -19,7 +19,7 @@ package com.navercorp.pinpoint.web.service;
 import java.util.List;
 
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 /**
  * @author netspider

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/CommonServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/CommonServiceImpl.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.List;
 import java.util.Objects;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapService.java
@@ -3,7 +3,7 @@ package com.navercorp.pinpoint.web.service;
 import com.navercorp.pinpoint.web.scatter.DragAreaQuery;
 import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.List;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/HeatMapServiceImpl.java
@@ -27,7 +27,7 @@ import com.navercorp.pinpoint.web.trace.dao.TraceDao;
 import com.navercorp.pinpoint.web.trace.service.SpanService;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.SpanHint;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartService.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartService.java
@@ -21,7 +21,7 @@ import com.navercorp.pinpoint.common.server.trace.ServerTraceId;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.web.scatter.ScatterData;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.List;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ScatterChartServiceImpl.java
@@ -29,7 +29,7 @@ import com.navercorp.pinpoint.web.trace.service.SpanService;
 import com.navercorp.pinpoint.web.util.ListListUtils;
 import com.navercorp.pinpoint.web.vo.GetTraceInfo;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
@@ -1,7 +1,6 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
 import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.Objects;
@@ -39,17 +38,10 @@ public class ServiceModelResolver {
     }
 
     protected Service resolveService(int serviceUid) {
-        return toService(serviceRegistryService.getService(serviceUid));
+        return serviceRegistryService.getService(serviceUid);
     }
 
     protected Service resolveService(String serviceName) {
-        return toService(serviceRegistryService.getService(serviceName));
-    }
-
-    protected static Service toService(ServiceEntity entity) {
-        if (entity == null) {
-            return null;
-        }
-        return new Service(entity.getName(), entity.getUid());
+        return serviceRegistryService.getService(serviceName);
     }
 }

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/ServiceModelResolver.java
@@ -2,7 +2,7 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
 import com.navercorp.pinpoint.service.vo.ServiceEntity;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 
 import java.util.Objects;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/util/ApplicationValidator.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/util/ApplicationValidator.java
@@ -5,7 +5,7 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/Application.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/Application.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.web.vo;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.navercorp.pinpoint.common.server.util.StringPrecondition;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.view.ApplicationSerializer;
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/vo/agent/AgentIdEntry.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/vo/agent/AgentIdEntry.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.web.vo.agent;
 
 import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;

--- a/web/src/main/java/com/navercorp/pinpoint/web/websocket/ActiveThreadCountHandler.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/websocket/ActiveThreadCountHandler.java
@@ -20,7 +20,7 @@ import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.web.security.ServerMapDataFilter;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.service.ServiceNotFoundException;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.websocket.message.PinpointWebSocketMessage;
 import com.navercorp.pinpoint.web.websocket.message.PinpointWebSocketMessageConverter;
 import com.navercorp.pinpoint.web.websocket.message.PinpointWebSocketMessageType;

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/ApplicationMapBuilderTest.java
@@ -37,7 +37,7 @@ import com.navercorp.pinpoint.web.service.AgentListV2Service;
 import com.navercorp.pinpoint.web.vo.Application;
 import com.navercorp.pinpoint.web.vo.ResponseHistograms;
 import com.navercorp.pinpoint.web.vo.ResponseTime;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentIdEntry;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
 import org.junit.jupiter.api.AutoClose;

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/appender/server/ServerInfoAppenderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/appender/server/ServerInfoAppenderTest.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.web.applicationmap.appender.server;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.navercorp.pinpoint.common.server.bo.SimpleAgentKey;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.common.server.util.AgentLifeCycleState;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;

--- a/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/nodes/ServiceNodeNameTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/applicationmap/nodes/ServiceNodeNameTest.java
@@ -2,7 +2,7 @@ package com.navercorp.pinpoint.web.applicationmap.nodes;
 
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/web/src/test/java/com/navercorp/pinpoint/web/component/DefaultApplicationFactoryTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/component/DefaultApplicationFactoryTest.java
@@ -4,7 +4,7 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/web/src/test/java/com/navercorp/pinpoint/web/controller/ApdexScoreControllerTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/controller/ApdexScoreControllerTest.java
@@ -8,7 +8,7 @@ import com.navercorp.pinpoint.web.component.ApplicationFactory;
 import com.navercorp.pinpoint.web.service.ApdexScoreService;
 import com.navercorp.pinpoint.web.service.ServiceModelResolver;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/web/src/test/java/com/navercorp/pinpoint/web/filter/LinkFilterTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/filter/LinkFilterTest.java
@@ -11,7 +11,7 @@ import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.loader.service.AnnotationKeyRegistryService;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.web.TestTraceUtils;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;

--- a/web/src/test/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDaoTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/scatter/dao/hbase/HbaseTraceIndexDaoTest.java
@@ -35,7 +35,7 @@ import com.navercorp.pinpoint.web.scatter.dao.TraceIndexDao;
 import com.navercorp.pinpoint.web.scatter.vo.Dot;
 import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Scan;
 import org.junit.jupiter.api.Assertions;

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/AdminServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/AdminServiceImplTest.java
@@ -3,7 +3,7 @@ package com.navercorp.pinpoint.web.service;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.service.component.ActiveAgentValidator;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/AgentListV2ServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/AgentListV2ServiceImplTest.java
@@ -17,7 +17,7 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.server.config.AgentProperties;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.common.timeseries.time.Range;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.web.applicationmap.dao.MapAgentResponseDao;

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ApplicationAgentListServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ApplicationAgentListServiceImplTest.java
@@ -24,7 +24,7 @@ import com.navercorp.pinpoint.web.applicationmap.dao.MapAgentResponseDao;
 import com.navercorp.pinpoint.web.dao.AgentInfoDao;
 import com.navercorp.pinpoint.web.dao.AgentLifeCycleDao;
 import com.navercorp.pinpoint.web.vo.Application;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.web.vo.agent.AgentAndStatus;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfo;
 import com.navercorp.pinpoint.web.vo.agent.AgentInfoFilters;

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
@@ -2,7 +2,6 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
 import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ class CachingServiceModelResolverTest {
         String serviceName = "serviceName";
         CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
 
-        Mockito.when(serviceRegistryService.getService(serviceName)).thenReturn(serviceEntity(100001, serviceName));
+        Mockito.when(serviceRegistryService.getService(serviceName)).thenReturn(service(100001, serviceName));
 
         assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100001));
         assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100001));
@@ -52,7 +51,7 @@ class CachingServiceModelResolverTest {
         int serviceUid = 100002;
         CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
 
-        Mockito.when(serviceRegistryService.getService(serviceUid)).thenReturn(serviceEntity(serviceUid, serviceName));
+        Mockito.when(serviceRegistryService.getService(serviceUid)).thenReturn(service(serviceUid, serviceName));
 
         assertThat(resolver.getService(serviceUid)).isEqualTo(new Service(serviceName, serviceUid));
         assertThat(resolver.getService(serviceUid)).isEqualTo(new Service(serviceName, serviceUid));
@@ -89,7 +88,7 @@ class CachingServiceModelResolverTest {
         String unRegisteredServiceName = "unRegisteredServiceName";
         CachingServiceModelResolver resolver = newResolver(Duration.ZERO);
 
-        Mockito.when(serviceRegistryService.getService(serviceName)).thenReturn(serviceEntity(100004, serviceName));
+        Mockito.when(serviceRegistryService.getService(serviceName)).thenReturn(service(100004, serviceName));
         Mockito.when(serviceRegistryService.getService(unRegisteredServiceName)).thenReturn(null);
 
         assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100004));
@@ -111,7 +110,7 @@ class CachingServiceModelResolverTest {
         CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
 
         Mockito.when(serviceRegistryService.getServiceList(anyInt()))
-                .thenReturn(List.of(serviceEntity(serviceUid, serviceName)));
+                .thenReturn(List.of(service(serviceUid, serviceName)));
 
         resolver.refresh();
 
@@ -129,7 +128,7 @@ class CachingServiceModelResolverTest {
         CachingServiceModelResolver resolver = newResolver(Duration.ofMinutes(1));
 
         Mockito.when(serviceRegistryService.getServiceList(anyInt()))
-                .thenReturn(List.of(serviceEntity(serviceUid, serviceName)));
+                .thenReturn(List.of(service(serviceUid, serviceName)));
 
         resolver.warmup();
 
@@ -146,10 +145,7 @@ class CachingServiceModelResolverTest {
         return new CachingServiceModelResolver(serviceRegistryService, cacheManager, properties, loadProperties);
     }
 
-    private ServiceEntity serviceEntity(int uid, String name) {
-        ServiceEntity service = new ServiceEntity();
-        service.setUid(uid);
-        service.setName(name);
-        return service;
+    private Service service(int uid, String name) {
+        return new Service(name, uid);
     }
 }

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/CachingServiceModelResolverTest.java
@@ -3,7 +3,7 @@ package com.navercorp.pinpoint.web.service;
 import com.navercorp.pinpoint.common.server.uid.cache.CaffeineCacheProperties;
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
 import com.navercorp.pinpoint.service.vo.ServiceEntity;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/HeatMapServiceImplTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/HeatMapServiceImplTest.java
@@ -27,7 +27,7 @@ import com.navercorp.pinpoint.web.scatter.vo.DotMetaData;
 import com.navercorp.pinpoint.web.trace.dao.TraceDao;
 import com.navercorp.pinpoint.web.trace.service.SpanService;
 import com.navercorp.pinpoint.web.vo.LimitedScanResult;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
@@ -2,7 +2,7 @@ package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
 import com.navercorp.pinpoint.service.vo.ServiceEntity;
-import com.navercorp.pinpoint.web.vo.Service;
+import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/service/ServiceModelResolverTest.java
@@ -1,7 +1,6 @@
 package com.navercorp.pinpoint.web.service;
 
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
-import com.navercorp.pinpoint.service.vo.ServiceEntity;
 import com.navercorp.pinpoint.common.server.uid.Service;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -19,7 +18,7 @@ class ServiceModelResolverTest {
         String serviceName = "serviceName";
         ServiceModelResolver resolver = new ServiceModelResolver(serviceRegistryService);
 
-        Mockito.when(serviceRegistryService.getService(serviceName)).thenReturn(serviceEntity(100000, serviceName));
+        Mockito.when(serviceRegistryService.getService(serviceName)).thenReturn(service(100000, serviceName));
 
         assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100000));
         assertThat(resolver.getService(serviceName)).isEqualTo(new Service(serviceName, 100000));
@@ -59,10 +58,7 @@ class ServiceModelResolverTest {
         assertThat(resolver.getService(unRegisteredServiceUid)).isEqualTo(Service.DEFAULT);
     }
 
-    private ServiceEntity serviceEntity(int uid, String name) {
-        ServiceEntity service = new ServiceEntity();
-        service.setUid(uid);
-        service.setName(name);
-        return service;
+    private Service service(int uid, String name) {
+        return new Service(name, uid);
     }
 }


### PR DESCRIPTION
This pull request refactors the handling of the `Service` and `ServiceEntity` classes throughout the codebase to clarify their responsibilities and improve maintainability. The main changes involve moving and renaming classes, updating imports, and changing method signatures and return types to use the correct representations of service data.

**Core refactoring and codebase cleanup:**

* The `Service` class has been moved from `web` to `common.server.uid`, making it a shared domain object, and all references across modules have been updated accordingly. [[1]](diffhunk://#diff-217feaed0c4cffab640f01e3a9179253bef3e041c14ca1ded84903f50cbbb8a6L1-L3) [[2]](diffhunk://#diff-16002e7364937d0b306f4968048ac8474c09c7d212f0ecb79cd378e55c8d04acL22-R22) [[3]](diffhunk://#diff-7838af4b7e9ae218eb4c61503064403cbeab05c109abc767e8b4dd756b4da283L20-R20) [[4]](diffhunk://#diff-09cb59b65e97791d342834f7a44c27a7d05f7e46f6edb6fe839523ef73a20531L38-R38) [[5]](diffhunk://#diff-a9c378244cbad9c98cf8125b9d78b950367df69f659a80817a9cd475520c4cb0L14-R14) [[6]](diffhunk://#diff-210d8bdd63fc800ed1c66b74e766059e0dfc7866bec539ec1d0a68d01cf1cc44L14-R14) [[7]](diffhunk://#diff-096c4e2d87085952cd3f07baa81da2a12ebc546672670696f6d1d6fee33c93ebL38-R38) [[8]](diffhunk://#diff-329824426b085fb9d44825072fde26a8f1f6e2d9da869a8f15cef736fe866e1dL6-R6) [[9]](diffhunk://#diff-44a692750e2a021a1bd094f66172d05c6bc26893f751f62dadd7ac42af1703cbL6-R7) [[10]](diffhunk://#diff-49c09959896fbbef68ee74b475313419b45d65fd43b630aade225b9e258844a5R5-L7)
* The `ServiceEntity` class has been moved and renamed from `service.vo` to `service.dao.dto`, with all relevant imports and references updated. [[1]](diffhunk://#diff-d0254692a5ba068639523950cdfe9276f2c9a03edd6a393ea05d5713995ab25cL1-R1) [[2]](diffhunk://#diff-59dd3575bae76c09be4f2a37ff82f83d42265da5f494e898ebaef5e345aeb697L1-R1) [[3]](diffhunk://#diff-09bc22db5ec667b4709d025a975df106214dc1862daef0e24980b41c0435e255L10-R10) [[4]](diffhunk://#diff-b6f8d2f1954d1fb87182ebd2a9729ad282e66c655742f886d32f07668f428bbeL8-R8) [[5]](diffhunk://#diff-3130c88486aeb1062121ae17f90a23d13cd4154cdaccaab4fe69d188c268921bL4-R4) [[6]](diffhunk://#diff-20711e71345363e596d4ba7cbecc997e42ac05b90f72d75319ba129655f37694L3-R3) [[7]](diffhunk://#diff-40825b7257550fee1e0b4dbf6005d394df9d706b81fac704bebaccb588f30b42L5-R5)

**API and service layer changes:**

* The `ServiceRegistryService` interface and its implementation now use the domain-level `Service` class instead of the DAO-level `ServiceEntity` for their method signatures and return types. This includes a new conversion method from `ServiceEntity` to `Service`. [[1]](diffhunk://#diff-1c520fbe5abb5b2ecbcc6d13bfbb4805faa5bdc1d4ab26037c064fa0e1cb784bL3-R17) [[2]](diffhunk://#diff-1b7c3957fef52871144f592a09e13914145646aa3cfea6e1299a544889aba80aL6-R17) [[3]](diffhunk://#diff-1b7c3957fef52871144f592a09e13914145646aa3cfea6e1299a544889aba80aL31-R32) [[4]](diffhunk://#diff-1b7c3957fef52871144f592a09e13914145646aa3cfea6e1299a544889aba80aL43-R44) [[5]](diffhunk://#diff-1b7c3957fef52871144f592a09e13914145646aa3cfea6e1299a544889aba80aL57-R74) [[6]](diffhunk://#diff-1b7c3957fef52871144f592a09e13914145646aa3cfea6e1299a544889aba80aR87-R93)
* The `ServiceRegistryController` and its tests now return and expect the domain-level `Service` object rather than the DAO-level `ServiceEntity`. [[1]](diffhunk://#diff-49c09959896fbbef68ee74b475313419b45d65fd43b630aade225b9e258844a5L57-R59) [[2]](diffhunk://#diff-329824426b085fb9d44825072fde26a8f1f6e2d9da869a8f15cef736fe866e1dL53-R54)

**Test updates:**

* All relevant tests have been updated to use the correct class names and to assert against the new `Service` class API (e.g., `getServiceName`, `getServiceUid`). [[1]](diffhunk://#diff-44a692750e2a021a1bd094f66172d05c6bc26893f751f62dadd7ac42af1703cbL47-R52) [[2]](diffhunk://#diff-44a692750e2a021a1bd094f66172d05c6bc26893f751f62dadd7ac42af1703cbL113-R125) [[3]](diffhunk://#diff-329824426b085fb9d44825072fde26a8f1f6e2d9da869a8f15cef736fe866e1dL53-R54)

These changes improve the separation of concerns between the domain model and data access layer, making the codebase easier to understand and maintain.