### PR TITLE
[#noissue] Align the OTLP trace mapper with the current RPC, messagin…

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorder.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorder.java
@@ -49,8 +49,16 @@ import java.util.function.Consumer;
  * the current semconv key ({@code gen_ai.usage.input_tokens} / {@code ...output_tokens}), then
  * the pre-rename semconv key ({@code ...prompt_tokens} / {@code ...completion_tokens}), then the
  * bare nonstandard key emitted by Claude Code ({@code input_tokens} / {@code output_tokens}).
- * The cache pair ({@code cache_read_tokens} / {@code cache_creation_tokens}) exists only in the
- * bare form — there is no semconv equivalent.</p>
+ * The cache pair resolves the same way: the GenAI semconv key
+ * ({@code gen_ai.usage.cache_read.input_tokens} / {@code gen_ai.usage.cache_write.input_tokens}),
+ * then the bare Claude Code key ({@code cache_read_tokens} / {@code cache_creation_tokens}).</p>
+ *
+ * <p>The {@code in} part always follows the semconv meaning — input tokens <em>including</em> the
+ * cached ones ({@code cache_r} / {@code cache_w} are subsets of it). The bare Claude Code
+ * {@code input_tokens} follows the Anthropic API instead, where the cached tokens are reported
+ * separately and excluded from {@code input_tokens}; when the input resolved from that bare key,
+ * the resolved cache parts are added to it so the usage line reads the same regardless of the
+ * emitting SDK. The raw attributes keep the original values.</p>
  *
  * <p>Bare keys are short, generic names ({@code input_tokens}, {@code ttft_ms}) that a non-LLM
  * instrumentation could coincidentally use, so the bare ladder steps apply only when the span
@@ -88,10 +96,16 @@ public final class OtlpGenAiRecorder {
     private static final String[] TOTAL_SEMCONV_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_TOTAL_TOKENS,
     };
+    private static final String[] CACHE_READ_SEMCONV_KEYS = {
+            OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+    };
     private static final String[] CACHE_READ_BARE_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS,
     };
-    private static final String[] CACHE_CREATION_BARE_KEYS = {
+    private static final String[] CACHE_WRITE_SEMCONV_KEYS = {
+            OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
+    };
+    private static final String[] CACHE_WRITE_BARE_KEYS = {
             OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS,
     };
     private static final String[] TTFT_BARE_KEYS = {
@@ -137,38 +151,73 @@ public final class OtlpGenAiRecorder {
     }
 
     private static String composeUsage(Map<String, AttributeValue> attributes, Set<String> consumedKeys, boolean genAiContext) {
-        final long input = resolveToken(attributes, consumedKeys, INPUT_SEMCONV_KEYS, INPUT_BARE_KEYS, genAiContext);
-        final long output = resolveToken(attributes, consumedKeys, OUTPUT_SEMCONV_KEYS, OUTPUT_BARE_KEYS, genAiContext);
-        final long cacheRead = genAiContext ? firstLong(attributes, consumedKeys, CACHE_READ_BARE_KEYS) : ABSENT;
-        final long cacheCreation = genAiContext ? firstLong(attributes, consumedKeys, CACHE_CREATION_BARE_KEYS) : ABSENT;
+        final Token input = resolveToken(attributes, consumedKeys, INPUT_SEMCONV_KEYS, INPUT_BARE_KEYS, genAiContext);
+        final Token output = resolveToken(attributes, consumedKeys, OUTPUT_SEMCONV_KEYS, OUTPUT_BARE_KEYS, genAiContext);
+        final Token cacheRead = resolveToken(attributes, consumedKeys, CACHE_READ_SEMCONV_KEYS, CACHE_READ_BARE_KEYS, genAiContext);
+        final Token cacheWrite = resolveToken(attributes, consumedKeys, CACHE_WRITE_SEMCONV_KEYS, CACHE_WRITE_BARE_KEYS, genAiContext);
         // Next to a resolved input/output a total is a derived duplicate (and may disagree — the
         // raw value is the evidence), so it is consumed only when neither half resolved.
-        final long total = (input == ABSENT && output == ABSENT)
+        final long total = (input.absent() && output.absent())
                 ? firstLong(attributes, consumedKeys, TOTAL_SEMCONV_KEYS)
                 : ABSENT;
-        if (input == ABSENT && output == ABSENT && total == ABSENT
-                && cacheRead == ABSENT && cacheCreation == ABSENT) {
+        if (input.absent() && output.absent() && total == ABSENT
+                && cacheRead.absent() && cacheWrite.absent()) {
             return null;
         }
         final StringJoiner joiner = new StringJoiner(" ");
-        appendPart(joiner, "in", input);
-        appendPart(joiner, "out", output);
+        appendPart(joiner, "in", normalizeInput(input, cacheRead, cacheWrite));
+        appendPart(joiner, "out", output.value());
         appendPart(joiner, "tot", total);
-        appendPart(joiner, "cache_r", cacheRead);
-        appendPart(joiner, "cache_w", cacheCreation);
+        appendPart(joiner, "cache_r", cacheRead.value());
+        appendPart(joiner, "cache_w", cacheWrite.value());
         return joiner.toString();
     }
 
-    private static long resolveToken(Map<String, AttributeValue> attributes, Set<String> consumedKeys,
-                                     String[] semconvKeys, String[] bareKeys, boolean genAiContext) {
+    /**
+     * Semconv meaning of {@code in}: input tokens including the cached ones. A bare Claude Code
+     * {@code input_tokens} excludes them (Anthropic API semantics), so the resolved cache parts
+     * are added back; a semconv-sourced input already includes them and is left as is.
+     */
+    private static long normalizeInput(Token input, Token cacheRead, Token cacheWrite) {
+        if (input.absent() || !input.bare()) {
+            return input.value();
+        }
+        long normalized = input.value();
+        if (!cacheRead.absent()) {
+            normalized += cacheRead.value();
+        }
+        if (!cacheWrite.absent()) {
+            normalized += cacheWrite.value();
+        }
+        return normalized;
+    }
+
+    /**
+     * A resolved token count and whether it came from a bare (nonstandard) key — the bare keys
+     * carry the Anthropic token semantics, the semconv keys the OTel ones.
+     */
+    private record Token(long value, boolean bare) {
+        private static final Token NONE = new Token(ABSENT, false);
+
+        boolean absent() {
+            return value == ABSENT;
+        }
+    }
+
+    private static Token resolveToken(Map<String, AttributeValue> attributes, Set<String> consumedKeys,
+                                      String[] semconvKeys, String[] bareKeys, boolean genAiContext) {
         final long semconv = firstLong(attributes, consumedKeys, semconvKeys);
         if (semconv != ABSENT) {
-            return semconv;
+            return new Token(semconv, false);
         }
         if (!genAiContext) {
-            return ABSENT;
+            return Token.NONE;
         }
-        return firstLong(attributes, consumedKeys, bareKeys);
+        final long bare = firstLong(attributes, consumedKeys, bareKeys);
+        if (bare == ABSENT) {
+            return Token.NONE;
+        }
+        return new Token(bare, true);
     }
 
     private static void appendPart(StringJoiner joiner, String label, long value) {

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGrpcStatusResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGrpcStatusResolver.java
@@ -17,6 +17,7 @@
 package com.navercorp.pinpoint.otlp.trace.collector.mapper;
 
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 import org.jspecify.annotations.Nullable;
 
@@ -73,20 +74,23 @@ public final class OtlpGrpcStatusResolver {
 
     /**
      * Returns the promoted gRPC status or {@code null} when none is present. The RC
-     * {@code rpc.response.status_code} carries the status NAME directly (numeric strings are
-     * translated defensively); the legacy keys carry the numeric code, typed as int (standard
-     * semconv) or as a numeric string (nonstandard variant) — both forms are accepted per key.
+     * {@code rpc.status_code} (and its predecessor {@code rpc.response.status_code}) carries the
+     * status NAME directly (numeric strings are translated defensively); the legacy keys carry
+     * the numeric code, typed as int (standard semconv) or as a numeric string (nonstandard
+     * variant) — both forms are accepted per key.
      */
     @Nullable
     public static GrpcStatus resolve(Map<String, AttributeValue> attributes) {
-        // RC generic key first — gated on the rpc system actually being grpc (peek only; the
+        // RC generic keys first — gated on the rpc system actually being grpc (peek only; the
         // status key itself is what the caller consumes via sourceKey()).
         if (isGrpcSystem(attributes)) {
-            final String status = AttributeUtils.getAttributeStringValue(
-                    attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_RESPONSE_STATUS_CODE, null);
-            if (status != null && !status.isEmpty()) {
-                return new GrpcStatus(normalizeStatus(status),
-                        OtlpTraceConstants.ATTRIBUTE_KEY_RPC_RESPONSE_STATUS_CODE);
+            for (String key : OtlpTraceConstants.RPC_STATUS_CODE_KEYS) {
+                final String status = AttributeUtils.getAttributeStringValue(attributes, key, null);
+                // Blank (whitespace-only) values are treated as absent so they neither get promoted
+                // as a bogus status name nor block the fallback to the predecessor / legacy keys.
+                if (StringUtils.hasText(status)) {
+                    return new GrpcStatus(normalizeStatus(status.trim()), key);
+                }
             }
         }
         for (String key : OtlpTraceConstants.GRPC_STATUS_CODE_KEYS) {
@@ -115,7 +119,7 @@ public final class OtlpGrpcStatusResolver {
      */
     private static String normalizeStatus(String status) {
         try {
-            return toStatusName(Long.parseLong(status.trim()));
+            return toStatusName(Long.parseLong(status));
         } catch (NumberFormatException e) {
             return status;
         }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpRpcMethodResolver.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpRpcMethodResolver.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Normalizes the RPC operation name to the fully-qualified form of the RC semantic conventions,
+ * {@code <service>/<method>} (e.g. {@code oteldemo.CheckoutService/PlaceOrder}).
+ *
+ * <p>Two attribute shapes arrive side by side while SDKs migrate:</p>
+ * <ul>
+ *   <li>RC (semconv 1.39+): {@code rpc.method} already carries the fully-qualified name and
+ *       {@code rpc.service} is deprecated / absent.</li>
+ *   <li>1.x: {@code rpc.service} = {@code oteldemo.CheckoutService}, {@code rpc.method} =
+ *       {@code PlaceOrder}.</li>
+ * </ul>
+ * Without normalization the same gRPC operation would land under two keys ({@code PlaceOrder}
+ * vs {@code oteldemo.CheckoutService/PlaceOrder}) in the transaction rpc, the exception
+ * uriTemplate and URI stat, and bare 1.x method names collide across services ({@code Get},
+ * {@code List}). The 1.x pair is therefore composed into the RC form; an RC value (contains a
+ * {@code /}) is passed through untouched, including the {@code _OTHER} placeholder.
+ *
+ * <p>The resolved keys are added to {@code consumedKeys} so the caller filters only the
+ * attributes that were promoted.</p>
+ */
+public final class OtlpRpcMethodResolver {
+
+    private static final char SEPARATOR = '/';
+
+    private OtlpRpcMethodResolver() {
+    }
+
+    /**
+     * Fully-qualified RPC method, or {@code null} when {@code rpc.method} is absent or blank.
+     * Consumes {@code rpc.method}, and {@code rpc.service} when it was composed in.
+     */
+    @Nullable
+    public static String resolve(Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
+        final String method = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_METHOD, null);
+        if (!hasText(method)) {
+            return null;
+        }
+        final String trimmedMethod = method.trim();
+        consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_METHOD);
+        if (trimmedMethod.indexOf(SEPARATOR) >= 0) {
+            // RC shape: already "<service>/<method>" (some senders keep a leading "/") — never
+            // re-prefix a service.
+            return trimmedMethod;
+        }
+        final String service = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SERVICE, null);
+        if (hasText(service)) {
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SERVICE);
+            return service.trim() + SEPARATOR + trimmedMethod;
+        }
+        // 1.x sender without rpc.service: nothing to qualify with, keep the bare method.
+        return trimmedMethod;
+    }
+
+    /**
+     * RPC service name for the endPoint fallback: {@code rpc.service} when a 1.x sender still
+     * emits it, otherwise the service part of a fully-qualified RC {@code rpc.method}
+     * ({@code oteldemo.CheckoutService/PlaceOrder} → {@code oteldemo.CheckoutService}; a leading
+     * {@code /} is ignored). {@code null} when neither yields a service. Only {@code rpc.service}
+     * is consumed here — {@code rpc.method} is consumed by {@link #resolve} on the rpc path.
+     */
+    @Nullable
+    public static String resolveService(Map<String, AttributeValue> attributes, Set<String> consumedKeys) {
+        final String service = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SERVICE, null);
+        if (hasText(service)) {
+            consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SERVICE);
+            return service.trim();
+        }
+        final String method = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_METHOD, null);
+        if (!hasText(method)) {
+            return null;
+        }
+        String qualified = method.trim();
+        if (qualified.charAt(0) == SEPARATOR) {
+            qualified = qualified.substring(1);
+        }
+        final int lastSeparator = qualified.lastIndexOf(SEPARATOR);
+        if (lastSeparator <= 0) {
+            return null;
+        }
+        return qualified.substring(0, lastSeparator);
+    }
+
+    private static boolean hasText(@Nullable String value) {
+        if (value == null) {
+            return false;
+        }
+        return !value.trim().isEmpty();
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceConstants.java
@@ -137,8 +137,10 @@ public class OtlpTraceConstants {
     // (may differ from the requested alias) and wins over request.model. Tokens: current semconv
     // names input_tokens/output_tokens, the pre-rename semconv used prompt_tokens/completion_tokens,
     // and Claude Code emits bare nonstandard keys (input_tokens/output_tokens/cache_read_tokens/
-    // cache_creation_tokens); the cache pair has no semconv equivalent. Only the key actually
-    // consumed is filtered from the raw attributes — non-promoted variants survive.
+    // cache_creation_tokens). The GenAI semconv (semantic-conventions-genai, Development) names
+    // the cache pair gen_ai.usage.cache_read.input_tokens / gen_ai.usage.cache_write.input_tokens.
+    // Only the key actually consumed is filtered from the raw attributes — non-promoted variants
+    // survive.
     public static final String ATTRIBUTE_KEY_GEN_AI_RESPONSE_MODEL = "gen_ai.response.model";
     public static final String ATTRIBUTE_KEY_GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
     public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens";
@@ -150,6 +152,12 @@ public class OtlpTraceConstants {
     // Some SDKs report only the total; consumed only when neither the input nor the output half
     // resolved — next to them a total is a derived duplicate and survives raw.
     public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens";
+    // Prompt-cache token counts. Semconv: cache_read / cache_write are subsets of input_tokens
+    // (input_tokens "SHOULD include all types of input tokens, including cached tokens"). The
+    // bare Claude Code pair follows the Anthropic API instead, where input_tokens EXCLUDES the
+    // cached tokens — OtlpGenAiRecorder normalizes the usage line to the semconv meaning.
+    public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens";
+    public static final String ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS = "gen_ai.usage.cache_write.input_tokens";
     public static final String ATTRIBUTE_KEY_CACHE_READ_TOKENS = "cache_read_tokens";
     public static final String ATTRIBUTE_KEY_CACHE_CREATION_TOKENS = "cache_creation_tokens";
     // Time to first token in milliseconds — bare nonstandard key emitted by Claude Code. OTel
@@ -177,8 +185,9 @@ public class OtlpTraceConstants {
     public static final String ATTRIBUTE_KEY_HTTP_URL = "http.url";
     public static final String ATTRIBUTE_KEY_HTTP_TARGET = "http.target";
     // rpc.service is deprecated in the RC semconv (folded into the fully-qualified rpc.method,
-    // e.g. "com.example.ExampleService/exampleMethod") but is kept as an endPoint fallback for
-    // 1.x SDKs that still emit it.
+    // e.g. "com.example.ExampleService/exampleMethod"). OtlpRpcMethodResolver composes the 1.x
+    // pair into that RC shape so the rpc / exception uriTemplate keys are the same for both
+    // generations, and derives the endPoint service from either key.
     public static final String ATTRIBUTE_KEY_RPC_SERVICE = "rpc.service";
     public static final String ATTRIBUTE_KEY_RPC_METHOD = "rpc.method";
     // RPC system identifier. RC semconv (Release Candidate): rpc.system.name; deprecated 1.x:
@@ -192,15 +201,21 @@ public class OtlpTraceConstants {
     public static final String RPC_SYSTEM_GRPC = "grpc";
     public static final String RPC_SYSTEM_APACHE_DUBBO = "apache_dubbo";
     public static final String RPC_SYSTEM_DUBBO = "dubbo";
-    // gRPC result status. RC semconv: rpc.response.status_code (string status NAME, e.g. "OK" /
+    // gRPC result status. RC semconv: rpc.status_code (string status NAME, e.g. "OK" /
     // "DEADLINE_EXCEEDED"; shared by all rpc systems, so it is only interpreted as a gRPC status
-    // when rpc.system(.name) == grpc). Deprecated 1.x: rpc.grpc.status_code (int 0-16);
-    // nonstandard variant grpc.status_code (numeric string) emitted by e.g. the ASP.NET Core
-    // gRPC instrumentation. Promoted to the grpc.status annotation via OtlpGrpcStatusResolver.
+    // when rpc.system(.name) == grpc). Its short-lived predecessor rpc.response.status_code
+    // (semconv 1.39-1.4x) carries the same value shape and is kept for SDKs that shipped it.
+    // Deprecated 1.x: rpc.grpc.status_code (int 0-16); nonstandard variant grpc.status_code
+    // (numeric string) emitted by e.g. the ASP.NET Core gRPC instrumentation. Promoted to the
+    // grpc.status annotation via OtlpGrpcStatusResolver.
+    public static final String ATTRIBUTE_KEY_RPC_STATUS_CODE = "rpc.status_code";
     public static final String ATTRIBUTE_KEY_RPC_RESPONSE_STATUS_CODE = "rpc.response.status_code";
     public static final String ATTRIBUTE_KEY_RPC_GRPC_STATUS_CODE = "rpc.grpc.status_code";
     public static final String ATTRIBUTE_KEY_GRPC_STATUS_CODE = "grpc.status_code";
-    public static final String ATTRIBUTE_KEY_MESSAGING_CLIENT_ID = "messaging.client_id";
+    // Messaging client identifier. Current semconv: messaging.client.id; deprecated 1.x:
+    // messaging.client_id. Resolved in that order by MessagingAttributeUtils.resolveClientId.
+    public static final String ATTRIBUTE_KEY_MESSAGING_CLIENT_ID = "messaging.client.id";
+    public static final String ATTRIBUTE_KEY_MESSAGING_CLIENT_ID_LEGACY = "messaging.client_id";
     public static final String ATTRIBUTE_KEY_SERVER_PORT = "server.port";
     public static final String ATTRIBUTE_KEY_SERVER_ADDRESS = "server.address";
     public static final String ATTRIBUTE_KEY_UPSTREAM_ADDRESS = "upstream_address";
@@ -286,6 +301,7 @@ public class OtlpTraceConstants {
             ATTRIBUTE_KEY_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
             ATTRIBUTE_KEY_MESSAGING_MESSAGE_ID,
             ATTRIBUTE_KEY_MESSAGING_CLIENT_ID,
+            ATTRIBUTE_KEY_MESSAGING_CLIENT_ID_LEGACY,
             // shared network endpoint keys — consumed by the root/SpanEvent endPoint chains AND
             // by MessagingAttributeUtils.resolveEndPoint, so they stay in the static set until
             // the messaging paths join the consumedKeys mechanism.
@@ -324,12 +340,21 @@ public class OtlpTraceConstants {
     public static final List<String> HTTP_METHOD_KEYS =
             List.of(ATTRIBUTE_KEY_HTTP_REQUEST_METHOD, ATTRIBUTE_KEY_HTTP_METHOD);
 
+    // Generic (all-rpc-system) status keys, RC before its predecessor. Handled separately from
+    // GRPC_STATUS_CODE_KEYS in OtlpGrpcStatusResolver because they need the rpc-system gate.
+    // Same consumedKeys handling: only the consumed variant is filtered.
+    public static final List<String> RPC_STATUS_CODE_KEYS =
+            List.of(ATTRIBUTE_KEY_RPC_STATUS_CODE, ATTRIBUTE_KEY_RPC_RESPONSE_STATUS_CODE);
+
     // gRPC status resolution order: standard RPC semconv before the nonstandard variant.
-    // (The RC rpc.response.status_code is handled separately in OtlpGrpcStatusResolver — it
-    // needs the rpc-system gate, unlike these gRPC-specific keys.)
     // Same consumedKeys handling: only the consumed variant is filtered.
     public static final List<String> GRPC_STATUS_CODE_KEYS =
             List.of(ATTRIBUTE_KEY_RPC_GRPC_STATUS_CODE, ATTRIBUTE_KEY_GRPC_STATUS_CODE);
+
+    // Messaging client id resolution order: current semconv (messaging.client.id) before the
+    // deprecated 1.x spelling (messaging.client_id). Both are in FILTERED_ATTRIBUTE_KEY_SET.
+    public static final List<String> MESSAGING_CLIENT_ID_KEYS =
+            List.of(ATTRIBUTE_KEY_MESSAGING_CLIENT_ID, ATTRIBUTE_KEY_MESSAGING_CLIENT_ID_LEGACY);
 
     // RPC system resolution order: RC semconv (rpc.system.name) before deprecated (rpc.system).
     // Same consumedKeys handling: only the consumed variant is filtered.

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapper.java
@@ -355,15 +355,17 @@ public class OtlpTraceSpanMapper {
             if (httpUrl != null) {
                 return extractHostAndPort(httpUrl);
             }
-            final String rpcService = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SERVICE, null);
+            // gRPC server without an address: 1.x rpc.service, or the service part of the RC
+            // fully-qualified rpc.method (rpc.service is deprecated there).
+            final String rpcService = OtlpRpcMethodResolver.resolveService(attributes, consumedKeys);
             if (rpcService != null) {
-                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_SERVICE);
                 return rpcService;
             }
         } else if (span.getKind().getNumber() == Span.SpanKind.SPAN_KIND_CONSUMER_VALUE) {
-            // Consumer for an unsupported messaging.system: fall back to client_id.
+            // Consumer for an unsupported messaging.system: fall back to the client id
+            // (messaging.client.id, or the deprecated messaging.client_id).
             // Known systems (kafka, rabbitmq) are handled in map() via the messaging dispatch.
-            return AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_MESSAGING_CLIENT_ID, null);
+            return MessagingAttributeUtils.resolveClientId(attributes);
         }
         return null;
     }
@@ -471,9 +473,10 @@ public class OtlpTraceSpanMapper {
                 consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_HTTP_TARGET);
                 return httpTarget;
             }
-            final String rpcMethod = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_METHOD, null);
+            // gRPC server: fully-qualified "<service>/<method>" (1.x rpc.service + rpc.method are
+            // composed into the RC shape so both generations share one rpc key).
+            final String rpcMethod = OtlpRpcMethodResolver.resolve(attributes, consumedKeys);
             if (rpcMethod != null) {
-                consumedKeys.add(OtlpTraceConstants.ATTRIBUTE_KEY_RPC_METHOD);
                 return rpcMethod;
             }
         }
@@ -529,8 +532,9 @@ public class OtlpTraceSpanMapper {
      * Unlike {@link #getServerSpanToRpc}, there is no raw url.path / http.url / http.target fallback
      * (an unrouted request must not fan the exception groups out per request: "/users/1", "/users/2",
      * ...) and no span-name fallback. Order: route template (http.route, next.route, micrometer uri)
-     * → rpc.method (gRPC servers) → "". Never null: the agent path stores "" as well, and a null would
-     * be persisted as Pinot's STRING null sentinel and shown as the literal "null".
+     * → fully-qualified rpc method (gRPC servers, {@link OtlpRpcMethodResolver}) → "". Never null:
+     * the agent path stores "" as well, and a null would be persisted as Pinot's STRING null
+     * sentinel and shown as the literal "null".
      */
     String getExceptionUriTemplate(Span span, Map<String, AttributeValue> attributes, InstrumentationScope scope) {
         final int kind = span.getKind().getNumber();
@@ -539,8 +543,8 @@ public class OtlpTraceSpanMapper {
             if (routeTemplate != null) {
                 return routeTemplate;
             }
-            final String rpcMethod = AttributeUtils.getAttributeStringValue(attributes, OtlpTraceConstants.ATTRIBUTE_KEY_RPC_METHOD, null);
-            if (hasText(rpcMethod)) {
+            final String rpcMethod = OtlpRpcMethodResolver.resolve(attributes, new HashSet<>());
+            if (rpcMethod != null) {
                 return rpcMethod;
             }
         }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/message/MessagingAttributeUtils.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/message/MessagingAttributeUtils.java
@@ -18,6 +18,7 @@ package com.navercorp.pinpoint.otlp.trace.collector.mapper.message;
 
 import com.navercorp.pinpoint.common.plugin.util.HostAndPort;
 import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import com.navercorp.pinpoint.common.util.StringUtils;
 import com.navercorp.pinpoint.otlp.trace.collector.mapper.OtlpTraceConstants;
 import com.navercorp.pinpoint.otlp.trace.collector.util.AttributeUtils;
 
@@ -79,17 +80,31 @@ public final class MessagingAttributeUtils {
     }
 
     /**
-     * Messaging endpoint with {@code messaging.client_id} fallback when no broker address
-     * is available. Shared between producer (SpanEvent) and consumer (Span) paths so both
-     * sides resolve the same value from the same OTel attributes.
+     * Messaging endpoint with client-id fallback when no broker address is available. Shared
+     * between producer (SpanEvent) and consumer (Span) paths so both sides resolve the same
+     * value from the same OTel attributes.
      */
     public static String resolveEndPoint(Map<String, AttributeValue> attributes) {
         final String broker = getBrokerAddress(attributes);
         if (broker != null) {
             return broker;
         }
-        return AttributeUtils.getAttributeStringValue(attributes,
-                OtlpTraceConstants.ATTRIBUTE_KEY_MESSAGING_CLIENT_ID, null);
+        return resolveClientId(attributes);
+    }
+
+    /**
+     * Messaging client identifier: current semconv {@code messaging.client.id} first, then the
+     * deprecated 1.x spelling {@code messaging.client_id}. A blank (empty / whitespace-only) value
+     * counts as absent so the fallback order still applies. Returns {@code null} when neither is set.
+     */
+    public static String resolveClientId(Map<String, AttributeValue> attributes) {
+        for (String key : OtlpTraceConstants.MESSAGING_CLIENT_ID_KEYS) {
+            final String clientId = AttributeUtils.getAttributeStringValue(attributes, key, null);
+            if (StringUtils.hasText(clientId)) {
+                return clientId;
+            }
+        }
+        return null;
     }
 
     /**

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackTraceParserRegistry.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackTraceParserRegistry.java
@@ -48,6 +48,7 @@ public final class StackTraceParserRegistry {
 
         this.byLanguage = Map.of(
                 "java", java,
+                "kotlin", java, // opentelemetry-kotlin on JVM/Android emits java.lang.Throwable stacks
                 "nodejs", node,
                 "webjs", node, // browser JS shares the V8 stack shape
                 "python", python,

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapperTest.java
@@ -344,6 +344,28 @@ class OtlpExceptionMapperTest {
     }
 
     @Test
+    void map_kotlinSdkLanguage_parsedWithJavaParser() {
+        // telemetry.sdk.language=kotlin (opentelemetry-kotlin on JVM/Android): the stack is a
+        // java.lang.Throwable print, so the Java parser is selected by the attribute.
+        String stackTrace = "java.lang.IllegalStateException: boom\n"
+                + "\tat com.example.OrderService.place(OrderService.kt:42)\n"
+                + "\tat com.example.OrderController.post(OrderController.kt:17)\n";
+        Span span = spanBuilder(EXCEPTION_SPAN_ID)
+                .addEvents(exceptionEvent(exceptionType("java.lang.IllegalStateException"),
+                        kv("exception.stacktrace", strVal(stackTrace))))
+                .build();
+
+        ExceptionWrapperBo wrapper = mapper.map(id(), span, ROOT_SPAN_ID_LONG, "/api/orders", "kotlin")
+                .orElseThrow().getExceptionWrapperBos().get(0);
+
+        assertThat(wrapper.getStackTraceElements()).hasSize(2);
+        assertThat(wrapper.getStackTraceElements().get(0).getClassName()).isEqualTo("com.example.OrderService");
+        assertThat(wrapper.getStackTraceElements().get(0).getMethodName()).isEqualTo("place");
+        assertThat(wrapper.getStackTraceElements().get(0).getFileName()).isEqualTo("OrderService.kt");
+        assertThat(wrapper.getStackTraceElements().get(0).getLineNumber()).isEqualTo(42);
+    }
+
+    @Test
     void map_unrecognizedStackTraceFormat_keptAsRawLineFrames() {
         // Ruby-style stack under no language attribute: no parser matches, but the frames must not
         // be dropped — an empty list would collapse every unparsed exception into one shared

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorderTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpGenAiRecorderTest.java
@@ -97,13 +97,95 @@ class OtlpGenAiRecorderTest {
                 OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS, AttributeValue.of(5000L),
                 OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS, AttributeValue.of(0L)));
 
-        // zero is a legitimate value and stays visible
-        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:1200 out:340 cache_r:5000 cache_w:0");
+        // The bare Anthropic-style input_tokens excludes the cached tokens; "in" is normalized to the
+        // semconv meaning (including them): 1200 + 5000 + 0. Zero is a legitimate value and stays
+        // visible.
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:6200 out:340 cache_r:5000 cache_w:0");
         assertThat(consumedKeys).containsExactlyInAnyOrder(
                 OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS,
                 OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS,
                 OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS,
                 OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS);
+    }
+
+    @Test
+    void usage_bareInputWithoutCache_notAdjusted() {
+        // nothing to add back when the bare shape carries no cache parts
+        record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of(1200L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_OUTPUT_TOKENS, AttributeValue.of(340L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:1200 out:340");
+    }
+
+    @Test
+    void usage_semconvCacheKeys_inputAlreadyIncludesCache() {
+        // GenAI semconv shape: input_tokens includes the cached tokens, cache_* are subsets → no adjustment
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS, AttributeValue.of(6200L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_OUTPUT_TOKENS, AttributeValue.of(340L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, AttributeValue.of(5000L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS, AttributeValue.of(0L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:6200 out:340 cache_r:5000 cache_w:0");
+        assertThat(consumedKeys).containsExactlyInAnyOrder(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS,
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_OUTPUT_TOKENS,
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS);
+    }
+
+    @Test
+    void usage_semconvCacheKeys_resolveWithoutGenAiContextMarker() {
+        // the namespaced keys are their own proof of GenAI context
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, AttributeValue.of(5000L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("cache_r:5000");
+    }
+
+    @Test
+    void usage_semconvCacheKeysWinOverBare_onlyWinnerConsumed() {
+        record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, AttributeValue.of(5000L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS, AttributeValue.of(999L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("cache_r:5000");
+        assertThat(consumedKeys).containsExactly(OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS);
+    }
+
+    @Test
+    void usage_bareInputWithSemconvCache_inputAdjusted() {
+        // mixed: the input came from the bare (exclusive) key, so the cache parts are added back
+        // whichever key they resolved from
+        record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_INPUT_TOKENS, AttributeValue.of(1200L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, AttributeValue.of(5000L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:6200 cache_r:5000");
+    }
+
+    @Test
+    void usage_semconvInputWithBareCache_inputNotAdjusted() {
+        // mixed the other way: a semconv input already includes the cache, whatever key the cache used
+        record(Map.of(
+                OtlpTraceConstants.ATTRIBUTE_KEY_GEN_AI_USAGE_INPUT_TOKENS, AttributeValue.of(6200L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS, AttributeValue.of(5000L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("in:6200 cache_r:5000");
+    }
+
+    @Test
+    void usage_bareCacheOnly_noInputToAdjust() {
+        record(Map.of(
+                GEN_AI_SYSTEM, AttributeValue.of("anthropic"),
+                OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_READ_TOKENS, AttributeValue.of(5000L),
+                OtlpTraceConstants.ATTRIBUTE_KEY_CACHE_CREATION_TOKENS, AttributeValue.of(120L)));
+
+        assertThat(annotationValue(AnnotationKey.GEN_AI_USAGE)).isEqualTo("cache_r:5000 cache_w:120");
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpRpcMethodResolverTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpRpcMethodResolverTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.mapper;
+
+import com.navercorp.pinpoint.common.trace.attribute.AttributeValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpRpcMethodResolverTest {
+
+    private static Map<String, AttributeValue> attrs(String... keyValues) {
+        Map<String, AttributeValue> map = new HashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            map.put(keyValues[i], AttributeValue.of(keyValues[i + 1]));
+        }
+        return map;
+    }
+
+    @Test
+    void resolve_legacyPair_composedIntoFullyQualified_consumesBoth() {
+        Set<String> consumed = new HashSet<>();
+        String rpc = OtlpRpcMethodResolver.resolve(
+                attrs("rpc.service", "oteldemo.CheckoutService", "rpc.method", "PlaceOrder"), consumed);
+        assertThat(rpc).isEqualTo("oteldemo.CheckoutService/PlaceOrder");
+        assertThat(consumed).containsExactlyInAnyOrder("rpc.service", "rpc.method");
+    }
+
+    @Test
+    void resolve_rcFullyQualified_passedThrough_serviceNotConsumed() {
+        // A stale rpc.service next to an RC rpc.method must not be prefixed twice.
+        Set<String> consumed = new HashSet<>();
+        String rpc = OtlpRpcMethodResolver.resolve(
+                attrs("rpc.service", "oteldemo.CheckoutService", "rpc.method", "oteldemo.CheckoutService/PlaceOrder"), consumed);
+        assertThat(rpc).isEqualTo("oteldemo.CheckoutService/PlaceOrder");
+        assertThat(consumed).containsExactly("rpc.method");
+    }
+
+    @Test
+    void resolve_leadingSlash_keptAsIs() {
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpRpcMethodResolver.resolve(attrs("rpc.method", "/flagd.evaluation.v1.Service/EventStream"), consumed))
+                .isEqualTo("/flagd.evaluation.v1.Service/EventStream");
+    }
+
+    @Test
+    void resolve_methodOnly_staysBare() {
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpRpcMethodResolver.resolve(attrs("rpc.method", "GetAds"), consumed)).isEqualTo("GetAds");
+        assertThat(consumed).containsExactly("rpc.method");
+    }
+
+    @Test
+    void resolve_otherPlaceholder_composedWithService() {
+        // RC "_OTHER" (unrecognized method) is treated like any method name.
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpRpcMethodResolver.resolve(attrs("rpc.service", "svc.Api", "rpc.method", "_OTHER"), consumed))
+                .isEqualTo("svc.Api/_OTHER");
+    }
+
+    @Test
+    void resolve_blankOrMissingMethod_isNull_consumesNothing() {
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpRpcMethodResolver.resolve(attrs("rpc.service", "svc.Api", "rpc.method", " "), consumed)).isNull();
+        assertThat(OtlpRpcMethodResolver.resolve(attrs("rpc.service", "svc.Api"), consumed)).isNull();
+        assertThat(consumed).isEmpty();
+    }
+
+    @Test
+    void resolve_blankService_ignored() {
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpRpcMethodResolver.resolve(attrs("rpc.service", "  ", "rpc.method", "GetAds"), consumed)).isEqualTo("GetAds");
+        assertThat(consumed).containsExactly("rpc.method");
+    }
+
+    @Test
+    void resolve_trimsWhitespace() {
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpRpcMethodResolver.resolve(attrs("rpc.service", " svc.Api ", "rpc.method", " Get "), consumed))
+                .isEqualTo("svc.Api/Get");
+    }
+
+    @Test
+    void resolveService_legacyKey_consumed() {
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpRpcMethodResolver.resolveService(attrs("rpc.service", "oteldemo.CartService", "rpc.method", "AddItem"), consumed))
+                .isEqualTo("oteldemo.CartService");
+        assertThat(consumed).containsExactly("rpc.service");
+    }
+
+    @Test
+    void resolveService_derivedFromFullyQualifiedMethod_methodNotConsumed() {
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpRpcMethodResolver.resolveService(attrs("rpc.method", "oteldemo.CartService/AddItem"), consumed))
+                .isEqualTo("oteldemo.CartService");
+        assertThat(consumed).isEmpty();
+    }
+
+    @Test
+    void resolveService_leadingSlashIgnored() {
+        assertThat(OtlpRpcMethodResolver.resolveService(attrs("rpc.method", "/flagd.evaluation.v1.Service/EventStream"), new HashSet<>()))
+                .isEqualTo("flagd.evaluation.v1.Service");
+    }
+
+    @Test
+    void resolveService_nestedPath_usesLastSeparator() {
+        assertThat(OtlpRpcMethodResolver.resolveService(attrs("rpc.method", "a/b/c"), new HashSet<>())).isEqualTo("a/b");
+    }
+
+    @Test
+    void resolveService_bareMethodOrSlashOnly_isNull() {
+        Set<String> consumed = new HashSet<>();
+        assertThat(OtlpRpcMethodResolver.resolveService(attrs("rpc.method", "AddItem"), consumed)).isNull();
+        assertThat(OtlpRpcMethodResolver.resolveService(attrs("rpc.method", "/AddItem"), consumed)).isNull();
+        assertThat(OtlpRpcMethodResolver.resolveService(attrs("rpc.method", "/"), consumed)).isNull();
+        assertThat(OtlpRpcMethodResolver.resolveService(attrs(), consumed)).isNull();
+        assertThat(consumed).isEmpty();
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanEventMapperTest.java
@@ -788,6 +788,33 @@ class OtlpTraceSpanEventMapperTest {
     }
 
     @Test
+    void map_producer_endPoint_blankCurrentClientIdKey_fallsBackToLegacy() {
+        // A present-but-blank messaging.client.id must not win over the deprecated twin.
+        Span span = span(Span.SpanKind.SPAN_KIND_PRODUCER,
+                kv("messaging.system", strVal("kafka")),
+                kv("messaging.destination.name", strVal("orders")),
+                kv("messaging.client.id", strVal(" ")),
+                kv("messaging.client_id", strVal("legacy-1")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(event.getEndPoint()).isEqualTo("legacy-1");
+    }
+
+    @Test
+    void map_producer_endPoint_fallsBackToCurrentClientIdKey() {
+        // Current semconv spelling messaging.client.id; the deprecated twin is only a fallback.
+        Span span = span(Span.SpanKind.SPAN_KIND_PRODUCER,
+                kv("messaging.system", strVal("kafka")),
+                kv("messaging.destination.name", strVal("orders")),
+                kv("messaging.client.id", strVal("producer-42")),
+                kv("messaging.client_id", strVal("legacy-1")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(event.getEndPoint()).isEqualTo("producer-42");
+        assertThat(attributeKeys(event)).doesNotContain("messaging.client.id", "messaging.client_id");
+    }
+
+    @Test
     void map_producer_destinationId_fallsBackToEndPoint_whenDestinationNameAbsent() {
         Span span = span(Span.SpanKind.SPAN_KIND_PRODUCER,
                 kv("messaging.system", strVal("kafka")),
@@ -873,6 +900,57 @@ class OtlpTraceSpanEventMapperTest {
         SpanEventBo event = mapSingle(span);
         assertThat(findAnnotation(event, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("UNAVAILABLE");
         assertThat(attributeKeys(event)).doesNotContain("rpc.response.status_code");
+    }
+
+    @Test
+    void map_client_grpcStatus_rcStatusCode_promoted() {
+        // Current RC key rpc.status_code (replaces rpc.response.status_code and
+        // rpc.grpc.status_code): status NAME, promoted only because the rpc system is grpc.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.status_code", strVal("DEADLINE_EXCEEDED")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("DEADLINE_EXCEEDED");
+        assertThat(attributeKeys(event)).doesNotContain("rpc.status_code");
+    }
+
+    @Test
+    void map_client_grpcStatus_rcStatusCode_numericString_translated() {
+        // A sender emitting the legacy numeric shape under the new key is translated to the name.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.status_code", strVal("14")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("UNAVAILABLE");
+    }
+
+    @Test
+    void map_client_grpcStatus_rcStatusCode_winsOverPredecessor_onlyConsumedKeyRemoved() {
+        // rpc.status_code takes precedence over rpc.response.status_code; the non-consumed
+        // predecessor stays in the raw attributes.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.status_code", strVal("OK")),
+                kv("rpc.response.status_code", strVal("UNAVAILABLE")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("OK");
+        assertThat(attributeKeys(event)).doesNotContain("rpc.status_code");
+        assertThat(attributeKeys(event)).contains("rpc.response.status_code");
+    }
+
+    @Test
+    void map_client_grpcStatus_rcStatusCode_nonGrpcSystem_notPromoted() {
+        // rpc.status_code is shared by all rpc systems; a jsonrpc error code must not become a
+        // gRPC status annotation.
+        Span span = span(Span.SpanKind.SPAN_KIND_CLIENT,
+                kv("rpc.system.name", strVal("jsonrpc")),
+                kv("rpc.status_code", strVal("-32602")));
+
+        SpanEventBo event = mapSingle(span);
+        assertThat(findAnnotation(event, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isNull();
     }
 
     @Test
@@ -1227,7 +1305,8 @@ class OtlpTraceSpanEventMapperTest {
         // unclassified kind keeps the INTERNAL_METHOD fallback — the promotion is annotation-only
         assertThat(event.getServiceType()).isEqualTo(ServiceType.INTERNAL_METHOD.getCode());
         assertThat(findAnnotation(event, GEN_AI_MODEL)).isEqualTo("claude-sonnet-4-5");
-        assertThat(findAnnotation(event, GEN_AI_USAGE)).isEqualTo("in:1200 out:340 cache_r:5000 cache_w:0");
+        // bare Anthropic-style input excludes the cache → "in" normalized to the semconv meaning
+        assertThat(findAnnotation(event, GEN_AI_USAGE)).isEqualTo("in:6200 out:340 cache_r:5000 cache_w:0");
         // consumed keys leave the raw attribute list; non-promoted gen_ai keys survive
         assertThat(attributeKeys(event))
                 .doesNotContain(

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -407,6 +407,66 @@ class OtlpTraceSpanMapperTest {
     }
 
     @Test
+    void map_consumer_kafka_endPointFallsBackToCurrentClientIdKey() {
+        // Current semconv spelling messaging.client.id (messaging.client_id is deprecated).
+        Span span = consumerKafkaSpan(
+                kv("messaging.client.id", strVal("consumer-42"))
+        );
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("consumer-42");
+        // both spellings are in the static filtered set
+        assertThat(attributeKeys(bo)).doesNotContain("messaging.client.id", "messaging.client_id");
+    }
+
+    @Test
+    void map_consumer_kafka_blankCurrentClientIdKey_fallsBackToLegacy() {
+        // A present-but-blank messaging.client.id is treated as absent: the deprecated twin still
+        // supplies the endPoint instead of an empty string.
+        Span span = consumerKafkaSpan(
+                kv("messaging.client.id", strVal("   ")),
+                kv("messaging.client_id", strVal("legacy-1"))
+        );
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("legacy-1");
+    }
+
+    @Test
+    void map_consumer_kafka_blankClientIdKeysOnly_noEndPoint() {
+        Span span = consumerKafkaSpan(
+                kv("messaging.client.id", strVal("")),
+                kv("messaging.client_id", strVal(" "))
+        );
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isNull();
+    }
+
+    @Test
+    void map_consumer_kafka_currentClientIdKeyWinsOverLegacy() {
+        Span span = consumerKafkaSpan(
+                kv("messaging.client.id", strVal("consumer-42")),
+                kv("messaging.client_id", strVal("legacy-1"))
+        );
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("consumer-42");
+    }
+
+    @Test
+    void map_consumer_unsupportedSystem_endPointFallsBackToCurrentClientIdKey() {
+        // Unsupported messaging.system takes the generic consumer fallback in
+        // getRootSpanToEndPoint, which must accept the current client id key too.
+        Span span = Span.newBuilder()
+                .setName("jobs process")
+                .setTraceId(ByteString.copyFrom(TRACE_ID))
+                .setSpanId(ByteString.copyFrom(SPAN_ID))
+                .setKindValue(Span.SpanKind.SPAN_KIND_CONSUMER_VALUE)
+                .addAttributes(kv("messaging.system", strVal("nats")))
+                .addAttributes(kv("messaging.client.id", strVal("nats-client-7")))
+                .build();
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("nats-client-7");
+    }
+
+    @Test
     void map_consumer_kafka_acceptorHostUsesBroker() {
         Span span = consumerKafkaSpan(
                 kv("server.address", strVal("broker1.example.com")),
@@ -622,11 +682,21 @@ class OtlpTraceSpanMapperTest {
 
     @Test
     void exceptionUriTemplate_rpcMethod_forGrpcServer() {
+        // 1.x pair is composed into the RC fully-qualified form so both generations share one key.
         Span span = kindSpan(Span.SpanKind.SPAN_KIND_SERVER_VALUE, "oteldemo.CheckoutService/PlaceOrder",
                 kv("rpc.system", strVal("grpc")),
                 kv("rpc.service", strVal("oteldemo.CheckoutService")),
                 kv("rpc.method", strVal("PlaceOrder")));
-        assertThat(exceptionUriTemplate(span)).isEqualTo("PlaceOrder");
+        assertThat(exceptionUriTemplate(span)).isEqualTo("oteldemo.CheckoutService/PlaceOrder");
+    }
+
+    @Test
+    void exceptionUriTemplate_rcFullyQualifiedRpcMethod_passedThrough() {
+        // RC semconv: rpc.method already fully-qualified, rpc.service absent.
+        Span span = kindSpan(Span.SpanKind.SPAN_KIND_SERVER_VALUE, "oteldemo.CheckoutService/PlaceOrder",
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.method", strVal("oteldemo.CheckoutService/PlaceOrder")));
+        assertThat(exceptionUriTemplate(span)).isEqualTo("oteldemo.CheckoutService/PlaceOrder");
     }
 
     @Test
@@ -1066,14 +1136,75 @@ class OtlpTraceSpanMapperTest {
 
     @Test
     void map_server_rpcServiceAndMethod_consumed_filtered() {
-        // rpc.service → endPoint, rpc.method → rpc; both consumed → both filtered.
+        // 1.x pair: rpc.service → endPoint, rpc.service/rpc.method → rpc (RC form); both consumed → both filtered.
         Span span = serverSpan(
                 kv("rpc.service", strVal("oteldemo.CartService")),
                 kv("rpc.method", strVal("AddItem")));
         SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
-        assertThat(bo.getRpc()).isEqualTo("AddItem");
+        assertThat(bo.getRpc()).isEqualTo("oteldemo.CartService/AddItem");
         assertThat(bo.getEndPoint()).isEqualTo("oteldemo.CartService");
         assertThat(attributeKeys(bo)).doesNotContain("rpc.service", "rpc.method");
+    }
+
+    @Test
+    void map_server_rcFullyQualifiedRpcMethod_rpcAndEndPoint() {
+        // RC semconv: only rpc.method ("<service>/<method>"); the endPoint service is derived from it.
+        Span span = serverSpan(
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.method", strVal("oteldemo.CartService/AddItem")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRpc()).isEqualTo("oteldemo.CartService/AddItem");
+        assertThat(bo.getEndPoint()).isEqualTo("oteldemo.CartService");
+        assertThat(attributeKeys(bo)).doesNotContain("rpc.method");
+    }
+
+    @Test
+    void map_server_staleRpcServiceNextToRcMethod_notPrefixedTwice_bothFiltered() {
+        // A dual-emitting migration SDK: the RC rpc.method is passed through; rpc.service still
+        // serves the endPoint fallback, so both keys end up consumed.
+        Span span = serverSpan(
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.service", strVal("oteldemo.CartService")),
+                kv("rpc.method", strVal("oteldemo.CartService/AddItem")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRpc()).isEqualTo("oteldemo.CartService/AddItem");
+        assertThat(bo.getEndPoint()).isEqualTo("oteldemo.CartService");
+        assertThat(attributeKeys(bo)).doesNotContain("rpc.service", "rpc.method");
+    }
+
+    @Test
+    void map_server_blankRpcMethod_rpcFallsBackToSpanName() {
+        // A blank rpc.method is treated as absent (previously it became an empty rpc); the span
+        // name is the last fallback and the untouched attribute is retained.
+        Span span = serverSpan(
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.method", strVal("  ")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRpc()).isEqualTo("HTTP GET /api");
+        assertThat(attributeKeys(bo)).contains("rpc.method");
+    }
+
+    @Test
+    void map_server_rpcMethodWithoutService_staysBare() {
+        // 1.x sender that omits rpc.service: nothing to qualify with, and no endPoint service.
+        Span span = serverSpan(
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.method", strVal("AddItem")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getRpc()).isEqualTo("AddItem");
+        assertThat(bo.getEndPoint()).isNull();
+    }
+
+    @Test
+    void map_server_rpcMethod_serverAddressWinsOverDerivedService() {
+        // The address keys stay first in the endPoint chain; the rpc service is only a fallback.
+        Span span = serverSpan(
+                kv("server.address", strVal("cart.svc")),
+                kv("server.port", intVal(7070)),
+                kv("rpc.method", strVal("oteldemo.CartService/AddItem")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(bo.getEndPoint()).isEqualTo("cart.svc:7070");
+        assertThat(bo.getRpc()).isEqualTo("oteldemo.CartService/AddItem");
     }
 
     @Test
@@ -1215,6 +1346,80 @@ class OtlpTraceSpanMapperTest {
         SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
         assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isNull();
         assertThat(attributeKeys(bo)).contains("rpc.response.status_code");
+    }
+
+    @Test
+    void map_server_grpcStatus_rcStatusCode_promoted_filtered() {
+        // Current RC key rpc.status_code (successor of rpc.response.status_code) on the root span.
+        Span span = serverSpan(
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.status_code", strVal("UNAVAILABLE")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("UNAVAILABLE");
+        assertThat(attributeKeys(bo)).doesNotContain("rpc.status_code");
+    }
+
+    @Test
+    void map_server_grpcStatus_rcStatusCode_winsOverPredecessorAndLegacy_onlyConsumedFiltered() {
+        // A triple-emitting migration SDK: rpc.status_code wins; the non-consumed twins stay raw.
+        Span span = serverSpan(
+                kv("rpc.system.name", strVal("grpc")),
+                kv("rpc.status_code", strVal("OK")),
+                kv("rpc.response.status_code", strVal("UNAVAILABLE")),
+                kv("rpc.grpc.status_code", intVal(14)));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("OK");
+        assertThat(attributeKeys(bo)).doesNotContain("rpc.status_code")
+                .contains("rpc.response.status_code", "rpc.grpc.status_code");
+    }
+
+    @Test
+    void map_server_rpcStatusCode_withoutRpcSystem_notPromoted() {
+        // The generic keys need the rpc-system gate; without it only the gRPC-specific legacy
+        // keys are considered, so nothing is promoted and the raw attribute is retained.
+        Span span = serverSpan(kv("rpc.status_code", strVal("UNAVAILABLE")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isNull();
+        assertThat(attributeKeys(bo)).contains("rpc.status_code");
+    }
+
+    @Test
+    void map_server_grpcStatus_blankRcStatusCode_treatedAsAbsent_fallsBackToLegacy() {
+        // A whitespace-only rpc.status_code is not a status name: it must neither be promoted
+        // nor block the fallback to the legacy numeric key. The blank attribute itself is not
+        // consumed, so it stays in the raw attribute list.
+        Span span = serverSpan(
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.status_code", strVal("   ")),
+                kv("rpc.grpc.status_code", intVal(14)));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isEqualTo("UNAVAILABLE");
+        assertThat(attributeKeys(bo)).contains("rpc.status_code").doesNotContain("rpc.grpc.status_code");
+    }
+
+    @Test
+    void map_server_grpcStatus_blankRcStatusCodeOnly_notPromoted() {
+        Span span = serverSpan(
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.status_code", strVal(" ")));
+        SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
+        assertThat(findAnnotation(bo, OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS)).isNull();
+        assertThat(attributeKeys(bo)).contains("rpc.status_code");
+    }
+
+    @Test
+    void map_server_grpcStatus_paddedRcStatusCode_trimmed() {
+        // Surrounding whitespace is stripped before promotion, for names and numeric strings alike.
+        Span named = serverSpan(
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.status_code", strVal(" DEADLINE_EXCEEDED ")));
+        assertThat(findAnnotation(newMapper().map(id(), named, NO_SCOPE), OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS))
+                .isEqualTo("DEADLINE_EXCEEDED");
+        Span numeric = serverSpan(
+                kv("rpc.system", strVal("grpc")),
+                kv("rpc.status_code", strVal(" 4 ")));
+        assertThat(findAnnotation(newMapper().map(id(), numeric, NO_SCOPE), OtlpTraceConstants.ANNOTATION_KEY_GRPC_STATUS))
+                .isEqualTo("DEADLINE_EXCEEDED");
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackTraceParsersTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/stacktrace/StackTraceParsersTest.java
@@ -253,6 +253,14 @@ class StackTraceParsersTest {
     }
 
     @Test
+    void kotlinLanguage_mapsToJavaParser() {
+        // telemetry.sdk.language=kotlin (opentelemetry-kotlin on JVM/Android) emits JVM stacks.
+        // The attribute mapping must win even when the content alone would not sniff as java.
+        assertThat(registry.select("kotlin", JAVA_STACK).name()).isEqualTo("java");
+        assertThat(registry.select("Kotlin", RUBY_STACK).name()).isEqualTo("java");
+    }
+
+    @Test
     void sink_capsFramesAndMarksTruncated() {
         StackFrameSink sink = new StackFrameSink(2);
         registry.rawFallback().parse("a\nb\nc\nd", sink);


### PR DESCRIPTION
…g and GenAI semantic conventions

Semantic conventions 1.39-1.44 and the GenAI conventions renamed keys that the mapper still read only under their earlier spellings, and folded rpc.service into a fully-qualified rpc.method. Both generations arrive side by side while SDKs migrate (opentelemetry-java-instrumentation 3.0 will switch the defaults), so each change accepts the current shape and keeps the previous one as a fallback.

rpc.status_code (RC): replaces both rpc.response.status_code and the gRPC-specific rpc.grpc.status_code. OtlpGrpcStatusResolver resolves the generic keys in the order rpc.status_code, rpc.response.status_code (same rpc-system gate and name/numeric normalization) before the legacy gRPC-specific keys; only the consumed key is filtered.

rpc.method fully-qualified ("<service>/<method>"), rpc.service deprecated: the same gRPC operation was recorded under two keys ("PlaceOrder" from 1.x senders, "oteldemo.CheckoutService/PlaceOrder" from RC senders) in the transaction rpc, the exception uriTemplate (Error Analysis "Path") and URI stat, and bare 1.x method names collided across services ("Get", "List"). The new OtlpRpcMethodResolver produces one shape: an rpc.method containing "/" is passed through, otherwise it is composed with rpc.service; a 1.x sender without rpc.service keeps the bare method; blank values are treated as absent. The gRPC-server endPoint fallback uses rpc.service when present and otherwise the service part of the fully-qualified rpc.method, so RC senders keep an endPoint. getServerSpanToRpc, getExceptionUriTemplate and getServerSpanToEndPoint delegate to it. Note: the stored key for gRPC entry points changes from "<method>" to "<service>/<method>" from the deploy on.

messaging.client.id: replaces messaging.client_id. MessagingAttributeUtils.resolveClientId resolves current-then-legacy and is shared by the messaging endPoint fallback (producer and consumer) and the unsupported-system consumer fallback; both spellings stay in the filtered attribute set.

telemetry.sdk.language=kotlin: the stable enum gained "kotlin" (opentelemetry-kotlin). On JVM/Android it emits java.lang.Throwable stacks, so StackTraceParserRegistry maps it to the Java parser instead of relying on content sniffing.

GenAI prompt-cache tokens: gen_ai.usage.cache_read.input_tokens and gen_ai.usage.cache_write.input_tokens (semantic-conventions-genai, Development) now resolve through the same ladder as the other tokens in OtlpGenAiRecorder - semconv key first, then the bare Claude Code key (cache_read_tokens / cache_creation_tokens) only with GenAI context - so spans from the OTel GenAI instrumentations show cache_r / cache_w in the gen_ai.usage annotation. The two shapes disagree on what "input" means: semconv input_tokens includes the cached tokens (the cache_* counters are subsets), the Anthropic API / Claude Code input_tokens excludes them. The "in" part is normalized to the semconv meaning - when the input resolved from the bare key the resolved cache parts are added back (1200 + 5000 + 0 -> in:6200) - so the usage line reads the same regardless of the emitting SDK. Raw attributes keep the original values.

Tests (+39, module 729): OtlpRpcMethodResolverTest (13); root-span and SpanEvent rpc.status_code promotion, numeric translation, precedence over the predecessor and legacy keys with consumed-key filtering, non-grpc system and missing rpc-system gate not promoted; RC-only rpc.method rpc and derived endPoint, stale rpc.service next to an RC rpc.method not prefixed twice, method without service stays bare, blank rpc.method falls back to the span name, server.address wins over the derived service, RC uriTemplate pass-through; messaging.client.id consumer/producer fallbacks, precedence over the legacy key and filtering of both spellings; kotlin mapping in the registry and end-to-end through OtlpExceptionMapper; GenAI semconv cache keys with an already-inclusive input, without the context marker, winning over the bare twin, both mixed directions, bare cache without input and bare input without cache (the Claude Code fixtures now expect in:6200).