### PR TITLE
[#14228] Report the forked dependency descriptor as CONTAINER so the IDE does not duplicate its node

### DIFF
--- a/agent-module/plugins-it/spring-it/spring-7-it/pom.xml
+++ b/agent-module/plugins-it/spring-it/spring-7-it/pom.xml
@@ -32,7 +32,7 @@
         <jdk.version>17</jdk.version>
         <jdk.home>${env.JAVA_17_HOME}</jdk.home>
         <spring.version>${spring7.version}</spring.version>
-        <jakarta.servlet.version>${jakarta.servlet6.version}</jakarta.servlet.version>
+        <jakarta.servlet.version>6.1.0</jakarta.servlet.version>
     </properties>
 
     <dependencies>

--- a/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/async/SpringWebMvc_7_x_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/async/SpringWebMvc_7_x_IT.java
@@ -11,6 +11,7 @@ import com.navercorp.pinpoint.test.plugin.PinpointAgent;
 import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -26,9 +27,9 @@ import java.lang.reflect.Method;
 @PluginForkedTest
 @PinpointAgent(AgentPath.PATH)
 @JvmVersion(17)
-@Dependency({"org.springframework:spring-webmvc:[7.0.0,7.max]", "org.springframework:spring-test", "jakarta.servlet:jakarta.servlet-api:6.0.0"})
+@Dependency({"org.springframework:spring-webmvc:[7.0.0,7.max]", "org.springframework:spring-test", "jakarta.servlet:jakarta.servlet-api:6.1.0"})
 @ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-plugin"})
-//@Disabled
+@Disabled
 public class SpringWebMvc_7_x_IT {
     private static final String SPRING_MVC = "SPRING_MVC";
 

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginForkedTestDependencyTestDescriptor.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/junit5/descriptor/PluginForkedTestDependencyTestDescriptor.java
@@ -39,7 +39,7 @@ public class PluginForkedTestDependencyTestDescriptor extends PluginTestDescript
 
     @Override
     public Type getType() {
-        return Type.CONTAINER_AND_TEST;
+        return Type.CONTAINER;
     }
 
     @Override

--- a/agent-module/plugins-test-module/plugins-test/src/main/resources/tinylog.properties
+++ b/agent-module/plugins-test-module/plugins-test/src/main/resources/tinylog.properties
@@ -1,7 +1,7 @@
 writer        = console
 writer.format = {date:MM-dd HH:mm:ss} {{level}|min-size=5} [{tag}:{{pid}|min-size=5}] {{class-name}|min-size=24}:{line} -- {message|indent=4}
 # ERROR, WARN, INFO, DEBUG, TRACE
-writer.level  = DEBUG
+writer.level  = INFO
 #writer.tag    = PLUGIN-TEST
 
 autoshutdown = true


### PR DESCRIPTION
This pull request includes several dependency and configuration updates, as well as a test annotation change and a modification to test descriptor behavior. The main focus is on updating the Jakarta Servlet version to 6.1.0 and adjusting related test and logging configurations.

**Dependency and Version Updates:**

* Updated the `jakarta.servlet.version` property in `pom.xml` and the test dependency in `SpringWebMvc_7_x_IT.java` to use version 6.1.0 instead of 6.0.0. [[1]](diffhunk://#diff-9de45f07d4adf6300097b924d989ddffe6c82f2739694d8d351adaaa4ea3ef25L35-R35) [[2]](diffhunk://#diff-c8092e88f5edaedf0ea28bc4ca2ee6e7a7da7d4afe129191cffa643aec1727d6L29-R32)

**Test Configuration Changes:**

* Enabled the `@Disabled` annotation on the `SpringWebMvc_7_x_IT` integration test, ensuring it is skipped during test runs.
* Added the `@Disabled` import to the test file for clarity and correctness.

**Logging and Test Descriptor Adjustments:**

* Changed the log level in `tinylog.properties` from `DEBUG` to `INFO` to reduce log verbosity during test runs.
* Modified the `PluginForkedTestDependencyTestDescriptor` to return `Type.CONTAINER` instead of `Type.CONTAINER_AND_TEST`, likely affecting how tests are discovered and executed in the test framework.