### PR TITLE
[#noissue] Expect the Unknown endPoint fallback when an OTLP consumer…

### DIFF
--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpTraceSpanMapperTest.java
@@ -433,13 +433,18 @@ class OtlpTraceSpanMapperTest {
     }
 
     @Test
-    void map_consumer_kafka_blankClientIdKeysOnly_noEndPoint() {
+    void map_consumer_kafka_blankClientIdKeysOnly_fallsBackToUnknown() {
+        // Blank client id keys count as absent: the consumer address fields must not carry the
+        // blank value. Without a broker the endPoint falls back to "Unknown" (the fields are never
+        // null, see MessageConsumerRecorder) and the acceptorHost to the destination name.
         Span span = consumerKafkaSpan(
                 kv("messaging.client.id", strVal("")),
                 kv("messaging.client_id", strVal(" "))
         );
         SpanBo bo = newMapper().map(id(), span, NO_SCOPE);
-        assertThat(bo.getEndPoint()).isNull();
+        assertThat(bo.getEndPoint()).isEqualTo(OtlpTraceConstants.UNKNOWN_ADDRESS);
+        assertThat(bo.getRemoteAddr()).isEqualTo(OtlpTraceConstants.UNKNOWN_ADDRESS);
+        assertThat(bo.getAcceptorHost()).isEqualTo("orders");
     }
 
     @Test


### PR DESCRIPTION
… span carries only blank client id keys

The blank client id test from the semantic convention update asserted a null endPoint, while the consumer address fix merged right after it makes the consumer endPoint, remoteAddr and acceptorHost never null. Each change was green on its own base; combined on master the test fails.

Keep the test's intent (blank client id keys count as absent) and assert the fallbacks instead: "Unknown" for endPoint and remoteAddr, and the destination name for acceptorHost.