### PR TITLE
Tie the map search option to the base application it searches from

### DIFF
--- a/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.test.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { GetServiceMap } from '@pinpoint-fe/ui/src/constants';
+
+const mockUseGetServiceMap = jest.fn();
+const mockIsDefaultService = jest.fn();
+const mockQueryOption = {
+  inbound: 3,
+  outbound: 2,
+  wasOnly: true,
+  bidirectional: true,
+};
+
+jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
+  useGetServiceMap: (...args: unknown[]) => mockUseGetServiceMap(...args),
+  useIsDefaultService: () => mockIsDefaultService(),
+  useExperimentals: () => ({ statisticsAgentState: { value: true } }),
+  useServerMapSearchParameters: () => ({
+    application: { applicationName: 'a-1', serviceType: 'SPRING_BOOT' },
+    dateRange: { from: new Date('2024-01-01T00:00:00'), to: new Date('2024-01-01T01:00:00') },
+    queryOption: mockQueryOption,
+  }),
+}));
+
+// cytoscape를 끌고 오는 실제 map은 이 테스트의 관심사가 아니다. 조회 파라미터만 본다.
+jest.mock('../ServerMap/ServerMapCore', () => ({
+  ServerMapCore: () => null,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { ServiceMapFetcher } from './ServiceMapFetcher';
+
+const getRequestedParams = (): GetServiceMap.Parameters => mockUseGetServiceMap.mock.calls[0][0];
+
+describe('ServiceMapFetcher', () => {
+  beforeEach(() => {
+    mockUseGetServiceMap.mockReturnValue({ data: undefined, isLoading: false, error: null });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // DEFAULT service는 고른 application 하나를 기준으로 map을 그리므로 조회 조건 박스가 있고,
+  // 거기서 정한 값이 그대로 조회에 실려야 한다(servermap과 같다).
+  test('sends the search option of the DEFAULT service', () => {
+    mockIsDefaultService.mockReturnValue(true);
+
+    render(<ServiceMapFetcher />);
+
+    expect(getRequestedParams()).toMatchObject({
+      applicationName: 'a-1',
+      serviceTypeName: 'SPRING_BOOT',
+      calleeRange: 3,
+      callerRange: 2,
+      wasOnly: true,
+      bidirectional: true,
+    });
+  });
+
+  // DEFAULT가 아닌 service는 기준 application이 없어 조회 조건 박스도 없다. 경로에 남아 있는
+  // 값이 있더라도 싣지 않아야 백엔드가 지금까지와 같은 고정값으로 map을 그린다.
+  test('omits the search option when the service has no base application', () => {
+    mockIsDefaultService.mockReturnValue(false);
+
+    render(<ServiceMapFetcher />);
+
+    const params = getRequestedParams();
+    expect(params.calleeRange).toBeUndefined();
+    expect(params.callerRange).toBeUndefined();
+    expect(params.wasOnly).toBeUndefined();
+    expect(params.bidirectional).toBeUndefined();
+    expect(params.applicationName).toBeUndefined();
+  });
+});

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServiceMap/ServiceMapFetcher.tsx
@@ -37,7 +37,7 @@ export const ServiceMapFetcher = ({ shouldPoll, ...props }: ServiceMapFetcherPro
   const setCurrentServer = useSetAtom(currentServerAtom);
   const setServerMapCurrentTarget = useSetAtom(serverMapCurrentTargetAtom);
   const serverMapCurrentTarget = useAtomValue(serverMapCurrentTargetAtom);
-  const { application, dateRange } = useServerMapSearchParameters();
+  const { application, dateRange, queryOption } = useServerMapSearchParameters();
   const isDefaultService = useIsDefaultService();
   const experimentalOption = useExperimentals();
   const useStatisticsAgentState =
@@ -56,6 +56,14 @@ export const ServiceMapFetcher = ({ shouldPoll, ...props }: ServiceMapFetcherPro
       serviceTypeName: isDefaultService ? application?.serviceType : undefined,
       from: toBasicISOString(dateRange.from),
       to: toBasicISOString(dateRange.to),
+      // 조회 조건(inbound/outbound/APP ONLY/양방향)은 기준 application에서 몇 단계까지 뻗어
+      // 나갈지를 정하는 값이다. 기준 application이 없는 DEFAULT 외 service에서는 정할 대상이
+      // 없어 화면에도 조회 조건 박스를 띄우지 않으므로(→ `ServerMapPage`), 요청에도 싣지 않는다.
+      // 싣지 않으면 백엔드가 지금까지와 같은 고정값으로 map을 그린다.
+      calleeRange: isDefaultService ? queryOption.inbound : undefined,
+      callerRange: isDefaultService ? queryOption.outbound : undefined,
+      wasOnly: isDefaultService ? queryOption.wasOnly : undefined,
+      bidirectional: isDefaultService ? queryOption.bidirectional : undefined,
       useStatisticsAgentState,
     },
     { requiresApplication: isDefaultService, shouldPoll: !!shouldPoll },

--- a/web-frontend/src/main/v3/packages/ui/src/constants/types/GetServiceMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/constants/types/GetServiceMap.ts
@@ -11,6 +11,15 @@ export namespace GetServiceMap {
     serviceTypeCode?: number;
     from: number | string;
     to: number | string;
+    /**
+     * map 탐색 조건(화면의 조회 조건 박스). 기준 application에서 몇 단계까지 뻗어 나갈지를
+     * 정하는 값이라 기준 application이 있는 DEFAULT service에서만 싣는다. 그 외 service는
+     * 조회 조건 박스 자체가 없고, 백엔드가 고정값으로 map을 그린다.
+     */
+    calleeRange?: number;
+    callerRange?: number;
+    wasOnly?: boolean;
+    bidirectional?: boolean;
     useStatisticsAgentState?: boolean;
   }
 

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ServerMap.tsx
@@ -272,15 +272,23 @@ export const ServerMapPage = ({
                 </div>
               )}
               <MapView
-                queryOption={queryOption}
-                onApplyChangedOption={(option) => {
-                  navigate(
-                    `${getPagePath(application)}?${convertParamsToQueryString({
-                      ...getFormattedDateRange(dateRange),
-                      ...option,
-                    })}`,
-                  );
-                }}
+                queryOption={requiresApplication ? queryOption : undefined}
+                // 조회 조건(inbound/outbound/APP ONLY/양방향)은 기준 application에서 몇 단계까지
+                // 뻗어 나갈지를 정하는 값이다. 기준 application이 없는 map에서는 정할 대상이
+                // 없으므로 조회 조건 박스를 띄우지 않는다(`ServerMapCore`는 이 핸들러가 없으면
+                // 박스를 그리지 않는다). DEFAULT가 아닌 service의 servicemap이 여기에 해당한다.
+                onApplyChangedOption={
+                  requiresApplication
+                    ? (option) => {
+                        navigate(
+                          `${getPagePath(application)}?${convertParamsToQueryString({
+                            ...getFormattedDateRange(dateRange),
+                            ...option,
+                          })}`,
+                        );
+                      }
+                    : undefined
+                }
                 onClickMenuItem={handleClickMenuItem}
               />
             </div>


### PR DESCRIPTION
## Summary
- The search option box (inbound / outbound / APP ONLY / bidirectional) decides how many hops to walk out from the base application. The servicemap of a non-DEFAULT service has no base application — it collects every application of the service — so the box is now hidden there instead of sitting on screen with nothing to act on.
- On the servicemap of the DEFAULT service the box stays, and the request now carries `calleeRange` / `callerRange` / `wasOnly` / `bidirectional`, mapped exactly as the servermap does.
- Making `/api/servermap/serviceMap` read those parameters is a backend change and is **not** part of this PR. Until that lands the backend keeps building its fixed `SearchOption`, so the drawn map is unchanged for every service.

The servermap is untouched: `requiresApplication` defaults to `true`, so both the box and the request stay exactly as before.

## Test plan
- [ ] `/serverMap` — the option box is present and applying a change redraws the map, unchanged from before.
- [ ] `/serviceMap/DEFAULT` — the option box is present; applying a change puts `calleeRange` / `callerRange` / `wasOnly` / `bidirectional` on the `/api/servermap/serviceMap` request.
- [ ] `/serviceMap/{some non-DEFAULT service}` — no option box, and the request carries none of those parameters.
- [ ] `/serviceMap/realtime/...` — polling keeps working for both a DEFAULT and a non-DEFAULT service.
- [ ] `yarn build` and `yarn test` pass.
