### PR TITLE
[#noissue] Make enableServiceMap a user-settable experimental

### DIFF
--- a/web-frontend/src/main/v3/.claude/rules/service-map.md
+++ b/web-frontend/src/main/v3/.claude/rules/service-map.md
@@ -1,7 +1,30 @@
 # Service / ServiceMap 규칙
 
-`experimental.enableServiceMap` 설정이 켜져 있을 때만 존재하는 개념이다. 꺼져 있으면 백엔드가
+`experimental.enableServiceMap`이 켜져 있을 때만 존재하는 개념이다. 꺼져 있으면 백엔드가
 모든 요청을 기본 service(`DEFAULT`)로 해석하므로, 화면도 service 개념이 없는 것처럼 동작해야 한다.
+
+## 켜짐 여부를 읽는 곳은 하나다
+
+configuration API의 `experimental.enableServiceMap.value`가 **기본값**이고, 사용자가 Experimental
+설정에서 값을 정하면 그 값(localStorage `serviceMap`)이 이긴다. 규칙은
+`pickEnableServiceMap` 하나뿐이고, 두 갈래로만 읽는다:
+
+| 읽는 곳 | 경로 |
+|---|---|
+| 화면(훅·컴포넌트) | `useEnableServiceMap()` |
+| 렌더 밖(fetch 인터셉터) | `getEnableServiceMap(configuration)` |
+
+- **`configuration?.['experimental.enableServiceMap.value']`를 직접 읽지 않는다.** 직접 읽으면
+  localStorage로 끈 사용자에게도 그 화면만 켜진 것처럼 동작하거나(반대로) 화면에는 service 개념이
+  없는데 헤더는 실려 나간다. 타입 검사로 잡히지 않는 어긋남이다.
+- **저장된 값이 없는 상태(`null`)를 boolean으로 눌러 담지 않는다.** 다른 experimental처럼
+  `useLocalStorage(key, !!config값)`으로 두면 configuration이 도착하기 전에 마운트되는 순간
+  `false`가 localStorage에 박혀, 사용자가 고른 적 없는 값이 서버 기본값을 영구히 덮어쓴다.
+  그래서 `useExperimentals`도 이 키만 초기값을 `null`로 두고 seed 하지 않는다.
+- 체크박스에 보이는 값도 같은 함수를 지난다(`useExperimentals`). 화면·헤더·체크박스가 갈리면
+  사용자는 켜 놓은 줄 알고 꺼진 화면을 본다.
+- 설정을 바꾸면 새로고침 없이 반영된다. `useLocalStorage`가 `local-storage` 이벤트로 같은 key를
+  읽는 인스턴스들을 깨우고, 인터셉터는 매 요청마다 localStorage를 다시 읽는다.
 
 ## 로드맵 (중요 — 설계 판단의 전제)
 
@@ -43,7 +66,8 @@ servermap이 사라진 뒤에도 **DEFAULT service 사용자는 여전히 applic
   `loader/realtime.ts`, `pages/ServerMap/Realtime.tsx`를 지우고 기본값을 servicemap 쪽으로 옮긴다.
 - filteredMap → 경로에 serviceName이 항상 실리므로 `FilteredMapPage`의 돌아갈 map 분기
   (`Servermap` ↔ `Servicemap`)와 로더의 serviceName 없는 형태 처리를 지운다.
-- `enableServiceMap` 설정 분기 → 설정이 없어지면 `useIsDefaultService`가 "DEFAULT인가?"만 보면 됨
+- `enableServiceMap` 설정 분기 → 설정이 없어지면 `useIsDefaultService`가 "DEFAULT인가?"만 보면 되고,
+  `useEnableServiceMap`/`pickEnableServiceMap`과 Experimental 항목도 함께 지운다
 
 ## servicemap의 두 모드
 
@@ -247,6 +271,9 @@ servermap/filteredMap 응답에는 이 필드가 없어 그 화면들의 동작�
 
 | 관심사 | 위치 |
 |---|---|
+| 켜짐 여부 판단 (화면) | `hooks/utility/useEnableServiceMap.ts` |
+| 켜짐 여부 판단 (렌더 밖) | `utils/experimental.ts` (`pickEnableServiceMap`, `getEnableServiceMap`) |
+| Experimental 설정 항목 | `hooks/utility/useExperimentals.ts`, `pages/config/Experimentals.tsx` |
 | DEFAULT 여부 판단 | `hooks/utility/useIsDefaultService.ts` |
 | 경로에 실린 serviceName 읽기 | `utils/helper/application.ts` (`getServiceNameFromPath`) |
 | 경로 분해 (로더용) | `utils/helper/application.ts` (`parseServiceScopedPath`) |

--- a/web-frontend/src/main/v3/.claude/rules/service-map.md
+++ b/web-frontend/src/main/v3/.claude/rules/service-map.md
@@ -6,8 +6,10 @@
 ## 켜짐 여부를 읽는 곳은 하나다
 
 configuration API의 `experimental.enableServiceMap.value`가 **기본값**이고, 사용자가 Experimental
-설정에서 값을 정하면 그 값(localStorage `serviceMap`)이 이긴다. 규칙은
-`pickEnableServiceMap` 하나뿐이고, 두 갈래로만 읽는다:
+설정에서 값을 정하면 그 값이 이긴다. 저장되는 localStorage key는 `pp.serviceMap`
+(= `EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP`)이다 — 다른 experimental key와 달리 접두사가
+붙으므로 devtools에서 찾을 때 주의한다. 규칙은 `pickEnableServiceMap` 하나뿐이고,
+두 갈래로만 읽는다:
 
 | 읽는 곳 | 경로 |
 |---|---|

--- a/web-frontend/src/main/v3/apps/web/dev-mock/index.ts
+++ b/web-frontend/src/main/v3/apps/web/dev-mock/index.ts
@@ -118,6 +118,7 @@ const FALLBACK_CONFIGURATION = {
   'experimental.sampleScatter.value': false,
   'experimental.sampleScatter.description': 'mock',
   'experimental.enableServiceMap.value': true,
+  'experimental.enableServiceMap.description': 'mock',
   'periodMax.exceptionTrace': 28,
   'periodInterval.exceptionTrace': ['5m', '20m', '1h', '3h', '6h', '12h', '1d', '2d'],
   'periodMax.inspector': 28,
@@ -156,6 +157,8 @@ const forMockApplication =
 
 const handlers: Record<string, MockHandler> = {
   // 설정이 꺼져 있으면 화면에 service 개념 자체가 없으므로 여기서 강제로 켠다.
+  // 이것은 어디까지나 **기본값**이다. Experimental 설정에서 끄면 localStorage 값이 이기므로
+  // (`pickEnableServiceMap`) mock을 켜 둬도 화면은 꺼진 상태로 뜬다.
   '/api/configuration': async () => {
     const upstream = await fetchUpstream<Record<string, unknown>>('/api/configuration');
     return {

--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation, useNavigate } from 'react-router';
 import {
   resolveRequestService,
   useClearApplicationOnServiceChange,
+  useEnableServiceMap,
   useExperimentals,
   useGetConfiguration,
   useServicesFetch,
@@ -30,7 +31,8 @@ export const InitialFetchOutlet = () => {
   const searchParameters = Object.fromEntries(new URLSearchParams(search));
   const setSearchParameters = useSetAtom(searchParametersAtom);
 
-  const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
+  // configuration 기본값 위에 사용자가 Experimental 설정에서 고른 값(localStorage)이 얹힌다.
+  const enableServiceMap = useEnableServiceMap();
   // 쿼리 캐시는 "요청이 해석되는 service"(serviceScopedQueryKeyHashFn)로 분리되지만,
   // 그 해시는 store를 명령형으로 읽으므로 쿼리 훅이 다시 렌더링되지 않으면 갱신되지 않는다.
   // service를 바꿨는데 해시가 그대로면 새 헤더로 받은 응답이 이전 service 키에 쌓인다.

--- a/web-frontend/src/main/v3/apps/web/src/hooks/useMenuItems.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/hooks/useMenuItems.tsx
@@ -5,7 +5,11 @@ import {
   DEFAULT_SERVICE,
   searchParametersAtom,
 } from '@pinpoint-fe/ui/src/atoms';
-import { useIsDefaultService, useServiceNameForLink } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useEnableServiceMap,
+  useIsDefaultService,
+  useServiceNameForLink,
+} from '@pinpoint-fe/ui/src/hooks';
 import {
   PiBugBeetle,
   PiChartBar,
@@ -31,6 +35,7 @@ export const useMenuItems = () => {
   // 그대로 이어받는다. (serviceName이 실린 경로면 그 값, 아니면 전역 선택값)
   const serviceName = useServiceNameForLink() ?? DEFAULT_SERVICE;
   const isDefaultService = useIsDefaultService();
+  const enableServiceMap = useEnableServiceMap();
 
   const menuItems: MenuItem[] = [
     {
@@ -47,7 +52,7 @@ export const useMenuItems = () => {
       // 실어 보내면 페이지가 곧 경로에서 지우면서 한 번 더 이동한다.
       href: getServiceMapPath(serviceName, isDefaultService ? application : null, searchParameters),
       // service 기능(experimental.enableServiceMap)이 켜져 있을 때만 노출한다.
-      hide: !configuration?.['experimental.enableServiceMap.value'],
+      hide: !enableServiceMap,
     },
     {
       icon: <PiChartLine />,

--- a/web-frontend/src/main/v3/packages/ui/src/components/Service/useServiceSideNavigation.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Service/useServiceSideNavigation.tsx
@@ -10,14 +10,13 @@ import {
   servicesAtom,
 } from '@pinpoint-fe/ui/src/atoms';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
-import { useConfiguration } from '@pinpoint-fe/ui/src/hooks';
+import { useEnableServiceMap } from '@pinpoint-fe/ui/src/hooks';
 import { buildServiceSidebarItems } from '../Layout/serviceMenu';
 import { SERVICE_CONFIG_MENU } from './serviceConfigMenu';
 import type { SideNavigationMenuItem } from '../Layout/LayoutWithSideNavigation';
 
 export const useServiceSideNavigation = (serviceGroupItems: SideNavigationMenuItem[] = []) => {
-  const configuration = useConfiguration();
-  const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
+  const enableServiceMap = useEnableServiceMap();
   const services = useAtomValue(servicesAtom);
   const selectedService = useAtomValue(selectedServiceAtom);
   const setSelectedService = useSetAtom(selectedServiceAtom);

--- a/web-frontend/src/main/v3/packages/ui/src/constants/ExperimentalConfigKeys.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/ExperimentalConfigKeys.ts
@@ -5,4 +5,5 @@ export enum EXPERIMENTAL_CONFIG_KEYS {
   // UPDATE_SERVER_MAP_LAYOUT_MANUALLY = 'updateServerMapLayoutManually',
   // USE_SCATTER_CHART_V2 = 'useScatterChartV2',
   USE_STATISTICS_AGENT_STATE = 'statisticsAgentState',
+  ENABLE_SERVICE_MAP = 'pp.serviceMap',
 }

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/Configuration.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/Configuration.ts
@@ -26,6 +26,7 @@ export interface Configuration {
   'experimental.enableServerSideScanForScatter.value': boolean;
   'experimental.sampleScatter.value': boolean;
   'experimental.enableServiceMap.value': boolean;
+  'experimental.enableServiceMap.description': string;
   'periodMax.exceptionTrace': number;
   'periodInterval.exceptionTrace': string[];
   'periodMax.inspector': number;

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
@@ -1,7 +1,7 @@
 import { getDefaultStore } from 'jotai';
 import { configurationAtom, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
 import { BASE_PATH } from '@pinpoint-fe/ui/src/constants';
-import { getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';
+import { getEnableServiceMap, getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';
 
 /**
  * 백엔드(service-module)의 `ServiceConstants.KEY`와 동일한 헤더 이름.
@@ -60,13 +60,15 @@ const isApiRequest = (input: RequestInfo | URL): boolean => {
 let installed = false;
 
 /**
- * 전역 `fetch`를 한 번 래핑하여, configuration의
- * `experimental.enableServiceMap.value`가 true일 때 백엔드로 가는 모든
+ * 전역 `fetch`를 한 번 래핑하여, `enableServiceMap`이 true일 때 백엔드로 가는 모든
  * `/api` 요청 헤더에 그 요청이 해석되는 service(`resolveRequestService`)를 주입한다.
  * 화면별 예외는 없다. 설정이 꺼져 있으면 헤더를 아예 붙이지 않아 백엔드가 기본 service로 해석한다.
  *
- * configuration은 부트스트랩 이후 비동기로 로드/갱신되므로, 값을 캡처하지 않고
- * 매 요청 시 `configurationAtom`에서 최신값을 읽는다.
+ * 켜짐 여부는 `getEnableServiceMap`이 정한다. 사용자가 Experimental 설정에서 고른 값
+ * (localStorage)이 configuration 기본값을 덮으므로, 설정을 바꾸면 다음 요청부터 바로 반영된다.
+ *
+ * configuration과 localStorage는 모두 부트스트랩 이후 바뀔 수 있으므로, 값을 캡처하지 않고
+ * 매 요청 시 최신값을 읽는다.
  *
  * configuration과 service 모두 Jotai 기본 store(`getDefaultStore`)에서 읽으므로
  * 컴포넌트의 `useAtomValue`/`useSetAtom`과 동일한 상태를 참조한다.
@@ -82,8 +84,7 @@ export const installServiceNameFetchInterceptor = () => {
 
   window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
     try {
-      const configuration = store.get(configurationAtom);
-      const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
+      const enableServiceMap = getEnableServiceMap(store.get(configurationAtom));
 
       if (enableServiceMap && isApiRequest(input)) {
         // 캐시 키와 어긋나지 않도록 헤더도 `resolveRequestService`와 같은 규칙에서 파생한다.

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapTargetServiceName.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapTargetServiceName.ts
@@ -1,7 +1,7 @@
 import { useAtomValue } from 'jotai';
 import { serverMapCurrentTargetDataAtom } from '@pinpoint-fe/ui/src/atoms';
 import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
-import { useConfiguration } from '../utility/useConfiguration';
+import { useEnableServiceMap } from '../utility/useEnableServiceMap';
 
 /**
  * map에서 고른 노드/링크가 소속된 service. 고른 것이 없으면 undefined다.
@@ -23,10 +23,10 @@ import { useConfiguration } from '../utility/useConfiguration';
  * 헤더가 새어 나가지 않도록 여기 한 곳에서 막는다.
  */
 export const useServerMapTargetServiceName = () => {
-  const configuration = useConfiguration();
+  const enableServiceMap = useEnableServiceMap();
   const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom);
 
-  if (!configuration?.['experimental.enableServiceMap.value'] || !currentTargetData) {
+  if (!enableServiceMap || !currentTargetData) {
     return undefined;
   }
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
@@ -3,6 +3,7 @@ export * from './useCaptureKeydown';
 export * from './useClearApplicationOnServiceChange';
 export * from './useConfiguration';
 export * from './useDateFormat';
+export * from './useEnableServiceMap';
 export * from './useExperimentals';
 export * from './useHeightToBottom';
 export * from './useIsDefaultService';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useEnableServiceMap.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useEnableServiceMap.test.tsx
@@ -1,0 +1,79 @@
+import { renderHook, act } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration, EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
+import { useEnableServiceMap } from './useEnableServiceMap';
+import { useExperimentals } from './useExperimentals';
+
+const store = getDefaultStore();
+
+const configWithServiceMap = (enable: boolean) =>
+  ({ 'experimental.enableServiceMap.value': enable }) as unknown as Configuration;
+
+const renderEnableServiceMap = (configuration?: Configuration) => {
+  act(() => {
+    store.set(configurationAtom, configuration);
+  });
+  return renderHook(() => useEnableServiceMap());
+};
+
+describe('useEnableServiceMap', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    act(() => {
+      store.set(configurationAtom, undefined);
+    });
+  });
+
+  test('uses the configuration value as the default', () => {
+    expect(renderEnableServiceMap(configWithServiceMap(true)).result.current).toBe(true);
+    expect(renderEnableServiceMap(configWithServiceMap(false)).result.current).toBe(false);
+  });
+
+  test('the stored value wins over the configuration default', () => {
+    window.localStorage.setItem(EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP, 'true');
+
+    expect(renderEnableServiceMap(configWithServiceMap(false)).result.current).toBe(true);
+  });
+
+  // 값을 읽기만 해도 localStorage에 기록되면, 사용자가 고른 적 없는 값이 서버 기본값을 덮어쓴다.
+  // (configuration이 도착하기 전에 마운트되면 false가 박힌다.)
+  test('reading does not write anything to localStorage', () => {
+    renderEnableServiceMap(undefined);
+    renderEnableServiceMap(configWithServiceMap(true));
+
+    expect(window.localStorage.getItem(EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP)).toBeNull();
+  });
+
+  test('a configuration that arrives after mount is picked up', () => {
+    const { result } = renderEnableServiceMap(undefined);
+    expect(result.current).toBe(false);
+
+    act(() => {
+      store.set(configurationAtom, configWithServiceMap(true));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  test('toggling it in the Experimental page reaches readers without a reload', () => {
+    act(() => {
+      store.set(configurationAtom, configWithServiceMap(false));
+    });
+    const reader = renderHook(() => useEnableServiceMap());
+    const experimentals = renderHook(() => useExperimentals(configWithServiceMap(false)));
+
+    expect(reader.result.current).toBe(false);
+    expect(experimentals.result.current[EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP].value).toBe(
+      false,
+    );
+
+    act(() => {
+      experimentals.result.current[EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP].setter(true);
+    });
+
+    expect(reader.result.current).toBe(true);
+    // 렌더 밖(fetch 인터셉터)도 같은 값을 읽어야 하므로 localStorage에 남아야 한다.
+    expect(window.localStorage.getItem(EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP)).toBe('true');
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useEnableServiceMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useEnableServiceMap.ts
@@ -1,0 +1,27 @@
+import { EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
+import { pickEnableServiceMap } from '@pinpoint-fe/ui/src/utils';
+import { useConfiguration } from './useConfiguration';
+import { useLocalStorage } from './useLocalStorage';
+
+/**
+ * service / servicemap 기능이 켜져 있는지. 화면에서 이 값을 읽는 유일한 경로다.
+ *
+ * configuration API의 값을 기본값으로 쓰되, 사용자가 Experimental 설정에서 값을 정했으면
+ * localStorage에 저장된 그 값이 이긴다(`pickEnableServiceMap`).
+ *
+ * `useLocalStorage`는 같은 key를 쓰는 다른 인스턴스의 쓰기를 `local-storage` 이벤트로 받으므로,
+ * Experimental 설정에서 체크박스를 누르면 이 훅을 쓰는 화면들이 새로고침 없이 함께 반응한다.
+ *
+ * 초기값을 `null`로 두는 것이 중요하다. 여기서 boolean을 기본값으로 주면 configuration이
+ * 도착하기 전에 그 값이 localStorage에 기록되어, 사용자가 고른 적 없는 값이 서버 기본값을
+ * 영구히 덮어쓴다.
+ */
+export const useEnableServiceMap = () => {
+  const configuration = useConfiguration();
+  const [storedEnableServiceMap] = useLocalStorage<boolean | null>(
+    EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP,
+    null,
+  );
+
+  return pickEnableServiceMap(storedEnableServiceMap, configuration);
+};

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useExperimentals.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useExperimentals.ts
@@ -1,4 +1,5 @@
 import { Configuration, EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
+import { pickEnableServiceMap } from '@pinpoint-fe/ui/src/utils';
 import { useLocalStorage } from './useLocalStorage';
 import { useUpdateEffect } from 'usehooks-ts';
 
@@ -10,6 +11,14 @@ export const useExperimentals = (initialValue?: Configuration) => {
   const [useStatisticsAgentState, setUseStatisticsAgentState] = useLocalStorage(
     EXPERIMENTAL_CONFIG_KEYS.USE_STATISTICS_AGENT_STATE,
     !!initialValue?.['experimental.useStatisticsAgentState.value'],
+  );
+  // 다른 experimental과 달리 초기값이 `null`이다. 이 값은 화면 밖(fetch 인터셉터)에서도
+  // 읽히고 configuration이 도착하기 전에 이 훅이 먼저 마운트되므로, boolean을 기본값으로 주면
+  // 사용자가 고른 적 없는 `false`가 localStorage에 박혀 서버 기본값을 영구히 덮어쓴다.
+  // "저장된 값 없음"을 null로 남겨 두고, 실제 판단은 읽는 시점에 `pickEnableServiceMap`이 한다.
+  const [enableServiceMap, setEnableServiceMap] = useLocalStorage<boolean | null>(
+    EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP,
+    null,
   );
 
   useUpdateEffect(() => {
@@ -23,6 +32,7 @@ export const useExperimentals = (initialValue?: Configuration) => {
         initialValue?.['experimental.useStatisticsAgentState.value'] || false,
       );
     }
+    // enableServiceMap은 여기서 seed 하지 않는다. 위 주석 참고.
   }, [initialValue]);
 
   const experimentalMap = {
@@ -35,6 +45,12 @@ export const useExperimentals = (initialValue?: Configuration) => {
       description: initialValue?.['experimental.useStatisticsAgentState.description'],
       value: useStatisticsAgentState,
       setter: setUseStatisticsAgentState,
+    },
+    [EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP]: {
+      description: initialValue?.['experimental.enableServiceMap.description'],
+      // 체크박스에 보이는 값도 화면·헤더와 같은 규칙에서 나와야 한다.
+      value: pickEnableServiceMap(enableServiceMap, initialValue),
+      setter: setEnableServiceMap,
     },
   };
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServiceNameForLink.ts
@@ -2,14 +2,15 @@ import { useLocation } from 'react-router';
 import { useAtomValue } from 'jotai';
 import { selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
 import { getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';
-import { useConfiguration } from './useConfiguration';
+import { useEnableServiceMap } from './useEnableServiceMap';
 
 /**
  * 다른 화면으로 넘기는 링크(`getTransactionListPath`)에 실을 service 이름.
  * 실을 필요가 없으면 undefined를 반환하므로 링크 형태는 그대로 유지된다.
  *
- * configuration은 `configurationAtom`에서 직접 읽는다. 저장소는 그 atom 하나뿐이므로
- * 확장 저장소(naver 등)에서 이 파일을 그대로 복사해도 같은 값을 본다.
+ * 켜짐 여부는 `useEnableServiceMap` 하나로 판단한다(configuration 기본값 + 사용자가 고른
+ * localStorage 값). 저장소는 `configurationAtom` 하나뿐이므로 확장 저장소(naver 등)에서 이
+ * 파일을 그대로 복사해도 같은 값을 본다.
  *
  * 판단 규칙은 요청 헤더/캐시 키와 같은 `resolveRequestService`를 그대로 따른다.
  * - enableServiceMap이 꺼져 있으면 service 개념 자체가 없으므로 싣지 않는다.
@@ -18,11 +19,11 @@ import { useConfiguration } from './useConfiguration';
  *   화면 안에서 이동해도 처음 열었을 때의 service가 유지된다.
  */
 export const useServiceNameForLink = () => {
-  const configuration = useConfiguration();
+  const enableServiceMap = useEnableServiceMap();
   const selectedService = useAtomValue(selectedServiceAtom);
   const { pathname } = useLocation();
 
-  if (!configuration?.['experimental.enableServiceMap.value']) {
+  if (!enableServiceMap) {
     return undefined;
   }
 

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useServicesFetch.ts
@@ -2,15 +2,14 @@ import React from 'react';
 import { useSetAtom } from 'jotai';
 import { servicesAtom } from '@pinpoint-fe/ui/src/atoms';
 import { useGetServices } from '@pinpoint-fe/ui/src/hooks';
-import { useConfiguration } from './useConfiguration';
+import { useEnableServiceMap } from './useEnableServiceMap';
 
 export const useServicesFetch = () => {
-  // configurationAtom에서 직접 읽어 enable을 판단한다. fetch 인터셉터도 동일한 atom으로
-  // enableServiceMap을 판단하므로, atom이 채워진 뒤에 /api/v2/services가 발생해야
-  // pServiceName 헤더가 누락되지 않는다. (raw config로 enable하면 atom이 채워지기 전에
-  // 요청이 나가 헤더가 빠진다. atom을 직접 읽는 지금 구조가 그 순서를 보장한다.)
-  const configuration = useConfiguration();
-  const enableServiceMap = !!configuration?.['experimental.enableServiceMap.value'];
+  // configurationAtom에서 직접 읽어 enable을 판단한다(`useEnableServiceMap`). fetch 인터셉터도
+  // 동일한 atom과 동일한 규칙으로 enableServiceMap을 판단하므로, atom이 채워진 뒤에
+  // /api/v2/services가 발생해야 pServiceName 헤더가 누락되지 않는다. (raw config로 enable하면
+  // atom이 채워지기 전에 요청이 나가 헤더가 빠진다. atom을 직접 읽는 지금 구조가 그 순서를 보장한다.)
+  const enableServiceMap = useEnableServiceMap();
   const { data: services } = useGetServices({ enabled: enableServiceMap });
   const setServices = useSetAtom(servicesAtom);
 

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/Experimentals.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/Experimentals.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import { configurationAtom } from '@pinpoint-fe/ui/src/atoms';
+import { Configuration, EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
+import { ExperimentalPage } from './Experimentals';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const store = getDefaultStore();
+
+// 체크박스 라벨은 configuration이 내려주는 description이다.
+const SERVICE_MAP_LABEL = 'Enable service-based application map grouping.';
+const configuration = {
+  'experimental.enableServerMapRealTime.description': 'Enable server map real time.',
+  'experimental.useStatisticsAgentState.description': 'Use statistics agent state.',
+  'experimental.enableServiceMap.description': SERVICE_MAP_LABEL,
+  'experimental.enableServiceMap.value': false,
+} as unknown as Configuration;
+
+const serviceMapCheckbox = () =>
+  document.getElementById(EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP);
+
+describe('ExperimentalPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    store.set(configurationAtom, configuration);
+  });
+
+  test('exposes the enableServiceMap item by default', () => {
+    render(<ExperimentalPage />);
+
+    expect(serviceMapCheckbox()).not.toBeNull();
+    expect(screen.getByText(SERVICE_MAP_LABEL)).toBeDefined();
+  });
+
+  test('hides the enableServiceMap item when the renderer opts out', () => {
+    render(<ExperimentalPage showEnableServiceMap={false} />);
+
+    expect(serviceMapCheckbox()).toBeNull();
+    expect(screen.queryByText(SERVICE_MAP_LABEL)).toBeNull();
+  });
+
+  // showEnableServiceMap=false는 절대적이다. 항목을 그릴지와 체크 상태를 정하는 값은 다른
+  // 것이므로, configuration이 켜 놓았든 localStorage에 저장된 값이 있든 나오면 안 된다.
+  test('stays hidden even when configuration has the value on', () => {
+    store.set(configurationAtom, {
+      ...configuration,
+      'experimental.enableServiceMap.value': true,
+    } as unknown as Configuration);
+
+    render(<ExperimentalPage showEnableServiceMap={false} />);
+
+    expect(serviceMapCheckbox()).toBeNull();
+    expect(screen.queryByText(SERVICE_MAP_LABEL)).toBeNull();
+  });
+
+  test('stays hidden even when the user had already stored an override', () => {
+    window.localStorage.setItem(EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP, 'true');
+
+    render(<ExperimentalPage showEnableServiceMap={false} />);
+
+    expect(serviceMapCheckbox()).toBeNull();
+    expect(screen.queryByText(SERVICE_MAP_LABEL)).toBeNull();
+  });
+
+  // 다른 항목을 눌러 리렌더가 일어나도 숨긴 항목이 되살아나지 않아야 한다.
+  test('stays hidden across a re-render caused by toggling another item', () => {
+    render(<ExperimentalPage showEnableServiceMap={false} />);
+
+    const realTime = document.getElementById(
+      EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVER_MAP_REAL_TIME,
+    ) as HTMLElement;
+    fireEvent.click(realTime);
+
+    expect(serviceMapCheckbox()).toBeNull();
+    expect(screen.queryByText(SERVICE_MAP_LABEL)).toBeNull();
+  });
+
+  test('the other experimental items stay put either way', () => {
+    const { unmount } = render(<ExperimentalPage showEnableServiceMap={false} />);
+
+    expect(
+      document.getElementById(EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVER_MAP_REAL_TIME),
+    ).not.toBeNull();
+    expect(
+      document.getElementById(EXPERIMENTAL_CONFIG_KEYS.USE_STATISTICS_AGENT_STATE),
+    ).not.toBeNull();
+    unmount();
+
+    render(<ExperimentalPage />);
+
+    expect(
+      document.getElementById(EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVER_MAP_REAL_TIME),
+    ).not.toBeNull();
+    expect(
+      document.getElementById(EXPERIMENTAL_CONFIG_KEYS.USE_STATISTICS_AGENT_STATE),
+    ).not.toBeNull();
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/pages/config/Experimentals.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/config/Experimentals.tsx
@@ -1,12 +1,37 @@
 import { useTranslation } from 'react-i18next';
-import { Checkbox } from '../../components';
+import { Checkbox } from '../../components/ui/checkbox';
 import { EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
-import { useConfiguration, useExperimentals } from '@pinpoint-fe/ui/src/hooks';
+import { useConfiguration } from '../../hooks/utility/useConfiguration';
+import { useExperimentals } from '../../hooks/utility/useExperimentals';
 
-export const ExperimentalPage = () => {
+export interface ExperimentalPageProps {
+  /**
+   * `enableServiceMap` 항목을 이 화면에 노출할지. 기본은 노출한다.
+   *
+   * 노출 여부를 저장소(naver 등)나 배포 환경에 따라 다르게 두기 위한 prop이다. 판단 기준을
+   * 이 패키지가 알 필요는 없으므로(그런 값이 프론트엔드에 없다) 렌더하는 쪽에서 정해 내려준다.
+   *
+   * **UI 노출만 가른다.** 값 자체는 `pickEnableServiceMap`이 정하므로, 여기서 숨겨도 이미
+   * localStorage에 저장된 값이 있으면 그 값이 계속 쓰인다. 숨긴 화면에는 되돌릴 UI가 없다는
+   * 뜻이므로, 값까지 서버 설정으로 고정해야 한다면 그건 별도 처리가 필요하다.
+   */
+  showEnableServiceMap?: boolean;
+}
+
+export const ExperimentalPage = ({ showEnableServiceMap = true }: ExperimentalPageProps) => {
   const configuration = useConfiguration();
   const { t } = useTranslation();
   const experimentalMap = useExperimentals(configuration);
+
+  // `showEnableServiceMap`이 false면 이 항목은 어떤 경우에도 렌더하지 않는다. configuration이
+  // 켜 놓았든 localStorage에 저장된 값이 있든 상관없다 — 그 값들은 항목을 그릴지가 아니라
+  // 체크 상태만 정한다.
+  const experimentalKeys = Object.values(EXPERIMENTAL_CONFIG_KEYS).filter((key) => {
+    if (key === EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP) {
+      return showEnableServiceMap;
+    }
+    return true;
+  });
 
   return (
     <div className="space-y-6">
@@ -20,7 +45,7 @@ export const ExperimentalPage = () => {
         className="shrink-0 bg-border h-[1px] w-full"
       ></div>
       <div className="space-y-2">
-        {Object.values(EXPERIMENTAL_CONFIG_KEYS).map((key) => {
+        {experimentalKeys.map((key) => {
           return (
             <div className="flex items-center space-x-2" key={key}>
               <Checkbox

--- a/web-frontend/src/main/v3/packages/ui/src/utils/experimental.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/experimental.test.ts
@@ -1,0 +1,58 @@
+import { Configuration, EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
+import { getEnableServiceMap, pickEnableServiceMap } from './experimental';
+
+const configWithServiceMap = (enable: boolean) =>
+  ({ 'experimental.enableServiceMap.value': enable }) as unknown as Configuration;
+
+describe('pickEnableServiceMap', () => {
+  test('uses the configuration value while the user has picked nothing', () => {
+    expect(pickEnableServiceMap(null, configWithServiceMap(true))).toBe(true);
+    expect(pickEnableServiceMap(undefined, configWithServiceMap(true))).toBe(true);
+    expect(pickEnableServiceMap(null, configWithServiceMap(false))).toBe(false);
+  });
+
+  test('is false while configuration has not loaded yet', () => {
+    expect(pickEnableServiceMap(null, undefined)).toBe(false);
+  });
+
+  // 이 화면(useServicesFetch)과 요청 헤더(인터셉터)가 같은 규칙을 지나야 하는 이유.
+  // 저장된 값이 있으면 configuration이 도착하기 전부터 켜진 것으로 보이는데, 그때 인터셉터가
+  // configuration만 봤다면 /api/v2/services가 pServiceName 없이 나간다.
+  test('a stored value applies before configuration has loaded', () => {
+    expect(pickEnableServiceMap(true, undefined)).toBe(true);
+    expect(pickEnableServiceMap(false, undefined)).toBe(false);
+  });
+
+  test('the value the user picked wins over the configuration default, both ways', () => {
+    expect(pickEnableServiceMap(true, configWithServiceMap(false))).toBe(true);
+    expect(pickEnableServiceMap(false, configWithServiceMap(true))).toBe(false);
+  });
+
+  // localStorage에 사람이 손으로 넣은 값이나 예전 형식이 남아 있어도 기본값으로 흘러가야 한다.
+  test('ignores a stored value that is not a boolean', () => {
+    expect(pickEnableServiceMap('true', configWithServiceMap(false))).toBe(false);
+    expect(pickEnableServiceMap(1, configWithServiceMap(false))).toBe(false);
+  });
+});
+
+describe('getEnableServiceMap', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('falls back to configuration when nothing is stored', () => {
+    expect(getEnableServiceMap(configWithServiceMap(true))).toBe(true);
+  });
+
+  test('reads the stored override', () => {
+    window.localStorage.setItem(EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP, 'false');
+
+    expect(getEnableServiceMap(configWithServiceMap(true))).toBe(false);
+  });
+
+  test('a broken stored value does not throw, it falls back to configuration', () => {
+    window.localStorage.setItem(EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP, '{oops');
+
+    expect(getEnableServiceMap(configWithServiceMap(true))).toBe(true);
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/utils/experimental.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/experimental.ts
@@ -1,0 +1,27 @@
+import { Configuration, EXPERIMENTAL_CONFIG_KEYS } from '@pinpoint-fe/ui/src/constants';
+import { getLocalStorageValue } from './localStorage';
+
+/**
+ * `experimental.enableServiceMap`의 값을 정하는 단 하나의 규칙.
+ *
+ * 사용자가 Experimental 설정에서 값을 정했으면 그 값(localStorage)을 쓰고, 정하지 않았으면
+ * configuration API가 내려준 값을 기본값으로 쓴다. **저장된 값이 없는 상태를 boolean으로
+ * 눌러 담지 않는다** — 아직 고르지 않은 값을 configuration으로 seed 해 두면 서버 설정이
+ * 바뀌어도 먼저 접속했던 브라우저는 옛 기본값에 고정된다. 그래서 판단은 읽는 시점에 한다.
+ *
+ * 요청 헤더(`serviceNameFetchInterceptor`)와 화면(`useEnableServiceMap`)이 같은 값을 봐야
+ * 하므로 두 경로 모두 이 함수를 지난다. 한쪽만 localStorage를 보면 화면에는 service 개념이
+ * 없는데 헤더는 실려 나가는(또는 그 반대의) 어긋남이 생긴다.
+ */
+export const pickEnableServiceMap = (stored: unknown, configuration?: Configuration) =>
+  typeof stored === 'boolean' ? stored : !!configuration?.['experimental.enableServiceMap.value'];
+
+/**
+ * 렌더 밖(fetch 인터셉터 등)에서 읽는 경로. localStorage를 그 자리에서 읽으므로 설정을 바꾼
+ * 직후의 요청부터 바로 반영된다.
+ */
+export const getEnableServiceMap = (configuration?: Configuration) =>
+  pickEnableServiceMap(
+    getLocalStorageValue(EXPERIMENTAL_CONFIG_KEYS.ENABLE_SERVICE_MAP),
+    configuration,
+  );

--- a/web-frontend/src/main/v3/packages/ui/src/utils/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './array';
 export * from './date';
 export * from './dom';
+export * from './experimental';
 export * from './format';
 export * from './functions';
 export * from './helper';


### PR DESCRIPTION
## Summary

- `experimental.enableServiceMap` was read straight from the configuration API in seven places, so trying the feature meant changing server config. It is now an experimental toggle: the configuration value is the default, and a value the user picks on the Experimental page (localStorage) wins.
- Screens (`useEnableServiceMap`) and the `fetch` interceptor (`getEnableServiceMap`) both derive from one rule, `pickEnableServiceMap`. If only one side read localStorage, the `pServiceName` header would go out for a service the screen does not believe exists — a split nothing would catch at compile time.
- Unlike the other experimentals this key starts as `null` rather than a boolean. `useExperimentals` mounts before the configuration query resolves and the `useLocalStorage` wrapper persists whatever it holds, so a boolean default would write `false` into localStorage and permanently override a server-side `true` the user never opted out of. Resolution happens at read time instead.
- `ExperimentalPage` takes `showEnableServiceMap` (default `true`) so a consuming repo can keep the item off the page. It gates rendering only, not the resolved value.

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (114 suites, 972 tests)
- [x] `yarn lint` reports no errors
- [x] New unit tests cover the resolution rule: precedence in both directions, configuration arriving after mount, non-boolean/corrupt stored values, and that reading never writes to localStorage
- [x] New tests cover `showEnableServiceMap`: hidden when opted out even if configuration has the value on, even if localStorage already holds an override, and across a re-render triggered by another checkbox (verified non-vacuous by temporarily breaking the guard — 4 tests failed)
- [x] Existing service/servicemap suites pass unchanged, confirming that with nothing stored the configuration value still governs
- [ ] Manual: Config → Experimental shows the new checkbox; toggling it makes the Servicemap menu item and service side-navigation appear/disappear without a reload, and `/api` requests gain or lose the `pServiceName` header accordingly