### PR TITLE
[#14224] Decouple service map activation from experimental.enableServiceMap flag

### DIFF
--- a/collector/src/main/resources/pinpoint-collector-root.properties
+++ b/collector/src/main/resources/pinpoint-collector-root.properties
@@ -61,6 +61,8 @@ pinpoint.collector.realtime.atc.demand.duration=12500
 pinpoint.collector.realtime.atc.supply.throttle.termMillis=100
 pinpoint.collector.realtime.atc.enable-count-metric=false
 
+pinpoint.collector.service.lookup.enabled=false
+
 # Pinpoint service lookup cache (Do not change, under development)
 collector.service.lookup.cache.initialCapacity=16
 collector.service.lookup.cache.maximumSize=2000

--- a/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapProperties.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/applicationmap/config/MapProperties.java
@@ -3,7 +3,7 @@ package com.navercorp.pinpoint.web.applicationmap.config;
 import org.springframework.beans.factory.annotation.Value;
 
 public class MapProperties {
-    @Value("${experimental.enableServiceMap.value:false}")
+    @Value("${pinpoint.modules.web.servicemap.enabled:false}")
     private boolean enableServiceMap;
 
     public boolean isEnableServiceMap() {

--- a/web/src/main/resources/pinpoint-web-root.properties
+++ b/web/src/main/resources/pinpoint-web-root.properties
@@ -145,3 +145,5 @@ experimental.sampleScatter.description=Sample data in the scatter chart.
 experimental.sampleScatter.value=true
 experimental.enableServiceMap.description=Enable service-based application map grouping.
 experimental.enableServiceMap.value=false
+
+pinpoint.modules.web.servicemap.enabled=false


### PR DESCRIPTION
Resolves #14224.

`experimental.enableServiceMap.value` currently gates both the backend service map (the `/serviceMap` endpoint and service-scoped node/link rendering via `MapProperties`) and is relayed to the frontend as a UI flag, coupling backend behavior to a frontend experimental flag.

This introduces a dedicated backend switch `pinpoint.modules.web.servicemap.enabled` (default `false`) that `MapProperties` reads, leaving `experimental.enableServiceMap.value` purely for the frontend. It also declares a default (`false`) for the collector `pinpoint.collector.service.lookup.enabled` in properties, so the service concept can be enabled per environment via application.yml overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)