### PR TITLE
[#14210] Inject AsyncContextFactory directly instead of resolving a Provider per recorder

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncTraceContext.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncTraceContext.java
@@ -22,6 +22,7 @@ import com.navercorp.pinpoint.profiler.context.id.LocalTraceRoot;
 import com.navercorp.pinpoint.profiler.context.id.TraceRoot;
 
 import java.util.Objects;
+import java.util.function.Supplier;
 
 
 /**
@@ -29,33 +30,23 @@ import java.util.Objects;
  */
 public class DefaultAsyncTraceContext implements AsyncTraceContext {
 
-    private final Provider<BaseTraceFactory> baseTraceFactoryProvider;
-    // Lazily resolved singleton; see DefaultRecorderFactory for why the Provider is kept and why the
-    // plain (non-volatile) field is enough.
-    private BaseTraceFactory baseTraceFactory;
+    // Supplied lazily: BaseTraceFactory -> RecorderFactory -> AsyncContextFactory -> AsyncTraceContext -> BaseTraceFactory
+    // is a construction cycle, so the factory cannot be injected directly. The supplier is expected to be memoized.
+    private final Supplier<BaseTraceFactory> baseTraceFactorySupplier;
 
-    public DefaultAsyncTraceContext(Provider<BaseTraceFactory> baseTraceFactoryProvider) {
-        this.baseTraceFactoryProvider = Objects.requireNonNull(baseTraceFactoryProvider, "baseTraceFactoryProvider");
-    }
-
-    private BaseTraceFactory baseTraceFactory() {
-        BaseTraceFactory factory = this.baseTraceFactory;
-        if (factory == null) {
-            factory = baseTraceFactoryProvider.get();
-            this.baseTraceFactory = factory;
-        }
-        return factory;
+    public DefaultAsyncTraceContext(Supplier<BaseTraceFactory> baseTraceFactorySupplier) {
+        this.baseTraceFactorySupplier = Objects.requireNonNull(baseTraceFactorySupplier, "baseTraceFactorySupplier");
     }
 
     @Override
     public Trace continueAsyncContextTraceObject(TraceRoot traceRoot, LocalAsyncId localAsyncId, boolean asyncTraceBlock) {
-        final BaseTraceFactory baseTraceFactory = baseTraceFactory();
+        final BaseTraceFactory baseTraceFactory = baseTraceFactorySupplier.get();
         return baseTraceFactory.continueAsyncContextTraceObject(traceRoot, localAsyncId, asyncTraceBlock);
     }
 
     @Override
     public Trace continueDisableAsyncContextTraceObject(LocalTraceRoot traceRoot) {
-        final BaseTraceFactory baseTraceFactory = baseTraceFactory();
+        final BaseTraceFactory baseTraceFactory = baseTraceFactorySupplier.get();
         return baseTraceFactory.continueDisableAsyncContextTraceObject(traceRoot);
     }
 

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/AsyncContextFactoryProvider.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/AsyncContextFactoryProvider.java
@@ -33,17 +33,17 @@ import java.util.Objects;
  */
 public class AsyncContextFactoryProvider implements Provider<AsyncContextFactory> {
 
-    private final Provider<AsyncTraceContext> asyncTraceContextProvider;
+    private final AsyncTraceContext asyncTraceContext;
     private final AsyncIdGenerator asyncIdGenerator;
     private final Binder<Trace> binder;
     private final PredefinedMethodDescriptorRegistry predefinedMethodDescriptorRegistry;
 
     @Inject
-    public AsyncContextFactoryProvider(Provider<AsyncTraceContext> asyncTraceContextProvider,
+    public AsyncContextFactoryProvider(AsyncTraceContext asyncTraceContext,
                                        AsyncIdGenerator asyncIdGenerator,
                                        Binder<Trace> binder,
                                        PredefinedMethodDescriptorRegistry predefinedMethodDescriptorRegistry) {
-        this.asyncTraceContextProvider = Objects.requireNonNull(asyncTraceContextProvider, "asyncTraceContextProvider");
+        this.asyncTraceContext = Objects.requireNonNull(asyncTraceContext, "asyncTraceContext");
         this.asyncIdGenerator = Objects.requireNonNull(asyncIdGenerator, "asyncIdGenerator");
         this.binder = Objects.requireNonNull(binder, "binder");
         this.predefinedMethodDescriptorRegistry = Objects.requireNonNull(predefinedMethodDescriptorRegistry, "predefinedMethodDescriptorRegistry");
@@ -53,7 +53,6 @@ public class AsyncContextFactoryProvider implements Provider<AsyncContextFactory
 
     @Override
     public AsyncContextFactory get() {
-        final AsyncTraceContext asyncTraceContext = asyncTraceContextProvider.get();
         return new DefaultAsyncContextFactory(asyncTraceContext, binder, asyncIdGenerator, predefinedMethodDescriptorRegistry);
     }
 }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/AsyncTraceContextProvider.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/AsyncTraceContextProvider.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.profiler.context.provider;
 
+import com.google.common.base.Suppliers;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.navercorp.pinpoint.profiler.context.AsyncTraceContext;
@@ -23,6 +24,7 @@ import com.navercorp.pinpoint.profiler.context.BaseTraceFactory;
 import com.navercorp.pinpoint.profiler.context.DefaultAsyncTraceContext;
 
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -39,6 +41,9 @@ public class AsyncTraceContextProvider implements Provider<AsyncTraceContext> {
 
     @Override
     public AsyncTraceContext get() {
-        return new DefaultAsyncTraceContext(baseTraceFactoryProvider);
+        // Every Guice Provider.get() enters a new InternalContext; the binding is a singleton,
+        // so resolve it once and hand the async trace path a plain Supplier.
+        Supplier<BaseTraceFactory> baseTraceFactory = Suppliers.memoize(baseTraceFactoryProvider::get);
+        return new DefaultAsyncTraceContext(baseTraceFactory);
     }
 }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultRecorderFactory.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultRecorderFactory.java
@@ -42,14 +42,7 @@ public class DefaultRecorderFactory implements RecorderFactory {
 
     private final StringMetaDataService stringMetaDataService;
     private final SqlMetaDataService sqlMetaDataService;
-    private final Provider<AsyncContextFactory> asyncContextFactoryProvider;
-    // Lazily resolved singleton. The Provider only exists to break the
-    // BaseTraceFactory -> RecorderFactory -> AsyncContextFactory -> AsyncTraceContext -> BaseTraceFactory
-    // construction cycle; every Guice Provider.get() enters a new InternalContext, which is too
-    // expensive to pay per span event recorder on the request path.
-    // Plain (non-volatile) racy cache: the singleton is immutable (final fields only), so a stale null
-    // just re-reads the same instance from the provider.
-    private AsyncContextFactory asyncContextFactory;
+    private final AsyncContextFactory asyncContextFactory;
     private final IgnoreErrorHandler errorHandler;
 
     private final ExceptionRecorderFactory exceptionRecorderFactory;
@@ -57,29 +50,20 @@ public class DefaultRecorderFactory implements RecorderFactory {
     private final SqlCountService sqlCountService;
 
     @Inject
-    public DefaultRecorderFactory(Provider<AsyncContextFactory> asyncContextFactoryProvider,
+    public DefaultRecorderFactory(AsyncContextFactory asyncContextFactory,
                                   StringMetaDataService stringMetaDataService,
                                   SqlMetaDataService sqlMetaDataService,
                                   IgnoreErrorHandler errorHandler,
                                   ExceptionRecorderFactory exceptionRecorderFactory,
                                   ErrorRecorderFactory errorRecorderFactory,
                                   SqlCountService sqlCountService) {
-        this.asyncContextFactoryProvider = Objects.requireNonNull(asyncContextFactoryProvider, "asyncContextFactoryProvider");
+        this.asyncContextFactory = Objects.requireNonNull(asyncContextFactory, "asyncContextFactory");
         this.stringMetaDataService = Objects.requireNonNull(stringMetaDataService, "stringMetaDataService");
         this.sqlMetaDataService = Objects.requireNonNull(sqlMetaDataService, "sqlMetaDataService");
         this.errorHandler = Objects.requireNonNull(errorHandler, "errorHandler");
         this.exceptionRecorderFactory = Objects.requireNonNull(exceptionRecorderFactory, "exceptionRecorderFactory");
         this.errorRecorderFactory = Objects.requireNonNull(errorRecorderFactory, "errorRecorderFactory");
         this.sqlCountService = Objects.requireNonNull(sqlCountService, "sqlCountService");
-    }
-
-    private AsyncContextFactory asyncContextFactory() {
-        AsyncContextFactory factory = this.asyncContextFactory;
-        if (factory == null) {
-            factory = asyncContextFactoryProvider.get();
-            this.asyncContextFactory = factory;
-        }
-        return factory;
     }
 
     @Override
@@ -114,7 +98,6 @@ public class DefaultRecorderFactory implements RecorderFactory {
     public WrappedSpanEventRecorder newWrappedSpanEventRecorder(TraceRoot traceRoot) {
         Objects.requireNonNull(traceRoot, "traceRoot");
 
-        final AsyncContextFactory asyncContextFactory = asyncContextFactory();
         ExceptionRecorder exceptionRecorder = exceptionRecorderFactory.newRecorder(traceRoot);
         ErrorRecorder errorRecorder = errorRecorderFactory.newRecorder(traceRoot);
 
@@ -127,7 +110,6 @@ public class DefaultRecorderFactory implements RecorderFactory {
         Objects.requireNonNull(traceRoot, "traceRoot");
         Objects.requireNonNull(asyncState, "asyncState");
 
-        final AsyncContextFactory asyncContextFactory = asyncContextFactory();
         ExceptionRecorder exceptionRecorder = exceptionRecorderFactory.newRecorder(traceRoot);
         ErrorRecorder errorRecorder = errorRecorderFactory.newRecorder(traceRoot);
 
@@ -139,7 +121,6 @@ public class DefaultRecorderFactory implements RecorderFactory {
     public WrappedSpanEventRecorder newChildTraceSpanEventRecorder(TraceRoot traceRoot) {
         Objects.requireNonNull(traceRoot, "traceRoot");
 
-        final AsyncContextFactory asyncContextFactory = asyncContextFactory();
         ExceptionRecorder exceptionRecorder = exceptionRecorderFactory.newRecorder(traceRoot);
         ErrorRecorder errorRecorder = errorRecorderFactory.newRecorder(traceRoot);
 
@@ -163,7 +144,6 @@ public class DefaultRecorderFactory implements RecorderFactory {
     }
 
     private DisableSpanEventRecorder newDisableSpanEventRecorder0(LocalTraceRoot traceRoot, AsyncState asyncState) {
-        final AsyncContextFactory asyncContextFactory = asyncContextFactory();
         return new DisableSpanEventRecorder(traceRoot, asyncContextFactory, asyncState);
     }
 
@@ -172,7 +152,6 @@ public class DefaultRecorderFactory implements RecorderFactory {
         Objects.requireNonNull(traceRoot, "traceRoot");
         Objects.requireNonNull(asyncState, "asyncState");
 
-        final AsyncContextFactory asyncContextFactory = asyncContextFactory();
         return new DisableChildTraceSpanEventRecorder(traceRoot, asyncContextFactory, asyncState);
     }
 }

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/AsyncContextTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/AsyncContextTest.java
@@ -1,5 +1,6 @@
 package com.navercorp.pinpoint.profiler.context;
 
+import com.google.common.base.Suppliers;
 import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.profiler.context.id.TraceRoot;
@@ -53,7 +54,7 @@ public abstract class AsyncContextTest {
                 });
         when(baseTraceFactoryProvider.get()).thenReturn(baseTraceFactory);
 
-        return new DefaultAsyncTraceContext(baseTraceFactoryProvider);
+        return new DefaultAsyncTraceContext(Suppliers.memoize(baseTraceFactoryProvider::get));
     }
 
     @BeforeEach

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncTraceContextTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/DefaultAsyncTraceContextTest.java
@@ -1,5 +1,7 @@
 package com.navercorp.pinpoint.profiler.context;
 
+import com.google.common.base.Suppliers;
+import com.google.inject.Provider;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.profiler.context.id.LocalTraceRoot;
 import com.navercorp.pinpoint.profiler.context.id.TraceRoot;
@@ -50,7 +52,7 @@ public class DefaultAsyncTraceContextTest {
                 });
         when(baseTraceFactoryProvider.get()).thenReturn(baseTraceFactory);
 
-        return new DefaultAsyncTraceContext(baseTraceFactoryProvider);
+        return new DefaultAsyncTraceContext(Suppliers.memoize(baseTraceFactoryProvider::get));
     }
 
 //    @MockitoSettings(strictness = Strictness.LENIENT)
@@ -71,14 +73,14 @@ public class DefaultAsyncTraceContextTest {
     @Test
     public void baseTraceFactoryProvider_isResolvedLazilyAndOnce() {
         BaseTraceFactory baseTraceFactory = mock(DefaultBaseTraceFactory.class);
-        BaseTraceFactoryProvider baseTraceFactoryProvider = mock(BaseTraceFactoryProvider.class);
+        Provider<BaseTraceFactory> baseTraceFactoryProvider = mock(BaseTraceFactoryProvider.class);
         when(baseTraceFactoryProvider.get()).thenReturn(baseTraceFactory);
         when(baseTraceFactory.continueAsyncContextTraceObject(any(TraceRoot.class), any(LocalAsyncId.class), any(Boolean.class)))
                 .thenReturn(mock(ChildTrace.class));
         when(baseTraceFactory.continueDisableAsyncContextTraceObject(any(LocalTraceRoot.class)))
                 .thenReturn(mock(DisableChildTrace.class));
 
-        AsyncTraceContext asyncTraceContext = new DefaultAsyncTraceContext(baseTraceFactoryProvider);
+        AsyncTraceContext asyncTraceContext = new DefaultAsyncTraceContext(Suppliers.memoize(baseTraceFactoryProvider::get));
         // the Provider breaks a Guice construction cycle: it must not be resolved in the constructor
         verify(baseTraceFactoryProvider, never()).get();
 

--- a/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultRecorderFactoryTest.java
+++ b/agent-module/profiler/src/test/java/com/navercorp/pinpoint/profiler/context/recorder/DefaultRecorderFactoryTest.java
@@ -16,7 +16,6 @@
 
 package com.navercorp.pinpoint.profiler.context.recorder;
 
-import com.google.inject.Provider;
 import com.navercorp.pinpoint.bootstrap.context.AsyncState;
 import com.navercorp.pinpoint.bootstrap.context.ErrorRecorder;
 import com.navercorp.pinpoint.profiler.context.AsyncContextFactory;
@@ -38,33 +37,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- * The {@code Provider<AsyncContextFactory>} breaks a Guice construction cycle, but every
- * {@code Provider.get()} enters a new Guice {@code InternalContext}. The factory must therefore
- * resolve the singleton lazily and exactly once, never eagerly in the constructor.
- */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class DefaultRecorderFactoryTest {
 
-    @Mock
-    private Provider<AsyncContextFactory> asyncContextFactoryProvider;
     @Mock
     private AsyncContextFactory asyncContextFactory;
     @Mock
@@ -90,68 +70,23 @@ class DefaultRecorderFactoryTest {
 
     @BeforeEach
     void setUp() {
-        when(asyncContextFactoryProvider.get()).thenReturn(asyncContextFactory);
         when(exceptionRecorderFactory.newRecorder(any(TraceRoot.class))).thenReturn(mock(ExceptionRecorder.class));
         when(errorRecorderFactory.newRecorder(any(LocalTraceRoot.class))).thenReturn(mock(ErrorRecorder.class));
 
-        this.factory = new DefaultRecorderFactory(asyncContextFactoryProvider, stringMetaDataService, sqlMetaDataService,
+        this.factory = new DefaultRecorderFactory(asyncContextFactory, stringMetaDataService, sqlMetaDataService,
                 errorHandler, exceptionRecorderFactory, errorRecorderFactory, sqlCountService);
     }
 
-    @Test
-    void constructor_doesNotResolveProvider() {
-        // resolving eagerly would re-introduce the construction cycle the Provider exists to break
-        verify(asyncContextFactoryProvider, never()).get();
-    }
 
     @Test
-    void asyncContextFactory_isResolvedOnceAcrossAllRecorderKinds() {
+    void newRecorder_allRecorderKinds() {
         Assertions.assertNotNull(factory.newWrappedSpanEventRecorder(traceRoot));
         Assertions.assertNotNull(factory.newWrappedSpanEventRecorder(traceRoot, asyncState));
         Assertions.assertNotNull(factory.newChildTraceSpanEventRecorder(traceRoot));
         Assertions.assertNotNull(factory.newDisableSpanEventRecorder(localTraceRoot));
         Assertions.assertNotNull(factory.newDisableSpanEventRecorder(localTraceRoot, asyncState));
         Assertions.assertNotNull(factory.newDisableChildTraceSpanEventRecorder(localTraceRoot, asyncState));
-        // a second round must not touch the provider again
         Assertions.assertNotNull(factory.newChildTraceSpanEventRecorder(traceRoot));
-
-        verify(asyncContextFactoryProvider, times(1)).get();
     }
 
-    @Test
-    void concurrentFirstCalls_resolveTheSameSingleton() throws Exception {
-        final int threads = 8;
-        final AtomicInteger providerCalls = new AtomicInteger();
-        final AsyncContextFactory singleton = mock(AsyncContextFactory.class);
-        when(asyncContextFactoryProvider.get()).thenAnswer(invocation -> {
-            providerCalls.incrementAndGet();
-            return singleton;
-        });
-
-        final CountDownLatch start = new CountDownLatch(1);
-        final ExecutorService executor = Executors.newFixedThreadPool(threads);
-        try {
-            List<Future<Object>> futures = new ArrayList<>();
-            for (int i = 0; i < threads; i++) {
-                futures.add(executor.submit((Callable<Object>) () -> {
-                    start.await();
-                    return factory.newChildTraceSpanEventRecorder(traceRoot);
-                }));
-            }
-            start.countDown();
-            for (Future<Object> future : futures) {
-                Assertions.assertNotNull(future.get());
-            }
-        } finally {
-            executor.shutdownNow();
-        }
-
-        // the benign race may call the provider more than once, but every call yields the same singleton
-        final int callsAfterRace = providerCalls.get();
-        Assertions.assertTrue(callsAfterRace >= 1 && callsAfterRace <= threads);
-        // once warmed up the cache is authoritative: no further provider calls
-        factory.newChildTraceSpanEventRecorder(traceRoot);
-        factory.newWrappedSpanEventRecorder(traceRoot);
-        Assertions.assertEquals(callsAfterRace, providerCalls.get());
-    }
 }


### PR DESCRIPTION
This pull request refactors the dependency injection and lifecycle management for several core tracing components in the profiler module. The main focus is on breaking construction cycles by replacing direct Guice `Provider` dependencies with Java `Supplier` and by memoizing factory lookups where appropriate. This change simplifies object creation, improves clarity, and ensures that dependencies are resolved in a more controlled and efficient manner.

### Dependency injection and construction cycle resolution

* Refactored `DefaultAsyncTraceContext` to accept a `Supplier<BaseTraceFactory>` instead of a Guice `Provider`, breaking a construction cycle and clarifying lazy initialization. (`DefaultAsyncTraceContext.java`)
* Updated `AsyncTraceContextProvider` to use a memoized `Supplier<BaseTraceFactory>` (via Guava's `Suppliers.memoize`) to ensure singleton behavior and efficient factory resolution. (`AsyncTraceContextProvider.java`) [[1]](diffhunk://#diff-7fd8c4299b82d39243e9b99c96db262316f5c3b3ca061a8b50e82955a0a99f0eR19-R27) [[2]](diffhunk://#diff-7fd8c4299b82d39243e9b99c96db262316f5c3b3ca061a8b50e82955a0a99f0eL42-R47)

### Simplification of provider usage

* Changed `AsyncContextFactoryProvider` and `DefaultRecorderFactory` to inject concrete instances (`AsyncTraceContext`, `AsyncContextFactory`) directly rather than using Guice `Provider`. This reduces indirection and potential for misuse. (`AsyncContextFactoryProvider.java`, `DefaultRecorderFactory.java`) [[1]](diffhunk://#diff-bd981a5761e9f9acd182287b5a03694416a84ee7b8529848f57ca78a021e9a7cL36-R46) [[2]](diffhunk://#diff-bd981a5761e9f9acd182287b5a03694416a84ee7b8529848f57ca78a021e9a7cL56) [[3]](diffhunk://#diff-e9d51c8a5d1a9956028774c0da77210f79405c33d0aa83cf3fee56677366f340L20) [[4]](diffhunk://#diff-e9d51c8a5d1a9956028774c0da77210f79405c33d0aa83cf3fee56677366f340L45-R59)
* Removed redundant provider `.get()` calls throughout `DefaultRecorderFactory`, as the dependencies are now injected directly. (`DefaultRecorderFactory.java`) [[1]](diffhunk://#diff-e9d51c8a5d1a9956028774c0da77210f79405c33d0aa83cf3fee56677366f340L101) [[2]](diffhunk://#diff-e9d51c8a5d1a9956028774c0da77210f79405c33d0aa83cf3fee56677366f340L114) [[3]](diffhunk://#diff-e9d51c8a5d1a9956028774c0da77210f79405c33d0aa83cf3fee56677366f340L126) [[4]](diffhunk://#diff-e9d51c8a5d1a9956028774c0da77210f79405c33d0aa83cf3fee56677366f340L150) [[5]](diffhunk://#diff-e9d51c8a5d1a9956028774c0da77210f79405c33d0aa83cf3fee56677366f340L159)

### Test adjustments

* Updated tests to pass a `Supplier` (using lambda) instead of a `Provider` to the `DefaultAsyncTraceContext` constructor, aligning with the new production code signature. (`AsyncContextTest.java`, `DefaultAsyncTraceContextTest.java`) [[1]](diffhunk://#diff-6b74962d33197d75512c97299f5fb73e9e8708222d20efe88e524448f34466c7L56-R56) [[2]](diffhunk://#diff-dbe224a174c79ffedd6c2a61fa99efc9fb628451cb23ac4313a1c52e55f65c5cL47-R47)