### PR TITLE
[#noissue] Inline the map chart query parameters and keep the map root as their base

### DIFF
--- a/web-frontend/src/main/v3/.claude/rules/service-map.md
+++ b/web-frontend/src/main/v3/.claude/rules/service-map.md
@@ -217,7 +217,7 @@ React Query가 곧바로 요청을 날린다 — 그 service에 없는 applicati
 같은 commit에 배치되므로 짝이 어긋나지 않는다). queryKey와 헤더에는 prop이 아니라 그 state
 (`requestServiceName`)를 쓴다. deferred를 쓰는 스캐터는 serviceName도 같이 deferred로 넘긴다.
 
-→ `useGetScatterData`, `useGetScatterRealtimeData`, `HeatmapFetcher`, `HeatmapRealtimeFetcher`
+→ `useGetScatterData`, `useGetScatterRealtimeData`, `HeatmapRealtimeFetcher`
 
 **파라미터를 그 자리에서 계산하는 훅은 이 처리가 필요 없다** — 애초에 어긋날 렌더가 없으므로
 serviceName도 prop을 그대로 쓴다(`useGetAgentOverview`, `useGetApdexScore`,
@@ -246,23 +246,105 @@ serviceName도 prop을 그대로 쓴다(`useGetAgentOverview`, `useGetApdexScore
 (`HeatmapRealtimeFetcher`의 `request`). 단 `setQueryParams`를 바깥으로 반환하는 훅은
 setter 모양이 공개 API라서 합치는 비용이 더 크다 — 스캐터 두 훅은 그대로 둔다.
 
-### 조회의 기준 application은 고른 대상이다 (경로가 아니다)
+### 통계 API의 기준 application은 map의 루트다 (고른 노드가 아니다)
 
-경로의 application은 map을 그린 service 소속이다. 그런데 요청은 **고른 노드의 service**로 나가므로
-(위 절) 경로의 application을 기준으로 삼으면 백엔드가 그 이름을 남의 service에서 찾아 빈 데이터를
-준다. 그래서 고른 대상이 있으면 **언제나 그것이 기준**이고, 없을 때(첫 로딩, 기준을 정할 수 없는
-merged 묶음)만 경로의 application으로 돌아간다.
+**고른 노드로 갈아서 보내면 안 된다.** 코드만 봐서는 `applicationName`이 "조회할 대상"처럼 보이는데,
+백엔드에서 그 자리는 **map을 그린 루트**다. 고른 노드는 `nodeKey`로 따로 싣는다.
+
+`ServerMapHistogramController#getStatisticsFromServerMap`이 둘을 비교한다:
+
+| `applicationName` vs `nodeKey` | 백엔드 동작 |
+|---|---|
+| 같다 (루트를 클릭) | 루트를 기준으로 map을 떠서 **모든** 호출자/피호출자와의 히스토그램 |
+| 다르다 (다른 노드를 클릭) | 히스토그램 대상은 `nodeKey`의 노드, **루트를 그 노드의 상대(from/to)로 넣는다** — "루트에서 본 그 노드"의 수치 |
+
+루트를 상대편으로 넣는다는 것 자체가 둘이 서로 다른 것이라는 전제다. 고른 노드로 맞춰 버리면
+언제나 "같다"가 되어 `nodeKey` 파라미터와 불일치 분기가 죽은 코드가 된다.
+
+**게다가 `currentTarget`의 `applicationName`·`serviceType`은 조회용 식별자가 아니다** — 화면 표시용
+필드다. 그대로 기준으로 실으면 타입 검사에 걸리지 않고 조용히 빈 데이터나 400이 된다:
+
+| 노드 | `applicationName` / `serviceType` (표시용) | `nodeKey` (조회용) | 결과 |
+|---|---|---|---|
+| USER | `USER` / `USER` — 이름이 리터럴로 치환된다 | `ApiGateway_SPRING_BOOT^USER` — 이쪽도 합성값이라 루트가 못 된다 | 존재하지 않는 app이 루트가 되어 **빈 히스토그램** |
+| MySQL | `{dbId}` / `MYSQL` (desc) | `{dbId}^MYSQL_EXECUTE_QUERY` (name) | 백엔드는 name으로 해석 → 2100≠2101 → **빈 히스토그램** |
+| MSSQL | `{dbId}` / `MSSQLSERVER` (desc) | `{dbId}^MSSQL_EXECUTE_QUERY` | 그 이름의 타입이 없어 **400** + 에러 토스트 |
+
+`USER`는 `Node#getApplicationTextName()`이 리터럴로 치환하고, DB류는 `*_EXECUTE_QUERY`(name)와
+desc가 갈린다(`MYSQL`/`ORACLE`/`POSTGRESQL`/`MONGO`/`CUBRID`/`INFORMIX`/`CLICK_HOUSE`/`UNKNOWN_DB`,
+그리고 이름 자체가 없는 `MSSQLSERVER`·`JDK_HTTPCONNECTOR`). **WAS 노드는 둘이 일치해서 아무 문제가
+없어 보인다** — 그래서 WAS만 눌러 보면 빌드·테스트·CI가 전부 통과한 채로 이 버그가 지나간다.
 
 ```ts
-const baseApplication = selectedTargetApplication ?? application;
+const baseApplication = isCrossServiceTarget
+  ? selectedTargetApplication
+  : (application ?? selectedTargetApplication);
 ```
 
+노드가 기준으로 쓰이는 경로가 두 개 있다. 둘 다 경로에 쓸 수 있는 루트가 없는 경우다:
+
+| 경로 | 언제 |
+|---|---|
+| `isCrossServiceTarget` | 다른 service의 노드를 고름. 요청이 그 노드의 service로 나가는데 경로의 application은 화면 service 소속이라 그 service에 없어 루트가 성립하지 않는다 (이슈 #10497) |
+| `application ?? selectedTargetApplication` | 경로에 application이 아예 없음 = **비DEFAULT servicemap** |
+
+이 두 경로에서 노드의 식별자를 **표시용 필드로 쓰면 안 된다.** 노드 종류에 따라 두 갈래로 뽑는다:
+
+| 노드 | 기준 application | 왜 |
+|---|---|---|
+| USER | **나가는 링크의 `targetInfo`** → `findCalleeApplication` | 이 USER가 호출하는 WAS. USER 노드 자신은 기준이 될 수 없다(아래) |
+| 그 외 | **`nodeKey`를 쪼갠 값** → `parseNodeKeyApplication` | 그 application을 직접 열어 본 것과 같은 결과 |
+
+`nodeKey`로 뽑으면 `applicationName == nodeKey`가 되어 백엔드는 "같다" 분기를 탄다. 즉 그 노드를
+루트로 map을 떠서 **모든** 상대와의 수치를 낸다 — "직접 열어 본 것과 같은 결과"라는 기존 의도와 일치한다.
+
+**USER 노드만 예외인 이유: 이름이 합성값이다.** 내부 application 이름이
+`{앱이름}_{호출되는쪽 타입이름}`이다(`UserNodeUtils#newUserNodeName`) — `ApiGateway@SPRING_BOOT`를
+호출하는 USER 노드는 `ApiGateway_SPRING_BOOT^USER`다. 그런 이름의 application은 실제로 없으므로
+루트가 될 수 없고, **문자열을 쪼개 되돌릴 수도 없다**:
+
+- 앱 이름에 `_`가 들어갈 수 있다 — `IdValidateUtils.ID_PATTERN_VALUE` = `[a-zA-Z0-9._\-]+`
+- 타입 이름에도 `_`가 들어간다 — `SPRING_BOOT`, `MYSQL_EXECUTE_QUERY`, `KAFKA_CLIENT` …
+- 그래서 `my_app_TOMCAT`은 `my_app`+`TOMCAT`일 수도, `my`+`app_TOMCAT`일 수도 있다. 첫 `_`든
+  마지막 `_`든 일반적으로 틀린다. (`serviceKey`의 applicationName 토큰도 같은 합성값이라 같은 문제다.)
+
+응답의 `targetInfo`에 그 값이 파싱 없이 들어 있으므로 그것을 쓴다. 백엔드는 USER가 그 WAS의
+호출자임을 `isToNode`로 알아내 `toApplications`에 넣는다 — 즉 servermap이 경로의 application을
+루트로 보내던 것과 같은 요청이 된다.
+
+servermap은 경로에 항상 application이 있어 이 두 경로를 타지 않으므로 영향이 없다 — 그래서 이
+버그는 servicemap에서만 드러난다.
 - **어느 application을 기준으로 삼을지는 훅이 아니라 호출부가 정한다.** `useGetHistogramStatistics`는
   `applicationName`/`serviceType`을 받기만 한다 — 그 판단은 화면의 사정이라 훅이 알 수 없다.
   → `ServerMapChartBoard`의 `baseApplication`
 - 링크(엣지)를 고르면 출발지 노드가 기준이다. merged 묶음은 기준이 없다
   → `getSelectedTargetApplication`
-- `nodeKey`/`linkKey`는 고른 대상 자신에서 나오므로 기준 application과 짝이 맞는다.
+- `/histogram/statistics/links`(linkKey)는 `applicationName`을 **아예 쓰지 않는다.** `linkKey`를
+  `~`로 쪼개 양쪽 application을 만드는 것이 전부다(`getLinkTimeHistogramData`는 `appForm`을 읽지
+  않는다). 그래서 **링크 선택은 이 절의 문제와 무관하다** — 기준 application을 무엇으로 보내도
+  결과가 같고, 타입 해석조차 하지 않으므로 400도 나지 않는다. `linkKey`의 두 쪽은 각각 `nodeKey`와
+  같은 `getName()` 형식이고 실제 application 이름이라(`LinkName#getLinkKey` → `NodeName.toNodeKey`)
+  이미 정확하다. 링크의 출발지는 호출하는 쪽이라 WAS 아니면 USER인데 WAS는 name==desc라
+  어긋날 값도 없다. **그래서 링크 쪽은 표시용 `sourceInfo`를 그대로 둔다.**
+
+#### 이 필드의 의미는 한 번 바뀌었다 (그래서 헷갈린다)
+
+같은 `/statistics` 경로에 `params`로 갈리는 변형이 여럿이고, **변형마다 `applicationName`의 의미가
+다르다.** FE가 쓰는 변형이 2025-08-11에 바뀌었으므로 그 전 코드를 근거로 삼으면 안 된다.
+
+| 시기 | FE가 쓰던 것 | `applicationName` | 노드를 알려주는 방법 |
+|---|---|---|---|
+| ~2025-08-11 | 호출 안 함 — 노드 히스토그램은 **servermap 응답**(`nodeData.histogram`)에 실려 왔다 | — | — |
+| 〃 (agent 상세만) | `getResponseTimeHistogramDataV2` = **from/to 명시 변형** | **고른 노드** | `serviceTypeCode`(숫자) + `fromApplicationNames`/`toApplicationNames`를 FE가 계산해 명시 |
+| 2025-08-11~ (`e5037bf950`) | `/histogram/statistics` = **nodeKey 변형** | **map의 루트** | `nodeKey` |
+
+- **옛 변형에서 노드를 `applicationName`으로 보낸 건 맞았다.** from/to를 호출자가 명시하니 백엔드가
+  루트를 필요로 하지 않았고, 타입을 **코드(숫자)** 로 보내 desc/name 어긋남도 없었다.
+  그 직관을 nodeKey 변형에 그대로 옮기면 안 된다 — 거기서 그 자리는 루트다.
+- from/to 명시 변형은 백엔드에 아직 살아 있고(`getNodeHistogramData`), `GetHistogramStatistics.Parameters`의
+  `fromApplicationNames`/`fromServiceTypeCodes`/`toApplicationNames`/`toServiceTypeCodes`와 계산 헬퍼
+  `useServerMapLinkedData`도 남아 있다(`ServerListFetcher`가 쓴다). "노드 자신의 전체 수치"가
+  필요해지면 라벨을 루트 자리에 밀어넣는 것보다 이 변형으로 가는 편이 정합적이다.
 
 액티브 스레드(실시간)는 WebSocket이라 헤더가 없다. 지금도 service를 싣지 않는다.
 
@@ -283,6 +365,10 @@ link key는 노드 이름 둘을 `~`로 이은 것이라 같은 규칙을 따른
 - **id에서 application을 읽을 때는 `parseNodeApplication`을 쓴다.** 뒤 두 토큰이 application이다.
   URL 세그먼트용인 `getApplicationTypeAndName`으로 읽으면 3단에서 applicationName에
   `serviceName^applicationName`이 들어온다(정규식이 greedy).
+- **`key`에서 읽은 것을 조회 파라미터로 보내지 않는다.** `key`의 serviceType은 `getDesc()`라
+  백엔드가 이름으로 찾을 때 어긋난다. 조회에 쓸 값은 `nodeKey`에서 뽑는다
+  → `parseNodeKeyApplication` (위 "통계 API의 기준 application은 map의 루트다").
+  `parseNodeApplication`은 화면 표시·비교·URL 세그먼트용이다.
 - **노드/링크를 application으로 찾을 때는 `findNodeOfApplication`·`findLinkOfApplications`를 쓴다.**
   `key`의 뒤 두 토큰으로 비교하므로 2단/3단 어느 쪽이든 찾는다.
 - serviceName은 escape되지 않으므로(applicationName만 `ApplicationNameEscaper`로 escape된다)
@@ -360,11 +446,13 @@ servermap/filteredMap 응답에는 이 필드가 없어 그 화면들의 동작�
   (`serverMapCurrentTargetAtom`, `currentServerAtom`)을 명시적으로 비워야 한다. 안 비우면
   ChartsBoard가 없는 노드를 기준으로 조회를 시작하고, 새 경로에는 기준 application도 없어서
   `applicationName` 없는 요청이 나가 400을 받는다. → `useClearApplicationOnServiceChange`
-- **경로의 application을 통계 조회의 기준으로 쓰면 안 된다.** 고른 노드가 다른 service 소속일 때
-  (또는 비DEFAULT 모드에서 다른 화면 링크를 타고 application이 실려 들어올 때) 클릭한 노드와 다른
-  application의 수치를 보여준다. → 위 "조회의 기준 application은 고른 대상이다"
-- **통계 API는 기준 application이 필수다.** service 전체 map에는 URL에 application이 아예 없으므로,
-  고른 대상이 없으면 조회가 성립하지 않는다.
+- **통계 조회의 기준을 고른 노드로 갈아 끼우면 안 된다.** 그 자리는 map의 루트이고, 고른 노드는
+  `nodeKey`로 이미 실려 나간다. 갈아 끼우면 USER 노드와 DB 노드가 조용히 비거나 400이 된다.
+  → 위 "통계 API의 기준 application은 map의 루트다"
+- **경로에 남은 application 세그먼트가 통계 조회의 기준이 된다.** 비DEFAULT 모드에서 다른 화면
+  링크를 타고 application이 실려 들어오면, 클릭한 노드와 다른 application의 수치를 보여준다.
+- **통계 API는 기준 application이 필수다.** service 전체 map에는 URL에 application이 없으므로,
+  선택된 노드(링크는 출발지 노드)를 기준으로 삼는다. → `getSelectedTargetApplication`
 - **`useSuspenseQuery`는 `enabled`를 지원하지 않는다.** `useGetApdexScore`처럼 `shouldPoll`에 따라
   suspense를 쓰는 훅은 `enabled`로 막을 수 없다. `skipToken`을 쓰면 영원히 suspend 되므로,
   컴포넌트에서 조회 대상이 없을 때 fetcher를 마운트하지 않는 쪽으로 막는다.

--- a/web-frontend/src/main/v3/.claude/rules/service-map.md
+++ b/web-frontend/src/main/v3/.claude/rules/service-map.md
@@ -217,17 +217,52 @@ React Query가 곧바로 요청을 날린다 — 그 service에 없는 applicati
 같은 commit에 배치되므로 짝이 어긋나지 않는다). queryKey와 헤더에는 prop이 아니라 그 state
 (`requestServiceName`)를 쓴다. deferred를 쓰는 스캐터는 serviceName도 같이 deferred로 넘긴다.
 
-→ `useGetApdexScore`, `useGetHistogramStatistics`, `useGetScatterData`,
-`useGetScatterRealtimeData`, `HeatmapFetcher`, `HeatmapRealtimeFetcher`
+→ `useGetScatterData`, `useGetScatterRealtimeData`, `HeatmapFetcher`, `HeatmapRealtimeFetcher`
 
-파라미터를 그 자리에서 계산하는 훅(`useGetAgentOverview`)은 이 처리가 필요 없다.
+**파라미터를 그 자리에서 계산하는 훅은 이 처리가 필요 없다** — 애초에 어긋날 렌더가 없으므로
+serviceName도 prop을 그대로 쓴다(`useGetAgentOverview`, `useGetApdexScore`,
+`useGetHistogramStatistics`, `HeatmapFetcher`).
 링크 생성에 쓰는 값은 요청이 아니므로 최신 prop을 그대로 쓴다(`HeatmapChartCore`).
 
-### 통계 API는 기준 application도 함께 갈아야 한다
+### state를 없앨 수 있는지는 그 state가 무엇을 담고 있는지로 갈린다
 
-경로의 application은 화면 service 소속이라, 대상의 service로 나가는 요청의 기준이 될 수 없다
-(백엔드가 그 이름을 대상의 service에서 찾는다). 대상이 다른 service면 노드 자신을 기준으로 삼는다.
-→ `useGetHistogramStatistics`의 `ignorePathApplication`
+**props의 사본이면 없앨 수 있다.** effect에 조건이 없고 deps가 입력 전부를 덮고 있으면 그 state는
+"한 박자 늦추기"만 한다. queryKey는 구조를 직렬화해 비교하므로(`serviceScopedQueryKeyHashFn`)
+매 렌더 새 객체를 만들어도 내용이 같으면 재조회되지 않는다 — 객체 identity를 고정하려고 state를
+쓸 이유는 없다. 다만 state는 "대상이 사라져도 이전 파라미터를 유지"하는 역할도 겸하므로,
+호출자가 대상 없이 훅을 마운트한 채로 두지 않는지 함께 봐야 한다
+(`ApdexScore`는 대상이 없으면 fetcher를 마운트하지 않고, `useGetHeatmapAppData`·
+`useGetHistogramStatistics`는 `enabled`로 막는다).
+
+**props로 알 수 없는 값이 들어 있으면 없앨 수 없다.** 그 값은 렌더 중에 계산할 방법이 없다.
+
+| 대상 | state에 담긴, props가 아닌 값 |
+|---|---|
+| `HeatmapRealtimeFetcher` | `lastToTimestamp` ref — 응답마다 바뀌므로 렌더에서 읽으면 5초 tick을 벗어나 요청이 연달아 나간다. effect가 tick마다 한 번씩 표본을 뜬다 |
+| `useGetScatterData` / `useGetScatterRealtimeData` | ① 응답의 `resultFrom`으로 다음 `to`를 정하는 역방향 페이징 ② 캔버스 픽셀 크기로 정해지는 `xGroupUnit`/`yGroupUnit` — `setQueryParams`를 반환해 호출부(`ScatterChartFetcher`, `ScatterChartRealtimeFetcher`)가 넣는다. `getQueryString`이 필수로 요구하므로 차트가 크기를 알려줄 때까지 조회가 시작되지 않는다 |
+
+이 경우 serviceName만 prop으로 되돌릴 수도 없다(짝이 어긋난다). state를 남겨야 한다면
+**파라미터와 serviceName을 한 state에 담아** 그 규칙을 자료 구조로 지킨다
+(`HeatmapRealtimeFetcher`의 `request`). 단 `setQueryParams`를 바깥으로 반환하는 훅은
+setter 모양이 공개 API라서 합치는 비용이 더 크다 — 스캐터 두 훅은 그대로 둔다.
+
+### 조회의 기준 application은 고른 대상이다 (경로가 아니다)
+
+경로의 application은 map을 그린 service 소속이다. 그런데 요청은 **고른 노드의 service**로 나가므로
+(위 절) 경로의 application을 기준으로 삼으면 백엔드가 그 이름을 남의 service에서 찾아 빈 데이터를
+준다. 그래서 고른 대상이 있으면 **언제나 그것이 기준**이고, 없을 때(첫 로딩, 기준을 정할 수 없는
+merged 묶음)만 경로의 application으로 돌아간다.
+
+```ts
+const baseApplication = selectedTargetApplication ?? application;
+```
+
+- **어느 application을 기준으로 삼을지는 훅이 아니라 호출부가 정한다.** `useGetHistogramStatistics`는
+  `applicationName`/`serviceType`을 받기만 한다 — 그 판단은 화면의 사정이라 훅이 알 수 없다.
+  → `ServerMapChartBoard`의 `baseApplication`
+- 링크(엣지)를 고르면 출발지 노드가 기준이다. merged 묶음은 기준이 없다
+  → `getSelectedTargetApplication`
+- `nodeKey`/`linkKey`는 고른 대상 자신에서 나오므로 기준 application과 짝이 맞는다.
 
 액티브 스레드(실시간)는 WebSocket이라 헤더가 없다. 지금도 service를 싣지 않는다.
 
@@ -325,11 +360,11 @@ servermap/filteredMap 응답에는 이 필드가 없어 그 화면들의 동작�
   (`serverMapCurrentTargetAtom`, `currentServerAtom`)을 명시적으로 비워야 한다. 안 비우면
   ChartsBoard가 없는 노드를 기준으로 조회를 시작하고, 새 경로에는 기준 application도 없어서
   `applicationName` 없는 요청이 나가 400을 받는다. → `useClearApplicationOnServiceChange`
-- **경로에 남은 application 세그먼트가 통계 조회의 기준이 된다.** 비DEFAULT 모드에서 다른 화면
-  링크를 타고 application이 실려 들어오면, 클릭한 노드와 다른 application의 수치를 보여준다.
-- **통계 API는 기준 application이 필수다.** service 전체 map에는 URL에 application이 없으므로,
-  선택된 노드(링크는 출발지 노드)를 기준으로 삼는다. → `useGetHistogramStatistics`의
-  `fallbackApplication`
+- **경로의 application을 통계 조회의 기준으로 쓰면 안 된다.** 고른 노드가 다른 service 소속일 때
+  (또는 비DEFAULT 모드에서 다른 화면 링크를 타고 application이 실려 들어올 때) 클릭한 노드와 다른
+  application의 수치를 보여준다. → 위 "조회의 기준 application은 고른 대상이다"
+- **통계 API는 기준 application이 필수다.** service 전체 map에는 URL에 application이 아예 없으므로,
+  고른 대상이 없으면 조회가 성립하지 않는다.
 - **`useSuspenseQuery`는 `enabled`를 지원하지 않는다.** `useGetApdexScore`처럼 `shouldPoll`에 따라
   suspense를 쓰는 훅은 `enabled`로 막을 수 없다. `skipToken`을 쓰면 영원히 suspend 되므로,
   컴포넌트에서 조회 대상이 없을 때 fetcher를 마운트하지 않는 쪽으로 막는다.

--- a/web-frontend/src/main/v3/packages/ui/src/components/ApdexScore/ApdexScoreFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ApdexScore/ApdexScoreFetcher.tsx
@@ -1,8 +1,15 @@
 import { Separator } from '../ui/separator';
-import { useGetApdexScore, UseGetApdexScoreProps } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useGetApdexScore,
+  UseGetApdexScoreProps,
+  useServerMapSearchParameters,
+} from '@pinpoint-fe/ui/src/hooks';
 import { HelpPopover } from '..';
 import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
-export interface ApdexScoreFetcherProps extends UseGetApdexScoreProps {}
+
+// 기간은 호출부에서 받지 않고 여기서 URL을 읽는다. 조회 훅은 URL과 분리해 두어야 하므로
+// (`.claude/rules/api-hooks.md`) 읽는 자리를 컴포넌트로 내렸다.
+export interface ApdexScoreFetcherProps extends Omit<UseGetApdexScoreProps, 'dateRange'> {}
 
 enum RANK {
   EXCELLENT,
@@ -35,7 +42,8 @@ export const getRank = (score: number) => {
 };
 
 export const ApdexScoreFetcher = (props: ApdexScoreFetcherProps) => {
-  const { data } = useGetApdexScore(props);
+  const { dateRange } = useServerMapSearchParameters();
+  const { data } = useGetApdexScore({ ...props, dateRange });
 
   const score = data?.apdexScore || 0;
 

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapFetcher.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import HeatmapChartCore, { HeatmapChartCoreProps } from './core/HeatmapChartCore';
 import {
   useServerMapSearchParameters,
@@ -25,7 +24,7 @@ export const HeatmapFetcher = ({
   const { dateRange } = useServerMapSearchParameters();
   const [setting] = useStoragedSetting(APP_SETTING_KEYS.HEATMAP_SETTING);
 
-  const [parameters, setParameters] = React.useState<GetHeatmapAppData.Parameters>({
+  const parameters: GetHeatmapAppData.Parameters = {
     applicationName: nodeData?.applicationName,
     serviceTypeName: nodeData?.serviceType,
     from: toBasicISOString(dateRange.from),
@@ -33,35 +32,8 @@ export const HeatmapFetcher = ({
     minElapsedTime: Number(setting?.yMin) || DefaultAxisY[0],
     maxElapsedTime: Number(setting?.yMax) || DefaultAxisY[1],
     agentId: agentId,
-  });
-  // 조회 파라미터가 effect로 한 박자 늦게 따라오므로 serviceName도 같은 effect에서 함께 갱신한다.
-  // 그러지 않으면 대상이 바뀌는 렌더에서 (이전 application, 새 service) 짝의 queryKey가 한 번
-  // 만들어져, 그 service에 없는 application을 조회하는 요청이 나간다.
-  // (아래 HeatmapChartCore에 넘기는 값은 링크 생성용이라 최신값 그대로 쓴다.)
-  const [requestServiceName, setRequestServiceName] = React.useState(serviceName);
-  const { data, isLoading, error } = useGetHeatmapAppData(parameters, requestServiceName);
-
-  React.useEffect(() => {
-    setParameters({
-      applicationName: nodeData?.applicationName,
-      serviceTypeName: nodeData?.serviceType,
-      from: toBasicISOString(dateRange.from),
-      to: toBasicISOString(dateRange.to),
-      minElapsedTime: Number(setting?.yMin) || DefaultAxisY[0],
-      maxElapsedTime: Number(setting?.yMax) || DefaultAxisY[1],
-      agentId: agentId,
-    });
-    setRequestServiceName(serviceName);
-  }, [
-    dateRange.from.getTime(),
-    dateRange.to.getTime(),
-    setting?.yMin,
-    setting?.yMax,
-    nodeData?.applicationName,
-    nodeData?.serviceType,
-    agentId,
-    serviceName,
-  ]);
+  };
+  const { data, isLoading, error } = useGetHeatmapAppData(parameters, serviceName);
 
   return (
     <div className="relative w-full h-full">

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapRealtimeFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/HeatmapRealtimeFetcher.tsx
@@ -69,36 +69,39 @@ export const HeatmapRealtimeFetcher = ({
 
   const [setting] = useStoragedSetting(APP_SETTING_KEYS.HEATMAP_SETTING);
 
-  const [parameters, setParameters] = React.useState<GetHeatmapAppData.Parameters>({
-    applicationName: nodeData?.applicationName,
-    serviceTypeName: nodeData?.serviceType,
-    from: toBasicISOString(realtimeDateRange.from),
-    to: toBasicISOString(realtimeDateRange.to),
-    minElapsedTime: Number(setting?.yMin) || DefaultAxisY[0],
-    maxElapsedTime: Number(setting?.yMax) || DefaultAxisY[1],
-    agentId: agentId,
-  });
-  // 조회 파라미터가 effect로 한 박자 늦게 따라오므로 serviceName도 같은 effect에서 함께 갱신한다.
-  // 그러지 않으면 대상이 바뀌는 렌더에서 (이전 application, 새 service) 짝의 queryKey가 한 번
-  // 만들어져, 그 service에 없는 application을 조회하는 요청이 나간다.
-  // (아래 HeatmapChartCore에 넘기는 값은 링크 생성용이라 최신값 그대로 쓴다.)
-  const [requestServiceName, setRequestServiceName] = React.useState(serviceName);
-  const { data, isLoading } = useGetHeatmapAppData(parameters, requestServiceName);
-
-  React.useEffect(() => {
-    setParameters({
+  const [request, setRequest] = React.useState<{
+    parameters: GetHeatmapAppData.Parameters;
+    serviceName?: string;
+  }>({
+    parameters: {
       applicationName: nodeData?.applicationName,
       serviceTypeName: nodeData?.serviceType,
-      from:
-        !!lastToTimestamp?.current && lastToTimestamp?.current < realtimeDateRange.from.getTime()
-          ? toBasicISOString(new Date(lastToTimestamp?.current))
-          : toBasicISOString(realtimeDateRange.from),
+      from: toBasicISOString(realtimeDateRange.from),
       to: toBasicISOString(realtimeDateRange.to),
       minElapsedTime: Number(setting?.yMin) || DefaultAxisY[0],
       maxElapsedTime: Number(setting?.yMax) || DefaultAxisY[1],
       agentId: agentId,
+    },
+    serviceName,
+  });
+  const { data, isLoading } = useGetHeatmapAppData(request.parameters, request.serviceName);
+
+  React.useEffect(() => {
+    setRequest({
+      parameters: {
+        applicationName: nodeData?.applicationName,
+        serviceTypeName: nodeData?.serviceType,
+        from:
+          !!lastToTimestamp?.current && lastToTimestamp?.current < realtimeDateRange.from.getTime()
+            ? toBasicISOString(new Date(lastToTimestamp?.current))
+            : toBasicISOString(realtimeDateRange.from),
+        to: toBasicISOString(realtimeDateRange.to),
+        minElapsedTime: Number(setting?.yMin) || DefaultAxisY[0],
+        maxElapsedTime: Number(setting?.yMax) || DefaultAxisY[1],
+        agentId: agentId,
+      },
+      serviceName,
     });
-    setRequestServiceName(serviceName);
   }, [
     realtimeDateRange.from.getTime(),
     realtimeDateRange.to.getTime(),

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
@@ -19,7 +19,11 @@ import {
   ChartsBoardHeader,
 } from '@pinpoint-fe/ui/src/components';
 import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
-import { useExperimentals, useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
+import {
+  useExperimentals,
+  useServerMapSearchParameters,
+  useServiceNameForLink,
+} from '@pinpoint-fe/ui/src/hooks';
 import { MdArrowBackIosNew, MdArrowForwardIos } from 'react-icons/md';
 import { PiArrowSquareOut } from 'react-icons/pi';
 import {
@@ -115,12 +119,26 @@ export const ServerMapChartsBoardFetcher = ({
     [serverMapCurrentTarget, currentTargetData, serverMapData],
   );
 
+  // servicemap은 다른 service의 application도 함께 그린다. 그런 노드를 고르면 이 패널의 조회는
+  // 화면의 service가 아니라 그 노드의 service로 나가야 한다. 아래 차트/목록에 prop으로 내려준다.
   const targetServiceName = useServerMapTargetServiceName();
-  // 조회 기준은 **고른 대상**이다. map을 그린 service(경로)와 고른 노드의 service가 다를 수 있는데
-  // (A service의 servicemap에 B service의 b-1이 함께 그려진다) 요청은 고른 노드의 service로 나가므로
-  // 경로의 application을 기준으로 삼으면 백엔드가 그 이름을 남의 service에서 찾는다. (이슈 #10497)
-  // 고른 것이 없을 때(첫 로딩, merged 묶음)만 경로의 application으로 돌아간다.
-  const baseApplication = selectedTargetApplication ?? application;
+  const screenServiceName = useServiceNameForLink();
+  const isCrossServiceTarget =
+    !!targetServiceName && !!screenServiceName && targetServiceName !== screenServiceName;
+
+  // 통계 API의 기준 application은 **map을 그린 루트**다(고른 노드가 아니다). 고른 노드는 nodeKey로
+  // 따로 싣는다. 백엔드가 둘을 비교해, 다르면 루트를 고른 노드의 상대(from/to)로 넣어
+  // "루트에서 본 그 노드"의 히스토그램을 만든다 → `ServerMapHistogramController#getStatisticsFromServerMap`.
+  // 그래서 여기서 고른 노드를 기준으로 바꿔 보내면 안 된다. currentTarget의 applicationName·serviceType은
+  // 화면 표시용 필드라서(USER 노드는 리터럴 "USER", DB 노드의 serviceType은 `MYSQL` 같은 desc)
+  // 백엔드가 이름으로 해석하는 nodeKey 형식(`MYSQL_EXECUTE_QUERY`)과 어긋나, 조회가 조용히 비거나 400이 된다.
+  //
+  // 예외는 다른 service의 노드를 고른 경우다. 이 요청은 그 노드의 service로 나가는데(`serviceName`)
+  // 경로의 application은 화면 service 소속이라 그 service에 존재하지 않아 루트가 성립하지 않는다.
+  // 그때만 노드 자신을 기준으로 삼는다 — 그 application을 직접 열어 본 것과 같은 결과가 된다. (이슈 #10497)
+  const baseApplication = isCrossServiceTarget
+    ? selectedTargetApplication
+    : (application ?? selectedTargetApplication);
 
   const { data, isLoading } = useGetHistogramStatistics({
     useStatisticsAgentState,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ServerMap/ServerMapChartBoard.tsx
@@ -19,11 +19,7 @@ import {
   ChartsBoardHeader,
 } from '@pinpoint-fe/ui/src/components';
 import { GetServerMap } from '@pinpoint-fe/ui/src/constants';
-import {
-  useExperimentals,
-  useServerMapSearchParameters,
-  useServiceNameForLink,
-} from '@pinpoint-fe/ui/src/hooks';
+import { useExperimentals, useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { MdArrowBackIosNew, MdArrowForwardIos } from 'react-icons/md';
 import { PiArrowSquareOut } from 'react-icons/pi';
 import {
@@ -86,7 +82,7 @@ export const ServerMapChartsBoardFetcher = ({
 }: ServerMapChartsBoardFetcherProps) => {
   const { t } = useTranslation();
   const experimentalOption = useExperimentals();
-  const { application, dateRange, pathname } = useServerMapSearchParameters();
+  const { application, dateRange, queryOption, pathname } = useServerMapSearchParameters();
 
   const chartType = useAtomValue(serverMapChartTypeAtom);
   const scatterData = useAtomValue(scatterDataAtom);
@@ -119,29 +115,23 @@ export const ServerMapChartsBoardFetcher = ({
     [serverMapCurrentTarget, currentTargetData, serverMapData],
   );
 
-  // servicemap은 다른 service의 application도 함께 그린다. 그런 노드를 고르면 이 패널의 조회는
-  // 화면의 service가 아니라 그 노드의 service로 나가야 한다. 아래 차트/목록에 prop으로 내려준다.
-  //
-  // 대상이 다른 service면 경로의 application(화면 service 소속)은 통계 조회의 기준이 될 수 없다.
-  // 요청이 노드의 service로 나가므로 백엔드가 그 이름을 노드의 service에서 찾게 되기 때문이다.
-  // 그때는 노드 자신을 기준으로 삼는다 — 그 application을 직접 열어 본 것과 같은 결과가 된다.
   const targetServiceName = useServerMapTargetServiceName();
-  const screenServiceName = useServiceNameForLink();
-  const isCrossServiceTarget =
-    !!targetServiceName && !!screenServiceName && targetServiceName !== screenServiceName;
-
-  const baseApplication = isCrossServiceTarget
-    ? selectedTargetApplication
-    : (application ?? selectedTargetApplication);
+  // 조회 기준은 **고른 대상**이다. map을 그린 service(경로)와 고른 노드의 service가 다를 수 있는데
+  // (A service의 servicemap에 B service의 b-1이 함께 그려진다) 요청은 고른 노드의 service로 나가므로
+  // 경로의 application을 기준으로 삼으면 백엔드가 그 이름을 남의 service에서 찾는다. (이슈 #10497)
+  // 고른 것이 없을 때(첫 로딩, merged 묶음)만 경로의 application으로 돌아간다.
+  const baseApplication = selectedTargetApplication ?? application;
 
   const { data, isLoading } = useGetHistogramStatistics({
     useStatisticsAgentState,
+    applicationName: baseApplication?.applicationName,
+    serviceType: baseApplication?.serviceType,
+    dateRange,
+    queryOption,
     nodeKey:
       (currentTargetData as GetServerMap.NodeData)?.nodeKey ||
       (baseApplication ? getApplicationKey(baseApplication) : undefined), // 원래 optional인데 첫 페이지 로딩 시 currentTargetData가 없을 때, currentTargetData가 application으로 잡힐 때 두번 중복 call 방지를 위해 required 처럼 사용
     linkKey: (currentTargetData as GetServerMap.LinkData)?.linkKey,
-    fallbackApplication: selectedTargetApplication,
-    ignorePathApplication: isCrossServiceTarget,
     serviceName: targetServiceName,
   });
 
@@ -239,7 +229,7 @@ export const ServerMapChartsBoardFetcher = ({
   // 조회 대상 없는 차트가 남으므로, 차트 대신 무엇을 해야 하는지 알려준다.
   if (!serverMapCurrentTarget && !application) {
     return (
-      <div className="flex justify-center items-center w-full h-full text-muted-foreground">
+      <div className="flex items-center justify-center w-full h-full text-muted-foreground">
         {t('SERVER_MAP.SELECT_NODE_FOR_CHART')}
       </div>
     );

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApdexScore.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetApdexScore.ts
@@ -1,8 +1,6 @@
-import React from 'react';
 import { GetApdexScore, END_POINTS, GetServerMap } from '@pinpoint-fe/ui/src/constants';
 import { convertParamsToQueryString, toBasicISOString } from '@pinpoint-fe/ui/src/utils';
 import { keepPreviousData, useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { useServerMapSearchParameters } from '../searchParameters';
 import { queryFn } from './reactQueryHelper';
 
 const getQueryString = (queryParams: Partial<GetApdexScore.Parameters>) => {
@@ -20,7 +18,11 @@ const getQueryString = (queryParams: Partial<GetApdexScore.Parameters>) => {
 
 export type UseGetApdexScoreProps = {
   nodeData?: GetServerMap.NodeData;
-  disableFetch?: boolean;
+  /**
+   * 조회할 기간. 훅이 URL을 직접 읽지 않고 호출자에게 받는다 — 조회 훅을 라우터 상태와
+   * 분리해 두기 위한 것이다(`.claude/rules/api-hooks.md`). 읽는 자리는 `ApdexScoreFetcher`다.
+   */
+  dateRange: { from: Date; to: Date };
   shouldPoll?: boolean;
   agentId?: string;
   /**
@@ -35,47 +37,23 @@ export type UseGetApdexScoreProps = {
 
 export const useGetApdexScore = ({
   nodeData,
+  dateRange,
   shouldPoll,
   agentId,
   serviceName,
 }: UseGetApdexScoreProps) => {
-  const { dateRange } = useServerMapSearchParameters();
-  const from = toBasicISOString(dateRange.from);
-  const to = toBasicISOString(dateRange.to);
-  const [queryParams, setQueryParams] = React.useState<Partial<GetApdexScore.Parameters>>({
-    from,
-    to,
+  const queryString = getQueryString({
+    from: toBasicISOString(dateRange.from),
+    to: toBasicISOString(dateRange.to),
     applicationName: nodeData?.applicationName,
     serviceTypeName: nodeData?.serviceType,
-    agentId: agentId,
+    agentId,
   });
-  // 조회 파라미터가 effect로 한 박자 늦게 따라오므로 serviceName도 같은 effect에서 함께 갱신한다.
-  // 그러지 않으면 대상이 바뀌는 렌더에서 (이전 application, 새 service) 짝의 queryKey가 한 번
-  // 만들어져, 그 service에 없는 application을 조회하는 요청이 나간다.
-  const [requestServiceName, setRequestServiceName] = React.useState(serviceName);
-
-  React.useEffect(() => {
-    if (nodeData) {
-      setQueryParams((prev) => ({
-        ...prev,
-        applicationName: nodeData?.applicationName,
-        serviceTypeName: nodeData?.serviceType,
-        from: from,
-        to: to,
-        agentId,
-      }));
-      setRequestServiceName(serviceName);
-    }
-  }, [nodeData, from, to, agentId, serviceName]);
-
-  const queryString = getQueryString(queryParams);
 
   const query = shouldPoll ? useQuery : useSuspenseQuery;
   const { data, isLoading } = query({
-    queryKey: [END_POINTS.APDEX_SCORE, queryString, requestServiceName],
-    queryFn: queryFn(`${END_POINTS.APDEX_SCORE}${queryString}`, {
-      serviceName: requestServiceName,
-    }),
+    queryKey: [END_POINTS.APDEX_SCORE, queryString, serviceName],
+    queryFn: queryFn(`${END_POINTS.APDEX_SCORE}${queryString}`, { serviceName }),
     gcTime: shouldPoll ? 0 : 30000,
     staleTime: shouldPoll ? 0 : 30000,
     placeholderData: shouldPoll ? keepPreviousData : undefined,

--- a/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHistogramStatistics.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/hooks/api/useGetHistogramStatistics.ts
@@ -1,7 +1,5 @@
-import React from 'react';
-import { ApplicationType, END_POINTS, GetHistogramStatistics } from '@pinpoint-fe/ui/src/constants';
+import { END_POINTS, GetHistogramStatistics } from '@pinpoint-fe/ui/src/constants';
 import { convertParamsToQueryString, toBasicISOString } from '@pinpoint-fe/ui/src/utils';
-import { useServerMapSearchParameters } from '../searchParameters';
 import { useQuery } from '@tanstack/react-query';
 import { queryFn } from './reactQueryHelper';
 
@@ -21,104 +19,50 @@ const getQueryString = (queryParams: Partial<GetHistogramStatistics.Parameters>)
 };
 
 export const useGetHistogramStatistics = ({
+  applicationName,
+  serviceType,
+  dateRange,
+  queryOption,
   useStatisticsAgentState,
   nodeKey,
   linkKey,
-  fallbackApplication,
-  ignorePathApplication,
   serviceName,
 }: {
+  applicationName?: string;
+  serviceType?: string;
+  dateRange: { from: Date; to: Date };
+  queryOption: {
+    inbound?: number;
+    outbound?: number;
+    wasOnly?: boolean;
+    bidirectional?: boolean;
+  };
   useStatisticsAgentState?: boolean;
   nodeKey?: string;
   linkKey?: string;
-  /**
-   * 경로에 application이 없을 때 기준 application으로 쓸 값.
-   * service 전체를 모아 그린 servicemap에는 경로에 application이 없는데,
-   * 통계 API는 기준 application이 필수라 선택된 노드/링크에서 끌어와야 한다.
-   */
-  fallbackApplication?: ApplicationType;
-  /**
-   * true면 경로의 application을 무시하고 `fallbackApplication`을 기준으로 쓴다.
-   *
-   * 다른 service의 노드를 고른 경우가 여기에 해당한다. 이 요청은 그 노드의 service로 나가는데
-   * (`serviceName`) 경로의 application은 지금 화면의 service 소속이라, 백엔드가 그 이름을
-   * 노드의 service에서 찾게 되어 기준이 성립하지 않는다.
-   */
-  ignorePathApplication?: boolean;
-  /**
-   * 이 조회가 나갈 service. 지정하면 `pServiceName` 헤더를 직접 싣고 캐시도 그 단위로 갈린다.
-   *
-   * 화면의 service와 조회 대상의 service가 다를 때 넘긴다 — servicemap은 다른 service의
-   * application도 함께 그리기 때문이다(`useServerMapTargetServiceName`). 넘기지 않으면 기존대로
-   * fetch 인터셉터가 경로/전역 선택값으로 결정한다.
-   */
   serviceName?: string;
 }) => {
-  const {
-    dateRange,
-    search,
-    application: applicationFromPath,
-    queryOption,
-  } = useServerMapSearchParameters();
-  const application =
-    (ignorePathApplication ? undefined : applicationFromPath) ?? fallbackApplication;
-  const from = toBasicISOString(dateRange.from);
-  const to = toBasicISOString(dateRange.to);
-
-  const [queryParams, setQueryParams] = React.useState<Partial<GetHistogramStatistics.Parameters>>({
-    from,
-    to,
+  const queryString = getQueryString({
+    from: toBasicISOString(dateRange.from),
+    to: toBasicISOString(dateRange.to),
     calleeRange: queryOption.inbound,
     callerRange: queryOption.outbound,
     wasOnly: !!queryOption.wasOnly,
     bidirectional: !!queryOption.bidirectional,
-    serviceTypeName: application?.serviceType,
-    applicationName: application?.applicationName,
+    serviceTypeName: serviceType,
+    applicationName,
     useStatisticsAgentState,
     nodeKey,
     linkKey,
   });
-  // 조회 파라미터가 effect로 한 박자 늦게 따라오므로 serviceName도 같은 effect에서 함께 갱신한다.
-  // 그러지 않으면 대상이 바뀌는 렌더에서 (이전 application, 새 service) 짝의 queryKey가 한 번
-  // 만들어져, 그 service에 없는 application을 조회하는 요청이 나간다.
-  const [requestServiceName, setRequestServiceName] = React.useState(serviceName);
-  const queryString = getQueryString(queryParams);
-
-  React.useEffect(() => {
-    setQueryParams((prev) => ({
-      ...prev,
-      applicationName: application?.applicationName,
-      serviceTypeName: application?.serviceType,
-      calleeRange: queryOption.inbound,
-      callerRange: queryOption.outbound,
-      wasOnly: !!queryOption.wasOnly,
-      bidirectional: !!queryOption.bidirectional,
-      useStatisticsAgentState,
-      nodeKey,
-      linkKey,
-      from,
-      to,
-    }));
-    setRequestServiceName(serviceName);
-  }, [
-    application?.applicationName,
-    application?.serviceType,
-    from,
-    to,
-    search,
-    useStatisticsAgentState,
-    nodeKey,
-    linkKey,
-    serviceName,
-  ]);
 
   const { data, isLoading } = useQuery<GetHistogramStatistics.Response>({
-    queryKey: [END_POINTS.HISTOGRAM_STATISTICS, queryString, requestServiceName],
+    queryKey: [END_POINTS.HISTOGRAM_STATISTICS, queryString, serviceName],
     queryFn: queryFn(
       linkKey
         ? `${END_POINTS.HISTOGRAM_STATISTICS_LINKS}${queryString}`
         : `${END_POINTS.HISTOGRAM_STATISTICS}${queryString}`,
-      { serviceName: requestServiceName },
+      { serviceName },
     ),
     enabled: !!queryString,
   });

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.test.ts
@@ -1,4 +1,5 @@
 import {
+  findCalleeApplication,
   findCallerApplication,
   findLinkOfApplications,
   findNodeOfApplication,
@@ -7,6 +8,7 @@ import {
   getTimeSeriesApdexInfo,
   isMergedMapTarget,
   parseNodeApplication,
+  parseNodeKeyApplication,
 } from './serverMap';
 import {
   ApplicationType,
@@ -570,6 +572,130 @@ describe('Test serverMap helper utils', () => {
         expect(findCallerApplication([inboundLink], undefined)).toBeUndefined();
         expect(findCallerApplication(undefined, 'A^a-mongo-1^MONGO')).toBeUndefined();
         expect(findCallerApplication([inboundLink], 'A^a-mongo-9^MONGO')).toBeUndefined();
+      });
+    });
+
+    // 표시용 필드를 그대로 기준으로 쓰면 백엔드가 해석하는 값과 어긋난다. USER 노드는 이름이
+    // 리터럴 "USER"로 치환되고, DB 노드의 serviceType은 getDesc() 형식이라 백엔드가 이름으로
+    // 찾을 때 다른 타입에 붙거나(MYSQL 2100 ≠ MYSQL_EXECUTE_QUERY 2101) 아예 없어서 400이 된다.
+    describe('기준 application의 식별자는 nodeKey에서 뽑는다', () => {
+      test('DB 노드는 desc가 아니라 nodeKey의 serviceType 이름을 쓴다', () => {
+        expect(
+          getSelectedTargetApplication(
+            { type: 'node', applicationName: 'a-mysql-1', serviceType: 'MYSQL' },
+            {
+              key: 'a-mysql-1^MYSQL',
+              nodeKey: 'a-mysql-1^MYSQL_EXECUTE_QUERY',
+            } as GetServerMap.NodeData,
+          ),
+        ).toEqual({ applicationName: 'a-mysql-1', serviceType: 'MYSQL_EXECUTE_QUERY' });
+      });
+
+      test('nodeKey를 아직 모르면 표시용 필드로 폴백한다', () => {
+        expect(
+          getSelectedTargetApplication(
+            { type: 'node', applicationName: 'a-1', serviceType: 'TOMCAT' },
+            { key: 'a-1^TOMCAT' } as GetServerMap.NodeData,
+          ),
+        ).toEqual({ applicationName: 'a-1', serviceType: 'TOMCAT' });
+      });
+
+      test('parseNodeKeyApplication은 첫 ^ 하나로만 쪼갠다', () => {
+        expect(parseNodeKeyApplication('a-1^TOMCAT')).toEqual({
+          applicationName: 'a-1',
+          serviceType: 'TOMCAT',
+        });
+        // applicationName은 escape되므로 실제로는 ^가 없지만, 백엔드와 같은 규칙(limit 2)을 지킨다.
+        expect(parseNodeKeyApplication('a-1^TOMCAT^EXTRA')).toEqual({
+          applicationName: 'a-1',
+          serviceType: 'TOMCAT^EXTRA',
+        });
+      });
+
+      test('parseNodeKeyApplication은 쪼갤 수 없으면 undefined다', () => {
+        expect(parseNodeKeyApplication(undefined)).toBeUndefined();
+        expect(parseNodeKeyApplication('')).toBeUndefined();
+        expect(parseNodeKeyApplication('a-1')).toBeUndefined();
+        expect(parseNodeKeyApplication('^TOMCAT')).toBeUndefined();
+        expect(parseNodeKeyApplication('a-1^')).toBeUndefined();
+      });
+    });
+
+    // USER 노드의 application 이름은 `{앱이름}_{타입이름}`으로 합성된 값이고, 양쪽 다 `_`를
+    // 가질 수 있어 문자열로는 되돌릴 수 없다. 나가는 링크의 targetInfo에서 그대로 읽는다.
+    describe('USER 노드의 기준 application', () => {
+      const userNodeTarget = {
+        type: 'node' as const,
+        applicationName: 'USER',
+        serviceType: 'USER',
+      };
+      const userNodeData = {
+        key: 'ApiGateway_SPRING_BOOT^USER',
+        nodeKey: 'ApiGateway_SPRING_BOOT^USER',
+        serviceType: 'USER',
+      } as GetServerMap.NodeData;
+      const outboundLink = {
+        from: 'ApiGateway_SPRING_BOOT^USER',
+        to: 'ApiGateway^SPRING_BOOT',
+        targetInfo: { applicationName: 'ApiGateway', serviceType: 'SPRING_BOOT' },
+      } as GetServerMap.LinkData;
+
+      test('나가는 링크의 도착지(호출되는 WAS)가 기준이다', () => {
+        expect(getSelectedTargetApplication(userNodeTarget, userNodeData, [outboundLink])).toEqual({
+          applicationName: 'ApiGateway',
+          serviceType: 'SPRING_BOOT',
+        });
+      });
+
+      test('앱 이름에 _가 있어도 문자열을 쪼개지 않으므로 정확하다', () => {
+        expect(
+          getSelectedTargetApplication(
+            userNodeTarget,
+            { ...userNodeData, key: 'my_app_TOMCAT^USER' } as GetServerMap.NodeData,
+            [
+              {
+                from: 'my_app_TOMCAT^USER',
+                to: 'my_app^TOMCAT',
+                targetInfo: { applicationName: 'my_app', serviceType: 'TOMCAT' },
+              } as GetServerMap.LinkData,
+            ],
+          ),
+        ).toEqual({ applicationName: 'my_app', serviceType: 'TOMCAT' });
+      });
+
+      test('나가는 링크가 여럿이면 정할 수 없으므로 그 보정을 하지 않는다', () => {
+        const anotherOutbound = {
+          from: 'ApiGateway_SPRING_BOOT^USER',
+          to: 'Other^TOMCAT',
+          targetInfo: { applicationName: 'Other', serviceType: 'TOMCAT' },
+        } as GetServerMap.LinkData;
+
+        expect(
+          getSelectedTargetApplication(userNodeTarget, userNodeData, [
+            outboundLink,
+            anotherOutbound,
+          ]),
+        ).toEqual({ applicationName: 'ApiGateway_SPRING_BOOT', serviceType: 'USER' });
+      });
+
+      test('findCalleeApplication은 노드 key나 링크가 없으면 undefined다', () => {
+        expect(findCalleeApplication([outboundLink], undefined)).toBeUndefined();
+        expect(findCalleeApplication(undefined, 'ApiGateway_SPRING_BOOT^USER')).toBeUndefined();
+        expect(findCalleeApplication([outboundLink], 'Nope^USER')).toBeUndefined();
+      });
+
+      // 들어오는 링크를 보는 findCallerApplication과 방향이 섞이지 않아야 한다.
+      test('USER 노드는 들어오는 링크를 기준으로 삼지 않는다', () => {
+        const inboundToWas = {
+          from: 'ApiGateway_SPRING_BOOT^USER',
+          to: 'ApiGateway^SPRING_BOOT',
+          sourceInfo: { applicationName: 'USER', serviceType: 'USER' },
+          targetInfo: { applicationName: 'ApiGateway', serviceType: 'SPRING_BOOT' },
+        } as GetServerMap.LinkData;
+
+        expect(
+          findCallerApplication([inboundToWas], 'ApiGateway_SPRING_BOOT^USER'),
+        ).toBeUndefined();
       });
     });
   });

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/serverMap.ts
@@ -269,6 +269,78 @@ export const findCallerApplication = (
 };
 
 /**
+ * 이 노드가 호출하는 application(나가는 링크의 도착지). 하나로 정해지지 않으면 undefined다.
+ * `findCallerApplication`의 반대 방향이다.
+ *
+ * **USER 노드의 기준 application을 찾는 데 쓴다.** USER 노드의 내부 application 이름은
+ * `{앱이름}_{호출되는쪽 타입이름}`으로 합성된 값이라(`UserNodeUtils#newUserNodeName`) 그 자체로는
+ * 조회 기준이 될 수 없다. 그리고 **문자열을 쪼개 되돌릴 수도 없다** — 앱 이름과 타입 이름 둘 다
+ * `_`를 가질 수 있어서(`IdValidateUtils.ID_PATTERN_VALUE` = `[a-zA-Z0-9._\-]+`,
+ * 타입 쪽은 `SPRING_BOOT`·`MYSQL_EXECUTE_QUERY` 등) 경계를 알 수 없다:
+ * `my_app_TOMCAT`은 `my_app`+`TOMCAT`일 수도 `my`+`app_TOMCAT`일 수도 있다.
+ *
+ * 나가는 링크의 `targetInfo`가 그 값을 **파싱 없이** 갖고 있다:
+ * `{ from: 'ApiGateway_SPRING_BOOT^USER', targetInfo: { applicationName: 'ApiGateway',
+ * serviceType: 'SPRING_BOOT' } }`. 이 값이 곧 백엔드가 기대하는 루트다 — USER 노드는 그 WAS의
+ * 호출자이므로 백엔드가 `isToNode`로 방향을 알아내 `toApplications`에 넣는다.
+ *
+ * @param nodeKey 노드의 `key` 필드(링크의 `from`/`to`와 같은 형식). `nodeKey` 필드가 아니다.
+ */
+export const findCalleeApplication = (
+  links: (GetServerMap.LinkData | FilteredMap.LinkData)[] | undefined,
+  nodeKey: string | undefined,
+): ApplicationType | undefined => {
+  if (!nodeKey) {
+    return undefined;
+  }
+
+  const outboundLinks = (links ?? []).filter((link) => link.from === nodeKey);
+  if (outboundLinks.length !== 1) {
+    return undefined;
+  }
+
+  const { applicationName, serviceType } = outboundLinks[0].targetInfo ?? {};
+  return applicationName && serviceType ? { applicationName, serviceType } : undefined;
+};
+
+/**
+ * `nodeKey`(`applicationName^serviceTypeName`)에서 **조회용** application을 만든다.
+ *
+ * 노드의 `applicationName`·`serviceType` 필드는 화면 표시용이라 조회 기준으로 쓸 수 없다.
+ * 타입 검사에 걸리지 않고 조용히 빈 데이터나 400이 되므로 반드시 `nodeKey`에서 뽑는다:
+ *
+ * | 노드 | 표시용 필드 | `nodeKey` |
+ * |---|---|---|
+ * | USER | `USER` / `USER` — 이름이 리터럴로 치환된다(`Node#getApplicationTextName`, 2014년부터) | `myapp_TOMCAT^USER` |
+ * | MySQL | `{dbId}` / `MYSQL` — `serviceType`은 `getDesc()`다 | `{dbId}^MYSQL_EXECUTE_QUERY` |
+ * | MSSQL | `{dbId}` / `MSSQLSERVER` — 그 이름의 타입이 없어 400이 된다 | `{dbId}^MSSQL_EXECUTE_QUERY` |
+ *
+ * 백엔드는 `serviceTypeName`을 `getName()`으로 해석하므로(`ApplicationValidator#newApplication`
+ * → `findServiceTypeByName`) desc를 보내면 다른 타입에 붙거나 `UNDEFINED`가 된다.
+ * map 노드로 뜨는 타입 중 desc≠name인 것: `MYSQL`/`ORACLE`/`POSTGRESQL`/`MONGO`/`CUBRID`/
+ * `INFORMIX`/`CLICK_HOUSE`/`UNKNOWN_DB`의 `*_EXECUTE_QUERY`, `MSSQLSERVER`, `JDK_HTTPCONNECTOR`.
+ * WAS 타입은 둘이 같아서 문제가 드러나지 않는다 — WAS 노드만 눌러 보면 정상으로 보인다.
+ *
+ * 구분자는 **첫 `^`** 하나다. 백엔드도 같은 규칙으로 쪼갠다
+ * (`ServerMapHistogramController#newApplication`의 `split(nodeKey, 2)`).
+ * `key`와 달리 `nodeKey`는 servicemap에서도 항상 2단이다(`NodeView`가 service를 붙이지 않는다).
+ */
+export const parseNodeKeyApplication = (nodeKey?: string): ApplicationType | undefined => {
+  if (!nodeKey) {
+    return undefined;
+  }
+
+  const delimiterIndex = nodeKey.indexOf('^');
+  if (delimiterIndex <= 0) {
+    return undefined;
+  }
+
+  const applicationName = nodeKey.slice(0, delimiterIndex);
+  const serviceType = nodeKey.slice(delimiterIndex + 1);
+  return applicationName && serviceType ? { applicationName, serviceType } : undefined;
+};
+
+/**
  * 우측 패널의 조회가 기준으로 삼을 application. 경로에 application이 없는 화면
  * (service 전체를 모아 그린 servicemap)에서 이 값이 기준이 된다.
  *
@@ -279,8 +351,12 @@ export const findCallerApplication = (
  * - **merged 묶음 목록에서 고른 노드는 그 노드의 호출자가 기준이다.** servermap에서는 경로의
  *   application(map 중심)이 그 자리를 맡는데, 경로에 application이 없는 servicemap에서 노드 자신을
  *   기준으로 두면 요청이 다른 분기로 빠져 수치가 달라진다(→ `findCallerApplication`).
- * - 그 외 노드면 그 노드. 클릭 즉시 채워지는 `currentTarget`에서 읽는다(조회된 데이터를 기다리지
- *   않는다). 노드 자신을 기준으로 삼는 것은 그 application을 직접 열어 본 것과 같은 결과가 된다.
+ * - **USER 노드는 그 USER가 호출하는 WAS가 기준이다**(→ `findCalleeApplication`). 이름이
+ *   `{앱이름}_{타입이름}`으로 합성된 값이라 자기 자신을 기준으로 삼을 수 없다.
+ * - 그 외 노드면 그 노드. 노드 자신을 기준으로 삼는 것은 그 application을 직접 열어 본 것과 같은
+ *   결과가 된다. **식별자는 `nodeKey`에서 뽑는다**(→ `parseNodeKeyApplication`) — 표시용
+ *   `applicationName`/`serviceType`을 그대로 쓰면 DB·캐시 노드가 조용히 빈 데이터나 400이 된다.
+ *   nodeKey를 아직 모르는 순간에는 클릭 즉시 채워지는 `currentTarget`으로 폴백한다.
  * - 링크면 출발지 노드. 링크 통계의 기준도 출발지이므로 같은 기준이다.
  */
 export const getSelectedTargetApplication = (
@@ -304,21 +380,42 @@ export const getSelectedTargetApplication = (
   }
 
   if (currentTarget?.type === 'node') {
+    const nodeData = currentTargetData as GetServerMap.NodeData | undefined;
+
     const isFromMergedGroup = !!(currentTarget.nodes || currentTarget.edges);
     if (isFromMergedGroup) {
-      const caller = findCallerApplication(
-        links,
-        (currentTargetData as GetServerMap.NodeData | undefined)?.key,
-      );
+      const caller = findCallerApplication(links, nodeData?.key);
       if (caller) {
         return caller;
       }
+    }
+
+    // USER 노드는 이름이 합성값이라 자기 자신이 기준이 될 수 없다. 이 USER가 호출하는 WAS가
+    // 기준이다 → `findCalleeApplication`. (`serviceType`은 USER 타입에서 name==desc=='USER'라
+    // 표시용 필드로도 안전하게 판별된다. 같은 판별을 `serverMapCurrentTargetDataAtom`도 쓴다.)
+    if ((currentTarget.serviceType ?? nodeData?.serviceType) === 'USER') {
+      const callee = findCalleeApplication(links, nodeData?.key);
+      if (callee) {
+        return callee;
+      }
+    }
+
+    // 노드 자신이 기준일 때도 **표시용 필드가 아니라 `nodeKey`에서** 뽑는다
+    // (→ `parseNodeKeyApplication`). map 데이터가 아직 안 붙어 nodeKey를 모르는 순간에는
+    // 표시용 필드로 폴백한다 — 예전과 같은 동작이고, 붙는 즉시 정확한 값으로 바뀐다.
+    const fromNodeKey = parseNodeKeyApplication(nodeData?.nodeKey);
+    if (fromNodeKey) {
+      return fromNodeKey;
     }
 
     const { applicationName, serviceType } = currentTarget;
     return applicationName && serviceType ? { applicationName, serviceType } : undefined;
   }
 
+  // 링크는 표시용 `sourceInfo`를 그대로 쓴다. `/histogram/statistics/links`는 `applicationName`을
+  // 읽지 않고 `linkKey`만 쪼개 양쪽 application을 만들기 때문에(`getLinkTimeHistogramData`)
+  // 이 값이 조회에 영향을 주지 않는다. 링크의 출발지는 호출하는 쪽이라 WAS 아니면 USER인데,
+  // WAS는 name==desc라 어긋날 값도 없다.
   const sourceInfo = (currentTargetData as GetServerMap.LinkData | undefined)?.sourceInfo;
   return sourceInfo?.applicationName && sourceInfo?.serviceType
     ? { applicationName: sourceInfo.applicationName, serviceType: sourceInfo.serviceType }


### PR DESCRIPTION
## Summary

- The chart hooks compute their query parameters where they are used instead of holding them in state and syncing them in an effect. On the render where the target changed, the parameters were still the previous ones while `serviceName` was already the new one, and that pair formed a queryKey nobody had cached — React Query immediately asked the new service for the previous application.
- `useGetApdexScore` and `useGetHistogramStatistics` take the date range, the map query option and the base application explicitly, so they no longer depend on router state and the screen keeps the decision about what to query.
- The base application of those queries stays the **root of the map**, which is what the statistics API reads it as. The clicked node travels separately in `nodeKey`; the backend compares the two and, when they differ, feeds the root in as that node's from/to peer. Only a node with no usable root falls back to itself — a service map with no application in the path, or a node belonging to another service — and there the identity comes from `nodeKey` instead of the display fields.

## Notes

`HeatmapRealtimeFetcher` keeps its state: `from` samples the `lastToTimestamp` ref that every response rewrites, and reading that ref during render would fire requests outside the five second cadence. Its two states are merged into one so that the parameters and `serviceName` can only change together.

`HeatmapFetcher` keeps reading the URL itself — it is mounted only on non-realtime paths, where no ticking window is involved.

A node's `applicationName` and `serviceType` are display fields, so they cannot be sent as a query identity. A USER node reports the literal `"USER"`, and a database node reports the service type `getDesc()` while the backend resolves `getName()` — `MYSQL` lands on 2100 instead of `MYSQL_EXECUTE_QUERY` 2101, and `MSSQLSERVER` resolves to nothing and answers 400. WAS nodes agree on both, which is why this only shows up on USER and database nodes. `nodeKey` carries the real application name and the `getName()` service type, so the base is derived from it (`parseNodeKeyApplication`).

A USER node is the exception: its own name is synthesised as `{application}_{calleeServiceType}` (`UserNodeUtils#newUserNodeName`) and cannot be split back, because an application name may contain `_` (`IdValidateUtils.ID_PATTERN_VALUE`) and so may a service type name — `my_app_TOMCAT` is ambiguous. It takes the application it calls from the outgoing link's `targetInfo` instead (`findCalleeApplication`).

`/histogram/statistics/links` never reads `applicationName` — it only splits `linkKey`, whose halves are already in the `nodeKey` format — so link selections are left as they were.

## Test plan

- [x] `yarn build`, `yarn test` and `yarn lint` pass
- [ ] Server map: pick an application, click a node and a link — the response time histogram and the server list show that target's numbers
- [ ] Server map: click a `USER` node and a database node — the histogram and the server list are unchanged from before this PR
- [ ] Server map: click a merged node group, then a node inside it — the base falls back correctly and the numbers match the caller's branch
- [ ] Service map (DEFAULT service): click a node that belongs to another service — the charts show that node's numbers instead of coming back empty
- [ ] Service map (non-DEFAULT service): the charts work with no application in the path, including on a `USER` node and a database node
- [ ] Change the period and the map search options (inbound / outbound / wasOnly / bidirectional) — the charts follow, and each change fires one request
- [ ] Switch targets while watching the network panel — no request goes out for the previous application
- [ ] Realtime: the Apdex score and the heatmap keep updating on the five second cadence
- [ ] Filtered map: the Apdex score and the charts are unchanged
