### PR TITLE
[#14229] Use the shared route template for OTLP URI stat

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
@@ -140,9 +140,11 @@ public class OtlpTraceMapper {
                         final AgentInfoBo agentInfoBo = agentInfoMapper.map(spanBo, resourceAttributeMap);
                         mapperData.addAgentInfoBo(agentInfoBo);
 
-                        // URI stat source: only entry-point spans carrying an http.route template.
-                        // The raw url.path fallback is intentionally excluded to keep uriStat low-cardinality.
-                        final String uriTemplate = spanMapper.getUriTemplate(rootSpan, rootAttributes);
+                        // URI stat source: only entry-point spans carrying a route template (http.route,
+                        // next.route, micrometer uri — the same template the rpc and the exception
+                        // uriTemplate resolve). The raw url.path fallback is intentionally excluded to
+                        // keep uriStat low-cardinality.
+                        final String uriTemplate = spanMapper.getUriTemplate(rootSpan, rootAttributes, rootScopedSpan.scope());
                         if (uriTemplate != null) {
                             mapperData.addUriStatSpan(new OtlpUriStatSpan(
                                     spanBo.getServiceName(), spanBo.getApplicationName(), spanBo.getAgentId(),

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -28,7 +28,6 @@ import com.navercorp.pinpoint.common.server.bo.TraceSourceType;
 import com.navercorp.pinpoint.common.server.trace.OtelServerTraceId;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.ServiceType;
-import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.common.util.IdValidateUtils;
 import com.navercorp.pinpoint.io.SpanVersion;
@@ -549,21 +548,18 @@ public class OtlpTraceSpanMapper {
     }
 
     /**
-     * Returns the matched route template (http.route, e.g. "/users/{id}") for SERVER/INTERNAL
-     * spans, or null when the request was not routed. URI stat must aggregate by this
-     * low-cardinality template only: unlike {@link #getServerSpanToRpc}, it never falls back to the
-     * raw url.path, since path variables would explode the Pinot uriStat cardinality. This mirrors
-     * the Pinpoint agent feeding URI stat solely from SpanRecorder.recordUriTemplate.
+     * Returns the matched route template of a SERVER/INTERNAL entry-point span for URI stat, or null
+     * when the request was not routed. The template is the same one the rpc and the exception
+     * uriTemplate use ({@link #resolveRouteTemplate}: http.route, Next.js next.route, Spring Boot
+     * micrometer-tracing {@code uri}), so the three views agree on what "routed" means. URI stat
+     * must aggregate by this low-cardinality template only: unlike {@link #getServerSpanToRpc}, it
+     * never falls back to the raw url.path, since path variables would explode the Pinot uriStat
+     * cardinality. This mirrors the Pinpoint agent feeding URI stat solely from
+     * SpanRecorder.recordUriTemplate. Consumed keys are not tracked (throwaway set): the caller's
+     * annotation filtering is decided by {@link #map} alone.
      */
-    String getUriTemplate(Span span, Map<String, AttributeValue> attributes) {
-        final int kind = span.getKind().getNumber();
-        if (kind == Span.SpanKind.SPAN_KIND_SERVER_VALUE || kind == Span.SpanKind.SPAN_KIND_INTERNAL_VALUE) {
-            final String httpRoute = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_ROUTE, null);
-            if (StringUtils.hasLength(httpRoute)) {
-                return httpRoute;
-            }
-        }
-        return null;
+    String getUriTemplate(Span span, Map<String, AttributeValue> attributes, InstrumentationScope scope) {
+        return resolveRouteTemplate(span, attributes, new HashSet<>(), OtlpMicrometerAttributes.isMicrometerScope(scope));
     }
 
     public static String extractPath(String url) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpUriStatSpan.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpUriStatSpan.java
@@ -18,7 +18,7 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 /**
  * A single entry-point span's contribution to URI stat, captured during trace mapping while the
- * OTel http.route attribute is still available. Deliberately free of any uristat-module type so the
+ * OTel route template attributes (http.route, next.route, micrometer uri) are still available. Deliberately free of any uristat-module type so the
  * always-on {@link OtlpTraceMapper} does not depend on the optional uristat collector; aggregation
  * into UriStat records happens later in OtlpUriStatService, which only loads when the uristat module
  * is enabled.

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -719,6 +719,21 @@ class OtlpTraceMapperTest {
     }
 
     @Test
+    void uriStat_rootWithNextRoute_collected() {
+        // A Next.js entry point routed via next.route (no http.route) contributes like an http.route one.
+        Span root = Span.newBuilder(serverRoot(ROOT_A, "GET", false))
+                .clearAttributes()
+                .addAttributes(kv("next.route", strVal("/api/products/[productId]/index")))
+                .addAttributes(kv("url.path", strVal("/api/products/0PUK6V6EV0")))
+                .build();
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(root));
+
+        assertThat(data.getUriStatSpanList()).hasSize(1);
+        assertThat(data.getUriStatSpanList().get(0).getUri()).isEqualTo("/api/products/[productId]/index");
+    }
+
+    @Test
     void uriStat_rootWithoutRoute_notCollected() {
         // Unrouted SERVER root: the trace itself is stored, but no uriStat record is derived —
         // there is no raw-path fallback (low-cardinality contract).

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -1359,7 +1359,7 @@ class OtlpTraceSpanMapperTest {
         Span span = serverSpan(
                 kv("http.route", strVal("/api/users/{id}")),
                 kv("url.path", strVal("/api/users/123")));
-        assertThat(newMapper().getUriTemplate(span, attrs(span))).isEqualTo("/api/users/{id}");
+        assertThat(newMapper().getUriTemplate(span, attrs(span), NO_SCOPE)).isEqualTo("/api/users/{id}");
     }
 
     @Test
@@ -1368,7 +1368,7 @@ class OtlpTraceSpanMapperTest {
         // would explode the Pinot uriStat cardinality, mirroring the native agent feeding URI stat
         // solely from recordUriTemplate.
         Span span = serverSpan(kv("url.path", strVal("/api/users/123")));
-        assertThat(newMapper().getUriTemplate(span, attrs(span))).isNull();
+        assertThat(newMapper().getUriTemplate(span, attrs(span), NO_SCOPE)).isNull();
     }
 
     @Test
@@ -1377,7 +1377,7 @@ class OtlpTraceSpanMapperTest {
         Span span = serverSpan(kv("http.route", strVal("/api/users/{id}"))).toBuilder()
                 .setKindValue(Span.SpanKind.SPAN_KIND_CLIENT_VALUE)
                 .build();
-        assertThat(newMapper().getUriTemplate(span, attrs(span))).isNull();
+        assertThat(newMapper().getUriTemplate(span, attrs(span), NO_SCOPE)).isNull();
     }
 
     @Test
@@ -1387,7 +1387,7 @@ class OtlpTraceSpanMapperTest {
         Span span = serverSpan(kv("http.route", strVal("/api/users/[id]"))).toBuilder()
                 .setKindValue(Span.SpanKind.SPAN_KIND_INTERNAL_VALUE)
                 .build();
-        assertThat(newMapper().getUriTemplate(span, attrs(span))).isEqualTo("/api/users/[id]");
+        assertThat(newMapper().getUriTemplate(span, attrs(span), NO_SCOPE)).isEqualTo("/api/users/[id]");
     }
 
     @Test
@@ -1397,7 +1397,50 @@ class OtlpTraceSpanMapperTest {
         Span span = serverSpan(
                 kv("http.route", strVal("")),
                 kv("url.path", strVal("/api/users/123")));
-        assertThat(newMapper().getUriTemplate(span, attrs(span))).isNull();
+        assertThat(newMapper().getUriTemplate(span, attrs(span), NO_SCOPE)).isNull();
+    }
+
+    @Test
+    void uriTemplate_nextRoute_whenNoHttpRoute() {
+        // Next.js emits its route pattern as next.route — a template like http.route, not a raw path.
+        Span span = serverSpan(
+                kv("next.route", strVal("/api/products/[productId]/index")),
+                kv("url.path", strVal("/api/products/0PUK6V6EV0")));
+        assertThat(newMapper().getUriTemplate(span, attrs(span), NO_SCOPE)).isEqualTo("/api/products/[productId]/index");
+    }
+
+    @Test
+    void uriTemplate_micrometerUri_forSpringBootScope() {
+        // Spring Boot micrometer-tracing carries the matched pattern in the `uri` tag.
+        Span span = serverSpan(
+                kv("uri", strVal("/user/{id}")),
+                kv("http.url", strVal("http://svc/user/42")));
+        assertThat(newMapper().getUriTemplate(span, attrs(span), scope(OtlpMicrometerAttributes.SCOPE_SPRING_BOOT, "3.5.0"))).isEqualTo("/user/{id}");
+    }
+
+    @Test
+    void uriTemplate_micrometerPlaceholder_isNull() {
+        // No-route placeholders ("/**", "NOT_FOUND", ...) are not templates → no uriStat key.
+        Span span = serverSpan(
+                kv("uri", strVal("NOT_FOUND")),
+                kv("http.url", strVal("http://svc/no/such/path")));
+        assertThat(newMapper().getUriTemplate(span, attrs(span), scope(OtlpMicrometerAttributes.SCOPE_SPRING_BOOT, "3.5.0"))).isNull();
+    }
+
+    @Test
+    void uriTemplate_micrometerUri_onlyForServerKind() {
+        // The micrometer `uri` tag is interpreted on SERVER spans only (same rule as the rpc).
+        Span span = serverSpan(kv("uri", strVal("/user/{id}"))).toBuilder()
+                .setKindValue(Span.SpanKind.SPAN_KIND_INTERNAL_VALUE)
+                .build();
+        assertThat(newMapper().getUriTemplate(span, attrs(span), scope(OtlpMicrometerAttributes.SCOPE_SPRING_BOOT, "3.5.0"))).isNull();
+    }
+
+    @Test
+    void uriTemplate_uriTag_ignoredOutsideMicrometerScope() {
+        // A `uri` attribute from another instrumentation is not a known template source.
+        Span span = serverSpan(kv("uri", strVal("/user/{id}")));
+        assertThat(newMapper().getUriTemplate(span, attrs(span), scope("my-custom-tracer", ""))).isNull();
     }
 
     // =======================================================================


### PR DESCRIPTION
URI stat from OTLP traces only accepted http.route as the template, while the transaction rpc and the exception uriTemplate already resolve the same template from http.route, Next.js next.route and the Spring Boot micrometer-tracing uri tag. Routed requests of a Next.js app without http.route or of a micrometer-tracing app therefore had an rpc but no URI stat.

- getUriTemplate delegates to resolveRouteTemplate, so the three views agree on what "routed" means; the raw url.path fallback stays excluded (low cardinality, like the agent feeding URI stat solely from recordUriTemplate)
- micrometer uri applies to SERVER spans only and its no-route placeholders ("/**", "NOT_FOUND", ...) still yield no uriStat key
- Consumed keys are not tracked by the URI stat lookup; annotation filtering is decided by map() alone