### PR TITLE
[#noissue] Upgrade react-router to 7.18.3 and import it as react-router

### DIFF
--- a/web-frontend/src/main/v3/apps/web/package.json
+++ b/web-frontend/src/main/v3/apps/web/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^19.0.0",
     "react-i18next": "^13.0.2",
     "react-icons": "^5.2.1",
-    "react-router-dom": "^6.30.4",
+    "react-router": "^7.18.3",
     "usehooks-ts": "^2.9.1",
     "zod": "^3.22.4"
   },

--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/ConfigurationOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/ConfigurationOutlet.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 import { LayoutWithConfiguration } from './LayoutWithConfiguration';
 
 export const ConfigurationOutlet = () => {

--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router';
 import {
   resolveRequestService,
   useClearApplicationOnServiceChange,

--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/LayoutWithConfiguration.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/LayoutWithConfiguration.tsx
@@ -5,7 +5,7 @@ import {
   SERVICE_CONFIG_MENU,
   isServiceConfigPath,
 } from '@pinpoint-fe/ui';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useAtomValue } from 'jotai';
 import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
 

--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/SideNavigationOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/SideNavigationOutlet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 import { LayoutWithSideNavigation } from './LayoutWithSideNavigation';
 
 export const SideNavigationOutlet = () => {

--- a/web-frontend/src/main/v3/apps/web/src/main.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router';
 import { Provider as JotaiProvider, getDefaultStore } from 'jotai';
 import { IconContext } from 'react-icons';
 // import { ReactToastContainer, queryClient } from '@pinpoint-fe/ui';

--- a/web-frontend/src/main/v3/apps/web/src/routes/index.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { lazy } from 'react';
-import { createBrowserRouter, redirect } from 'react-router-dom';
+import { createBrowserRouter, redirect } from 'react-router';
 import {
   serverMapRouteLoader,
   serviceMapRouteLoader,

--- a/web-frontend/src/main/v3/packages/ui/jest.config.cjs
+++ b/web-frontend/src/main/v3/packages/ui/jest.config.cjs
@@ -2,6 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/jest.setup.cjs'],
   moduleDirectories: ['node_modules'],
   // Ignore compiled build output so jest does not pick up dist/*.js (ESM) alongside src tests.
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],

--- a/web-frontend/src/main/v3/packages/ui/jest.setup.cjs
+++ b/web-frontend/src/main/v3/packages/ui/jest.setup.cjs
@@ -1,0 +1,12 @@
+// react-router v7의 CJS 엔트리는 server-runtime까지 함께 싣고, 그 모듈이 로드 시점에
+// `new TextEncoder()`를 만든다. jest의 jsdom 환경에는 TextEncoder/TextDecoder 전역이
+// 없어서 `jest.requireActual('react-router')`를 쓰는 스위트가 임포트에서 바로 죽는다.
+// Node의 구현을 전역에 채워 넣는다.
+const { TextEncoder, TextDecoder } = require('node:util');
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder;
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  globalThis.TextDecoder = TextDecoder;
+}

--- a/web-frontend/src/main/v3/packages/ui/package.json
+++ b/web-frontend/src/main/v3/packages/ui/package.json
@@ -23,7 +23,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-i18next": "^13.0.2",
-    "react-router-dom": "^6.30.4"
+    "react-router": "^7.18.3"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.10",
@@ -126,6 +126,7 @@
     "postcss": "^8.4.29",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.5.11",
+    "react-router": "^7.18.3",
     "storybook": "^9.1.19",
     "tailwind-merge": "^2.2.1",
     "tailwind-scrollbar-hide": "^1.1.7",

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { AgentActiveThreadView } from './AgentActiveThreadView';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useAtom, useAtomValue } from 'jotai';
 import {
   activeThreadTargetAtom,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Button/ApplicationLinkButton.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Button/ApplicationLinkButton.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ApplicationType } from '@pinpoint-fe/ui/src/constants';
 import { useSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { Button } from '../ui';

--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/user-group/user-group/UserGroupTableFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/user-group/user-group/UserGroupTableFetcher.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { DataTable } from '../../../DataTable';
 import { useReactToastifyToast } from '../../../Toast';
 import { getUserGroupTableColumns } from './userGroupTableColumns';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { APP_PATH, ConfigUserGroup } from '@pinpoint-fe/ui/src/constants';
 import { convertParamsToQueryString } from '@pinpoint-fe/ui/src/utils';
 import { UserGroupTableToolbar } from './UserGroupTableToolbar';

--- a/web-frontend/src/main/v3/packages/ui/src/components/Config/user-group/user-group/UserGroupTableToolbar.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Config/user-group/user-group/UserGroupTableToolbar.tsx
@@ -4,7 +4,7 @@ import { RxMagnifyingGlass } from 'react-icons/rx';
 import { UserGroupAddPopup } from './UserGroupAddPopup';
 import { Button, Input } from '../../../ui';
 import { MdOutlineAdd } from 'react-icons/md';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 import { convertParamsToQueryString } from '@pinpoint-fe/ui/src/utils';
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/Error/RouteErrorFallback.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Error/RouteErrorFallback.tsx
@@ -1,4 +1,4 @@
-import { useRouteError } from 'react-router-dom';
+import { useRouteError } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { Button } from '../ui';
 import { ErrorDetailDialog } from './ErrorDetailDialog';

--- a/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/sidebar/ErrorAnalysisGroupByFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/sidebar/ErrorAnalysisGroupByFetcher.tsx
@@ -5,7 +5,7 @@ import {
 import { cn } from '../../../lib';
 import { Checkbox } from '../../ui';
 import { Label } from '../../ui/label';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   getErrorAnalysisPath,
   convertParamsToQueryString,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/sidebar/ErrorAnalysisSidebar.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/sidebar/ErrorAnalysisSidebar.tsx
@@ -7,7 +7,7 @@ import {
   convertParamsToQueryString,
   getFormattedDateRange,
 } from '@pinpoint-fe/ui/src/utils';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { ApplicationLinkButton } from '../../Button/ApplicationLinkButton';
 
 export const ErrorAnalysisSidebar = () => {

--- a/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/table/ErrorAnalysisGroupedTableFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ErrorAnalysis/table/ErrorAnalysisGroupedTableFetcher.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   useErrorAnalysisSearchParameters,
   useGetErrorAnalysisGroupedErrorListData,

--- a/web-frontend/src/main/v3/packages/ui/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/GlobalSearch/GlobalSearch.tsx
@@ -17,7 +17,7 @@ import {
 import { useAtom } from 'jotai';
 import React from 'react';
 import { createPortal } from 'react-dom';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { getTransactionDetailPathByTransactionId, isRegexString } from '@pinpoint-fe/ui/src/utils';
 import { PiStack } from 'react-icons/pi';
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/Inspector/sidebar/InspectorSidebar.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Inspector/sidebar/InspectorSidebar.tsx
@@ -7,7 +7,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { ApplicationLinkButton } from '../../Button/ApplicationLinkButton';
 import { Separator } from '../../ui';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 export const InspectorSidebar = () => {
   const navigate = useNavigate();

--- a/web-frontend/src/main/v3/packages/ui/src/components/Layout/LayoutWithAlarm.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Layout/LayoutWithAlarm.tsx
@@ -4,7 +4,7 @@ import { Separator } from '../../components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../components/ui/tabs';
 import { t } from 'i18next';
 import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 export interface LayoutWithAlarmProps {
   children?: React.ReactNode;
 }

--- a/web-frontend/src/main/v3/packages/ui/src/components/Layout/LayoutWithConfiguration.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Layout/LayoutWithConfiguration.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import { Separator } from '..';
 import { cn } from '../../lib';

--- a/web-frontend/src/main/v3/packages/ui/src/components/Layout/LayoutWithSideNavigation.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Layout/LayoutWithSideNavigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import {
   IMAGE_PATH,
   APP_PATH,

--- a/web-frontend/src/main/v3/packages/ui/src/components/OpenTelemetry/dashboard/OpenTelemteryDashboardFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/OpenTelemetry/dashboard/OpenTelemteryDashboardFetcher.tsx
@@ -1,7 +1,7 @@
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import React from 'react';
-import { useBlocker } from 'react-router-dom';
+import { useBlocker } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   AlertDialog,

--- a/web-frontend/src/main/v3/packages/ui/src/components/OpenTelemetry/sidebar/OpenTelemetrySidebar.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/OpenTelemetry/sidebar/OpenTelemetrySidebar.tsx
@@ -7,7 +7,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { ApplicationLinkButton } from '../../Button/ApplicationLinkButton';
 import { Separator } from '../../ui';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 export const OpenTelemetrySidebar = () => {
   const navigate = useNavigate();

--- a/web-frontend/src/main/v3/packages/ui/src/components/Service/useServiceSideNavigation.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Service/useServiceSideNavigation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TbCategory } from 'react-icons/tb';
 import { LuPlus, LuEllipsis } from 'react-icons/lu';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
   DEFAULT_SERVICE,

--- a/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/sidebar/SystemMetricSidebar.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/SystemMetric/sidebar/SystemMetricSidebar.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useSystemMetricSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import {
   getSystemMetricPath,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/call-tree/callTreeTableColumns.tsx
@@ -6,7 +6,7 @@ import {
 } from '@pinpoint-fe/ui/src/constants';
 import { ColumnDef } from '@tanstack/react-table';
 import { formatInTimeZone } from 'date-fns-tz';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   FaFire,
   FaDatabase,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-info/TransactionInfoFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-info/TransactionInfoFetcher.tsx
@@ -4,7 +4,7 @@ import { useGetTransactionInfo } from '@pinpoint-fe/ui/src/hooks';
 import { useAtom, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { FaChevronRight } from 'react-icons/fa6';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Button, HelpPopover, Tabs, TabsContent, TabsList, TabsTrigger } from '../..';
 import { CallTree } from '..';
 import {

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListByFilterMapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListByFilterMapFetcher.tsx
@@ -13,7 +13,7 @@ import {
 } from '@pinpoint-fe/ui/src/constants';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../../ui';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 declare global {
   interface Window {

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListByTrace.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListByTrace.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useSetAtom } from 'jotai';
 import { TransactionListTable, TransactionListTableProps } from './TransactionListTable';
 import {

--- a/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListTable.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Transaction/transaction-list/TransactionListTable.tsx
@@ -7,7 +7,7 @@ import {
   getTransactionListPath,
   getTransactionTableUniqueKey,
 } from '@pinpoint-fe/ui/src/utils';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useSetAtom } from 'jotai';
 import { transactionInfoCallTreeFocusId } from '@pinpoint-fe/ui/src/atoms';
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/URL/sidebar/UrlSidebar.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/URL/sidebar/UrlSidebar.tsx
@@ -7,7 +7,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { ApplicationLinkButton } from '../../Button/ApplicationLinkButton';
 import { Separator } from '../../ui';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 export const UrlSidebar = () => {
   const navigate = useNavigate();

--- a/web-frontend/src/main/v3/packages/ui/src/components/Webhook/WebhookCheckedList.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Webhook/WebhookCheckedList.tsx
@@ -6,7 +6,7 @@ import { useGetWebhook } from '@pinpoint-fe/ui/src/hooks';
 import { ScrollArea } from '../../components/ui/scroll-area';
 import { cn } from '../../lib/utils';
 import { Label } from '../../components';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
 export interface WebhookCheckedListProps extends WebhookListFetcherProps {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useErrorAnalysisSearchParameters.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useErrorAnalysisSearchParameters.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
 import { getDateRange, getSearchParameters } from './utils';
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useFilteredMapParameters.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useFilteredMapParameters.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import {
   getApplicationTypeAndName,
   getServiceNameFromPath,

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useInspectorSearchParameters.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useInspectorSearchParameters.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
 import { getDateRange, getSearchParameters } from './utils';
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useOpenTelemetrySearchParameters.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useOpenTelemetrySearchParameters.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
 import { getDateRange, getSearchParameters } from './utils';
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useSearchParameters.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useSearchParameters.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
 
 export const useSearchParameters = () => {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useServerMapSearchParameters.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useServerMapSearchParameters.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderHook, render, act, fireEvent, screen } from '@testing-library/react';
-import { MemoryRouter, useNavigate } from 'react-router-dom';
+import { MemoryRouter, useNavigate } from 'react-router';
 import { useServerMapSearchParameters } from './useServerMapSearchParameters';
 
 const renderAt = (path: string) =>

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useServerMapSearchParameters.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useServerMapSearchParameters.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { addMilliseconds } from 'date-fns';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
 import { getSearchParameters, getDateRange, getRealtimeDateRange } from './utils';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useSystemMetricSearchParameters.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useSystemMetricSearchParameters.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { getDateRange, getSearchParameters } from './utils';
 
 export const useSystemMetricSearchParameters = () => {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useTransactionSearchParameters.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useTransactionSearchParameters.test.tsx
@@ -2,8 +2,8 @@ import { renderHook } from '@testing-library/react';
 import { useTransactionSearchParameters } from './useTransactionSearchParameters';
 
 const mockLocation = { pathname: '', search: '' };
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useLocation: () => mockLocation,
 }));
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useUrlStatSearchParameters.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/searchParameters/useUrlStatSearchParameters.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
 import { getDateRange, getSearchParameters } from './utils';
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.test.tsx
@@ -12,8 +12,8 @@ import { useClearApplicationOnServiceChange } from './useClearApplicationOnServi
 
 const mockNavigate = jest.fn();
 const mockLocation = { pathname: '/serviceMap/DEFAULT' };
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
   useLocation: () => mockLocation,
 }));

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
   currentServerAtom,

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useIsDefaultService.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useIsDefaultService.test.tsx
@@ -5,8 +5,8 @@ import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import { useIsDefaultService } from './useIsDefaultService';
 
 const mockLocation = { pathname: '/serviceMap' };
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useLocation: () => mockLocation,
 }));
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.test.tsx
@@ -5,8 +5,8 @@ import { Configuration } from '@pinpoint-fe/ui/src/constants';
 import { useServiceNameForLink } from './useServiceNameForLink';
 
 const mockLocation = { pathname: '/serviceMap/test-app@SPRING_BOOT' };
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useLocation: () => mockLocation,
 }));
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useAtomValue } from 'jotai';
 import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
 import { getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useSyncSelectedServiceWithPath.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useSyncSelectedServiceWithPath.test.tsx
@@ -4,8 +4,8 @@ import { DEFAULT_SERVICE, selectedServiceAtom, servicesAtom } from '@pinpoint-fe
 import { useSyncSelectedServiceWithPath } from './useSyncSelectedServiceWithPath';
 
 const mockLocation = { pathname: '/serviceMap/aaa' };
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useLocation: () => mockLocation,
 }));
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useSyncSelectedServiceWithPath.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useSyncSelectedServiceWithPath.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useAtom, useAtomValue } from 'jotai';
 import { selectedServiceAtom, servicesAtom } from '@pinpoint-fe/ui/src/atoms';
 import { getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';

--- a/web-frontend/src/main/v3/packages/ui/src/loader/__fixtures__/loaderArgs.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/__fixtures__/loaderArgs.ts
@@ -1,0 +1,30 @@
+import type { LoaderFunctionArgs } from 'react-router';
+
+/**
+ * 로더 테스트가 넘기는 인자 스텁.
+ *
+ * 로더는 전부 `params`와 `request`만 destructure한다. react-router v7.18이
+ * `LoaderFunctionArgs`에 더한 `url`·`pattern`은 런타임이 채워 주는 값이라 어느
+ * 로더도 읽지 않으므로, 여기서는 형태만 맞춘다.
+ *
+ * 파싱되지 않는 url도 그대로 받는다. 로더가 잘못된 url을 어떻게 처리하는지 확인하는
+ * 테스트가 일부러 그런 값을 넘기기 때문이다 — 그 경우 로더가 `request.url`로 직접
+ * `new URL`을 해서 던지는 것이 확인 대상이다.
+ */
+export const makeArgs = (url: string, params: Record<string, string> = {}) => {
+  let parsedUrl: URL | undefined;
+
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    // 위 주석 참고. 스텁이 대신 던지면 정작 로더가 실행되지 않는다.
+  }
+
+  return {
+    params,
+    request: { url } as Request,
+    url: parsedUrl,
+    pattern: '',
+    context: {},
+  } as unknown as LoaderFunctionArgs;
+};

--- a/web-frontend/src/main/v3/packages/ui/src/loader/errorAnalysis.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/errorAnalysis.test.ts
@@ -1,7 +1,7 @@
 import { errorAnalysisRouteLoader } from './errorAnalysis';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -14,6 +14,8 @@ import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/errorAnalysis.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/errorAnalysis.test.ts
@@ -1,3 +1,4 @@
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { errorAnalysisRouteLoader } from './errorAnalysis';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
@@ -10,14 +11,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const APP = 'TestApp@SPRING_BOOT';
 const BASE = `${APP_PATH.ERROR_ANALYSIS}/${APP}`;

--- a/web-frontend/src/main/v3/packages/ui/src/loader/errorAnalysis.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/errorAnalysis.ts
@@ -12,7 +12,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { parse } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const errorAnalysisRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
   const application = getApplicationTypeAndName(params.application!);

--- a/web-frontend/src/main/v3/packages/ui/src/loader/filteredMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/filteredMap.test.ts
@@ -1,6 +1,6 @@
 import { filteredMapRouteLoader } from './filteredMap';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -13,6 +13,8 @@ import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string) => ({
   params: {},
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/filteredMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/filteredMap.test.ts
@@ -1,3 +1,4 @@
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { filteredMapRouteLoader } from './filteredMap';
 
 jest.mock('react-router', () => ({
@@ -9,14 +10,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string) => ({
-  params: {},
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const APP = 'ACL-PORTAL-DEV@SPRING_BOOT';
 const VALID = 'from=2023-11-10-14-30-00&to=2023-11-10-15-00-00';

--- a/web-frontend/src/main/v3/packages/ui/src/loader/filteredMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/filteredMap.ts
@@ -1,6 +1,6 @@
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 import { parseServiceScopedPath } from '@pinpoint-fe/ui/src/utils';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 import { resolveMapDateRangeRedirect } from './mapDateRange';
 
 /**

--- a/web-frontend/src/main/v3/packages/ui/src/loader/handleV2.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/handleV2.test.ts
@@ -1,13 +1,15 @@
 import { handleV2RouteLoader } from './handleV2';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/handleV2.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/handleV2.test.ts
@@ -1,17 +1,10 @@
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { handleV2RouteLoader } from './handleV2';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
 jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 describe('handleV2RouteLoader', () => {
   test('redirects to serverMap with formatted v3 date params for valid v2 params', () => {

--- a/web-frontend/src/main/v3/packages/ui/src/loader/handleV2.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/handleV2.ts
@@ -1,7 +1,7 @@
 import { APP_PATH, SEARCH_PARAMETER_DATE_FORMAT } from '@pinpoint-fe/ui/src/constants';
 import { convertTimeStringToTime, convertParamsToQueryString } from '@pinpoint-fe/ui/src/utils';
 import { parse, format, subMilliseconds } from 'date-fns';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const handleV2RouteLoader = ({ params, request }: LoaderFunctionArgs) => {
   const basePath = `${APP_PATH.SERVER_MAP}/${params.application}`;

--- a/web-frontend/src/main/v3/packages/ui/src/loader/inspector.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/inspector.test.ts
@@ -1,3 +1,4 @@
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { inspectorRouteLoader } from './inspector';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
@@ -10,14 +11,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const APP = 'TestApp@SPRING_BOOT';
 const VALID = 'from=2023-11-10-14-30-00&to=2023-11-10-15-00-00';

--- a/web-frontend/src/main/v3/packages/ui/src/loader/inspector.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/inspector.test.ts
@@ -1,7 +1,7 @@
 import { inspectorRouteLoader } from './inspector';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -14,6 +14,8 @@ import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/inspector.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/inspector.ts
@@ -12,7 +12,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { parse } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const inspectorRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
   const application = getApplicationTypeAndName(params.application!);

--- a/web-frontend/src/main/v3/packages/ui/src/loader/openTelemetry.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/openTelemetry.test.ts
@@ -1,3 +1,4 @@
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { openTelemetryRouteLoader } from './openTelemetry';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
@@ -10,14 +11,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const APP = 'TestApp@SPRING_BOOT';
 const BASE = `${APP_PATH.OPEN_TELEMETRY_METRIC}/${APP}`;

--- a/web-frontend/src/main/v3/packages/ui/src/loader/openTelemetry.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/openTelemetry.test.ts
@@ -1,7 +1,7 @@
 import { openTelemetryRouteLoader } from './openTelemetry';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -14,6 +14,8 @@ import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/openTelemetry.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/openTelemetry.ts
@@ -12,7 +12,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { parse } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const openTelemetryRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
   const application = getApplicationTypeAndName(params.application!);

--- a/web-frontend/src/main/v3/packages/ui/src/loader/realtime.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/realtime.test.ts
@@ -1,12 +1,15 @@
+import type { LoaderFunctionArgs } from 'react-router';
 import { realtimeLoader } from './realtime';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 
@@ -52,7 +55,7 @@ describe('realtimeLoader', () => {
       params: { application: 'TestApp@SPRING_BOOT' },
       request: { url: 'not-a-valid-url' } as unknown as Request,
       context: {},
-    });
+    } as unknown as LoaderFunctionArgs);
     expect(result).toBeNull();
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/loader/realtime.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/realtime.test.ts
@@ -1,17 +1,9 @@
-import type { LoaderFunctionArgs } from 'react-router';
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { realtimeLoader } from './realtime';
 
 jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 describe('realtimeLoader', () => {
   beforeEach(() => {
@@ -51,11 +43,9 @@ describe('realtimeLoader', () => {
   });
 
   test('returns null when an exception is thrown', () => {
-    const result = realtimeLoader({
-      params: { application: 'TestApp@SPRING_BOOT' },
-      request: { url: 'not-a-valid-url' } as unknown as Request,
-      context: {},
-    } as unknown as LoaderFunctionArgs);
+    const result = realtimeLoader(
+      makeArgs('not-a-valid-url', { application: 'TestApp@SPRING_BOOT' }),
+    );
     expect(result).toBeNull();
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/loader/realtime.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/realtime.ts
@@ -1,5 +1,5 @@
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const realtimeLoader = ({ params, request }: LoaderFunctionArgs) => {
   try {

--- a/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.test.ts
@@ -1,4 +1,4 @@
-import type { LoaderFunctionArgs } from 'react-router';
+import { makeArgs } from './__fixtures__/loaderArgs';
 import {
   scatterOrHeatmapFullScreenLoader,
   scatterOrHeatmapFullScreenRealtimeLoader,
@@ -13,14 +13,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const APP = 'TestApp@SPRING_BOOT';
 // The loader derives the base path from the first URL path segment.
@@ -95,11 +87,9 @@ describe('scatterOrHeatmapFullScreenRealtimeLoader', () => {
 
   test('returns null when an exception is thrown', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    const result = scatterOrHeatmapFullScreenRealtimeLoader({
-      params: { application: APP },
-      request: { url: 'not-a-valid-url' } as unknown as Request,
-      context: {},
-    } as unknown as LoaderFunctionArgs);
+    const result = scatterOrHeatmapFullScreenRealtimeLoader(
+      makeArgs('not-a-valid-url', { application: APP }),
+    );
     expect(result).toBeNull();
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.test.ts
@@ -1,9 +1,10 @@
+import type { LoaderFunctionArgs } from 'react-router';
 import {
   scatterOrHeatmapFullScreenLoader,
   scatterOrHeatmapFullScreenRealtimeLoader,
 } from './scatterOrHeatmapFullScreen';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -16,6 +17,8 @@ import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 
@@ -96,7 +99,7 @@ describe('scatterOrHeatmapFullScreenRealtimeLoader', () => {
       params: { application: APP },
       request: { url: 'not-a-valid-url' } as unknown as Request,
       context: {},
-    });
+    } as unknown as LoaderFunctionArgs);
     expect(result).toBeNull();
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.ts
@@ -8,7 +8,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { parse } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const scatterOrHeatmapFullScreenLoader = async ({ params, request }: LoaderFunctionArgs) => {
   const application = getApplicationTypeAndName(params.application);

--- a/web-frontend/src/main/v3/packages/ui/src/loader/serverMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/serverMap.test.ts
@@ -1,6 +1,6 @@
 import { serverMapRouteLoader } from './serverMap';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -13,6 +13,8 @@ import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/serverMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/serverMap.test.ts
@@ -1,3 +1,4 @@
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { serverMapRouteLoader } from './serverMap';
 
 jest.mock('react-router', () => ({
@@ -9,14 +10,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const APP = 'TestApp@SPRING_BOOT';
 const BASE = `/serverMap/${APP}`;

--- a/web-frontend/src/main/v3/packages/ui/src/loader/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/serverMap.ts
@@ -15,7 +15,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { parse } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 /**
  * map 페이지의 날짜 파라미터를 검증/정규화하는 공용 로더.

--- a/web-frontend/src/main/v3/packages/ui/src/loader/serviceMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/serviceMap.test.ts
@@ -1,3 +1,4 @@
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { serviceMapRouteLoader } from './serviceMap';
 
 jest.mock('react-router', () => ({
@@ -10,14 +11,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getConfiguration, getRequestService } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string) => ({
-  params: {},
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const APP = 'TestApp@SPRING_BOOT';
 const DEFAULT_BASE = `/serviceMap/DEFAULT/${APP}`;

--- a/web-frontend/src/main/v3/packages/ui/src/loader/serviceMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/serviceMap.test.ts
@@ -1,6 +1,6 @@
 import { serviceMapRouteLoader } from './serviceMap';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -14,6 +14,8 @@ import { getConfiguration, getRequestService } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string) => ({
   params: {},
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/serviceMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/serviceMap.ts
@@ -2,7 +2,7 @@ import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 import { DEFAULT_SERVICE } from '@pinpoint-fe/ui/src/atoms';
 import { getRequestService } from '@pinpoint-fe/ui/src/hooks';
 import { getServiceMapPath, parseServiceScopedPath } from '@pinpoint-fe/ui/src/utils';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 import { resolveMapDateRangeRedirect } from './mapDateRange';
 
 /**

--- a/web-frontend/src/main/v3/packages/ui/src/loader/serviceMapRealtime.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/serviceMapRealtime.test.ts
@@ -1,6 +1,7 @@
+import type { LoaderFunctionArgs } from 'react-router';
 import { serviceMapRealtimeLoader } from './serviceMapRealtime';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -13,6 +14,8 @@ import { getRequestService } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string) => ({
   params: {},
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 
@@ -114,7 +117,7 @@ describe('serviceMapRealtimeLoader', () => {
         params: {},
         request: { url: 'not-a-valid-url' } as unknown as Request,
         context: {},
-      }),
+      } as unknown as LoaderFunctionArgs),
     ).toBeNull();
 
     jest.restoreAllMocks();

--- a/web-frontend/src/main/v3/packages/ui/src/loader/serviceMapRealtime.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/serviceMapRealtime.test.ts
@@ -1,4 +1,4 @@
-import type { LoaderFunctionArgs } from 'react-router';
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { serviceMapRealtimeLoader } from './serviceMapRealtime';
 
 jest.mock('react-router', () => ({
@@ -10,14 +10,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getRequestService } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string) => ({
-  params: {},
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const APP = 'TestApp@SPRING_BOOT';
 const BASE = `/serviceMap/realtime/DEFAULT/${APP}`;
@@ -112,13 +104,7 @@ describe('serviceMapRealtimeLoader', () => {
   test('returns null when an exception is thrown', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(
-      serviceMapRealtimeLoader({
-        params: {},
-        request: { url: 'not-a-valid-url' } as unknown as Request,
-        context: {},
-      } as unknown as LoaderFunctionArgs),
-    ).toBeNull();
+    expect(serviceMapRealtimeLoader(makeArgs('not-a-valid-url'))).toBeNull();
 
     jest.restoreAllMocks();
   });

--- a/web-frontend/src/main/v3/packages/ui/src/loader/serviceMapRealtime.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/serviceMapRealtime.ts
@@ -2,7 +2,7 @@ import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 import { DEFAULT_SERVICE } from '@pinpoint-fe/ui/src/atoms';
 import { getRequestService } from '@pinpoint-fe/ui/src/hooks';
 import { getServiceMapRealtimePath, parseServiceScopedPath } from '@pinpoint-fe/ui/src/utils';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 /**
  * servicemap 실시간 보기의 라우트 로더.

--- a/web-frontend/src/main/v3/packages/ui/src/loader/systemMetric.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/systemMetric.test.ts
@@ -1,7 +1,7 @@
 import { systemMetricRouteLoader } from './systemMetric';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -14,6 +14,8 @@ import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/systemMetric.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/systemMetric.test.ts
@@ -1,3 +1,4 @@
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { systemMetricRouteLoader } from './systemMetric';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
@@ -10,14 +11,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const HOST_GROUP = 'my-host-group';
 const BASE = `${APP_PATH.SYSTEM_METRIC}/${HOST_GROUP}`;

--- a/web-frontend/src/main/v3/packages/ui/src/loader/systemMetric.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/systemMetric.ts
@@ -8,7 +8,7 @@ import { isValidDateRange } from '@pinpoint-fe/ui/src/utils';
 import { getParsedDateRange, getTimezone } from '@pinpoint-fe/ui/src/utils';
 import { parse } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const systemMetricRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
   const hostGroup = params.hostGroup || null;

--- a/web-frontend/src/main/v3/packages/ui/src/loader/threadDump.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/threadDump.test.ts
@@ -1,13 +1,16 @@
+import type { LoaderFunctionArgs } from 'react-router';
 import { threadDumpRouteLoader } from './threadDump';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 
@@ -53,7 +56,7 @@ describe('threadDumpRouteLoader', () => {
       params: { application: 'TestApp@SPRING_BOOT' },
       request: { url: 'not-a-valid-url' } as unknown as Request,
       context: {},
-    });
+    } as unknown as LoaderFunctionArgs);
     expect(result).toBeNull();
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/loader/threadDump.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/threadDump.test.ts
@@ -1,18 +1,10 @@
-import type { LoaderFunctionArgs } from 'react-router';
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { threadDumpRouteLoader } from './threadDump';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
 jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 describe('threadDumpRouteLoader', () => {
   beforeEach(() => {
@@ -52,11 +44,9 @@ describe('threadDumpRouteLoader', () => {
   });
 
   test('returns null when an exception is thrown', () => {
-    const result = threadDumpRouteLoader({
-      params: { application: 'TestApp@SPRING_BOOT' },
-      request: { url: 'not-a-valid-url' } as unknown as Request,
-      context: {},
-    } as unknown as LoaderFunctionArgs);
+    const result = threadDumpRouteLoader(
+      makeArgs('not-a-valid-url', { application: 'TestApp@SPRING_BOOT' }),
+    );
     expect(result).toBeNull();
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/loader/threadDump.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/threadDump.ts
@@ -1,6 +1,6 @@
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const threadDumpRouteLoader = ({ params, request }: LoaderFunctionArgs) => {
   try {

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transaction.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transaction.test.ts
@@ -1,7 +1,7 @@
 import { transactionRouteLoader } from './transaction';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -14,6 +14,8 @@ import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transaction.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transaction.test.ts
@@ -1,3 +1,4 @@
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { transactionRouteLoader } from './transaction';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
@@ -10,14 +11,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const APP = 'TestApp@SPRING_BOOT';
 const BASE = `${APP_PATH.TRANSACTION_LIST}/${APP}`;

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transaction.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transaction.ts
@@ -13,7 +13,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { parse } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const transactionRouteLoader = async ({ request }: LoaderFunctionArgs) => {
   const requestUrl = new URL(request.url);

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transactionDetail.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transactionDetail.test.ts
@@ -1,18 +1,10 @@
-import type { LoaderFunctionArgs } from 'react-router';
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { transactionDetailRouteLoader } from './transactionDetail';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
 jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 describe('transactionDetailRouteLoader', () => {
   beforeEach(() => {
@@ -58,11 +50,9 @@ describe('transactionDetailRouteLoader', () => {
   });
 
   test('returns null when an exception is thrown', () => {
-    const result = transactionDetailRouteLoader({
-      params: { application: 'TestApp@SPRING_BOOT' },
-      request: { url: 'not-a-valid-url' } as unknown as Request,
-      context: {},
-    } as unknown as LoaderFunctionArgs);
+    const result = transactionDetailRouteLoader(
+      makeArgs('not-a-valid-url', { application: 'TestApp@SPRING_BOOT' }),
+    );
     expect(result).toBeNull();
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transactionDetail.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transactionDetail.test.ts
@@ -1,13 +1,16 @@
+import type { LoaderFunctionArgs } from 'react-router';
 import { transactionDetailRouteLoader } from './transactionDetail';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 
@@ -59,7 +62,7 @@ describe('transactionDetailRouteLoader', () => {
       params: { application: 'TestApp@SPRING_BOOT' },
       request: { url: 'not-a-valid-url' } as unknown as Request,
       context: {},
-    });
+    } as unknown as LoaderFunctionArgs);
     expect(result).toBeNull();
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/loader/transactionDetail.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/transactionDetail.ts
@@ -1,6 +1,6 @@
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 import { getApplicationTypeAndName, getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const transactionDetailRouteLoader = ({ request }: LoaderFunctionArgs) => {
   try {

--- a/web-frontend/src/main/v3/packages/ui/src/loader/urlStatistic.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/urlStatistic.test.ts
@@ -1,7 +1,7 @@
 import { urlStatisticRouteLoader } from './urlStatistic';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   redirect: (url: string) => ({ __isRedirect: true, url }),
 }));
 
@@ -14,6 +14,8 @@ import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 const makeArgs = (url: string, params: Record<string, string> = {}) => ({
   params,
   request: { url } as Request,
+  url: new URL(url),
+  pattern: '',
   context: {},
 });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/urlStatistic.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/urlStatistic.test.ts
@@ -1,3 +1,4 @@
+import { makeArgs } from './__fixtures__/loaderArgs';
 import { urlStatisticRouteLoader } from './urlStatistic';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 
@@ -10,14 +11,6 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 }));
 
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
-
-const makeArgs = (url: string, params: Record<string, string> = {}) => ({
-  params,
-  request: { url } as Request,
-  url: new URL(url),
-  pattern: '',
-  context: {},
-});
 
 const APP = 'TestApp@SPRING_BOOT';
 const BASE = `${APP_PATH.URL_STATISTIC}/${APP}`;

--- a/web-frontend/src/main/v3/packages/ui/src/loader/urlStatistic.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/urlStatistic.ts
@@ -12,7 +12,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { parse } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
-import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, redirect } from 'react-router';
 
 export const urlStatisticRouteLoader = async ({ params, request }: LoaderFunctionArgs) => {
   const application = getApplicationTypeAndName(params.application!);

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ErrorAnalysis.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ErrorAnalysis.tsx
@@ -19,7 +19,7 @@ import {
   ApplicationCombinedList,
   ApplicationCombinedListProps,
 } from '../components';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   convertParamsToQueryString,
   getErrorAnalysisPath,

--- a/web-frontend/src/main/v3/packages/ui/src/pages/FilteredMap.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/FilteredMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAtom } from 'jotai';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import {
   convertParamsToQueryString,
   getServerImagePath,

--- a/web-frontend/src/main/v3/packages/ui/src/pages/Inspector.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/Inspector.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useConfiguration, useInspectorSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { useTranslation } from 'react-i18next';
 import {

--- a/web-frontend/src/main/v3/packages/ui/src/pages/OpenTelemetry.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/OpenTelemetry.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   DatetimePicker,

--- a/web-frontend/src/main/v3/packages/ui/src/pages/Realtime.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/Realtime.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAtom } from 'jotai';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { getServerMapPath, getServerImagePath, getRealtimePath } from '@pinpoint-fe/ui/src/utils';
 import { serverMapCurrentTargetAtom } from '@pinpoint-fe/ui/src/atoms';
 import { useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ScatterOrHeatmapFullScreen.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ScatterOrHeatmapFullScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   convertParamsToQueryString,
   getHeatmapFullScreenPath,
@@ -10,7 +10,7 @@ import {
 } from '@pinpoint-fe/ui/src/utils';
 import { useConfiguration, useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import {
   ApplicationCombinedList,
   DatetimePicker,

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAtom, useAtomValue } from 'jotai';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   getServerMapPath,

--- a/web-frontend/src/main/v3/packages/ui/src/pages/SystemMetric.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/SystemMetric.tsx
@@ -8,7 +8,7 @@ import {
   SystemMetricChartList,
   LayoutWithContentSidebar,
 } from '../components';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import { useConfiguration, useSystemMetricSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { convertParamsToQueryString, getSystemMetricPath } from '@pinpoint-fe/ui/src/utils';
 import { useTranslation } from 'react-i18next';

--- a/web-frontend/src/main/v3/packages/ui/src/pages/UrlStatistic.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/UrlStatistic.tsx
@@ -10,7 +10,7 @@ import {
   UrlStatChart,
   UrlSummary,
 } from '../components';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { convertParamsToQueryString, getUrlStatPath } from '@pinpoint-fe/ui/src/utils';
 import { useConfiguration, useUrlStatSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { useTranslation } from 'react-i18next';

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/UserGroup.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/UserGroup.tsx
@@ -1,7 +1,7 @@
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
 import { useSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { MdArrowForwardIos } from 'react-icons/md';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { UserGroup, GroupMember } from '../../components/Config';
 
 export const UserGroupPage = () => {

--- a/web-frontend/src/main/v3/packages/ui/vite.config.ts
+++ b/web-frontend/src/main/v3/packages/ui/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       external: [
         'react',
         'react-dom',
-        'react-router-dom',
+        'react-router',
         'jotai',
         'i18next',
         'react-i18next',

--- a/web-frontend/src/main/v3/yarn.lock
+++ b/web-frontend/src/main/v3/yarn.lock
@@ -2904,11 +2904,6 @@
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.36.1.tgz#edb8081e3872ae68a4eb4a65e62233d0754ec186"
   integrity sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==
 
-"@remix-run/router@1.23.4":
-  version "1.23.4"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.4.tgz#d2becd2afca4a40c30a659d913b9b0bcc28bced8"
-  integrity sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==
-
 "@rolldown/pluginutils@1.0.0-beta.27":
   version "1.0.0-beta.27"
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz#47d2bf4cef6d470b22f5831b420f8964e0bf755f"
@@ -5055,6 +5050,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
+  integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
 
 core-js-compat@^3.48.0:
   version "3.50.0"
@@ -8142,20 +8142,13 @@ react-responsive@^10.0.1:
     prop-types "^15.6.1"
     shallow-equal "^3.1.0"
 
-react-router-dom@^6.30.4:
-  version "6.30.6"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.6.tgz#acaf0db65efeddabd0840616243c97f578b3baf3"
-  integrity sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==
+react-router@^7.18.3:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.18.3.tgz#2a3257aa7c5edd5a71f878063e4c7f3fcfc4b76a"
+  integrity sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==
   dependencies:
-    "@remix-run/router" "1.23.4"
-    react-router "6.30.6"
-
-react-router@6.30.6:
-  version "6.30.6"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.6.tgz#a2ad70f3472de61c61e44182b3e5a25fd91f9f68"
-  integrity sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==
-  dependencies:
-    "@remix-run/router" "1.23.4"
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
 
 react-stately@3.49.0:
   version "3.49.0"
@@ -8485,6 +8478,11 @@ semver@~7.7.4:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+set-cookie-parser@^2.6.0:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz#ccd08673a9ae5d2e44ea2a2de25089e67c7edf68"
+  integrity sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==
 
 shallow-equal@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
## Summary

- Upgrades `react-router` 6.30.4 → **7.18.3**, clearing the last two open advisories in the frontend (`yarn audit` goes from 2 to 0). Both are patched only in `>= 7.18.0`, so 6.x had no fix: open redirect via backslash in `<Link>`/`useNavigate`, and arbitrary constructor injection via `deserializeErrors`.
- Drops `react-router-dom`. In v7 it is a re-export of `react-router` and it stopped being published past 7.18.3, so the 88 files importing from it now import `react-router` directly. `packages/ui` had only declared it as a peer dependency and relied on `apps/web` hoisting it; it is now a devDependency there too.
- A second commit lifts the loader test args stub into one shared fixture, which is what keeps SonarCloud's duplication gate green. Details below.
- Stage 3 of the frontend dependency catch-up, after stage 1 (`2e8c244`) and stage 2 (`c261967`).

Three things needed more than a renamed import specifier:

| | |
|---|---|
| The v6 future flags (`v7_relativeSplatPath`, `v7_partialHydration`, `v7_startTransition`, …) are the defaults in v7 and the options carrying them are gone | Turned them on against 6.30 first to separate the behaviour change from the version bump; nothing broke, so they are simply absent here |
| `LoaderFunctionArgs` gained `url` and `pattern` in 7.18 | The router fills them in at runtime and no loader reads them — every one destructures only `params` and `request` — so this is confined to the stub args the loader tests build |
| jest's jsdom environment has no `TextEncoder` global, and react-router's CJS entry constructs one at module load | Took out the 6 suites that `jest.requireActual` it; a setup file supplies Node's |

## The second commit: one shared loader-args fixture

`c257197` follows from the second row above — the `LoaderFunctionArgs` one. Adding `url` and `pattern` to fifteen copies of the same `makeArgs` helper tripped SonarCloud: **22.3% duplication on new code** against a 3% gate. The duplication is older than this PR — eight loader test files already opened with the same seventeen-line preamble — but touching lines inside that block is what made Sonar count all of it as new.

So the fixture moves to `packages/ui/src/loader/__fixtures__/loaderArgs.ts` and the local copies go: 28 insertions against 152 deletions. What is left in common is the two `jest.mock` calls, which have to stay in each file because jest hoists them per module.

The shared version also tolerates a `url` that does not parse, which folds in the five hand-rolled stubs that existed only to get `'not-a-valid-url'` past the `URL` constructor. Those tests check that the loader throws on `request.url`, so the stub must not throw first.

No existing `makeArgs` call site changed, and duplication on new code is now 0.0%.

## Why not v8

`react-router@8` is out, but it is a separate piece of work, not a bigger version of this one:

- **Node `>= 22.22.0`.** This repo pins 22.13.1 in three places, including the root `pom.xml` `plugin.frontend.node.version` that drives the Maven web build. `yarn install` refuses outright: `The engine "node" is incompatible with this module`.
- **ESM-only** (`"type": "module"`, no `main`, no `require` condition). `packages/ui`'s 111 suites run on babel-jest's CJS runtime and fail with `Cannot use import statement outside a module`; a `transformIgnorePatterns` tweak gets past the entry but not the nested modules.

Everything else in v8 is small for this codebase, and moving the imports off `react-router-dom` here is exactly its prerequisite.

## Test plan

- [x] `yarn install --frozen-lockfile`
- [x] `yarn audit` — 2 advisories → 0
- [x] `yarn build` (root) and per-package builds: `server-map`, `scatter-chart`, `datetime-picker`, `ui`
- [x] `yarn test` — 119 suites / 1027 cases pass
- [x] `yarn lint` — 0 errors, no prettier churn
- [x] SonarCloud Quality Gate — duplication on new code 22.3% → 0.0%
- [x] `matchRoutes` parity: `/serviceMap/realtime` still ranks ahead of `/serviceMap/:serviceName?`, and `%2F` in params is still decoded (which is why the loaders read the raw pathname)
- [x] Path parity: the tightened parsing leaves the app's encoded segments and filter query strings byte-identical
- [ ] `yarn test:e2e` — **not run**, needs a backend on `:8080`
- [ ] Manual: navigating to a lazy page now keeps the previous page on screen instead of blanking it, because router state updates run in a transition by default in v7. The side navigation is outside that Suspense boundary and is unaffected, and in-page skeletons still render.

