### PR TITLE
[#noissue] Keep virtualized table cells inside their column

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/DataTable/VirtualizedDataTable.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/DataTable/VirtualizedDataTable.tsx
@@ -284,7 +284,12 @@ export function VirtualizedDataTable<TData, TValue>({
                         key={cell.id}
                         style={{ width: cell.column.getSize() }}
                         className={cn(
-                          'grow',
+                          // Rows are flex containers, so a cell's default `min-width: auto`
+                          // lets long unbreakable content push the cell past its column width
+                          // and cover the next column. `min-w-0` + `overflow-hidden` keep the
+                          // cell inside its column, and `break-words` wraps such content
+                          // instead of hiding it behind the clip.
+                          'grow min-w-0 overflow-hidden break-words',
                           (cell.column.columnDef?.meta as MetaType)?.cellClassName,
                           {
                             truncate: enableColumnResizing,


### PR DESCRIPTION
## Summary
- Virtualized table rows are flex containers, so a cell's default `min-width: auto` let long unbreakable content (e.g. a URL with no spaces) grow the cell past its column width and paint over the neighbouring columns. Cells now keep to their column (`min-w-0 overflow-hidden`) and wrap such content instead of hiding it (`break-words`).
- Only tables with column resizing were unaffected before, because their `truncate` class happened to clip the overflow; those keep the same single-line ellipsis, since `truncate` still wins the class merge.

## Test plan
- [ ] `yarn build` passes
- [ ] `yarn test` passes
- [ ] Agent Active Thread / Error Analysis (grouped) / URL Summary tables: a value longer than its column stays inside the column instead of covering the next one
- [ ] Error Analysis (grouped) Volume column: the mini chart and its max-value label are still fully visible
- [ ] Transaction List / Call Tree / Agent Statistic / Thread Dump tables (column resizing on): long values still truncate to one line with an ellipsis, and resizing still works
