### PR TITLE
[#noissue] Inject the bounded active trace map into DefaultActiveTrac…

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/active/DefaultActiveTraceRepository.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/active/DefaultActiveTraceRepository.java
@@ -16,12 +16,9 @@
 
 package com.navercorp.pinpoint.profiler.context.active;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.navercorp.pinpoint.common.trace.HistogramSchema;
 import com.navercorp.pinpoint.common.trace.HistogramSchemas;
 import com.navercorp.pinpoint.common.trace.HistogramSlot;
-import com.navercorp.pinpoint.profiler.cache.CaffeineBuilder;
 import com.navercorp.pinpoint.profiler.context.id.LocalTraceRoot;
 import com.navercorp.pinpoint.profiler.monitor.metric.response.ResponseTimeCollector;
 import org.apache.logging.log4j.LogManager;
@@ -39,9 +36,6 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class DefaultActiveTraceRepository implements ActiveTraceRepository {
 
-    // memory leak defense threshold
-    private static final int DEFAULT_MAX_ACTIVE_TRACE_SIZE = 1024 * 10;
-
     private final Logger logger = LogManager.getLogger(this.getClass());
     private final boolean isDebug = logger.isDebugEnabled();
 
@@ -53,24 +47,14 @@ public class DefaultActiveTraceRepository implements ActiveTraceRepository {
     private final HistogramSchema histogramSchema = HistogramSchemas.NORMAL_SCHEMA;
     private final ActiveTraceHistogram emptyActiveTraceHistogram = new EmptyActiveTraceHistogram(histogramSchema);
 
-    public DefaultActiveTraceRepository(ResponseTimeCollector responseTimeCollector) {
-        this(responseTimeCollector, DEFAULT_MAX_ACTIVE_TRACE_SIZE);
-    }
-
-    public DefaultActiveTraceRepository(ResponseTimeCollector responseTimeCollector, int maxActiveTraceSize) {
+    /**
+     * @param activeTraceInfoMap bounded map that holds the traces in flight; the bound is the memory leak
+     *                           defense, so the provider decides the size and the eviction policy
+     */
+    public DefaultActiveTraceRepository(ResponseTimeCollector responseTimeCollector, ConcurrentMap<ActiveTraceHandle, ActiveTrace> activeTraceInfoMap) {
         this.responseTimeCollector = Objects.requireNonNull(responseTimeCollector, "responseTimeCollector");
-        this.activeTraceInfoMap = createCache(maxActiveTraceSize);
+        this.activeTraceInfoMap = Objects.requireNonNull(activeTraceInfoMap, "activeTraceInfoMap");
     }
-
-    private ConcurrentMap<ActiveTraceHandle, ActiveTrace> createCache(int maxActiveTraceSize) {
-        final Caffeine<Object, Object> cacheBuilder = CaffeineBuilder.newBuilder();
-        cacheBuilder.initialCapacity(maxActiveTraceSize);
-        cacheBuilder.maximumSize(maxActiveTraceSize);
-
-        final Cache<ActiveTraceHandle, ActiveTrace> localCache = cacheBuilder.build();
-        return localCache.asMap();
-    }
-
 
     private void remove(ActiveTraceHandle key, long purgeTime) {
         if (isDebug) {

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/ActiveTraceRepositoryProvider.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/context/provider/ActiveTraceRepositoryProvider.java
@@ -19,6 +19,11 @@ package com.navercorp.pinpoint.profiler.context.provider;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.navercorp.pinpoint.profiler.cache.CaffeineBuilder;
+import com.navercorp.pinpoint.profiler.context.active.ActiveTrace;
+import com.navercorp.pinpoint.profiler.context.active.ActiveTraceHandle;
 import com.navercorp.pinpoint.profiler.context.active.ActiveTraceRepository;
 import com.navercorp.pinpoint.profiler.context.active.DefaultActiveTraceRepository;
 import com.navercorp.pinpoint.profiler.context.active.EmptyActiveTraceRepository;
@@ -26,12 +31,15 @@ import com.navercorp.pinpoint.profiler.context.module.config.TraceAgentActiveThr
 import com.navercorp.pinpoint.profiler.monitor.metric.response.ResponseTimeCollector;
 
 import java.util.Objects;
+import java.util.concurrent.ConcurrentMap;
 
 
 /**
  * @author Woonduk Kang(emeroad)
  */
 public class ActiveTraceRepositoryProvider implements Provider<ActiveTraceRepository> {
+    // memory leak defense threshold
+    private static final int DEFAULT_MAX_ACTIVE_TRACE_SIZE = 1024 * 10;
 
     private final boolean isTraceAgentActiveThread;
     private final ResponseTimeCollector responseTimeCollector;
@@ -45,10 +53,21 @@ public class ActiveTraceRepositoryProvider implements Provider<ActiveTraceReposi
 
     public ActiveTraceRepository get() {
         if (isTraceAgentActiveThread) {
-            return new DefaultActiveTraceRepository(responseTimeCollector);
+            final ConcurrentMap<ActiveTraceHandle, ActiveTrace> activeTraceInfoMap = newActiveTraceMap(DEFAULT_MAX_ACTIVE_TRACE_SIZE);
+            return new DefaultActiveTraceRepository(responseTimeCollector, activeTraceInfoMap);
         }
-        ActiveTraceRepository emptyActiveTraceRepository = new EmptyActiveTraceRepository(responseTimeCollector);
-        return emptyActiveTraceRepository;
+        return new EmptyActiveTraceRepository(responseTimeCollector);
     }
 
+    /**
+     * Bounded, oom safe map: traces that are never closed are evicted once the bound is reached.
+     */
+    private ConcurrentMap<ActiveTraceHandle, ActiveTrace> newActiveTraceMap(int maxActiveTraceSize) {
+        final Caffeine<Object, Object> cacheBuilder = CaffeineBuilder.newBuilder();
+        cacheBuilder.initialCapacity(maxActiveTraceSize);
+        cacheBuilder.maximumSize(maxActiveTraceSize);
+
+        final Cache<ActiveTraceHandle, ActiveTrace> localCache = cacheBuilder.build();
+        return localCache.asMap();
+    }
 }


### PR DESCRIPTION
…eRepository instead of building it inside

This pull request refactors how active trace storage is managed in the profiler module. The main change is to move the responsibility for creating and configuring the bounded active trace map from `DefaultActiveTraceRepository` to its provider, making the repository itself more flexible and decoupled from specific cache implementations. This also clarifies the memory leak defense mechanism.

The most important changes are:

**Refactoring Active Trace Repository Construction:**
* Changed `DefaultActiveTraceRepository` to accept a pre-built, externally provided `ConcurrentMap<ActiveTraceHandle, ActiveTrace>` instead of constructing its own cache internally. The constructor that accepted a size parameter and the internal cache creation logic were removed. [[1]](diffhunk://#diff-22be6b7a4af29e67cf580e428b10c6142b5f21f8257fafcedab4421ef0f5ef22L42-L44) [[2]](diffhunk://#diff-22be6b7a4af29e67cf580e428b10c6142b5f21f8257fafcedab4421ef0f5ef22L56-L74)

**Provider Responsibility and Memory Safety:**
* Moved the logic for creating a bounded, memory-leak-safe active trace map to `ActiveTraceRepositoryProvider`, which now builds and injects the cache using `CaffeineBuilder`. The memory leak defense threshold constant was also moved here. [[1]](diffhunk://#diff-b3e78cd100178249a15c11675a4ad71e37fcddc4edbba72c40e91599f377f465R22-R42) [[2]](diffhunk://#diff-b3e78cd100178249a15c11675a4ad71e37fcddc4edbba72c40e91599f377f465L48-R72)

**Code Cleanup:**
* Removed unused imports from `DefaultActiveTraceRepository` related to cache construction, since cache creation is now handled externally.

These changes improve separation of concerns and make it easier to adjust or test the active trace storage mechanism.