### PR TITLE
[#14228] Upgrade JUnit to 5.14.4 and reuse the jupiter class lifecycle by delegation

### DIFF
--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/DelegatingClassTestDescriptor.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/DelegatingClassTestDescriptor.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.test.plugin.junit5.descriptor;
+
+import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestClassAware;
+import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource;
+import org.junit.platform.engine.support.hierarchical.Node;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Reuses the jupiter class lifecycle by delegation instead of inheritance: since JUnit 5.13
+ * the {@code Node} lifecycle methods of {@code ClassBasedTestDescriptor} are {@code final},
+ * so they can no longer be overridden. This wrapper is the node in the descriptor tree and
+ * forwards to an out-of-tree {@link ClassTestDescriptor}; subclasses intercept the lifecycle
+ * by overriding the forwarding methods and invoking {@code delegate} where jupiter behavior
+ * is still wanted.
+ */
+public abstract class DelegatingClassTestDescriptor extends AbstractTestDescriptor
+        implements Node<JupiterEngineExecutionContext>, TestClassAware {
+
+    protected final ClassTestDescriptor delegate;
+
+    DelegatingClassTestDescriptor(ClassTestDescriptor delegate) {
+        super(delegate.getUniqueId(), delegate.getDisplayName(), delegate.getSource().orElse(null));
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+    }
+
+    // --- TestClassAware --------------------------------------------------------
+
+    @Override
+    public Class<?> getTestClass() {
+        return delegate.getTestClass();
+    }
+
+    @Override
+    public List<Class<?>> getEnclosingTestClasses() {
+        return delegate.getEnclosingTestClasses();
+    }
+
+    // --- TestDescriptor ------------------------------------------------------
+
+    @Override
+    public Type getType() {
+        return delegate.getType();
+    }
+
+    /**
+     * Method descriptors inherit class-level {@code @Tag}s by merging the tags of their
+     * ancestors, so the wrapper must expose the delegate's tags or tag filtering breaks.
+     */
+    @Override
+    public Set<TestTag> getTags() {
+        return delegate.getTags();
+    }
+
+    @Override
+    public String getLegacyReportingName() {
+        return delegate.getLegacyReportingName();
+    }
+
+    @Override
+    public boolean mayRegisterTests() {
+        return delegate.mayRegisterTests();
+    }
+
+    // --- Node ----------------------------------------------------------------
+
+    @Override
+    public ExecutionMode getExecutionMode() {
+        return delegate.getExecutionMode();
+    }
+
+    @Override
+    public Set<ExclusiveResource> getExclusiveResources() {
+        return delegate.getExclusiveResources();
+    }
+
+    @Override
+    public SkipResult shouldBeSkipped(JupiterEngineExecutionContext context) throws Exception {
+        return delegate.shouldBeSkipped(context);
+    }
+
+    @Override
+    public JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) throws Exception {
+        return delegate.prepare(context);
+    }
+
+    @Override
+    public JupiterEngineExecutionContext before(JupiterEngineExecutionContext context) throws Exception {
+        return delegate.before(context);
+    }
+
+    @Override
+    public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor) throws Exception {
+        return delegate.execute(context, dynamicTestExecutor);
+    }
+
+    @Override
+    public void after(JupiterEngineExecutionContext context) throws Exception {
+        delegate.after(context);
+    }
+
+    @Override
+    public void cleanUp(JupiterEngineExecutionContext context) throws Exception {
+        delegate.cleanUp(context);
+    }
+
+    @Override
+    public void nodeSkipped(JupiterEngineExecutionContext context, TestDescriptor testDescriptor, SkipResult result) {
+        delegate.nodeSkipped(context, testDescriptor, result);
+    }
+
+    @Override
+    public void nodeFinished(JupiterEngineExecutionContext context, TestDescriptor testDescriptor, TestExecutionResult result) {
+        delegate.nodeFinished(context, testDescriptor, result);
+    }
+}

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginForkedTestClassTestDescriptor.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginForkedTestClassTestDescriptor.java
@@ -27,12 +27,12 @@ import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 import static org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory.createThrowableCollector;
 
-public class PluginForkedTestClassTestDescriptor extends ClassTestDescriptor {
+public class PluginForkedTestClassTestDescriptor extends DelegatingClassTestDescriptor {
 
     private PluginTestReport testReport;
 
     public PluginForkedTestClassTestDescriptor(UniqueId uniqueId, Class<?> testClass, JupiterConfiguration configuration) {
-        super(uniqueId, testClass, configuration);
+        super(new ClassTestDescriptor(uniqueId, testClass, configuration));
     }
 
     @Override

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginForkedTestUnitTestDescriptor.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginForkedTestUnitTestDescriptor.java
@@ -72,7 +72,8 @@ public class PluginForkedTestUnitTestDescriptor extends PluginTestDescriptor {
         JupiterEngineDescriptor engineDescriptor = new JupiterEngineDescriptor(this.getUniqueId(), configuration);
         ExtensionContext jupiterExtensionContext = ExtensionContextFactory.jupiterEngineContext(
                 context.getExecutionListener(), engineDescriptor,
-                context.getConfiguration(), extensionRegistry);
+                context.getConfiguration(), extensionRegistry,
+                context.getLauncherStoreFacade());
 
         // @formatter:off
         return context.extend()

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginJunitTestClassTestDescriptor.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginJunitTestClassTestDescriptor.java
@@ -24,12 +24,12 @@ import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.platform.engine.UniqueId;
 
 
-public class PluginJunitTestClassTestDescriptor extends ClassTestDescriptor {
+public class PluginJunitTestClassTestDescriptor extends DelegatingClassTestDescriptor {
 
     private final ThreadContextExecutor executor;
 
     public PluginJunitTestClassTestDescriptor(UniqueId uniqueId, Class<?> testClass, JupiterConfiguration configuration, TestContext testContext) {
-        super(uniqueId, testClass, configuration);
+        super(new ClassTestDescriptor(uniqueId, testClass, configuration));
         this.executor = new ThreadContextExecutor(testContext.getClassLoader());
     }
 
@@ -37,14 +37,14 @@ public class PluginJunitTestClassTestDescriptor extends ClassTestDescriptor {
     @Override
     public JupiterEngineExecutionContext before(JupiterEngineExecutionContext context) {
         return this.executor.call(() -> {
-            return super.before(context);
+            return delegate.before(context);
         });
     }
 
     @Override
     public void after(JupiterEngineExecutionContext context) {
         this.executor.run(() -> {
-            super.after(context);
+            delegate.after(context);
         });
     }
 }

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginTestClassTestDescriptor.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginTestClassTestDescriptor.java
@@ -24,14 +24,12 @@ import org.junit.platform.engine.UniqueId;
 
 import java.util.Objects;
 
-public class PluginTestClassTestDescriptor extends ClassTestDescriptor {
+public class PluginTestClassTestDescriptor extends DelegatingClassTestDescriptor {
 
-    private final Class<?> testClass;
     private final PluginTestInstance pluginTestInstance;
 
     public PluginTestClassTestDescriptor(UniqueId uniqueId, Class<?> testClass, JupiterConfiguration configuration, PluginTestInstance pluginTestInstance) {
-        super(uniqueId, testClass, configuration);
-        this.testClass = testClass;
+        super(new ClassTestDescriptor(uniqueId, testClass, configuration));
         this.pluginTestInstance = Objects.requireNonNull(pluginTestInstance, "pluginTestInstance");
     }
 
@@ -39,20 +37,20 @@ public class PluginTestClassTestDescriptor extends ClassTestDescriptor {
     @Override
     public JupiterEngineExecutionContext before(JupiterEngineExecutionContext context) {
         return this.pluginTestInstance.call(() -> {
-            return super.before(context);
+            return delegate.before(context);
         }, false);
     }
 
     @Override
     public void after(JupiterEngineExecutionContext context) {
         this.pluginTestInstance.run(() -> {
-            super.after(context);
+            delegate.after(context);
         }, false);
     }
 
     @Override
     public void cleanUp(JupiterEngineExecutionContext context) throws Exception {
-        super.cleanUp(context);
+        delegate.cleanUp(context);
         this.pluginTestInstance.clear();
     }
 }

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/TestClassAwareUtils.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/TestClassAwareUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.test.plugin.junit5.descriptor;
+
+import org.junit.jupiter.engine.descriptor.TestClassAware;
+import org.junit.platform.engine.TestDescriptor;
+
+import java.util.Objects;
+
+public final class TestClassAwareUtils {
+
+    private TestClassAwareUtils() {
+    }
+
+    /**
+     * Reads the test class of a descriptor the builders expect to be {@link TestClassAware}.
+     * A jupiter upgrade can silently change the descriptor hierarchy, so a mismatch fails
+     * with the offending descriptor type instead of a bare {@link ClassCastException}.
+     */
+    public static Class<?> getTestClass(TestDescriptor testDescriptor) {
+        Objects.requireNonNull(testDescriptor, "testDescriptor");
+        if (testDescriptor instanceof TestClassAware) {
+            return ((TestClassAware) testDescriptor).getTestClass();
+        }
+        throw new IllegalArgumentException("not a TestClassAware descriptor. type:" + testDescriptor.getClass().getName()
+                + ", uniqueId:" + testDescriptor.getUniqueId());
+    }
+}

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/PluginTestEngine.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/PluginTestEngine.java
@@ -22,10 +22,11 @@ import com.navercorp.pinpoint.test.plugin.junit5.engine.discovery.TestDescriptor
 import org.junit.jupiter.engine.config.CachingJupiterConfiguration;
 import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
-import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestClassAware;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.jupiter.engine.discovery.DiscoverySelectorResolver;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.jupiter.engine.execution.LauncherStoreFacade;
 import org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
@@ -79,9 +80,11 @@ public class PluginTestEngine extends HierarchicalTestEngine<JupiterEngineExecut
         List<TestDescriptor> pluginTestDescriptorList = new ArrayList<>();
 
         try {
+            // only the raw descriptors just produced by the jupiter resolver reach this loop;
+            // the plugin wrappers replacing them are added after it
             for (TestDescriptor testDescriptor : engineDescriptor.getChildren()) {
-                if (testDescriptor instanceof ClassTestDescriptor) {
-                    final Class<?> testClass = ((ClassTestDescriptor) testDescriptor).getTestClass();
+                if (testDescriptor instanceof TestClassAware) {
+                    final Class<?> testClass = ((TestClassAware) testDescriptor).getTestClass();
                     TestDescriptor pluginTestDescriptor = getDescriptor(testDescriptor, testClass, configuration);
                     if (pluginTestDescriptor != null) {
                         pluginTestDescriptorList.add(pluginTestDescriptor);
@@ -116,7 +119,7 @@ public class PluginTestEngine extends HierarchicalTestEngine<JupiterEngineExecut
     @Override
     public JupiterEngineExecutionContext createExecutionContext(ExecutionRequest request) {
         return new JupiterEngineExecutionContext(request.getEngineExecutionListener(),
-                getJupiterConfiguration(request));
+                getJupiterConfiguration(request), new LauncherStoreFacade(request.getStore()));
     }
 
     private JupiterConfiguration getJupiterConfiguration(ExecutionRequest request) {

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/discovery/PluginForkedTestDescriptorBuilder.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/discovery/PluginForkedTestDescriptorBuilder.java
@@ -8,7 +8,7 @@ import com.navercorp.pinpoint.test.plugin.junit5.descriptor.PluginForkedTestDepe
 import com.navercorp.pinpoint.test.plugin.junit5.descriptor.PluginForkedTestMethodTestDescriptor;
 import com.navercorp.pinpoint.test.plugin.junit5.descriptor.PluginForkedTestUnitTestDescriptor;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
-import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import com.navercorp.pinpoint.test.plugin.junit5.descriptor.TestClassAwareUtils;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.engine.TestDescriptor;
@@ -24,12 +24,14 @@ public class PluginForkedTestDescriptorBuilder implements TestDescriptorBuilder 
     }
 
     public TestDescriptor build(TestDescriptor testDescriptor, JupiterConfiguration configuration) {
-        final DefaultPluginForkedTestSuite testSuite = new DefaultPluginForkedTestSuite(((ClassTestDescriptor) testDescriptor).getTestClass());
+        Class<?> testClass = TestClassAwareUtils.getTestClass(testDescriptor);
+
+        final DefaultPluginForkedTestSuite testSuite = new DefaultPluginForkedTestSuite(testClass);
         final List<PluginForkedTestInstance> testInstanceList = testSuite.getPluginTestInstanceList();
         final TestDescriptorFactory factory = new TestDescriptorFactory(configuration);
 
         // Unit
-        final PluginForkedTestUnitTestDescriptor pluginTestUnitTestDescriptor = new PluginForkedTestUnitTestDescriptor(testDescriptor.getUniqueId(), ((ClassTestDescriptor) testDescriptor).getTestClass(), configuration, testInstanceList);
+        final PluginForkedTestUnitTestDescriptor pluginTestUnitTestDescriptor = new PluginForkedTestUnitTestDescriptor(testDescriptor.getUniqueId(), testClass, configuration, testInstanceList);
         for (PluginForkedTestInstance pluginTestInstance : testInstanceList) {
             final String testId = pluginTestInstance.getTestId();
             // Dependency

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/discovery/PluginJunitTestDescriptorBuilder.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/discovery/PluginJunitTestDescriptorBuilder.java
@@ -22,7 +22,7 @@ import com.navercorp.pinpoint.profiler.test.junit5.TestContext;
 import com.navercorp.pinpoint.test.plugin.junit5.descriptor.PluginJunitTestClassTestDescriptor;
 import com.navercorp.pinpoint.test.plugin.junit5.descriptor.PluginJunitTestMethodTestDescriptor;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
-import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import com.navercorp.pinpoint.test.plugin.junit5.descriptor.TestClassAwareUtils;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
@@ -38,19 +38,21 @@ public class PluginJunitTestDescriptorBuilder implements TestDescriptorBuilder {
     }
 
     public TestDescriptor build(TestDescriptor testDescriptor, JupiterConfiguration configuration) {
-        final TestContext testContext = new TestContext(new TestClassWrapper(((ClassTestDescriptor) testDescriptor).getTestClass()));
-        final Class<?> testClass = testContext.createTestClass();
+        final Class<?> testClass = TestClassAwareUtils.getTestClass(testDescriptor);
+
+        final TestContext testContext = new TestContext(new TestClassWrapper(testClass));
+        final Class<?> newTestClass = testContext.createTestClass();
 
         // Class
-        final PluginJunitTestClassTestDescriptor pluginTestClassTestDescriptor = new PluginJunitTestClassTestDescriptor(testDescriptor.getUniqueId(), testClass, configuration, testContext);
+        final PluginJunitTestClassTestDescriptor pluginTestClassTestDescriptor = new PluginJunitTestClassTestDescriptor(testDescriptor.getUniqueId(), newTestClass, configuration, testContext);
         //switchTestDescriptor(testDescriptor, pluginTestClassTestDescriptor);
         for (TestDescriptor descriptor : testDescriptor.getChildren()) {
             if (descriptor instanceof TestMethodTestDescriptor) {
                 final Method method = ((TestMethodTestDescriptor) descriptor).getTestMethod();
-                final Method testMethod = ReflectionUtils.findMethod(testClass, method.getName(), method.getParameterTypes()).orElseThrow(() -> new IllegalStateException("not found method"));
+                final Method testMethod = ReflectionUtils.findMethod(newTestClass, method.getName(), method.getParameterTypes()).orElseThrow(() -> new IllegalStateException("not found method"));
 
                 final PluginJunitTestMethodTestDescriptor pluginTestMethodTestDescriptor = new PluginJunitTestMethodTestDescriptor(
-                        descriptor.getUniqueId(), testClass, testMethod, pluginTestClassTestDescriptor::getEnclosingTestClasses, configuration, testContext
+                        descriptor.getUniqueId(), newTestClass, testMethod, pluginTestClassTestDescriptor::getEnclosingTestClasses, configuration, testContext
                 );
                 pluginTestClassTestDescriptor.addChild(pluginTestMethodTestDescriptor);
             }

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/discovery/PluginTestDescriptorBuilder.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/engine/discovery/PluginTestDescriptorBuilder.java
@@ -9,7 +9,7 @@ import com.navercorp.pinpoint.test.plugin.junit5.descriptor.PluginTestMethodTest
 import com.navercorp.pinpoint.test.plugin.junit5.descriptor.PluginTestUnitTestDescriptor;
 import com.navercorp.pinpoint.test.plugin.shared.PluginSharedInstance;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
-import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import com.navercorp.pinpoint.test.plugin.junit5.descriptor.TestClassAwareUtils;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.engine.TestDescriptor;
@@ -25,13 +25,15 @@ public class PluginTestDescriptorBuilder implements TestDescriptorBuilder {
     }
 
     public TestDescriptor build(TestDescriptor testDescriptor, JupiterConfiguration configuration) {
-        final DefaultPluginTestSuite testSuite = new DefaultPluginTestSuite(((ClassTestDescriptor) testDescriptor).getTestClass());
+        final Class<?> testClass = TestClassAwareUtils.getTestClass(testDescriptor);
+
+        final DefaultPluginTestSuite testSuite = new DefaultPluginTestSuite(testClass);
         final PluginSharedInstance sharedInstance = testSuite.getPluginSharedInstance();
         final List<PluginTestInstance> testInstanceList = testSuite.getPluginTestInstanceList();
         final TestDescriptorFactory factory = new TestDescriptorFactory(configuration);
 
         // Unit
-        final PluginTestUnitTestDescriptor pluginTestUnitTestDescriptor = new PluginTestUnitTestDescriptor(testDescriptor.getUniqueId(), ((ClassTestDescriptor) testDescriptor).getTestClass(), configuration, sharedInstance);
+        final PluginTestUnitTestDescriptor pluginTestUnitTestDescriptor = new PluginTestUnitTestDescriptor(testDescriptor.getUniqueId(), testClass, configuration, sharedInstance);
         for (PluginTestInstance pluginTestInstance : testInstanceList) {
             final String testId = pluginTestInstance.getTestId();
             // Dependency

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionContextFactory.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionContextFactory.java
@@ -18,6 +18,7 @@ package org.junit.jupiter.engine.descriptor;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.execution.LauncherStoreFacade;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.EngineExecutionListener;
 
@@ -26,8 +27,9 @@ public final class ExtensionContextFactory {
     public static ExtensionContext jupiterEngineContext(EngineExecutionListener engineExecutionListener,
                                                         JupiterEngineDescriptor testDescriptor,
                                                         JupiterConfiguration configuration,
-                                                        ExtensionRegistry extensionRegistry) {
-        return new JupiterEngineExtensionContext(engineExecutionListener, testDescriptor, configuration, extensionRegistry);
+                                                        ExtensionRegistry extensionRegistry,
+                                                        LauncherStoreFacade launcherStoreFacade) {
+        return new JupiterEngineExtensionContext(engineExecutionListener, testDescriptor, configuration, extensionRegistry, launcherStoreFacade);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
         <bytebuddy.version>1.12.23</bytebuddy.version>
 
         <testcontainers.version>2.0.5</testcontainers.version>
-        <junit-jupiter.version>5.12.2</junit-jupiter.version>
+        <junit-jupiter.version>5.14.4</junit-jupiter.version>
         <h2database.version>2.2.224</h2database.version>
 
         <!-- maven-plugin -->


### PR DESCRIPTION
…cle by delegation


This pull request refactors how JUnit 5 test class descriptors are implemented in the plugin test module to adapt to changes in JUnit 5.14+, where key lifecycle methods are now final and cannot be overridden. The solution introduces a new `DelegatingClassTestDescriptor` class that delegates lifecycle operations to an internal `ClassTestDescriptor`, and updates all custom test class descriptors to extend this new base class. Additionally, it updates the JUnit Jupiter dependency to 5.14.4 and improves context handling by passing a `LauncherStoreFacade` where needed.

**JUnit 5 test descriptor refactoring:**
* Introduced `DelegatingClassTestDescriptor`, an abstract class that delegates all lifecycle and test descriptor operations to an internal `ClassTestDescriptor`. This allows for custom behavior via delegation now that JUnit's lifecycle methods are final. (`DelegatingClassTestDescriptor.java`)
* Updated `PluginTestClassTestDescriptor`, `PluginJunitTestClassTestDescriptor`, and `PluginForkedTestClassTestDescriptor` to extend `DelegatingClassTestDescriptor` instead of directly extending `ClassTestDescriptor`. Their lifecycle overrides now delegate to the internal descriptor. [[1]](diffhunk://#diff-bb4b857106fb891938742f18f14de1946a22d5fc395ae6aa91681008a7fcb546L27-R53) [[2]](diffhunk://#diff-5bdb4af120a6544ffc389f70e56db9f1984c468e94fdc33a1a2e0e117c993784L27-R47) [[3]](diffhunk://#diff-b3e4212f5c35cdce6ec3b0c549042bfe8b3488d4b1a1bb8b923fc063af52f2a9L30-R35)

**JUnit 5 version update:**
* Upgraded JUnit Jupiter version from 5.12.2 to 5.14.4 in the Maven configuration for compatibility with recent JUnit changes. (`pom.xml`)

**Test execution context improvements:**
* Updated context creation to pass a `LauncherStoreFacade` to the `JupiterEngineExecutionContext` and through the extension context factory, ensuring correct integration with JUnit 5.14's execution model. (`PluginTestEngine.java`, `ExtensionContextFactory.java`, `PluginForkedTestUnitTestDescriptor.java`) [[1]](diffhunk://#diff-df8b156df838a87a6f3eed01312359ced360e25fc94731da699690f0719d8d39R29) [[2]](diffhunk://#diff-df8b156df838a87a6f3eed01312359ced360e25fc94731da699690f0719d8d39L119-R120) [[3]](diffhunk://#diff-31874872e564f3464c3c0a739e509efdb4c5f26649dc9363e6695e403df555a7R21) [[4]](diffhunk://#diff-31874872e564f3464c3c0a739e509efdb4c5f26649dc9363e6695e403df555a7L29-R32) [[5]](diffhunk://#diff-56212a9c89aaa3d559da2853419aa9a3439f6a1488398b6c95047fac79340824L75-R76)