### PR TITLE
Stop the servermap chart board from querying the same target twice

### DIFF
--- a/web-frontend/src/main/v3/.claude/rules/service-map.md
+++ b/web-frontend/src/main/v3/.claude/rules/service-map.md
@@ -125,8 +125,21 @@ service 전체를 대상으로 필터를 걸 수 있게 할지 정해지면 경�
 
 - 진실의 원천은 URL이다. 전역 선택값(`selectedServiceAtom`)은 탭 간 공유 저장소라, 링크를 새 탭에
   열어 둔 뒤 원래 탭에서 service를 바꾸면 화면과 어긋난다.
+- **`pServiceName`을 정하는 순서는 하나다** (`serviceNameFetchInterceptor`):
+  1. 요청에 이미 실려 있으면 → 건드리지 않고 그대로 보낸다(호출자가 직접 실은 값이 항상 이긴다).
+  2. 경로에 serviceName이 실려 있으면 → 그 값.
+  3. 둘 다 아니면 → 전역으로 선택한 service.
+  2·3은 `resolveRequestService` 하나가 정한다.
 - 요청 헤더(`resolveRequestService`)와 캐시 키(`serviceScopedQueryKeyHashFn`)가 **같은 규칙**에서
   파생돼야 한다. 다르면 헤더는 A service로 나가는데 캐시는 B service 키에 쌓인다.
+- **렌더 밖에서 경로를 읽을 때 `window.location`을 보지 않는다** — `getCurrentRouterPath()`를 쓴다.
+  뒤로/앞으로 가기(popstate)에서는 브라우저가 주소를 먼저 바꾸고 react-router의 location 상태는
+  그 다음 렌더에 반영된다. 그 사이 한 렌더 동안 조회 파라미터는 이전 경로의 것인데 service만
+  새 경로의 것이 되어, 캐시에 없는 키가 만들어지고 곧바로 요청이 나갔다(service를 넘나드는
+  뒤로가기에서 map 조회가 한 번 더 나가던 원인). `getCurrentRouterPath()`는 라우터가 렌더한 경로를
+  돌려주므로 파라미터와 service가 항상 같은 렌더에서 함께 바뀐다.
+  → `useSyncRenderedRouterPath` (조회 화면들보다 위에서 한 번 호출: `InitialFetchOutlet`).
+  호출을 빠뜨리면 `window.location` 폴백으로 동작한다(고쳐지지 않을 뿐 깨지지는 않는다).
 - 싣는 화면 목록: `SERVICE_NAME_SEGMENT_PAGES` (`utils/helper/application.ts`).
   **앞으로는 serviceName을 싣는 것이 기본**이고, 아직 안 옮긴 화면은 줄어드는 예외다.
   그 경로에서는 serviceName을 읽을 수 없어 전역 선택값으로 폴백한다.
@@ -156,10 +169,25 @@ A로 나가면 백엔드가 A service에서 `b-1`을 찾으므로 데이터가 �
 **prop을 받지 않으면 화면의 service로 조회한다**(`serviceName ?? useServiceNameForLink()`).
 그래서 filteredMap·inspector처럼 이 값을 넘기지 않는 화면은 동작이 그대로다.
 
-- 값의 출처는 백엔드가 노드마다 내려주는 `serviceName`(= `application.getService()`)이다.
-  링크는 자기 service가 없어 출발지 노드의 service를 쓴다(링크 통계의 기준 application과 같다).
+- **기본값은 언제나 화면의 service(`useServiceNameForLink`)다.** 노드를 골랐다고 바뀌지 않는다.
+  요구사항이 그렇다 — "pServiceName 헤더는 global로 설정한 serviceName"(이슈 #10587).
+  아직 고른 대상이 없을 때도 undefined가 아니라 이 값을 준다. map이 도착해 기준 노드가
+  잡히기까지 한 박자가 걸리는데, 그동안 undefined를 주면 헤더는 인터셉터가 어차피 같은 값으로
+  채우는데 **queryKey만 갈려** 같은 요청이 두 번 나간다.
+- **노드의 `serviceName`으로 갈아타는 판단은 `enableServiceMap` 하나로 한다.** 그 설정이 곧
+  "어느 map이 보이는가"이므로(꺼짐 → servermap만, 켜짐 → servicemap만) 경로를 따로 보지 않는다.
+  켜져 있으면 이 훅까지 온 노드는 언제나 servicemap이 그린 것이다.
+  > 두 map이 함께 보이던 시절에는 경로가 servicemap인지 따로 봐야 했다. 백엔드는 **servermap
+  > 응답에도** 노드마다 `serviceName`을 실어 보내는데(`NodeView`가 `application.getService()`를
+  > 무조건 쓴다) 그 값은 *application이 저장된 service*(대개 `DEFAULT`)이지 조회할 service가
+  > 아니다. 그대로 쓰면 기준 노드가 잡히기 전 첫 조회는 global service로, 잡힌 뒤 두 번째 조회는
+  > `DEFAULT`로 나가 **헤더도 캐시 키도 갈려** 같은 화면을 두 번 조회하고 두 번째 결과는 엉뚱한
+  > service의 것이 됐다. (이슈 #10587 — DEFAULT가 아닌 service를 고른 채 servermap에 들어가면
+  > `/getApdexScore`, `/heatmap/applicationData`, `/histogram/statistics`가 두 번씩 호출되던 원인)
+  > 이제 그 상태 자체가 만들어지지 않는다.
 - `enableServiceMap`이 꺼져 있으면 `useServerMapTargetServiceName`이 undefined를 반환한다.
   설정이 꺼진 저장소로 헤더가 새어 나가지 않도록 **그 한 곳에서** 막는다.
+  (폴백으로 쓰는 `useServiceNameForLink`도 같은 규칙이라 둘이 어긋나지 않는다.)
 - **prop을 내려주는 곳을 빠뜨리면 그 차트만 조용히 화면의 service로 조회한다.** 화면은 멀쩡히
   그려지고 숫자만 비어서, 타입 검사로도 잡히지 않는다. 우측 패널에 조회하는 컴포넌트를 새로
   추가하면 `serviceName`도 함께 내려야 한다.
@@ -253,6 +281,37 @@ servermap/filteredMap 응답에는 이 필드가 없어 그 화면들의 동작�
   돌려준다. 기준으로 삼을 한쪽만 보고 통과시키면 Application→Service가 새어나간다(출발지가
   WAS라 출발지를 기준으로 잡고 열린다). 어느 쪽이 기준인지(`sourceIsWas`)와 무관하게 양쪽을 본다.
 
+## map의 선택은 경로에 묶인다
+
+`serverMapCurrentTargetAtom`(map에서 고른 노드/링크)은 **그것을 고른 경로와 함께** 저장된다.
+경로가 바뀌면 이전 경로의 선택은 그 즉시 남의 것이다.
+
+페이지들이 경로 변경 effect에서 이 값을 비우지만 **effect는 한 박자 늦다.** 그 사이 우측 패널이
+**(새 application, 이전 경로에서 고른 노드)** 라는 있지도 않은 짝으로 한 번 렌더되고, 조회 훅들이
+그 짝으로 파라미터를 갱신해 화면을 떠난 대상 조회가 한 번 더 나갔다 — application 선택 박스로
+바꿀 때도, 브라우저 뒤로/앞으로 갈 때도 똑같이 생겼다. (이슈 #10587)
+
+- **조회 파라미터를 만드는 곳은 아톰을 직접 읽지 않는다.** `useServerMapCurrentTarget` /
+  `useServerMapCurrentTargetData`로 읽으면 경로가 바뀐 그 렌더부터 undefined다.
+  → 지금 쓰는 곳: `ServerMapChartsBoardFetcher`, `ServerListFetcher`, `Realtime`,
+    `AgentActiveThreadFetcher`, `useServerMapTargetServiceName`
+- **경로 도장은 아톰의 write 함수 한 곳에서 찍는다.** 값을 넣는 곳이 여러 군데(map fetcher들,
+  페이지들, 병합 노드 목록)라 호출부마다 경로를 넘기게 하면 한 곳만 빠뜨려도 조용히 어긋난다.
+- **도장과 비교는 같은 출처(`getCurrentRouterPath`)를 쓴다.** 비교하는 쪽만 `useLocation()`의
+  값을 쓰면 basename이 붙고 안 붙는 차이로 늘 어긋난다. `useLocation()`은 경로가 바뀔 때 다시
+  렌더시키는 구독 용도다.
+- **선택을 정하는 쪽(`ServerMapPage`의 `serverMapData` effect)도 이 훅으로 읽는다.** 새 map이
+  왔을 때 "이전 선택을 유지할지 기준 노드로 갈아끼울지"를 판단하는데, 아톰을 그대로 읽으면
+  `nodes`를 들고 있는 선택(merged 노드)은 이 map에 있는지 확인하지 않고 유지되며 **지금 경로로
+  도장을 다시 찍는다.** 그러면 이 map에 없는 노드가 선택된 상태가 되어, 조회 대상이 없는데도
+  우측 패널이 그려지고 `applicationName` 없는 요청이 나간다 —
+  servermap에서 노드를 고른 뒤 비DEFAULT servicemap으로 이동할 때 실제로 겪었다
+  (`/heatmap/applicationData` → 400 "Required parameter 'applicationName' is not present.").
+- query string만 바뀌는 이동(기간·조회 옵션 변경)은 경로가 그대로라 선택이 유지된다.
+- **조회 훅에도 대상 없음 가드를 둔다.** 위 규칙만으로 막으면 새 컴포넌트가 하나 늘 때 다시
+  샌다. `applicationName`이 필수인 API는 훅의 `enabled`에서 막는다
+  (`useGetHeatmapAppData` — `queryString`은 물음표 때문에 항상 truthy라 그것으로는 못 막는다).
+
 ## 함정 (실제로 겪은 것들)
 
 - **아톰은 화면 remount로 지워지지 않는다.** `InitialFetchOutlet`의 `key={requestService}`는
@@ -268,6 +327,7 @@ servermap/filteredMap 응답에는 이 필드가 없어 그 화면들의 동작�
 - **`useSuspenseQuery`는 `enabled`를 지원하지 않는다.** `useGetApdexScore`처럼 `shouldPoll`에 따라
   suspense를 쓰는 훅은 `enabled`로 막을 수 없다. `skipToken`을 쓰면 영원히 suspend 되므로,
   컴포넌트에서 조회 대상이 없을 때 fetcher를 마운트하지 않는 쪽으로 막는다.
+- **이전 선택을 effect로 버리면 한 박자 늦다.** → 아래 "map의 선택은 경로에 묶인다".
 
 ## 관련 파일
 
@@ -281,6 +341,9 @@ servermap/filteredMap 응답에는 이 필드가 없어 그 화면들의 동작�
 | 경로 분해 (로더용) | `utils/helper/application.ts` (`parseServiceScopedPath`) |
 | 경로 만들기 | `utils/helper/route.ts` (`getServiceMapPath`, `getServiceMapRealtimePath`, `getFilteredMapPath`, `getTransactionListPath`) |
 | 조회 대상의 service | `hooks/serverMap/useServerMapTargetServiceName.ts` |
+| 지금 경로에서 고른 선택 | `hooks/serverMap/useServerMapCurrentTarget.ts` |
+| 선택에 경로 도장 찍기 | `atoms/serverMap.ts` (`serverMapCurrentTargetAtom`) |
+| 렌더 밖에서 읽는 지금 경로 | `utils/helper/route.ts` (`getCurrentRouterPath`), `hooks/utility/useSyncRenderedRouterPath.ts` |
 | 요청 헤더 주입 | `hooks/api/serviceNameFetchInterceptor.ts` |
 | service 단위 캐시 키 | `hooks/api/reactQueryHelper.tsx` (`serviceScopedQueryKeyHashFn`) |
 | service 변경 시 초기화 | `hooks/utility/useClearApplicationOnServiceChange.ts` |

--- a/web-frontend/src/main/v3/.claude/rules/service-map.md
+++ b/web-frontend/src/main/v3/.claude/rules/service-map.md
@@ -92,6 +92,12 @@ service다** — 모든 조회에 `pServiceName` 헤더가 실리고 캐시도 s
   map만 그리고, 우측 패널은 조회를 시작하지 않은 채 노드를 고르라는 안내 문구를 띄운다
   (`SERVER_MAP.SELECT_NODE_FOR_CHART`, `SERVER_MAP.REAL_TIME.SELECT_NODE`).
   로딩 스켈레톤을 그대로 두면 영원히 로딩 중인 화면처럼 보이기 때문이다.
+- **service를 바꾸면 history에 쌓인다(replace가 아니다).** 사용자가 화면을 옮기는 행위라
+  뒤로가기로 이전 service의 화면에 돌아갈 수 있어야 한다. replace로 두면 A → B로 옮긴 뒤
+  뒤로가기가 A를 건너뛰고 service를 고르기 전 화면으로 나간다.
+  → `useClearApplicationOnServiceChange`
+  (경로가 이미 그 service를 가리키면 이동 자체를 하지 않으므로 항목이 중복으로 쌓이지 않는다.
+   로더가 붙이는 from/to 리다이렉트도 항목을 하나 더 만들지 않는다 — service 전환 1회 = 항목 1개.)
 
 ## filteredMap 연결
 

--- a/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/components/Layout/InitialFetchOutlet.tsx
@@ -17,6 +17,7 @@ import {
 } from '@pinpoint-fe/ui/src/atoms';
 import { APP_PATH, Configuration } from '@pinpoint-fe/ui/src/constants';
 import { getApplicationTypeAndName } from '@pinpoint-fe/ui/src/utils';
+import { useSyncRenderedRouterPath } from '@pinpoint-fe/ui/src/hooks';
 import { NotFound404 } from '@pinpoint-fe/ui';
 
 export const InitialFetchOutlet = () => {
@@ -39,6 +40,9 @@ export const InitialFetchOutlet = () => {
   // 이 값을 key로 두어 페이지 서브트리를 remount 해, 모든 쿼리가 새 service 키로 다시 붙게 한다.
   // (사이드 네비게이션은 상위 SideNavigationOutlet에 있어 remount 대상이 아니다.)
   // 해시와 동일한 값을 얻으려면 경로 판단도 해시와 같은 함수(window.location 기준)를 써야 한다.
+  // 렌더 밖에서 경로를 읽는 곳들(요청 헤더·캐시 키·선택의 경로 도장)이 라우터가 렌더한 경로를
+  // 보도록 여기서 맞춘다. 조회를 하는 화면들보다 위이므로 같은 렌더 패스에서 반영된다.
+  useSyncRenderedRouterPath();
   const selectedService = useAtomValue(selectedServiceAtom);
   const requestService = resolveRequestService(selectedService);
 

--- a/web-frontend/src/main/v3/packages/ui/src/atoms/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/atoms/serverMap.ts
@@ -7,6 +7,7 @@ import {
 } from '@pinpoint-fe/ui/src/constants';
 import { Node, Edge } from '@pinpoint-fe/server-map';
 import { isNodeOfApplication } from '@pinpoint-fe/ui/src/utils/helper/serverMap';
+import { getCurrentRouterPath } from '@pinpoint-fe/ui/src/utils/helper/route';
 
 export type CurrentTarget = {
   id?: string;
@@ -30,8 +31,46 @@ export const serverMapDataAtom = atom<GetServerMap.Response | FilteredMap.Respon
   undefined,
 );
 
-// 서버맵에서 선택된 타겟
-export const serverMapCurrentTargetAtom = atom<CurrentTarget | undefined>(undefined);
+/**
+ * 선택된 타겟과 **그것을 고른 경로**. 경로를 함께 담는 이유는 아래 `serverMapCurrentTargetAtom`
+ * 주석 참고.
+ */
+type StampedCurrentTarget = {
+  /** 선택이 이루어진 시점의 라우터 경로(basename 제외). */
+  path: string;
+  target: CurrentTarget | undefined;
+};
+
+const serverMapCurrentTargetStampedAtom = atom<StampedCurrentTarget | undefined>(undefined);
+
+/**
+ * 서버맵에서 선택된 타겟.
+ *
+ * **선택은 그것을 고른 경로에 묶인다.** 경로가 바뀌면(application 변경, 뒤로/앞으로 가기) 이전
+ * 경로의 선택은 그 즉시 남의 것이 되므로, 쓸 때 지금 경로를 함께 도장 찍어 둔다. 읽는 쪽은
+ * `useServerMapCurrentTarget`/`useServerMapCurrentTargetData`로 지금 경로의 선택만 본다.
+ *
+ * 페이지들이 경로 변경 effect에서 이 값을 비우지만 그것은 한 박자 늦다. 그 사이 우측 패널이
+ * **(새 application, 이전 경로에서 고른 노드)** 라는 있지도 않은 짝으로 한 번 렌더되고, 조회
+ * 훅들이 그 짝으로 파라미터를 갱신해 화면을 떠난 대상 조회가 한 번 더 나갔다. (이슈 #10587)
+ *
+ * 도장은 여기 한 곳에서 찍는다. 값을 넣는 곳이 여러 군데(map fetcher들, 페이지, 병합 노드 목록)
+ * 라서 호출부마다 경로를 넘기게 하면 한 곳만 빠뜨려도 조용히 어긋난다.
+ */
+export const serverMapCurrentTargetAtom = atom(
+  (get) => get(serverMapCurrentTargetStampedAtom)?.target,
+  (_get, set, target: CurrentTarget | undefined) => {
+    set(serverMapCurrentTargetStampedAtom, {
+      path: getCurrentRouterPath(),
+      target,
+    });
+  },
+);
+
+/** 선택이 이루어진 경로. `useServerMapCurrentTarget`이 지금 경로와 비교하는 데 쓴다. */
+export const serverMapCurrentTargetPathAtom = atom(
+  (get) => get(serverMapCurrentTargetStampedAtom)?.path,
+);
 
 export const serverMapCurrentTargetDataAtom = atom((get) => {
   const currentTarget = get(serverMapCurrentTargetAtom);

--- a/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/AgentActiveThread/AgentActiveThreadFetcher.tsx
@@ -3,12 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { AgentActiveThreadView } from './AgentActiveThreadView';
 import { useLocation } from 'react-router';
-import { useAtom, useAtomValue } from 'jotai';
-import {
-  activeThreadTargetAtom,
-  serverMapCurrentTargetAtom,
-  serverMapCurrentTargetDataAtom,
-} from '@pinpoint-fe/ui/src/atoms';
+import { useAtom } from 'jotai';
+import { activeThreadTargetAtom } from '@pinpoint-fe/ui/src/atoms';
 import { AgentActiveThreadSkeleton } from './AgentActiveThreadSkeleton';
 import { useActiveThreadSocket } from './useActiveThreadSocket';
 import {
@@ -23,7 +19,11 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { BsGearFill } from 'react-icons/bs';
 import { AgentActiveSetting, AgentActiveSettingType, DefaultValue } from './AgentActiveSetting';
 import { HelpPopover } from '@pinpoint-fe/ui/src/components/HelpPopover';
-import { useTimezone } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useServerMapCurrentTarget,
+  useServerMapCurrentTargetData,
+  useTimezone,
+} from '@pinpoint-fe/ui/src/hooks';
 
 export interface ActiveRequestProps {}
 
@@ -42,7 +42,9 @@ export interface AgentActiveThreadFetcherProps {
 export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetcherProps) => {
   const { t } = useTranslation();
   const [timezone] = useTimezone();
-  const currentServerMapTarget = useAtomValue(serverMapCurrentTargetAtom);
+  // 이전 경로에서 고른 것은 읽지 않는다. 아톰을 그대로 읽으면 application을 바꾼 직후 한 렌더
+  // 동안 이전 경로의 노드로 activeThreadCount 요청이 나간다. (이슈 #10587)
+  const currentServerMapTarget = useServerMapCurrentTarget();
   const { pathname } = useLocation();
   const [storedTarget, setStoredTarget] = useAtom(activeThreadTargetAtom);
   // 다른 화면에서 고정해 둔 대상은 이 화면의 것이 아니다. 경로가 같을 때만 이어 쓴다.
@@ -51,7 +53,7 @@ export const AgentActiveThreadFetcher = ({ serviceName }: AgentActiveThreadFetch
   const applicationName = currentServerMapTarget?.applicationName || '';
   const serviceType = currentServerMapTarget?.serviceType;
   const [isApplicationLocked, setApplicationLock] = React.useState(true);
-  const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom) as GetServerMap.NodeData;
+  const currentTargetData = useServerMapCurrentTargetData() as GetServerMap.NodeData;
   const [showSetting, setShowSetting] = React.useState(false);
   const [setting, setSetting] = React.useState<AgentActiveSettingType>(DefaultValue);
   /**

--- a/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Realtime/Realtime.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import {
   ChartsBoard,
@@ -22,13 +22,14 @@ import {
 } from '..';
 import {
   useServerMapSearchParameters,
+  useServerMapCurrentTarget,
+  useServerMapCurrentTargetData,
   useServerMapTargetServiceName,
   useTabFocus,
 } from '@pinpoint-fe/ui/src/hooks';
 import {
   CurrentTarget,
   serverMapCurrentTargetAtom,
-  serverMapCurrentTargetDataAtom,
   serverMapDataAtom,
   serverMapChartTypeAtom,
 } from '@pinpoint-fe/ui/src/atoms';
@@ -56,8 +57,11 @@ export const Realtime = ({ MapView = ServerMap, requiresApplication = true }: Re
   const isFocus = useTabFocus();
   const containerRef = React.useRef<HTMLDivElement>(null);
   const { application } = useServerMapSearchParameters();
-  const [serverMapCurrentTarget, setServerMapCurrentTarget] = useAtom(serverMapCurrentTargetAtom);
-  const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom) as GetServerMap.NodeData;
+  // 이전 경로에서 고른 것은 읽지 않는다. 아톰을 그대로 읽으면 application을 바꾼 직후 한 렌더
+  // 동안 "새 application + 이전 경로의 노드"로 조회가 나간다. (이슈 #10587)
+  const setServerMapCurrentTarget = useSetAtom(serverMapCurrentTargetAtom);
+  const serverMapCurrentTarget = useServerMapCurrentTarget();
+  const currentTargetData = useServerMapCurrentTargetData() as GetServerMap.NodeData;
   const serverMapData = useAtomValue(serverMapDataAtom);
   const { t } = useTranslation();
   // 기준 application이 필요 없는 map은 고를 대상이 없으므로 곧바로 그린다.

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerList/ServerListFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerList/ServerListFetcher.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
-  serverMapCurrentTargetDataAtom,
   currentServerAtom,
   currentServerAgentIdAtom,
   serverMapDataAtom,
-  serverMapCurrentTargetAtom,
 } from '@pinpoint-fe/ui/src/atoms';
 import { GetServerMap, BASE_PATH, GetHistogramStatistics } from '@pinpoint-fe/ui/src/constants';
 import { getParsedDate, getInspectorPath, toBasicISOString } from '@pinpoint-fe/ui/src/utils';
@@ -14,6 +12,10 @@ import {
   useSearchParameters,
   useServerMapLinkedData,
 } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useServerMapCurrentTarget,
+  useServerMapCurrentTargetData,
+} from '@pinpoint-fe/ui/src/hooks/serverMap/useServerMapCurrentTarget';
 import { ServerList as SL, ServerListProps, Button, ServerListSkeleton } from '@pinpoint-fe/ui';
 import { upperCase } from 'lodash';
 
@@ -28,9 +30,9 @@ export interface ServerListFetcherProps extends ServerListProps {
 
 export const ServerListFetcher = ({ nodeStatistics, serviceName }: ServerListFetcherProps) => {
   const { searchParameters } = useSearchParameters();
-  // 값은 쓰지 않지만 atom 구독은 유지해야 하므로 호출은 남긴다.
-  useAtomValue(serverMapCurrentTargetAtom);
-  const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom) as GetServerMap.NodeData;
+  // 값은 쓰지 않지만 선택 자체의 구독은 유지해야 하므로 호출은 남긴다.
+  useServerMapCurrentTarget();
+  const currentTargetData = useServerMapCurrentTargetData() as GetServerMap.NodeData;
   const setCurrentServer = useSetAtom(currentServerAtom);
   const currentServerAgent = useAtomValue(currentServerAgentIdAtom);
   const serverMapData = useAtomValue(serverMapDataAtom);

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
@@ -18,7 +18,7 @@ import {
   ScatterChartStatic,
   ChartsBoardHeader,
 } from '@pinpoint-fe/ui/src/components';
-import { ApplicationType, GetServerMap } from '@pinpoint-fe/ui/src/constants';
+import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import {
   useExperimentals,
   useServerMapSearchParameters,
@@ -32,16 +32,23 @@ import {
   scatterDataAtom,
   serverMapChartTypeAtom,
   serverMapCurrentTargetAtom,
-  serverMapCurrentTargetDataAtom,
   serverMapDataAtom,
 } from '@pinpoint-fe/ui/src/atoms';
-import { useAtom, useAtomValue } from 'jotai';
-import { getApplicationKey, getServerImagePath } from '@pinpoint-fe/ui/src/utils';
+import { useAtomValue, useSetAtom } from 'jotai';
+import {
+  getApplicationKey,
+  getSelectedTargetApplication,
+  getServerImagePath,
+} from '@pinpoint-fe/ui/src/utils';
 import { cn } from '@pinpoint-fe/ui/src/lib';
 import { RxChevronRight } from 'react-icons/rx';
 import { ServerListForCommon } from '@pinpoint-fe/ui/src/components/ServerList/ServerListForCommon';
 import { useGetHistogramStatistics } from '@pinpoint-fe/ui/src/hooks/api/useGetHistogramStatistics';
 import { useServerMapTargetServiceName } from '@pinpoint-fe/ui/src/hooks/serverMap/useServerMapTargetServiceName';
+import {
+  useServerMapCurrentTarget,
+  useServerMapCurrentTargetData,
+} from '@pinpoint-fe/ui/src/hooks/serverMap/useServerMapCurrentTarget';
 
 export interface ServerMapChartsBoardProps extends ServerMapChartsBoardFetcherProps {}
 
@@ -91,26 +98,26 @@ export const ServerMapChartsBoardFetcher = ({
   // /api/servermap/serverMap 로 가져온 data
   const serverMapData = useAtomValue(serverMapDataAtom);
   // serverMap에서 클릭 된 target (node 또는 link)
-  const [serverMapCurrentTarget, setServerMapCurrentTarget] = useAtom(serverMapCurrentTargetAtom);
+  // 이전 경로에서 고른 것은 읽지 않는다(→ `useServerMapCurrentTarget`). 아톰을 그대로 읽으면
+  // 경로가 바뀐 직후 한 렌더 동안 "새 application + 이전 경로의 노드"로 조회가 나간다. (#10587)
+  const setServerMapCurrentTarget = useSetAtom(serverMapCurrentTargetAtom);
+  const serverMapCurrentTarget = useServerMapCurrentTarget();
   // 클릭 된 serverMap target의 data (serverMapCurrentTarget, serverMapData를 이용해 나온 값) serverMap이 클릭되었을 때 주는 node/link의 데이터가 충분치 않아서 사용하는 값
-  const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom);
+  const currentTargetData = useServerMapCurrentTargetData();
   // VIEW SERVERS로 열었을 때 왼쪽에 클릭된 서버
   const currentServer = useAtomValue(currentServerAtom);
 
-  // service 전체를 모아 그린 servicemap에는 경로에 application이 없다. 통계 API는 기준
-  // application이 필수이므로, 이때는 선택된 노드(링크는 출발지 노드)를 기준으로 삼는다.
-  // 노드 자신을 기준으로 조회하는 것은 그 application을 직접 열어 본 것과 같은 결과가 된다.
-  const selectedTargetApplication = React.useMemo<ApplicationType | undefined>(() => {
-    if (serverMapCurrentTarget?.type === 'node') {
-      const { applicationName, serviceType } = serverMapCurrentTarget;
-      return applicationName && serviceType ? { applicationName, serviceType } : undefined;
-    }
-
-    const sourceInfo = (currentTargetData as GetServerMap.LinkData)?.sourceInfo;
-    return sourceInfo?.applicationName && sourceInfo?.serviceType
-      ? { applicationName: sourceInfo.applicationName, serviceType: sourceInfo.serviceType }
-      : undefined;
-  }, [serverMapCurrentTarget, currentTargetData]);
+  // 조회의 기준이 될 application. merged 대상(그래프가 여러 개를 하나로 묶어 그린 것)은 기준이
+  // 없다는 판단까지 규칙이 하나다 → `utils/helper/serverMap`의 `getSelectedTargetApplication`
+  const selectedTargetApplication = React.useMemo(
+    () =>
+      getSelectedTargetApplication(
+        serverMapCurrentTarget,
+        currentTargetData,
+        serverMapData?.applicationMapData?.linkDataArray as GetServerMap.LinkData[] | undefined,
+      ),
+    [serverMapCurrentTarget, currentTargetData, serverMapData],
+  );
 
   // servicemap은 다른 service의 application도 함께 그린다. 그런 노드를 고르면 이 패널의 조회는
   // 화면의 service가 아니라 그 노드의 service로 나가야 한다. 아래 차트/목록에 prop으로 내려준다.

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.test.ts
@@ -102,6 +102,58 @@ describe('serviceNameFetchInterceptor', () => {
     expect(headerOfLastCall()).toBe('other-service');
   });
 
+  // pServiceName을 정하는 순서: 1) 이미 실린 값 → 2) 경로의 serviceName → 3) 전역 선택값
+  describe('pServiceName 우선순위', () => {
+    beforeEach(() => {
+      store.set(configurationAtom, configWithServiceMap(true));
+      store.set(selectedServiceAtom, 'global-service');
+      window.history.replaceState({}, '', '/transactionList/path-service/app-name@TOMCAT');
+    });
+
+    test('1) 이미 실린 값이 경로·전역 선택값을 모두 이긴다', async () => {
+      await window.fetch('/api/transactionmetadata', {
+        headers: { [SERVICE_NAME_HEADER]: 'caller-service' },
+      });
+
+      expect(headerOfLastCall()).toBe('caller-service');
+    });
+
+    // "건드리지 않고 그대로 보낸다" — 헤더를 다시 만들어 넘기지도 않는다.
+    test('1) 이미 실려 있으면 요청을 그대로 넘긴다', async () => {
+      const init = { headers: { [SERVICE_NAME_HEADER]: 'caller-service' } };
+
+      await window.fetch('/api/transactionmetadata', init);
+
+      const [, sentInit] = lastCall() as unknown as [RequestInfo | URL, RequestInit | undefined];
+      expect(sentInit).toBe(init);
+    });
+
+    test('2) 실린 값이 없으면 경로의 serviceName이 전역 선택값을 이긴다', async () => {
+      await window.fetch('/api/transactionmetadata');
+
+      expect(headerOfLastCall()).toBe('path-service');
+    });
+
+    test('3) 경로에도 없으면 전역 선택값으로 나간다', async () => {
+      window.history.replaceState({}, '', '/serverMap/app-name@TOMCAT');
+
+      await window.fetch('/api/transactionmetadata');
+
+      expect(headerOfLastCall()).toBe('global-service');
+    });
+
+    // 설정이 꺼져 있으면 인터셉터는 아무 것도 하지 않는다. 실린 헤더를 지우지도 않는다.
+    test('설정이 꺼져 있어도 이미 실린 값은 그대로 나간다', async () => {
+      store.set(configurationAtom, configWithServiceMap(false));
+
+      await window.fetch('/api/transactionmetadata', {
+        headers: { [SERVICE_NAME_HEADER]: 'caller-service' },
+      });
+
+      expect(headerOfLastCall()).toBe('caller-service');
+    });
+  });
+
   test.each([
     ['/serverMap/app-name@TOMCAT?from=1&to=2'],
     ['/serverMap/realtime/app-name@TOMCAT'],

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/serviceNameFetchInterceptor.ts
@@ -1,7 +1,10 @@
 import { getDefaultStore } from 'jotai';
 import { configurationAtom, selectedServiceAtom } from '@pinpoint-fe/ui/src/atoms';
-import { BASE_PATH } from '@pinpoint-fe/ui/src/constants';
-import { getEnableServiceMap, getServiceNameFromPath } from '@pinpoint-fe/ui/src/utils';
+import {
+  getCurrentRouterPath,
+  getEnableServiceMap,
+  getServiceNameFromPath,
+} from '@pinpoint-fe/ui/src/utils';
 
 /**
  * 백엔드(service-module)의 `ServiceConstants.KEY`와 동일한 헤더 이름.
@@ -12,27 +15,26 @@ export const SERVICE_NAME_HEADER = 'pServiceName';
 const API_PATH_PREFIX = '/api';
 
 /**
- * `window.location.pathname`에는 라우터 basename(BASE_PATH)이 포함되므로, 라우터가 보는
- * 경로와 비교하려면 접두사를 떼어내야 한다. BASE_PATH가 비어 있으면 그대로 반환한다.
- */
-const toRouterPath = (pathname: string) =>
-  BASE_PATH && pathname.startsWith(BASE_PATH) ? pathname.slice(BASE_PATH.length) : pathname;
-
-/**
- * 이 요청이 실제로 어떤 service로 해석되는지 반환한다. enableServiceMap이 켜져 있으면
- * 예외 없이 모든 화면(ServerMap 포함)이 선택된 service 범위에서 조회된다.
+ * 요청에 `pServiceName`이 실려 있지 않을 때 어느 service로 해석할지 정한다
+ * (인터셉터 규칙의 2·3단계). enableServiceMap이 켜져 있으면 예외 없이 모든 화면
+ * (ServerMap 포함)이 선택된 service 범위에서 조회된다.
  *
- * 경로에 serviceName이 실려 있으면(`getServiceNameFromPath`) 전역 선택값
- * (`selectedServiceAtom`)보다 그것을 우선한다. 전역 선택값은 탭 간 공유 저장소라서, 링크를 새 탭에
- * 열어 둔 뒤 원래 탭에서 service를 바꾸면 화면과 어긋난다. 아직 serviceName을 싣지 않는 화면만
- * 전역 선택값으로 폴백한다.
+ * 2) 경로에 serviceName이 실려 있으면(`getServiceNameFromPath`) 전역 선택값
+ *    (`selectedServiceAtom`)보다 그것을 우선한다. 전역 선택값은 탭 간 공유 저장소라서, 링크를
+ *    새 탭에 열어 둔 뒤 원래 탭에서 service를 바꾸면 화면과 어긋난다.
+ * 3) 아직 serviceName을 싣지 않는 화면만 전역 선택값으로 폴백한다.
+ *
+ * 경로는 주소창(`window.location`)이 아니라 **라우터가 렌더한 경로**
+ * (`getCurrentRouterPath`)에서 읽는다. 뒤로/앞으로 가기에서 주소창이 라우터보다 앞서가면
+ * 조회 파라미터는 이전 경로의 것인데 service만 새 경로의 것이 되어 같은 조회가 두 번 나간다.
+ * (이슈 #10587)
  *
  * 요청 헤더(아래 인터셉터)와 캐시 키(reactQueryHelper의 `serviceScopedQueryKeyHashFn`)는
  * 반드시 같은 규칙에서 파생되어야 한다. 서로 다른 규칙을 쓰면 헤더는 A service로 나가는데
  * 캐시는 B service 키에 쌓여 다른 service의 데이터가 섞인다.
  */
 export const resolveRequestService = (selectedService: string) =>
-  getServiceNameFromPath(toRouterPath(window.location.pathname)) || selectedService;
+  getServiceNameFromPath(getCurrentRouterPath()) || selectedService;
 
 /** `resolveRequestService`를 현재 선택된 service에 적용한 값. 렌더 밖(모듈 레벨)에서 쓴다. */
 export const getRequestService = () =>
@@ -60,12 +62,23 @@ const isApiRequest = (input: RequestInfo | URL): boolean => {
 let installed = false;
 
 /**
- * 전역 `fetch`를 한 번 래핑하여, `enableServiceMap`이 true일 때 백엔드로 가는 모든
- * `/api` 요청 헤더에 그 요청이 해석되는 service(`resolveRequestService`)를 주입한다.
- * 화면별 예외는 없다. 설정이 꺼져 있으면 헤더를 아예 붙이지 않아 백엔드가 기본 service로 해석한다.
+ * 전역 `fetch`를 한 번 래핑하여, 백엔드로 가는 `/api` 요청에 `pServiceName` 헤더를 싣는다.
  *
- * 켜짐 여부는 `getEnableServiceMap`이 정한다. 사용자가 Experimental 설정에서 고른 값
- * (localStorage)이 configuration 기본값을 덮으므로, 설정을 바꾸면 다음 요청부터 바로 반영된다.
+ * **어느 service로 나갈지는 이 순서로 정한다.**
+ *
+ * 1. 요청에 `pServiceName`이 이미 실려 있으면 → **건드리지 않고 그대로 보낸다.**
+ *    호출자가 직접 실은 값이 항상 이긴다. 인터셉터는 경로와 전역 선택값만 보므로 "고른 노드가
+ *    화면과 다른 service 소속"이라는 사실(`useServerMapTargetServiceName`)을 알 수 없다.
+ * 2. 경로에 serviceName이 실려 있으면(`getServiceNameFromPath`) → 그 값으로 보낸다.
+ * 3. 둘 다 아니면 → 전역으로 선택한 service(`selectedServiceAtom`)로 보낸다.
+ *
+ * 2와 3은 `resolveRequestService` 하나가 정한다. 캐시 키(`serviceScopedQueryKeyHashFn`)도 같은
+ * 함수를 지나야 한다 — 다르면 헤더는 A service로 나가는데 캐시는 B service 키에 쌓인다.
+ *
+ * `enableServiceMap`이 꺼져 있으면 아무 것도 하지 않는다(백엔드가 모든 요청을 기본 service로
+ * 해석한다). 켜짐 여부는 `getEnableServiceMap`이 정하며, 사용자가 Experimental 설정에서 고른 값
+ * (localStorage)이 configuration 기본값을 덮으므로 설정을 바꾸면 다음 요청부터 바로 반영된다.
+ * 이때도 1번은 그대로다 — 호출자가 실은 헤더를 인터셉터가 지우지는 않는다.
  *
  * configuration과 localStorage는 모두 부트스트랩 이후 바뀔 수 있으므로, 값을 캡처하지 않고
  * 매 요청 시 최신값을 읽는다.
@@ -84,29 +97,35 @@ export const installServiceNameFetchInterceptor = () => {
 
   window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
     try {
-      const enableServiceMap = getEnableServiceMap(store.get(configurationAtom));
-
-      if (enableServiceMap && isApiRequest(input)) {
-        // 캐시 키와 어긋나지 않도록 헤더도 `resolveRequestService`와 같은 규칙에서 파생한다.
-        const selectedService = resolveRequestService(store.get(selectedServiceAtom));
-
-        if (selectedService) {
-          const headers = new Headers(
-            init?.headers ?? (isRequestObject(input) ? input.headers : undefined),
-          );
-
-          // 호출자가 직접 실은 값이 우선이다. 인터셉터는 경로/전역 선택값만 보므로, 조회 대상이
-          // 화면과 다른 service에 속한다는 사실(`useServerMapTargetServiceName`)을 알 수 없다.
-          if (!headers.has(SERVICE_NAME_HEADER)) {
-            headers.set(SERVICE_NAME_HEADER, selectedService);
-          }
-          return originalFetch(input, { ...init, headers });
-        }
+      if (!isApiRequest(input)) {
+        return originalFetch(input, init);
       }
+
+      if (!getEnableServiceMap(store.get(configurationAtom))) {
+        return originalFetch(input, init);
+      }
+
+      const headers = new Headers(
+        init?.headers ?? (isRequestObject(input) ? input.headers : undefined),
+      );
+
+      // 1) 이미 실려 있으면 그대로 보낸다. 헤더를 다시 만들지도 않는다.
+      if (headers.has(SERVICE_NAME_HEADER)) {
+        return originalFetch(input, init);
+      }
+
+      // 2) 경로의 serviceName → 3) 전역 선택값
+      const requestService = resolveRequestService(store.get(selectedServiceAtom));
+
+      if (!requestService) {
+        return originalFetch(input, init);
+      }
+
+      headers.set(SERVICE_NAME_HEADER, requestService);
+      return originalFetch(input, { ...init, headers });
     } catch {
       // 인터셉터 내부 오류가 요청 자체를 막지 않도록 원본 fetch로 폴백한다.
+      return originalFetch(input, init);
     }
-
-    return originalFetch(input, init);
   };
 };

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHeatmapAppData.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHeatmapAppData.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { END_POINTS } from '@pinpoint-fe/ui/src/constants';
+
+// reactQueryHelper는 ErrorToast를 통해 ECharts(ESM)까지 끌어오는데 babel-jest가 변환하지 않는다.
+// 같은 동작의 fetch 구현으로 대체해 이 테스트는 요청 여부/URL만 본다.
+const mockQueryFn = jest.fn();
+jest.mock('./reactQueryHelper', () => ({
+  queryFn: (url: string, options?: { serviceName?: string }) => mockQueryFn(url, options),
+}));
+
+import { useGetHeatmapAppData } from './useGetHeatmapAppData';
+
+const createWrapper = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};
+
+const range = { from: '20260907T000000Z', to: '20260907T002000Z' };
+
+describe('useGetHeatmapAppData', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    mockQueryFn.mockImplementation((url: string) => async () => {
+      const response = await fetch(url);
+      return response.json();
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const flush = async () => {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
+
+  // 이 API는 applicationName이 필수다. 조회 대상이 정해지기 전에 부르면
+  // 400 "Required parameter 'applicationName' is not present." 가 온다. (이슈 #10587)
+  test('does not fetch until the target application is known', async () => {
+    renderHook(() => useGetHeatmapAppData({ ...range }), { wrapper: createWrapper() });
+    await flush();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('does not fetch when only the application name is known', async () => {
+    renderHook(() => useGetHeatmapAppData({ ...range, applicationName: 'app-a' }), {
+      wrapper: createWrapper(),
+    });
+    await flush();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('fetches once the application and its service type are known', async () => {
+    renderHook(
+      () => useGetHeatmapAppData({ ...range, applicationName: 'app-a', serviceTypeName: 'TOMCAT' }),
+      { wrapper: createWrapper() },
+    );
+    await flush();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain(END_POINTS.HEATMAP_APP_DATA);
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('applicationName=app-a');
+  });
+
+  test('carries the given service on the request', async () => {
+    renderHook(
+      () =>
+        useGetHeatmapAppData(
+          { ...range, applicationName: 'b-1', serviceTypeName: 'TOMCAT' },
+          'bService',
+        ),
+      { wrapper: createWrapper() },
+    );
+    await flush();
+
+    expect(mockQueryFn).toHaveBeenCalledWith(expect.stringContaining('applicationName=b-1'), {
+      serviceName: 'bService',
+    });
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHeatmapAppData.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHeatmapAppData.ts
@@ -14,10 +14,14 @@ export const useGetHeatmapAppData = (
   serviceName?: string,
 ) => {
   const queryString = `?${convertParamsToQueryString(parameters)}`;
+  // 조회 대상이 정해지기 전에는 요청을 보내지 않는다. 이 API는 applicationName이 필수라
+  // 없이 부르면 400("Required parameter 'applicationName' is not present.")이다.
+  // queryString은 물음표 때문에 항상 truthy라 그것만으로는 막지 못한다. (이슈 #10587)
+  const hasTarget = !!parameters.applicationName && !!parameters.serviceTypeName;
   const { data, isLoading, refetch, error } = useQuery<GetHeatmapAppData.Response>({
     queryKey: [END_POINTS.HEATMAP_APP_DATA, parameters, serviceName],
     queryFn: queryFn(`${END_POINTS.HEATMAP_APP_DATA}${queryString}`, { serviceName }),
-    enabled: !!queryString,
+    enabled: hasTarget,
     // HeatmapFetcher renders a full inline error overlay for this failure — suppress the
     // redundant global error toast so the user sees a single error signal.
     meta: { ignoreGlobalError: true },

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/index.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/index.tsx
@@ -1,3 +1,4 @@
 export * from './useFilterWizardOnClickApply';
+export * from './useServerMapCurrentTarget';
 export * from './useServerMapOnClickMenuItem';
 export * from './useServerMapTargetServiceName';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapCurrentTarget.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapCurrentTarget.test.tsx
@@ -1,0 +1,92 @@
+import { renderHook, act } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import {
+  CurrentTarget,
+  serverMapCurrentTargetAtom,
+  serverMapDataAtom,
+} from '@pinpoint-fe/ui/src/atoms';
+import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
+import {
+  useServerMapCurrentTarget,
+  useServerMapCurrentTargetData,
+} from './useServerMapCurrentTarget';
+
+// 이 훅은 `useLocation()`을 다시 렌더시키는 구독으로만 쓰고, 경로 값 자체는
+// `window.location`에서 읽는다(아톰이 도장 찍는 곳과 같은 출처).
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useLocation: () => ({ pathname: globalThis.location.pathname }),
+}));
+
+const store = getDefaultStore();
+
+const node = (applicationName: string) =>
+  ({
+    key: `${applicationName}^TOMCAT`,
+    nodeKey: `${applicationName}^TOMCAT`,
+    applicationName,
+    serviceType: 'TOMCAT',
+  }) as GetServerMap.NodeData;
+
+const goTo = (pathname: string) => {
+  window.history.pushState({}, '', pathname);
+};
+
+const setTarget = (target?: CurrentTarget) => {
+  act(() => {
+    store.set(serverMapCurrentTargetAtom, target);
+  });
+};
+
+describe('useServerMapCurrentTarget', () => {
+  beforeEach(() => {
+    goTo('/serverMap/app-a@TOMCAT');
+    act(() => {
+      store.set(serverMapDataAtom, {
+        applicationMapData: { nodeDataArray: [node('app-a'), node('app-b')], linkDataArray: [] },
+      } as unknown as GetServerMap.Response);
+    });
+    setTarget(undefined);
+  });
+
+  test('gives the selection made on the path being viewed', () => {
+    setTarget({ id: 'app-a^TOMCAT', type: 'node', applicationName: 'app-a' });
+
+    expect(renderHook(() => useServerMapCurrentTarget()).result.current?.id).toBe('app-a^TOMCAT');
+    expect(
+      (renderHook(() => useServerMapCurrentTargetData()).result.current as GetServerMap.NodeData)
+        ?.applicationName,
+    ).toBe('app-a');
+  });
+
+  // 페이지가 경로 변경 effect에서 아톰을 비우기 전 한 렌더 동안 이전 선택이 남아 있다.
+  // 그 짝(새 application + 이전 경로의 노드)으로 조회가 한 번 더 나가던 원인. (이슈 #10587)
+  test('drops the selection as soon as the path changes, before the atom is cleared', () => {
+    setTarget({ id: 'app-a^TOMCAT', type: 'node', applicationName: 'app-a' });
+    goTo('/serverMap/app-b@TOMCAT');
+
+    expect(renderHook(() => useServerMapCurrentTarget()).result.current).toBeUndefined();
+    expect(renderHook(() => useServerMapCurrentTargetData()).result.current).toBeUndefined();
+  });
+
+  // 기간·조회 옵션 변경은 query string만 바꾼다. 고른 노드는 그대로여야 한다.
+  test('keeps the selection when only the query string changes', () => {
+    setTarget({ id: 'app-a^TOMCAT', type: 'node', applicationName: 'app-a' });
+    goTo('/serverMap/app-a@TOMCAT?from=2026-09-07-11-00-00&to=2026-09-07-11-20-00');
+
+    expect(renderHook(() => useServerMapCurrentTarget()).result.current?.id).toBe('app-a^TOMCAT');
+  });
+
+  // 새 경로에서 다시 고르면 그 선택은 이 경로의 것이다.
+  test('takes the selection again once it is made on the new path', () => {
+    setTarget({ id: 'app-a^TOMCAT', type: 'node', applicationName: 'app-a' });
+    goTo('/serverMap/app-b@TOMCAT');
+    setTarget({ id: 'app-b^TOMCAT', type: 'node', applicationName: 'app-b' });
+
+    expect(renderHook(() => useServerMapCurrentTarget()).result.current?.id).toBe('app-b^TOMCAT');
+  });
+
+  test('is undefined when nothing has ever been picked', () => {
+    expect(renderHook(() => useServerMapCurrentTarget()).result.current).toBeUndefined();
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapCurrentTarget.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapCurrentTarget.ts
@@ -1,0 +1,49 @@
+import { useLocation } from 'react-router';
+import { useAtomValue } from 'jotai';
+import {
+  serverMapCurrentTargetAtom,
+  serverMapCurrentTargetDataAtom,
+  serverMapCurrentTargetPathAtom,
+} from '@pinpoint-fe/ui/src/atoms';
+import { getCurrentRouterPath } from '@pinpoint-fe/ui/src/utils';
+
+/**
+ * 아톰에 담긴 선택이 **지금 보고 있는 경로에서 고른 것인지** 여부.
+ *
+ * 아톰은 경로가 바뀌어도 그대로 남아 있고, 페이지들은 경로 변경 effect에서 비운다. effect는 한
+ * 박자 늦으므로 그 사이 한 렌더 동안 이전 경로의 선택이 보인다. 선택에 찍어 둔 경로와 지금
+ * 경로를 비교하면 그 한 렌더도 남의 것으로 판정할 수 있다.
+ *
+ * 지금 경로는 아톰이 도장 찍을 때와 **같은 출처**(`getCurrentRouterPath`)에서 읽는다. 한쪽만
+ * `useLocation()`의 값을 쓰면 basename이나 라우터 종류에 따라 두 값이 어긋나 선택이 늘 남의
+ * 것으로 판정될 수 있다. `useLocation()`은 경로가 바뀔 때 다시 렌더시키는 구독 용도로만 쓴다.
+ *
+ * 선택이 아예 없으면(도장도 없으면) "지금 경로의 것"으로 본다 — 없는 것은 어느 경로에서도
+ * 똑같이 없기 때문이다.
+ */
+const useIsTargetOnCurrentPath = () => {
+  useLocation();
+  const targetPath = useAtomValue(serverMapCurrentTargetPathAtom);
+
+  return targetPath === undefined || targetPath === getCurrentRouterPath();
+};
+
+/**
+ * 지금 경로에서 고른 map의 노드/링크. 이전 경로에서 고른 것은 undefined다.
+ *
+ * 조회 파라미터를 만드는 곳은 아톰(`serverMapCurrentTargetAtom`)을 직접 읽지 말고 이 훅을 쓴다.
+ * 직접 읽으면 경로가 바뀐 직후 한 렌더 동안 **(새 application, 이전 경로의 노드)** 짝으로
+ * 조회가 한 번 더 나간다. (이슈 #10587)
+ */
+export const useServerMapCurrentTarget = () => {
+  const currentTarget = useAtomValue(serverMapCurrentTargetAtom);
+
+  return useIsTargetOnCurrentPath() ? currentTarget : undefined;
+};
+
+/** 위와 같은 규칙으로 읽는 `serverMapCurrentTargetDataAtom`. */
+export const useServerMapCurrentTargetData = () => {
+  const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom);
+
+  return useIsTargetOnCurrentPath() ? currentTargetData : undefined;
+};

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapTargetServiceName.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapTargetServiceName.test.tsx
@@ -3,11 +3,19 @@ import { getDefaultStore } from 'jotai';
 import {
   configurationAtom,
   CurrentTarget,
+  selectedServiceAtom,
   serverMapCurrentTargetAtom,
   serverMapDataAtom,
 } from '@pinpoint-fe/ui/src/atoms';
 import { Configuration, GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { useServerMapTargetServiceName } from './useServerMapTargetServiceName';
+
+// 화면의 service는 경로에서 읽으므로(`useServiceNameForLink`) 위치를 갈아 끼울 수 있게 한다.
+const mockLocation = { pathname: '/serviceMap/aService' };
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useLocation: () => mockLocation,
+}));
 
 const store = getDefaultStore();
 
@@ -49,14 +57,49 @@ const render = () => renderHook(() => useServerMapTargetServiceName()).result.cu
 
 describe('useServerMapTargetServiceName', () => {
   beforeEach(() => {
+    mockLocation.pathname = '/serviceMap/aService';
+    act(() => {
+      store.set(selectedServiceAtom, 'aService');
+    });
     setEnableServiceMap(true);
   });
 
-  test('is undefined while nothing is picked, so the screen service keeps being used', () => {
+  // 값이 도중에 undefined에서 화면의 service로 바뀌면 같은 요청이 서로 다른 캐시 키로 두 번
+  // 쌓여 조회가 한 번 더 나간다(이슈 #10587). 처음부터 화면의 service를 준다.
+  test('is the screen service while nothing is picked yet', () => {
     setMap([node('aService', 'a-1')]);
     setTarget(undefined);
 
-    expect(render()).toBeUndefined();
+    expect(render()).toBe('aService');
+  });
+
+  // 경로에 serviceName이 없는 화면(servermap)에서는 전역 선택값이 화면의 service다.
+  test('falls back to the globally selected service when the path carries none', () => {
+    mockLocation.pathname = '/serverMap/a-1@SPRING_BOOT';
+    setMap([node('aService', 'a-1')]);
+    setTarget(undefined);
+
+    expect(render()).toBe('aService');
+  });
+
+  // 설정이 곧 "어느 map이 보이는가"다 — 켜져 있으면 servicemap만 보이고 servermap URL은 렌더
+  // 전에 옮겨지므로(`getHiddenMapPageRedirect`), 여기까지 온 노드는 servicemap이 그린 것이다.
+  // 그래서 경로를 따로 보지 않고 설정 하나로 갈린다. (이슈 #10587)
+  test('takes the picked node service without looking at the path', () => {
+    mockLocation.pathname = '/serviceMap';
+    setMap([node('bService', 'b-1')]);
+    setTarget({ id: 'bService^b-1^SPRING_BOOT', type: 'node' });
+
+    expect(render()).toBe('bService');
+  });
+
+  // servicemap 실시간도 group을 펼쳐 다른 service의 노드를 고를 수 있다.
+  test('takes the picked node service on servicemap realtime', () => {
+    mockLocation.pathname = '/serviceMap/realtime/aService';
+    setMap([node('aService', 'a-1'), node('bService', 'b-1')]);
+    setTarget({ id: 'bService^b-1^SPRING_BOOT', type: 'node' });
+
+    expect(render()).toBe('bService');
   });
 
   test('is the service of the picked node', () => {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapTargetServiceName.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/serverMap/useServerMapTargetServiceName.ts
@@ -1,37 +1,52 @@
-import { useAtomValue } from 'jotai';
-import { serverMapCurrentTargetDataAtom } from '@pinpoint-fe/ui/src/atoms';
 import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { useEnableServiceMap } from '../utility/useEnableServiceMap';
+import { useServiceNameForLink } from '../utility/useServiceNameForLink';
+import { useServerMapCurrentTargetData } from './useServerMapCurrentTarget';
 
 /**
- * map에서 고른 노드/링크가 소속된 service. 고른 것이 없으면 undefined다.
+ * 우측 패널의 조회가 나갈 service.
  *
- * servicemap은 다른 service를 묶은 group 노드까지 함께 그리고, group을 펼쳐 그 안의
- * application을 고를 수 있다. 그렇게 고른 대상은 화면의 service와 다른 service에 속하므로,
- * 그 대상을 조회하는 요청은 화면의 service가 아니라 이 값으로 나가야 한다.
+ * 기본값은 이 화면의 service(`useServiceNameForLink` = 경로의 serviceName ?? 전역 선택값)다.
+ * map에서 고른 노드/링크가 다른 service에 속하면 그 service로 갈아탄다 — servicemap은 다른
+ * service를 묶은 group 노드까지 함께 그리고, group을 펼쳐 그 안의 application을 고를 수 있다.
+ * 그렇게 고른 대상은 이 화면의 service에 없는 application이라 화면의 service로 조회하면 빈
+ * 데이터가 온다. (이슈 #10497)
+ *
+ * **`enableServiceMap` 하나로 갈린다.** 그 설정이 곧 "어느 map이 보이는가"이기 때문이다 —
+ * 꺼져 있으면 servermap만, 켜져 있으면 servicemap만 보이고, 감춘 쪽 URL은 렌더 전에 남은 쪽으로
+ * 옮겨진다(`getHiddenMapPageRedirect`). 그래서 이 훅까지 온 노드는 켜져 있으면 언제나 servicemap이
+ * 그린 것이다.
+ *
+ * > 두 map이 함께 보이던 시절에는 경로가 servicemap인지 따로 봐야 했다. servermap 응답에도
+ * > 노드마다 `serviceName`이 실려 오는데(`NodeView`가 `application.getService()`를 무조건 쓴다)
+ * > 그 값은 *application이 저장된 service*(대개 `DEFAULT`)이지 조회할 service가 아니어서, 그대로
+ * > 쓰면 첫 조회는 global service로, 기준 노드가 잡힌 뒤 두 번째 조회는 `DEFAULT`로 나갔다.
+ * > 헤더도 캐시 키도 갈려 같은 화면을 두 번 조회하고 두 번째 결과는 엉뚱한 service의 것이 됐다.
+ * > (이슈 #10587) 이제 그 상태 자체가 만들어지지 않으므로 경로를 따로 보지 않는다.
+ *
+ * 설정이 꺼져 있으면 undefined다. service 개념 자체가 없고(백엔드가 모든 요청을 기본 service로
+ * 해석한다) 이 값이 그대로 요청 헤더가 되므로, 설정이 꺼진 저장소에 헤더가 새어 나가지 않도록
+ * 여기 한 곳에서 막는다. (`useServiceNameForLink`도 같은 규칙이다.)
  *
  * 이 값은 우측 패널의 컴포넌트들에 `serviceName` prop으로 내려간다. 받은 컴포넌트는 조회 훅과
  * 다른 화면으로 넘기는 링크에 그대로 쓰고, 받지 않은 화면(filteredMap, inspector 등)은 기존대로
  * 화면의 service로 조회한다.
  *
- * 값은 백엔드가 노드마다 내려주는 `serviceName`(= `application.getService()`)이다.
- * 링크는 자기 service가 없으므로 출발지 노드의 service를 쓴다. 링크 통계의 기준 application도
- * 출발지 노드이므로(`ServerMapChartsBoardFetcher`) 같은 기준이다.
- *
- * `enableServiceMap`이 꺼져 있으면 service 개념 자체가 없으므로(백엔드가 모든 요청을 기본
- * service로 해석한다) 항상 undefined다. 이 값이 그대로 요청 헤더가 되므로, 설정이 꺼진 저장소에
- * 헤더가 새어 나가지 않도록 여기 한 곳에서 막는다.
+ * 링크(엣지)는 자기 service가 없으므로 출발지 노드의 service를 쓴다. 링크 통계의 기준
+ * application도 출발지 노드이므로(`ServerMapChartsBoardFetcher`) 같은 기준이다.
  */
 export const useServerMapTargetServiceName = () => {
   const enableServiceMap = useEnableServiceMap();
-  const currentTargetData = useAtomValue(serverMapCurrentTargetDataAtom);
+  const currentTargetData = useServerMapCurrentTargetData();
+  const screenServiceName = useServiceNameForLink();
 
-  if (!enableServiceMap || !currentTargetData) {
+  if (!enableServiceMap) {
     return undefined;
   }
 
   return (
-    (currentTargetData as GetServerMap.NodeData).serviceName ??
-    (currentTargetData as GetServerMap.LinkData).sourceInfo?.serviceName
+    (currentTargetData as GetServerMap.NodeData)?.serviceName ??
+    (currentTargetData as GetServerMap.LinkData)?.sourceInfo?.serviceName ??
+    screenServiceName
   );
 };

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/index.ts
@@ -11,6 +11,7 @@ export * from './useLanguage';
 export * from './useLocalStorage';
 export * from './useServerMapLinkedData';
 export * from './useServiceNameForLink';
+export * from './useSyncRenderedRouterPath';
 export * from './useServicesFetch';
 export * from './useStoragedSetting';
 export * from './useSyncSelectedServiceWithPath';

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.test.tsx
@@ -108,7 +108,23 @@ describe('useClearApplicationOnServiceChange', () => {
     act(() => {
       store.set(selectedServiceAtom, 'svc-a');
     });
-    expect(mockNavigate).toHaveBeenCalledWith(`${APP_PATH.SERVICE_MAP}/svc-a`, { replace: true });
+    expect(mockNavigate).toHaveBeenCalledWith(`${APP_PATH.SERVICE_MAP}/svc-a`);
+  });
+
+  // service를 고르는 것은 사용자가 화면을 옮기는 행위다. replace로 두면 A → B로 옮긴 뒤
+  // 뒤로가기가 A를 건너뛰고 service를 고르기 전 화면으로 나간다.
+  test('pushes the new service onto history so back returns to the previous service', () => {
+    renderClearHook(true);
+    act(() => {
+      store.set(selectedServiceAtom, 'svc-a');
+    });
+    act(() => {
+      store.set(selectedServiceAtom, 'svc-b');
+    });
+
+    expect(mockNavigate).toHaveBeenNthCalledWith(1, `${APP_PATH.SERVICE_MAP}/svc-a`);
+    expect(mockNavigate).toHaveBeenNthCalledWith(2, `${APP_PATH.SERVICE_MAP}/svc-b`);
+    expect(mockNavigate).not.toHaveBeenCalledWith(expect.anything(), { replace: true });
   });
 
   test('encodes a service name that would otherwise break the path', () => {
@@ -116,9 +132,7 @@ describe('useClearApplicationOnServiceChange', () => {
     act(() => {
       store.set(selectedServiceAtom, 'team/a@b');
     });
-    expect(mockNavigate).toHaveBeenCalledWith(`${APP_PATH.SERVICE_MAP}/team%2Fa%40b`, {
-      replace: true,
-    });
+    expect(mockNavigate).toHaveBeenCalledWith(`${APP_PATH.SERVICE_MAP}/team%2Fa%40b`);
   });
 
   test('does not navigate on initial mount', () => {

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useClearApplicationOnServiceChange.ts
@@ -29,6 +29,12 @@ import { getServiceMapPath, getServiceNameFromPath } from '@pinpoint-fe/ui/src/u
  *    query string(?from=...&to=...)은 굳이 유지하지 않는다. 라우트 로더가 기본 시간 범위를
  *    채워주고, DEFAULT service는 어차피 application을 고르는 순간 다시 채워진다.
  *
+ *    **history에 쌓는다(replace가 아니다).** service를 고르는 것은 사용자가 화면을 옮기는
+ *    행위라 뒤로가기로 이전 service의 화면에 돌아갈 수 있어야 한다. replace로 두면 A → B로
+ *    옮긴 뒤 뒤로가기가 A를 건너뛰고 service를 고르기 전 화면으로 나간다.
+ *    (이 훅이 처음 생겼을 때는 "현재 URL에서 application 세그먼트만 떼는" 정규화였고, 그때는
+ *     replace가 맞았다. 다른 service의 map으로 옮기는 지금은 그렇지 않다.)
+ *
  * 단, 경로가 이미 새 service를 가리키고 있으면(주소창을 직접 고쳐 들어온 경우 —
  * `useSyncSelectedServiceWithPath`가 그 값을 전역 선택값에 반영한다) 2)까지만 하고 멈춘다.
  * 사용자가 보려고 지정한 화면이므로 servicemap으로 끌고 가면 안 되고, application도 경로에서
@@ -63,7 +69,7 @@ export const useClearApplicationOnServiceChange = (enabled: boolean) => {
     // 저장된 application 무효화 → 네비게이션 링크가 base 경로로 바뀐다.
     setSearchParameters((prev) => ({ ...prev, application: {} as ApplicationType }));
 
-    navigate(getServiceMapPath(selectedService), { replace: true });
+    navigate(getServiceMapPath(selectedService));
   }, [
     selectedService,
     enabled,

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useSyncRenderedRouterPath.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useSyncRenderedRouterPath.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook } from '@testing-library/react';
+
+const goTo = (pathname: string) => window.history.pushState({}, '', pathname);
+
+/**
+ * 모듈 레벨 값(`renderedRouterPath`)을 다루므로 테스트마다 모듈을 새로 읽는다.
+ * "아직 한 번도 동기화되지 않은" 상태를 만들 방법이 그것뿐이다.
+ */
+const load = () => {
+  jest.resetModules();
+  const route = require('@pinpoint-fe/ui/src/utils/helper/route');
+  const sync = require('./useSyncRenderedRouterPath');
+  return { getCurrentRouterPath: route.getCurrentRouterPath, ...sync };
+};
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useLocation: () => ({ pathname: globalThis.location.pathname }),
+}));
+
+describe('useSyncRenderedRouterPath', () => {
+  // 부트스트랩과 라우트 로더는 렌더 전에 돌아간다. 그때는 라우터도 같은 주소를 보고 있다.
+  test('falls back to window.location before anything has rendered', () => {
+    goTo('/serviceMap/aService');
+    const { getCurrentRouterPath } = load();
+
+    expect(getCurrentRouterPath()).toBe('/serviceMap/aService');
+  });
+
+  test('reports the path the router rendered', () => {
+    goTo('/serviceMap/aService');
+    const { getCurrentRouterPath, useSyncRenderedRouterPath } = load();
+    renderHook(() => useSyncRenderedRouterPath());
+
+    expect(getCurrentRouterPath()).toBe('/serviceMap/aService');
+  });
+
+  // popstate에서는 브라우저가 주소를 먼저 바꾸고 라우터의 location은 다음 렌더에 반영된다.
+  // 그 사이 service만 새 경로의 것이 되면 (이전 파라미터, 새 service) 짝의 캐시 키가 만들어져
+  // 조회가 한 번 더 나간다. 그래서 렌더될 때까지 이전 경로를 유지해야 한다. (이슈 #10587)
+  test('keeps the previous path until the router renders the new one', () => {
+    goTo('/serviceMap/aService');
+    const { getCurrentRouterPath, useSyncRenderedRouterPath } = load();
+    const { rerender } = renderHook(() => useSyncRenderedRouterPath());
+
+    // 브라우저 주소만 먼저 바뀐 상태 (라우터는 아직 렌더하지 않았다)
+    goTo('/serviceMap/bService');
+    expect(getCurrentRouterPath()).toBe('/serviceMap/aService');
+
+    // 라우터가 새 경로로 렌더하면 그때 따라간다
+    rerender();
+    expect(getCurrentRouterPath()).toBe('/serviceMap/bService');
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useSyncRenderedRouterPath.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/utility/useSyncRenderedRouterPath.ts
@@ -1,0 +1,28 @@
+import { useLocation } from 'react-router';
+import { setRenderedRouterPath } from '@pinpoint-fe/ui/src/utils';
+
+/**
+ * 렌더 밖에서 읽는 "지금 경로"(`getCurrentRouterPath`)를 라우터가 렌더한 경로로 맞춘다.
+ *
+ * 요청 헤더(`resolveRequestService`)와 캐시 키(`serviceScopedQueryKeyHashFn`), map에서 고른
+ * 선택의 경로 도장(`serverMapCurrentTargetAtom`)은 렌더 밖에서 경로를 읽어야 한다. 그것을
+ * `window.location`에서 읽으면 뒤로/앞으로 가기에서 **라우터보다 앞서간다** — 브라우저가 주소를
+ * 먼저 바꾸고 라우터의 location 상태는 그 다음 렌더에 반영되기 때문이다. 그 사이 한 렌더 동안
+ * 조회 파라미터는 이전 경로의 것인데 service만 새 경로의 것이 되어, 캐시에 없는 키가 만들어지고
+ * 곧바로 요청이 나간다. (이슈 #10587)
+ *
+ * **effect가 아니라 렌더 중에 갱신한다.** 같은 렌더 패스에서 아래쪽 조회 훅들이 이미 이 값을
+ * 읽기 때문에, effect로 미루면 그 패스는 여전히 옛 값을 본다. 렌더한 location에서 그대로 파생된
+ * 값이라 몇 번을 다시 렌더해도 같은 값이 된다.
+ *
+ * **조회를 하는 화면들보다 위에서 한 번 호출해야 한다**(`InitialFetchOutlet`). 아무도 호출하지
+ * 않으면 `getCurrentRouterPath`가 `window.location` 폴백으로 동작하므로, 호출을 빠뜨린 저장소는
+ * 예전과 똑같이 동작한다(고쳐지지 않을 뿐 깨지지는 않는다).
+ */
+export const useSyncRenderedRouterPath = () => {
+  const { pathname } = useLocation();
+
+  setRenderedRouterPath(pathname);
+
+  return pathname;
+};

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
@@ -11,6 +11,7 @@ import {
   getRealtimePath,
 } from '@pinpoint-fe/ui/src/utils';
 import { useConfiguration, useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import { useServerMapCurrentTarget } from '@pinpoint-fe/ui/src/hooks/serverMap';
 import {
   serverMapDataAtom,
   serverMapCurrentTargetAtom,
@@ -76,7 +77,12 @@ export const ServerMapPage = ({
   const navigate = useNavigate();
   const { dateRange, application, search, searchParameters, queryOption, pathname } =
     useServerMapSearchParameters();
-  const [serverMapCurrentTarget, setServerMapCurrentTarget] = useAtom(serverMapCurrentTargetAtom);
+  const setServerMapCurrentTarget = useSetAtom(serverMapCurrentTargetAtom);
+  // 이전 경로에서 고른 선택은 이 map에서 살려 두지 않는다. 아톰을 그대로 읽으면 (merged 노드처럼
+  // `nodes`를 들고 있는 선택은) 아래 effect가 그것을 그대로 유지하며 지금 경로로 도장을 다시
+  // 찍어, 이 map에 없는 노드가 선택된 상태가 된다. 그러면 조회 대상이 없는데도 우측 패널이
+  // 그려져 `applicationName` 없는 요청이 나간다(`/heatmap/applicationData` 400). (이슈 #10587)
+  const serverMapCurrentTarget = useServerMapCurrentTarget();
   const serverMapData = useAtomValue(serverMapDataAtom);
   const [showFilter, setShowFilter] = React.useState(false);
   const [filter, setFilter] = React.useState<FilteredMap.FilterState>();

--- a/web-frontend/src/main/v3/packages/ui/src/utils/date.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/date.test.ts
@@ -261,5 +261,14 @@ describe('Test date utils', () => {
       expect(result).toBe(false);
       consoleSpy.mockRestore();
     });
+
+    // `Intl.DateTimeFormat(undefined, { timeZone: undefined })`는 예외가 나지 않는다.
+    // 값이 없는 것까지 유효하다고 하면 `getTimezone`이 system timezone으로 폴백하지 못하고,
+    // 저장된 timezone이 아직 없는 첫 방문에서 화면이 UTC로 한 번 조회한 뒤 실제 timezone으로
+    // 한 번 더 조회한다. (이슈 #10587)
+    test('Return false when no timezone is stored yet', () => {
+      expect(isValidTimezone(undefined)).toBe(false);
+      expect(isValidTimezone('')).toBe(false);
+    });
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/utils/date.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/date.ts
@@ -155,7 +155,16 @@ export const toBasicISOStringMs = (date: Date): string => {
   );
 };
 
-export const isValidTimezone = (tz: string): boolean => {
+export const isValidTimezone = (tz?: string): boolean => {
+  // `timeZone: undefined`는 "지정하지 않음"이라 예외가 나지 않는다. 그래서 값이 없는 것까지
+  // 유효하다고 판정하면 `getTimezone`이 system timezone으로 폴백하지 못하고 undefined를 그대로
+  // 돌려주고, date-fns-tz가 그것을 UTC로 해석한다. 저장된 timezone이 아직 없는 첫 방문에서
+  // 화면이 UTC로 조회를 한 번 하고, timezone이 저장된 뒤 같은 조회가 실제 timezone으로 한 번 더
+  // 나갔다(같은 URL인데 from/to가 offset만큼 어긋난다). (이슈 #10587)
+  if (!tz) {
+    return false;
+  }
+
   try {
     Intl.DateTimeFormat(undefined, { timeZone: tz });
     return true;

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.ts
@@ -1,11 +1,46 @@
 import {
   ApplicationType,
   APP_PATH,
+  BASE_PATH,
   GetServerMap,
   IMAGE_PATH,
   FilteredMapType as FilteredMap,
 } from '@pinpoint-fe/ui/src/constants';
 import { convertParamsToQueryString } from '../string';
+
+/**
+ * `window.location.pathname`에는 라우터 basename(BASE_PATH)이 포함되므로, 라우터가 보는 경로
+ * (`useLocation().pathname`)와 비교하려면 접두사를 떼어내야 한다. BASE_PATH가 비어 있으면
+ * 그대로 반환한다.
+ *
+ * 렌더 밖에서 지금 경로를 알아야 하는 곳들이 같은 규칙을 써야 한다
+ * (`serviceNameFetchInterceptor`의 요청 헤더, `serverMapCurrentTargetAtom`의 선택 경로 도장).
+ */
+export const toRouterPath = (pathname: string) =>
+  BASE_PATH && pathname.startsWith(BASE_PATH) ? pathname.slice(BASE_PATH.length) : pathname;
+
+/**
+ * 라우터가 **렌더한** 경로. `useSyncRenderedRouterPath`가 렌더 중에 갱신한다.
+ *
+ * `window.location`을 직접 보면 안 된다. 뒤로/앞으로 가기(popstate)에서는 브라우저가 주소를 먼저
+ * 바꾸고 react-router의 location 상태는 그 다음 렌더에 반영되므로, 그 사이 한 렌더 동안
+ * **"이전 경로의 파라미터 + 새 경로의 service"** 라는 짝이 만들어진다. 조회 파라미터는 라우터에서,
+ * service는 window.location에서 오기 때문이다. 그 짝은 캐시에 없는 키라 React Query가 곧바로
+ * 요청을 날린다 — service를 넘나드는 뒤로가기에서 map 조회가 한 번 더 나가던 원인이다.
+ * (이슈 #10587)
+ *
+ * 아직 한 번도 렌더되지 않았으면(부트스트랩, 라우트 로더) `window.location`으로 폴백한다.
+ * 그 시점에는 라우터도 같은 주소를 보고 있으므로 어긋날 여지가 없다.
+ */
+let renderedRouterPath: string | undefined;
+
+/** `useSyncRenderedRouterPath` 전용. 다른 곳에서 호출하지 않는다. */
+export const setRenderedRouterPath = (pathname: string) => {
+  renderedRouterPath = pathname;
+};
+
+export const getCurrentRouterPath = () =>
+  renderedRouterPath ?? toRouterPath(window.location.pathname);
 
 export const getServerImagePath = (application?: ApplicationType | GetServerMap.NodeData) => {
   return `${IMAGE_PATH}/servers/${application?.serviceType || 'UNKNOWN'}.png`;

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.test.ts
@@ -1,8 +1,11 @@
 import {
+  findCallerApplication,
   findLinkOfApplications,
   findNodeOfApplication,
   getBaseNodeId,
+  getSelectedTargetApplication,
   getTimeSeriesApdexInfo,
+  isMergedMapTarget,
   parseNodeApplication,
 } from './serverMap';
 import {
@@ -430,6 +433,144 @@ describe('Test serverMap helper utils', () => {
       expect(
         findLinkOfApplications(makeLinks(['blogService~shopService']), from, to),
       ).toBeUndefined();
+    });
+  });
+
+  // 그래프가 여러 노드를 하나로 묶어 그린 merged 노드는 기준 application이 없다.
+  // 그 자리에 있는 이름은 그래프가 붙인 라벨("total: 2")이라, 그대로 조회에 쓰면 그 이름으로
+  // 요청이 나간다. servermap은 경로의 application이 기준이 되어 가려져 있었고, 경로에
+  // application이 없는 servicemap에서 드러났다. (이슈 #10587)
+  describe('Test "isMergedMapTarget" / "getSelectedTargetApplication"', () => {
+    const mergedNodeTarget = {
+      // merge가 붙이는 합성 id. map 데이터에 없으므로 currentTargetData가 잡히지 않는다.
+      id: 'a-1^TOMCAT_MergeSingleNodesByServerMap^MONGO',
+      type: 'node' as const,
+      applicationName: 'total: 2',
+      serviceType: 'MONGO',
+      nodes: [{ id: 'a-mongo-1^MONGO' }, { id: 'a-mongo-2^MONGO' }],
+    };
+
+    const pickedFromMergedList = {
+      // 목록에서 자식을 고르면 목록을 계속 보여주려고 nodes는 남고 id만 실제 key로 바뀐다.
+      ...mergedNodeTarget,
+      id: 'a-mongo-1^MONGO',
+      applicationName: 'a-mongo-1',
+      serviceType: 'MONGO',
+    };
+
+    const mongoNodeData = {
+      key: 'a-mongo-1^MONGO',
+      applicationName: 'a-mongo-1',
+      serviceType: 'MONGO',
+    } as GetServerMap.NodeData;
+
+    test('merged 노드는 merged로 판별하고 기준 application을 주지 않는다', () => {
+      expect(isMergedMapTarget(mergedNodeTarget, undefined)).toBe(true);
+      expect(getSelectedTargetApplication(mergedNodeTarget, undefined)).toBeUndefined();
+    });
+
+    test('목록에서 자식을 고르면 그 노드가 기준이 된다', () => {
+      expect(isMergedMapTarget(pickedFromMergedList, mongoNodeData)).toBe(false);
+      expect(getSelectedTargetApplication(pickedFromMergedList, mongoNodeData)).toEqual({
+        applicationName: 'a-mongo-1',
+        serviceType: 'MONGO',
+      });
+    });
+
+    test('평범한 노드는 그 노드가 기준이다', () => {
+      expect(
+        getSelectedTargetApplication(
+          { type: 'node', applicationName: 'a-1', serviceType: 'TOMCAT' },
+          mongoNodeData,
+        ),
+      ).toEqual({ applicationName: 'a-1', serviceType: 'TOMCAT' });
+    });
+
+    test('링크는 출발지 노드가 기준이다', () => {
+      const linkData = {
+        sourceInfo: { applicationName: 'a-1', serviceType: 'TOMCAT' },
+        targetInfo: { applicationName: 'a-2', serviceType: 'TOMCAT' },
+      } as GetServerMap.LinkData;
+
+      expect(getSelectedTargetApplication({ type: 'edge' }, linkData)).toEqual({
+        applicationName: 'a-1',
+        serviceType: 'TOMCAT',
+      });
+    });
+
+    test('merged 링크도 기준 application을 주지 않는다', () => {
+      const mergedEdgeTarget = { type: 'edge' as const, edges: [{ target: 'a-mongo-1^MONGO' }] };
+
+      expect(isMergedMapTarget(mergedEdgeTarget, undefined)).toBe(true);
+      expect(getSelectedTargetApplication(mergedEdgeTarget, undefined)).toBeUndefined();
+    });
+
+    test('고른 것이 없으면 기준도 없다', () => {
+      expect(isMergedMapTarget(undefined, undefined)).toBe(false);
+      expect(getSelectedTargetApplication(undefined, undefined)).toBeUndefined();
+    });
+
+    // 통계 API는 applicationName/serviceTypeName을 "상대편(기준) application"으로 쓴다.
+    // DB처럼 자기 agent가 없는 리프 노드는 호출자 링크에서 수치가 나오므로, 기준이 노드 자신이면
+    // 백엔드가 그 노드를 map 중심으로 놓는 다른 분기로 빠진다. servermap은 경로의 application이
+    // 그 자리를 맡지만 경로에 application이 없는 servicemap에는 그것이 없다. (이슈 #10587)
+    describe('merged 묶음에서 고른 노드의 기준 application', () => {
+      const inboundLink = {
+        to: 'A^a-mongo-1^MONGO',
+        sourceInfo: { applicationName: 'a-1', serviceType: 'TOMCAT' },
+      } as GetServerMap.LinkData;
+
+      const pickedNodeData = { key: 'A^a-mongo-1^MONGO' } as GetServerMap.NodeData;
+
+      const pickedTarget = {
+        type: 'node' as const,
+        applicationName: 'a-mongo-1',
+        serviceType: 'MONGO',
+        nodes: [{ id: 'A^a-mongo-1^MONGO' }, { id: 'A^a-mongo-2^MONGO' }],
+      };
+
+      test('들어오는 링크가 하나면 그 출발지가 기준이다', () => {
+        expect(getSelectedTargetApplication(pickedTarget, pickedNodeData, [inboundLink])).toEqual({
+          applicationName: 'a-1',
+          serviceType: 'TOMCAT',
+        });
+      });
+
+      // 어느 쪽을 기준으로 삼을지 정할 수 없으면 기존 기준(노드 자신)을 그대로 쓴다.
+      test('들어오는 링크가 여럿이면 노드 자신이 기준이다', () => {
+        const anotherInbound = {
+          to: 'A^a-mongo-1^MONGO',
+          sourceInfo: { applicationName: 'a-2', serviceType: 'TOMCAT' },
+        } as GetServerMap.LinkData;
+
+        expect(
+          getSelectedTargetApplication(pickedTarget, pickedNodeData, [inboundLink, anotherInbound]),
+        ).toEqual({ applicationName: 'a-mongo-1', serviceType: 'MONGO' });
+      });
+
+      test('링크 정보가 없으면 노드 자신이 기준이다', () => {
+        expect(getSelectedTargetApplication(pickedTarget, pickedNodeData)).toEqual({
+          applicationName: 'a-mongo-1',
+          serviceType: 'MONGO',
+        });
+      });
+
+      // merged 묶음에서 고른 것이 아니면 호출자를 찾지 않는다(그 노드를 직접 열어 본 것과 같아야 한다).
+      test('merged 묶음이 아니면 호출자를 기준으로 삼지 않는다', () => {
+        expect(
+          getSelectedTargetApplication(
+            { type: 'node', applicationName: 'a-mongo-1', serviceType: 'MONGO' },
+            pickedNodeData,
+            [inboundLink],
+          ),
+        ).toEqual({ applicationName: 'a-mongo-1', serviceType: 'MONGO' });
+      });
+
+      test('findCallerApplication은 노드 key가 없으면 undefined다', () => {
+        expect(findCallerApplication([inboundLink], undefined)).toBeUndefined();
+        expect(findCallerApplication(undefined, 'A^a-mongo-1^MONGO')).toBeUndefined();
+        expect(findCallerApplication([inboundLink], 'A^a-mongo-9^MONGO')).toBeUndefined();
+      });
     });
   });
 });

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
@@ -225,3 +225,102 @@ export const getTimeSeriesApdexInfo = (
     .slice(0, APDEX_SLOT_MAX)
     .map((score) => (score === APDEX_UNCOLLECTED ? 1 : score));
 };
+
+/**
+ * map에서 고른 대상이 **merged**인지 — 그래프가 여러 노드/링크를 하나로 묶어 그린 것.
+ *
+ * 묶인 것의 id는 합성값(`{source}_MergeSingleNodesByServerMap^MONGO`)이라 map 데이터에서 찾을 수
+ * 없다. 그래서 "묶음 목록(`nodes`/`edges`)은 있는데 그 id로 찾은 데이터는 없다"로 판별한다.
+ *
+ * 목록에서 자식 하나를 고르면 `nodes`는 목록을 계속 보여주려고 그대로 남고 id만 실제 노드 key로
+ * 바뀐다. 그러면 데이터가 잡히므로 더 이상 merged가 아니다.
+ */
+export const isMergedMapTarget = (
+  currentTarget: { nodes?: unknown[]; edges?: unknown[] } | undefined,
+  currentTargetData: unknown,
+): boolean => !!(currentTarget?.nodes || currentTarget?.edges) && !currentTargetData;
+
+/**
+ * 이 노드를 호출하는 application(들어오는 링크의 출발지). 하나로 정해지지 않으면 undefined다.
+ *
+ * 통계 API는 `applicationName`/`serviceTypeName`을 **상대편(기준) application**으로 쓰고
+ * `nodeKey`로 볼 노드를 정한다(`ServerMapHistogramController#getStatisticsFromServerMap`).
+ * DB·캐시처럼 자기 agent가 없는 리프 노드는 호출자 링크에서 수치가 나오므로, 기준을 노드 자신으로
+ * 두면 백엔드가 그 노드를 map 중심으로 놓는 다른 분기로 빠진다.
+ *
+ * 들어오는 링크가 여럿이면 어느 쪽을 기준으로 삼을지 정할 수 없으므로 undefined를 돌려주고,
+ * 호출부가 기존 기준(노드 자신)을 그대로 쓰게 한다.
+ */
+export const findCallerApplication = (
+  links: (GetServerMap.LinkData | FilteredMap.LinkData)[] | undefined,
+  nodeKey: string | undefined,
+): ApplicationType | undefined => {
+  if (!nodeKey) {
+    return undefined;
+  }
+
+  const inboundLinks = (links ?? []).filter((link) => link.to === nodeKey);
+  if (inboundLinks.length !== 1) {
+    return undefined;
+  }
+
+  const { applicationName, serviceType } = inboundLinks[0].sourceInfo ?? {};
+  return applicationName && serviceType ? { applicationName, serviceType } : undefined;
+};
+
+/**
+ * 우측 패널의 조회가 기준으로 삼을 application. 경로에 application이 없는 화면
+ * (service 전체를 모아 그린 servicemap)에서 이 값이 기준이 된다.
+ *
+ * - merged 대상이면 **없다.** 여러 application을 묶은 것이라 기준이 성립하지 않는다.
+ *   `applicationName` 자리에 있는 것은 그래프가 붙인 라벨("total: 2")이므로 그대로 쓰면 그 이름으로
+ *   조회가 나간다. servermap은 경로의 application이 기준이 되어 가려져 있었고, 경로에 application이
+ *   없는 servicemap에서 드러났다. (이슈 #10587)
+ * - **merged 묶음 목록에서 고른 노드는 그 노드의 호출자가 기준이다.** servermap에서는 경로의
+ *   application(map 중심)이 그 자리를 맡는데, 경로에 application이 없는 servicemap에서 노드 자신을
+ *   기준으로 두면 요청이 다른 분기로 빠져 수치가 달라진다(→ `findCallerApplication`).
+ * - 그 외 노드면 그 노드. 클릭 즉시 채워지는 `currentTarget`에서 읽는다(조회된 데이터를 기다리지
+ *   않는다). 노드 자신을 기준으로 삼는 것은 그 application을 직접 열어 본 것과 같은 결과가 된다.
+ * - 링크면 출발지 노드. 링크 통계의 기준도 출발지이므로 같은 기준이다.
+ */
+export const getSelectedTargetApplication = (
+  currentTarget:
+    | {
+        type?: 'node' | 'edge';
+        applicationName?: string;
+        serviceType?: string;
+        nodes?: unknown[];
+        edges?: unknown[];
+      }
+    | undefined,
+  // map API마다 노드/링크 타입이 갈리므로(servermap · servicemap · filteredMap)
+  // 여기서는 읽는 필드만 좁혀서 본다.
+  currentTargetData: unknown,
+  /** merged 묶음에서 고른 노드의 호출자를 찾는 데 쓴다. 없으면 그 보정을 하지 않는다. */
+  links?: (GetServerMap.LinkData | FilteredMap.LinkData)[],
+): ApplicationType | undefined => {
+  if (isMergedMapTarget(currentTarget, currentTargetData)) {
+    return undefined;
+  }
+
+  if (currentTarget?.type === 'node') {
+    const isFromMergedGroup = !!(currentTarget.nodes || currentTarget.edges);
+    if (isFromMergedGroup) {
+      const caller = findCallerApplication(
+        links,
+        (currentTargetData as GetServerMap.NodeData | undefined)?.key,
+      );
+      if (caller) {
+        return caller;
+      }
+    }
+
+    const { applicationName, serviceType } = currentTarget;
+    return applicationName && serviceType ? { applicationName, serviceType } : undefined;
+  }
+
+  const sourceInfo = (currentTargetData as GetServerMap.LinkData | undefined)?.sourceInfo;
+  return sourceInfo?.applicationName && sourceInfo?.serviceType
+    ? { applicationName: sourceInfo.applicationName, serviceType: sourceInfo.serviceType }
+    : undefined;
+};


### PR DESCRIPTION
## Summary

- The map chart board queried the same target two or three times on entry, and with a non-DEFAULT service selected the extra request went out for the wrong service: `useServerMapTargetServiceName` took the `serviceName` the backend writes on every map node, which on a servermap response is the service the application is *stored* under (usually `DEFAULT`), not the service to query with. The decision now rests on `enableServiceMap` alone, since that setting is which map is visible.
- The map selection now carries the route it was made on, so readers that build query parameters drop a selection belonging to another route. Clearing it in a pathname effect was one beat late, and the panel rendered once with the new application paired with the node picked on the old path. The same render also mixed sources for the request service, which is now read from the path the router rendered rather than from `window.location` — the address bar runs ahead of the router on `popstate`.
- A merged node is not an application: the name in its place is the label the graph gives it (`total: 2`), and on a servicemap, where no application rides in the path to mask it, that label went out as `applicationName`. Picking one of its children now queries with the child's caller as the counterpart, the role the path application plays on a servermap.
- `/heatmap/applicationData` no longer fetches without `applicationName` (it used to 400 when moving from a servermap node to a non-DEFAULT servicemap), and `isValidTimezone` no longer accepts `undefined`, which had made the first visit read its date range as UTC and then again with the real offset.
- Switching service now pushes onto history instead of replacing, so back returns to the previous service's map rather than skipping past it.

> [!IMPORTANT]
> Depends on `feat/servicemap-menu-toggle` (only one map menu visible at a time, hidden URLs moved before render). `useServerMapTargetServiceName` relies on that invariant: with `enableServiceMap` on, a node reaching it was always drawn by the servicemap. **Merge that first.** Verified both together on a scratch branch — every scenario below passes.

## Test plan

- [ ] `yarn build`, `yarn test`, `yarn lint`
- [ ] Servermap with a non-DEFAULT service selected: pick an application, then another — `/getApdexScore`, `/heatmap/applicationData` and `/histogram/statistics` each go out once, carrying the global service
- [ ] Servermap: click a node in the map, then use browser back/forward — one request per query, no request for the target just left
- [ ] Servicemap (DEFAULT and non-DEFAULT): same counts; expanding a service group and picking a child still queries with that child's service
- [ ] Servermap → click a node → Servicemap on a non-DEFAULT service: no `/heatmap/applicationData` 400
- [ ] Merged node (a DB/cache leaf drawn as `total: N`) on both maps: the panel lists the merged applications and nothing is queried until one is picked; picking one queries with its caller as `applicationName`/`serviceTypeName`
- [ ] Service switch: blank → service A → service B, then back — lands on A's map, one map request
- [ ] `experimental.enableServiceMap` off: no `pServiceName` header anywhere, servermap unchanged
