### PR TITLE
[#14210] Cache the singletons behind the Guice Providers on the trace…

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncTraceContext.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncTraceContext.java
@@ -30,8 +30,9 @@ import java.util.Objects;
 public class DefaultAsyncTraceContext implements AsyncTraceContext {
 
     private final Provider<BaseTraceFactory> baseTraceFactoryProvider;
-    // Lazily resolved singleton; see DefaultRecorderFactory for why the Provider is kept.
-    private volatile BaseTraceFactory baseTraceFactory;
+    // Lazily resolved singleton; see DefaultRecorderFactory for why the Provider is kept and why the
+    // plain (non-volatile) field is enough.
+    private BaseTraceFactory baseTraceFactory;
 
     public DefaultAsyncTraceContext(Provider<BaseTraceFactory> baseTraceFactoryProvider) {
         this.baseTraceFactoryProvider = Objects.requireNonNull(baseTraceFactoryProvider, "baseTraceFactoryProvider");
@@ -40,7 +41,6 @@ public class DefaultAsyncTraceContext implements AsyncTraceContext {
     private BaseTraceFactory baseTraceFactory() {
         BaseTraceFactory factory = this.baseTraceFactory;
         if (factory == null) {
-            // Benign race: the binding is a singleton, so concurrent first calls resolve the same instance.
             factory = baseTraceFactoryProvider.get();
             this.baseTraceFactory = factory;
         }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncTraceContext.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncTraceContext.java
@@ -30,20 +30,32 @@ import java.util.Objects;
 public class DefaultAsyncTraceContext implements AsyncTraceContext {
 
     private final Provider<BaseTraceFactory> baseTraceFactoryProvider;
+    // Lazily resolved singleton; see DefaultRecorderFactory for why the Provider is kept.
+    private volatile BaseTraceFactory baseTraceFactory;
 
     public DefaultAsyncTraceContext(Provider<BaseTraceFactory> baseTraceFactoryProvider) {
         this.baseTraceFactoryProvider = Objects.requireNonNull(baseTraceFactoryProvider, "baseTraceFactoryProvider");
     }
 
+    private BaseTraceFactory baseTraceFactory() {
+        BaseTraceFactory factory = this.baseTraceFactory;
+        if (factory == null) {
+            // Benign race: the binding is a singleton, so concurrent first calls resolve the same instance.
+            factory = baseTraceFactoryProvider.get();
+            this.baseTraceFactory = factory;
+        }
+        return factory;
+    }
+
     @Override
     public Trace continueAsyncContextTraceObject(TraceRoot traceRoot, LocalAsyncId localAsyncId, boolean asyncTraceBlock) {
-        final BaseTraceFactory baseTraceFactory = baseTraceFactoryProvider.get();
+        final BaseTraceFactory baseTraceFactory = baseTraceFactory();
         return baseTraceFactory.continueAsyncContextTraceObject(traceRoot, localAsyncId, asyncTraceBlock);
     }
 
     @Override
     public Trace continueDisableAsyncContextTraceObject(LocalTraceRoot traceRoot) {
-        final BaseTraceFactory baseTraceFactory = baseTraceFactoryProvider.get();
+        final BaseTraceFactory baseTraceFactory = baseTraceFactory();
         return baseTraceFactory.continueDisableAsyncContextTraceObject(traceRoot);
     }
 

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultRecorderFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultRecorderFactory.java
@@ -47,7 +47,9 @@ public class DefaultRecorderFactory implements RecorderFactory {
     // BaseTraceFactory -> RecorderFactory -> AsyncContextFactory -> AsyncTraceContext -> BaseTraceFactory
     // construction cycle; every Guice Provider.get() enters a new InternalContext, which is too
     // expensive to pay per span event recorder on the request path.
-    private volatile AsyncContextFactory asyncContextFactory;
+    // Plain (non-volatile) racy cache: the singleton is immutable (final fields only), so a stale null
+    // just re-reads the same instance from the provider.
+    private AsyncContextFactory asyncContextFactory;
     private final IgnoreErrorHandler errorHandler;
 
     private final ExceptionRecorderFactory exceptionRecorderFactory;
@@ -74,7 +76,6 @@ public class DefaultRecorderFactory implements RecorderFactory {
     private AsyncContextFactory asyncContextFactory() {
         AsyncContextFactory factory = this.asyncContextFactory;
         if (factory == null) {
-            // Benign race: the binding is a singleton, so concurrent first calls resolve the same instance.
             factory = asyncContextFactoryProvider.get();
             this.asyncContextFactory = factory;
         }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultRecorderFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultRecorderFactory.java
@@ -43,6 +43,11 @@ public class DefaultRecorderFactory implements RecorderFactory {
     private final StringMetaDataService stringMetaDataService;
     private final SqlMetaDataService sqlMetaDataService;
     private final Provider<AsyncContextFactory> asyncContextFactoryProvider;
+    // Lazily resolved singleton. The Provider only exists to break the
+    // BaseTraceFactory -> RecorderFactory -> AsyncContextFactory -> AsyncTraceContext -> BaseTraceFactory
+    // construction cycle; every Guice Provider.get() enters a new InternalContext, which is too
+    // expensive to pay per span event recorder on the request path.
+    private volatile AsyncContextFactory asyncContextFactory;
     private final IgnoreErrorHandler errorHandler;
 
     private final ExceptionRecorderFactory exceptionRecorderFactory;
@@ -64,6 +69,16 @@ public class DefaultRecorderFactory implements RecorderFactory {
         this.exceptionRecorderFactory = Objects.requireNonNull(exceptionRecorderFactory, "exceptionRecorderFactory");
         this.errorRecorderFactory = Objects.requireNonNull(errorRecorderFactory, "errorRecorderFactory");
         this.sqlCountService = Objects.requireNonNull(sqlCountService, "sqlCountService");
+    }
+
+    private AsyncContextFactory asyncContextFactory() {
+        AsyncContextFactory factory = this.asyncContextFactory;
+        if (factory == null) {
+            // Benign race: the binding is a singleton, so concurrent first calls resolve the same instance.
+            factory = asyncContextFactoryProvider.get();
+            this.asyncContextFactory = factory;
+        }
+        return factory;
     }
 
     @Override
@@ -98,7 +113,7 @@ public class DefaultRecorderFactory implements RecorderFactory {
     public WrappedSpanEventRecorder newWrappedSpanEventRecorder(TraceRoot traceRoot) {
         Objects.requireNonNull(traceRoot, "traceRoot");
 
-        final AsyncContextFactory asyncContextFactory = asyncContextFactoryProvider.get();
+        final AsyncContextFactory asyncContextFactory = asyncContextFactory();
         ExceptionRecorder exceptionRecorder = exceptionRecorderFactory.newRecorder(traceRoot);
         ErrorRecorder errorRecorder = errorRecorderFactory.newRecorder(traceRoot);
 
@@ -111,7 +126,7 @@ public class DefaultRecorderFactory implements RecorderFactory {
         Objects.requireNonNull(traceRoot, "traceRoot");
         Objects.requireNonNull(asyncState, "asyncState");
 
-        final AsyncContextFactory asyncContextFactory = asyncContextFactoryProvider.get();
+        final AsyncContextFactory asyncContextFactory = asyncContextFactory();
         ExceptionRecorder exceptionRecorder = exceptionRecorderFactory.newRecorder(traceRoot);
         ErrorRecorder errorRecorder = errorRecorderFactory.newRecorder(traceRoot);
 
@@ -123,7 +138,7 @@ public class DefaultRecorderFactory implements RecorderFactory {
     public WrappedSpanEventRecorder newChildTraceSpanEventRecorder(TraceRoot traceRoot) {
         Objects.requireNonNull(traceRoot, "traceRoot");
 
-        final AsyncContextFactory asyncContextFactory = asyncContextFactoryProvider.get();
+        final AsyncContextFactory asyncContextFactory = asyncContextFactory();
         ExceptionRecorder exceptionRecorder = exceptionRecorderFactory.newRecorder(traceRoot);
         ErrorRecorder errorRecorder = errorRecorderFactory.newRecorder(traceRoot);
 
@@ -147,7 +162,7 @@ public class DefaultRecorderFactory implements RecorderFactory {
     }
 
     private DisableSpanEventRecorder newDisableSpanEventRecorder0(LocalTraceRoot traceRoot, AsyncState asyncState) {
-        final AsyncContextFactory asyncContextFactory = asyncContextFactoryProvider.get();
+        final AsyncContextFactory asyncContextFactory = asyncContextFactory();
         return new DisableSpanEventRecorder(traceRoot, asyncContextFactory, asyncState);
     }
 
@@ -156,7 +171,7 @@ public class DefaultRecorderFactory implements RecorderFactory {
         Objects.requireNonNull(traceRoot, "traceRoot");
         Objects.requireNonNull(asyncState, "asyncState");
 
-        final AsyncContextFactory asyncContextFactory = asyncContextFactoryProvider.get();
+        final AsyncContextFactory asyncContextFactory = asyncContextFactory();
         return new DisableChildTraceSpanEventRecorder(traceRoot, asyncContextFactory, asyncState);
     }
 }

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncTraceContextTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncTraceContextTest.java
@@ -1,8 +1,11 @@
 package com.navercorp.pinpoint.profiler.context;
 
 import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.profiler.context.id.LocalTraceRoot;
 import com.navercorp.pinpoint.profiler.context.id.TraceRoot;
 import com.navercorp.pinpoint.profiler.context.provider.BaseTraceFactoryProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -11,6 +14,9 @@ import org.mockito.stubbing.Answer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,5 +67,29 @@ public class DefaultAsyncTraceContextTest {
 //        assertTrue(newTraceDisabled instanceof DisableAsyncChildTrace);
 //        assertNull(asyncTraceContext.currentRawTraceObject().get());
 //    }
+
+    @Test
+    public void baseTraceFactoryProvider_isResolvedLazilyAndOnce() {
+        BaseTraceFactory baseTraceFactory = mock(DefaultBaseTraceFactory.class);
+        BaseTraceFactoryProvider baseTraceFactoryProvider = mock(BaseTraceFactoryProvider.class);
+        when(baseTraceFactoryProvider.get()).thenReturn(baseTraceFactory);
+        when(baseTraceFactory.continueAsyncContextTraceObject(any(TraceRoot.class), any(LocalAsyncId.class), any(Boolean.class)))
+                .thenReturn(mock(ChildTrace.class));
+        when(baseTraceFactory.continueDisableAsyncContextTraceObject(any(LocalTraceRoot.class)))
+                .thenReturn(mock(DisableChildTrace.class));
+
+        AsyncTraceContext asyncTraceContext = new DefaultAsyncTraceContext(baseTraceFactoryProvider);
+        // the Provider breaks a Guice construction cycle: it must not be resolved in the constructor
+        verify(baseTraceFactoryProvider, never()).get();
+
+        Assertions.assertNotNull(asyncTraceContext.continueAsyncContextTraceObject(traceRoot, localAsyncId, true));
+        Assertions.assertNotNull(asyncTraceContext.continueAsyncContextTraceObject(traceRoot, localAsyncId, false));
+        Assertions.assertNotNull(asyncTraceContext.continueDisableAsyncContextTraceObject(traceRoot));
+
+        // every Provider.get() enters a new Guice InternalContext; the singleton must be cached after the first call
+        verify(baseTraceFactoryProvider, times(1)).get();
+        verify(baseTraceFactory, times(2)).continueAsyncContextTraceObject(any(TraceRoot.class), any(LocalAsyncId.class), any(Boolean.class));
+        verify(baseTraceFactory, times(1)).continueDisableAsyncContextTraceObject(any(LocalTraceRoot.class));
+    }
 
 }

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultRecorderFactoryTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultRecorderFactoryTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.profiler.context.recorder;
+
+import com.google.inject.Provider;
+import com.navercorp.pinpoint.bootstrap.context.AsyncState;
+import com.navercorp.pinpoint.bootstrap.context.ErrorRecorder;
+import com.navercorp.pinpoint.profiler.context.AsyncContextFactory;
+import com.navercorp.pinpoint.profiler.context.SqlCountService;
+import com.navercorp.pinpoint.profiler.context.error.ErrorRecorderFactory;
+import com.navercorp.pinpoint.profiler.context.errorhandler.IgnoreErrorHandler;
+import com.navercorp.pinpoint.profiler.context.exception.ExceptionRecorder;
+import com.navercorp.pinpoint.profiler.context.exception.ExceptionRecorderFactory;
+import com.navercorp.pinpoint.profiler.context.id.LocalTraceRoot;
+import com.navercorp.pinpoint.profiler.context.id.TraceRoot;
+import com.navercorp.pinpoint.profiler.metadata.SqlMetaDataService;
+import com.navercorp.pinpoint.profiler.metadata.StringMetaDataService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The {@code Provider<AsyncContextFactory>} breaks a Guice construction cycle, but every
+ * {@code Provider.get()} enters a new Guice {@code InternalContext}. The factory must therefore
+ * resolve the singleton lazily and exactly once, never eagerly in the constructor.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DefaultRecorderFactoryTest {
+
+    @Mock
+    private Provider<AsyncContextFactory> asyncContextFactoryProvider;
+    @Mock
+    private AsyncContextFactory asyncContextFactory;
+    @Mock
+    private StringMetaDataService stringMetaDataService;
+    @Mock
+    private SqlMetaDataService sqlMetaDataService;
+    @Mock
+    private IgnoreErrorHandler errorHandler;
+    @Mock
+    private ExceptionRecorderFactory exceptionRecorderFactory;
+    @Mock
+    private ErrorRecorderFactory errorRecorderFactory;
+    @Mock
+    private SqlCountService sqlCountService;
+    @Mock
+    private TraceRoot traceRoot;
+    @Mock
+    private LocalTraceRoot localTraceRoot;
+    @Mock
+    private AsyncState asyncState;
+
+    private DefaultRecorderFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        when(asyncContextFactoryProvider.get()).thenReturn(asyncContextFactory);
+        when(exceptionRecorderFactory.newRecorder(any(TraceRoot.class))).thenReturn(mock(ExceptionRecorder.class));
+        when(errorRecorderFactory.newRecorder(any(LocalTraceRoot.class))).thenReturn(mock(ErrorRecorder.class));
+
+        this.factory = new DefaultRecorderFactory(asyncContextFactoryProvider, stringMetaDataService, sqlMetaDataService,
+                errorHandler, exceptionRecorderFactory, errorRecorderFactory, sqlCountService);
+    }
+
+    @Test
+    void constructor_doesNotResolveProvider() {
+        // resolving eagerly would re-introduce the construction cycle the Provider exists to break
+        verify(asyncContextFactoryProvider, never()).get();
+    }
+
+    @Test
+    void asyncContextFactory_isResolvedOnceAcrossAllRecorderKinds() {
+        Assertions.assertNotNull(factory.newWrappedSpanEventRecorder(traceRoot));
+        Assertions.assertNotNull(factory.newWrappedSpanEventRecorder(traceRoot, asyncState));
+        Assertions.assertNotNull(factory.newChildTraceSpanEventRecorder(traceRoot));
+        Assertions.assertNotNull(factory.newDisableSpanEventRecorder(localTraceRoot));
+        Assertions.assertNotNull(factory.newDisableSpanEventRecorder(localTraceRoot, asyncState));
+        Assertions.assertNotNull(factory.newDisableChildTraceSpanEventRecorder(localTraceRoot, asyncState));
+        // a second round must not touch the provider again
+        Assertions.assertNotNull(factory.newChildTraceSpanEventRecorder(traceRoot));
+
+        verify(asyncContextFactoryProvider, times(1)).get();
+    }
+
+    @Test
+    void concurrentFirstCalls_resolveTheSameSingleton() throws Exception {
+        final int threads = 8;
+        final AtomicInteger providerCalls = new AtomicInteger();
+        final AsyncContextFactory singleton = mock(AsyncContextFactory.class);
+        when(asyncContextFactoryProvider.get()).thenAnswer(invocation -> {
+            providerCalls.incrementAndGet();
+            return singleton;
+        });
+
+        final CountDownLatch start = new CountDownLatch(1);
+        final ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<Object>> futures = new ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                futures.add(executor.submit((Callable<Object>) () -> {
+                    start.await();
+                    return factory.newChildTraceSpanEventRecorder(traceRoot);
+                }));
+            }
+            start.countDown();
+            for (Future<Object> future : futures) {
+                Assertions.assertNotNull(future.get());
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        // the benign race may call the provider more than once, but every call yields the same singleton
+        final int callsAfterRace = providerCalls.get();
+        Assertions.assertTrue(callsAfterRace >= 1 && callsAfterRace <= threads);
+        // once warmed up the cache is authoritative: no further provider calls
+        factory.newChildTraceSpanEventRecorder(traceRoot);
+        factory.newWrappedSpanEventRecorder(traceRoot);
+        Assertions.assertEquals(callsAfterRace, providerCalls.get());
+    }
+}


### PR DESCRIPTION
… request path


DefaultRecorderFactory and DefaultAsyncTraceContext take Provider<AsyncContextFactory> / Provider<BaseTraceFactory> only to break the
BaseTraceFactory -> RecorderFactory -> AsyncContextFactory -> AsyncTraceContext -> BaseTraceFactory construction cycle, but they called Provider.get() on every span event recorder creation and every async trace continuation. Each Guice Provider.get() enters a new InternalContext (InternalContext + IdentityHashMap table), which showed up as ~7% of all sampled allocation on the webflux benchmark (8.3 GB / 60 s, all on request threads).

Both bindings are singletons, so resolve them lazily on first use and cache the instance in a volatile field. The constructor still does not touch the Provider, keeping the cycle intact; the benign first-call race only re-reads the same singleton.