### PR TITLE
[#noissue] Record suspended Ktor client completion on the resume trace

### DIFF
--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationInterceptor.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationInterceptor.java
@@ -17,6 +17,8 @@
 
 package com.navercorp.pinpoint.plugin.ktor.client;
 
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import com.navercorp.pinpoint.bootstrap.interceptor.AroundInterceptor;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
@@ -24,6 +26,11 @@ import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
 public class KtorClientContinuationInterceptor implements AroundInterceptor {
     private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
     private final boolean isDebug = logger.isDebugEnabled();
+    private final TraceContext traceContext;
+
+    public KtorClientContinuationInterceptor(TraceContext traceContext) {
+        this.traceContext = traceContext;
+    }
 
     @Override
     public void before(Object target, Object[] args) {
@@ -49,7 +56,12 @@ public class KtorClientContinuationInterceptor implements AroundInterceptor {
 
         try {
             try {
-                holder.finishAsync(throwable);
+                // Record the completion span on the trace that is live at resume time instead of
+                // binding a new async trace onto the thread-shared coroutine binder. The resume
+                // trace already carries the right parent chain and is owned by its creator, so
+                // this interceptor only pushes a span event onto it and never closes it.
+                Trace trace = traceContext.currentRawTraceObject();
+                holder.recordCompletion(trace, throwable);
             } catch (Throwable finishThrowable) {
                 logger.warn(
                         "Failed to finish Ktor client trace in continuation interceptor. {}",

--- a/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceHolder.java
+++ b/agent-module/plugins/ktor/src/main/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceHolder.java
@@ -27,7 +27,6 @@ import com.navercorp.pinpoint.bootstrap.context.Trace;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogManager;
 import com.navercorp.pinpoint.bootstrap.logging.PluginLogger;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
-import com.navercorp.pinpoint.bootstrap.util.ScopeUtils;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -79,39 +78,77 @@ public class KtorClientTraceHolder {
         }
     }
 
-    public void finishAsync(Throwable throwable) {
+    public void recordCompletion(Trace trace, Throwable throwable) {
         if (!asyncClosed.compareAndSet(false, true)) {
             return;
         }
 
-        Trace asyncTrace = null;
-        boolean blockStarted = false;
+        Trace ownedAsyncTrace = null;
         try {
-            // Other plugins may bind their own async trace to the shared coroutine binder on
-            // this thread; in that case we are only a nested participant. Track ownership via
-            // ScopeUtils so we close the trace only when we own it. ScopeUtils is Pinpoint-internal
-            // (not a plugin API surface), so re-verify entryAsyncTraceScope/leaveAsyncTraceScope/
-            // isAsyncTraceEndScope signatures on every agent bump.
-            asyncTrace = asyncContext.continueAsyncTraceObject(true);
-            if (asyncTrace == null) {
-                logger.warn("Could not continue Ktor client async trace");
+            if (trace != null) {
+                // The trace that is live at resume time belongs to whoever resumed the
+                // coroutine (the coroutines plugin's continuation trace, or the original
+                // caller). Only a span event is pushed onto it; it is never closed here.
+                recordSpanEvent(trace, throwable);
                 return;
             }
 
-            ScopeUtils.entryAsyncTraceScope(asyncTrace);
-            SpanEventRecorder recorder = asyncTrace.traceBlockBegin();
+            // No trace is live on this thread (e.g. coroutines tracing is disabled and the
+            // suspended call resumes on the client engine thread). The binder is provably
+            // empty, so the async trace created below is exclusively owned by this holder:
+            // record on it and close it, so the async chunk is flushed and the binder is
+            // restored to its previous (empty) state.
+            ownedAsyncTrace = asyncContext.continueAsyncTraceObject(true);
+            if (ownedAsyncTrace == null) {
+                logger.warn("Could not continue Ktor client async trace");
+                return;
+            }
+            recordSpanEvent(ownedAsyncTrace, throwable);
+        } catch (Throwable throwableInTrace) {
+            logger.warn(
+                    "Failed to record Ktor client completion span. {}",
+                    throwableInTrace.getMessage(),
+                    throwableInTrace
+            );
+        } finally {
+            closeOwnedAsyncTrace(ownedAsyncTrace);
+            finishAsyncState();
+        }
+    }
+
+    private void recordSpanEvent(Trace trace, Throwable throwable) {
+        boolean blockStarted = false;
+        try {
+            SpanEventRecorder recorder = trace.traceBlockBegin();
             blockStarted = true;
             recorder.recordServiceType(KtorConstants.KTOR_CLIENT_INTERNAL);
             record(recorder, throwable);
-        } catch (Throwable throwableInAsyncTrace) {
-            logger.warn(
-                    "Failed to finish Ktor client async trace. {}",
-                    throwableInAsyncTrace.getMessage(),
-                    throwableInAsyncTrace
-            );
         } finally {
-            closeAsyncTrace(asyncTrace, blockStarted);
-            finishAsyncState();
+            if (blockStarted) {
+                try {
+                    trace.traceBlockEnd();
+                } catch (Throwable endThrowable) {
+                    logger.warn("Failed to end Ktor client completion block. {}", endThrowable.getMessage(), endThrowable);
+                }
+            }
+        }
+    }
+
+    private void closeOwnedAsyncTrace(Trace ownedAsyncTrace) {
+        if (ownedAsyncTrace == null) {
+            return;
+        }
+        try {
+            ownedAsyncTrace.close();
+        } catch (Throwable closeThrowable) {
+            logger.warn("Failed to close Ktor client async trace. {}", closeThrowable.getMessage(), closeThrowable);
+        }
+        // Restore the thread binder unconditionally: the binder slot is provably ours in
+        // this path, so it must be cleared even when the trace close itself failed.
+        try {
+            asyncContext.close();
+        } catch (Throwable binderThrowable) {
+            logger.warn("Failed to close Ktor client async context. {}", binderThrowable.getMessage(), binderThrowable);
         }
     }
 
@@ -123,41 +160,6 @@ public class KtorClientTraceHolder {
         // asyncContext.close() would clear the shared thread binder and break another plugin's
         // in-flight trace. Only finish() is safe in this path.
         finishAsyncState();
-    }
-
-    private void closeAsyncTrace(Trace asyncTrace, boolean blockStarted) {
-        if (asyncTrace == null) {
-            return;
-        }
-
-        boolean scopeLeft = false;
-        try {
-            scopeLeft = ScopeUtils.leaveAsyncTraceScope(asyncTrace);
-            if (!scopeLeft) {
-                logger.warn("Failed to leave Ktor client async trace scope. {}", asyncTrace);
-            }
-        } catch (Throwable scopeThrowable) {
-            logger.warn("Failed to leave Ktor client async trace scope. {}", scopeThrowable.getMessage(), scopeThrowable);
-        }
-
-        // traceBlockEnd() must always pair with traceBlockBegin() regardless of nesting,
-        // otherwise the owning scope's close() sees an unbalanced stack id.
-        if (blockStarted) {
-            try {
-                asyncTrace.traceBlockEnd();
-            } catch (Throwable endThrowable) {
-                logger.warn("Failed to end Ktor client async trace block. {}", endThrowable.getMessage(), endThrowable);
-            }
-        }
-
-        try {
-            if (scopeLeft && ScopeUtils.isAsyncTraceEndScope(asyncTrace)) {
-                asyncTrace.close();
-                asyncContext.close();
-            }
-        } catch (Throwable closeThrowable) {
-            logger.warn("Failed to close Ktor client async trace. {}", closeThrowable.getMessage(), closeThrowable);
-        }
     }
 
     private void finishAsyncState() {

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationInterceptorTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientContinuationInterceptorTest.java
@@ -16,6 +16,8 @@
 
 package com.navercorp.pinpoint.plugin.ktor.client;
 
+import com.navercorp.pinpoint.bootstrap.context.Trace;
+import com.navercorp.pinpoint.bootstrap.context.TraceContext;
 import kotlin.coroutines.intrinsics.IntrinsicsKt;
 import org.junit.jupiter.api.Test;
 
@@ -25,56 +27,110 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class KtorClientContinuationInterceptorTest {
 
     @Test
-    void resumedResultFinishesHolderAndClearsAccessor() {
+    void resumedResultRecordsCompletionOnCurrentTraceAndClearsAccessor() {
+        Trace trace = mock(Trace.class);
+        TraceContext traceContext = mock(TraceContext.class);
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
         KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
         TestAccessor target = new TestAccessor(holder);
 
-        new KtorClientContinuationInterceptor().after(target, new Object[0], new Object(), null);
+        new KtorClientContinuationInterceptor(traceContext).after(target, new Object[0], new Object(), null);
 
-        verify(holder, times(1)).finishAsync(null);
+        verify(holder, times(1)).recordCompletion(trace, null);
         assertNull(target.trace);
     }
 
     @Test
+    void nullCurrentTraceIsPassedThroughToHolder() {
+        TraceContext traceContext = mock(TraceContext.class);
+        when(traceContext.currentRawTraceObject()).thenReturn(null);
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+        TestAccessor target = new TestAccessor(holder);
+
+        new KtorClientContinuationInterceptor(traceContext).after(target, new Object[0], new Object(), null);
+
+        verify(holder, times(1)).recordCompletion(null, null);
+        assertNull(target.trace);
+    }
+
+    @Test
+    void throwableIsForwardedToHolder() {
+        Trace trace = mock(Trace.class);
+        TraceContext traceContext = mock(TraceContext.class);
+        when(traceContext.currentRawTraceObject()).thenReturn(trace);
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+        TestAccessor target = new TestAccessor(holder);
+        Throwable throwable = new IllegalStateException("boom");
+
+        new KtorClientContinuationInterceptor(traceContext).after(target, new Object[0], new Object(), throwable);
+
+        verify(holder, times(1)).recordCompletion(trace, throwable);
+    }
+
+    @Test
     void suspendedMarkerReturnsSkipsFinishButKeepsHolder() {
+        TraceContext traceContext = mock(TraceContext.class);
         KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
         TestAccessor target = new TestAccessor(holder);
         Object marker = IntrinsicsKt.getCOROUTINE_SUSPENDED();
 
-        new KtorClientContinuationInterceptor().after(target, new Object[0], marker, null);
+        new KtorClientContinuationInterceptor(traceContext).after(target, new Object[0], marker, null);
 
-        verify(holder, never()).finishAsync(null);
+        verifyNoInteractions(traceContext);
+        verify(holder, never()).recordCompletion(any(), any());
         assertSame(holder, target.trace);
     }
 
     @Test
     void missingHolderIsNoOp() {
+        TraceContext traceContext = mock(TraceContext.class);
         TestAccessor target = new TestAccessor(null);
 
-        new KtorClientContinuationInterceptor().after(target, new Object[0], new Object(), null);
+        new KtorClientContinuationInterceptor(traceContext).after(target, new Object[0], new Object(), null);
 
+        verifyNoInteractions(traceContext);
         assertNull(target.trace);
     }
 
     @Test
     void nonAccessorTargetIsIgnored() {
-        new KtorClientContinuationInterceptor().after(new Object(), new Object[0], new Object(), null);
-        // no-op expectation
+        TraceContext traceContext = mock(TraceContext.class);
+
+        new KtorClientContinuationInterceptor(traceContext).after(new Object(), new Object[0], new Object(), null);
+
+        verifyNoInteractions(traceContext);
     }
 
     @Test
     void holderThrowingDoesNotPropagateAndClearsAccessor() {
+        TraceContext traceContext = mock(TraceContext.class);
         KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
-        doThrow(new IllegalStateException("finishAsync boom")).when(holder).finishAsync(null);
+        doThrow(new IllegalStateException("recordCompletion boom")).when(holder).recordCompletion(null, null);
         TestAccessor target = new TestAccessor(holder);
 
-        new KtorClientContinuationInterceptor().after(target, new Object[0], new Object(), null);
+        new KtorClientContinuationInterceptor(traceContext).after(target, new Object[0], new Object(), null);
 
+        assertNull(target.trace);
+    }
+
+    @Test
+    void currentTraceLookupFailureIsSwallowedAndAccessorCleared() {
+        TraceContext traceContext = mock(TraceContext.class);
+        when(traceContext.currentRawTraceObject()).thenThrow(new IllegalStateException("lookup boom"));
+        KtorClientTraceHolder holder = mock(KtorClientTraceHolder.class);
+        TestAccessor target = new TestAccessor(holder);
+
+        new KtorClientContinuationInterceptor(traceContext).after(target, new Object[0], new Object(), null);
+
+        verify(holder, never()).recordCompletion(any(), any());
         assertNull(target.trace);
     }
 

--- a/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceHolderTest.java
+++ b/agent-module/plugins/ktor/src/test/java/com/navercorp/pinpoint/plugin/ktor/client/KtorClientTraceHolderTest.java
@@ -20,7 +20,6 @@ import com.navercorp.pinpoint.bootstrap.context.AsyncContext;
 import com.navercorp.pinpoint.bootstrap.context.MethodDescriptor;
 import com.navercorp.pinpoint.bootstrap.context.SpanEventRecorder;
 import com.navercorp.pinpoint.bootstrap.context.Trace;
-import com.navercorp.pinpoint.bootstrap.context.scope.TraceScope;
 import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestRecorder;
 import com.navercorp.pinpoint.plugin.ktor.KtorConstants;
 import com.navercorp.pinpoint.plugin.ktor.KtorPluginConfig;
@@ -36,6 +35,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class KtorClientTraceHolderTest {
@@ -52,8 +52,7 @@ class KtorClientTraceHolderTest {
     @SuppressWarnings("unchecked")
     private final ClientRequestRecorder<Object> requestRecorder = mock(ClientRequestRecorder.class);
     private final SpanEventRecorder recorder = mock(SpanEventRecorder.class);
-    private final Trace asyncTrace = mock(Trace.class);
-    private final TraceScope asyncScope = mock(TraceScope.class);
+    private final Trace resumeTrace = mock(Trace.class);
 
     private KtorClientTraceHolder newHolder() {
         return new KtorClientTraceHolder(asyncContext, request, methodDescriptor, config, requestRecorder);
@@ -111,42 +110,59 @@ class KtorClientTraceHolderTest {
     }
 
     @Test
-    void finishAsyncRecordsAndClosesOwnedTrace() {
-        startAsyncTrace();
+    void recordCompletionRecordsOnGivenTraceWithoutClosingIt() {
+        startResumeTrace();
         KtorClientTraceHolder holder = newHolder();
         Throwable throwable = new IllegalStateException("boom");
 
-        holder.finishAsync(throwable);
+        holder.recordCompletion(resumeTrace, throwable);
 
+        verify(resumeTrace, times(1)).traceBlockBegin();
         verify(recorder, times(1)).recordServiceType(KtorConstants.KTOR_CLIENT_INTERNAL);
         verify(requestRecorder, times(1)).record(recorder, request, throwable);
         verify(recorder, times(1)).recordApi(methodDescriptor);
-        verify(asyncScope, times(1)).tryEnter();
-        verify(asyncScope, times(1)).leave();
-        verify(asyncTrace, times(1)).traceBlockEnd();
-        verify(asyncTrace, times(1)).close();
+        verify(resumeTrace, times(1)).traceBlockEnd();
+        verify(resumeTrace, never()).close();
+        verify(asyncContext, times(1)).finish();
+        verifyNoMoreInteractions(asyncContext);
+    }
+
+    @Test
+    void recordCompletionWithoutLiveTraceFallsBackToOwnedAsyncTrace() {
+        when(asyncContext.continueAsyncTraceObject(true)).thenReturn(resumeTrace);
+        when(resumeTrace.traceBlockBegin()).thenReturn(recorder);
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.recordCompletion(null, null);
+
+        verify(asyncContext, times(1)).continueAsyncTraceObject(true);
+        verify(recorder, times(1)).recordServiceType(KtorConstants.KTOR_CLIENT_INTERNAL);
+        verify(resumeTrace, times(1)).traceBlockEnd();
+        verify(resumeTrace, times(1)).close();
         verify(asyncContext, times(1)).close();
         verify(asyncContext, times(1)).finish();
     }
 
     @Test
-    void secondFinishAsyncIsNoOp() {
-        startAsyncTrace();
+    void fallbackFailureIsSwallowedAndStillClosesOwnedTrace() {
+        when(asyncContext.continueAsyncTraceObject(true)).thenReturn(resumeTrace);
+        when(resumeTrace.traceBlockBegin()).thenThrow(new IllegalStateException("begin boom"));
         KtorClientTraceHolder holder = newHolder();
 
-        holder.finishAsync(null);
-        holder.finishAsync(null);
+        holder.recordCompletion(null, null);
 
-        verify(asyncTrace, times(1)).traceBlockEnd();
+        verify(resumeTrace, never()).traceBlockEnd();
+        verify(resumeTrace, times(1)).close();
+        verify(asyncContext, times(1)).close();
         verify(asyncContext, times(1)).finish();
     }
 
     @Test
-    void finishAsyncWithoutAsyncTraceOnlyFinishesState() {
+    void fallbackWhenContinueReturnsNullOnlyFinishesState() {
         when(asyncContext.continueAsyncTraceObject(true)).thenReturn(null);
         KtorClientTraceHolder holder = newHolder();
 
-        holder.finishAsync(null);
+        holder.recordCompletion(null, null);
 
         verifyNoInteractions(requestRecorder);
         verify(asyncContext, times(1)).finish();
@@ -154,57 +170,73 @@ class KtorClientTraceHolderTest {
     }
 
     @Test
-    void nestedAsyncScopeIsLeftButNotClosed() {
-        startAsyncTrace();
-        // another plugin owns the shared coroutine binder, so the scope cannot be left
-        when(asyncScope.canLeave()).thenReturn(false);
+    void fallbackCloseFailureStillClosesBinderAndFinishesState() {
+        when(asyncContext.continueAsyncTraceObject(true)).thenReturn(resumeTrace);
+        when(resumeTrace.traceBlockBegin()).thenReturn(recorder);
+        doThrow(new IllegalStateException("close boom")).when(resumeTrace).close();
         KtorClientTraceHolder holder = newHolder();
 
-        holder.finishAsync(null);
+        holder.recordCompletion(null, null);
 
-        verify(asyncScope, never()).leave();
-        verify(asyncTrace, times(1)).traceBlockEnd();
-        verify(asyncTrace, never()).close();
-        verify(asyncContext, never()).close();
+        verify(asyncContext, times(1)).close();
         verify(asyncContext, times(1)).finish();
     }
 
     @Test
-    void activeAsyncScopeBlocksClose() {
-        startAsyncTrace();
-        // the scope was left by us but the owner has not finished yet
-        when(asyncScope.isActive()).thenReturn(true);
+    void secondRecordCompletionIsNoOp() {
+        startResumeTrace();
         KtorClientTraceHolder holder = newHolder();
 
-        holder.finishAsync(null);
+        holder.recordCompletion(resumeTrace, null);
+        holder.recordCompletion(resumeTrace, null);
 
-        verify(asyncTrace, times(1)).traceBlockEnd();
-        verify(asyncTrace, never()).close();
-        verify(asyncContext, never()).close();
+        verify(resumeTrace, times(1)).traceBlockBegin();
         verify(asyncContext, times(1)).finish();
     }
 
     @Test
-    void continuationFailureIsSwallowed() {
-        when(asyncContext.continueAsyncTraceObject(true)).thenThrow(new IllegalStateException("continuation boom"));
+    void recordFailureIsSwallowedAndStillFinishesState() {
+        startResumeTrace();
+        doThrow(new IllegalStateException("record boom")).when(requestRecorder).record(recorder, request, null);
         KtorClientTraceHolder holder = newHolder();
 
-        holder.finishAsync(null);
+        holder.recordCompletion(resumeTrace, null);
 
+        verify(resumeTrace, times(1)).traceBlockEnd();
         verify(asyncContext, times(1)).finish();
-        verify(asyncContext, never()).close();
     }
 
     @Test
-    void closeFailureDoesNotSkipFinish() {
-        startAsyncTrace();
-        doThrow(new IllegalStateException("close boom")).when(asyncTrace).close();
+    void blockBeginFailureStillFinishesState() {
+        when(resumeTrace.traceBlockBegin()).thenThrow(new IllegalStateException("begin boom"));
         KtorClientTraceHolder holder = newHolder();
 
-        holder.finishAsync(null);
+        holder.recordCompletion(resumeTrace, null);
 
-        verify(asyncTrace, times(1)).traceBlockEnd();
+        verify(resumeTrace, never()).traceBlockEnd();
         verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void blockEndFailureStillFinishesState() {
+        startResumeTrace();
+        doThrow(new IllegalStateException("end boom")).when(resumeTrace).traceBlockEnd();
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.recordCompletion(resumeTrace, null);
+
+        verify(asyncContext, times(1)).finish();
+    }
+
+    @Test
+    void recordCompletionOnLiveTraceNeverTouchesAsyncBinder() {
+        startResumeTrace();
+        KtorClientTraceHolder holder = newHolder();
+
+        holder.recordCompletion(resumeTrace, null);
+
+        verify(asyncContext, never()).continueAsyncTraceObject(true);
+        verify(asyncContext, never()).close();
     }
 
     @Test
@@ -212,18 +244,18 @@ class KtorClientTraceHolderTest {
         KtorClientTraceHolder holder = newHolder();
 
         holder.cancelAsync();
-        holder.finishAsync(null);
+        holder.recordCompletion(resumeTrace, null);
 
         verify(asyncContext, times(1)).finish();
-        verify(asyncContext, never()).continueAsyncTraceObject(true);
+        verifyNoInteractions(resumeTrace);
     }
 
     @Test
-    void cancelAsyncAfterFinishIsNoOp() {
-        startAsyncTrace();
+    void cancelAsyncAfterRecordCompletionIsNoOp() {
+        startResumeTrace();
         KtorClientTraceHolder holder = newHolder();
 
-        holder.finishAsync(null);
+        holder.recordCompletion(resumeTrace, null);
         holder.cancelAsync();
 
         verify(asyncContext, times(1)).finish();
@@ -239,54 +271,7 @@ class KtorClientTraceHolderTest {
         verify(asyncContext, times(1)).finish();
     }
 
-    @Test
-    void leaveScopeFailureIsSwallowed() {
-        startAsyncTrace();
-        when(asyncScope.canLeave()).thenThrow(new IllegalStateException("leave boom"));
-        KtorClientTraceHolder holder = newHolder();
-
-        holder.finishAsync(null);
-
-        verify(asyncTrace, times(1)).traceBlockEnd();
-        verify(asyncTrace, never()).close();
-        verify(asyncContext, times(1)).finish();
-    }
-
-    @Test
-    void blockEndFailureStillClosesOwnedTrace() {
-        startAsyncTrace();
-        doThrow(new IllegalStateException("end boom")).when(asyncTrace).traceBlockEnd();
-        KtorClientTraceHolder holder = newHolder();
-
-        holder.finishAsync(null);
-
-        verify(asyncTrace, times(1)).close();
-        verify(asyncContext, times(1)).close();
-        verify(asyncContext, times(1)).finish();
-    }
-
-    @Test
-    void blockBeginFailureLeavesScopeWithoutEnd() {
-        when(asyncContext.continueAsyncTraceObject(true)).thenReturn(asyncTrace);
-        when(asyncTrace.traceBlockBegin()).thenThrow(new IllegalStateException("begin boom"));
-        when(asyncTrace.getScope(AsyncContext.ASYNC_TRACE_SCOPE)).thenReturn(asyncScope);
-        when(asyncTrace.isAsync()).thenReturn(true);
-        when(asyncScope.canLeave()).thenReturn(true);
-        KtorClientTraceHolder holder = newHolder();
-
-        holder.finishAsync(null);
-
-        verify(asyncTrace, never()).traceBlockEnd();
-        verify(asyncTrace, times(1)).close();
-        verify(asyncContext, times(1)).close();
-        verify(asyncContext, times(1)).finish();
-    }
-
-    private void startAsyncTrace() {
-        when(asyncContext.continueAsyncTraceObject(true)).thenReturn(asyncTrace);
-        when(asyncTrace.traceBlockBegin()).thenReturn(recorder);
-        when(asyncTrace.getScope(AsyncContext.ASYNC_TRACE_SCOPE)).thenReturn(asyncScope);
-        when(asyncTrace.isAsync()).thenReturn(true);
-        when(asyncScope.canLeave()).thenReturn(true);
+    private void startResumeTrace() {
+        when(resumeTrace.traceBlockBegin()).thenReturn(recorder);
     }
 }


### PR DESCRIPTION
## Summary

Fix the recording of the `KTOR_CLIENT_INTERNAL` completion span for suspended Ktor client calls. When a trace is live at resume time, the span is now recorded directly on that trace instead of binding a new async trace onto the thread-shared coroutine binder. When no trace is live (default configuration), the previous owned-async-trace path is preserved.

## Problem

`KtorClientTraceHolder.finishAsync()` recorded the completion span via `AsyncContext.continueAsyncTraceObject(true)` on the coroutine resume thread. That call binds onto the **thread-shared coroutine binder**, so the result depends on what else happens to be bound there:

- **Foreign-trace nesting.** When the coroutines plugin has already bound its own continuation trace to the binder for the same resume (`profiler.kotlin.coroutines.enable=true`), `continueAsyncTraceObject(true)` returns that foreign trace and the completion span lands inside it as a nested participant. The plugin then has to guess ownership through `ScopeUtils` (a Pinpoint-internal API, not a plugin surface) to decide whether it may close the trace — and that close path could close the coroutines plugin's mid-flight continuation trace, breaking that plugin's own trace bookkeeping.
- Measured with a real agent (coroutines plugin enabled): the completion span of a suspended call whose I/O took ~1.5s appeared inside a foreign continuation trace instead of the caller's trace.

## Fix

- `KtorClientTraceHolder.finishAsync(Throwable)` → `recordCompletion(Trace, Throwable)`:
  - **Live trace at resume time** (coroutines plugin enabled): records the span event **directly on the trace that is live at resume time** (`TraceContext.currentRawTraceObject()`). That trace already carries the right parent chain and is owned by its creator (the coroutines plugin or the original caller), so the holder only pushes a span event onto it and never closes it. The `ScopeUtils` dependency and the foreign-trace close danger are removed.
  - **No trace at resume time** (default configuration: coroutines tracing disabled, the suspended call resumes on the client engine thread): the binder is provably empty, so the holder falls back to `asyncContext.continueAsyncTraceObject(true)` and **exclusively owns** the created async trace — records on it and closes it. Default-configuration behavior is preserved without the `ScopeUtils` ownership guessing. The binder restore (`asyncContext.close()`) runs unconditionally, even if the trace close itself fails.
- `KtorClientContinuationInterceptor` now takes a `TraceContext` constructor argument (standard `addInterceptor` auto-injection; same pattern as the vertx plugin's `HandleExceptionInterceptor(TraceContext)`) and passes `currentRawTraceObject()` to the holder.
- The once-only guard (CAS) and the `asyncContext.finish()` cleanup are unchanged.

### Before / after (suspended call, ~1.5s of I/O, coroutines plugin enabled)

```
Before:                                   After:
ROOT (foreign continuation trace)         ROOT
└─ ...                                      ├─ KTOR_CLIENT execute (7ms)
   └─ KTOR_CLIENT_INTERNAL completion       └─ KTOR_CLIENT_INTERNAL completion (0ms)
      lands inside a foreign trace,            recorded at resume time on the
      and the old close path could              resume trace (never closed here)
      close that foreign trace mid-flight
```

## Verification

- **Unit tests**: 78 pass for the module; holder/interceptor tests were rewritten for the new API (records on the given trace without closing it, fallback owned-trace path with close, once-only CAS, begin/end/close failure paths, binder untouched on the live-trace path).
- **Real-agent measurement** (this change built into a plugin jar, loaded by a real Pinpoint agent, spans sent to a Pinpoint collector; local test app calling a 1.5s slow endpoint):
  - coroutines plugin enabled, launch pattern: `execute` ends at suspension (5ms) and the completion span is recorded on the resume trace 1.55s later, nested under the coroutine `resumeWith` — the live-trace path.
  - default configuration, coroutines plugin disabled, runBlocking pattern: `execute` ends at suspension (5ms) on the caller's trace and the completion span is recorded 1.58s later via the owned async trace fallback — the same visible result as the previous implementation, without the `ScopeUtils` ownership guessing.
  - default configuration, coroutines plugin disabled, fire-and-forget coroutine (no live trace at call time): no span is recorded, unchanged from the previous behavior.
- **Beta deployment**: the live-trace recording mechanism was verified on a beta deployment of a large Kotlin service — 25/25 sampled suspended ktor calls showed the completion span on the caller's trace, with no `UNDEFINED` spans and no corrupted trace trees over a 20+ minute observation window.

---
cc @jaehong-kim — you reviewed the original Ktor client instrumentation PRs (#14090, #14182). This fixes the completion-span recording on top of that work.
