### PR TITLE
[#noissue] Remove the unmodifiable list wrapping from the internal class metadata and share the empty list for empty inputs

### DIFF
--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/classreading/DefaultInternalClassMetadata.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/classreading/DefaultInternalClassMetadata.java
@@ -35,8 +35,8 @@ public class DefaultInternalClassMetadata implements InternalClassMetadata {
         this.classInternalName = classInternalName;
         this.superClassInternalName = superClassInternalName;
 
-        this.interfaceInternalNames = defaultInterfaceName(interfaceInternalNames);
-        this.annotationInternalNames = defaultAnnotationName(annotationInternalNames);
+        this.interfaceInternalNames = defaultList(interfaceInternalNames);
+        this.annotationInternalNames = defaultList(annotationInternalNames);
 
         this.isInterface = isInterface;
         this.isAnnotation = isAnnotation;
@@ -44,17 +44,16 @@ public class DefaultInternalClassMetadata implements InternalClassMetadata {
         this.isInnerClass = isInnerClass;
     }
 
-    private List<String> defaultInterfaceName(List<String> interfaceInternalNames) {
-        if (interfaceInternalNames == null) {
+    // internal, short-lived and read-only: no defensive copy, only the empty list is shared.
+    private static <T> List<T> defaultList(final List<T> list) {
+        if (isEmpty(list)) {
             return Collections.emptyList();
         }
-        return Collections.unmodifiableList(interfaceInternalNames);
+        return list;
     }
-    private List<String> defaultAnnotationName(List<String> annotationInternalNames) {
-        if (annotationInternalNames == null) {
-            return Collections.emptyList();
-        }
-        return Collections.unmodifiableList(annotationInternalNames);
+
+    private static <T> boolean isEmpty(List<T> list) {
+        return list == null || list.isEmpty();
     }
 
     @Override
@@ -97,16 +96,14 @@ public class DefaultInternalClassMetadata implements InternalClassMetadata {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("{");
-        sb.append("classInternalName='").append(classInternalName).append('\'');
-        sb.append(", superClassInternalName='").append(superClassInternalName).append('\'');
-        sb.append(", interfaceInternalNames=").append(interfaceInternalNames);
-        sb.append(", annotationInternalNames=").append(annotationInternalNames);
-        sb.append(", isInterface=").append(isInterface);
-        sb.append(", isAnnotation=").append(isAnnotation);
-        sb.append(", isSynthetic=").append(isSynthetic);
-        sb.append(", isInnerClass=").append(isInnerClass);
-        sb.append('}');
-        return sb.toString();
+        return "{" + "classInternalName='" + classInternalName + '\'' +
+                ", superClassInternalName='" + superClassInternalName + '\'' +
+                ", interfaceInternalNames=" + interfaceInternalNames +
+                ", annotationInternalNames=" + annotationInternalNames +
+                ", isInterface=" + isInterface +
+                ", isAnnotation=" + isAnnotation +
+                ", isSynthetic=" + isSynthetic +
+                ", isInnerClass=" + isInnerClass +
+                '}';
     }
 }

--- a/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/classreading/DefaultSimpleClassMetadata.java
+++ b/agent-module/profiler/src/main/java/com/navercorp/pinpoint/profiler/instrument/classreading/DefaultSimpleClassMetadata.java
@@ -19,7 +19,6 @@ package com.navercorp.pinpoint.profiler.instrument.classreading;
 
 import com.navercorp.pinpoint.profiler.util.JavaAssistUtils;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -46,7 +45,8 @@ public class DefaultSimpleClassMetadata implements SimpleClassMetadata {
         this.className = JavaAssistUtils.jvmNameToJavaName(classInternalName);
 
         this.superClassName = defaultSuperClassName(superClassInternalName);
-        this.interfaceNames = defaultInterfaceName(interfaceInternalNames);
+        // jvmNameToJavaName returns the shared empty list for null or empty input.
+        this.interfaceNames = JavaAssistUtils.jvmNameToJavaName(interfaceInternalNames);
 
         this.classBinary = classBinary;
     }
@@ -56,13 +56,6 @@ public class DefaultSimpleClassMetadata implements SimpleClassMetadata {
             return null;
         }
         return JavaAssistUtils.jvmNameToJavaName(superClassInternalName);
-    }
-
-    private List<String> defaultInterfaceName(List<String> interfaceInternalNames) {
-        if (interfaceInternalNames == null) {
-            return Collections.emptyList();
-        }
-        return Collections.unmodifiableList(JavaAssistUtils.jvmNameToJavaName(interfaceInternalNames));
     }
 
     @Override


### PR DESCRIPTION
…ass metadata and share the empty list for empty inputs

This pull request refactors how empty or null lists are handled in class metadata classes, simplifying the logic and reducing unnecessary object creation. The main focus is on improving the handling of interface and annotation names by consistently returning shared empty lists when appropriate, and removing redundant defensive copying.

**Refactoring and simplification of list handling:**

* Replaced separate methods for handling empty interface and annotation name lists with a generic `defaultList` method in `DefaultInternalClassMetadata`, which returns a shared empty list for null or empty input instead of creating unmodifiable copies.
* Updated `DefaultSimpleClassMetadata` to rely on `JavaAssistUtils.jvmNameToJavaName` for handling empty or null interface name lists, removing the now-redundant `defaultInterfaceName` method and associated imports. [[1]](diffhunk://#diff-0deebb31e623f9b4151437ae1de8c0d27d00dbd40b429682846dc94d303b536cL49-R49) [[2]](diffhunk://#diff-0deebb31e623f9b4151437ae1de8c0d27d00dbd40b429682846dc94d303b536cL61-L67) [[3]](diffhunk://#diff-0deebb31e623f9b4151437ae1de8c0d27d00dbd40b429682846dc94d303b536cL22)

**Code cleanup:**

* Simplified the `toString` method in `DefaultInternalClassMetadata` by replacing the use of `StringBuilder` with direct string concatenation, making the code more concise.