### PR TITLE
Open the agent id/name tooltip beside the list instead of over it

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/Agent/AgentIdNameTooltip.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Agent/AgentIdNameTooltip.tsx
@@ -5,14 +5,31 @@ export const AgentIdNameTooltip = ({
   agentId,
   agentName,
   usePortal = false,
+  side,
 }: {
   children: React.ReactNode;
   agentId: string;
   agentName: string;
   usePortal?: boolean;
+  /**
+   * 툴팁이 붙을 방향. 넘기지 않으면 기본값인 위쪽이다.
+   *
+   * 세로로 늘어선 목록 위에서는 위쪽 툴팁이 바로 윗줄을 가린다. 목록 바깥에 여백이 있는
+   * 화면이라면 옆으로 빼는 편이 낫다.
+   */
+  side?: React.ComponentProps<typeof TooltipContent>['side'];
 }) => {
   const content = (
-    <TooltipContent>
+    <TooltipContent
+      side={side}
+      /*
+       * 이 툴팁은 목록 옆 차트 영역 위에 뜬다. 그런데 이 저장소는 차트를 덮는 안내/로딩
+       * 오버레이에 z-[1000]을 쓰고(ScatterChartCore, HeatmapChartCore, ServerMapChartBoard),
+       * TooltipContent의 기본값은 z-50이라 그 반투명 오버레이 뒤로 깔려 뿌옇게 비친다.
+       * 오버레이보다 한 단계 위로 올린다.
+       */
+      className="z-[1001]"
+    >
       <div>
         <span className="text-gray-500">Agent ID:</span> {agentId}
       </div>

--- a/web-frontend/src/main/v3/packages/ui/src/components/Agent/AgentListFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Agent/AgentListFetcher.tsx
@@ -102,6 +102,7 @@ export const AgentListFetcher = ({
                 key={instance?.agentId}
                 agentId={instance.agentId}
                 agentName={instance.agentName}
+                side="right"
               >
                 <div
                   className={cn(

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveTable.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveTable.tsx
@@ -50,9 +50,14 @@ export const AgentActiveTable = ({
 
           return (
             <TooltipProvider delayDuration={0}>
-              <div className="flex gap-1 items-center">
-                <AgentIdNameTooltip agentId={value} agentName={agentName} usePortal={true}>
-                  <div className="flex gap-1 items-center">
+              <div className="flex items-center gap-1">
+                <AgentIdNameTooltip
+                  agentId={value}
+                  agentName={agentName}
+                  usePortal={true}
+                  side="left"
+                >
+                  <div className="flex items-center gap-1">
                     <span>{agentName}</span>
                   </div>
                 </AgentIdNameTooltip>

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerList/ServerList.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerList/ServerList.tsx
@@ -50,6 +50,7 @@ export const ServerList = ({
                 key={instance.agentId}
                 agentId={instance.agentId}
                 agentName={instance.agentName}
+                side="right"
               >
                 <div
                   className={cn(
@@ -73,7 +74,7 @@ export const ServerList = ({
                   )}
                   {instance?.hasInspector && (
                     <Button
-                      className="z-10 p-1 ml-auto h-5 rounded-sm text-xxs"
+                      className="z-10 h-5 p-1 ml-auto rounded-sm text-xxs"
                       onClick={() => onClickInspectorLink?.(instance.agentId)}
                     >
                       <FaChartLine className="text-white" />


### PR DESCRIPTION
## Summary

- The agent id/name tooltip opened above the hovered row. In a vertical list that is exactly where the previous row sits, so reading down the list hid the entry being read.
- It now opens beside the list. The agent lists (Inspector, Error Analysis, URL Statistic, OpenTelemetry sidebars) and the server list open it to the right, where the panel beside them is. The active thread table opens it to the left, because `Server` is its first column and the row's own numbers follow to the right - opening right there would only trade one covered row for the covered numbers.
- Moving it sideways puts it over the charts, and this repo layers its guide and loading overlays at `z-[1000]` (`ScatterChartCore`, `HeatmapChartCore`, `HeatmapFetcher`, `ServerMapChartBoard`). The shadcn default of `z-50` left the tooltip washed out behind the translucent one, so the tooltip is raised above that layer rather than lowering an overlay level four of them share.

The direction is a new `side` prop on `AgentIdNameTooltip`; leaving it off keeps the old behaviour, so nothing outside the three call sites moves.

## Test plan

- [ ] Inspector: hover an agent in the left `Agent List` - the tooltip opens to the right, over the content area, and no longer covers the row above. Same for the Error Analysis, URL Statistic and OpenTelemetry sidebars.
- [ ] ServerMap: select a node, open `VIEW SERVERS`, hover a server - the tooltip opens to the right, over the agent charts.
- [ ] Same screen with the heatmap guide overlay showing ("To view the scatter chart by agent..."): the tooltip is fully opaque and on top, not dimmed behind the white panel.
- [ ] ServerMap realtime: hover an agent name in the `Server` column of the active thread table - the tooltip opens to the left, over the chart, covering none of the table.
- [ ] Narrow the window so there is no room on the chosen side - the tooltip flips instead of running off screen.
