### PR TITLE
[#14235] Parse multi-language OTLP exception stacktraces

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapper.java
@@ -24,6 +24,10 @@ import com.navercorp.pinpoint.common.server.util.Utf8;
 import com.navercorp.pinpoint.common.trace.ServiceType;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.common.util.StringUtils;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace.StackFrame;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace.StackFrameSink;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace.StackTraceParser;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace.StackTraceParserRegistry;
 import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -46,6 +50,11 @@ public class OtlpExceptionMapper {
     private static final String EMPTY = "";
 
     private static final String TRUNCATED_METRIC = "collector.otlptrace.exception.truncated";
+    // Which language parser handled each stacktrace — watch the raw-fallback share to decide
+    // which language parser to add next.
+    private static final String PARSED_METRIC = "collector.otlptrace.exception.parsed";
+
+    private static final StackTraceParserRegistry PARSER_REGISTRY = new StackTraceParserRegistry();
 
     // Byte-based caps for the client-supplied exception fields (unlike the native path, these arrive
     // as free-form strings from a third-party exporter). Mirrors the module's attribute/SQL/event/link
@@ -62,9 +71,14 @@ public class OtlpExceptionMapper {
     private final Counter messageTruncatedCounter;
     private final Counter stackTraceDepthTruncatedCounter;
     private final Counter frameValueTruncatedCounter;
+    private final MeterRegistry meterRegistry;
 
     public OtlpExceptionMapper(
-            @Value("${pinpoint.collector.otlptrace.exception.message-max-bytes:8192}") int messageMaxBytes,
+            // Default aligned with the native agent's errormessage cap (profiler.exceptiontrace
+            // .errormessage.max=2048) so both sources bound the Pinot errorMessage column alike.
+            // Unit stays bytes (the agent caps chars): stricter for multi-byte text, identical for
+            // the ASCII-dominant common case.
+            @Value("${pinpoint.collector.otlptrace.exception.message-max-bytes:2048}") int messageMaxBytes,
             @Value("${pinpoint.collector.otlptrace.exception.stacktrace.max-depth:256}") int stackTraceMaxDepth,
             @Value("${pinpoint.collector.otlptrace.exception.stacktrace.frame-max-bytes:2048}") int frameMaxBytes,
             MeterRegistry meterRegistry) {
@@ -83,6 +97,7 @@ public class OtlpExceptionMapper {
         this.messageTruncatedCounter = meterRegistry.counter(TRUNCATED_METRIC, "field", "message");
         this.stackTraceDepthTruncatedCounter = meterRegistry.counter(TRUNCATED_METRIC, "field", "stacktrace_depth");
         this.frameValueTruncatedCounter = meterRegistry.counter(TRUNCATED_METRIC, "field", "frame_value");
+        this.meterRegistry = meterRegistry;
     }
 
     /**
@@ -100,6 +115,15 @@ public class OtlpExceptionMapper {
      * exceptionId discriminator instead.
      */
     public Optional<ExceptionMetaDataBo> map(IdAndName idAndName, Span exceptionSpan, long rootSpanId, String uriTemplate) {
+        return map(idAndName, exceptionSpan, rootSpanId, uriTemplate, null);
+    }
+
+    /**
+     * @param sdkLanguage the {@code telemetry.sdk.language} resource attribute (java, nodejs,
+     *                    python, dotnet, go, ...) used to pick the stacktrace parser; {@code null}
+     *                    falls back to content sniffing
+     */
+    public Optional<ExceptionMetaDataBo> map(IdAndName idAndName, Span exceptionSpan, long rootSpanId, String uriTemplate, String sdkLanguage) {
         Span.Event exceptionEvent = ExceptionAttributeUtils.findExceptionEvent(exceptionSpan);
         if (exceptionEvent == null) {
             return Optional.empty();
@@ -123,7 +147,7 @@ public class OtlpExceptionMapper {
         // span id, use the exception-bearing span's id as the exceptionId so multiple exceptions
         // in one transaction stay distinct under (transactionId, rootSpanId, exceptionId).
         final long exceptionSpanId = OtlpTraceMapperUtils.getSpanId(exceptionSpan.getSpanId());
-        final List<StackTraceElementWrapperBo> stackTrace = parseStackTrace(stackTraceStr);
+        final List<StackTraceElementWrapperBo> stackTrace = parseStackTrace(stackTraceStr, sdkLanguage);
 
         ExceptionWrapperBo wrapper = new ExceptionWrapperBo(
                 exceptionType,
@@ -148,68 +172,41 @@ public class OtlpExceptionMapper {
         return Optional.of(bo);
     }
 
-    List<StackTraceElementWrapperBo> parseStackTrace(String stackTrace) {
-        List<StackTraceElementWrapperBo> result = new ArrayList<>();
+    /**
+     * Parses the flattened stacktrace with the language parser selected by
+     * {@code telemetry.sdk.language} (or content sniffing when absent). A parser that yields zero
+     * frames — a format it does not actually understand, e.g. a Ruby stack under an unmapped
+     * language value — falls back to raw-line frames so the detail view keeps the original text
+     * and the stack-trace grouping hash stays distinctive instead of collapsing every unparsed
+     * exception into one shared "empty stack" group.
+     */
+    List<StackTraceElementWrapperBo> parseStackTrace(String stackTrace, String sdkLanguage) {
         if (!StringUtils.hasLength(stackTrace)) {
-            return result;
+            return new ArrayList<>();
         }
 
-        for (String line : stackTrace.split("\n")) {
-            // Cap the number of frames: the flattened stacktrace is client-supplied, so its frame
-            // count is unbounded (up to the request-size limit) without this guard.
-            if (stackTraceMaxDepth > 0 && result.size() >= stackTraceMaxDepth) {
-                stackTraceDepthTruncatedCounter.increment();
-                break;
-            }
+        StackTraceParser parser = PARSER_REGISTRY.select(sdkLanguage, stackTrace);
+        StackFrameSink sink = new StackFrameSink(stackTraceMaxDepth);
+        parser.parse(stackTrace, sink);
 
-            final String trimmed = line.trim();
-            if (!trimmed.startsWith("at ")) {
-                continue;
-            }
+        if (sink.frames().isEmpty() && parser != PARSER_REGISTRY.rawFallback()) {
+            parser = PARSER_REGISTRY.rawFallback();
+            sink = new StackFrameSink(stackTraceMaxDepth);
+            parser.parse(stackTrace, sink);
+        }
 
-            final String element = trimmed.substring(3);
-            final int parenOpen = element.lastIndexOf('(');
-            final int parenClose = element.lastIndexOf(')');
-            if (parenOpen < 0 || parenClose <= parenOpen) {
-                continue;
-            }
+        if (sink.isTruncated()) {
+            stackTraceDepthTruncatedCounter.increment();
+        }
+        meterRegistry.counter(PARSED_METRIC, "parser", parser.name()).increment();
 
-            final String methodSignature = element.substring(0, parenOpen);
-            final String fileInfo = element.substring(parenOpen + 1, parenClose);
-
-            final int lastDot = methodSignature.lastIndexOf('.');
-            if (lastDot < 0) {
-                continue;
-            }
-
-            final String className = methodSignature.substring(0, lastDot);
-            final String methodName = methodSignature.substring(lastDot + 1);
-            if (!StringUtils.hasLength(className) || !StringUtils.hasLength(methodName)) {
-                continue;
-            }
-
-            final String fileName;
-            final int lineNumber;
-            final int colonIdx = fileInfo.lastIndexOf(':');
-            if (colonIdx >= 0) {
-                fileName = fileInfo.substring(0, colonIdx);
-                int parsed;
-                try {
-                    parsed = Integer.parseInt(fileInfo.substring(colonIdx + 1));
-                } catch (NumberFormatException e) {
-                    parsed = 0;
-                }
-                lineNumber = parsed;
-            } else {
-                fileName = fileInfo;
-                lineNumber = "Native Method".equals(fileInfo) ? -2 : -1;
-            }
-
+        final List<StackTraceElementWrapperBo> result = new ArrayList<>(sink.frames().size());
+        for (StackFrame frame : sink.frames()) {
             result.add(new StackTraceElementWrapperBo(
-                    cap(className, frameMaxBytes, frameValueTruncatedCounter),
-                    cap(fileName, frameMaxBytes, frameValueTruncatedCounter),
-                    lineNumber,
-                    cap(methodName, frameMaxBytes, frameValueTruncatedCounter)));
+                    cap(frame.className(), frameMaxBytes, frameValueTruncatedCounter),
+                    cap(frame.fileName(), frameMaxBytes, frameValueTruncatedCounter),
+                    frame.lineNumber(),
+                    cap(frame.methodName(), frameMaxBytes, frameValueTruncatedCounter)));
         }
         return result;
     }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -248,6 +248,7 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_PROCESS_CREATION_TIME = "process.creation.time";
     public static final String ATTRIBUTE_KEY_PROCESS_RUNTIME_DESCRIPTION = "process.runtime.description";
     public static final String ATTRIBUTE_KEY_TELEMETRY_SDK_VERSION = "telemetry.sdk.version";
+    public static final String ATTRIBUTE_KEY_TELEMETRY_SDK_LANGUAGE = "telemetry.sdk.language";
 
     // Raw-attribute filtering follows one rule: "filter only what was promoted, on the path
     // that promoted it, only when it actually was promoted". Most keys are therefore excluded

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
@@ -25,6 +25,7 @@ import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import io.opentelemetry.proto.common.v1.InstrumentationScope;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.ScopeSpans;
@@ -98,6 +99,9 @@ public class OtlpTraceMapper {
             // Stateless, per-ResourceSpans: UNSET(-1) when process.creation.time is absent/unusable,
             // in which case the span mapper keeps the span-start-time approximation.
             final long agentStartTime = agentStartTimeResolver.resolve(resourceAttributeMap);
+            // Selects the exception stacktrace parser; null falls back to content sniffing.
+            final String sdkLanguage = AttributeUtils.getAttributeStringValue(
+                    resourceAttributeMap, OtlpTraceConstants.ATTRIBUTE_KEY_TELEMETRY_SDK_LANGUAGE, null);
 
             final List<ScopeSpans> scopeSpanList = resourceSpan.getScopeSpansList();
             final Map<ByteString, List<ScopedSpan>> spanMap = getSpanMap(scopeSpanList, mapperData.getRejectedSpan());
@@ -122,14 +126,14 @@ public class OtlpTraceMapper {
                         final SpanBo spanBo = spanMapper.map(idAndName, rootSpan, rootScopedSpan.scope(), agentStartTime);
 
                         // root span's own exception
-                        recordException(mapperData, idAndName, rootSpan, rootSpanId, rootUriTemplate);
+                        recordException(mapperData, idAndName, rootSpan, rootSpanId, rootUriTemplate, sdkLanguage);
 
                         // Exceptions on linked child spans are recorded as findLinkSpan traverses the
                         // original OTel spans (where the full stacktrace is still available). Orphan
                         // spans not linked to any root are intentionally skipped: without a root there
                         // is no transaction spanId to link the exception to.
                         final List<SpanEventBo> spanEventList = findLinkSpan(spanBo.getStartTimeNanos(), childSpanList, rootSpan.getSpanId(), 1,
-                                childSpan -> recordException(mapperData, idAndName, childSpan, rootSpanId, rootUriTemplate));
+                                childSpan -> recordException(mapperData, idAndName, childSpan, rootSpanId, rootUriTemplate, sdkLanguage));
                         spanBo.addSpanEventBoList(spanEventList);
                         mapperData.addSpanBo(spanBo);
                         final AgentInfoBo agentInfoBo = agentInfoMapper.map(spanBo, resourceAttributeMap);
@@ -192,9 +196,9 @@ public class OtlpTraceMapper {
      * (transaction) span id and URI. Failures are isolated here so a malformed exception payload
      * never aborts span/trace mapping.
      */
-    private void recordException(OtlpTraceMapperData mapperData, IdAndName idAndName, Span span, long rootSpanId, String uriTemplate) {
+    private void recordException(OtlpTraceMapperData mapperData, IdAndName idAndName, Span span, long rootSpanId, String uriTemplate, String sdkLanguage) {
         try {
-            exceptionMapper.map(idAndName, span, rootSpanId, uriTemplate)
+            exceptionMapper.map(idAndName, span, rootSpanId, uriTemplate, sdkLanguage)
                     .ifPresent(mapperData::addExceptionMetaDataBo);
         } catch (Exception e) {
             logMappingError("Failed to map exception", e);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/DotNetStackTraceParser.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/DotNetStackTraceParser.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * .NET {@code Exception.ToString()} format:
+ * <pre>{@code
+ * at Cart.Services.CartService.GetCart(GetCartRequest request) in /app/services/CartService.cs:line 42
+ * at lambda_method1(Closure, Object)
+ * --- End of stack trace from previous location ---
+ * }</pre>
+ * Parens hold the parameter list (NOT file info — the JVM parser would misread it as a file
+ * name); the optional {@code in file:line N} suffix carries the source location.
+ */
+public class DotNetStackTraceParser implements StackTraceParser {
+
+    private static final Pattern FRAME = Pattern.compile("^at\\s+(.+?)\\((.*?)\\)(?:\\s+in\\s+(.+):line\\s+(\\d+))?$");
+    private static final Pattern IN_LINE_MARKER = Pattern.compile("\\sin\\s.+:line\\s+\\d+");
+
+    private static final String UNKNOWN = "<unknown>";
+
+    @Override
+    public String name() {
+        return "dotnet";
+    }
+
+    @Override
+    public boolean matches(String stackTrace) {
+        // The " in file:line N" suffix is the unambiguous .NET marker; frames without any source
+        // info are left to the language attribute (they are shaped too much like JVM frames).
+        return IN_LINE_MARKER.matcher(stackTrace).find();
+    }
+
+    @Override
+    public void parse(String stackTrace, StackFrameSink sink) {
+        for (String line : stackTrace.split("\n")) {
+            final String trimmed = line.trim();
+            if (!trimmed.startsWith("at ")) {
+                continue;
+            }
+            final Matcher matcher = FRAME.matcher(trimmed);
+            if (!matcher.matches()) {
+                continue;
+            }
+
+            final String signature = matcher.group(1).trim();
+            if (!StringUtils.hasLength(signature)) {
+                continue;
+            }
+            final String className;
+            final String methodName;
+            final int lastDot = signature.lastIndexOf('.');
+            if (lastDot > 0 && lastDot < signature.length() - 1) {
+                className = signature.substring(0, lastDot);
+                methodName = signature.substring(lastDot + 1);
+            } else {
+                className = UNKNOWN;
+                methodName = signature;
+            }
+
+            final String fileName = matcher.group(3) != null ? matcher.group(3) : "";
+            final int lineNumber = matcher.group(4) != null ? parseInt(matcher.group(4)) : -1;
+
+            if (!sink.add(new StackFrame(className, fileName, lineNumber, methodName))) {
+                return;
+            }
+        }
+    }
+
+    private static int parseInt(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/GoStackTraceParser.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/GoStackTraceParser.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Go {@code runtime/debug.Stack()} format — two-line pairs:
+ * <pre>{@code
+ * goroutine 1 [running]:
+ * github.com/acme/pkg.(*Service).Handle(0xc000010000)
+ *         /app/service.go:42 +0x5e
+ * main.main()
+ *         /app/main.go:10 +0x20
+ * }</pre>
+ * The trailing {@code +0x...} program-counter offset is dropped: it varies per build, and keeping
+ * it would destabilize the stack-trace grouping hash across deployments.
+ */
+public class GoStackTraceParser implements StackTraceParser {
+
+    private static final Pattern GOROUTINE_HEADER = Pattern.compile("^goroutine\\s+\\d+\\s+\\[.*\\]:$");
+    private static final Pattern FILE_LINE = Pattern.compile("^(.+\\.go):(\\d+)(?:\\s+\\+0x[0-9a-fA-F]+)?$");
+    private static final String CREATED_BY = "created by ";
+
+    @Override
+    public String name() {
+        return "go";
+    }
+
+    @Override
+    public boolean matches(String stackTrace) {
+        for (String line : stackTrace.split("\n")) {
+            final String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (GOROUTINE_HEADER.matcher(trimmed).matches() || FILE_LINE.matcher(trimmed).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void parse(String stackTrace, StackFrameSink sink) {
+        final String[] lines = stackTrace.split("\n");
+        for (int i = 0; i < lines.length - 1; i++) {
+            final String funcLine = lines[i].trim();
+            if (funcLine.isEmpty() || GOROUTINE_HEADER.matcher(funcLine).matches()) {
+                continue;
+            }
+            final Matcher fileLine = FILE_LINE.matcher(lines[i + 1].trim());
+            if (!fileLine.matches()) {
+                continue;
+            }
+
+            final StackFrame frame = frame(funcLine, fileLine.group(1), parseInt(fileLine.group(2)));
+            if (frame != null && !sink.add(frame)) {
+                return;
+            }
+            i++; // consume the file line of this pair
+        }
+    }
+
+    private static StackFrame frame(String funcLine, String fileName, int lineNumber) {
+        String signature = funcLine;
+        if (signature.startsWith(CREATED_BY)) {
+            signature = signature.substring(CREATED_BY.length());
+        }
+        // Drop the argument list: "pkg.(*T).Method(0xc000010000)" → "pkg.(*T).Method".
+        final int argsParen = signature.lastIndexOf('(');
+        if (argsParen > 0 && signature.endsWith(")")) {
+            // Receiver parens like "(*T)" sit before the last dot; the args paren is after it.
+            final int lastDot = signature.lastIndexOf('.');
+            if (argsParen > lastDot) {
+                signature = signature.substring(0, argsParen);
+            }
+        }
+
+        final int lastDot = signature.lastIndexOf('.');
+        if (lastDot <= 0 || lastDot >= signature.length() - 1) {
+            return null;
+        }
+        final String className = signature.substring(0, lastDot);
+        final String methodName = signature.substring(lastDot + 1);
+        if (!StringUtils.hasLength(className) || !StringUtils.hasLength(methodName)) {
+            return null;
+        }
+        return new StackFrame(className, fileName, lineNumber, methodName);
+    }
+
+    private static int parseInt(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/JavaStackTraceParser.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/JavaStackTraceParser.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+/**
+ * Java/JVM {@code Throwable.printStackTrace} format:
+ * <pre>{@code at com.example.Service.handle(Service.java:42)}</pre>
+ * with {@code (Native Method)} → line -2 and {@code (Unknown Source)} → line -1.
+ *
+ * <p>"Caused by:" sections are NOT split into separate exceptions yet — their frames merge into
+ * one flat list (the pre-existing semantics). Chain decomposition is a planned follow-up; this
+ * parser is where the "Caused by:" boundary would be detected.
+ */
+public class JavaStackTraceParser implements StackTraceParser {
+
+    @Override
+    public String name() {
+        return "java";
+    }
+
+    @Override
+    public boolean matches(String stackTrace) {
+        for (String line : stackTrace.split("\n")) {
+            final String trimmed = line.trim();
+            if (!trimmed.startsWith("at ")) {
+                continue;
+            }
+            // A JVM frame's parens hold file info, never "file:line:col" (that tail is V8/Node).
+            final String element = trimmed.substring(3);
+            final int parenOpen = element.lastIndexOf('(');
+            final int parenClose = element.lastIndexOf(')');
+            if (parenOpen < 0 || parenClose <= parenOpen) {
+                return false;
+            }
+            final String fileInfo = element.substring(parenOpen + 1, parenClose);
+            if (fileInfo.matches(".*:\\d+:\\d+$")) {
+                return false;
+            }
+            return element.substring(0, parenOpen).lastIndexOf('.') > 0;
+        }
+        return false;
+    }
+
+    @Override
+    public void parse(String stackTrace, StackFrameSink sink) {
+        for (String line : stackTrace.split("\n")) {
+            final String trimmed = line.trim();
+            if (!trimmed.startsWith("at ")) {
+                continue;
+            }
+
+            final String element = trimmed.substring(3);
+            final int parenOpen = element.lastIndexOf('(');
+            final int parenClose = element.lastIndexOf(')');
+            if (parenOpen < 0 || parenClose <= parenOpen) {
+                continue;
+            }
+
+            final String methodSignature = element.substring(0, parenOpen);
+            final String fileInfo = element.substring(parenOpen + 1, parenClose);
+
+            final int lastDot = methodSignature.lastIndexOf('.');
+            if (lastDot < 0) {
+                continue;
+            }
+
+            final String className = methodSignature.substring(0, lastDot);
+            final String methodName = methodSignature.substring(lastDot + 1);
+            if (!StringUtils.hasLength(className) || !StringUtils.hasLength(methodName)) {
+                continue;
+            }
+
+            final String fileName;
+            final int lineNumber;
+            final int colonIdx = fileInfo.lastIndexOf(':');
+            if (colonIdx >= 0) {
+                fileName = fileInfo.substring(0, colonIdx);
+                int parsed;
+                try {
+                    parsed = Integer.parseInt(fileInfo.substring(colonIdx + 1));
+                } catch (NumberFormatException e) {
+                    // malformed line token (e.g. "Foo.java:??") -> unknown, per the StackFrame contract
+                    parsed = -1;
+                }
+                lineNumber = parsed;
+            } else {
+                fileName = fileInfo;
+                lineNumber = "Native Method".equals(fileInfo) ? -2 : -1;
+            }
+
+            if (!sink.add(new StackFrame(className, fileName, lineNumber, methodName))) {
+                return;
+            }
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/NodeStackTraceParser.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/NodeStackTraceParser.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * V8 (Node.js / Chromium) {@code error.stack} format:
+ * <pre>{@code
+ * at handler (/app/routes/user.js:10:15)          — named frame
+ * at async UserService.load (/app/svc.js:22:9)    — async frame
+ * at Layer.handle [as handle_request] (...)       — aliased frame
+ * at /app/index.js:3:1                            — anonymous frame
+ * at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+ * }</pre>
+ * The location tail is {@code file:line:column}; the column is dropped (Pinpoint frames carry a
+ * line number only). Parens without a {@code :line:col} tail (e.g. {@code (native)}) keep the
+ * content as the file name with line -1.
+ */
+public class NodeStackTraceParser implements StackTraceParser {
+
+    private static final Pattern LOCATION = Pattern.compile("^(.+):(\\d+):(\\d+)$");
+    private static final Pattern PARENS_FRAME = Pattern.compile("^at\\s+(?:async\\s+)?(.+?)\\s+\\((.+)\\)$");
+    private static final Pattern BARE_FRAME = Pattern.compile("^at\\s+(?:async\\s+)?([^()].*?):(\\d+):(\\d+)$");
+
+    private static final String ANONYMOUS = "<anonymous>";
+
+    @Override
+    public String name() {
+        return "node";
+    }
+
+    @Override
+    public boolean matches(String stackTrace) {
+        for (String line : stackTrace.split("\n")) {
+            final String trimmed = line.trim();
+            if (!trimmed.startsWith("at ")) {
+                continue;
+            }
+            if (BARE_FRAME.matcher(trimmed).matches()) {
+                return true;
+            }
+            final Matcher parens = PARENS_FRAME.matcher(trimmed);
+            if (parens.matches() && LOCATION.matcher(parens.group(2)).matches()) {
+                return true;
+            }
+            // e.g. "at Array.map (<anonymous>)" — a built-in frame without a location tail;
+            // keep scanning, a later frame decides.
+        }
+        return false;
+    }
+
+    @Override
+    public void parse(String stackTrace, StackFrameSink sink) {
+        for (String line : stackTrace.split("\n")) {
+            final String trimmed = line.trim();
+            if (!trimmed.startsWith("at ")) {
+                continue;
+            }
+
+            final StackFrame frame = parseLine(trimmed);
+            if (frame != null && !sink.add(frame)) {
+                return;
+            }
+        }
+    }
+
+    private StackFrame parseLine(String trimmed) {
+        final Matcher parens = PARENS_FRAME.matcher(trimmed);
+        if (parens.matches()) {
+            final String function = stripAlias(parens.group(1));
+            final String inner = parens.group(2);
+            final Matcher location = LOCATION.matcher(inner);
+            if (location.matches()) {
+                return frame(function, location.group(1), parseInt(location.group(2)));
+            }
+            // e.g. "(native)", "(node:internal/timers)" — no line info
+            return frame(function, inner, -1);
+        }
+
+        final Matcher bare = BARE_FRAME.matcher(trimmed);
+        if (bare.matches()) {
+            return frame(null, bare.group(1), parseInt(bare.group(2)));
+        }
+        return null;
+    }
+
+    /** Drops the "[as alias]" decoration V8 appends to re-bound methods. */
+    private static String stripAlias(String function) {
+        final int alias = function.indexOf(" [as ");
+        return alias > 0 ? function.substring(0, alias) : function;
+    }
+
+    private static StackFrame frame(String function, String fileName, int lineNumber) {
+        final String className;
+        final String methodName;
+        if (!StringUtils.hasLength(function)) {
+            className = ANONYMOUS;
+            methodName = ANONYMOUS;
+        } else {
+            final int lastDot = function.lastIndexOf('.');
+            if (lastDot > 0 && lastDot < function.length() - 1) {
+                className = function.substring(0, lastDot);
+                methodName = function.substring(lastDot + 1);
+            } else {
+                className = ANONYMOUS;
+                methodName = function;
+            }
+        }
+        return new StackFrame(className, fileName, lineNumber, methodName);
+    }
+
+    private static int parseInt(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/PythonStackTraceParser.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/PythonStackTraceParser.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+import com.navercorp.pinpoint.common.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * CPython {@code traceback.format_exception} format:
+ * <pre>{@code
+ * Traceback (most recent call last):
+ *   File "/app/main.py", line 10, in handler
+ *     do_work()
+ *   File "/app/svc.py", line 3, in do_work
+ * ValueError: boom
+ * }</pre>
+ * Frame mapping: methodName = the {@code in} function ({@code <module>} when absent), fileName =
+ * the quoted path, className = the file's module name (basename without {@code .py}).
+ *
+ * <p>Python prints frames outermost-first ("most recent call last") — the reverse of the JVM
+ * convention every other consumer of these frames assumes. Frames are reversed to
+ * innermost-first so the detail view reads top-down to the throw site and the stack-trace hash
+ * groups consistently across languages. (When the frame cap truncates, the innermost frames are
+ * the ones kept.) Chained-exception separators ("The above exception was the direct cause ...")
+ * are not split yet — chain decomposition is the planned follow-up.
+ */
+public class PythonStackTraceParser implements StackTraceParser {
+
+    private static final Pattern FRAME = Pattern.compile("^File\\s+\"(.+)\",\\s+line\\s+(\\d+)(?:,\\s+in\\s+(.+))?$");
+    private static final String TRACEBACK_HEADER = "Traceback (most recent call last)";
+    private static final String MODULE = "<module>";
+
+    @Override
+    public String name() {
+        return "python";
+    }
+
+    @Override
+    public boolean matches(String stackTrace) {
+        if (stackTrace.contains(TRACEBACK_HEADER)) {
+            return true;
+        }
+        for (String line : stackTrace.split("\n")) {
+            if (FRAME.matcher(line.trim()).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void parse(String stackTrace, StackFrameSink sink) {
+        final List<StackFrame> outermostFirst = new ArrayList<>();
+        for (String line : stackTrace.split("\n")) {
+            final Matcher matcher = FRAME.matcher(line.trim());
+            if (!matcher.matches()) {
+                continue;
+            }
+
+            final String fileName = matcher.group(1);
+            final int lineNumber = parseInt(matcher.group(2));
+            final String function = matcher.group(3);
+            final String methodName = StringUtils.hasLength(function) ? function : MODULE;
+            outermostFirst.add(new StackFrame(moduleName(fileName), fileName, lineNumber, methodName));
+        }
+
+        for (int i = outermostFirst.size() - 1; i >= 0; i--) {
+            if (!sink.add(outermostFirst.get(i))) {
+                return;
+            }
+        }
+    }
+
+    /** {@code /app/pkg/main.py} → {@code main}; falls back to {@code <module>} when empty. */
+    private static String moduleName(String path) {
+        int cut = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+        String base = cut >= 0 ? path.substring(cut + 1) : path;
+        if (base.endsWith(".py")) {
+            base = base.substring(0, base.length() - 3);
+        }
+        return StringUtils.hasLength(base) ? base : MODULE;
+    }
+
+    private static int parseInt(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/RawStackTraceParser.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/RawStackTraceParser.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+import java.util.regex.Pattern;
+
+/**
+ * Last-resort parser for unrecognized formats (Ruby, PHP, Rust, custom SDKs, ...): each non-blank
+ * line becomes one frame with the raw line as the class name. This keeps two things working that
+ * an empty frame list would break: the Error Analysis detail view still shows the original text,
+ * and the stack-trace grouping hash stays distinctive instead of collapsing every unparsed
+ * exception into one shared "empty stack" group.
+ *
+ * <p>Hex addresses ({@code 0x...}) are scrubbed before hashing-relevant storage — they vary per
+ * process and would otherwise split one logical error into many groups.
+ */
+public class RawStackTraceParser implements StackTraceParser {
+
+    private static final Pattern HEX_ADDRESS = Pattern.compile("0x[0-9a-fA-F]+");
+
+    private static final String UNKNOWN_METHOD = "?";
+
+    @Override
+    public String name() {
+        return "raw-fallback";
+    }
+
+    @Override
+    public boolean matches(String stackTrace) {
+        return true;
+    }
+
+    @Override
+    public void parse(String stackTrace, StackFrameSink sink) {
+        for (String line : stackTrace.split("\n")) {
+            final String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            final String scrubbed = HEX_ADDRESS.matcher(trimmed).replaceAll("0x?");
+            if (!sink.add(new StackFrame(scrubbed, "", -1, UNKNOWN_METHOD))) {
+                return;
+            }
+        }
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackFrame.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackFrame.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+/**
+ * One parsed stack frame, language-neutral. {@code className} and {@code methodName} must be
+ * non-empty (the storage model rejects empty values); {@code fileName} may be empty when the
+ * source format carries no file info. {@code lineNumber} follows the Java convention:
+ * {@code -1} = unknown, {@code -2} = native method.
+ */
+public record StackFrame(String className, String fileName, int lineNumber, String methodName) {
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackFrameSink.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackFrameSink.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Bounded frame collector shared by all parsers. The flattened stacktrace is client-supplied, so
+ * the frame count is unbounded without this cap; parsers stop as soon as {@link #add} returns
+ * {@code false} and the caller reads {@link #isTruncated()} for the truncation metric.
+ */
+public final class StackFrameSink {
+
+    private final int maxFrames;
+    private final List<StackFrame> frames = new ArrayList<>();
+    private boolean truncated = false;
+
+    /**
+     * @param maxFrames maximum frames to keep; {@code <= 0} means unlimited
+     */
+    public StackFrameSink(int maxFrames) {
+        this.maxFrames = maxFrames;
+    }
+
+    /**
+     * Adds a frame; returns {@code false} (and marks this sink truncated) once the cap is reached.
+     */
+    public boolean add(StackFrame frame) {
+        if (maxFrames > 0 && frames.size() >= maxFrames) {
+            truncated = true;
+            return false;
+        }
+        frames.add(frame);
+        return true;
+    }
+
+    public List<StackFrame> frames() {
+        return frames;
+    }
+
+    public boolean isTruncated() {
+        return truncated;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackTraceParser.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackTraceParser.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+/**
+ * Parses one language's {@code exception.stacktrace} string format into structured frames.
+ * Implementations are stateless and line-tolerant: unrecognized lines are skipped, never fatal.
+ */
+public interface StackTraceParser {
+
+    /** Short stable identifier used as the {@code parser} metric tag. */
+    String name();
+
+    /**
+     * Content sniffing: whether this parser recognizes the given stacktrace text. Used only when
+     * the {@code telemetry.sdk.language} resource attribute is absent or unmapped.
+     */
+    boolean matches(String stackTrace);
+
+    /** Parses frames into {@code sink}, stopping when the sink refuses further frames. */
+    void parse(String stackTrace, StackFrameSink sink);
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackTraceParserRegistry.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackTraceParserRegistry.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Selects the stacktrace parser in two stages:
+ * <ol>
+ *   <li>the {@code telemetry.sdk.language} resource attribute (OTel spec values: java, nodejs,
+ *       webjs, python, dotnet, go, ...) — deterministic when present;</li>
+ *   <li>content sniffing over the stacktrace text, ordered from the most distinctive format to
+ *       the least (Python's header, Go's goroutine dump, .NET's " in file:line N", V8's
+ *       ":line:col" tail, then the JVM shape).</li>
+ * </ol>
+ * Unknown languages/formats fall back to {@link RawStackTraceParser}, which is also the caller's
+ * second pass when a selected parser yields zero frames (e.g. a Ruby stack under an unmapped
+ * language value).
+ */
+public final class StackTraceParserRegistry {
+
+    private final Map<String, StackTraceParser> byLanguage;
+    private final List<StackTraceParser> sniffOrder;
+    private final StackTraceParser rawFallback = new RawStackTraceParser();
+
+    public StackTraceParserRegistry() {
+        final StackTraceParser java = new JavaStackTraceParser();
+        final StackTraceParser node = new NodeStackTraceParser();
+        final StackTraceParser python = new PythonStackTraceParser();
+        final StackTraceParser dotNet = new DotNetStackTraceParser();
+        final StackTraceParser go = new GoStackTraceParser();
+
+        this.byLanguage = Map.of(
+                "java", java,
+                "nodejs", node,
+                "webjs", node, // browser JS shares the V8 stack shape
+                "python", python,
+                "dotnet", dotNet,
+                "go", go
+        );
+        this.sniffOrder = List.of(python, go, dotNet, node, java);
+    }
+
+    /**
+     * @param sdkLanguage the {@code telemetry.sdk.language} resource attribute, or {@code null}
+     */
+    public StackTraceParser select(String sdkLanguage, String stackTrace) {
+        if (sdkLanguage != null) {
+            final StackTraceParser byAttr = byLanguage.get(sdkLanguage.trim().toLowerCase(Locale.ROOT));
+            if (byAttr != null) {
+                return byAttr;
+            }
+        }
+        for (StackTraceParser parser : sniffOrder) {
+            if (parser.matches(stackTrace)) {
+                return parser;
+            }
+        }
+        return rawFallback;
+    }
+
+    public StackTraceParser rawFallback() {
+        return rawFallback;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/pinpoint-otlptrace-grpc-root.properties
+++ b/otlptrace/otlptrace-collector/src/main/resources/otlptrace/collector/pinpoint-otlptrace-grpc-root.properties
@@ -59,7 +59,10 @@ pinpoint.collector.otlptrace.link.value-max-bytes=8192
 # surfaced via the collector.otlptrace.exception.truncated meter (tag field=message|stacktrace_depth|
 # frame_value). max-depth is the parsed stacktrace frame count (OTel sends one flattened string, so the
 # unbounded axis is frame count, not the native exception-chain depth); <= 0 means unlimited.
-pinpoint.collector.otlptrace.exception.message-max-bytes=8192
+# message-max-bytes is aligned with the native agent's errormessage cap
+# (profiler.exceptiontrace.errormessage.max=2048) so both sources bound the Pinot errorMessage
+# column alike (the agent caps chars; bytes are stricter for multi-byte text, identical for ASCII).
+pinpoint.collector.otlptrace.exception.message-max-bytes=2048
 pinpoint.collector.otlptrace.exception.stacktrace.max-depth=256
 pinpoint.collector.otlptrace.exception.stacktrace.frame-max-bytes=2048
 # Global in-flight wire-byte ceiling (Semaphore admission). Bounds heap regardless of connection

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapperTest.java
@@ -42,7 +42,7 @@ class OtlpExceptionMapperTest {
     private static final long EXCEPTION_SPAN_ID_LONG = OtlpTraceMapperUtils.getSpanId(ByteString.copyFrom(EXCEPTION_SPAN_ID));
     private static final long ROOT_SPAN_ID_LONG = OtlpTraceMapperUtils.getSpanId(ByteString.copyFrom(ROOT_SPAN_ID));
 
-    private static final int MESSAGE_MAX_BYTES = 8192;
+    private static final int MESSAGE_MAX_BYTES = 2048; // production default, aligned with the agent's errormessage.max
     private static final int STACKTRACE_MAX_DEPTH = 256;
     private static final int FRAME_MAX_BYTES = 2048;
 
@@ -315,5 +315,52 @@ class OtlpExceptionMapperTest {
         ExceptionMetaDataBo bo = mapper.map(id(), span, ROOT_SPAN_ID_LONG, "/api/users/{id}").orElseThrow();
 
         assertThat(bo.getUriTemplate()).isEqualTo("/api/users/{id}");
+    }
+
+    // =======================================================================
+    // multi-language stacktrace parsing (parser selected by telemetry.sdk.language)
+    // =======================================================================
+
+    @Test
+    void map_pythonStackTrace_parsedViaSdkLanguage() {
+        String stackTrace = "Traceback (most recent call last):\n"
+                + "  File \"/app/main.py\", line 10, in handler\n"
+                + "    do_work()\n"
+                + "  File \"/app/work.py\", line 3, in do_work\n"
+                + "ValueError: boom\n";
+        Span span = spanBuilder(EXCEPTION_SPAN_ID)
+                .addEvents(exceptionEvent(exceptionType("ValueError"),
+                        kv("exception.stacktrace", strVal(stackTrace))))
+                .build();
+
+        ExceptionWrapperBo wrapper = mapper.map(id(), span, ROOT_SPAN_ID_LONG, "/api/orders", "python")
+                .orElseThrow().getExceptionWrapperBos().get(0);
+
+        assertThat(wrapper.getStackTraceElements()).hasSize(2);
+        // normalized to innermost-first: the throw site (work.py) comes before its caller
+        assertThat(wrapper.getStackTraceElements().get(0).getFileName()).isEqualTo("/app/work.py");
+        assertThat(wrapper.getStackTraceElements().get(0).getLineNumber()).isEqualTo(3);
+        assertThat(wrapper.getStackTraceElements().get(0).getMethodName()).isEqualTo("do_work");
+    }
+
+    @Test
+    void map_unrecognizedStackTraceFormat_keptAsRawLineFrames() {
+        // Ruby-style stack under no language attribute: no parser matches, but the frames must not
+        // be dropped — an empty list would collapse every unparsed exception into one shared
+        // "empty stack" hash group and blank the detail view.
+        String stackTrace = "/app/services/order.rb:12:in `place'\n"
+                + "/app/controllers/orders_controller.rb:5:in `create'\n";
+        Span span = spanBuilder(EXCEPTION_SPAN_ID)
+                .addEvents(exceptionEvent(exceptionType("RuntimeError"),
+                        kv("exception.stacktrace", strVal(stackTrace))))
+                .build();
+
+        ExceptionWrapperBo wrapper = mapper.map(id(), span, ROOT_SPAN_ID_LONG, "/api/orders")
+                .orElseThrow().getExceptionWrapperBos().get(0);
+
+        assertThat(wrapper.getStackTraceElements()).hasSize(2);
+        assertThat(wrapper.getStackTraceElements().get(0).getClassName())
+                .isEqualTo("/app/services/order.rb:12:in `place'");
+        assertThat(wrapper.getStackTraceElements().get(0).getMethodName()).isEqualTo("?");
     }
 }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -112,7 +112,7 @@ class OtlpTraceMapperTest {
                 8192);
         OtlpTraceSpanChunkMapper spanChunkMapper = new OtlpTraceSpanChunkMapper(spanEventMapper);
         return new OtlpTraceMapper(spanMapper, spanEventMapper, spanChunkMapper,
-                new OtlpAgentInfoMapper(), new OtlpExceptionMapper(8192, 256, 2048, new SimpleMeterRegistry()),
+                new OtlpAgentInfoMapper(), new OtlpExceptionMapper(2048, 256, 2048, new SimpleMeterRegistry()),
                 exceptionInfoResolver, new OtlpAgentStartTimeResolver(new SimpleMeterRegistry()), false);
     }
 

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackTraceParsersTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackTraceParsersTest.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper.stacktrace;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real-world {@code exception.stacktrace} fixtures per OTel SDK language, exercising both the
+ * language selection (attribute + sniffing) and the frame extraction rules.
+ */
+class StackTraceParsersTest {
+
+    private final StackTraceParserRegistry registry = new StackTraceParserRegistry();
+
+    private List<StackFrame> parse(String sdkLanguage, String stackTrace) {
+        StackTraceParser parser = registry.select(sdkLanguage, stackTrace);
+        StackFrameSink sink = new StackFrameSink(256);
+        parser.parse(stackTrace, sink);
+        return sink.frames();
+    }
+
+    // =======================================================================
+    // Java
+    // =======================================================================
+
+    private static final String JAVA_STACK = """
+            java.lang.IllegalStateException: boom
+            \tat com.example.Service.handle(Service.java:42)
+            \tat java.base/java.lang.Thread.run(Thread.java:833)
+            \tat com.example.Native.call(Native Method)
+            Caused by: java.io.IOException: io down
+            \tat com.example.Io.read(Io.java:7)
+            \t... 3 more
+            """;
+
+    @Test
+    void java_framesAndSpecialLines() {
+        List<StackFrame> frames = parse("java", JAVA_STACK);
+
+        // current semantics: "Caused by:" frames merge into one flat list (chain split = follow-up)
+        assertThat(frames).hasSize(4);
+        assertThat(frames.get(0)).isEqualTo(new StackFrame("com.example.Service", "Service.java", 42, "handle"));
+        assertThat(frames.get(2).lineNumber()).isEqualTo(-2); // Native Method
+        assertThat(frames.get(3)).isEqualTo(new StackFrame("com.example.Io", "Io.java", 7, "read"));
+    }
+
+    @Test
+    void java_malformedLineToken_isUnknownLine() {
+        List<StackFrame> frames = parse("java", "\tat com.example.Foo.bar(Foo.java:??)\n");
+
+        assertThat(frames).containsExactly(new StackFrame("com.example.Foo", "Foo.java", -1, "bar"));
+    }
+
+    @Test
+    void java_selectedBySniffingWithoutLanguageAttribute() {
+        assertThat(registry.select(null, JAVA_STACK).name()).isEqualTo("java");
+    }
+
+    // =======================================================================
+    // Node.js (V8)
+    // =======================================================================
+
+    private static final String NODE_STACK = """
+            Error: boom
+                at handler (/app/routes/user.js:10:15)
+                at async UserService.load (/app/services/user.js:22:9)
+                at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
+                at /app/index.js:3:1
+                at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+            """;
+
+    @Test
+    void node_framesLineNotColumn() {
+        List<StackFrame> frames = parse("nodejs", NODE_STACK);
+
+        assertThat(frames).hasSize(5);
+        // the location tail is file:line:column — line must be the middle token, not the column
+        assertThat(frames.get(0)).isEqualTo(new StackFrame("<anonymous>", "/app/routes/user.js", 10, "handler"));
+        assertThat(frames.get(1)).isEqualTo(new StackFrame("UserService", "/app/services/user.js", 22, "load"));
+        // "[as alias]" decoration dropped
+        assertThat(frames.get(2)).isEqualTo(new StackFrame("Layer", "/app/node_modules/express/lib/router/layer.js", 95, "handle"));
+        // anonymous frame (no function, no parens)
+        assertThat(frames.get(3)).isEqualTo(new StackFrame("<anonymous>", "/app/index.js", 3, "<anonymous>"));
+        assertThat(frames.get(4).fileName()).isEqualTo("node:internal/process/task_queues");
+    }
+
+    @Test
+    void node_selectedBySniffing_firstFrameWithoutLocation() {
+        // Built-in frames carry no file:line:col tail; sniffing must keep scanning to the next frame.
+        String stack = "TypeError: boom\n"
+                + "    at Array.map (<anonymous>)\n"
+                + "    at handler (/app/routes/user.js:10:15)\n";
+
+        assertThat(registry.select(null, stack).name()).isEqualTo("node");
+        assertThat(parse(null, stack)).containsExactly(
+                new StackFrame("Array", "<anonymous>", -1, "map"),
+                new StackFrame("<anonymous>", "/app/routes/user.js", 10, "handler"));
+    }
+
+    @Test
+    void node_selectedBySniffing_notMistakenForJava() {
+        // V8 frames also start with "at ", but the :line:col tail must route to the node parser.
+        assertThat(registry.select(null, NODE_STACK).name()).isEqualTo("node");
+    }
+
+    // =======================================================================
+    // Python
+    // =======================================================================
+
+    private static final String PYTHON_STACK = """
+            Traceback (most recent call last):
+              File "/app/main.py", line 10, in handler
+                do_work()
+              File "/app/services/work.py", line 3, in do_work
+                raise ValueError("boom")
+            ValueError: boom
+            """;
+
+    @Test
+    void python_framesReversedToInnermostFirst() {
+        List<StackFrame> frames = parse("python", PYTHON_STACK);
+
+        assertThat(frames).hasSize(2);
+        // python prints outermost-first; frames are normalized to innermost-first (throw site on top)
+        assertThat(frames.get(0)).isEqualTo(new StackFrame("work", "/app/services/work.py", 3, "do_work"));
+        assertThat(frames.get(1)).isEqualTo(new StackFrame("main", "/app/main.py", 10, "handler"));
+    }
+
+    @Test
+    void python_selectedBySniffing() {
+        assertThat(registry.select(null, PYTHON_STACK).name()).isEqualTo("python");
+    }
+
+    // =======================================================================
+    // .NET
+    // =======================================================================
+
+    private static final String DOTNET_STACK = """
+            System.InvalidOperationException: boom
+               at Cart.Services.CartService.GetCart(GetCartRequest request) in /app/services/CartService.cs:line 42
+               at Grpc.AspNetCore.Server.Internal.CallHandlers.UnaryServerCallHandler`3.HandleCallAsyncCore(HttpContext httpContext, HttpContextServerCallContext serverCallContext)
+               --- End of stack trace from previous location ---
+               at lambda_method1(Closure, Object)
+            """;
+
+    @Test
+    void dotnet_argListNotMistakenForFileInfo() {
+        List<StackFrame> frames = parse("dotnet", DOTNET_STACK);
+
+        assertThat(frames).hasSize(3);
+        // parens hold the parameter list; the source location comes from the " in file:line N" suffix
+        assertThat(frames.get(0)).isEqualTo(new StackFrame(
+                "Cart.Services.CartService", "/app/services/CartService.cs", 42, "GetCart"));
+        // frame without source info: file empty, line unknown
+        assertThat(frames.get(1).fileName()).isEmpty();
+        assertThat(frames.get(1).lineNumber()).isEqualTo(-1);
+        // signature without a dot keeps the whole name as the method
+        assertThat(frames.get(2)).isEqualTo(new StackFrame("<unknown>", "", -1, "lambda_method1"));
+    }
+
+    @Test
+    void dotnet_selectedBySniffingViaInLineMarker() {
+        assertThat(registry.select(null, DOTNET_STACK).name()).isEqualTo("dotnet");
+    }
+
+    // =======================================================================
+    // Go
+    // =======================================================================
+
+    private static final String GO_STACK = """
+            goroutine 19 [running]:
+            github.com/acme/shop/checkout.(*Service).PlaceOrder(0xc000010000, {0x8b1e20, 0xc0000a4000})
+            \t/app/checkout/service.go:42 +0x5e
+            main.main()
+            \t/app/main.go:10 +0x20
+            created by net/http.(*Server).Serve
+            \t/usr/local/go/src/net/http/server.go:3086 +0x5cb
+            """;
+
+    @Test
+    void go_pairsParsed_offsetDropped() {
+        List<StackFrame> frames = parse("go", GO_STACK);
+
+        assertThat(frames).hasSize(3);
+        assertThat(frames.get(0)).isEqualTo(new StackFrame(
+                "github.com/acme/shop/checkout.(*Service)", "/app/checkout/service.go", 42, "PlaceOrder"));
+        assertThat(frames.get(1)).isEqualTo(new StackFrame("main", "/app/main.go", 10, "main"));
+        // "created by" prefix stripped; the +0x program-counter offset never reaches the frame
+        assertThat(frames.get(2)).isEqualTo(new StackFrame(
+                "net/http.(*Server)", "/usr/local/go/src/net/http/server.go", 3086, "Serve"));
+    }
+
+    @Test
+    void go_selectedBySniffingViaGoroutineHeader() {
+        assertThat(registry.select(null, GO_STACK).name()).isEqualTo("go");
+    }
+
+    // =======================================================================
+    // Raw fallback (unrecognized formats)
+    // =======================================================================
+
+    private static final String RUBY_STACK = """
+            /app/services/order.rb:12:in `place'
+            /app/controllers/orders_controller.rb:5:in `create'
+            """;
+
+    @Test
+    void unknownFormat_fallsBackToRawLines() {
+        assertThat(registry.select(null, RUBY_STACK).name()).isEqualTo("raw-fallback");
+
+        List<StackFrame> frames = parse(null, RUBY_STACK);
+        assertThat(frames).hasSize(2);
+        assertThat(frames.get(0).className()).isEqualTo("/app/services/order.rb:12:in `place'");
+        assertThat(frames.get(0).methodName()).isEqualTo("?");
+    }
+
+    @Test
+    void rawFallback_scrubsHexAddressesForStableGrouping() {
+        StackFrameSink sink = new StackFrameSink(16);
+        registry.rawFallback().parse("panic at 0xc000010af8 in worker", sink);
+
+        assertThat(sink.frames().get(0).className()).isEqualTo("panic at 0x? in worker");
+    }
+
+    @Test
+    void unmappedLanguage_fallsBackToSniffing() {
+        // e.g. "ruby": no dedicated parser → sniffing → raw fallback
+        assertThat(registry.select("ruby", RUBY_STACK).name()).isEqualTo("raw-fallback");
+        // an unmapped language with a recognizable format still routes by content
+        assertThat(registry.select("kotlin-native", JAVA_STACK).name()).isEqualTo("java");
+    }
+
+    @Test
+    void sink_capsFramesAndMarksTruncated() {
+        StackFrameSink sink = new StackFrameSink(2);
+        registry.rawFallback().parse("a\nb\nc\nd", sink);
+
+        assertThat(sink.frames()).hasSize(2);
+        assertThat(sink.isTruncated()).isTrue();
+    }
+
+    // =======================================================================
+    // Real captured fixtures (src/test/resources/stacktrace/*.txt)
+    //
+    // Captured verbatim from each runtime on Windows, exactly as the OTel SDK
+    // records exception.stacktrace: Java = Throwable.printStackTrace, Python =
+    // traceback.format_exception (CPython 3.14), Node = error.stack (Node 24),
+    // Go = runtime/debug.Stack() (Go 1.26). They carry the real-world artifacts
+    // hand-written fixtures miss: JDK module prefixes, "... N more" elisions,
+    // Python 3.11+ caret marker lines, Windows drive-letter paths (bare V8
+    // frames included), V8 "(<anonymous>)" locations, and Go paths with spaces.
+    // =======================================================================
+
+    private static String readFixture(String name) {
+        try (InputStream in = StackTraceParsersTest.class.getResourceAsStream("/stacktrace/" + name)) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Test
+    void realJava_printStackTrace_chained() {
+        String stackTrace = readFixture("java-chained.txt");
+        assertThat(registry.select(null, stackTrace).name()).isEqualTo("java");
+
+        List<StackFrame> frames = parse("java", stackTrace);
+
+        // 8 outer frames + 1 per "Caused by:" section; "... N more" elisions contribute nothing
+        assertThat(frames).hasSize(10);
+        assertThat(frames.get(0)).isEqualTo(new StackFrame("ChainTest", "ChainTest.java", 9, "main"));
+        // JDK module prefix stays in the class name; (Native Method) → line -2
+        assertThat(frames.get(1)).isEqualTo(new StackFrame(
+                "java.base/jdk.internal.reflect.NativeMethodAccessorImpl", "Native Method", -2, "invoke0"));
+        // merged "Caused by:" frames (flat semantics), innermost last
+        assertThat(frames.get(8)).isEqualTo(new StackFrame("ChainTest", "ChainTest.java", 5, "middle"));
+        assertThat(frames.get(9)).isEqualTo(new StackFrame("ChainTest", "ChainTest.java", 3, "inner"));
+    }
+
+    @Test
+    void realPython_formatException_chained() {
+        String stackTrace = readFixture("python-chained.txt");
+        assertThat(registry.select(null, stackTrace).name()).isEqualTo("python");
+
+        List<StackFrame> frames = parse("python", stackTrace);
+
+        // 2 frames per segment; caret marker lines (~~~^^^) and source echoes contribute nothing.
+        // Normalized to innermost-first: the final raise site leads, the root-cause segment trails.
+        assertThat(frames).hasSize(4);
+        assertThat(frames.get(0)).isEqualTo(new StackFrame(
+                "handler", "C:\\Temp\\otelapp\\handler.py", 8, "handle"));
+        assertThat(frames.get(1)).isEqualTo(new StackFrame(
+                "handler", "C:\\Temp\\otelapp\\handler.py", 12, "<module>"));
+        assertThat(frames.get(2)).isEqualTo(new StackFrame(
+                "work", "C:\\Temp\\otelapp\\services\\work.py", 2, "do_work"));
+        assertThat(frames.get(3)).isEqualTo(new StackFrame(
+                "handler", "C:\\Temp\\otelapp\\handler.py", 6, "handle"));
+    }
+
+    @Test
+    void realNode_errorStack() {
+        String stackTrace = readFixture("node-stack.txt");
+        assertThat(registry.select(null, stackTrace).name()).isEqualTo("node");
+
+        List<StackFrame> frames = parse("nodejs", stackTrace);
+
+        assertThat(frames).hasSize(10);
+        // bare frame with a Windows drive-letter path: the drive colon must not confuse file:line:col
+        assertThat(frames.get(0)).isEqualTo(new StackFrame(
+                "<anonymous>", "C:\\Temp\\otelapp\\server.js", 8, "<anonymous>"));
+        // "(<anonymous>)" location: no line info
+        assertThat(frames.get(1)).isEqualTo(new StackFrame("Array", "<anonymous>", -1, "map"));
+        // line is the middle token (8), never the column (16)
+        assertThat(frames.get(2)).isEqualTo(new StackFrame(
+                "<anonymous>", "C:\\Temp\\otelapp\\server.js", 8, "fetchUser"));
+        assertThat(frames.get(3)).isEqualTo(new StackFrame(
+                "UserService", "C:\\Temp\\otelapp\\server.js", 4, "load"));
+        // real V8 quirk kept as-is: "Object..js" splits on the last dot
+        assertThat(frames.get(7).className()).isEqualTo("Object.");
+        assertThat(frames.get(7).methodName()).isEqualTo("js");
+    }
+
+    @Test
+    void realGo_debugStack() {
+        String stackTrace = readFixture("go-stack.txt");
+        assertThat(registry.select(null, stackTrace).name()).isEqualTo("go");
+
+        List<StackFrame> frames = parse("go", stackTrace);
+
+        assertThat(frames).hasSize(2);
+        // a path containing a space ("Program Files") must parse; the +0x offset never survives
+        assertThat(frames.get(0)).isEqualTo(new StackFrame(
+                "runtime/debug", "C:/Program Files/Go/src/runtime/debug/stack.go", 26, "Stack"));
+        assertThat(frames.get(1)).isEqualTo(new StackFrame(
+                "main", "C:/Temp/otelapp/gosvc/main.go", 17, "main"));
+    }
+
+    // =======================================================================
+    // Real captured fixtures — Linux paths (same generators run in containers:
+    // CPython 3.12, Node 22, Go 1.23, .NET SDK 8.0). Java is path-independent
+    // (frames carry only the file basename), so it has no Linux variant.
+    // =======================================================================
+
+    @Test
+    void realPythonLinux_formatException_chained() {
+        String stackTrace = readFixture("python-chained-linux.txt");
+        assertThat(registry.select(null, stackTrace).name()).isEqualTo("python");
+
+        List<StackFrame> frames = parse("python", stackTrace);
+
+        assertThat(frames).hasSize(4);
+        assertThat(frames.get(0)).isEqualTo(new StackFrame("handler", "/app/handler.py", 8, "handle"));
+        assertThat(frames.get(2)).isEqualTo(new StackFrame("work", "/app/services/work.py", 2, "do_work"));
+    }
+
+    @Test
+    void realNodeLinux_errorStack() {
+        String stackTrace = readFixture("node-stack-linux.txt");
+        assertThat(registry.select(null, stackTrace).name()).isEqualTo("node");
+
+        List<StackFrame> frames = parse("nodejs", stackTrace);
+
+        assertThat(frames).hasSize(10);
+        // bare frame with an absolute Unix path
+        assertThat(frames.get(0)).isEqualTo(new StackFrame("<anonymous>", "/app/server.js", 8, "<anonymous>"));
+        assertThat(frames.get(2)).isEqualTo(new StackFrame("<anonymous>", "/app/server.js", 8, "fetchUser"));
+        assertThat(frames.get(3)).isEqualTo(new StackFrame("UserService", "/app/server.js", 4, "load"));
+    }
+
+    @Test
+    void realGoLinux_debugStack() {
+        String stackTrace = readFixture("go-stack-linux.txt");
+        assertThat(registry.select(null, stackTrace).name()).isEqualTo("go");
+
+        List<StackFrame> frames = parse("go", stackTrace);
+
+        assertThat(frames).hasSize(2);
+        assertThat(frames.get(0)).isEqualTo(new StackFrame(
+                "runtime/debug", "/usr/local/go/src/runtime/debug/stack.go", 26, "Stack"));
+        assertThat(frames.get(1)).isEqualTo(new StackFrame("main", "/app/gosvc/main.go", 17, "main"));
+    }
+
+    @Test
+    void realDotNetLinux_toStringChained() {
+        // First real .NET capture (Exception.ToString() from the .NET 8 SDK container): the
+        // " ---> Inner: msg" chain header and "--- End of inner exception stack trace ---"
+        // separator are skipped (flat semantics); inner frames come first in text order.
+        String stackTrace = readFixture("dotnet-chained-linux.txt");
+        assertThat(registry.select(null, stackTrace).name()).isEqualTo("dotnet");
+
+        List<StackFrame> frames = parse("dotnet", stackTrace);
+
+        assertThat(frames).hasSize(4);
+        assertThat(frames.get(0)).isEqualTo(new StackFrame("OrderService", "/app/Program.cs", 5, "Validate"));
+        assertThat(frames.get(1)).isEqualTo(new StackFrame("OrderService", "/app/Program.cs", 7, "Place"));
+        assertThat(frames.get(2)).isEqualTo(new StackFrame("OrderService", "/app/Program.cs", 8, "Place"));
+        assertThat(frames.get(3)).isEqualTo(new StackFrame("Program", "/app/Program.cs", 13, "Main"));
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/resources/stacktrace/dotnet-chained-linux.txt
+++ b/otlptrace/otlptrace-collector/src/test/resources/stacktrace/dotnet-chained-linux.txt
@@ -1,0 +1,7 @@
+System.InvalidOperationException: order placement failed
+ ---> System.ArgumentException: invalid order id: 42
+   at OrderService.Validate(Int32 id) in /app/Program.cs:line 5
+   at OrderService.Place(Int32 id) in /app/Program.cs:line 7
+   --- End of inner exception stack trace ---
+   at OrderService.Place(Int32 id) in /app/Program.cs:line 8
+   at Program.Main() in /app/Program.cs:line 13

--- a/otlptrace/otlptrace-collector/src/test/resources/stacktrace/go-stack-linux.txt
+++ b/otlptrace/otlptrace-collector/src/test/resources/stacktrace/go-stack-linux.txt
@@ -1,0 +1,6 @@
+goroutine 1 [running]:
+runtime/debug.Stack()
+	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
+main.main()
+	/app/gosvc/main.go:17 +0x17b
+

--- a/otlptrace/otlptrace-collector/src/test/resources/stacktrace/go-stack.txt
+++ b/otlptrace/otlptrace-collector/src/test/resources/stacktrace/go-stack.txt
@@ -1,0 +1,6 @@
+goroutine 1 [running]:
+runtime/debug.Stack()
+	C:/Program Files/Go/src/runtime/debug/stack.go:26 +0x5e
+main.main()
+	C:/Temp/otelapp/gosvc/main.go:17 +0x1db
+

--- a/otlptrace/otlptrace-collector/src/test/resources/stacktrace/java-chained.txt
+++ b/otlptrace/otlptrace-collector/src/test/resources/stacktrace/java-chained.txt
@@ -1,0 +1,16 @@
+java.lang.RuntimeException: outer wrap
+	at ChainTest.main(ChainTest.java:9)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
+	at jdk.compiler/com.sun.tools.javac.launcher.Main.execute(Main.java:419)
+	at jdk.compiler/com.sun.tools.javac.launcher.Main.run(Main.java:192)
+	at jdk.compiler/com.sun.tools.javac.launcher.Main.main(Main.java:132)
+Caused by: java.lang.IllegalStateException: wrapped in middle
+	at ChainTest.middle(ChainTest.java:5)
+	... 8 more
+Caused by: java.lang.IllegalArgumentException: root cause boom
+	at ChainTest.inner(ChainTest.java:3)
+	... 9 more
+

--- a/otlptrace/otlptrace-collector/src/test/resources/stacktrace/node-stack-linux.txt
+++ b/otlptrace/otlptrace-collector/src/test/resources/stacktrace/node-stack-linux.txt
@@ -1,0 +1,11 @@
+Error: user not found: 42
+    at /app/server.js:8:34
+    at Array.map (<anonymous>)
+    at fetchUser (/app/server.js:8:16)
+    at UserService.load (/app/server.js:4:22)
+    at handler (/app/server.js:11:30)
+    at Object.<anonymous> (/app/server.js:13:1)
+    at Module._compile (node:internal/modules/cjs/loader:1781:14)
+    at Object..js (node:internal/modules/cjs/loader:1913:10)
+    at Module.load (node:internal/modules/cjs/loader:1505:32)
+    at Function._load (node:internal/modules/cjs/loader:1309:12)

--- a/otlptrace/otlptrace-collector/src/test/resources/stacktrace/node-stack.txt
+++ b/otlptrace/otlptrace-collector/src/test/resources/stacktrace/node-stack.txt
@@ -1,0 +1,11 @@
+Error: user not found: 42
+    at C:\Temp\otelapp\server.js:8:34
+    at Array.map (<anonymous>)
+    at fetchUser (C:\Temp\otelapp\server.js:8:16)
+    at UserService.load (C:\Temp\otelapp\server.js:4:22)
+    at handler (C:\Temp\otelapp\server.js:11:30)
+    at Object.<anonymous> (C:\Temp\otelapp\server.js:13:1)
+    at Module._compile (node:internal/modules/cjs/loader:1871:14)
+    at Object..js (node:internal/modules/cjs/loader:2002:10)
+    at Module.load (node:internal/modules/cjs/loader:1594:32)
+    at Module._load (node:internal/modules/cjs/loader:1396:12)

--- a/otlptrace/otlptrace-collector/src/test/resources/stacktrace/python-chained-linux.txt
+++ b/otlptrace/otlptrace-collector/src/test/resources/stacktrace/python-chained-linux.txt
@@ -1,0 +1,15 @@
+Traceback (most recent call last):
+  File "/app/handler.py", line 6, in handle
+    do_work(order_id)
+  File "/app/services/work.py", line 2, in do_work
+    raise ValueError(f"invalid order state: {order_id}")
+ValueError: invalid order state: 42
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/app/handler.py", line 12, in <module>
+    handle(42)
+  File "/app/handler.py", line 8, in handle
+    raise RuntimeError("order processing failed") from e
+RuntimeError: order processing failed

--- a/otlptrace/otlptrace-collector/src/test/resources/stacktrace/python-chained.txt
+++ b/otlptrace/otlptrace-collector/src/test/resources/stacktrace/python-chained.txt
@@ -1,0 +1,17 @@
+Traceback (most recent call last):
+  File "C:\Temp\otelapp\handler.py", line 6, in handle
+    do_work(order_id)
+    ~~~~~~~^^^^^^^^^^
+  File "C:\Temp\otelapp\services\work.py", line 2, in do_work
+    raise ValueError(f"invalid order state: {order_id}")
+ValueError: invalid order state: 42
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "C:\Temp\otelapp\handler.py", line 12, in <module>
+    handle(42)
+    ~~~~~~^^^^
+  File "C:\Temp\otelapp\handler.py", line 8, in handle
+    raise RuntimeError("order processing failed") from e
+RuntimeError: order processing failed


### PR DESCRIPTION
Error Analysis for OTel traces previously parsed exception.stacktrace with a JVM-format-only parser: Python/.NET/Go/Ruby stacks yielded zero frames, collapsing every non-Java exception into one shared empty-stack hash group and blanking the detail view, and V8 (Node.js) frames misread the column as the line number.

- Language-specific parsers (java/node/python/dotnet/go) selected by the telemetry.sdk.language resource attribute, with content sniffing when the attribute is absent
- Python frames are normalized to innermost-first (JVM convention) so the detail view reads top-down to the throw site and the stack-trace hash groups consistently across languages
- Go +0x program-counter offsets are dropped (vary per build) to keep the grouping hash stable across deployments
- Unrecognized formats fall back to raw-line frames (hex addresses scrubbed) instead of an empty list, keeping the original text visible and the hash distinctive
- collector.otlptrace.exception.parsed{parser} counter shows which parser handled each stacktrace - the raw-fallback share tells which language parser to add next
- The default exception.message-max-bytes is lowered 8192 -> 2048, aligning with the native agent errormessage cap (2048 chars) so both sources bound the Pinot errorMessage column alike
- Exception chain decomposition (Caused by:) is a planned follow-up; the existing flat-merge semantics are kept and pinned by tests