### PR TITLE
[#noissue] Fix inverted namespace check in HbaseTestCluster and drop io.micrometer.common usages

### DIFF
--- a/collector-monitor/pom.xml
+++ b/collector-monitor/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>micrometer-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
         </dependency>

--- a/collector-monitor/src/main/java/com/navercorp/pinpoint/collector/monitor/micrometer/binder/NetworkMetricsBinder.java
+++ b/collector-monitor/src/main/java/com/navercorp/pinpoint/collector/monitor/micrometer/binder/NetworkMetricsBinder.java
@@ -15,12 +15,12 @@
  */
 package com.navercorp.pinpoint.collector.monitor.micrometer.binder;
 
-import io.micrometer.common.lang.NonNull;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import org.jspecify.annotations.NonNull;
 import oshi.SystemInfo;
 import oshi.hardware.NetworkIF;
 import oshi.software.os.OSProcess;

--- a/hbase-testcluster/src/main/java/com/navercorp/pinpoint/common/hbase/it/HbaseTestCluster.java
+++ b/hbase-testcluster/src/main/java/com/navercorp/pinpoint/common/hbase/it/HbaseTestCluster.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.common.hbase.it;
 
-import io.micrometer.common.util.StringUtils;
 import jakarta.annotation.PostConstruct;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.NamespaceDescriptor;
@@ -32,6 +31,7 @@ import org.apache.hadoop.hbase.testing.TestingHBaseCluster;
 import org.apache.hadoop.hbase.testing.TestingHBaseClusterOption;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.util.StringUtils;
 
 import java.util.Objects;
 
@@ -145,7 +145,7 @@ public class HbaseTestCluster implements AutoCloseable {
 
 
     public void createNamespaceIfMissing(String namespace) throws Exception {
-        if (!StringUtils.isEmpty(namespace)) {
+        if (!StringUtils.hasLength(namespace)) {
             throw new IllegalArgumentException("namespace must not be empty");
         }
         try (Connection connection = ConnectionFactory.createConnection(cluster.getConf());


### PR DESCRIPTION
- HbaseTestCluster: !isEmpty(namespace) rejected valid input and accepted empty; use StringUtils.hasLength
- NetworkMetricsBinder: replace micrometer NonNull with org.jspecify.annotations.NonNull
- collector-monitor: declare jspecify dependency explicitly
