### PR TITLE
[#noissue] Import the Error Analysis storage config into the OTLPTRAC…

### DIFF
--- a/collector-starter/src/main/resources/profiles/local/pinpoint-collector.properties
+++ b/collector-starter/src/main/resources/profiles/local/pinpoint-collector.properties
@@ -15,3 +15,8 @@ pinpoint.collector.otlptrace.application-name-fallback.enabled=true
 # so URI stat counts/apdex reflect the sampled population, unlike the native agent's pre-sampling totals.
 pinpoint.collector.otlptrace.uristat.enabled=true
 pinpoint.modules.collector.uristat.enabled=true
+
+# Error Analysis storage module (Kafka/Pinot exception traces). Read by the BASIC collector for
+# agent exceptions and by the OTLPTRACE collector for OTel exception span events; without it the
+# OTLPTRACE app has no ExceptionMetaDataService and OTel exceptions are not stored.
+pinpoint.modules.collector.exceptiontrace.enabled=true

--- a/collector-starter/src/main/resources/profiles/release/pinpoint-collector.properties
+++ b/collector-starter/src/main/resources/profiles/release/pinpoint-collector.properties
@@ -14,3 +14,9 @@ pinpoint.collector.otlptrace.application-name-fallback.enabled=false
 # (pinpoint.modules.collector.uristat.enabled=true). Off by default: OTLP spans are sampled,
 # so URI stat counts/apdex reflect the sampled population, unlike the native agent's pre-sampling totals.
 pinpoint.collector.otlptrace.uristat.enabled=false
+
+# Error Analysis storage module (Kafka/Pinot exception traces). Read by the BASIC collector for
+# agent exceptions and by the OTLPTRACE collector for OTel exception span events; without it the
+# OTLPTRACE app has no ExceptionMetaDataService and OTel exceptions are not stored. Off by default:
+# requires the Pinot/Kafka exception-trace infrastructure.
+pinpoint.modules.collector.exceptiontrace.enabled=false

--- a/otlptrace/README.md
+++ b/otlptrace/README.md
@@ -236,6 +236,19 @@ Off by default for two reasons: it requires the URI stat storage module, and OTL
 **sampled** — so counts/apdex reflect the sampled population rather than the native agent's
 pre-sampling totals. Keep that distinction in mind when reading charts that mix both sources.
 
+## Error Analysis
+
+The collector maps every OTel `exception` span event to an Error Analysis record
+(`ExceptionMetaDataBo`, see `OtlpExceptionMapper`) and writes it through the same Kafka/Pinot
+exception-trace store the native agent uses. The store is a separate collector module, so it has to
+be enabled explicitly; without it the OTLPTRACE app has no `ExceptionMetaDataService` and the mapped
+exceptions are silently dropped (traces and URI stat are unaffected).
+
+| Property | Default | Notes |
+|---|---|---|
+| `pinpoint.modules.collector.exceptiontrace.enabled` | `false` | **Prerequisite.** Provides the exception-trace storage beans (`ExceptionTraceCollectorConfig`: Pinot + Kafka). The BASIC collector reads the same flag for agent exceptions. The `local` profile turns it on. |
+| `pinpoint.modules.web.exceptiontrace.enabled` | `false` | Web side: shows the Error Analysis menu that reads the store. |
+
 ## otlptrace-otel-extension
 
 A small **sender-side** OTel SDK extension that adds a `pp=...` entry to the

--- a/otlptrace/otlptrace-collector/README.md
+++ b/otlptrace/otlptrace-collector/README.md
@@ -158,6 +158,7 @@ gRPC server executor (4 threads / queue 256)
 | scatter index | `HbaseTraceIndexDao` (v2) | `TRACE_INDEX` / `TRACE_INDEX_META` | async — **future discarded** |
 | server-map stats | `BulkWriter.increment` | link/response-stats tables | in-memory aggregation + 5s flush |
 | store event | `SpanStorePublisher` | (Spring event) | published from the async callback |
+| exception traces (Error Analysis) | `PinotExceptionMetaDataService` → `ExceptionTraceDao` | Kafka topic → Pinot `exceptionTrace` | one record per mapped `exception` span event; only when `pinpoint.modules.collector.exceptiontrace.enabled=true` (the module's `ExceptionTraceCollectorConfig` import), otherwise the `Optional<ExceptionMetaDataService>` is empty and the records are dropped |
 
 spanChunk uses only `TraceV2`/CF `S` (no scatter index). AgentInfo (`AGENTINFO`/CF `Info`,
 rowkey=`agentId+startTime`) and ApplicationIndex v2 (`APPLICATION`, `AGENT_ID`) are synchronous put +

--- a/otlptrace/otlptrace-collector/pom.xml
+++ b/otlptrace/otlptrace-collector/pom.xml
@@ -33,6 +33,10 @@
             <groupId>com.navercorp.pinpoint</groupId>
             <artifactId>pinpoint-uristat-collector</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-exceptiontrace-collector</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
@@ -31,6 +31,7 @@ import com.navercorp.pinpoint.common.server.executor.ExecutorCustomizer;
 import com.navercorp.pinpoint.common.server.executor.ThreadPoolExecutorCustomizer;
 import com.navercorp.pinpoint.common.server.uid.ObjectNameVersion;
 import com.navercorp.pinpoint.common.server.util.IgnoreAddressFilter;
+import com.navercorp.pinpoint.exceptiontrace.collector.ExceptionTraceCollectorConfig;
 import com.navercorp.pinpoint.grpc.channelz.ChannelzRegistry;
 import com.navercorp.pinpoint.otlp.trace.collector.service.GrpcOtlpTraceService;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportService;
@@ -75,6 +76,14 @@ import java.util.concurrent.Executor;
         // import the OTLP trace app runs as its own Spring context with no uristat beans, so
         // OtlpUriStatService cannot be created even when both uristat flags are true.
         UriStatCollectorConfig.class,
+
+        // Error Analysis storage beans (PinotExceptionMetaDataService / ExceptionTraceDao / Kafka
+        // template) that OtlpTraceExportService writes the mapped ExceptionMetaDataBo to. Same
+        // situation as the uristat import above: self-guarded by
+        // @ConditionalOnProperty(exceptiontrace.enabled), and without it this standalone context has
+        // no ExceptionMetaDataService at all — the Optional injection stays empty and OTel exceptions
+        // are silently not stored. The BASIC app gets the same config from PinpointCollectorStarter.
+        ExceptionTraceCollectorConfig.class,
 
         OtlpTraceCollectorPropertySources.class,
         OtlpTraceCollectorHbaseModule.class,

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModuleTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModuleTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector;
+
+import com.navercorp.pinpoint.exceptiontrace.collector.ExceptionTraceCollectorConfig;
+import com.navercorp.pinpoint.uristat.collector.UriStatCollectorConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpTraceCollectorModuleTest {
+
+    /**
+     * The OTLPTRACE app is its own Spring context, so every storage module its export path writes
+     * to must be imported here explicitly — the BASIC app gets them from PinpointCollectorStarter.
+     * Dropping one of these does not fail the build or the boot (the services are injected as
+     * Optional / conditional beans); it silently stops storing that data.
+     */
+    @Test
+    void module_importsTheStorageConfigsTheExportPathWritesTo() {
+        Import imports = OtlpTraceCollectorModule.class.getAnnotation(Import.class);
+
+        assertThat(imports).isNotNull();
+        assertThat(imports.value())
+                .contains(UriStatCollectorConfig.class, ExceptionTraceCollectorConfig.class);
+    }
+}


### PR DESCRIPTION
…E collector so OTel exceptions are stored

The OTLP trace collector maps every OTel "exception" span event to an ExceptionMetaDataBo and hands it to ExceptionMetaDataService, but the OTLPTRACE app is its own Spring context and never imported ExceptionTraceCollectorConfig - only the BASIC app gets it from PinpointCollectorStarter. Without it there is no ExceptionMetaDataService in the context at all (EmptyExceptionMetaDataService lives in a package only the BASIC module scans), the Optional injection stays empty and the mapped exceptions are silently dropped. Traces and URI stat were unaffected, so Error Analysis for OTel traces simply showed nothing.

Import ExceptionTraceCollectorConfig into OtlpTraceCollectorModule next to UriStatCollectorConfig (same pattern: self-guarded by pinpoint.modules.collector.exceptiontrace.enabled), add the module dependency, and declare the flag in the collector profiles (on for local, off for release, like uristat). A test pins both storage imports, since dropping one fails neither the build nor the boot. README documents the prerequisite.

Verified with the collector-starter exec jar, profile local, run OTLPTRACE: ExceptionTracePropertySources and kafka-topic-exception.properties are loaded, and two OTLP/JSON exception span events (sc.grpc-rc, sc.grpc-legacy) arrive in Pinot exceptionTraceV1 with uriTemplate, stack frames and hash.