### PR TITLE
[#noissue] Split the spring webmvc ITs by version and add a spring 7 IT

### DIFF
--- a/agent-module/plugins-it/spring-it/spring-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebMvc_5_1_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebMvc_5_1_IT.java
@@ -42,25 +42,24 @@ import java.lang.reflect.Method;
 @PluginTest
 @PinpointAgent(AgentPath.PATH)
 @JvmVersion(8)
-@Dependency({"org.springframework:spring-webmvc:[5.0.0.RELEASE,5.max]", "org.springframework:spring-test", "javax.servlet:javax.servlet-api:4.0.1"})
+@Dependency({"org.springframework:spring-webmvc:[5.0.0.RELEASE,5.1.20.RELEASE]", "org.springframework:spring-test", "javax.servlet:javax.servlet-api:4.0.1"})
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-plugin"})
-public class SpringWebMvc_5_x_IT {
+public class SpringWebMvc_5_1_IT {
     private static final String SPRING_MVC = "SPRING_MVC";
 
     @Test
     public void testRequest() throws Exception {
         MockServletConfig config = new MockServletConfig();
+        config.addInitParameter("contextConfigLocation", "classpath:spring-web-test.xml");
+
+        DispatcherServlet servlet = new DispatcherServlet();
+        servlet.init(config);
+
         MockHttpServletRequest req = new MockHttpServletRequest();
         MockHttpServletResponse res = new MockHttpServletResponse();
-
-        config.addInitParameter("contextConfigLocation", "classpath:spring-web-test.xml");
         req.setMethod("GET");
         req.setRequestURI("/");
         req.setRemoteAddr("1.2.3.4");
-        
-        DispatcherServlet servlet = new DispatcherServlet();
-        servlet.init(config);
-        
         servlet.service(req, res);
         
         Method method = FrameworkServlet.class.getDeclaredMethod("doGet", HttpServletRequest.class, HttpServletResponse.class);

--- a/agent-module/plugins-it/spring-it/spring-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebMvc_5_2_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebMvc_5_2_IT.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Test;
+
+
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@JvmVersion(8)
+@Dependency({"org.springframework:spring-webmvc:[5.2.0.RELEASE,5.2.25.RELEASE]", "org.springframework:spring-test", "javax.servlet:javax.servlet-api:4.0.1"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-plugin"})
+public class SpringWebMvc_5_2_IT extends SpringWebMvc_5_1_IT {
+
+    @Test
+    public void testRequest() throws Exception {
+        super.testRequest();
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebMvc_5_3_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebMvc_5_3_IT.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Test;
+
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@JvmVersion(8)
+@Dependency({"org.springframework:spring-webmvc:[5.3.0,5.3.39]", "org.springframework:spring-test", "javax.servlet:javax.servlet-api:4.0.1"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-plugin"})
+public class SpringWebMvc_5_3_IT extends SpringWebMvc_5_1_IT {
+
+    @Test
+    public void testRequest() throws Exception {
+        super.testRequest();
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-6-it/pom.xml
+++ b/agent-module/plugins-it/spring-it/spring-6-it/pom.xml
@@ -29,10 +29,10 @@
     <packaging>jar</packaging>
 
     <properties>
-        <jdk.version>1.8</jdk.version>
-        <jdk.home>${env.JAVA_8_HOME}</jdk.home>
-        <spring.version>${spring5.version}</spring.version>
-        <jakarta.servlet.version>${jakarta.servlet5.version}</jakarta.servlet.version>
+        <jdk.version>17</jdk.version>
+        <jdk.home>${env.JAVA_17_HOME}</jdk.home>
+        <spring.version>${spring6.version}</spring.version>
+        <jakarta.servlet.version>${jakarta.servlet6.version}</jakarta.servlet.version>
     </properties>
 
     <dependencies>

--- a/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/async/SpringWebMvc_7_x_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/async/SpringWebMvc_7_x_IT.java
@@ -1,4 +1,4 @@
-package com.navercorp.pinpoint.it.plugin.spring.web;
+package com.navercorp.pinpoint.it.plugin.spring.async;
 
 import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
 import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
@@ -11,39 +11,47 @@ import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.FrameworkServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import java.lang.reflect.Method;
 
 @PluginForkedTest
 @PinpointAgent(AgentPath.PATH)
 @JvmVersion(17)
-@Dependency({"org.springframework:spring-webmvc:[6.0.0,6.max]", "org.springframework:spring-test", "jakarta.servlet:jakarta.servlet-api:6.0.0"})
+@Dependency({"org.springframework:spring-webmvc:[7.0.0,7.max]", "org.springframework:spring-test", "jakarta.servlet:jakarta.servlet-api:6.0.0"})
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-plugin"})
-@Disabled
-public class SpringWebMvc_6_x_IT {
+//@Disabled
+public class SpringWebMvc_7_x_IT {
     private static final String SPRING_MVC = "SPRING_MVC";
+
+    // the equivalent of the old spring-web-test.xml (<mvc:annotation-driven/>)
+    @Configuration
+    @EnableWebMvc
+    static class WebConfig {
+    }
 
     @Test
     public void testRequest() throws Exception {
-        MockServletConfig config = new MockServletConfig();
-        config.addInitParameter("contextConfigLocation", "classpath:spring-web-test.xml");
+        AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
+        context.register(WebConfig.class);
 
-        DispatcherServlet servlet = new DispatcherServlet();
-        servlet.init(config);
+        DispatcherServlet servlet = new DispatcherServlet(context);
+        servlet.init(new MockServletConfig());
 
         MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
         req.setMethod("GET");
         req.setRequestURI("/");
         req.setRemoteAddr("1.2.3.4");
-        MockHttpServletResponse res = new MockHttpServletResponse();
-
         servlet.service(req, res);
 
         Method method = FrameworkServlet.class.getDeclaredMethod("doGet", HttpServletRequest.class, HttpServletResponse.class);


### PR DESCRIPTION
- Initialize the spring 7 DispatcherServlet IT with java config
- Split the spring 5 webmvc IT into 5.1 / 5.2 / 5.3 and clean up the split ITs
- Target JDK 17 and spring 6 in the spring-6-it build
