### PR TITLE
[#14256] Upgrade maven-resolver to 1.9.27 and maven-core to 3.9.16 in plugins-test

### DIFF
--- a/agent-module/plugins-test-module/plugins-test/pom.xml
+++ b/agent-module/plugins-test-module/plugins-test/pom.xml
@@ -13,8 +13,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven-resolver>1.6.3</maven-resolver>
-        <maven-core>3.8.8</maven-core>
+        <maven-resolver>1.9.27</maven-resolver>
+        <maven-core>3.9.16</maven-core>
         <tinylog.version>2.7.0</tinylog.version>
         <pinpoint.agent.dir>${project.basedir}/../../agent/target/pinpoint-agent-${project.version}</pinpoint.agent.dir>
         <pinpoint.agent.bootjar>${pinpoint.agent.dir}/pinpoint-bootstrap-${project.version}.jar</pinpoint.agent.bootjar>
@@ -46,6 +46,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-supplier</artifactId>
+            <version>${maven-resolver}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
             <artifactId>maven-resolver-api</artifactId>
             <version>${maven-resolver}</version>
         </dependency>
@@ -71,11 +76,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-transport-classpath</artifactId>
-            <version>${maven-resolver}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
             <artifactId>maven-resolver-transport-file</artifactId>
             <version>${maven-resolver}</version>
         </dependency>
@@ -89,11 +89,6 @@
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-transport-wagon</artifactId>
-            <version>${maven-resolver}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/maven/DependencyResolver.java
+++ b/agent-module/plugins-test-module/plugins-test/src/main/java/com/navercorp/pinpoint/test/plugin/maven/DependencyResolver.java
@@ -25,10 +25,8 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
-import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyFilter;
-import org.eclipse.aether.impl.DefaultServiceLocator;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.LocalRepositoryManager;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -39,9 +37,10 @@ import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
-import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
+import org.eclipse.aether.transport.http.ChecksumExtractor;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.filter.DependencyFilterUtils;
 import org.eclipse.aether.version.Version;
@@ -56,6 +55,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Properties;
 import java.util.function.Predicate;
 
 import static com.navercorp.pinpoint.test.plugin.util.CollectionUtils.union;
@@ -73,25 +73,36 @@ public class DependencyResolver {
     private final RepositorySystemSession session;
 
     static RepositorySystem newRepositorySystem(boolean supportRemote) {
-        DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
-        locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
-        locator.addService(TransporterFactory.class, FileTransporterFactory.class);
-        if (supportRemote) {
-            locator.addService(TransporterFactory.class, org.eclipse.aether.transport.http.HttpTransporterFactory.class);
+        // DefaultServiceLocator is deprecated since maven-resolver 1.9 and removed in 2.0.
+        // RepositorySystemSupplier wires file + http transports by default, so the remote support is opt-out.
+        return new PinpointRepositorySystemSupplier(supportRemote).get();
+    }
+
+    static class PinpointRepositorySystemSupplier extends RepositorySystemSupplier {
+        private final boolean supportRemote;
+
+        PinpointRepositorySystemSupplier(boolean supportRemote) {
+            this.supportRemote = supportRemote;
         }
 
-        locator.setErrorHandler(new DefaultServiceLocator.ErrorHandler() {
-            @Override
-            public void serviceCreationFailed(Class<?> type, Class<?> impl, Throwable exception) {
-                logger.error(exception, "serviceCreationFailed type:{}, impl:{} {}", type, impl);
+        @Override
+        protected Map<String, TransporterFactory> getTransporterFactories(Map<String, ChecksumExtractor> extractors) {
+            final Map<String, TransporterFactory> factories = super.getTransporterFactories(extractors);
+            if (!supportRemote) {
+                factories.remove(HttpTransporterFactory.NAME);
             }
-        });
-
-        return locator.getService(RepositorySystem.class);
+            return factories;
+        }
     }
 
     static DefaultRepositorySystemSession newRepositorySystemSession(RepositorySystem system) {
         DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+        // maven-resolver-provider 3.9 no longer copies the JVM system properties into the session as 3.8 did.
+        // Without java.version the model builder fails the <jdk> profile activation of every POM it reads,
+        // the descriptor is then ignored as invalid and no transitive dependency is resolved.
+        final Properties systemProperties = copySystemProperties();
+        session.setSystemProperties(systemProperties);
+        session.setConfigProperties(systemProperties);
         session.setCache(newRepositoryCache());
 
         MavenRepository mavenRepository = new MavenRepository();
@@ -105,6 +116,16 @@ public class DependencyResolver {
         session.setLocalRepositoryManager(localRepositoryManager);
 
         return session;
+    }
+
+    private static Properties copySystemProperties() {
+        final Properties copy = new Properties();
+        final Properties systemProperties = System.getProperties();
+        // guard against ConcurrentModificationException
+        synchronized (systemProperties) {
+            copy.putAll(systemProperties);
+        }
+        return copy;
     }
 
     private static RepositoryCache newRepositoryCache() {

--- a/agent-module/plugins-test-module/plugins-test/src/test/java/com/navercorp/pinpoint/test/plugin/maven/DependencyResolverTest.java
+++ b/agent-module/plugins-test-module/plugins-test/src/test/java/com/navercorp/pinpoint/test/plugin/maven/DependencyResolverTest.java
@@ -18,11 +18,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.Assertions;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -31,6 +35,31 @@ import java.util.Map;
  */
 public class DependencyResolverTest {
     private final Logger logger = LogManager.getLogger(this.getClass());
+
+    @Test
+    public void transporterFactories_supportRemote() {
+        Map<String, TransporterFactory> remote = new DependencyResolver.PinpointRepositorySystemSupplier(true)
+                .getTransporterFactories(Collections.emptyMap());
+        Assertions.assertThat(remote).containsKeys(FileTransporterFactory.NAME, HttpTransporterFactory.NAME);
+
+        Map<String, TransporterFactory> local = new DependencyResolver.PinpointRepositorySystemSupplier(false)
+                .getTransporterFactories(Collections.emptyMap());
+        Assertions.assertThat(local).containsKey(FileTransporterFactory.NAME);
+        Assertions.assertThat(local).doesNotContainKey(HttpTransporterFactory.NAME);
+    }
+
+    @Test
+    public void resolveArtifactsAndDependencies_includes_transitive_dependencies() throws DependencyResolutionException {
+        DependencyResolverFactory factory = new DependencyResolverFactory();
+        DependencyResolver resolver = factory.get();
+
+        // maven-resolver-util depends on maven-resolver-api; the resolver-provider POMs carry <jdk> profiles,
+        // so this also fails when the session lacks the JVM system properties.
+        List<Path> files = resolver.resolveArtifactsAndDependencies("org.apache.maven.resolver:maven-resolver-util:1.9.27");
+
+        Assertions.assertThat(files).hasSize(2);
+        Assertions.assertThat(files).anySatisfy(path -> Assertions.assertThat(path.getFileName().toString()).isEqualTo("maven-resolver-api-1.9.27.jar"));
+    }
 
     @Test
     public void test() {


### PR DESCRIPTION
- Replace the deprecated DefaultServiceLocator wiring with RepositorySystemSupplier
- Copy the JVM system properties into the session: provider 3.9 no longer does it and the <jdk> profile activation of every POM fails without java.version, which silently drops all transitive dependencies
- Remove the unused maven-resolver-transport-wagon and maven-resolver-transport-classpath dependencies
