### PR TITLE
[#14229] Record OTLP ingest volume, rejection reasons, wire bytes and…

### DIFF
--- a/otlptrace/README.md
+++ b/otlptrace/README.md
@@ -191,8 +191,11 @@ let the rest fall through to the OTel semconv keys.
 
 When an identifier fails validation, the **span is rejected**: the OTLP export
 call fails (gRPC `INVALID_ARGUMENT` / partial-success response on HTTP), the
-rejected-span count is incremented, and the collector logs a message like one
-of the following — the offending value is appended after `=`:
+rejected-span count is incremented — every span of the offending `ResourceSpans`
+is counted, and the collector metric `collector.otlptrace.span.rejected` records
+them under `reason=invalid_resource` (see the collector README, *Ingest metrics*,
+for the other reason codes) — and the collector logs a message like one of the
+following — the offending value is appended after `=`:
 
 | Failure | Message |
 |---|---|

--- a/otlptrace/otlptrace-collector/README.md
+++ b/otlptrace/otlptrace-collector/README.md
@@ -65,14 +65,18 @@ OTLP exporter
 1. **Byte admission**: `tryAcquire` on the Semaphore for `request.getSerializedSize()`; on failure,
    return `UNAVAILABLE` immediately. The reason for using `UNAVAILABLE` instead of `RESOURCE_EXHAUSTED`
    (OTLP exporters retry it unconditionally) is documented in a comment.
+   Counted as `collector.otlptrace.request.rejected{transport=grpc, reason=inflight_bytes}`.
 2. **Worker offload**: submitted to the worker executor via `Context.current().wrap()` — non-blocking
    for the gRPC handler thread. On queue saturation (`RejectedExecutionException`), release the permit
-   and return `UNAVAILABLE`.
+   and return `UNAVAILABLE`. Counted as `request.rejected{transport=grpc, reason=executor_rejected}` —
+   the two UNAVAILABLE causes are indistinguishable on the wire but separate in the metric.
 3. **Cancellation check**: if the client has cancelled by execution time, skip mapping; the permit is
    released in a finally block.
 4. **Response semantics**:
    - Server-side error (insert failure) → `UNAVAILABLE` for the whole batch (drives retry, prevents loss)
-   - Client data fault (mapping reject) → OTLP-spec `ExportTracePartialSuccess` (rejectedSpans + errorMessage)
+   - Client data fault (mapping reject) → OTLP-spec `ExportTracePartialSuccess` (rejectedSpans + errorMessage);
+     the same spans are counted per reason in `collector.otlptrace.span.rejected{reason}` (see
+     [Ingest metrics](#ingest-metrics))
    - Unexpected exception in the worker → `INTERNAL` (prevents a poison-data retry storm)
 
 ---
@@ -83,11 +87,12 @@ OTLP exporter
   dispatched on the request Content-Type; the response body mirrors the request encoding (per the
   OTLP/HTTP spec, no Accept negotiation). Any other Content-Type → **415**.
   **`Content-Encoding: gzip` is supported** (decompressed by `OtlpTraceDecompressionFilter`,
-  Content-Type agnostic); any other encoding → **415**.
+  Content-Type agnostic); any other encoding → **415** (`request.rejected{reason=unsupported_encoding}`).
 - Body parsing: raw `byte[]` + explicit branch — protobuf via `ExportTraceServiceRequest.parseFrom`,
   OTLP/JSON via `OtlpJsonTraceParser` (a Jackson streaming rewrite of the spec's hex-encoded
   `traceId`/`spanId`/`parentSpanId` fields to base64, then the standard proto3 `JsonFormat` parse).
-  A body that fails to parse → **400 + `google.rpc.Status`** in the request encoding.
+  A body that fails to parse → **400 + `google.rpc.Status`** in the request encoding
+  (`request.rejected{reason=parse_error}`).
 - Executed synchronously on the Tomcat request thread (no worker offload)
 
 ### Admission Filter (`OtlpTraceHttpAdmissionFilter`)
@@ -95,10 +100,10 @@ OTLP exporter
 Registered only for `/v1/traces` with `Ordered.HIGHEST_PRECEDENCE`, so it runs **before** protobuf
 deserialization. A 3-stage gate:
 
-1. Content-Length > 4MB → **413**. If the length is unknown (chunked), pessimistically reserve 4MB and
-   block on overflow via `LimitedRequestWrapper`.
-2. Concurrent-request Semaphore(64) failure → **503 + Retry-After (1s)**
-3. in-flight byte Semaphore (256MB)
+1. Content-Length > 4MB → **413** (`request.rejected{reason=payload_too_large}`). If the length is
+   unknown (chunked), pessimistically reserve 4MB and block on overflow via `LimitedRequestWrapper`.
+2. Concurrent-request Semaphore(64) failure → **503 + Retry-After (1s)** (`reason=concurrency`)
+3. in-flight byte Semaphore (256MB) failure → **503 + Retry-After (1s)** (`reason=inflight_bytes`)
 
 Permits are released in a finally block after the entire request (parse + insert) completes.
 Config keys: `pinpoint.collector.otlptrace.http.*`
@@ -121,6 +126,7 @@ The gRPC path needs no counterpart (grpc-java decompresses `grpc-encoding: gzip`
 | agentId dedup cache | Shared Caffeine bean (`otlpAgentIdCache`, thread-safe, cross-transport) | Same |
 | Execution thread | Worker executor offload | Synchronous on the Tomcat request thread |
 | Backpressure | UNAVAILABLE | 503 + Retry-After |
+| Rejection metric | `request.rejected{transport=grpc, reason=inflight_bytes\|executor_rejected}` | `request.rejected{transport=http, reason=inflight_bytes\|concurrency\|payload_too_large\|unsupported_encoding\|parse_error}` |
 | partial success | Responds per spec | **Not emitted — always 200 (bug)** |
 | Server-side error | Drives retry via UNAVAILABLE | **Always 200 → silent loss (bug)** |
 
@@ -171,6 +177,58 @@ whether a failure **surfaces before the response**:
 | spanChunk put failure | **Fully ignored** — future discarded + success event always published |
 | scatter index failure | future discarded, no metric — loss that is invisible in scatter |
 | server-map stats | Up to 5s of increments lost on process death (acceptable by design) |
+
+### Ingest metrics
+
+The pre-existing meters count **requests** (`grpc.server.requests.received{service=otlptrace}`,
+`http.server.requests{uri=/v1/traces}`) or **worker tasks** (`grpcOtlpTraceWorkerExecutor.*`, one
+task per gRPC export call). An export call is a batch of arbitrary size, so none of them yields
+spans per second. `OtlpTraceIngestMetrics` adds span-level counters to the same `MeterRegistry`
+(they reach whatever exporter the registry is wired to — no extra configuration):
+
+| Metric | Tags | Meaning |
+|---|---|---|
+| `collector.otlptrace.span.received` | `transport=grpc\|http` | spans carried by accepted export requests, counted before mapping |
+| `collector.otlptrace.span.stored` | `transport`, `type=span\|spanChunk` | root spans / orphan sub-trees handed to storage |
+| `collector.otlptrace.span.rejected` | `transport`, `reason` (table below) | spans dropped during mapping; also reported to the client as `ExportTracePartialSuccess.rejected_spans` |
+| `collector.otlptrace.request.rejected` | `transport`, `reason` (table below) | whole requests refused before mapping; the span count is unknown, so these do not appear in `span.received` |
+| `collector.otlptrace.request.bytes` | `transport` | wire bytes of admitted requests (gRPC serialized size; HTTP declared length, or bytes actually read for chunked bodies). Distribution: count / total / mean / max per step |
+| `collector.otlptrace.admission.inflight.bytes`, `.admission.limit.bytes` | `transport` | bytes currently reserved by the in-flight admission semaphore vs. the budget (`admission.max-in-flight-bytes` / `http.admission.max-in-flight-bytes`); gauges, sampled per step |
+| `collector.otlptrace.admission.inflight.requests`, `.admission.limit.requests` | `transport=http` | requests currently past the concurrency gate vs. `http.max-concurrent-requests` |
+
+Every (transport, reason) series is registered at startup, so it exists at zero before the first
+event. `received − rejected` is the number of spans that made it into transactions/span chunks;
+`received / grpcOtlpTraceWorkerExecutor.submitted` is the average batch size, `request.bytes.total`
+(rate) is the ingress in bytes per second, `request.bytes.max` against the 4MB per-request cap shows
+how close clients run to a 413 / RESOURCE_EXHAUSTED, and `admission.inflight.bytes / admission.limit.bytes`
+is the steady-state utilisation of the in-flight budget — a sub-step spike that hits the budget
+appears only as `request.rejected{reason=inflight_bytes}`.
+
+**Span reject reasons** (`OtlpTraceRejectReason`, tag `reason`) — the tag value is the stable
+identifier; renaming one is a dashboard change:
+
+| `reason` | Where | Cause | Client action |
+|---|---|---|---|
+| `unsampled` | `OtlpTraceMapper.getSpanMap` | W3C trace-flags present with the sampled bit clear | export only sampled spans (SDK sampler / exporter filter) |
+| `invalid_id` | `OtlpTraceMapper.getSpanMap` | trace/span/parent id of wrong length or all-zero | fix the SDK / propagator |
+| `invalid_resource` | `OtlpTraceMapper.getId` | no usable application/agent identifier on the `ResourceSpans` (see the top-level README, *Validation errors*); every span of that resource is rejected | fix `service.name` / `pinpoint.*` resource attributes |
+| `orphan` | end of `OtlpTraceMapper.map` | a non-root span whose parent is not in the request (batch split, dropped parent) | usually benign; check exporter batching if persistent |
+| `mapping_error` | `OtlpTraceMapper.map` (root / span-chunk try-catch) | the mapper threw on a span | collector-side fault candidate — alert on this one |
+
+**Request reject reasons** (`OtlpTraceIngestMetrics.RequestRejectReason`):
+
+| `reason` | Transport | Response | Cause |
+|---|---|---|---|
+| `inflight_bytes` | grpc, http | UNAVAILABLE / 503 + Retry-After | in-flight byte budget exhausted (`admission.max-in-flight-bytes`, `http.admission.max-in-flight-bytes`) |
+| `executor_rejected` | grpc | UNAVAILABLE | worker executor queue full |
+| `concurrency` | http | 503 + Retry-After | `http.max-concurrent-requests` reached |
+| `payload_too_large` | http | 413 | Content-Length above `http.max-request-bytes` |
+| `unsupported_encoding` | http | 415 | `Content-Encoding` other than `gzip` / `identity` |
+| `parse_error` | http | 400 | protobuf/JSON body did not parse |
+
+The first three are capacity signals (retried by the exporter, no loss); the last three are client
+faults (not retried). The gRPC `processing.duration{statusCode=UNAVAILABLE}` count equals
+`inflight_bytes + executor_rejected` for that transport.
 
 ---
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorHttpModule.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorHttpModule.java
@@ -23,6 +23,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
 
 @Configuration
 public class OtlpTraceCollectorHttpModule {
@@ -40,9 +41,10 @@ public class OtlpTraceCollectorHttpModule {
             @Value("${pinpoint.collector.otlptrace.http.max-request-bytes:4194304}") int maxRequestBytes,
             @Value("${pinpoint.collector.otlptrace.http.admission.max-in-flight-bytes:268435456}") int maxInFlightBytes,
             @Value("${pinpoint.collector.otlptrace.http.max-concurrent-requests:64}") int maxConcurrentRequests,
-            @Value("${pinpoint.collector.otlptrace.http.rejected.retry-after-seconds:1}") int retryAfterSeconds) {
+            @Value("${pinpoint.collector.otlptrace.http.rejected.retry-after-seconds:1}") int retryAfterSeconds,
+            OtlpTraceIngestMetrics ingestMetrics) {
         OtlpTraceHttpAdmissionFilter filter =
-                new OtlpTraceHttpAdmissionFilter(maxRequestBytes, maxInFlightBytes, maxConcurrentRequests, retryAfterSeconds);
+                new OtlpTraceHttpAdmissionFilter(maxRequestBytes, maxInFlightBytes, maxConcurrentRequests, retryAfterSeconds, ingestMetrics);
         FilterRegistrationBean<OtlpTraceHttpAdmissionFilter> registration = new FilterRegistrationBean<>(filter);
         registration.addUrlPatterns(OTLP_HTTP_TRACES_PATH);
         registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
@@ -57,8 +59,9 @@ public class OtlpTraceCollectorHttpModule {
      */
     @Bean
     public FilterRegistrationBean<OtlpTraceDecompressionFilter> otlpTraceDecompressionFilter(
-            @Value("${pinpoint.collector.otlptrace.http.max-decompressed-request-bytes:16777216}") int maxDecompressedBytes) {
-        OtlpTraceDecompressionFilter filter = new OtlpTraceDecompressionFilter(maxDecompressedBytes);
+            @Value("${pinpoint.collector.otlptrace.http.max-decompressed-request-bytes:16777216}") int maxDecompressedBytes,
+            OtlpTraceIngestMetrics ingestMetrics) {
+        OtlpTraceDecompressionFilter filter = new OtlpTraceDecompressionFilter(maxDecompressedBytes, ingestMetrics);
         FilterRegistrationBean<OtlpTraceDecompressionFilter> registration = new FilterRegistrationBean<>(filter);
         registration.addUrlPatterns(OTLP_HTTP_TRACES_PATH);
         registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 1);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
@@ -32,6 +32,7 @@ import com.navercorp.pinpoint.common.server.util.IgnoreAddressFilter;
 import com.navercorp.pinpoint.grpc.channelz.ChannelzRegistry;
 import com.navercorp.pinpoint.otlp.trace.collector.service.GrpcOtlpTraceService;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportService;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpUriStatService;
 import com.navercorp.pinpoint.pinot.tenant.TenantProvider;
 import com.navercorp.pinpoint.uristat.collector.UriStatCollectorConfig;
@@ -104,8 +105,9 @@ public class OtlpTraceCollectorModule {
     public ServerServiceDefinition serverServiceDefinition(OtlpTraceExportService exportService,
                                                            @Qualifier("grpcOtlpTraceWorkerExecutor") Executor workerExecutor,
                                                            @Value("${pinpoint.collector.otlptrace.admission.max-in-flight-bytes:268435456}") int maxInFlightBytes,
+                                                           OtlpTraceIngestMetrics ingestMetrics,
                                                            MeterRegistry meterRegistry) {
-        BindableService spanService = new GrpcOtlpTraceService(exportService, workerExecutor, maxInFlightBytes);
+        BindableService spanService = new GrpcOtlpTraceService(exportService, workerExecutor, maxInFlightBytes, ingestMetrics);
         // gRPC server metrics (request count / latency / status code) for the OTLP trace endpoint,
         // tagged service=otlptrace to match the agent/stat/span receivers' metrics.
         final ServerInterceptor metricInterceptor = new MetricCollectingServerInterceptor(meterRegistry,

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorRejectedSpan.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorRejectedSpan.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2026 NAVER Corp.
+ * Copyright 2024 NAVER Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,18 +17,41 @@
 package com.navercorp.pinpoint.otlp.trace.collector;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
+/**
+ * Per-request tally of spans rejected during mapping (client-side data faults). The total and the
+ * message list feed the OTLP {@code ExportTracePartialSuccess} response; the per-reason counts feed
+ * the {@code collector.otlptrace.span.rejected{reason}} metric so the same rejections are visible
+ * as a server-side time series and not only in the client's response.
+ */
 public class OtlpTraceCollectorRejectedSpan {
     private long count;
-    private List<String> messageList = new ArrayList<>();
+    private final Map<OtlpTraceRejectReason, Long> countByReason = new EnumMap<>(OtlpTraceRejectReason.class);
+    private final List<String> messageList = new ArrayList<>();
 
     public long count() {
         return count;
     }
 
-    public void addCount(long count) {
+    public void addCount(OtlpTraceRejectReason reason, long count) {
+        if (count <= 0) {
+            return;
+        }
         this.count += count;
+        this.countByReason.merge(reason, count, Long::sum);
+    }
+
+    public long count(OtlpTraceRejectReason reason) {
+        return countByReason.getOrDefault(reason, 0L);
+    }
+
+    /** Rejected span count per reason; only reasons that occurred are present. */
+    public Map<OtlpTraceRejectReason, Long> countByReason() {
+        return Collections.unmodifiableMap(countByReason);
     }
 
     public String getMessage() {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceRejectReason.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceRejectReason.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector;
+
+/**
+ * Why a span was rejected during mapping (a client-side data fault reported back through the OTLP
+ * {@code ExportTracePartialSuccess} and counted per reason in the
+ * {@code collector.otlptrace.span.rejected} metric). The {@link #tagValue()} is the stable
+ * identifier used both as the metric {@code reason} tag and in the README, so a rename here is a
+ * dashboard change.
+ */
+public enum OtlpTraceRejectReason {
+    /** W3C trace-flags present with the sampled bit clear: the span is not part of a sampled trace. */
+    UNSAMPLED("unsampled", "unsampled span"),
+    /** Malformed trace/span/parent id (wrong length or all-zero). */
+    INVALID_ID("invalid_id", "invalid id"),
+    /** The ResourceSpans carries no usable application/agent identifier (validation failure). */
+    INVALID_RESOURCE("invalid_resource", "invalid resource"),
+    /** A non-root span whose parent is not in the request, so it could not be linked into a trace. */
+    ORPHAN("orphan", "orphan span"),
+    /** The mapper threw while converting a root span or a span chunk (collector-side fault candidate). */
+    MAPPING_ERROR("mapping_error", "mapping error");
+
+    private final String tagValue;
+    private final String message;
+
+    OtlpTraceRejectReason(String tagValue, String message) {
+        this.tagValue = tagValue;
+        this.message = message;
+    }
+
+    /** Metric tag value (snake_case), also the identifier documented in the README. */
+    public String tagValue() {
+        return tagValue;
+    }
+
+    /** Human-readable label used in the partial-success error message, e.g. {@code invalid id (3)}. */
+    public String message() {
+        return message;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceController.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceController.java
@@ -23,6 +23,7 @@ import com.google.rpc.Code;
 import com.google.rpc.Status;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportResult;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportService;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceResponseMapper;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
@@ -46,9 +47,11 @@ public class OtlpTraceController {
     private static final JsonFormat.Printer JSON_PRINTER = JsonFormat.printer().omittingInsignificantWhitespace();
 
     private final OtlpTraceExportService exportService;
+    private final OtlpTraceIngestMetrics ingestMetrics;
 
-    public OtlpTraceController(OtlpTraceExportService exportService) {
+    public OtlpTraceController(OtlpTraceExportService exportService, OtlpTraceIngestMetrics ingestMetrics) {
         this.exportService = Objects.requireNonNull(exportService, "exportService");
+        this.ingestMetrics = Objects.requireNonNull(ingestMetrics, "ingestMetrics");
     }
 
     // OTLP/HTTP response semantics (M-1), shared with the gRPC path via OtlpTraceResponseMapper:
@@ -68,6 +71,7 @@ public class OtlpTraceController {
         try {
             request = parseRequest(body, json);
         } catch (InvalidProtocolBufferException | OtlpTraceParseException e) {
+            ingestMetrics.requestRejected(OtlpTraceIngestMetrics.Transport.HTTP, OtlpTraceIngestMetrics.RequestRejectReason.PARSE_ERROR);
             final Status status = Status.newBuilder()
                     .setCode(Code.INVALID_ARGUMENT_VALUE)
                     .setMessage(errorMessage(e))
@@ -78,7 +82,7 @@ public class OtlpTraceController {
         }
 
         final List<ResourceSpans> resourceSpanList = request.getResourceSpansList();
-        final OtlpTraceExportResult result = exportService.export(resourceSpanList);
+        final OtlpTraceExportResult result = exportService.export(resourceSpanList, OtlpTraceIngestMetrics.Transport.HTTP);
 
         if (OtlpTraceResponseMapper.isServerError(result)) {
             // Mirror the gRPC UNAVAILABLE path with a retryable 503 carrying a google.rpc.Status body,

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceDecompressionFilter.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceDecompressionFilter.java
@@ -16,6 +16,7 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.controller;
 
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletException;
@@ -34,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Objects;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -69,9 +71,11 @@ public class OtlpTraceDecompressionFilter extends OncePerRequestFilter {
     private final Logger logger = LogManager.getLogger(this.getClass());
 
     private final int maxDecompressedBytes;
+    private final OtlpTraceIngestMetrics ingestMetrics;
 
-    public OtlpTraceDecompressionFilter(int maxDecompressedBytes) {
+    public OtlpTraceDecompressionFilter(int maxDecompressedBytes, OtlpTraceIngestMetrics ingestMetrics) {
         this.maxDecompressedBytes = maxDecompressedBytes;
+        this.ingestMetrics = Objects.requireNonNull(ingestMetrics, "ingestMetrics");
     }
 
     @Override
@@ -87,6 +91,7 @@ public class OtlpTraceDecompressionFilter extends OncePerRequestFilter {
             // Only gzip is defined for OTLP/HTTP; reject anything else (incl. multi-encoding) explicitly
             // rather than letting an undecoded body fail later as an opaque 400.
             logger.warn("OTLP/HTTP trace request rejected. Unsupported Content-Encoding={}", encoding);
+            ingestMetrics.requestRejected(OtlpTraceIngestMetrics.Transport.HTTP, OtlpTraceIngestMetrics.RequestRejectReason.UNSUPPORTED_ENCODING);
             response.setStatus(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
             return;
         }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceHttpAdmissionFilter.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceHttpAdmissionFilter.java
@@ -16,6 +16,8 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.controller;
 
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics.RequestRejectReason;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletException;
@@ -28,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.Semaphore;
 
 /**
@@ -61,14 +64,23 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
     private final Semaphore admissionBytes;
     // Request-count gate: guards the servlet thread pool against a flood of small requests.
     private final Semaphore concurrency;
+    private final OtlpTraceIngestMetrics ingestMetrics;
 
-    public OtlpTraceHttpAdmissionFilter(int maxRequestBytes, int maxInFlightBytes, int maxConcurrentRequests, int retryAfterSeconds) {
+    public OtlpTraceHttpAdmissionFilter(int maxRequestBytes, int maxInFlightBytes, int maxConcurrentRequests, int retryAfterSeconds,
+                                        OtlpTraceIngestMetrics ingestMetrics) {
+        this.ingestMetrics = Objects.requireNonNull(ingestMetrics, "ingestMetrics");
         this.maxRequestBytes = maxRequestBytes;
         this.maxInFlightBytes = maxInFlightBytes;
         this.maxConcurrentRequests = maxConcurrentRequests;
         this.retryAfterSeconds = retryAfterSeconds;
         this.admissionBytes = new Semaphore(maxInFlightBytes);
         this.concurrency = new Semaphore(maxConcurrentRequests);
+        // Gate occupancy gauges (sampled per export step); both budgets are HTTP-only, kept separate
+        // from the gRPC admission on purpose.
+        ingestMetrics.registerInFlightBytes(OtlpTraceIngestMetrics.Transport.HTTP,
+                () -> (long) maxInFlightBytes - admissionBytes.availablePermits(), maxInFlightBytes);
+        ingestMetrics.registerInFlightRequests(OtlpTraceIngestMetrics.Transport.HTTP,
+                () -> maxConcurrentRequests - concurrency.availablePermits(), maxConcurrentRequests);
     }
 
     @Override
@@ -78,7 +90,7 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
         // 1) Size cap: reject before the body is buffered/parsed.
         final long contentLength = request.getContentLengthLong();
         if (contentLength > maxRequestBytes) {
-            reject(response, HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, false,
+            reject(response, HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, false, RequestRejectReason.PAYLOAD_TOO_LARGE,
                     "payload too large: contentLength=" + contentLength + ", max=" + maxRequestBytes);
             return;
         }
@@ -88,36 +100,48 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
 
         // 2) Concurrency gate.
         if (!concurrency.tryAcquire()) {
-            reject(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, true,
+            reject(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, true, RequestRejectReason.CONCURRENCY,
                     "concurrency limit exceeded: max=" + maxConcurrentRequests);
             return;
         }
         // 3) In-flight byte gate.
         if (!admissionBytes.tryAcquire(reserveBytes)) {
             concurrency.release();
-            reject(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, true,
+            reject(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, true, RequestRejectReason.INFLIGHT_BYTES,
                     "in-flight byte budget exhausted: reserve=" + reserveBytes + ", budget=" + maxInFlightBytes);
             return;
         }
 
+        // Wire bytes of the admitted request: the declared length, or — for a chunked body — what was
+        // actually read through the limiting stream (recorded after the request completes).
+        LimitedRequestWrapper limited = null;
         try {
-            final HttpServletRequest effectiveRequest = contentLength >= 0
-                    ? request
-                    // Unknown length: cap the stream so a chunked body cannot exceed maxRequestBytes in heap.
-                    : new LimitedRequestWrapper(request, maxRequestBytes);
+            final HttpServletRequest effectiveRequest;
+            if (contentLength >= 0) {
+                effectiveRequest = request;
+                ingestMetrics.requestBytes(OtlpTraceIngestMetrics.Transport.HTTP, contentLength);
+            } else {
+                // Unknown length: cap the stream so a chunked body cannot exceed maxRequestBytes in heap.
+                limited = new LimitedRequestWrapper(request, maxRequestBytes);
+                effectiveRequest = limited;
+            }
             filterChain.doFilter(effectiveRequest, response);
         } finally {
+            if (limited != null) {
+                ingestMetrics.requestBytes(OtlpTraceIngestMetrics.Transport.HTTP, limited.bytesRead());
+            }
             admissionBytes.release(reserveBytes);
             concurrency.release();
         }
     }
 
-    private void reject(HttpServletResponse response, int status, boolean retryable, String reason) {
+    private void reject(HttpServletResponse response, int status, boolean retryable, RequestRejectReason reason, String detail) {
         if (retryable) {
             response.setHeader("Retry-After", Integer.toString(retryAfterSeconds));
         }
         response.setStatus(status);
-        logger.warn("OTLP/HTTP trace request rejected. status={}, reason={}", status, reason);
+        ingestMetrics.requestRejected(OtlpTraceIngestMetrics.Transport.HTTP, reason);
+        logger.warn("OTLP/HTTP trace request rejected. status={}, reason={}, {}", status, reason.tagValue(), detail);
     }
 
     /**
@@ -125,6 +149,7 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
      */
     private static final class LimitedRequestWrapper extends HttpServletRequestWrapper {
         private final long limit;
+        private LimitedServletInputStream stream;
 
         private LimitedRequestWrapper(HttpServletRequest request, long limit) {
             super(request);
@@ -133,7 +158,15 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
 
         @Override
         public ServletInputStream getInputStream() throws IOException {
-            return new LimitedServletInputStream(super.getInputStream(), limit);
+            if (stream == null) {
+                stream = new LimitedServletInputStream(super.getInputStream(), limit);
+            }
+            return stream;
+        }
+
+        /** Bytes read so far through the limiting stream (0 when the body was never opened). */
+        long bytesRead() {
+            return stream == null ? 0 : stream.count;
         }
     }
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapper.java
@@ -25,6 +25,7 @@ import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
 import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceRejectReason;
 import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import io.opentelemetry.proto.common.v1.InstrumentationScope;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
@@ -88,7 +89,10 @@ public class OtlpTraceMapper {
     // link span, find parentSpanId
     public OtlpTraceMapperData map(List<ResourceSpans> resourceSpanList) {
         final OtlpTraceMapperData mapperData = new OtlpTraceMapperData();
-        int errorCount = 0;
+        // Two distinct reject reasons that used to share one "mapping error" bucket: a mapper
+        // exception (collector-side fault candidate) vs. spans left unlinkable (client batching).
+        int mappingErrorCount = 0;
+        int orphanCount = 0;
         for (ResourceSpans resourceSpan : resourceSpanList) {
             final Map<String, AttributeValue> resourceAttributeMap = OtlpTraceMapperUtils.getAttributeValueMap(resourceSpan.getResource().getAttributesList());
             final IdAndName idAndName = getId(mapperData, resourceSpan, resourceAttributeMap);
@@ -156,7 +160,7 @@ public class OtlpTraceMapper {
                                     uriStatKey, spanBo.getStartTimeMillis(), spanBo.getElapsed(), spanBo.getErrCode() != 0));
                         }
                     } catch (Exception e) {
-                        errorCount++;
+                        mappingErrorCount++;
                         logMappingError("Failed to map span", e);
                     }
                 }
@@ -169,7 +173,7 @@ public class OtlpTraceMapper {
                             mapperData.addSpanChunkBo(spanChunkBo);
                         }
                     } catch (Exception e) {
-                        errorCount++;
+                        mappingErrorCount++;
                         logMappingError("Failed to map spanChunk", e);
                     }
                 }
@@ -178,16 +182,21 @@ public class OtlpTraceMapper {
                     // Orphan/cyclic spans that couldn't be linked into any trace tree are dropped.
                     // Reflected to the client via the rejected-span count rather than an operator log
                     // (client-data shape issue, and dumping every span would risk log flooding).
-                    errorCount += childSpanList.size();
+                    orphanCount += childSpanList.size();
                     logger.debug("Dropped unknown spans count={}", childSpanList.size());
                 }
             }
         }
 
-        if (errorCount > 0) {
+        if (mappingErrorCount > 0) {
             OtlpTraceCollectorRejectedSpan rejectedSpan = mapperData.getRejectedSpan();
-            rejectedSpan.putMessage("mapping error (" + errorCount + ")");
-            rejectedSpan.addCount(errorCount);
+            rejectedSpan.putMessage(OtlpTraceRejectReason.MAPPING_ERROR.message() + " (" + mappingErrorCount + ")");
+            rejectedSpan.addCount(OtlpTraceRejectReason.MAPPING_ERROR, mappingErrorCount);
+        }
+        if (orphanCount > 0) {
+            OtlpTraceCollectorRejectedSpan rejectedSpan = mapperData.getRejectedSpan();
+            rejectedSpan.putMessage(OtlpTraceRejectReason.ORPHAN.message() + " (" + orphanCount + ")");
+            rejectedSpan.addCount(OtlpTraceRejectReason.ORPHAN, orphanCount);
         }
         return mapperData;
     }
@@ -233,9 +242,11 @@ public class OtlpTraceMapper {
 
     private void reject(OtlpTraceMapperData mapperData, ResourceSpans resourceSpan, String message) {
         OtlpTraceCollectorRejectedSpan rejectedSpan = mapperData.getRejectedSpan();
-        int spansCount = resourceSpan.getScopeSpansCount();
+        // Every span of the ResourceSpans is dropped with it. (This used to add getScopeSpansCount(),
+        // the number of scope blocks, which under-reported rejected_spans to the client.)
+        int spansCount = OtlpTraceMapperUtils.countSpans(resourceSpan);
         rejectedSpan.putMessage(message + " (" + spansCount + ")");
-        rejectedSpan.addCount(spansCount);
+        rejectedSpan.addCount(OtlpTraceRejectReason.INVALID_RESOURCE, spansCount);
     }
 
     Map<ByteString, List<ScopedSpan>> getSpanMap(List<ScopeSpans> scopeSpanList, OtlpTraceCollectorRejectedSpan rejectedSpan) {
@@ -270,14 +281,14 @@ public class OtlpTraceMapper {
             // stats. Reflected to the client via the rejected-span count (same policy as the
             // orphan-span drop); debug-level log only — a client-data shape issue, and dumping
             // every span would risk log flooding.
-            rejectedSpan.putMessage("unsampled span (" + unsampledCount + ")");
-            rejectedSpan.addCount(unsampledCount);
+            rejectedSpan.putMessage(OtlpTraceRejectReason.UNSAMPLED.message() + " (" + unsampledCount + ")");
+            rejectedSpan.addCount(OtlpTraceRejectReason.UNSAMPLED, unsampledCount);
             logger.debug("Dropped unsampled spans count={}", unsampledCount);
         }
         if (invalidIdCount > 0) {
             // Same client-data reject policy as above: count into rejected_spans, debug log only.
-            rejectedSpan.putMessage("invalid id (" + invalidIdCount + ")");
-            rejectedSpan.addCount(invalidIdCount);
+            rejectedSpan.putMessage(OtlpTraceRejectReason.INVALID_ID.message() + " (" + invalidIdCount + ")");
+            rejectedSpan.addCount(OtlpTraceRejectReason.INVALID_ID, invalidIdCount);
             logger.debug("Dropped spans with invalid trace/span id count={}", invalidIdCount);
         }
         return spanMap;

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtils.java
@@ -32,6 +32,8 @@ import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.InstrumentationScope;
 import io.opentelemetry.proto.common.v1.ArrayValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
@@ -44,6 +46,23 @@ import java.util.UUID;
 import java.util.function.Predicate;
 
 public class OtlpTraceMapperUtils {
+
+    /** Number of spans carried by the export request, regardless of what happens to them later. */
+    public static int countSpans(List<ResourceSpans> resourceSpanList) {
+        int count = 0;
+        for (ResourceSpans resourceSpans : resourceSpanList) {
+            count += countSpans(resourceSpans);
+        }
+        return count;
+    }
+
+    public static int countSpans(ResourceSpans resourceSpans) {
+        int count = 0;
+        for (ScopeSpans scopeSpans : resourceSpans.getScopeSpansList()) {
+            count += scopeSpans.getSpansCount();
+        }
+        return count;
+    }
     private static final String KEY_AGENT_ID = "pinpoint.agentId";
     private static final String KEY_AGENT_NAME = "pinpoint.agentName";
     private static final String KEY_APPLICATION_NAME = "pinpoint.applicationName";

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceService.java
@@ -49,12 +49,18 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
     // so concurrent requests cannot exhaust the heap regardless of request count or connection count.
     private final Semaphore admissionBytes;
     private final int maxInFlightBytes;
+    private final OtlpTraceIngestMetrics ingestMetrics;
 
-    public GrpcOtlpTraceService(OtlpTraceExportService exportService, Executor workerExecutor, int maxInFlightBytes) {
+    public GrpcOtlpTraceService(OtlpTraceExportService exportService, Executor workerExecutor, int maxInFlightBytes,
+                                OtlpTraceIngestMetrics ingestMetrics) {
         this.exportService = Objects.requireNonNull(exportService, "exportService");
         this.workerExecutor = Objects.requireNonNull(workerExecutor, "workerExecutor");
+        this.ingestMetrics = Objects.requireNonNull(ingestMetrics, "ingestMetrics");
         this.maxInFlightBytes = maxInFlightBytes;
         this.admissionBytes = new Semaphore(maxInFlightBytes);
+        // reserved = budget - free permits; sampled per export step (see OtlpTraceIngestMetrics).
+        ingestMetrics.registerInFlightBytes(OtlpTraceIngestMetrics.Transport.GRPC,
+                () -> (long) maxInFlightBytes - admissionBytes.availablePermits(), maxInFlightBytes);
     }
 
     @Override
@@ -66,9 +72,12 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
         final int requestBytes = request.getSerializedSize();
         if (!admissionBytes.tryAcquire(requestBytes)) {
             logger.warn("Failed to export. In-flight byte budget exhausted. requestBytes={}, budget={}", requestBytes, maxInFlightBytes);
+            ingestMetrics.requestRejected(OtlpTraceIngestMetrics.Transport.GRPC, OtlpTraceIngestMetrics.RequestRejectReason.INFLIGHT_BYTES);
             safeOnError(responseObserver, ADMISSION_REJECTED);
             return;
         }
+
+        ingestMetrics.requestBytes(OtlpTraceIngestMetrics.Transport.GRPC, requestBytes);
 
         final List<ResourceSpans> resourceSpanList = request.getResourceSpansList();
         // Offload the mapping/insert work onto the worker pool so the gRPC handler thread
@@ -99,12 +108,13 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
         } catch (RejectedExecutionException e) {
             admissionBytes.release(requestBytes);
             logger.warn("Failed to export. Worker executor rejected.");
+            ingestMetrics.requestRejected(OtlpTraceIngestMetrics.Transport.GRPC, OtlpTraceIngestMetrics.RequestRejectReason.EXECUTOR_REJECTED);
             safeOnError(responseObserver, EXECUTOR_REJECTED);
         }
     }
 
     private void handleExport(List<ResourceSpans> resourceSpanList, StreamObserver<ExportTraceServiceResponse> responseObserver) {
-        final OtlpTraceExportResult result = exportService.export(resourceSpanList);
+        final OtlpTraceExportResult result = exportService.export(resourceSpanList, OtlpTraceIngestMetrics.Transport.GRPC);
 
         if (OtlpTraceResponseMapper.isServerError(result)) {
             // Server-side / transient failures (HBase insert, agentInfo): ask the client to retry

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
@@ -26,8 +26,10 @@ import com.navercorp.pinpoint.common.server.bo.SpanChunkBo;
 import com.navercorp.pinpoint.common.server.bo.exception.ExceptionMetaDataBo;
 import com.navercorp.pinpoint.common.server.uid.ServiceUidSupplier;
 import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceRejectReason;
 import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapper;
 import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperData;
+import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperUtils;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
@@ -38,6 +40,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -77,6 +80,9 @@ public class OtlpTraceExportService {
     // Null unless both uristat flags are enabled (the bean is conditional).
     private final OtlpUriStatService uriStatService;
 
+    // Span-level ingest volume (received / stored / rejected-by-reason), per transport.
+    private final OtlpTraceIngestMetrics ingestMetrics;
+
     private final Counter spanInsertErrorCounter;
     private final Counter spanChunkInsertErrorCounter;
     private final Counter agentInfoInsertErrorCounter;
@@ -90,6 +96,7 @@ public class OtlpTraceExportService {
                                   Optional<ExceptionMetaDataService> exceptionMetaDataService,
                                   Optional<OtlpUriStatService> uriStatService,
                                   @Qualifier("otlpAgentIdCache") Cache<String, Boolean> agentIdCache,
+                                  OtlpTraceIngestMetrics ingestMetrics,
                                   MeterRegistry meterRegistry) {
         this.traceServiceList = Objects.requireNonNull(traceServiceList, "traceServiceList");
         this.agentInfoService = Objects.requireNonNull(agentInfoService, "agentInfoService");
@@ -98,6 +105,7 @@ public class OtlpTraceExportService {
         this.exceptionMetaDataService = exceptionMetaDataService.orElse(null);
         this.agentIdCache = Objects.requireNonNull(agentIdCache, "agentIdCache");
         this.uriStatService = uriStatService.orElse(null);
+        this.ingestMetrics = Objects.requireNonNull(ingestMetrics, "ingestMetrics");
         Objects.requireNonNull(meterRegistry, "meterRegistry");
         this.spanInsertErrorCounter = insertErrorCounter(meterRegistry, "span");
         this.spanChunkInsertErrorCounter = insertErrorCounter(meterRegistry, "spanChunk");
@@ -113,10 +121,23 @@ public class OtlpTraceExportService {
                 .register(meterRegistry);
     }
 
-    public OtlpTraceExportResult export(List<ResourceSpans> resourceSpanList) {
+    /**
+     * Maps and stores one export request. {@code transport} only tags the ingest metrics; the
+     * response semantics are transport-agnostic (see {@link OtlpTraceResponseMapper}).
+     */
+    public OtlpTraceExportResult export(List<ResourceSpans> resourceSpanList, OtlpTraceIngestMetrics.Transport transport) {
+        // Raw span count of the request, before mapping: the only place spans/sec can be measured
+        // (a request / worker task is a batch of arbitrary size).
+        ingestMetrics.spanReceived(transport, OtlpTraceMapperUtils.countSpans(resourceSpanList));
+
         final OtlpTraceMapperData otlpTraceMapperData = otlpTraceMapper.map(resourceSpanList);
         // Mapping rejects (invalid ids, unlinkable/orphan spans) are client-side data faults.
         final OtlpTraceCollectorRejectedSpan clientRejected = otlpTraceMapperData.getRejectedSpan();
+        for (Map.Entry<OtlpTraceRejectReason, Long> rejected : clientRejected.countByReason().entrySet()) {
+            ingestMetrics.spanRejected(transport, rejected.getKey(), rejected.getValue());
+        }
+        ingestMetrics.spanStored(transport, otlpTraceMapperData.getSpanBoList().size());
+        ingestMetrics.spanChunkStored(transport, otlpTraceMapperData.getSpanChunkBoList().size());
 
         int insertErrorCount = 0;
         for (SpanBo spanBo : otlpTraceMapperData.getSpanBoList()) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceIngestMetrics.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceIngestMetrics.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceRejectReason;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
+
+/**
+ * Ingest-volume counters for the OTLP trace endpoints, shared by the gRPC and HTTP transports.
+ * <p>
+ * The pre-existing meters count <em>requests</em> ({@code grpc.server.requests.received},
+ * {@code http.server.requests}) or <em>worker tasks</em> ({@code grpcOtlpTraceWorkerExecutor.*}, one
+ * task per export call); an export call carries a batch of spans, so none of them yields spans per
+ * second. These counters fill that gap at the span level and split the two rejection classes:
+ * <ul>
+ *   <li>{@code collector.otlptrace.span.received{transport}} — spans carried by accepted export
+ *       requests, before mapping.</li>
+ *   <li>{@code collector.otlptrace.span.stored{transport,type}} — root spans ({@code span}) and
+ *       orphan sub-trees ({@code spanChunk}) handed to storage.</li>
+ *   <li>{@code collector.otlptrace.span.rejected{transport,reason}} — spans dropped during mapping,
+ *       by {@link OtlpTraceRejectReason}. These are also reported to the client as
+ *       {@code ExportTracePartialSuccess}.</li>
+ *   <li>{@code collector.otlptrace.request.rejected{transport,reason}} — whole requests refused before
+ *       mapping (admission / parse), where the span count is unknown, by {@link RequestRejectReason}.</li>
+ *   <li>{@code collector.otlptrace.request.bytes{transport}} — wire bytes of admitted requests
+ *       (distribution: count / total / mean / max per step), so bytes per second, average batch size
+ *       and headroom against the per-request cap are visible.</li>
+ *   <li>{@code collector.otlptrace.admission.inflight.bytes{transport}} and
+ *       {@code .admission.limit.bytes{transport}} — bytes currently reserved by the in-flight
+ *       admission semaphore vs. its budget; {@code .admission.inflight.requests} /
+ *       {@code .admission.limit.requests} likewise for the HTTP concurrency gate. Gauges are sampled
+ *       per step, so sub-step spikes show up only through {@code request.rejected{inflight_bytes}}.</li>
+ * </ul>
+ * Every (transport, reason) combination is registered up front so the series exist at zero before
+ * the first event; a dashboard repeating on {@code reason} then shows a stable panel set. Callers
+ * only call {@link Counter#increment(double)} on the pre-built counters — no registry lookup on the
+ * hot path. All counters live in the collector's {@link MeterRegistry}, so they reach whichever
+ * exporter that registry is wired to (NPOT in the NAVER deployment) without extra configuration.
+ */
+@Component
+public class OtlpTraceIngestMetrics {
+
+    public static final String SPAN_RECEIVED = "collector.otlptrace.span.received";
+    public static final String SPAN_STORED = "collector.otlptrace.span.stored";
+    public static final String SPAN_REJECTED = "collector.otlptrace.span.rejected";
+    public static final String REQUEST_REJECTED = "collector.otlptrace.request.rejected";
+    public static final String REQUEST_BYTES = "collector.otlptrace.request.bytes";
+    public static final String ADMISSION_INFLIGHT_BYTES = "collector.otlptrace.admission.inflight.bytes";
+    public static final String ADMISSION_LIMIT_BYTES = "collector.otlptrace.admission.limit.bytes";
+    public static final String ADMISSION_INFLIGHT_REQUESTS = "collector.otlptrace.admission.inflight.requests";
+    public static final String ADMISSION_LIMIT_REQUESTS = "collector.otlptrace.admission.limit.requests";
+
+    public static final String TAG_TRANSPORT = "transport";
+    public static final String TAG_TYPE = "type";
+    public static final String TAG_REASON = "reason";
+
+    public static final String TYPE_SPAN = "span";
+    public static final String TYPE_SPAN_CHUNK = "spanChunk";
+
+    public enum Transport {
+        GRPC("grpc"),
+        HTTP("http");
+
+        private final String tagValue;
+
+        Transport(String tagValue) {
+            this.tagValue = tagValue;
+        }
+
+        public String tagValue() {
+            return tagValue;
+        }
+    }
+
+    /**
+     * Why a whole export request was refused before its spans were parsed or mapped. The response
+     * the client sees is listed per reason; every one of them is retryable except the client faults
+     * ({@code payload_too_large}, {@code unsupported_encoding}, {@code parse_error}).
+     */
+    public enum RequestRejectReason {
+        /** gRPC / HTTP: the in-flight byte budget is exhausted (gRPC UNAVAILABLE, HTTP 503 + Retry-After). */
+        INFLIGHT_BYTES("inflight_bytes"),
+        /** gRPC: the worker executor queue is full (UNAVAILABLE). */
+        EXECUTOR_REJECTED("executor_rejected"),
+        /** HTTP: the concurrent-request cap is reached (503 + Retry-After). */
+        CONCURRENCY("concurrency"),
+        /** HTTP: Content-Length above the per-request cap (413). */
+        PAYLOAD_TOO_LARGE("payload_too_large"),
+        /** HTTP: Content-Encoding other than gzip/identity (415). */
+        UNSUPPORTED_ENCODING("unsupported_encoding"),
+        /** HTTP: the protobuf/JSON body did not parse (400). */
+        PARSE_ERROR("parse_error");
+
+        private final String tagValue;
+
+        RequestRejectReason(String tagValue) {
+            this.tagValue = tagValue;
+        }
+
+        public String tagValue() {
+            return tagValue;
+        }
+    }
+
+    private static final Set<RequestRejectReason> GRPC_REQUEST_REASONS =
+            EnumSet.of(RequestRejectReason.INFLIGHT_BYTES, RequestRejectReason.EXECUTOR_REJECTED);
+    private static final Set<RequestRejectReason> HTTP_REQUEST_REASONS =
+            EnumSet.of(RequestRejectReason.INFLIGHT_BYTES, RequestRejectReason.CONCURRENCY,
+                    RequestRejectReason.PAYLOAD_TOO_LARGE, RequestRejectReason.UNSUPPORTED_ENCODING,
+                    RequestRejectReason.PARSE_ERROR);
+
+    private final Map<Transport, Counter> received = new EnumMap<>(Transport.class);
+    private final Map<Transport, Counter> storedSpan = new EnumMap<>(Transport.class);
+    private final Map<Transport, Counter> storedSpanChunk = new EnumMap<>(Transport.class);
+    private final Map<Transport, Map<OtlpTraceRejectReason, Counter>> spanRejected = new EnumMap<>(Transport.class);
+    private final Map<Transport, Map<RequestRejectReason, Counter>> requestRejected = new EnumMap<>(Transport.class);
+    private final Map<Transport, DistributionSummary> requestBytes = new EnumMap<>(Transport.class);
+    private final MeterRegistry meterRegistry;
+
+    public OtlpTraceIngestMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry");
+        for (Transport transport : Transport.values()) {
+            requestBytes.put(transport, DistributionSummary.builder(REQUEST_BYTES)
+                    .description("Wire bytes of admitted OTLP export requests (gRPC serialized size / HTTP body)")
+                    .baseUnit("bytes")
+                    .tag(TAG_TRANSPORT, transport.tagValue())
+                    .register(meterRegistry));
+            received.put(transport, Counter.builder(SPAN_RECEIVED)
+                    .description("OTLP spans carried by accepted export requests, before mapping")
+                    .tag(TAG_TRANSPORT, transport.tagValue())
+                    .register(meterRegistry));
+            storedSpan.put(transport, storedCounter(meterRegistry, transport, TYPE_SPAN));
+            storedSpanChunk.put(transport, storedCounter(meterRegistry, transport, TYPE_SPAN_CHUNK));
+
+            final Map<OtlpTraceRejectReason, Counter> byReason = new EnumMap<>(OtlpTraceRejectReason.class);
+            for (OtlpTraceRejectReason reason : OtlpTraceRejectReason.values()) {
+                byReason.put(reason, Counter.builder(SPAN_REJECTED)
+                        .description("OTLP spans rejected during mapping (client data fault, reported as partial success)")
+                        .tag(TAG_TRANSPORT, transport.tagValue())
+                        .tag(TAG_REASON, reason.tagValue())
+                        .register(meterRegistry));
+            }
+            spanRejected.put(transport, byReason);
+
+            final Map<RequestRejectReason, Counter> requestByReason = new EnumMap<>(RequestRejectReason.class);
+            final Set<RequestRejectReason> reasons = transport == Transport.GRPC ? GRPC_REQUEST_REASONS : HTTP_REQUEST_REASONS;
+            for (RequestRejectReason reason : reasons) {
+                requestByReason.put(reason, Counter.builder(REQUEST_REJECTED)
+                        .description("OTLP export requests refused before mapping (admission or parse failure)")
+                        .tag(TAG_TRANSPORT, transport.tagValue())
+                        .tag(TAG_REASON, reason.tagValue())
+                        .register(meterRegistry));
+            }
+            requestRejected.put(transport, requestByReason);
+        }
+    }
+
+    private static Counter storedCounter(MeterRegistry meterRegistry, Transport transport, String type) {
+        return Counter.builder(SPAN_STORED)
+                .description("OTLP root spans / span chunks handed to storage after mapping")
+                .tag(TAG_TRANSPORT, transport.tagValue())
+                .tag(TAG_TYPE, type)
+                .register(meterRegistry);
+    }
+
+    /** Wire size of one admitted request (recorded after the admission gates, before mapping). */
+    public void requestBytes(Transport transport, long bytes) {
+        if (bytes > 0) {
+            requestBytes.get(transport).record(bytes);
+        }
+    }
+
+    /**
+     * Exposes an in-flight byte admission gate as two gauges: bytes currently reserved and the
+     * budget. Registered by the owner of the semaphore (gRPC service / HTTP filter) at construction;
+     * the supplier is held strongly so the gauge never goes NaN through garbage collection.
+     */
+    public void registerInFlightBytes(Transport transport, LongSupplier reservedBytes, long limitBytes) {
+        Gauge.builder(ADMISSION_INFLIGHT_BYTES, reservedBytes::getAsLong)
+                .description("Bytes currently reserved by the in-flight admission semaphore")
+                .baseUnit("bytes")
+                .tag(TAG_TRANSPORT, transport.tagValue())
+                .strongReference(true)
+                .register(meterRegistry);
+        Gauge.builder(ADMISSION_LIMIT_BYTES, () -> limitBytes)
+                .description("In-flight byte budget (admission.max-in-flight-bytes)")
+                .baseUnit("bytes")
+                .tag(TAG_TRANSPORT, transport.tagValue())
+                .strongReference(true)
+                .register(meterRegistry);
+    }
+
+    /** HTTP-only concurrent-request gate: requests currently admitted and the cap. */
+    public void registerInFlightRequests(Transport transport, IntSupplier inFlightRequests, int limitRequests) {
+        Gauge.builder(ADMISSION_INFLIGHT_REQUESTS, inFlightRequests::getAsInt)
+                .description("Requests currently past the concurrency gate")
+                .tag(TAG_TRANSPORT, transport.tagValue())
+                .strongReference(true)
+                .register(meterRegistry);
+        Gauge.builder(ADMISSION_LIMIT_REQUESTS, () -> limitRequests)
+                .description("Concurrent-request cap (http.max-concurrent-requests)")
+                .tag(TAG_TRANSPORT, transport.tagValue())
+                .strongReference(true)
+                .register(meterRegistry);
+    }
+
+    public void spanReceived(Transport transport, int count) {
+        if (count > 0) {
+            received.get(transport).increment(count);
+        }
+    }
+
+    public void spanStored(Transport transport, int count) {
+        if (count > 0) {
+            storedSpan.get(transport).increment(count);
+        }
+    }
+
+    public void spanChunkStored(Transport transport, int count) {
+        if (count > 0) {
+            storedSpanChunk.get(transport).increment(count);
+        }
+    }
+
+    public void spanRejected(Transport transport, OtlpTraceRejectReason reason, long count) {
+        if (count > 0) {
+            spanRejected.get(transport).get(reason).increment(count);
+        }
+    }
+
+    /**
+     * Counts one refused request. The (transport, reason) pair must be one that transport can emit;
+     * an unknown pair is a programming error and fails fast.
+     */
+    public void requestRejected(Transport transport, RequestRejectReason reason) {
+        final Counter counter = requestRejected.get(transport).get(reason);
+        if (counter == null) {
+            throw new IllegalArgumentException("reason " + reason + " is not emitted by transport " + transport);
+        }
+        counter.increment();
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorRejectedSpanTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorRejectedSpanTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OtlpTraceCollectorRejectedSpanTest {
+
+    @Test
+    void addCount_accumulatesTotalAndPerReason() {
+        OtlpTraceCollectorRejectedSpan rejected = new OtlpTraceCollectorRejectedSpan();
+
+        rejected.addCount(OtlpTraceRejectReason.INVALID_ID, 2);
+        rejected.addCount(OtlpTraceRejectReason.ORPHAN, 3);
+        rejected.addCount(OtlpTraceRejectReason.INVALID_ID, 1);
+
+        assertThat(rejected.count()).isEqualTo(6);
+        assertThat(rejected.count(OtlpTraceRejectReason.INVALID_ID)).isEqualTo(3);
+        assertThat(rejected.count(OtlpTraceRejectReason.ORPHAN)).isEqualTo(3);
+        assertThat(rejected.count(OtlpTraceRejectReason.UNSAMPLED)).isZero();
+        assertThat(rejected.countByReason()).containsOnly(
+                Map.entry(OtlpTraceRejectReason.INVALID_ID, 3L),
+                Map.entry(OtlpTraceRejectReason.ORPHAN, 3L));
+    }
+
+    @Test
+    void addCount_zeroOrNegative_isIgnored() {
+        OtlpTraceCollectorRejectedSpan rejected = new OtlpTraceCollectorRejectedSpan();
+
+        rejected.addCount(OtlpTraceRejectReason.MAPPING_ERROR, 0);
+        rejected.addCount(OtlpTraceRejectReason.MAPPING_ERROR, -1);
+
+        assertThat(rejected.count()).isZero();
+        assertThat(rejected.countByReason()).isEmpty();
+    }
+
+    @Test
+    void countByReason_isReadOnly() {
+        OtlpTraceCollectorRejectedSpan rejected = new OtlpTraceCollectorRejectedSpan();
+        rejected.addCount(OtlpTraceRejectReason.UNSAMPLED, 1);
+
+        assertThatThrownBy(() -> rejected.countByReason().put(OtlpTraceRejectReason.ORPHAN, 1L))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void getMessage_joinsMessagesUnchangedByReasonTracking() {
+        // The partial-success errorMessage format is a client-facing contract; reason tracking must
+        // not alter it.
+        OtlpTraceCollectorRejectedSpan rejected = new OtlpTraceCollectorRejectedSpan();
+        rejected.putMessage(OtlpTraceRejectReason.INVALID_ID.message() + " (2)");
+        rejected.addCount(OtlpTraceRejectReason.INVALID_ID, 2);
+        rejected.putMessage("invalid pinpoint.agentId=bad id (1)");
+        rejected.addCount(OtlpTraceRejectReason.INVALID_RESOURCE, 1);
+
+        assertThat(rejected.getMessage()).isEqualTo("invalid id (2), invalid pinpoint.agentId=bad id (1)");
+        assertThat(rejected.count()).isEqualTo(3);
+    }
+
+    @Test
+    void reasonTagValues_areStableSnakeCase() {
+        // Documented in the README and used as the metric tag: a rename is a dashboard change.
+        assertThat(OtlpTraceRejectReason.UNSAMPLED.tagValue()).isEqualTo("unsampled");
+        assertThat(OtlpTraceRejectReason.INVALID_ID.tagValue()).isEqualTo("invalid_id");
+        assertThat(OtlpTraceRejectReason.INVALID_RESOURCE.tagValue()).isEqualTo("invalid_resource");
+        assertThat(OtlpTraceRejectReason.ORPHAN.tagValue()).isEqualTo("orphan");
+        assertThat(OtlpTraceRejectReason.MAPPING_ERROR.tagValue()).isEqualTo("mapping_error");
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceControllerTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceControllerTest.java
@@ -22,8 +22,11 @@ import com.google.protobuf.util.JsonFormat;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceRejectReason;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportResult;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportService;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
@@ -44,7 +47,9 @@ import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -62,12 +67,16 @@ class OtlpTraceControllerTest {
             "{\"traceId\":\"" + TRACE_ID_HEX + "\",\"spanId\":\"" + SPAN_ID_HEX + "\",\"name\":\"op\"}]}]}]}";
 
     private OtlpTraceExportService exportService;
+    private SimpleMeterRegistry meterRegistry;
+    private OtlpTraceIngestMetrics ingestMetrics;
     private MockMvc mockMvc;
 
     @BeforeEach
     void setUp() {
         exportService = mock(OtlpTraceExportService.class);
-        OtlpTraceController controller = new OtlpTraceController(exportService);
+        meterRegistry = new SimpleMeterRegistry();
+        ingestMetrics = new OtlpTraceIngestMetrics(meterRegistry);
+        OtlpTraceController controller = new OtlpTraceController(exportService, ingestMetrics);
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
@@ -77,7 +86,7 @@ class OtlpTraceControllerTest {
 
     private static OtlpTraceExportResult partialSuccessResult() {
         OtlpTraceCollectorRejectedSpan rejected = new OtlpTraceCollectorRejectedSpan();
-        rejected.addCount(5);
+        rejected.addCount(OtlpTraceRejectReason.INVALID_ID, 5);
         rejected.putMessage("invalid span");
         return new OtlpTraceExportResult(rejected, 0, "");
     }
@@ -105,7 +114,7 @@ class OtlpTraceControllerTest {
 
     @Test
     void protobuf_success() throws Exception {
-        when(exportService.export(anyList())).thenReturn(successResult());
+        when(exportService.export(anyList(), any())).thenReturn(successResult());
 
         MockHttpServletResponse response = mockMvc.perform(post("/v1/traces")
                         .contentType(MediaType.APPLICATION_PROTOBUF)
@@ -120,7 +129,7 @@ class OtlpTraceControllerTest {
 
     @Test
     void json_success() throws Exception {
-        when(exportService.export(anyList())).thenReturn(successResult());
+        when(exportService.export(anyList(), any())).thenReturn(successResult());
 
         mockMvc.perform(post("/v1/traces")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -132,7 +141,7 @@ class OtlpTraceControllerTest {
         // The hex IDs must arrive at the export service as the same raw bytes the protobuf path yields.
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<ResourceSpans>> captor = ArgumentCaptor.forClass((Class) List.class);
-        verify(exportService).export(captor.capture());
+        verify(exportService).export(captor.capture(), eq(OtlpTraceIngestMetrics.Transport.HTTP));
         Span span = captor.getValue().get(0).getScopeSpans(0).getSpans(0);
         assertThat(span.getTraceId()).isEqualTo(ByteString.copyFrom(HexFormat.of().parseHex(TRACE_ID_HEX)));
         assertThat(span.getSpanId()).isEqualTo(ByteString.copyFrom(HexFormat.of().parseHex(SPAN_ID_HEX)));
@@ -140,7 +149,7 @@ class OtlpTraceControllerTest {
 
     @Test
     void json_partialSuccess_int64AsString() throws Exception {
-        when(exportService.export(anyList())).thenReturn(partialSuccessResult());
+        when(exportService.export(anyList(), any())).thenReturn(partialSuccessResult());
 
         String body = mockMvc.perform(post("/v1/traces")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -158,7 +167,7 @@ class OtlpTraceControllerTest {
 
     @Test
     void json_serverError_503WithStatusBody() throws Exception {
-        when(exportService.export(anyList())).thenReturn(serverErrorResult());
+        when(exportService.export(anyList(), any())).thenReturn(serverErrorResult());
 
         String body = mockMvc.perform(post("/v1/traces")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -184,6 +193,24 @@ class OtlpTraceControllerTest {
         Status status = parseJson(body, Status.newBuilder()).build();
         assertThat(status.getCode()).isEqualTo(Code.INVALID_ARGUMENT_VALUE);
         assertThat(status.getMessage()).isEqualTo("not a hexadecimal digit: \"z\" = 122");
+    }
+
+    @Test
+    void parseFailure_countsRequestRejectedParseError_andNothingElse() throws Exception {
+        mockMvc.perform(post("/v1/traces")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"resourceSpans\":[{\"scopeSpans\":[{\"spans\":[{\"traceId\":\"zz\"}]}]}]}"))
+                .andExpect(status().isBadRequest());
+
+        assertThat(meterRegistry.get(OtlpTraceIngestMetrics.REQUEST_REJECTED)
+                .tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "http")
+                .tag(OtlpTraceIngestMetrics.TAG_REASON, "parse_error")
+                .counter().count()).isEqualTo(1.0);
+        // A refused request never reaches the span-level counters.
+        assertThat(meterRegistry.get(OtlpTraceIngestMetrics.SPAN_RECEIVED)
+                .tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "http")
+                .counter().count()).isZero();
+        verify(exportService, never()).export(anyList(), any());
     }
 
     @Test
@@ -220,7 +247,7 @@ class OtlpTraceControllerTest {
 
     @Test
     void protobuf_partialSuccess() throws Exception {
-        when(exportService.export(anyList())).thenReturn(partialSuccessResult());
+        when(exportService.export(anyList(), any())).thenReturn(partialSuccessResult());
 
         byte[] body = mockMvc.perform(post("/v1/traces")
                         .contentType(MediaType.APPLICATION_PROTOBUF)
@@ -236,7 +263,7 @@ class OtlpTraceControllerTest {
 
     @Test
     void protobuf_serverError_503WithStatusBody() throws Exception {
-        when(exportService.export(anyList())).thenReturn(serverErrorResult());
+        when(exportService.export(anyList(), any())).thenReturn(serverErrorResult());
 
         byte[] body = mockMvc.perform(post("/v1/traces")
                         .contentType(MediaType.APPLICATION_PROTOBUF)
@@ -253,7 +280,7 @@ class OtlpTraceControllerTest {
     @Test
     void json_acceptHeaderIgnored_responseMirrorsRequestContentType() throws Exception {
         // OTLP exporters do not negotiate: the response encoding follows the request body, not Accept.
-        when(exportService.export(anyList())).thenReturn(successResult());
+        when(exportService.export(anyList(), any())).thenReturn(successResult());
 
         mockMvc.perform(post("/v1/traces")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -266,7 +293,7 @@ class OtlpTraceControllerTest {
 
     @Test
     void json_emptyObject_exportsNothing() throws Exception {
-        when(exportService.export(anyList())).thenReturn(successResult());
+        when(exportService.export(anyList(), any())).thenReturn(successResult());
 
         mockMvc.perform(post("/v1/traces")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -274,7 +301,7 @@ class OtlpTraceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string("{}"));
 
-        verify(exportService).export(List.of());
+        verify(exportService).export(eq(List.of()), eq(OtlpTraceIngestMetrics.Transport.HTTP));
     }
 
     @Test
@@ -291,7 +318,7 @@ class OtlpTraceControllerTest {
                         .content(new byte[0]))
                 .andExpect(status().isBadRequest());
 
-        verify(exportService, never()).export(anyList());
+        verify(exportService, never()).export(anyList(), any());
     }
 
     @Test
@@ -303,7 +330,7 @@ class OtlpTraceControllerTest {
 
     @Test
     void json_contentTypeCharsetParameter_treatedAsJson() throws Exception {
-        when(exportService.export(anyList())).thenReturn(successResult());
+        when(exportService.export(anyList(), any())).thenReturn(successResult());
 
         mockMvc.perform(post("/v1/traces")
                         .header("Content-Type", "application/json; charset=utf-8")
@@ -323,10 +350,10 @@ class OtlpTraceControllerTest {
 
     @Test
     void json_gzip_decompressedByExistingFilter() throws Exception {
-        when(exportService.export(anyList())).thenReturn(successResult());
+        when(exportService.export(anyList(), any())).thenReturn(successResult());
 
-        MockMvc mvcWithFilter = MockMvcBuilders.standaloneSetup(new OtlpTraceController(exportService))
-                .addFilters(new OtlpTraceDecompressionFilter(16 * 1024 * 1024))
+        MockMvc mvcWithFilter = MockMvcBuilders.standaloneSetup(new OtlpTraceController(exportService, ingestMetrics))
+                .addFilters(new OtlpTraceDecompressionFilter(16 * 1024 * 1024, ingestMetrics))
                 .build();
 
         ByteArrayOutputStream compressed = new ByteArrayOutputStream();

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceDecompressionFilterTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceDecompressionFilterTest.java
@@ -21,6 +21,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockFilterChain;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.util.StreamUtils;
@@ -35,6 +37,39 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class OtlpTraceDecompressionFilterTest {
+
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final OtlpTraceIngestMetrics ingestMetrics = new OtlpTraceIngestMetrics(meterRegistry);
+
+    private double unsupportedEncodingCount() {
+        return meterRegistry.get(OtlpTraceIngestMetrics.REQUEST_REJECTED)
+                .tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "http")
+                .tag(OtlpTraceIngestMetrics.TAG_REASON, "unsupported_encoding")
+                .counter().count();
+    }
+
+    @Test
+    void unsupportedEncoding_countsRequestRejected() throws ServletException, IOException {
+        MockHttpServletRequest request = request("br", new byte[]{1, 2, 3});
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics).doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
+        assertThat(chain.getRequest()).as("chain must not run").isNull();
+        assertThat(unsupportedEncodingCount()).isEqualTo(1.0);
+    }
+
+    @Test
+    void gzipAndIdentity_doNotCountRequestRejected() throws ServletException, IOException {
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics)
+                .doFilter(request("gzip", gzip(new byte[]{1})), new MockHttpServletResponse(), new MockFilterChain());
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics)
+                .doFilter(request(null, new byte[]{1}), new MockHttpServletResponse(), new MockFilterChain());
+
+        assertThat(unsupportedEncodingCount()).isZero();
+    }
 
     private static final int MAX_DECOMPRESSED = 1024 * 1024; // 1MB
 
@@ -62,7 +97,7 @@ class OtlpTraceDecompressionFilterTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
-        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics).doFilter(request, response, chain);
 
         assertThat(chain.getRequest()).as("chain invoked with wrapped request").isNotNull();
         byte[] decoded = StreamUtils.copyToByteArray(chain.getRequest().getInputStream());
@@ -81,7 +116,7 @@ class OtlpTraceDecompressionFilterTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
-        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics).doFilter(request, response, chain);
 
         jakarta.servlet.ServletRequest wrapped = chain.getRequest();
         // Servlet wrapper contract: repeated getInputStream() must return the same instance, otherwise
@@ -98,7 +133,7 @@ class OtlpTraceDecompressionFilterTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
-        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics).doFilter(request, response, chain);
 
         jakarta.servlet.http.HttpServletRequest wrapped =
                 (jakarta.servlet.http.HttpServletRequest) chain.getRequest();
@@ -124,7 +159,7 @@ class OtlpTraceDecompressionFilterTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
-        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics).doFilter(request, response, chain);
 
         assertThat(chain.getRequest()).isNotNull();
         assertThat(StreamUtils.copyToByteArray(chain.getRequest().getInputStream())).isEqualTo(plain);
@@ -136,7 +171,7 @@ class OtlpTraceDecompressionFilterTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
-        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics).doFilter(request, response, chain);
 
         assertThat(chain.getRequest()).as("same request instance passed through").isSameAs(request);
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
@@ -148,7 +183,7 @@ class OtlpTraceDecompressionFilterTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
-        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics).doFilter(request, response, chain);
 
         assertThat(chain.getRequest()).isSameAs(request);
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
@@ -160,7 +195,7 @@ class OtlpTraceDecompressionFilterTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
-        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics).doFilter(request, response, chain);
 
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
         assertThat(chain.getRequest()).as("chain must not be invoked").isNull();
@@ -175,7 +210,7 @@ class OtlpTraceDecompressionFilterTest {
         MockFilterChain chain = new MockFilterChain();
 
         final int tinyLimit = 1024;
-        new OtlpTraceDecompressionFilter(tinyLimit).doFilter(request, response, chain);
+        new OtlpTraceDecompressionFilter(tinyLimit, ingestMetrics).doFilter(request, response, chain);
 
         assertThat(chain.getRequest()).isNotNull();
         assertThatThrownBy(() -> StreamUtils.copyToByteArray(chain.getRequest().getInputStream()))
@@ -189,7 +224,7 @@ class OtlpTraceDecompressionFilterTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
-        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED).doFilter(request, response, chain);
+        new OtlpTraceDecompressionFilter(MAX_DECOMPRESSED, ingestMetrics).doFilter(request, response, chain);
 
         assertThat(chain.getRequest()).isNotNull();
         // GZIPInputStream validates the header eagerly, so opening the body fails (surfaces as a 400).

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceHttpAdmissionFilterTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceHttpAdmissionFilterTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.controller;
+
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.util.StreamUtils;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpTraceHttpAdmissionFilterTest {
+
+    private static final int MAX_REQUEST_BYTES = 100;
+    private static final int RETRY_AFTER = 1;
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final OtlpTraceIngestMetrics metrics = new OtlpTraceIngestMetrics(registry);
+
+    private static MockHttpServletRequest request(int bodyBytes) {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/v1/traces");
+        request.setContent(new byte[bodyBytes]);
+        return request;
+    }
+
+    private double gauge(String name) {
+        return registry.get(name).tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "http").gauge().value();
+    }
+
+    @Test
+    void admitted_recordsDeclaredLength_andGaugesShowOccupancyDuringChain() throws ServletException, IOException {
+        OtlpTraceHttpAdmissionFilter filter = new OtlpTraceHttpAdmissionFilter(MAX_REQUEST_BYTES, 1_000, 8, RETRY_AFTER, metrics);
+        double[] duringBytes = new double[1];
+        double[] duringRequests = new double[1];
+        MockFilterChain chain = new MockFilterChain(new jakarta.servlet.http.HttpServlet() {
+            @Override
+            protected void service(jakarta.servlet.http.HttpServletRequest req, HttpServletResponse res) {
+                duringBytes[0] = gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_BYTES);
+                duringRequests[0] = gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_REQUESTS);
+            }
+        });
+
+        filter.doFilter(request(40), new MockHttpServletResponse(), chain);
+
+        assertThat(duringBytes[0]).isEqualTo(40.0);
+        assertThat(duringRequests[0]).isEqualTo(1.0);
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_BYTES)).isZero();
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_REQUESTS)).isZero();
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_LIMIT_BYTES)).isEqualTo(1_000.0);
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_LIMIT_REQUESTS)).isEqualTo(8.0);
+        DistributionSummary bytes = registry.get(OtlpTraceIngestMetrics.REQUEST_BYTES).tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "http").summary();
+        assertThat(bytes.count()).isEqualTo(1);
+        assertThat(bytes.totalAmount()).isEqualTo(40.0);
+    }
+
+    @Test
+    void chunkedBody_recordsBytesActuallyRead() throws ServletException, IOException {
+        OtlpTraceHttpAdmissionFilter filter = new OtlpTraceHttpAdmissionFilter(MAX_REQUEST_BYTES, 1_000, 8, RETRY_AFTER, metrics);
+        MockHttpServletRequest body = new MockHttpServletRequest("POST", "/v1/traces");
+        body.setContent(new byte[33]);
+        // MockHttpServletRequest reports the content length from the body; hide it like a chunked request.
+        jakarta.servlet.http.HttpServletRequest chunked = new UnknownLengthRequest(body);
+        MockFilterChain chain = new MockFilterChain(new jakarta.servlet.http.HttpServlet() {
+            @Override
+            protected void service(jakarta.servlet.http.HttpServletRequest req, HttpServletResponse res) throws IOException {
+                StreamUtils.copyToByteArray(req.getInputStream());
+            }
+        });
+
+        filter.doFilter(chunked, new MockHttpServletResponse(), chain);
+
+        DistributionSummary bytes = registry.get(OtlpTraceIngestMetrics.REQUEST_BYTES).tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "http").summary();
+        assertThat(bytes.count()).isEqualTo(1);
+        assertThat(bytes.totalAmount()).isEqualTo(33.0);
+    }
+
+    /** Hides the body length so the filter takes the chunked (unknown-length) path. */
+    private static final class UnknownLengthRequest extends jakarta.servlet.http.HttpServletRequestWrapper {
+        private UnknownLengthRequest(jakarta.servlet.http.HttpServletRequest request) {
+            super(request);
+        }
+
+        @Override
+        public int getContentLength() {
+            return -1;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return -1;
+        }
+    }
+
+    private double requestRejected(String reason) {
+        return registry.get(OtlpTraceIngestMetrics.REQUEST_REJECTED)
+                .tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "http")
+                .tag(OtlpTraceIngestMetrics.TAG_REASON, reason)
+                .counter().count();
+    }
+
+    @Test
+    void payloadTooLarge_413_countsPayloadTooLarge() throws ServletException, IOException {
+        OtlpTraceHttpAdmissionFilter filter = new OtlpTraceHttpAdmissionFilter(MAX_REQUEST_BYTES, 1_000, 8, RETRY_AFTER, metrics);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request(MAX_REQUEST_BYTES + 1), response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+        assertThat(response.getHeader("Retry-After")).as("client fault: not retryable").isNull();
+        assertThat(chain.getRequest()).isNull();
+        assertThat(requestRejected("payload_too_large")).isEqualTo(1.0);
+        assertThat(requestRejected("concurrency")).isZero();
+        assertThat(requestRejected("inflight_bytes")).isZero();
+    }
+
+    @Test
+    void concurrencyLimit_503RetryAfter_countsConcurrency() throws ServletException, IOException {
+        // Zero permits: the gate rejects every request without needing a blocked in-flight one.
+        OtlpTraceHttpAdmissionFilter filter = new OtlpTraceHttpAdmissionFilter(MAX_REQUEST_BYTES, 1_000, 0, RETRY_AFTER, metrics);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request(10), response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        assertThat(response.getHeader("Retry-After")).isEqualTo(Integer.toString(RETRY_AFTER));
+        assertThat(chain.getRequest()).isNull();
+        assertThat(requestRejected("concurrency")).isEqualTo(1.0);
+        assertThat(requestRejected("inflight_bytes")).isZero();
+    }
+
+    @Test
+    void inFlightBudgetExhausted_503RetryAfter_countsInflightBytes_andReleasesConcurrencyPermit() throws ServletException, IOException {
+        // Budget 10 bytes, request 50 bytes (below the per-request cap): the byte gate rejects.
+        OtlpTraceHttpAdmissionFilter filter = new OtlpTraceHttpAdmissionFilter(MAX_REQUEST_BYTES, 10, 1, RETRY_AFTER, metrics);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request(50), response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        assertThat(response.getHeader("Retry-After")).isEqualTo(Integer.toString(RETRY_AFTER));
+        assertThat(requestRejected("inflight_bytes")).isEqualTo(1.0);
+        assertThat(requestRejected("concurrency")).isZero();
+
+        // The single concurrency permit was given back: a small request now passes the gate.
+        MockHttpServletResponse okResponse = new MockHttpServletResponse();
+        MockFilterChain okChain = new MockFilterChain();
+        filter.doFilter(request(5), okResponse, okChain);
+        assertThat(okChain.getRequest()).isNotNull();
+        assertThat(okResponse.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+    }
+
+    @Test
+    void admitted_passesToChain_countsNothing() throws ServletException, IOException {
+        OtlpTraceHttpAdmissionFilter filter = new OtlpTraceHttpAdmissionFilter(MAX_REQUEST_BYTES, 1_000, 8, RETRY_AFTER, metrics);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request(10), response, chain);
+
+        assertThat(chain.getRequest()).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(registry.get(OtlpTraceIngestMetrics.REQUEST_REJECTED).counters())
+                .allSatisfy(c -> assertThat(c.count()).isZero());
+    }
+
+    @Test
+    void rejectedRequests_doNotRecordWireBytes() throws ServletException, IOException {
+        // 413 (per-request cap), 503 concurrency (zero permits) and 503 in-flight budget (10 bytes):
+        // request.bytes only measures admitted requests, so all three leave the summary empty.
+        new OtlpTraceHttpAdmissionFilter(MAX_REQUEST_BYTES, 1_000, 8, RETRY_AFTER, metrics)
+                .doFilter(request(MAX_REQUEST_BYTES + 1), new MockHttpServletResponse(), new MockFilterChain());
+        new OtlpTraceHttpAdmissionFilter(MAX_REQUEST_BYTES, 1_000, 0, RETRY_AFTER, metrics)
+                .doFilter(request(10), new MockHttpServletResponse(), new MockFilterChain());
+        new OtlpTraceHttpAdmissionFilter(MAX_REQUEST_BYTES, 10, 1, RETRY_AFTER, metrics)
+                .doFilter(request(50), new MockHttpServletResponse(), new MockFilterChain());
+
+        DistributionSummary bytes = registry.get(OtlpTraceIngestMetrics.REQUEST_BYTES).tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "http").summary();
+        assertThat(bytes.count()).isZero();
+        assertThat(requestRejected("payload_too_large")).isEqualTo(1.0);
+        assertThat(requestRejected("concurrency")).isEqualTo(1.0);
+        assertThat(requestRejected("inflight_bytes")).isEqualTo(1.0);
+    }
+
+    @Test
+    void chunkedBody_chainThrows_stillRecordsBytesRead_andReleasesPermits() throws ServletException, IOException {
+        // Single permit on both gates: a leaked permit would make the follow-up request fail.
+        OtlpTraceHttpAdmissionFilter filter = new OtlpTraceHttpAdmissionFilter(MAX_REQUEST_BYTES, MAX_REQUEST_BYTES, 1, RETRY_AFTER, metrics);
+        MockHttpServletRequest body = new MockHttpServletRequest("POST", "/v1/traces");
+        body.setContent(new byte[21]);
+        jakarta.servlet.http.HttpServletRequest chunked = new UnknownLengthRequest(body);
+        MockFilterChain failing = new MockFilterChain(new jakarta.servlet.http.HttpServlet() {
+            @Override
+            protected void service(jakarta.servlet.http.HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+                StreamUtils.copyToByteArray(req.getInputStream());
+                throw new ServletException("downstream failure");
+            }
+        });
+
+        assertThatThrownBy(() -> filter.doFilter(chunked, new MockHttpServletResponse(), failing))
+                .isInstanceOf(ServletException.class);
+
+        DistributionSummary bytes = registry.get(OtlpTraceIngestMetrics.REQUEST_BYTES).tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "http").summary();
+        assertThat(bytes.count()).isEqualTo(1);
+        assertThat(bytes.totalAmount()).isEqualTo(21.0);
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_BYTES)).isZero();
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_REQUESTS)).isZero();
+
+        MockFilterChain next = new MockFilterChain();
+        MockHttpServletResponse nextResponse = new MockHttpServletResponse();
+        filter.doFilter(request(5), nextResponse, next);
+        assertThat(next.getRequest()).as("permits released after the failed request").isNotNull();
+        assertThat(nextResponse.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(registry.get(OtlpTraceIngestMetrics.REQUEST_REJECTED).counters())
+                .allSatisfy(c -> assertThat(c.count()).isZero());
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.navercorp.pinpoint.common.server.bo.AnnotationBo;
 import com.navercorp.pinpoint.common.server.bo.SpanBo;
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceRejectReason;
 import com.navercorp.pinpoint.common.server.bo.SpanEventBo;
 import com.navercorp.pinpoint.common.server.bo.exception.ExceptionMetaDataBo;
 import com.navercorp.pinpoint.common.trace.AnnotationKey;
@@ -183,6 +184,38 @@ class OtlpTraceMapperTest {
         assertThat(data.getSpanBoList()).hasSize(1);
         assertThat(data.getRejectedSpan().count()).isEqualTo(1);
         assertThat(data.getRejectedSpan().getMessage()).contains("invalid id");
+    }
+
+    @Test
+    void invalidId_span_isCountedUnderInvalidIdReason() {
+        Span invalidRoot = serverRoot(new byte[8], "/bad", false);
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(invalidRoot));
+
+        assertThat(data.getRejectedSpan().count(OtlpTraceRejectReason.INVALID_ID)).isEqualTo(1);
+        assertThat(data.getRejectedSpan().countByReason()).containsOnlyKeys(OtlpTraceRejectReason.INVALID_ID);
+    }
+
+    @Test
+    void invalidResource_rejectsEverySpanOfTheResource_notTheScopeBlockCount() {
+        // No pinpoint.applicationName / agentId and fallback disabled -> the whole ResourceSpans is
+        // rejected. It carries 3 spans in 2 scope blocks: rejected_spans must be 3 (the old code
+        // added getScopeSpansCount() = 2).
+        ResourceSpans noIds = ResourceSpans.newBuilder()
+                .setResource(Resource.newBuilder().addAttributes(kv("service.name", strVal("svc"))))
+                .addScopeSpans(ScopeSpans.newBuilder()
+                        .addSpans(serverRoot(ROOT_A, "/a", false))
+                        .addSpans(serverRoot(ROOT_B, "/b", false)))
+                .addScopeSpans(ScopeSpans.newBuilder()
+                        .addSpans(serverRoot(CHILD, "/c", false)))
+                .build();
+
+        OtlpTraceMapperData data = newMapper().map(List.of(noIds));
+
+        assertThat(data.getSpanBoList()).isEmpty();
+        assertThat(data.getRejectedSpan().count()).isEqualTo(3);
+        assertThat(data.getRejectedSpan().count(OtlpTraceRejectReason.INVALID_RESOURCE)).isEqualTo(3);
+        assertThat(data.getRejectedSpan().getMessage()).endsWith("(3)");
     }
 
     @Test
@@ -612,6 +645,16 @@ class OtlpTraceMapperTest {
     }
 
     @Test
+    void unsampledSpan_isCountedUnderUnsampledReason() {
+        Span unsampledRoot = withFlags(serverRoot(ROOT_A, "/api/orders", false), UNSAMPLED_FLAGS);
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(unsampledRoot));
+
+        assertThat(data.getRejectedSpan().count(OtlpTraceRejectReason.UNSAMPLED)).isEqualTo(1);
+        assertThat(data.getRejectedSpan().count(OtlpTraceRejectReason.INVALID_ID)).isZero();
+    }
+
+    @Test
     void unsampledChild_droppedButSampledRootKept() {
         // per-span drop: the sampled root survives; the explicitly unsampled child is rejected
         Span root = serverRoot(ROOT_A, "/api/orders", false);
@@ -893,5 +936,30 @@ class OtlpTraceMapperTest {
         assertThat(data.getUriStatSpanList())
                 .extracting(OtlpUriStatSpan::getUri)
                 .containsExactly("/root");
+    }
+
+    // =======================================================================
+    // reject reason: orphan (unlinkable spans)
+    // =======================================================================
+
+    @Test
+    void unlinkableSpans_areCountedUnderOrphanReason() {
+        // A parentless CLIENT span becomes a local root and is stored as a spanChunk, while a
+        // two-span parent cycle (X <-> Y) hangs off no root at all: findLinkSpanChunk leaves it in
+        // the child list and the mapper drops it under the orphan reason (not mapping_error).
+        byte[] cycleX = {5, 5, 5, 5, 5, 5, 5, 5};
+        byte[] cycleY = {6, 6, 6, 6, 6, 6, 6, 6};
+        Span localRoot = clientChild(ORPHAN, ABSENT_PARENT, false);
+        Span x = clientChild(cycleX, cycleY, false);
+        Span y = clientChild(cycleY, cycleX, false);
+
+        OtlpTraceMapperData data = newMapper().map(resourceSpans(localRoot, x, y));
+
+        assertThat(data.getSpanBoList()).isEmpty();
+        assertThat(data.getSpanChunkBoList()).hasSize(1);
+        assertThat(data.getRejectedSpan().count()).isEqualTo(2);
+        assertThat(data.getRejectedSpan().count(OtlpTraceRejectReason.ORPHAN)).isEqualTo(2);
+        assertThat(data.getRejectedSpan().countByReason()).containsOnlyKeys(OtlpTraceRejectReason.ORPHAN);
+        assertThat(data.getRejectedSpan().getMessage()).contains(OtlpTraceRejectReason.ORPHAN.message() + " (2)");
     }
 }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceMapperUtilsTest.java
@@ -1,6 +1,9 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.google.protobuf.ByteString;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import com.navercorp.pinpoint.common.server.uid.ServiceUid;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeKeyValue;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
@@ -1065,4 +1068,39 @@ class OtlpTraceMapperUtilsTest {
         assertThat((String) map.get("bin")).hasSize(10);
     }
 
+    // =======================================================================
+    // countSpans
+    // =======================================================================
+
+    private static ScopeSpans scopeWithSpans(int count) {
+        ScopeSpans.Builder scope = ScopeSpans.newBuilder();
+        for (int i = 0; i < count; i++) {
+            scope.addSpans(Span.newBuilder().setName("span-" + i));
+        }
+        return scope.build();
+    }
+
+    @Test
+    void countSpans_sumsSpansAcrossScopeBlocksAndResources() {
+        ResourceSpans twoScopes = ResourceSpans.newBuilder()
+                .addScopeSpans(scopeWithSpans(2))
+                .addScopeSpans(scopeWithSpans(1))
+                .build();
+        ResourceSpans oneScope = ResourceSpans.newBuilder()
+                .addScopeSpans(scopeWithSpans(3))
+                .build();
+
+        // Not the number of scope blocks (2), but the spans they carry.
+        assertThat(OtlpTraceMapperUtils.countSpans(twoScopes)).isEqualTo(3);
+        assertThat(OtlpTraceMapperUtils.countSpans(List.of(twoScopes, oneScope))).isEqualTo(6);
+    }
+
+    @Test
+    void countSpans_emptyInputs_returnZero() {
+        ResourceSpans emptyScope = ResourceSpans.newBuilder().addScopeSpans(ScopeSpans.getDefaultInstance()).build();
+
+        assertThat(OtlpTraceMapperUtils.countSpans(List.of())).isZero();
+        assertThat(OtlpTraceMapperUtils.countSpans(ResourceSpans.getDefaultInstance())).isZero();
+        assertThat(OtlpTraceMapperUtils.countSpans(List.of(emptyScope))).isZero();
+    }
 }

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceServiceTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceServiceTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics.Transport;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GrpcOtlpTraceServiceTest {
+
+    private static final Executor DIRECT = Runnable::run;
+    private static final Executor REJECTING = task -> {
+        throw new RejectedExecutionException("queue full");
+    };
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final OtlpTraceIngestMetrics metrics = new OtlpTraceIngestMetrics(registry);
+    private final OtlpTraceExportService exportService = mock(OtlpTraceExportService.class);
+
+    /** Captures the response so the transport outcome (status / completion) can be asserted. */
+    private static final class RecordingObserver implements StreamObserver<ExportTraceServiceResponse> {
+        final List<ExportTraceServiceResponse> responses = new ArrayList<>();
+        Throwable error;
+        boolean completed;
+
+        @Override
+        public void onNext(ExportTraceServiceResponse value) {
+            responses.add(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+        }
+
+        @Override
+        public void onCompleted() {
+            completed = true;
+        }
+    }
+
+    private static ExportTraceServiceRequest request(int spans) {
+        ScopeSpans.Builder scope = ScopeSpans.newBuilder();
+        for (int i = 0; i < spans; i++) {
+            scope.addSpans(Span.newBuilder().setName("span-" + i));
+        }
+        return ExportTraceServiceRequest.newBuilder()
+                .addResourceSpans(ResourceSpans.newBuilder().addScopeSpans(scope))
+                .build();
+    }
+
+    private double gauge(String name) {
+        return registry.get(name).tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "grpc").gauge().value();
+    }
+
+    @Test
+    void admittedRequest_recordsWireBytes_andInFlightGaugeWhileQueued() {
+        // An executor that never runs the task keeps the request "in flight" (permit held).
+        List<Runnable> parked = new ArrayList<>();
+        Executor parking = parked::add;
+        when(exportService.export(anyList(), eq(Transport.GRPC)))
+                .thenReturn(new OtlpTraceExportResult(new OtlpTraceCollectorRejectedSpan(), 0, ""));
+        ExportTraceServiceRequest req = request(5);
+        GrpcOtlpTraceService service = new GrpcOtlpTraceService(exportService, parking, 1 << 20, metrics);
+
+        service.export(req, new RecordingObserver());
+
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_LIMIT_BYTES)).isEqualTo((double) (1 << 20));
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_BYTES)).isEqualTo((double) req.getSerializedSize());
+        DistributionSummary bytes = registry.get(OtlpTraceIngestMetrics.REQUEST_BYTES).tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "grpc").summary();
+        assertThat(bytes.count()).isEqualTo(1);
+        assertThat(bytes.totalAmount()).isEqualTo((double) req.getSerializedSize());
+
+        // Running the parked task releases the reservation.
+        parked.forEach(Runnable::run);
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_BYTES)).isZero();
+    }
+
+    @Test
+    void rejectedByAdmission_doesNotRecordWireBytes() {
+        GrpcOtlpTraceService service = new GrpcOtlpTraceService(exportService, DIRECT, 1, metrics);
+
+        service.export(request(3), new RecordingObserver());
+
+        assertThat(registry.get(OtlpTraceIngestMetrics.REQUEST_BYTES).tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "grpc").summary().count()).isZero();
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_BYTES)).isZero();
+    }
+
+    private double requestRejected(String reason) {
+        return registry.get(OtlpTraceIngestMetrics.REQUEST_REJECTED)
+                .tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "grpc")
+                .tag(OtlpTraceIngestMetrics.TAG_REASON, reason)
+                .counter().count();
+    }
+
+    @Test
+    void inFlightBudgetExhausted_unavailable_countsInflightBytes() {
+        // Budget of 1 byte: any real request is larger than the permit pool.
+        GrpcOtlpTraceService service = new GrpcOtlpTraceService(exportService, DIRECT, 1, metrics);
+        RecordingObserver observer = new RecordingObserver();
+
+        service.export(request(3), observer);
+
+        assertThat(Status.fromThrowable(observer.error).getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+        assertThat(observer.completed).isFalse();
+        assertThat(requestRejected("inflight_bytes")).isEqualTo(1.0);
+        assertThat(requestRejected("executor_rejected")).isZero();
+        verify(exportService, never()).export(anyList(), eq(Transport.GRPC));
+    }
+
+    @Test
+    void workerExecutorRejects_unavailable_countsExecutorRejected_andReleasesPermit() {
+        ExportTraceServiceRequest req = request(3);
+        // Budget exactly one request: if the permit were leaked on rejection, the second call would
+        // fail with inflight_bytes instead of executor_rejected.
+        GrpcOtlpTraceService service = new GrpcOtlpTraceService(exportService, REJECTING, req.getSerializedSize(), metrics);
+
+        RecordingObserver first = new RecordingObserver();
+        service.export(req, first);
+        RecordingObserver second = new RecordingObserver();
+        service.export(req, second);
+
+        assertThat(Status.fromThrowable(first.error).getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+        assertThat(Status.fromThrowable(second.error).getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+        assertThat(requestRejected("executor_rejected")).isEqualTo(2.0);
+        assertThat(requestRejected("inflight_bytes")).isZero();
+        verify(exportService, never()).export(anyList(), eq(Transport.GRPC));
+    }
+
+    @Test
+    void accepted_exportsWithGrpcTransport_andCountsNoRequestRejection() {
+        when(exportService.export(anyList(), eq(Transport.GRPC)))
+                .thenReturn(new OtlpTraceExportResult(new OtlpTraceCollectorRejectedSpan(), 0, ""));
+        GrpcOtlpTraceService service = new GrpcOtlpTraceService(exportService, DIRECT, 1 << 20, metrics);
+        RecordingObserver observer = new RecordingObserver();
+
+        service.export(request(3), observer);
+
+        assertThat(observer.error).isNull();
+        assertThat(observer.completed).isTrue();
+        assertThat(observer.responses).hasSize(1);
+        verify(exportService).export(anyList(), eq(Transport.GRPC));
+        assertThat(requestRejected("inflight_bytes")).isZero();
+        assertThat(requestRejected("executor_rejected")).isZero();
+    }
+
+    private void assertNoRequestRejection() {
+        assertThat(registry.get(OtlpTraceIngestMetrics.REQUEST_REJECTED).counters())
+                .allSatisfy(c -> assertThat(c.count()).isZero());
+    }
+
+    @Test
+    void serverErrorResult_unavailable_isNotARequestRejection_andReleasesPermit() {
+        // Storage-side failures are reported by the insert error counters, not request.rejected.
+        when(exportService.export(anyList(), eq(Transport.GRPC)))
+                .thenReturn(new OtlpTraceExportResult(new OtlpTraceCollectorRejectedSpan(), 3, "insert error (3)"));
+        GrpcOtlpTraceService service = new GrpcOtlpTraceService(exportService, DIRECT, 1 << 20, metrics);
+        RecordingObserver observer = new RecordingObserver();
+
+        service.export(request(3), observer);
+
+        assertThat(Status.fromThrowable(observer.error).getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+        assertThat(observer.completed).isFalse();
+        assertNoRequestRejection();
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_BYTES)).isZero();
+    }
+
+    @Test
+    void exportThrows_internal_isNotARequestRejection_andReleasesPermit() {
+        ExportTraceServiceRequest req = request(3);
+        when(exportService.export(anyList(), eq(Transport.GRPC)))
+                .thenThrow(new IllegalStateException("mapper fault"))
+                .thenReturn(new OtlpTraceExportResult(new OtlpTraceCollectorRejectedSpan(), 0, ""));
+        // Budget of exactly one request: a permit leaked by the failing call would turn the second
+        // call into an inflight_bytes rejection instead of a clean success.
+        GrpcOtlpTraceService service = new GrpcOtlpTraceService(exportService, DIRECT, req.getSerializedSize(), metrics);
+
+        RecordingObserver failed = new RecordingObserver();
+        service.export(req, failed);
+        RecordingObserver next = new RecordingObserver();
+        service.export(req, next);
+
+        assertThat(Status.fromThrowable(failed.error).getCode()).isEqualTo(Status.Code.INTERNAL);
+        assertThat(next.error).isNull();
+        assertThat(next.completed).isTrue();
+        assertNoRequestRejection();
+        assertThat(gauge(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_BYTES)).isZero();
+        // Both calls were admitted, so both are measured.
+        assertThat(registry.get(OtlpTraceIngestMetrics.REQUEST_BYTES).tag(OtlpTraceIngestMetrics.TAG_TRANSPORT, "grpc").summary().count()).isEqualTo(2);
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportServiceTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportServiceTest.java
@@ -23,11 +23,15 @@ import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceMapperData;
 import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpUriStatSpan;
 import com.navercorp.pinpoint.uristat.collector.dao.UriStatDao;
 import com.navercorp.pinpoint.uristat.collector.model.UriStat;
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceRejectReason;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
 import java.util.List;
 import java.util.Optional;
 
@@ -65,7 +69,56 @@ class OtlpTraceExportServiceTest {
                 Optional.empty(),
                 Optional.ofNullable(uriStatService),
                 Caffeine.newBuilder().maximumSize(16).build(),
+                new OtlpTraceIngestMetrics(meterRegistry),
                 meterRegistry);
+    }
+
+    private double count(String name, String... tags) {
+        return meterRegistry.get(name).tags(tags).counter().count();
+    }
+
+    private static ResourceSpans resourceSpansWithSpans(int spanCount) {
+        ScopeSpans.Builder scope = ScopeSpans.newBuilder();
+        for (int i = 0; i < spanCount; i++) {
+            scope.addSpans(Span.newBuilder().setName("s" + i));
+        }
+        return ResourceSpans.newBuilder().addScopeSpans(scope).build();
+    }
+
+    @Test
+    void ingestMetrics_receivedCountsRawSpans_storedCountsMappedBos_perTransport() {
+        OtlpTraceMapperData mapperData = new OtlpTraceMapperData();
+        mapperData.addSpanBo(new com.navercorp.pinpoint.common.server.bo.SpanBo());
+        mapperData.addSpanBo(new com.navercorp.pinpoint.common.server.bo.SpanBo());
+        mapperData.addSpanChunkBo(new com.navercorp.pinpoint.common.server.bo.SpanChunkBo());
+        OtlpTraceExportService service = newService(mapperData, null);
+
+        // 3 + 4 raw spans over two ResourceSpans, sent over HTTP
+        service.export(List.of(resourceSpansWithSpans(3), resourceSpansWithSpans(4)), OtlpTraceIngestMetrics.Transport.HTTP);
+
+        assertThat(count(OtlpTraceIngestMetrics.SPAN_RECEIVED, "transport", "http")).isEqualTo(7.0);
+        assertThat(count(OtlpTraceIngestMetrics.SPAN_STORED, "transport", "http", "type", "span")).isEqualTo(2.0);
+        assertThat(count(OtlpTraceIngestMetrics.SPAN_STORED, "transport", "http", "type", "spanChunk")).isEqualTo(1.0);
+        // the other transport stays untouched
+        assertThat(count(OtlpTraceIngestMetrics.SPAN_RECEIVED, "transport", "grpc")).isZero();
+    }
+
+    @Test
+    void ingestMetrics_rejectedSpans_countedPerReason() {
+        OtlpTraceMapperData mapperData = new OtlpTraceMapperData();
+        mapperData.getRejectedSpan().addCount(OtlpTraceRejectReason.INVALID_ID, 2);
+        mapperData.getRejectedSpan().addCount(OtlpTraceRejectReason.ORPHAN, 5);
+        mapperData.getRejectedSpan().addCount(OtlpTraceRejectReason.MAPPING_ERROR, 1);
+        OtlpTraceExportService service = newService(mapperData, null);
+
+        OtlpTraceExportResult result = service.export(List.of(resourceSpansWithSpans(8)), OtlpTraceIngestMetrics.Transport.GRPC);
+
+        assertThat(count(OtlpTraceIngestMetrics.SPAN_REJECTED, "transport", "grpc", "reason", "invalid_id")).isEqualTo(2.0);
+        assertThat(count(OtlpTraceIngestMetrics.SPAN_REJECTED, "transport", "grpc", "reason", "orphan")).isEqualTo(5.0);
+        assertThat(count(OtlpTraceIngestMetrics.SPAN_REJECTED, "transport", "grpc", "reason", "mapping_error")).isEqualTo(1.0);
+        assertThat(count(OtlpTraceIngestMetrics.SPAN_REJECTED, "transport", "grpc", "reason", "unsampled")).isZero();
+        // the client-facing total is unchanged by the metric split
+        assertThat(result.clientRejected().count()).isEqualTo(8);
     }
 
     private double uriStatErrorCount(MeterRegistry registry) {
@@ -79,7 +132,7 @@ class OtlpTraceExportServiceTest {
         OtlpTraceExportService service = newService(dataWithUriStatSpan(),
                 new OtlpUriStatService(captureDao, () -> "tenant1"));
 
-        OtlpTraceExportResult result = service.export(List.of());
+        OtlpTraceExportResult result = service.export(List.of(), OtlpTraceIngestMetrics.Transport.GRPC);
 
         assertThat(result.serverErrorCount()).isZero();
         assertThat(inserted).hasSize(1);
@@ -95,7 +148,7 @@ class OtlpTraceExportServiceTest {
         OtlpTraceExportService service = newService(dataWithUriStatSpan(),
                 new OtlpUriStatService(throwingDao, () -> "tenant1"));
 
-        OtlpTraceExportResult result = service.export(List.of());
+        OtlpTraceExportResult result = service.export(List.of(), OtlpTraceIngestMetrics.Transport.GRPC);
 
         // spans are already stored at this point: the export succeeds and the failure is
         // NOT counted toward serverErrorCount — only the uriStat error counter moves.
@@ -108,7 +161,7 @@ class OtlpTraceExportServiceTest {
     void uriStatDisabled_absentBean_exportsWithoutTouchingUriStat() {
         OtlpTraceExportService service = newService(dataWithUriStatSpan(), null);
 
-        OtlpTraceExportResult result = service.export(List.of());
+        OtlpTraceExportResult result = service.export(List.of(), OtlpTraceIngestMetrics.Transport.GRPC);
 
         assertThat(result.serverErrorCount()).isZero();
         assertThat(uriStatErrorCount(meterRegistry)).isZero();

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceIngestMetricsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceIngestMetricsTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceRejectReason;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics.RequestRejectReason;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics.Transport;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OtlpTraceIngestMetricsTest {
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final OtlpTraceIngestMetrics metrics = new OtlpTraceIngestMetrics(registry);
+
+    private double counter(String name, String... tags) {
+        return registry.get(name).tags(tags).counter().count();
+    }
+
+    @Test
+    void allSeries_arePreRegisteredAtZero() {
+        // Dashboards repeating on the reason tag rely on every combination existing before the
+        // first event, so a reason that never fired still renders as a flat zero line.
+        List<Counter> spanRejected = registry.get(OtlpTraceIngestMetrics.SPAN_REJECTED).counters().stream().toList();
+        assertThat(spanRejected).hasSize(Transport.values().length * OtlpTraceRejectReason.values().length);
+        assertThat(spanRejected).allSatisfy(c -> assertThat(c.count()).isZero());
+
+        assertThat(registry.get(OtlpTraceIngestMetrics.SPAN_RECEIVED).counters()).hasSize(2);
+        assertThat(registry.get(OtlpTraceIngestMetrics.SPAN_STORED).counters()).hasSize(4);
+        // grpc: inflight_bytes, executor_rejected / http: inflight_bytes, concurrency, payload_too_large,
+        // unsupported_encoding, parse_error
+        assertThat(registry.get(OtlpTraceIngestMetrics.REQUEST_REJECTED).counters()).hasSize(7);
+    }
+
+    @Test
+    void spanCounters_incrementByCount_perTransport() {
+        metrics.spanReceived(Transport.GRPC, 120);
+        metrics.spanReceived(Transport.HTTP, 5);
+        metrics.spanStored(Transport.GRPC, 30);
+        metrics.spanChunkStored(Transport.GRPC, 2);
+        metrics.spanRejected(Transport.GRPC, OtlpTraceRejectReason.ORPHAN, 4);
+
+        assertThat(counter(OtlpTraceIngestMetrics.SPAN_RECEIVED, "transport", "grpc")).isEqualTo(120.0);
+        assertThat(counter(OtlpTraceIngestMetrics.SPAN_RECEIVED, "transport", "http")).isEqualTo(5.0);
+        assertThat(counter(OtlpTraceIngestMetrics.SPAN_STORED, "transport", "grpc", "type", "span")).isEqualTo(30.0);
+        assertThat(counter(OtlpTraceIngestMetrics.SPAN_STORED, "transport", "grpc", "type", "spanChunk")).isEqualTo(2.0);
+        assertThat(counter(OtlpTraceIngestMetrics.SPAN_REJECTED, "transport", "grpc", "reason", "orphan")).isEqualTo(4.0);
+        assertThat(counter(OtlpTraceIngestMetrics.SPAN_REJECTED, "transport", "http", "reason", "orphan")).isZero();
+    }
+
+    @Test
+    void zeroCounts_leaveCountersUntouched() {
+        metrics.spanReceived(Transport.GRPC, 0);
+        metrics.spanRejected(Transport.HTTP, OtlpTraceRejectReason.INVALID_ID, 0);
+
+        assertThat(counter(OtlpTraceIngestMetrics.SPAN_RECEIVED, "transport", "grpc")).isZero();
+        assertThat(counter(OtlpTraceIngestMetrics.SPAN_REJECTED, "transport", "http", "reason", "invalid_id")).isZero();
+    }
+
+    @Test
+    void requestRejected_countsOnePerCall_withTransportSpecificReasons() {
+        metrics.requestRejected(Transport.GRPC, RequestRejectReason.INFLIGHT_BYTES);
+        metrics.requestRejected(Transport.GRPC, RequestRejectReason.INFLIGHT_BYTES);
+        metrics.requestRejected(Transport.HTTP, RequestRejectReason.PAYLOAD_TOO_LARGE);
+
+        assertThat(counter(OtlpTraceIngestMetrics.REQUEST_REJECTED, "transport", "grpc", "reason", "inflight_bytes")).isEqualTo(2.0);
+        assertThat(counter(OtlpTraceIngestMetrics.REQUEST_REJECTED, "transport", "http", "reason", "payload_too_large")).isEqualTo(1.0);
+        assertThat(counter(OtlpTraceIngestMetrics.REQUEST_REJECTED, "transport", "http", "reason", "inflight_bytes")).isZero();
+    }
+
+    @Test
+    void requestRejected_reasonNotEmittedByTransport_failsFast() {
+        // gRPC has no payload-size or encoding gate of its own; wiring such a pair is a bug.
+        assertThatThrownBy(() -> metrics.requestRejected(Transport.GRPC, RequestRejectReason.PAYLOAD_TOO_LARGE))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> metrics.requestRejected(Transport.HTTP, RequestRejectReason.EXECUTOR_REJECTED))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void requestBytes_recordsDistributionPerTransport() {
+        metrics.requestBytes(Transport.GRPC, 1_000);
+        metrics.requestBytes(Transport.GRPC, 3_000);
+        metrics.requestBytes(Transport.HTTP, 0); // ignored
+
+        DistributionSummary grpc = registry.get(OtlpTraceIngestMetrics.REQUEST_BYTES).tag("transport", "grpc").summary();
+        assertThat(grpc.count()).isEqualTo(2);
+        assertThat(grpc.totalAmount()).isEqualTo(4_000.0);
+        assertThat(grpc.max()).isEqualTo(3_000.0);
+        assertThat(registry.get(OtlpTraceIngestMetrics.REQUEST_BYTES).tag("transport", "http").summary().count()).isZero();
+    }
+
+    @Test
+    void inFlightGauges_trackSupplierAndLimit() {
+        long[] reserved = {0};
+        int[] requests = {0};
+        metrics.registerInFlightBytes(Transport.HTTP, () -> reserved[0], 256L << 20);
+        metrics.registerInFlightRequests(Transport.HTTP, () -> requests[0], 64);
+
+        reserved[0] = 12_345;
+        requests[0] = 7;
+
+        assertThat(registry.get(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_BYTES).tag("transport", "http").gauge().value()).isEqualTo(12_345.0);
+        assertThat(registry.get(OtlpTraceIngestMetrics.ADMISSION_LIMIT_BYTES).tag("transport", "http").gauge().value()).isEqualTo((double) (256L << 20));
+        assertThat(registry.get(OtlpTraceIngestMetrics.ADMISSION_INFLIGHT_REQUESTS).tag("transport", "http").gauge().value()).isEqualTo(7.0);
+        assertThat(registry.get(OtlpTraceIngestMetrics.ADMISSION_LIMIT_REQUESTS).tag("transport", "http").gauge().value()).isEqualTo(64.0);
+    }
+
+    @Test
+    void tagValues_areStableSnakeCase() {
+        assertThat(Transport.GRPC.tagValue()).isEqualTo("grpc");
+        assertThat(Transport.HTTP.tagValue()).isEqualTo("http");
+        assertThat(RequestRejectReason.INFLIGHT_BYTES.tagValue()).isEqualTo("inflight_bytes");
+        assertThat(RequestRejectReason.EXECUTOR_REJECTED.tagValue()).isEqualTo("executor_rejected");
+        assertThat(RequestRejectReason.CONCURRENCY.tagValue()).isEqualTo("concurrency");
+        assertThat(RequestRejectReason.PAYLOAD_TOO_LARGE.tagValue()).isEqualTo("payload_too_large");
+        assertThat(RequestRejectReason.UNSUPPORTED_ENCODING.tagValue()).isEqualTo("unsupported_encoding");
+        assertThat(RequestRejectReason.PARSE_ERROR.tagValue()).isEqualTo("parse_error");
+    }
+}


### PR DESCRIPTION
… admission gauges as metrics

Expose the OTLP trace ingest pipeline through the collector MeterRegistry so ingest volume and loss can be monitored per transport (gRPC / HTTP):

- collector.otlptrace.span.received{transport}: spans received per request
- collector.otlptrace.span.stored{transport,type}: spans / span chunks written
- collector.otlptrace.span.rejected{transport,reason}: unsampled, invalid_id, invalid_resource, orphan, mapping_error
- collector.otlptrace.request.rejected{transport,reason}: inflight_bytes, executor_rejected (gRPC) / inflight_bytes, concurrency, payload_too_large, unsupported_encoding, parse_error (HTTP)
- collector.otlptrace.request.bytes{transport}: wire bytes per admitted request
- collector.otlptrace.admission.{inflight,limit}.{bytes,requests}{transport}

All series are pre-registered at startup so dashboards repeating on the reason tag render flat zero lines before the first event; the hot path only increments pre-resolved meters (no per-span work, no allocation).

Rejection reasons are carried by OtlpTraceRejectReason and aggregated in OtlpTraceCollectorRejectedSpan (response format unchanged). Also fixes OtlpTraceMapper.reject() counting ScopeSpans blocks instead of spans.