### PR TITLE
[#noissue] Close the input stream on every path of IOUtils.toByteArray

### DIFF
--- a/commons/src/main/java/com/navercorp/pinpoint/common/util/IOUtils.java
+++ b/commons/src/main/java/com/navercorp/pinpoint/common/util/IOUtils.java
@@ -52,22 +52,20 @@ public final class IOUtils {
             throw new IllegalArgumentException("negative bufferSize");
         }
 
-        bufferSize = calculateBufferSize(inputStream, bufferSize);
-        final byte[] buffer = new byte[bufferSize];
-
-        final byte[] readBuffer = bufferRead(inputStream, buffer);
-        if (readBuffer != null) {
-            return readBuffer;
-        }
-
-        ByteArrayOutputStream outputStream;
         try {
-            outputStream = new ByteArrayOutputStream(buffer.length * 2);
+            bufferSize = calculateBufferSize(inputStream, bufferSize);
+            final byte[] buffer = new byte[bufferSize];
+
+            final byte[] readBuffer = bufferRead(inputStream, buffer);
+            if (readBuffer != null) {
+                return readBuffer;
+            }
+
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(buffer.length * 2);
             outputStream.write(buffer, 0, buffer.length);
 
             copy(inputStream, outputStream, buffer);
 
-            outputStream.flush();
             return outputStream.toByteArray();
         } finally {
             if (close) {

--- a/commons/src/test/java/com/navercorp/pinpoint/common/util/IOUtilsTest.java
+++ b/commons/src/test/java/com/navercorp/pinpoint/common/util/IOUtilsTest.java
@@ -2,6 +2,7 @@ package com.navercorp.pinpoint.common.util;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -64,6 +65,25 @@ public class IOUtilsTest {
         assertToByteArray(IOUtils.DEFAULT_BUFFER_SIZE * 2, 4096, 1024);
         assertToByteArray(IOUtils.DEFAULT_BUFFER_SIZE * 5, 4096, 1024);
         assertToByteArray(IOUtils.DEFAULT_BUFFER_SIZE * 10, 4096, 1024);
+    }
+
+    @Test
+    public void toByteArray_close_on_every_path() throws IOException {
+        // fast path: the stream ends before the buffer is full
+        assertClosed(100, 4096);
+        // exact fit: the buffer is full and the stream is at EOF
+        assertClosed(3000, 3000);
+        // slow path: available() underestimates the size
+        assertClosed(6000, 1);
+    }
+
+    private void assertClosed(final int sourceBytesSize, final int available) throws IOException {
+        ByteArrayInputStream inputStream = Mockito.spy(new ByteArrayInputStream(nextBytes(sourceBytesSize)));
+        Mockito.doReturn(available).when(inputStream).available();
+
+        IOUtils.toByteArray(inputStream, true);
+
+        Mockito.verify(inputStream).close();
     }
 
     private void assertToByteArray(final int sourceBytesSize) throws IOException {


### PR DESCRIPTION
This pull request refactors the `IOUtils.toByteArray` method to simplify resource management and improves test coverage to ensure input streams are closed in all code paths. The main logic is streamlined by removing unnecessary try blocks, and new unit tests are added to verify correct stream closure behavior.

**Refactoring and Resource Management:**

* Refactored `IOUtils.toByteArray` to remove a redundant try block around `ByteArrayOutputStream` creation, simplifying the code and ensuring the stream is closed in all execution paths (`IOUtils.java`) [[1]](diffhunk://#diff-c40c481397aff2032f52e230b3f2e02513332cd58fac36a7d34dbc1657d82082R55) [[2]](diffhunk://#diff-c40c481397aff2032f52e230b3f2e02513332cd58fac36a7d34dbc1657d82082L63-L70).

**Testing Improvements:**

* Added a new test `toByteArray_close_on_every_path` in `IOUtilsTest.java` using Mockito to verify that input streams are closed on all code paths, including fast path, exact fit, and slow path scenarios (`IOUtilsTest.java`).
* Introduced Mockito to the test imports to enable mocking and verification of stream closure (`IOUtilsTest.java`).