### PR TITLE
[#14229] Feed URI stat from OTLP trace entry-point spans

### DIFF
--- a/collector-starter/src/main/resources/profiles/local/pinpoint-collector.properties
+++ b/collector-starter/src/main/resources/profiles/local/pinpoint-collector.properties
@@ -9,3 +9,9 @@ collector.service.lookup.executor.queueCapacity=512
 
 # Allow applicationName→agentId fallback for OTel demo / sandbox traffic in dev.
 pinpoint.collector.otlptrace.application-name-fallback.enabled=true
+
+# Feed URI stat from OTLP traces. Requires the uristat storage module
+# (pinpoint.modules.collector.uristat.enabled=true). Off by default: OTLP spans are sampled,
+# so URI stat counts/apdex reflect the sampled population, unlike the native agent's pre-sampling totals.
+pinpoint.collector.otlptrace.uristat.enabled=true
+pinpoint.modules.collector.uristat.enabled=true

--- a/collector-starter/src/main/resources/profiles/release/pinpoint-collector.properties
+++ b/collector-starter/src/main/resources/profiles/release/pinpoint-collector.properties
@@ -9,3 +9,8 @@ collector.service.lookup.executor.queueCapacity=1024
 
 # Reject OTLP requests without a per-instance identifier in production.
 pinpoint.collector.otlptrace.application-name-fallback.enabled=false
+
+# Feed URI stat from OTLP traces. Requires the uristat storage module
+# (pinpoint.modules.collector.uristat.enabled=true). Off by default: OTLP spans are sampled,
+# so URI stat counts/apdex reflect the sampled population, unlike the native agent's pre-sampling totals.
+pinpoint.collector.otlptrace.uristat.enabled=false

--- a/otlptrace/README.md
+++ b/otlptrace/README.md
@@ -213,6 +213,26 @@ or violates the **`[a-zA-Z0-9._-]+` pattern** in the limits table above. Fix
 the offending attribute on the OTel agent side (no spaces, no special
 characters, within the length budget) and the error goes away.
 
+## URI stat
+
+The collector can also derive **URI stat** (per-endpoint response-time histograms, the data behind
+the URI Stat charts) from OTLP traces. It aggregates the entry-point spans of each export request by
+`(serviceName, applicationName, agentId, uri, 30s window)` and writes them to the same Kafka/Pinot
+store the native agent's URI stat uses.
+
+Only spans carrying an OTel `http.route` template (e.g. `/users/{id}`) contribute — the raw
+`url.path` (`/users/12345`) is deliberately excluded so the stat stays low-cardinality, mirroring the
+native agent recording URI stat solely from its resolved URI template.
+
+| Property | Default | Notes |
+|---|---|---|
+| `pinpoint.collector.otlptrace.uristat.enabled` | `false` | Enables OTLP → URI stat feeding. |
+| `pinpoint.modules.collector.uristat.enabled` | — | **Prerequisite.** Provides the shared URI stat storage module (Kafka/Pinot). Both flags must be `true`. |
+
+Off by default for two reasons: it requires the URI stat storage module, and OTLP spans are
+**sampled** — so counts/apdex reflect the sampled population rather than the native agent's
+pre-sampling totals. Keep that distinction in mind when reading charts that mix both sources.
+
 ## otlptrace-otel-extension
 
 A small **sender-side** OTel SDK extension that adds a `pp=...` entry to the

--- a/otlptrace/otlptrace-collector/pom.xml
+++ b/otlptrace/otlptrace-collector/pom.xml
@@ -29,6 +29,10 @@
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-pinot-kafka</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-uristat-collector</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
@@ -32,6 +32,10 @@ import com.navercorp.pinpoint.common.server.util.IgnoreAddressFilter;
 import com.navercorp.pinpoint.grpc.channelz.ChannelzRegistry;
 import com.navercorp.pinpoint.otlp.trace.collector.service.GrpcOtlpTraceService;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportService;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpUriStatService;
+import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.uristat.collector.UriStatCollectorConfig;
+import com.navercorp.pinpoint.uristat.collector.dao.UriStatDao;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.grpc.BindableService;
@@ -61,6 +65,12 @@ import java.util.concurrent.Executor;
         ServiceLookupConfiguration.class,
         StaticServiceLookupConfiguration.class,
         HeatmapCollectorModule.class,
+
+        // URI stat storage beans (UriStatDao / TenantProvider / kafkaUriStatTemplate) used by
+        // OtlpUriStatService. Self-guarded by @ConditionalOnProperty(uristat.enabled); without this
+        // import the OTLP trace app runs as its own Spring context with no uristat beans, so
+        // OtlpUriStatService cannot be created even when both uristat flags are true.
+        UriStatCollectorConfig.class,
 
         OtlpTraceCollectorPropertySources.class,
         OtlpTraceCollectorHbaseModule.class,
@@ -107,6 +117,17 @@ public class OtlpTraceCollectorModule {
     @Bean
     public ServerServiceDefinitions serviceList(@Qualifier("serverServiceDefinition") ServerServiceDefinition serviceDefinition) {
         return ServerServiceDefinitions.of(serviceDefinition);
+    }
+
+    // A @Bean method, not a component-scanned @Service: bean-method conditions are evaluated after
+    // the whole configuration tree (including the imported @PropertySources) is parsed, so the
+    // profile-file flags are visible here — a scanned class' condition would run before them.
+    @Bean
+    @ConditionalOnProperty(
+            name = {"pinpoint.modules.collector.uristat.enabled", "pinpoint.collector.otlptrace.uristat.enabled"},
+            havingValue = "true")
+    public OtlpUriStatService otlpUriStatService(UriStatDao uriStatDao, TenantProvider tenantProvider) {
+        return new OtlpUriStatService(uriStatDao, tenantProvider);
     }
 
     @Bean

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
@@ -134,6 +134,15 @@ public class OtlpTraceMapper {
                         mapperData.addSpanBo(spanBo);
                         final AgentInfoBo agentInfoBo = agentInfoMapper.map(spanBo, resourceAttributeMap);
                         mapperData.addAgentInfoBo(agentInfoBo);
+
+                        // URI stat source: only entry-point spans carrying an http.route template.
+                        // The raw url.path fallback is intentionally excluded to keep uriStat low-cardinality.
+                        final String uriTemplate = spanMapper.getUriTemplate(rootSpan, rootAttributes);
+                        if (uriTemplate != null) {
+                            mapperData.addUriStatSpan(new OtlpUriStatSpan(
+                                    spanBo.getServiceName(), spanBo.getApplicationName(), spanBo.getAgentId(),
+                                    uriTemplate, spanBo.getStartTimeMillis(), spanBo.getElapsed(), spanBo.getErrCode() != 0));
+                        }
                     } catch (Exception e) {
                         errorCount++;
                         logMappingError("Failed to map span", e);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperData.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperData.java
@@ -31,6 +31,7 @@ public class OtlpTraceMapperData {
     private final List<SpanChunkBo> spanChunkBoList = new ArrayList<>();
     private final List<AgentInfoBo> agentInfoBoList = new ArrayList<>();
     private final List<ExceptionMetaDataBo> exceptionMetaDataBoList = new ArrayList<>();
+    private final List<OtlpUriStatSpan> uriStatSpanList = new ArrayList<>();
     private final OtlpTraceCollectorRejectedSpan rejectedSpan = new OtlpTraceCollectorRejectedSpan();
 
     public List<SpanBo> getSpanBoList() {
@@ -63,6 +64,14 @@ public class OtlpTraceMapperData {
 
     public void addExceptionMetaDataBo(ExceptionMetaDataBo exceptionMetaDataBo) {
         exceptionMetaDataBoList.add(exceptionMetaDataBo);
+    }
+
+    public List<OtlpUriStatSpan> getUriStatSpanList() {
+        return uriStatSpanList;
+    }
+
+    public void addUriStatSpan(OtlpUriStatSpan uriStatSpan) {
+        uriStatSpanList.add(uriStatSpan);
     }
 
     public OtlpTraceCollectorRejectedSpan getRejectedSpan() {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -28,6 +28,7 @@ import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.OtelServerTraceId;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
+import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
 import com.navercorp.pinpoint.io.SpanVersion;
@@ -507,6 +508,24 @@ public class OtlpTraceSpanMapper {
         // Known messaging consumer rpc is built via OtlpMessagingConsumerResolver#buildConsumerRpc.
         // Consumer for unsupported messaging.system / unknown kind: fall back to the OTel span name.
         return span.getName();
+    }
+
+    /**
+     * Returns the matched route template (http.route, e.g. "/users/{id}") for SERVER/INTERNAL
+     * spans, or null when the request was not routed. URI stat must aggregate by this
+     * low-cardinality template only: unlike {@link #getServerSpanToRpc}, it never falls back to the
+     * raw url.path, since path variables would explode the Pinot uriStat cardinality. This mirrors
+     * the Pinpoint agent feeding URI stat solely from SpanRecorder.recordUriTemplate.
+     */
+    String getUriTemplate(Span span, Map<String, AttributeValue> attributes) {
+        final int kind = span.getKind().getNumber();
+        if (kind == Span.SpanKind.SPAN_KIND_SERVER_VALUE || kind == Span.SpanKind.SPAN_KIND_INTERNAL_VALUE) {
+            final String httpRoute = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_ROUTE, null);
+            if (StringUtils.hasLength(httpRoute)) {
+                return httpRoute;
+            }
+        }
+        return null;
     }
 
     public static String extractPath(String url) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpUriStatSpan.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpUriStatSpan.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+/**
+ * A single entry-point span's contribution to URI stat, captured during trace mapping while the
+ * OTel http.route attribute is still available. Deliberately free of any uristat-module type so the
+ * always-on {@link OtlpTraceMapper} does not depend on the optional uristat collector; aggregation
+ * into UriStat records happens later in OtlpUriStatService, which only loads when the uristat module
+ * is enabled.
+ */
+public class OtlpUriStatSpan {
+    private final String serviceName;
+    private final String applicationName;
+    private final String agentId;
+    private final String uri;
+    private final long startTime;
+    private final int elapsed;
+    private final boolean error;
+
+    public OtlpUriStatSpan(String serviceName, String applicationName, String agentId,
+                           String uri, long startTime, int elapsed, boolean error) {
+        this.serviceName = serviceName;
+        this.applicationName = applicationName;
+        this.agentId = agentId;
+        this.uri = uri;
+        this.startTime = startTime;
+        this.elapsed = elapsed;
+        this.error = error;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public String getAgentId() {
+        return agentId;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public int getElapsed() {
+        return elapsed;
+    }
+
+    public boolean isError() {
+        return error;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
@@ -74,17 +74,21 @@ public class OtlpTraceExportService {
     // Thread-safe, bounded dedup of already-persisted agentIds. Shared across transports so an
     // agentId first seen on gRPC is not re-inserted when it later arrives over HTTP (and vice versa).
     private final Cache<String, Boolean> agentIdCache;
+    // Null unless both uristat flags are enabled (the bean is conditional).
+    private final OtlpUriStatService uriStatService;
 
     private final Counter spanInsertErrorCounter;
     private final Counter spanChunkInsertErrorCounter;
     private final Counter agentInfoInsertErrorCounter;
     private final Counter exceptionInsertErrorCounter;
+    private final Counter uriStatInsertErrorCounter;
 
     public OtlpTraceExportService(TraceService[] traceServiceList,
                                   @Qualifier("hbaseOtlpAgentInfoService") HbaseOtlpAgentInfoService agentInfoService,
                                   @Qualifier("hbaseOtlpApplicationIndexV2Service") HbaseOtlpApplicationIndexV2Service applicationIndexV2Service,
                                   OtlpTraceMapper otlpTraceMapper,
                                   Optional<ExceptionMetaDataService> exceptionMetaDataService,
+                                  Optional<OtlpUriStatService> uriStatService,
                                   @Qualifier("otlpAgentIdCache") Cache<String, Boolean> agentIdCache,
                                   MeterRegistry meterRegistry) {
         this.traceServiceList = Objects.requireNonNull(traceServiceList, "traceServiceList");
@@ -93,11 +97,13 @@ public class OtlpTraceExportService {
         this.otlpTraceMapper = Objects.requireNonNull(otlpTraceMapper, "otlpTraceMapper");
         this.exceptionMetaDataService = exceptionMetaDataService.orElse(null);
         this.agentIdCache = Objects.requireNonNull(agentIdCache, "agentIdCache");
+        this.uriStatService = uriStatService.orElse(null);
         Objects.requireNonNull(meterRegistry, "meterRegistry");
         this.spanInsertErrorCounter = insertErrorCounter(meterRegistry, "span");
         this.spanChunkInsertErrorCounter = insertErrorCounter(meterRegistry, "spanChunk");
         this.agentInfoInsertErrorCounter = insertErrorCounter(meterRegistry, "agentInfo");
         this.exceptionInsertErrorCounter = insertErrorCounter(meterRegistry, "exception");
+        this.uriStatInsertErrorCounter = insertErrorCounter(meterRegistry, "uriStat");
     }
 
     private static Counter insertErrorCounter(MeterRegistry meterRegistry, String op) {
@@ -160,6 +166,17 @@ public class OtlpTraceExportService {
                     exceptionInsertErrorCounter.increment();
                     throttledLogger.warn("Failed to insert exceptionMetaData", e);
                 }
+            }
+        }
+
+        // Optional statistics side channel: a uriStat failure must not fail the trace export, so it
+        // is not counted toward serverErrorCount (spans are already stored at this point).
+        if (uriStatService != null) {
+            try {
+                uriStatService.store(otlpTraceMapperData.getUriStatSpanList());
+            } catch (Exception e) {
+                uriStatInsertErrorCounter.increment();
+                throttledLogger.warn("Failed to insert uriStat", e);
             }
         }
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpUriStatService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpUriStatService.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+import com.navercorp.pinpoint.common.trace.UriStatHistogramBucket;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpUriStatSpan;
+import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
+import com.navercorp.pinpoint.uristat.collector.dao.UriStatDao;
+import com.navercorp.pinpoint.uristat.collector.model.UriStat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Builds URI stat records from OTLP entry-point spans (Option B).
+ * <p>
+ * Unlike the native agent, which pre-aggregates over a 30s window before sending, OTLP spans arrive
+ * raw. Rather than emitting one record per span, this aggregates the spans of a single export
+ * request by (service, application, agent, uri, 30s window) so the number of Kafka/Pinot records
+ * stays close to the agent's volume. The web side re-aggregates with SUM/MAX at query time, so
+ * batch-level pre-aggregation is mathematically equivalent to per-span records.
+ * <p>
+ * Gated by two flags (AND), mirroring the native split between the shared uristat storage module
+ * and its per-source ingest toggle ({@code collector.stat.uri}):
+ * <ul>
+ *   <li>{@code pinpoint.modules.collector.uristat.enabled} — the shared storage module that provides
+ *       the {@link UriStatDao} and {@link TenantProvider} beans this service requires.</li>
+ *   <li>{@code pinpoint.collector.otlptrace.uristat.enabled} — the OTLP-specific switch, off by
+ *       default, so enabling native uristat does not silently turn on OTLP feeding.</li>
+ * </ul>
+ * If only the OTLP flag is set without the storage module, the AND fails and the bean is simply not
+ * created (no startup failure from the missing {@link UriStatDao}).
+ */
+/**
+ * Registered as an explicit @Bean in OtlpTraceCollectorModule rather than component-scanned:
+ * its enable flags live in the profile property files, which are contributed by an imported
+ * @PropertySources class — component-scan conditions are evaluated before those imports are
+ * processed, so a scanned @ConditionalOnProperty could never see the flags.
+ */
+public class OtlpUriStatService {
+
+    // Aligns with the agent's TickClock window and the web's default query granularity (30s), so
+    // truncating span timestamps to this window collapses records without changing chart buckets.
+    static final long WINDOW_SIZE_MS = 30_000L;
+
+    private static final int BUCKET_SIZE = 8;
+
+    private final UriStatDao uriStatDao;
+    private final TenantProvider tenantProvider;
+    private final int version = UriStatHistogramBucket.getLayout().getBucketVersion();
+
+    public OtlpUriStatService(UriStatDao uriStatDao, TenantProvider tenantProvider) {
+        this.uriStatDao = Objects.requireNonNull(uriStatDao, "uriStatDao");
+        this.tenantProvider = Objects.requireNonNull(tenantProvider, "tenantProvider");
+    }
+
+    public void store(List<OtlpUriStatSpan> uriStatSpanList) {
+        if (uriStatSpanList.isEmpty()) {
+            return;
+        }
+        final String tenantId = tenantProvider.getTenantId();
+
+        final Map<UriStatKey, UriStatAccumulator> accumulatorMap = new HashMap<>();
+        for (OtlpUriStatSpan span : uriStatSpanList) {
+            final long window = (span.getStartTime() / WINDOW_SIZE_MS) * WINDOW_SIZE_MS;
+            final UriStatKey key = new UriStatKey(span.getServiceName(), span.getApplicationName(),
+                    span.getAgentId(), span.getUri(), window);
+            accumulatorMap.computeIfAbsent(key, k -> new UriStatAccumulator())
+                    .add(span.getElapsed(), span.isError());
+        }
+
+        final List<UriStat> data = new ArrayList<>(accumulatorMap.size());
+        for (Map.Entry<UriStatKey, UriStatAccumulator> entry : accumulatorMap.entrySet()) {
+            final UriStatKey key = entry.getKey();
+            final UriStatAccumulator acc = entry.getValue();
+            data.add(new UriStat(key.window, tenantId, key.serviceName, key.applicationName, key.agentId, key.uri,
+                    acc.maxLatencyMs, acc.totalTimeMs,
+                    toList(acc.totalHistogram), toList(acc.failureHistogram),
+                    version));
+        }
+        uriStatDao.insert(data);
+    }
+
+    private static List<Integer> toList(int[] histogram) {
+        final List<Integer> list = new ArrayList<>(histogram.length);
+        for (int value : histogram) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    private static final class UriStatKey {
+        private final String serviceName;
+        private final String applicationName;
+        private final String agentId;
+        private final String uri;
+        private final long window;
+
+        private UriStatKey(String serviceName, String applicationName, String agentId, String uri, long window) {
+            this.serviceName = serviceName;
+            this.applicationName = applicationName;
+            this.agentId = agentId;
+            this.uri = uri;
+            this.window = window;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            UriStatKey that = (UriStatKey) o;
+            return window == that.window
+                    && Objects.equals(serviceName, that.serviceName)
+                    && Objects.equals(applicationName, that.applicationName)
+                    && Objects.equals(agentId, that.agentId)
+                    && Objects.equals(uri, that.uri);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(serviceName, applicationName, agentId, uri, window);
+        }
+    }
+
+    private static final class UriStatAccumulator {
+        private final int[] totalHistogram = new int[BUCKET_SIZE];
+        private final int[] failureHistogram = new int[BUCKET_SIZE];
+        private long totalTimeMs;
+        private long maxLatencyMs;
+
+        private void add(int elapsed, boolean error) {
+            final int index = UriStatHistogramBucket.getLayout().getBucket(elapsed).getIndex();
+            totalHistogram[index]++;
+            if (error) {
+                failureHistogram[index]++;
+            }
+            totalTimeMs += elapsed;
+            if (elapsed > maxLatencyMs) {
+                maxLatencyMs = elapsed;
+            }
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -649,4 +649,70 @@ class OtlpTraceMapperTest {
         assertThat(data.getSpanBoList()).hasSize(1);
         assertThat(data.getSpanBoList().get(0).getSpanOwner().getAgentStartTime()).isEqualTo(1000L);
     }
+
+    // =======================================================================
+    // URI stat collection — entry-point spans carrying http.route only
+    // =======================================================================
+
+    private static OtlpUriStatSpan uriStatSpanOf(OtlpTraceMapperData data, String uri) {
+        return data.getUriStatSpanList().stream()
+                .filter(s -> s.getUri().equals(uri))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Test
+    void uriStat_rootWithRoute_collectedWithSpanFields() {
+        Span okRoot = serverRoot(ROOT_A, "/api/orders", false);
+        Span errorRoot = withError(serverRoot(ROOT_B, "/api/items", false));
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(okRoot, errorRoot));
+
+        assertThat(data.getUriStatSpanList()).hasSize(2);
+        OtlpUriStatSpan ok = uriStatSpanOf(data, "/api/orders");
+        assertThat(ok).isNotNull();
+        assertThat(ok.getApplicationName()).isEqualTo("app-1");
+        assertThat(ok.getAgentId()).isEqualTo("agent-1");
+        // serverRoot: start 1_000_000_000ns = 1000ms, end 3_000_000_000ns → elapsed 2000ms
+        assertThat(ok.getStartTime()).isEqualTo(1000L);
+        assertThat(ok.getElapsed()).isEqualTo(2000);
+        assertThat(ok.isError()).isFalse();
+        // status ERROR → SpanBo errCode != 0 → feeds the failure histogram
+        OtlpUriStatSpan error = uriStatSpanOf(data, "/api/items");
+        assertThat(error).isNotNull();
+        assertThat(error.isError()).isTrue();
+    }
+
+    @Test
+    void uriStat_rootWithoutRoute_notCollected() {
+        // Unrouted SERVER root: the trace itself is stored, but no uriStat record is derived —
+        // there is no raw-path fallback (low-cardinality contract).
+        Span bareRoot = serverRoot(ROOT_A, "/api/orders", false).toBuilder()
+                .clearAttributes()
+                .build();
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(bareRoot));
+
+        assertThat(data.getSpanBoList()).hasSize(1);
+        assertThat(data.getUriStatSpanList()).isEmpty();
+    }
+
+    @Test
+    void uriStat_childSpanWithRoute_notCollected() {
+        // Only entry-point (root) spans feed URI stat. An INTERNAL child carrying http.route is
+        // kind-eligible for the template, but as a child it lands in the root's span events and
+        // must not add a second uriStat record.
+        Span root = serverRoot(ROOT_A, "/root", false);
+        Span internalChild = clientChild(CHILD, ROOT_A, false).toBuilder()
+                .setKindValue(Span.SpanKind.SPAN_KIND_INTERNAL_VALUE)
+                .addAttributes(kv("http.route", strVal("/child")))
+                .build();
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(root, internalChild));
+
+        assertThat(data.getSpanBoList()).hasSize(1);
+        assertThat(data.getUriStatSpanList())
+                .extracting(OtlpUriStatSpan::getUri)
+                .containsExactly("/root");
+    }
 }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -10,6 +10,7 @@ import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.ServiceTypeFactory;
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.loader.service.ServiceTypeRegistryService;
 import com.navercorp.pinpoint.otlp.trace.collector.mapper.message.ActiveMQMessagingConsumerHandler;
 import com.navercorp.pinpoint.otlp.trace.collector.mapper.message.KafkaMessagingConsumerHandler;
@@ -1194,6 +1195,60 @@ class OtlpTraceSpanMapperTest {
         assertThat(findAnnotation(bo, AnnotationKey.HTTP_METHOD.getCode())).isEqualTo("POST");
         assertThat(attributeKeys(bo)).doesNotContain("http.request.method");
         assertThat(attributeKeys(bo)).contains("http.method");
+    }
+
+    // =======================================================================
+    // getUriTemplate — URI stat template (http.route only, low-cardinality)
+    // =======================================================================
+
+    private static Map<String, AttributeValue> attrs(Span span) {
+        return OtlpTraceMapperUtils.getAttributeValueMap(span.getAttributesList());
+    }
+
+    @Test
+    void uriTemplate_httpRouteOnServerSpan() {
+        Span span = serverSpan(
+                kv("http.route", strVal("/api/users/{id}")),
+                kv("url.path", strVal("/api/users/123")));
+        assertThat(newMapper().getUriTemplate(span, attrs(span))).isEqualTo("/api/users/{id}");
+    }
+
+    @Test
+    void uriTemplate_nullForRawPathOnly() {
+        // Unrouted HTTP (only url.path, no http.route) → null, NOT the raw path: path variables
+        // would explode the Pinot uriStat cardinality, mirroring the native agent feeding URI stat
+        // solely from recordUriTemplate.
+        Span span = serverSpan(kv("url.path", strVal("/api/users/123")));
+        assertThat(newMapper().getUriTemplate(span, attrs(span))).isNull();
+    }
+
+    @Test
+    void uriTemplate_nullForClientSpan() {
+        // URI stat is an entry-point (server-side) statistic; client spans never contribute.
+        Span span = serverSpan(kv("http.route", strVal("/api/users/{id}"))).toBuilder()
+                .setKindValue(Span.SpanKind.SPAN_KIND_CLIENT_VALUE)
+                .build();
+        assertThat(newMapper().getUriTemplate(span, attrs(span))).isNull();
+    }
+
+    @Test
+    void uriTemplate_httpRouteOnInternalSpan() {
+        // Some instrumentations expose the routed entry as an INTERNAL span carrying http.route
+        // (e.g. Next.js route resolution) — the kind gate accepts SERVER and INTERNAL alike.
+        Span span = serverSpan(kv("http.route", strVal("/api/users/[id]"))).toBuilder()
+                .setKindValue(Span.SpanKind.SPAN_KIND_INTERNAL_VALUE)
+                .build();
+        assertThat(newMapper().getUriTemplate(span, attrs(span))).isEqualTo("/api/users/[id]");
+    }
+
+    @Test
+    void uriTemplate_nullForBlankRoute() {
+        // Real-world SDKs emit http.route as an empty string when no route matched — a blank
+        // template must not become a uriStat key.
+        Span span = serverSpan(
+                kv("http.route", strVal("")),
+                kv("url.path", strVal("/api/users/123")));
+        assertThat(newMapper().getUriTemplate(span, attrs(span))).isNull();
     }
 
     // =======================================================================

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportServiceTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportServiceTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.navercorp.pinpoint.collector.service.TraceService;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapper;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperData;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpUriStatSpan;
+import com.navercorp.pinpoint.uristat.collector.dao.UriStatDao;
+import com.navercorp.pinpoint.uristat.collector.model.UriStat;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The uriStat hook is an optional statistics side channel: it must receive the mapper's
+ * collected spans when enabled, do nothing when the bean is absent (flags off), and — the
+ * contract stated on the hook itself — a uriStat insert failure must never fail the trace
+ * export (it is counted and logged only).
+ */
+class OtlpTraceExportServiceTest {
+
+    private static final String INSERT_ERROR_METRIC = "collector.otlptrace.insert.error";
+
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    private static OtlpTraceMapperData dataWithUriStatSpan() {
+        OtlpTraceMapperData data = new OtlpTraceMapperData();
+        data.addUriStatSpan(new OtlpUriStatSpan("svc", "app", "agent", "/a", 1_000L, 100, false));
+        return data;
+    }
+
+    private OtlpTraceExportService newService(OtlpTraceMapperData mapperData, OtlpUriStatService uriStatService) {
+        OtlpTraceMapper mapper = mock(OtlpTraceMapper.class);
+        when(mapper.map(anyList())).thenReturn(mapperData);
+        return new OtlpTraceExportService(
+                new TraceService[0],
+                mock(HbaseOtlpAgentInfoService.class),
+                mock(HbaseOtlpApplicationIndexV2Service.class),
+                mapper,
+                Optional.empty(),
+                Optional.ofNullable(uriStatService),
+                Caffeine.newBuilder().maximumSize(16).build(),
+                meterRegistry);
+    }
+
+    private double uriStatErrorCount(MeterRegistry registry) {
+        return registry.get(INSERT_ERROR_METRIC).tag("op", "uriStat").counter().count();
+    }
+
+    @Test
+    void uriStatEnabled_receivesMapperCollectedSpans() {
+        List<UriStat> inserted = new ArrayList<>();
+        UriStatDao captureDao = inserted::addAll;
+        OtlpTraceExportService service = newService(dataWithUriStatSpan(),
+                new OtlpUriStatService(captureDao, () -> "tenant1"));
+
+        OtlpTraceExportResult result = service.export(List.of());
+
+        assertThat(result.serverErrorCount()).isZero();
+        assertThat(inserted).hasSize(1);
+        assertThat(inserted.get(0).getUri()).isEqualTo("/a");
+        assertThat(uriStatErrorCount(meterRegistry)).isZero();
+    }
+
+    @Test
+    void uriStatInsertFailure_doesNotFailExport_countsAndMovesOn() {
+        UriStatDao throwingDao = data -> {
+            throw new IllegalStateException("kafka down");
+        };
+        OtlpTraceExportService service = newService(dataWithUriStatSpan(),
+                new OtlpUriStatService(throwingDao, () -> "tenant1"));
+
+        OtlpTraceExportResult result = service.export(List.of());
+
+        // spans are already stored at this point: the export succeeds and the failure is
+        // NOT counted toward serverErrorCount — only the uriStat error counter moves.
+        assertThat(result.serverErrorCount()).isZero();
+        assertThat(result.serverMessage()).isEmpty();
+        assertThat(uriStatErrorCount(meterRegistry)).isEqualTo(1.0);
+    }
+
+    @Test
+    void uriStatDisabled_absentBean_exportsWithoutTouchingUriStat() {
+        OtlpTraceExportService service = newService(dataWithUriStatSpan(), null);
+
+        OtlpTraceExportResult result = service.export(List.of());
+
+        assertThat(result.serverErrorCount()).isZero();
+        assertThat(uriStatErrorCount(meterRegistry)).isZero();
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpUriStatServiceTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpUriStatServiceTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpUriStatSpan;
+import com.navercorp.pinpoint.uristat.collector.dao.UriStatDao;
+import com.navercorp.pinpoint.uristat.collector.model.UriStat;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpUriStatServiceTest {
+
+    private final List<UriStat> inserted = new ArrayList<>();
+    private final UriStatDao captureDao = inserted::addAll;
+    private final OtlpUriStatService service = new OtlpUriStatService(captureDao, () -> "tenant1");
+
+    private static OtlpUriStatSpan span(String uri, long startTime, int elapsed, boolean error) {
+        return new OtlpUriStatSpan("svc", "app", "agent", uri, startTime, elapsed, error);
+    }
+
+    @Test
+    void store_emptyInput_noInsert() {
+        service.store(List.of());
+        assertThat(inserted).isEmpty();
+    }
+
+    @Test
+    void store_sameUriSameWindow_aggregatesIntoSingleRecord() {
+        // Three requests to the same endpoint inside one 30s window: 50ms (bucket0), 150ms (bucket1),
+        // 150ms (bucket1). One aggregated record, not three.
+        service.store(List.of(
+                span("/users/{id}", 1_000, 50, false),
+                span("/users/{id}", 2_000, 150, false),
+                span("/users/{id}", 5_000, 150, true)));
+
+        assertThat(inserted).hasSize(1);
+        UriStat stat = inserted.get(0);
+        assertThat(stat.getUri()).isEqualTo("/users/{id}");
+        assertThat(stat.getCount()).isEqualTo(3);
+        assertThat(stat.getTimestamp()).isEqualTo(0); // 30s window floor
+        assertThat(stat.getTot0()).isEqualTo(1);
+        assertThat(stat.getTot1()).isEqualTo(2);
+        assertThat(stat.getMaxLatencyMs()).isEqualTo(150);
+        assertThat(stat.getTotalTimeMs()).isEqualTo(350);
+        // only the third request was an error → failure bucket1 = 1
+        assertThat(stat.getFailureCount()).isEqualTo(1);
+        assertThat(stat.getFail1()).isEqualTo(1);
+    }
+
+    @Test
+    void store_differentWindows_producesSeparateRecords() {
+        // Same uri, but startTimes fall into different 30s windows (0 and 30000).
+        service.store(List.of(
+                span("/a", 10_000, 100, false),
+                span("/a", 40_000, 100, false)));
+
+        assertThat(inserted).hasSize(2);
+        assertThat(inserted).extracting(UriStat::getTimestamp).containsExactlyInAnyOrder(0L, 30_000L);
+    }
+
+    @Test
+    void store_differentUris_producesSeparateRecords() {
+        service.store(List.of(
+                span("/a", 1_000, 100, false),
+                span("/b", 1_000, 100, false)));
+
+        assertThat(inserted).hasSize(2);
+        assertThat(inserted).extracting(UriStat::getUri).containsExactlyInAnyOrder("/a", "/b");
+    }
+
+    @Test
+    void store_windowBoundary_floorsToWindowStart() {
+        // 29,999ms still belongs to window 0; 30,000ms opens window 30,000 — exact floor semantics.
+        service.store(List.of(
+                span("/a", 29_999, 100, false),
+                span("/a", 30_000, 100, false)));
+
+        assertThat(inserted).hasSize(2);
+        assertThat(inserted).extracting(UriStat::getTimestamp).containsExactlyInAnyOrder(0L, 30_000L);
+    }
+
+    @Test
+    void store_setsTenantAndVersion() {
+        service.store(List.of(span("/a", 1_000, 9_000, false)));
+
+        UriStat stat = inserted.get(0);
+        assertThat(stat.getTenantId()).isEqualTo("tenant1");
+        assertThat(stat.getVersion()).isEqualTo(0);
+        assertThat(stat.getTot7()).isEqualTo(1); // 9000ms → OVER_8000 bucket
+    }
+}


### PR DESCRIPTION
Derive URI stat (per-endpoint response-time histograms) from OTLP traces and write it to the same Kafka/Pinot store the native agent uses.

- Only spans carrying an OTel http.route template contribute; the raw url.path is deliberately excluded to keep the stat low-cardinality, mirroring the native agent recording URI stat solely from its resolved URI template
- OtlpUriStatService aggregates entry-point spans by (serviceName, applicationName, agentId, uri, 30s window)
- Gated behind pinpoint.collector.otlptrace.uristat.enabled (default off) plus the uristat storage module flag; wired once in OtlpTraceExportService so both gRPC and HTTP transports are covered
- A uriStat insert failure is counted/logged but never fails the trace export