### PR TITLE
Find service-grouped applications in the service map search

### DIFF
--- a/web-frontend/src/main/v3/apps/web/dev-mock/mockData.ts
+++ b/web-frontend/src/main/v3/apps/web/dev-mock/mockData.ts
@@ -153,6 +153,16 @@ const makeAppLink = (source: any, target: any, timestamps: number[]) => {
       applicationName: source.applicationName,
       serviceTypeCode: source.serviceTypeCode,
       serviceTypeName: source.serviceType,
+      // outRpcList는 WAS→WAS 링크에만 실린다(백엔드 LinkView#writerFilterHint의
+      // `link.isWasToWasLink()`). 프론트도 양쪽 nodeCategory가 SERVER일 때만 이 값으로
+      // filteredMap hint를 만들므로(useServerMapOnClickMenuItem), 같은 조건으로 내려준다.
+      ...(source.nodeCategory === 'SERVER' && target.nodeCategory === 'SERVER'
+        ? {
+            outRpcList: [
+              { rpc: target.applicationName, rpcServiceTypeCode: target.serviceTypeCode },
+            ],
+          }
+        : {}),
     },
     totalCount: sumOf(histogram),
     errorCount: histogram.Error,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
@@ -10,10 +10,12 @@ import {
 import { FilteredMapType as FilteredMap, GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import {
   addCommas,
+  buildServerMapSearchList,
   findServiceGroupLink,
   findServiceGroupNode,
   getServerImagePath,
   getTimeSeriesApdexInfo,
+  ServerMapSearchItem,
 } from '@pinpoint-fe/ui/src/utils';
 import {
   ServerMapMenu,
@@ -271,6 +273,16 @@ export const ServerMapCore = ({
     setServerMapData({ nodes, edges });
   }, [data, unCheckedServiceTypes]);
 
+  // 검색 목록. service group 노드는 그 자체와 소속 application을 모두 담아, service에 묶인
+  // application도 이름으로 찾을 수 있게 한다.
+  const searchList = React.useMemo(
+    () =>
+      buildServerMapSearchList(
+        data?.applicationMapData?.nodeDataArray as GetServerMap.NodeData[] | undefined,
+      ),
+    [data],
+  );
+
   useUpdateEffect(() => {
     onMergeStateChange?.();
   }, [unCheckedServiceTypes]);
@@ -405,14 +417,38 @@ export const ServerMapCore = ({
     setPopperContentType(undefined);
   };
 
-  const handleClickSearchListItem = (item: GetServerMap.NodeData | FilteredMap.NodeData) => {
-    const { key } = item;
+  /**
+   * 그래프에 그려진 service group 노드 위에 자식 application 목록 팝업을 띄운다.
+   * group 노드는 merge 대상이 아니므로(shouldNotMerge) 항상 자기 key로 그려져 있다.
+   */
+  const openServiceGroupList = (group: GetServerMap.NodeData) => {
+    serviceGroupTargetRef.current = group;
+
+    const target = cyRef.current?.getElementById(group.key);
+    const position = target && !target.empty() ? target.renderedPosition() : undefined;
+
+    if (position) {
+      setPopperPosition({ x: position.x, y: position.y });
+    }
+    setPopperContentType(SERVERMAP_MENU_CONTENT_TYPE.SERVICE_GROUP_LIST);
+  };
+
+  /**
+   * 검색 목록에서 항목을 고르면 그 노드로 이동한다.
+   *
+   * service group(접힌 service)에 묶인 자식 application은 그래프에 노드가 없다 — 그려진 것은
+   * group 하나뿐이다. 그래서 센터링·선택은 group 노드에 하고, 자식 목록 팝업을 열어 무엇을
+   * 골랐는지 보여준 뒤 조회 대상만 그 application으로 넘긴다(group 노드 좌클릭 → 목록에서
+   * 자식 선택과 같은 상태다).
+   */
+  const handleClickSearchListItem = ({ node, serviceGroup }: ServerMapSearchItem) => {
+    const key = serviceGroup?.key ?? node.key;
     let clickedNode = cyRef.current?.getElementById(key);
 
     if (clickedNode?.empty()) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      clickedNode = cyRef.current?.nodes().filter((node: any) => {
-        const { nodes } = node.data();
+      clickedNode = cyRef.current?.nodes().filter((n: any) => {
+        const { nodes } = n.data();
 
         return Boolean(nodes) && nodes.some(({ id }: Node) => id === key);
       });
@@ -421,6 +457,23 @@ export const ServerMapCore = ({
     cyRef.current!.center(clickedNode);
     clickedNode?.select();
     clickedNode?.emit('tap');
+
+    // group 노드 자체를 골랐을 때도 좌클릭과 같이 자식 목록을 펼친다. group은 그 자체로 조회
+    // 대상이 될 수 없어(ServiceMapFetcher가 선택으로 만들지 않는다) 목록을 열지 않으면 노드만
+    // 가운데로 오고 아무 일도 일어나지 않은 화면이 된다.
+    const group =
+      serviceGroup ??
+      findServiceGroupNode(
+        data?.applicationMapData?.nodeDataArray as GetServerMap.NodeData[] | undefined,
+        node.key,
+      );
+
+    if (group) {
+      openServiceGroupList(group);
+    }
+    if (serviceGroup) {
+      onClickSubNode?.(node);
+    }
   };
 
   const reset = () => {
@@ -487,7 +540,7 @@ export const ServerMapCore = ({
           <div className="absolute flex flex-col gap-2 top-3 right-4 z-[3] bg-white">
             <ServerMapSearchList
               inputPlaceHolder={inputPlaceHolder}
-              list={data?.applicationMapData?.nodeDataArray}
+              list={searchList}
               onClickItem={handleClickSearchListItem}
             />
             {onApplyChangedOption && (
@@ -625,10 +678,13 @@ export const ServerMapCore = ({
                       ? subNodes.filter((n) => n.applicationName?.toLowerCase().includes(search))
                       : subNodes;
                     return (
+                      // w-max는 가장 긴 application 이름만큼 팝업을 넓힌다. 상한을 두지 않으면
+                      // 이름이 긴 노드에서 팝업이 map 컨테이너를 넘고, 그 상태로 검색 입력에
+                      // 포커스가 가면 브라우저가 map을 왼쪽으로 스크롤한다(위 클램프 주석 참고).
                       <ServerMapMenuContent
                         title={serviceGroupTargetRef.current?.applicationName ?? 'Service Group'}
                         onClose={() => setPopperContentType(undefined)}
-                        className="w-max min-w-72"
+                        className="w-max min-w-72 max-w-[22.5rem]"
                       >
                         <div className="px-3 pb-2">
                           <div className="relative">
@@ -656,8 +712,14 @@ export const ServerMapCore = ({
                                   className={cn(isSelected && 'bg-accent font-semibold')}
                                   onClick={() => onClickSubNode?.(subNode)}
                                 >
-                                  <img src={getServerImagePath(subNode)} width={28} />
-                                  <div className="whitespace-nowrap">{subNode.applicationName}</div>
+                                  <img
+                                    src={getServerImagePath(subNode)}
+                                    width={28}
+                                    className="shrink-0"
+                                  />
+                                  <div className="truncate" title={subNode.applicationName}>
+                                    {subNode.applicationName}
+                                  </div>
                                 </ServerMapMenuItem>
                               );
                             })
@@ -693,7 +755,7 @@ export const ServerMapCore = ({
                       <ServerMapMenuContent
                         title={linkTitle}
                         onClose={() => setPopperContentType(undefined)}
-                        className="w-max min-w-80"
+                        className="w-max min-w-80 max-w-[22.5rem]"
                       >
                         <div className="px-3 pb-2">
                           <div className="relative">
@@ -723,10 +785,13 @@ export const ServerMapCore = ({
                                   className={cn(isSelected && 'bg-accent font-semibold')}
                                   onClick={() => onClickSubLink?.(subLink)}
                                 >
-                                  <div className="flex items-center flex-1 gap-1 whitespace-nowrap">
-                                    <span>{fromName}</span>
-                                    <span className="text-muted-foreground">→</span>
-                                    <span>{toName}</span>
+                                  <div
+                                    className="flex items-center flex-1 min-w-0 gap-1"
+                                    title={`${fromName} → ${toName}`}
+                                  >
+                                    <span className="truncate">{fromName}</span>
+                                    <span className="shrink-0 text-muted-foreground">→</span>
+                                    <span className="truncate">{toName}</span>
                                   </div>
                                   <div className="ml-2 text-muted-foreground shrink-0">
                                     {addCommas(subLink.totalCount ?? 0)}

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapCore.tsx
@@ -712,8 +712,11 @@ export const ServerMapCore = ({
                                   className={cn(isSelected && 'bg-accent font-semibold')}
                                   onClick={() => onClickSubNode?.(subNode)}
                                 >
+                                  {/* 아이콘은 바로 옆 이름이 말해 주는 것을 되풀이할 뿐이라
+                                      스크린 리더에는 읽히지 않게 둔다. */}
                                   <img
                                     src={getServerImagePath(subNode)}
+                                    alt=""
                                     width={28}
                                     className="shrink-0"
                                   />

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapMenu.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapMenu.tsx
@@ -64,12 +64,13 @@ export const ServerMapMenuContent = ({
   return (
     <div className={cn('w-52', className)}>
       <div className="flex items-center h-8 gap-1 px-3 text-sm font-semibold">
-        <span className="flex-1 whitespace-nowrap">{title}</span>
+        {/* 제목은 service/application 이름이라 길 수 있다. 닫기 버튼을 밀어내지 않게 자른다. */}
+        <span className="flex-1 min-w-0 truncate">{title}</span>
         {onClose && (
           <button
             type="button"
             aria-label="Close"
-            className="p-0.5 text-muted-foreground hover:text-foreground"
+            className="shrink-0 p-0.5 text-muted-foreground hover:text-foreground"
             onClick={onClose}
           >
             <IoMdClose />

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMapSearchList/ServerMapSearchList.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMapSearchList/ServerMapSearchList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FaSearch } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
-import { FilteredMapType as FilteredMap, GetServerMap } from '@pinpoint-fe/ui/src/constants';
+import { ServerMapSearchItem } from '@pinpoint-fe/ui/src/utils';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Button } from '../ui/button';
 import {
@@ -15,8 +15,8 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '..';
 
 export interface ServerMapSearchListProps {
-  list?: GetServerMap.NodeData[] | FilteredMap.NodeData[];
-  onClickItem?: (nodeData: GetServerMap.NodeData | FilteredMap.NodeData) => void;
+  list?: ServerMapSearchItem[];
+  onClickItem?: (item: ServerMapSearchItem) => void;
   inputPlaceHolder?: string;
 }
 
@@ -28,8 +28,8 @@ export const ServerMapSearchList = ({
   const { t } = useTranslation();
   const [open, setOpen] = React.useState(false);
 
-  const handleClickItem: ServerMapSearchListProps['onClickItem'] = (node) => {
-    onClickItem?.(node);
+  const handleClickItem: ServerMapSearchListProps['onClickItem'] = (item) => {
+    onClickItem?.(item);
     setOpen(false);
   };
 
@@ -50,12 +50,39 @@ export const ServerMapSearchList = ({
                   <CommandList>
                     <CommandEmpty>{t('COMMON.EMPTY_ON_SEARCH')}</CommandEmpty>
                     <CommandGroup>
-                      {list.map((l, i) => {
-                        const text = `${l.applicationName} (${l.serviceType})`;
+                      {list.map((item, i) => {
+                        const { node, isServiceGroup, serviceName } = item;
+                        // service group은 application 묶음이라 serviceType이 없다. flatten이
+                        // 자식 첫 노드의 타입을 합성해 두지만 그것을 이름 뒤에 붙이면 B가
+                        // TOMCAT application인 것처럼 읽힌다. 이름만 보여준다.
+                        const text = isServiceGroup
+                          ? node.applicationName
+                          : `${node.applicationName} (${node.serviceType})`;
+                        // 소속 service를 보여주는 항목은 그 이름까지 값에 담는다. 이름이 같은
+                        // application이 다른 service에도 있을 수 있어(cmdk는 value로 항목을
+                        // 식별한다) 값이 겹치지 않게 하고, service 이름으로 검색해도 소속
+                        // application이 함께 걸리게 하기 위해서다.
+                        const value = serviceName ? `${text} ${serviceName}` : text;
 
                         return (
-                          <CommandItem key={i} value={text} onSelect={() => handleClickItem(l)}>
-                            <div className="truncate">{text}</div>
+                          <CommandItem
+                            key={`${node.key}-${i}`}
+                            value={value}
+                            onSelect={() => handleClickItem(item)}
+                          >
+                            <div className="flex-1 min-w-0 truncate" title={text}>
+                              {text}
+                            </div>
+                            {serviceName && (
+                              // 긴 service 이름이 application 이름을 밀어내지 않도록 폭을 제한한다.
+                              // shrink-0 없이 두면 이름이 긴 쪽이 행을 다 차지한다(왼쪽은 basis 0).
+                              <div
+                                className="max-w-[45%] pl-2 text-xs truncate shrink-0 text-muted-foreground"
+                                title={serviceName}
+                              >
+                                {serviceName}
+                              </div>
+                            )}
                           </CommandItem>
                         );
                       })}

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildServerMapSearchList,
   findServiceGroupLink,
   findServiceGroupNode,
   flattenServiceMapResponse,
@@ -228,5 +229,71 @@ describe('findServiceGroupNode / findServiceGroupLink', () => {
     expect(findServiceGroupLink([appLink], 'svcA^a^TOMCAT~svcA^b^TOMCAT')).toBeUndefined();
     expect(findServiceGroupNode(undefined, 'svcA')).toBeUndefined();
     expect(findServiceGroupLink(undefined, 'svcA~svcB')).toBeUndefined();
+  });
+});
+
+describe('buildServerMapSearchList', () => {
+  // servicemap 응답의 application 노드. key가 3단이라 자기 service를 알아볼 수 있다.
+  const appNode = {
+    key: 'svcA^a-1^TOMCAT',
+    applicationName: 'a-1',
+    serviceName: 'svcA',
+  } as GetServerMap.NodeData;
+
+  const makeGroup = (subNodes: GetServerMap.NodeData[]) =>
+    ({
+      key: 'svcB',
+      applicationName: 'svcB',
+      serviceName: 'svcB',
+      subNodes,
+    }) as unknown as GetServerMap.NodeData;
+
+  test('returns an empty list when there are no nodes', () => {
+    expect(buildServerMapSearchList(undefined)).toEqual([]);
+    expect(buildServerMapSearchList([])).toEqual([]);
+  });
+
+  // servicemap의 application 노드는 group에 묶여 있지 않아도 소속 service를 보여준다.
+  test('labels an application node with its own service', () => {
+    expect(buildServerMapSearchList([appNode])).toEqual([{ node: appNode, serviceName: 'svcA' }]);
+  });
+
+  // servermap 응답의 key는 2단이다. serviceName이 채워져 있어도 화면의 service 하나를
+  // 모든 행에 되풀이해 찍는 셈이라 표시하지 않는다.
+  test('does not label a node whose key carries no service', () => {
+    const serverMapNode = {
+      key: 'a-1^TOMCAT',
+      applicationName: 'a-1',
+      serviceName: 'DEFAULT',
+    } as GetServerMap.NodeData;
+
+    expect(buildServerMapSearchList([serverMapNode])).toEqual([
+      { node: serverMapNode, serviceName: undefined },
+    ]);
+  });
+
+  // 이슈 #10540 — service에 묶인 application(b-1, b-2)도 검색 목록에 있어야 한다.
+  test('expands a service group into the group itself and its applications', () => {
+    const b1 = { key: 'svcB^b-1^TOMCAT', applicationName: 'b-1' } as GetServerMap.NodeData;
+    const b2 = { key: 'svcB^b-2^TOMCAT', applicationName: 'b-2' } as GetServerMap.NodeData;
+    const group = makeGroup([b1, b2]);
+
+    expect(buildServerMapSearchList([appNode, group])).toEqual([
+      { node: appNode, serviceName: 'svcA' },
+      // group 항목은 이름이 곧 service다. serviceType(합성된 자식 타입)도, 소속 service도
+      // 표시하지 않는다.
+      { node: group, isServiceGroup: true },
+      { node: b1, serviceGroup: group, serviceName: 'svcB' },
+      { node: b2, serviceGroup: group, serviceName: 'svcB' },
+    ]);
+  });
+
+  // 자식이 없으면 group으로 볼 수 없다(findServiceGroupNode와 같은 판별).
+  test('treats a node with an empty subNodes array as a plain node', () => {
+    const emptyGroup = makeGroup([]);
+
+    expect(buildServerMapSearchList([emptyGroup])).toEqual([
+      { node: emptyGroup, serviceName: undefined },
+    ]);
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serviceMap.ts
@@ -135,3 +135,77 @@ export const findServiceGroupLink = <T extends GetServerMap.LinkData>(
   links?.find(
     (link) => link.key === key && Array.isArray(link.subLinks) && link.subLinks.length > 0,
   );
+
+/**
+ * map 검색 목록의 한 항목.
+ *
+ * service group(접힌 service) 노드는 그래프에 단일 노드로 그려지고 `applicationName`이
+ * serviceName이라, 목록에 노드 배열을 그대로 넘기면 그 service에 묶인 application(b-1, b-2)은
+ * 이름으로 찾을 수 없다. 그래서 group은 자기 자신과 소속 application을 모두 항목으로 편다.
+ */
+export interface ServerMapSearchItem {
+  node: GetServerMap.NodeData;
+  /**
+   * 이 항목이 service group 노드 자체일 때 true.
+   *
+   * group은 application 묶음이라 serviceType이 없다. `flattenServiceMapResponse`가 자식 첫
+   * 노드의 타입을 합성해 채워 두지만(merge 판정에 쓰인다) 사용자에게 보일 값은 아니다 —
+   * 이름 뒤에 붙이면 B가 TOMCAT application인 것처럼 읽힌다.
+   */
+  isServiceGroup?: boolean;
+  /**
+   * 이 항목이 service group에 묶인 자식 application일 때 그 group 노드. 아니면 undefined다.
+   *
+   * 자식 application은 그래프에 노드가 없으므로(그려진 것은 group 하나뿐이다) 목록에서 골랐을 때
+   * 센터링·선택의 대상은 group 노드이고, 조회 대상만 자식 application이 된다.
+   */
+  serviceGroup?: GetServerMap.NodeData;
+  /** 목록에 함께 보일 소속 service 이름. 표시할 것이 없으면 undefined다. */
+  serviceName?: string;
+}
+
+/**
+ * 목록에 함께 보일 소속 service 이름을 정한다. 표시하지 않을 노드는 undefined.
+ *
+ * 노드 key가 `serviceName^applicationName^serviceType`인 노드만 자기 service를 보여준다.
+ * servermap 응답의 key는 `applicationName^serviceType`뿐이라, 그 화면에서는 serviceName이
+ * 채워져 있어도 화면의 service 하나를 모든 행에 되풀이해 찍는 셈이 되므로 표시하지 않는다.
+ *
+ * serviceName은 escape되지 않아(applicationName만 escape된다) `^`가 들어오면 토큰이 더 늘 수 있다.
+ * 그래서 토큰 개수로 세지 않고 접두사로 확인한다.
+ */
+const resolveSearchServiceName = (node: GetServerMap.NodeData): string | undefined =>
+  node.serviceName && node.key?.startsWith(`${node.serviceName}^`) ? node.serviceName : undefined;
+
+/**
+ * 노드 배열을 검색 목록 항목으로 편다. service group은 group 자체 + 소속 application 순으로 담는다.
+ *
+ * group 자체를 남기는 이유: service 이름으로 찾아 들어오는 기존 경로(B를 검색해 B 그룹으로 이동)를
+ * 그대로 두기 위해서다. 판별은 `findServiceGroupNode`와 같이 `subNodes`로 한다 —
+ * servermap/filteredMap 응답에는 없는 필드라 그 화면들에서는 노드가 1:1로 담긴다.
+ *
+ * 소속 service 표시 여부는 그와 별개로 노드 key에서 판단한다(`resolveSearchServiceName`).
+ * servermap은 key가 2단이라 표시되지 않고, filteredMap은 `enableServiceMap`이 켜져 3단으로
+ * 내려올 때 표시된다 — 그 화면의 map도 여러 service의 노드를 함께 그리므로 같은 규칙이 맞다.
+ */
+export const buildServerMapSearchList = (
+  nodes: GetServerMap.NodeData[] | undefined,
+): ServerMapSearchItem[] =>
+  (nodes ?? []).flatMap((node): ServerMapSearchItem[] => {
+    const subNodes = node.subNodes;
+
+    if (!Array.isArray(subNodes) || subNodes.length === 0) {
+      return [{ node, serviceName: resolveSearchServiceName(node) }];
+    }
+
+    // group 노드 자체는 이름이 곧 service라 소속 service를 따로 붙이지 않는다.
+    return [
+      { node, isServiceGroup: true },
+      ...subNodes.map((subNode) => ({
+        node: subNode,
+        serviceGroup: node,
+        // 자식의 service는 group 엔트리가 알려준 값이 정본이다(자식 key에서 다시 읽지 않는다).
+        serviceName: node.serviceName,
+      })),
+    ];
+  });


### PR DESCRIPTION
## Summary
- A collapsed service is drawn as one group node whose `applicationName` is the service name, so the applications inside it could not be found by name in the map search. `buildServerMapSearchList` now expands a group into the group itself plus its member applications; picking a member centers/selects the group node (the only node on the graph), opens the child list popup and points only the query at that application — the same state as left-clicking the group and picking the child.
- Search rows show the owning service, but only when the node key carries one (3-segment key). Server map keys are 2-segment, so that screen is unchanged. The service name is folded into the cmdk value so equally named applications in different services stay distinct and a service name also matches its members.
- Long names in the group popups and menu titles truncate instead of pushing the popup past the map container, which made the map scroll sideways once the search input took focus.
- Dev mock now emits `outRpcList` on WAS→WAS links only, matching the backend condition the filtered map hint is built from.

## Test plan
- [ ] `yarn build` passes
- [ ] `yarn test` passes (new `buildServerMapSearchList` cases included)
- [ ] Service map (non-DEFAULT service): search a collapsed service by name → group node is centered and its application list opens
- [ ] Search an application that belongs to a collapsed service → group is centered, list opens, and the right panel charts load for that application
- [ ] Search an application drawn as its own node → centered and selected as before, no popup
- [ ] Server map (unchanged path): search list shows `name (serviceType)` with no service column and selection behaves as before
- [ ] Long service/application names: group node and group link popups stay inside the map, and focusing the popup search input does not scroll the map sideways