### PR TITLE
[#noissue] Harden server-side endPoint / rpc / remoteAddr mapping in …

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -30,6 +30,16 @@ public class OtlpTraceConstants {
     // without this fallback such client spans lose their endPoint/destinationId entirely.
     public static final String ATTRIBUTE_KEY_NET_PEER_NAME = "net.peer.name";
     public static final String ATTRIBUTE_KEY_NET_PEER_PORT = "net.peer.port";
+    // Legacy (semconv 1.x) SERVER-side network keys, still the default output of
+    // opentelemetry-go-contrib <= 0.60, opentelemetry-python-contrib and otel-js < 0.221:
+    //   net.host.name / net.host.port   -> server.address / server.port   (endPoint)
+    //   net.sock.peer.addr / .port      -> network.peer.address / .port   (remoteAddr)
+    //   http.client_ip                  -> client.address                 (remoteAddr)
+    public static final String ATTRIBUTE_KEY_NET_HOST_NAME = "net.host.name";
+    public static final String ATTRIBUTE_KEY_NET_HOST_PORT = "net.host.port";
+    public static final String ATTRIBUTE_KEY_NET_SOCK_PEER_ADDR = "net.sock.peer.addr";
+    public static final String ATTRIBUTE_KEY_NET_SOCK_PEER_PORT = "net.sock.peer.port";
+    public static final String ATTRIBUTE_KEY_HTTP_CLIENT_IP = "http.client_ip";
     // Full request URL of an HTTP client span. New semconv: url.full; legacy: http.url
     // (ATTRIBUTE_KEY_HTTP_URL). Host:port is extracted as an endPoint/destinationId fallback;
     // the raw attribute is kept (path/query carry information beyond the extracted host).

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -338,7 +338,16 @@ public class OtlpTraceSpanMapper {
                 final long serverPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT, 0L);
                 consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_ADDRESS);
                 consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_SERVER_PORT);
-                return HostAndPort.toHostAndPortString(serverAddress, (int) serverPort, 0);
+                return toEndPoint(serverAddress, serverPort);
+            }
+            // legacy (semconv 1.x) equivalent of server.address/server.port — still the default of
+            // opentelemetry-go-contrib <= 0.60, opentelemetry-python-contrib and otel-js < 0.221.
+            final String netHostName = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_HOST_NAME, null);
+            if (netHostName != null) {
+                final long netHostPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_HOST_PORT, 0L);
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NET_HOST_NAME);
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NET_HOST_PORT);
+                return toEndPoint(netHostName, netHostPort);
             }
             // http.url is deliberately NOT collected: only host:port is consumed and the raw URL
             // retains path/query information beyond the promoted field.
@@ -357,6 +366,41 @@ public class OtlpTraceSpanMapper {
             return AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_MESSAGING_CLIENT_ID, null);
         }
         return null;
+    }
+
+    /**
+     * Joins the host and port attributes into {@code host:port}. Some instrumentations put the raw
+     * HTTP {@code Host} header into the address attribute (opentelemetry-python-contrib util-http:
+     * {@code server.address} / {@code net.host.name} = {@code "localhost:18120"}) while also emitting
+     * the port attribute; appending the port again would yield {@code localhost:18120:18120}, so a
+     * host that already ends in {@code :<port>} is returned as-is. A bare IPv6 literal such as
+     * {@code ::1} has more than one colon and no bracket, so it still gets the port appended.
+     */
+    static String toEndPoint(String host, long port) {
+        if (port != 0 && hasPortSuffix(host)) {
+            return host;
+        }
+        return HostAndPort.toHostAndPortString(host, (int) port, 0);
+    }
+
+    static boolean hasPortSuffix(String host) {
+        final int colon = host.lastIndexOf(':');
+        if (colon <= 0 || colon == host.length() - 1) {
+            return false;
+        }
+        for (int i = colon + 1; i < host.length(); i++) {
+            if (!Character.isDigit(host.charAt(i))) {
+                return false;
+            }
+        }
+        // "host:8080" has a single colon; "[::1]:8080" closes the IPv6 literal right before it.
+        // Anything else with more colons ("::1", "fe80::1") is a bare IPv6 address.
+        return host.indexOf(':') == colon || host.charAt(colon - 1) == ']';
+    }
+
+    /** Route-template keys count only when they carry a non-blank value. */
+    static boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     public static String extractHostAndPort(String url) {
@@ -414,8 +458,11 @@ public class OtlpTraceSpanMapper {
             // http.route is the matched route template ("/users/{id}") — prefer it over the raw
             // url.path ("/users/12345") so the rpc field stays low-cardinality, matching the agent's
             // recordUriTemplate behavior. Falls through to url.path when the request is unrouted.
+            // A blank value is treated as absent: otelgin (Go) emits http.route="" for unmatched
+            // routes (404), which would otherwise be stored as an empty rpc. The blank key is not
+            // consumed, so it stays visible in the raw attribute list.
             final String httpRoute = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_ROUTE, null);
-            if (httpRoute != null) {
+            if (hasText(httpRoute)) {
                 consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_ROUTE);
                 return httpRoute;
             }
@@ -423,7 +470,7 @@ public class OtlpTraceSpanMapper {
             // not emit http.route, so prefer next.route over the raw url.path/http.url/http.target
             // to keep the rpc field low-cardinality (e.g. "/api/products/[productId]/index").
             final String nextRoute = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NEXT_ROUTE, null);
-            if (nextRoute != null) {
+            if (hasText(nextRoute)) {
                 consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NEXT_ROUTE);
                 return nextRoute;
             }
@@ -517,6 +564,22 @@ public class OtlpTraceSpanMapper {
                 consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_IP);
                 consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NETWORK_PEER_PORT);
                 return HostAndPort.toHostAndPortString(networkPeerIp, (int) networkPeerPort, 0);
+            }
+            // legacy (semconv 1.x) equivalents — net.sock.peer.addr/.port is the old
+            // network.peer.address/.port (same host:port shape as above), http.client_ip the old
+            // client.address. Default output of opentelemetry-go-contrib <= 0.60 and
+            // opentelemetry-python-contrib.
+            final String netSockPeerAddr = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_SOCK_PEER_ADDR, null);
+            if (netSockPeerAddr != null) {
+                final long netSockPeerPort = AttributeUtils.getAttributeIntValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_NET_SOCK_PEER_PORT, 0L);
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NET_SOCK_PEER_ADDR);
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_NET_SOCK_PEER_PORT);
+                return HostAndPort.toHostAndPortString(netSockPeerAddr, (int) netSockPeerPort, 0);
+            }
+            final String httpClientIp = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_CLIENT_IP, null);
+            if (httpClientIp != null) {
+                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_CLIENT_IP);
+                return httpClientIp;
             }
             return null;
         } else if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_CONSUMER_VALUE) {

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -691,6 +691,205 @@ class OtlpTraceSpanMapperTest {
         assertThat(bo.getRpc()).isEqualTo("/api/users/123");
     }
 
+    @Test
+    void map_server_blankHttpRoute_treatedAsAbsent() {
+        // otelgin (Go) emits http.route="" for an unmatched route (404). A blank template must not
+        // become the rpc; fall through to url.path and leave the blank key in the raw attributes.
+        Span span = serverSpan(
+                kv("http.route", strVal("")),
+                kv("url.path", strVal("/nosuchpath")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRpc()).isEqualTo("/nosuchpath");
+        assertThat(attributeKeys(bo)).contains("http.route").doesNotContain("url.path");
+    }
+
+    @Test
+    void map_server_whitespaceHttpRoute_treatedAsAbsent() {
+        Span span = serverSpan(
+                kv("http.route", strVal("  ")),
+                kv("url.path", strVal("/nosuchpath")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRpc()).isEqualTo("/nosuchpath");
+    }
+
+    @Test
+    void map_server_blankNextRoute_treatedAsAbsent() {
+        Span span = serverSpan(
+                kv("next.route", strVal("")),
+                kv("url.path", strVal("/api/products/1")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRpc()).isEqualTo("/api/products/1");
+        assertThat(attributeKeys(bo)).contains("next.route");
+    }
+
+    @Test
+    void map_server_blankHttpRoute_noOtherPathKeys_fallsToSpanName() {
+        // no path key at all → the existing span-name fallback applies, never the empty string
+        Span span = serverSpan(kv("http.route", strVal("")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRpc()).isEqualTo(span.getName()).isNotEmpty();
+    }
+
+    // =======================================================================
+    // map() — legacy (semconv 1.x) server-side network keys
+    // =======================================================================
+
+    @Test
+    void map_server_legacyNetHost_setsEndPoint() {
+        // opentelemetry-go-contrib <= 0.60 / python default: net.host.name + net.host.port instead of
+        // server.address + server.port. Previously the endPoint stayed null.
+        Span span = serverSpan(
+                kv("http.target", strVal("/remote")),
+                kv("net.host.name", strVal("localhost")),
+                kv("net.host.port", intVal(18092)));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("localhost:18092");
+        assertThat(attributeKeys(bo)).doesNotContain("net.host.name", "net.host.port");
+    }
+
+    @Test
+    void map_server_legacyNetHost_withoutPort() {
+        Span span = serverSpan(kv("net.host.name", strVal("api.internal")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("api.internal");
+    }
+
+    @Test
+    void map_server_serverAddressAlreadyHasPort_doesNotAppendPortAgain() {
+        // opentelemetry-python-contrib (util-http) copies the raw Host header into server.address and
+        // still emits server.port — previously stored as "localhost:18120:18120"
+        Span span = serverSpan(
+                kv("server.address", strVal("localhost:18120")),
+                kv("server.port", intVal(18120)));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("localhost:18120");
+    }
+
+    @Test
+    void map_server_legacyNetHostAlreadyHasPort_doesNotAppendPortAgain() {
+        // same instrumentation in old-semconv mode (Flask default)
+        Span span = serverSpan(
+                kv("net.host.name", strVal("localhost:18120")),
+                kv("net.host.port", intVal(18120)));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("localhost:18120");
+    }
+
+    @Test
+    void map_server_ipv6ServerAddress_stillGetsPort() {
+        Span span = serverSpan(
+                kv("server.address", strVal("::1")),
+                kv("server.port", intVal(18120)));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("::1:18120");
+    }
+
+    @Test
+    void hasPortSuffix() {
+        assertThat(OtlpTraceSpanMapper.hasPortSuffix("localhost:18120")).isTrue();
+        assertThat(OtlpTraceSpanMapper.hasPortSuffix("127.0.0.1:18131")).isTrue();
+        assertThat(OtlpTraceSpanMapper.hasPortSuffix("[::1]:18120")).isTrue();
+        assertThat(OtlpTraceSpanMapper.hasPortSuffix("localhost")).isFalse();
+        assertThat(OtlpTraceSpanMapper.hasPortSuffix("::1")).isFalse();
+        assertThat(OtlpTraceSpanMapper.hasPortSuffix("fe80::1")).isFalse();
+        assertThat(OtlpTraceSpanMapper.hasPortSuffix("localhost:")).isFalse();
+        assertThat(OtlpTraceSpanMapper.hasPortSuffix("host:abc")).isFalse();
+    }
+
+    @Test
+    void map_server_serverAddressAlreadyHasPort_withoutPortAttribute() {
+        // no server.port at all → the value is stored as-is either way
+        Span span = serverSpan(kv("server.address", strVal("localhost:18120")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("localhost:18120");
+    }
+
+    @Test
+    void map_server_blankHttpRoute_fallsToNextRoute() {
+        // the blank key is skipped, not the whole route-template stage: next.route still wins over url.path
+        Span span = serverSpan(
+                kv("http.route", strVal("")),
+                kv("next.route", strVal("/api/products/[id]")),
+                kv("url.path", strVal("/api/products/1")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRpc()).isEqualTo("/api/products/[id]");
+        assertThat(attributeKeys(bo)).contains("http.route").doesNotContain("next.route");
+    }
+
+    @Test
+    void map_server_legacyNetSockPeer_withoutPort() {
+        Span span = serverSpan(kv("net.sock.peer.addr", strVal("10.0.0.7")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRemoteAddr()).isEqualTo("10.0.0.7");
+    }
+
+    @Test
+    void map_server_legacyNetSockPeer_winsOverHttpClientIp() {
+        // both legacy keys present: the socket peer (the direct connection) is preferred, and only it is consumed
+        Span span = serverSpan(
+                kv("net.sock.peer.addr", strVal("::1")),
+                kv("net.sock.peer.port", intVal(5686)),
+                kv("http.client_ip", strVal("10.0.0.7")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRemoteAddr()).isEqualTo("::1:5686");
+        assertThat(attributeKeys(bo)).contains("http.client_ip").doesNotContain("net.sock.peer.addr");
+    }
+
+    @Test
+    void map_server_legacyNetPeerIp_winsOverNetSockPeer() {
+        // net.peer.ip (semconv <= 1.12, otel-js <= 0.220) sits before the semconv 1.x socket keys in the chain
+        Span span = serverSpan(
+                kv("net.peer.ip", strVal("127.0.0.1")),
+                kv("net.sock.peer.addr", strVal("::1")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRemoteAddr()).isEqualTo("127.0.0.1");
+        assertThat(attributeKeys(bo)).contains("net.sock.peer.addr").doesNotContain("net.peer.ip");
+    }
+
+    @Test
+    void map_server_stableServerAddress_winsOverLegacyNetHost() {
+        // http/dup mode emits both key sets — the stable key wins and only it is consumed
+        Span span = serverSpan(
+                kv("server.address", strVal("stable")),
+                kv("server.port", intVal(8080)),
+                kv("net.host.name", strVal("legacy")),
+                kv("net.host.port", intVal(18092)));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("stable:8080");
+        assertThat(attributeKeys(bo)).contains("net.host.name", "net.host.port").doesNotContain("server.address");
+    }
+
+    @Test
+    void map_server_legacyNetSockPeer_setsRemoteAddr() {
+        // net.sock.peer.addr/.port is the legacy network.peer.address/.port → same host:port shape
+        Span span = serverSpan(
+                kv("net.sock.peer.addr", strVal("::1")),
+                kv("net.sock.peer.port", intVal(5686)));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        // HostAndPort joins with ':' without bracketing IPv6, exactly like the network.peer.address branch
+        assertThat(bo.getRemoteAddr()).isEqualTo("::1:5686");
+        assertThat(attributeKeys(bo)).doesNotContain("net.sock.peer.addr", "net.sock.peer.port");
+    }
+
+    @Test
+    void map_server_legacyHttpClientIp_setsRemoteAddr() {
+        Span span = serverSpan(kv("http.client_ip", strVal("10.0.0.7")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRemoteAddr()).isEqualTo("10.0.0.7");
+        assertThat(attributeKeys(bo)).doesNotContain("http.client_ip");
+    }
+
+    @Test
+    void map_server_stableClientAddress_winsOverLegacyPeerKeys() {
+        Span span = serverSpan(
+                kv("client.address", strVal("192.168.0.1")),
+                kv("net.sock.peer.addr", strVal("::1")),
+                kv("http.client_ip", strVal("10.0.0.7")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRemoteAddr()).isEqualTo("192.168.0.1");
+        assertThat(attributeKeys(bo)).contains("net.sock.peer.addr", "http.client_ip");
+    }
+
     // =======================================================================
     // map() — consumedKeys: filter only what was actually promoted
     // =======================================================================


### PR DESCRIPTION
…the OTLP trace mapper

- Treat a blank http.route / next.route as absent so the rpc falls back to url.path (otelgin emits http.route="" for unmatched routes)
- Map the legacy (semconv 1.x) server-side network keys: net.host.name(+port) to endPoint, net.sock.peer.addr(+port) and http.client_ip to remoteAddr (opentelemetry-go-contrib <= 0.60, otel-js <= 0.220, opentelemetry-python-contrib default)
- Do not append the port twice when server.address / net.host.name already carries it (opentelemetry-python-contrib copies the raw Host header, e.g. "localhost:18120")