### PR TITLE
[#noissue] Open the OTLP trace collector seams a co-hosted OTLP logs …

### DIFF
--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModule.java
@@ -60,6 +60,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.concurrent.ThreadPoolExecutorFactoryBean;
 
+import java.util.List;
 import java.util.concurrent.Executor;
 
 @Configuration
@@ -138,9 +139,15 @@ public class OtlpTraceCollectorModule {
         return ServerInterceptors.intercept(spanService, metricInterceptor);
     }
 
+    /**
+     * Every {@link ServerServiceDefinition} bean in this context, so another OTLP signal's gRPC
+     * service (e.g. {@code LogsService}) registers on the same 9998 / 9448 servers just by declaring
+     * its definition bean — OTLP exporters send all signals to one endpoint and gRPC routes by
+     * service name.
+     */
     @Bean
-    public ServerServiceDefinitions serviceList(@Qualifier("serverServiceDefinition") ServerServiceDefinition serviceDefinition) {
-        return ServerServiceDefinitions.of(serviceDefinition);
+    public ServerServiceDefinitions serviceList(List<ServerServiceDefinition> serviceDefinitions) {
+        return ServerServiceDefinitions.of(serviceDefinitions.toArray(new ServerServiceDefinition[0]));
     }
 
     // A @Bean method, not a component-scanned @Service: bean-method conditions are evaluated after

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceController.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceController.java
@@ -21,10 +21,12 @@ import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpRequestRejectReason;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportResult;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportService;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceResponseMapper;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTransport;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
@@ -71,7 +73,7 @@ public class OtlpTraceController {
         try {
             request = parseRequest(body, json);
         } catch (InvalidProtocolBufferException | OtlpTraceParseException e) {
-            ingestMetrics.requestRejected(OtlpTraceIngestMetrics.Transport.HTTP, OtlpTraceIngestMetrics.RequestRejectReason.PARSE_ERROR);
+            ingestMetrics.requestRejected(OtlpTransport.HTTP, OtlpRequestRejectReason.PARSE_ERROR);
             final Status status = Status.newBuilder()
                     .setCode(Code.INVALID_ARGUMENT_VALUE)
                     .setMessage(errorMessage(e))
@@ -82,7 +84,7 @@ public class OtlpTraceController {
         }
 
         final List<ResourceSpans> resourceSpanList = request.getResourceSpansList();
-        final OtlpTraceExportResult result = exportService.export(resourceSpanList, OtlpTraceIngestMetrics.Transport.HTTP);
+        final OtlpTraceExportResult result = exportService.export(resourceSpanList, OtlpTransport.HTTP);
 
         if (OtlpTraceResponseMapper.isServerError(result)) {
             // Mirror the gRPC UNAVAILABLE path with a retryable 503 carrying a google.rpc.Status body,

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceDecompressionFilter.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceDecompressionFilter.java
@@ -16,7 +16,9 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.controller;
 
-import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpIngestAdmissionMetrics;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpRequestRejectReason;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTransport;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletException;
@@ -71,9 +73,9 @@ public class OtlpTraceDecompressionFilter extends OncePerRequestFilter {
     private final Logger logger = LogManager.getLogger(this.getClass());
 
     private final int maxDecompressedBytes;
-    private final OtlpTraceIngestMetrics ingestMetrics;
+    private final OtlpIngestAdmissionMetrics ingestMetrics;
 
-    public OtlpTraceDecompressionFilter(int maxDecompressedBytes, OtlpTraceIngestMetrics ingestMetrics) {
+    public OtlpTraceDecompressionFilter(int maxDecompressedBytes, OtlpIngestAdmissionMetrics ingestMetrics) {
         this.maxDecompressedBytes = maxDecompressedBytes;
         this.ingestMetrics = Objects.requireNonNull(ingestMetrics, "ingestMetrics");
     }
@@ -91,7 +93,7 @@ public class OtlpTraceDecompressionFilter extends OncePerRequestFilter {
             // Only gzip is defined for OTLP/HTTP; reject anything else (incl. multi-encoding) explicitly
             // rather than letting an undecoded body fail later as an opaque 400.
             logger.warn("OTLP/HTTP trace request rejected. Unsupported Content-Encoding={}", encoding);
-            ingestMetrics.requestRejected(OtlpTraceIngestMetrics.Transport.HTTP, OtlpTraceIngestMetrics.RequestRejectReason.UNSUPPORTED_ENCODING);
+            ingestMetrics.requestRejected(OtlpTransport.HTTP, OtlpRequestRejectReason.UNSUPPORTED_ENCODING);
             response.setStatus(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
             return;
         }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceHttpAdmissionFilter.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceHttpAdmissionFilter.java
@@ -16,8 +16,9 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector.controller;
 
-import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
-import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics.RequestRejectReason;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpIngestAdmissionMetrics;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpRequestRejectReason;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTransport;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletException;
@@ -64,10 +65,12 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
     private final Semaphore admissionBytes;
     // Request-count gate: guards the servlet thread pool against a flood of small requests.
     private final Semaphore concurrency;
-    private final OtlpTraceIngestMetrics ingestMetrics;
+    // The admission slice of the metrics only, so another OTLP endpoint can reuse this filter with
+    // its own metrics/budgets.
+    private final OtlpIngestAdmissionMetrics ingestMetrics;
 
     public OtlpTraceHttpAdmissionFilter(int maxRequestBytes, int maxInFlightBytes, int maxConcurrentRequests, int retryAfterSeconds,
-                                        OtlpTraceIngestMetrics ingestMetrics) {
+                                        OtlpIngestAdmissionMetrics ingestMetrics) {
         this.ingestMetrics = Objects.requireNonNull(ingestMetrics, "ingestMetrics");
         this.maxRequestBytes = maxRequestBytes;
         this.maxInFlightBytes = maxInFlightBytes;
@@ -77,9 +80,9 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
         this.concurrency = new Semaphore(maxConcurrentRequests);
         // Gate occupancy gauges (sampled per export step); both budgets are HTTP-only, kept separate
         // from the gRPC admission on purpose.
-        ingestMetrics.registerInFlightBytes(OtlpTraceIngestMetrics.Transport.HTTP,
+        ingestMetrics.registerInFlightBytes(OtlpTransport.HTTP,
                 () -> (long) maxInFlightBytes - admissionBytes.availablePermits(), maxInFlightBytes);
-        ingestMetrics.registerInFlightRequests(OtlpTraceIngestMetrics.Transport.HTTP,
+        ingestMetrics.registerInFlightRequests(OtlpTransport.HTTP,
                 () -> maxConcurrentRequests - concurrency.availablePermits(), maxConcurrentRequests);
     }
 
@@ -90,7 +93,7 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
         // 1) Size cap: reject before the body is buffered/parsed.
         final long contentLength = request.getContentLengthLong();
         if (contentLength > maxRequestBytes) {
-            reject(response, HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, false, RequestRejectReason.PAYLOAD_TOO_LARGE,
+            reject(response, HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, false, OtlpRequestRejectReason.PAYLOAD_TOO_LARGE,
                     "payload too large: contentLength=" + contentLength + ", max=" + maxRequestBytes);
             return;
         }
@@ -100,14 +103,14 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
 
         // 2) Concurrency gate.
         if (!concurrency.tryAcquire()) {
-            reject(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, true, RequestRejectReason.CONCURRENCY,
+            reject(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, true, OtlpRequestRejectReason.CONCURRENCY,
                     "concurrency limit exceeded: max=" + maxConcurrentRequests);
             return;
         }
         // 3) In-flight byte gate.
         if (!admissionBytes.tryAcquire(reserveBytes)) {
             concurrency.release();
-            reject(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, true, RequestRejectReason.INFLIGHT_BYTES,
+            reject(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, true, OtlpRequestRejectReason.INFLIGHT_BYTES,
                     "in-flight byte budget exhausted: reserve=" + reserveBytes + ", budget=" + maxInFlightBytes);
             return;
         }
@@ -119,7 +122,7 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
             final HttpServletRequest effectiveRequest;
             if (contentLength >= 0) {
                 effectiveRequest = request;
-                ingestMetrics.requestBytes(OtlpTraceIngestMetrics.Transport.HTTP, contentLength);
+                ingestMetrics.requestBytes(OtlpTransport.HTTP, contentLength);
             } else {
                 // Unknown length: cap the stream so a chunked body cannot exceed maxRequestBytes in heap.
                 limited = new LimitedRequestWrapper(request, maxRequestBytes);
@@ -128,19 +131,19 @@ public class OtlpTraceHttpAdmissionFilter extends OncePerRequestFilter {
             filterChain.doFilter(effectiveRequest, response);
         } finally {
             if (limited != null) {
-                ingestMetrics.requestBytes(OtlpTraceIngestMetrics.Transport.HTTP, limited.bytesRead());
+                ingestMetrics.requestBytes(OtlpTransport.HTTP, limited.bytesRead());
             }
             admissionBytes.release(reserveBytes);
             concurrency.release();
         }
     }
 
-    private void reject(HttpServletResponse response, int status, boolean retryable, RequestRejectReason reason, String detail) {
+    private void reject(HttpServletResponse response, int status, boolean retryable, OtlpRequestRejectReason reason, String detail) {
         if (retryable) {
             response.setHeader("Retry-After", Integer.toString(retryAfterSeconds));
         }
         response.setStatus(status);
-        ingestMetrics.requestRejected(OtlpTraceIngestMetrics.Transport.HTTP, reason);
+        ingestMetrics.requestRejected(OtlpTransport.HTTP, reason);
         logger.warn("OTLP/HTTP trace request rejected. status={}, reason={}, {}", status, reason.tagValue(), detail);
     }
 

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapper.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/mapper/OtlpExceptionMapper.java
@@ -180,7 +180,7 @@ public class OtlpExceptionMapper {
      * and the stack-trace grouping hash stays distinctive instead of collapsing every unparsed
      * exception into one shared "empty stack" group.
      */
-    List<StackTraceElementWrapperBo> parseStackTrace(String stackTrace, String sdkLanguage) {
+    public List<StackTraceElementWrapperBo> parseStackTrace(String stackTrace, String sdkLanguage) {
         if (!StringUtils.hasLength(stackTrace)) {
             return new ArrayList<>();
         }

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceService.java
@@ -59,7 +59,7 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
         this.maxInFlightBytes = maxInFlightBytes;
         this.admissionBytes = new Semaphore(maxInFlightBytes);
         // reserved = budget - free permits; sampled per export step (see OtlpTraceIngestMetrics).
-        ingestMetrics.registerInFlightBytes(OtlpTraceIngestMetrics.Transport.GRPC,
+        ingestMetrics.registerInFlightBytes(OtlpTransport.GRPC,
                 () -> (long) maxInFlightBytes - admissionBytes.availablePermits(), maxInFlightBytes);
     }
 
@@ -72,12 +72,12 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
         final int requestBytes = request.getSerializedSize();
         if (!admissionBytes.tryAcquire(requestBytes)) {
             logger.warn("Failed to export. In-flight byte budget exhausted. requestBytes={}, budget={}", requestBytes, maxInFlightBytes);
-            ingestMetrics.requestRejected(OtlpTraceIngestMetrics.Transport.GRPC, OtlpTraceIngestMetrics.RequestRejectReason.INFLIGHT_BYTES);
+            ingestMetrics.requestRejected(OtlpTransport.GRPC, OtlpRequestRejectReason.INFLIGHT_BYTES);
             safeOnError(responseObserver, ADMISSION_REJECTED);
             return;
         }
 
-        ingestMetrics.requestBytes(OtlpTraceIngestMetrics.Transport.GRPC, requestBytes);
+        ingestMetrics.requestBytes(OtlpTransport.GRPC, requestBytes);
 
         final List<ResourceSpans> resourceSpanList = request.getResourceSpansList();
         // Offload the mapping/insert work onto the worker pool so the gRPC handler thread
@@ -108,13 +108,13 @@ public class GrpcOtlpTraceService extends TraceServiceGrpc.TraceServiceImplBase 
         } catch (RejectedExecutionException e) {
             admissionBytes.release(requestBytes);
             logger.warn("Failed to export. Worker executor rejected.");
-            ingestMetrics.requestRejected(OtlpTraceIngestMetrics.Transport.GRPC, OtlpTraceIngestMetrics.RequestRejectReason.EXECUTOR_REJECTED);
+            ingestMetrics.requestRejected(OtlpTransport.GRPC, OtlpRequestRejectReason.EXECUTOR_REJECTED);
             safeOnError(responseObserver, EXECUTOR_REJECTED);
         }
     }
 
     private void handleExport(List<ResourceSpans> resourceSpanList, StreamObserver<ExportTraceServiceResponse> responseObserver) {
-        final OtlpTraceExportResult result = exportService.export(resourceSpanList, OtlpTraceIngestMetrics.Transport.GRPC);
+        final OtlpTraceExportResult result = exportService.export(resourceSpanList, OtlpTransport.GRPC);
 
         if (OtlpTraceResponseMapper.isServerError(result)) {
             // Server-side / transient failures (HBase insert, agentInfo): ask the client to retry

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpIngestAdmissionMetrics.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpIngestAdmissionMetrics.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
+
+/**
+ * The slice of the ingest metrics the transport-level admission code needs: request-level
+ * rejections, admitted wire bytes and the admission-gate gauges. The HTTP admission and
+ * decompression filters depend on this interface rather than on {@link OtlpTraceIngestMetrics}, so
+ * the same filter classes can front another OTLP signal's endpoint (e.g. {@code /v1/logs}) with
+ * that signal's own metrics and budgets. The value types it takes ({@link OtlpTransport},
+ * {@link OtlpRequestRejectReason}) are signal-neutral on purpose, so implementing it does not pull
+ * in the trace metrics class.
+ */
+public interface OtlpIngestAdmissionMetrics {
+
+    /** Counts one refused request; the (transport, reason) pair must be one the transport can emit. */
+    void requestRejected(OtlpTransport transport, OtlpRequestRejectReason reason);
+
+    /** Wire size of one admitted request. */
+    void requestBytes(OtlpTransport transport, long bytes);
+
+    /** Registers the in-flight byte gate as gauges (reserved bytes and the budget). */
+    void registerInFlightBytes(OtlpTransport transport, LongSupplier reservedBytes, long limitBytes);
+
+    /** Registers the concurrent-request gate as gauges (requests past the gate and the cap). */
+    void registerInFlightRequests(OtlpTransport transport, IntSupplier inFlightRequests, int limitRequests);
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpRequestRejectReason.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpRequestRejectReason.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+/**
+ * Why a whole OTLP export request was refused before its payload was parsed or mapped.
+ * Signal-neutral: every reason is a transport-level (admission, encoding, parse) fault, so the same
+ * tag values serve traces and logs alike. The response the client sees is listed per reason; every
+ * one of them is retryable except the client faults ({@code payload_too_large},
+ * {@code unsupported_encoding}, {@code parse_error}).
+ */
+public enum OtlpRequestRejectReason {
+    /** gRPC / HTTP: the in-flight byte budget is exhausted (gRPC UNAVAILABLE, HTTP 503 + Retry-After). */
+    INFLIGHT_BYTES("inflight_bytes"),
+    /** gRPC: the worker executor queue is full (UNAVAILABLE). */
+    EXECUTOR_REJECTED("executor_rejected"),
+    /** HTTP: the concurrent-request cap is reached (503 + Retry-After). */
+    CONCURRENCY("concurrency"),
+    /** HTTP: Content-Length above the per-request cap (413). */
+    PAYLOAD_TOO_LARGE("payload_too_large"),
+    /** HTTP: Content-Encoding other than gzip/identity (415). */
+    UNSUPPORTED_ENCODING("unsupported_encoding"),
+    /** HTTP: the protobuf/JSON body did not parse (400). */
+    PARSE_ERROR("parse_error");
+
+    private final String tagValue;
+
+    OtlpRequestRejectReason(String tagValue) {
+        this.tagValue = tagValue;
+    }
+
+    public String tagValue() {
+        return tagValue;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportService.java
@@ -125,7 +125,7 @@ public class OtlpTraceExportService {
      * Maps and stores one export request. {@code transport} only tags the ingest metrics; the
      * response semantics are transport-agnostic (see {@link OtlpTraceResponseMapper}).
      */
-    public OtlpTraceExportResult export(List<ResourceSpans> resourceSpanList, OtlpTraceIngestMetrics.Transport transport) {
+    public OtlpTraceExportResult export(List<ResourceSpans> resourceSpanList, OtlpTransport transport) {
         // Raw span count of the request, before mapping: the only place spans/sec can be measured
         // (a request / worker task is a batch of arbitrary size).
         ingestMetrics.spanReceived(transport, OtlpTraceMapperUtils.countSpans(resourceSpanList));

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceIngestMetrics.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceIngestMetrics.java
@@ -47,7 +47,7 @@ import java.util.function.LongSupplier;
  *       by {@link OtlpTraceRejectReason}. These are also reported to the client as
  *       {@code ExportTracePartialSuccess}.</li>
  *   <li>{@code collector.otlptrace.request.rejected{transport,reason}} — whole requests refused before
- *       mapping (admission / parse), where the span count is unknown, by {@link RequestRejectReason}.</li>
+ *       mapping (admission / parse), where the span count is unknown, by {@link OtlpRequestRejectReason}.</li>
  *   <li>{@code collector.otlptrace.request.bytes{transport}} — wire bytes of admitted requests
  *       (distribution: count / total / mean / max per step), so bytes per second, average batch size
  *       and headroom against the per-request cap are visible.</li>
@@ -64,7 +64,7 @@ import java.util.function.LongSupplier;
  * exporter that registry is wired to (NPOT in the NAVER deployment) without extra configuration.
  */
 @Component
-public class OtlpTraceIngestMetrics {
+public class OtlpTraceIngestMetrics implements OtlpIngestAdmissionMetrics {
 
     public static final String SPAN_RECEIVED = "collector.otlptrace.span.received";
     public static final String SPAN_STORED = "collector.otlptrace.span.stored";
@@ -83,69 +83,24 @@ public class OtlpTraceIngestMetrics {
     public static final String TYPE_SPAN = "span";
     public static final String TYPE_SPAN_CHUNK = "spanChunk";
 
-    public enum Transport {
-        GRPC("grpc"),
-        HTTP("http");
+    private static final Set<OtlpRequestRejectReason> GRPC_REQUEST_REASONS =
+            EnumSet.of(OtlpRequestRejectReason.INFLIGHT_BYTES, OtlpRequestRejectReason.EXECUTOR_REJECTED);
+    private static final Set<OtlpRequestRejectReason> HTTP_REQUEST_REASONS =
+            EnumSet.of(OtlpRequestRejectReason.INFLIGHT_BYTES, OtlpRequestRejectReason.CONCURRENCY,
+                    OtlpRequestRejectReason.PAYLOAD_TOO_LARGE, OtlpRequestRejectReason.UNSUPPORTED_ENCODING,
+                    OtlpRequestRejectReason.PARSE_ERROR);
 
-        private final String tagValue;
-
-        Transport(String tagValue) {
-            this.tagValue = tagValue;
-        }
-
-        public String tagValue() {
-            return tagValue;
-        }
-    }
-
-    /**
-     * Why a whole export request was refused before its spans were parsed or mapped. The response
-     * the client sees is listed per reason; every one of them is retryable except the client faults
-     * ({@code payload_too_large}, {@code unsupported_encoding}, {@code parse_error}).
-     */
-    public enum RequestRejectReason {
-        /** gRPC / HTTP: the in-flight byte budget is exhausted (gRPC UNAVAILABLE, HTTP 503 + Retry-After). */
-        INFLIGHT_BYTES("inflight_bytes"),
-        /** gRPC: the worker executor queue is full (UNAVAILABLE). */
-        EXECUTOR_REJECTED("executor_rejected"),
-        /** HTTP: the concurrent-request cap is reached (503 + Retry-After). */
-        CONCURRENCY("concurrency"),
-        /** HTTP: Content-Length above the per-request cap (413). */
-        PAYLOAD_TOO_LARGE("payload_too_large"),
-        /** HTTP: Content-Encoding other than gzip/identity (415). */
-        UNSUPPORTED_ENCODING("unsupported_encoding"),
-        /** HTTP: the protobuf/JSON body did not parse (400). */
-        PARSE_ERROR("parse_error");
-
-        private final String tagValue;
-
-        RequestRejectReason(String tagValue) {
-            this.tagValue = tagValue;
-        }
-
-        public String tagValue() {
-            return tagValue;
-        }
-    }
-
-    private static final Set<RequestRejectReason> GRPC_REQUEST_REASONS =
-            EnumSet.of(RequestRejectReason.INFLIGHT_BYTES, RequestRejectReason.EXECUTOR_REJECTED);
-    private static final Set<RequestRejectReason> HTTP_REQUEST_REASONS =
-            EnumSet.of(RequestRejectReason.INFLIGHT_BYTES, RequestRejectReason.CONCURRENCY,
-                    RequestRejectReason.PAYLOAD_TOO_LARGE, RequestRejectReason.UNSUPPORTED_ENCODING,
-                    RequestRejectReason.PARSE_ERROR);
-
-    private final Map<Transport, Counter> received = new EnumMap<>(Transport.class);
-    private final Map<Transport, Counter> storedSpan = new EnumMap<>(Transport.class);
-    private final Map<Transport, Counter> storedSpanChunk = new EnumMap<>(Transport.class);
-    private final Map<Transport, Map<OtlpTraceRejectReason, Counter>> spanRejected = new EnumMap<>(Transport.class);
-    private final Map<Transport, Map<RequestRejectReason, Counter>> requestRejected = new EnumMap<>(Transport.class);
-    private final Map<Transport, DistributionSummary> requestBytes = new EnumMap<>(Transport.class);
+    private final Map<OtlpTransport, Counter> received = new EnumMap<>(OtlpTransport.class);
+    private final Map<OtlpTransport, Counter> storedSpan = new EnumMap<>(OtlpTransport.class);
+    private final Map<OtlpTransport, Counter> storedSpanChunk = new EnumMap<>(OtlpTransport.class);
+    private final Map<OtlpTransport, Map<OtlpTraceRejectReason, Counter>> spanRejected = new EnumMap<>(OtlpTransport.class);
+    private final Map<OtlpTransport, Map<OtlpRequestRejectReason, Counter>> requestRejected = new EnumMap<>(OtlpTransport.class);
+    private final Map<OtlpTransport, DistributionSummary> requestBytes = new EnumMap<>(OtlpTransport.class);
     private final MeterRegistry meterRegistry;
 
     public OtlpTraceIngestMetrics(MeterRegistry meterRegistry) {
         this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry");
-        for (Transport transport : Transport.values()) {
+        for (OtlpTransport transport : OtlpTransport.values()) {
             requestBytes.put(transport, DistributionSummary.builder(REQUEST_BYTES)
                     .description("Wire bytes of admitted OTLP export requests (gRPC serialized size / HTTP body)")
                     .baseUnit("bytes")
@@ -168,9 +123,9 @@ public class OtlpTraceIngestMetrics {
             }
             spanRejected.put(transport, byReason);
 
-            final Map<RequestRejectReason, Counter> requestByReason = new EnumMap<>(RequestRejectReason.class);
-            final Set<RequestRejectReason> reasons = transport == Transport.GRPC ? GRPC_REQUEST_REASONS : HTTP_REQUEST_REASONS;
-            for (RequestRejectReason reason : reasons) {
+            final Map<OtlpRequestRejectReason, Counter> requestByReason = new EnumMap<>(OtlpRequestRejectReason.class);
+            final Set<OtlpRequestRejectReason> reasons = transport == OtlpTransport.GRPC ? GRPC_REQUEST_REASONS : HTTP_REQUEST_REASONS;
+            for (OtlpRequestRejectReason reason : reasons) {
                 requestByReason.put(reason, Counter.builder(REQUEST_REJECTED)
                         .description("OTLP export requests refused before mapping (admission or parse failure)")
                         .tag(TAG_TRANSPORT, transport.tagValue())
@@ -181,7 +136,7 @@ public class OtlpTraceIngestMetrics {
         }
     }
 
-    private static Counter storedCounter(MeterRegistry meterRegistry, Transport transport, String type) {
+    private static Counter storedCounter(MeterRegistry meterRegistry, OtlpTransport transport, String type) {
         return Counter.builder(SPAN_STORED)
                 .description("OTLP root spans / span chunks handed to storage after mapping")
                 .tag(TAG_TRANSPORT, transport.tagValue())
@@ -190,7 +145,8 @@ public class OtlpTraceIngestMetrics {
     }
 
     /** Wire size of one admitted request (recorded after the admission gates, before mapping). */
-    public void requestBytes(Transport transport, long bytes) {
+    @Override
+    public void requestBytes(OtlpTransport transport, long bytes) {
         if (bytes > 0) {
             requestBytes.get(transport).record(bytes);
         }
@@ -201,7 +157,8 @@ public class OtlpTraceIngestMetrics {
      * budget. Registered by the owner of the semaphore (gRPC service / HTTP filter) at construction;
      * the supplier is held strongly so the gauge never goes NaN through garbage collection.
      */
-    public void registerInFlightBytes(Transport transport, LongSupplier reservedBytes, long limitBytes) {
+    @Override
+    public void registerInFlightBytes(OtlpTransport transport, LongSupplier reservedBytes, long limitBytes) {
         Gauge.builder(ADMISSION_INFLIGHT_BYTES, reservedBytes::getAsLong)
                 .description("Bytes currently reserved by the in-flight admission semaphore")
                 .baseUnit("bytes")
@@ -217,7 +174,8 @@ public class OtlpTraceIngestMetrics {
     }
 
     /** HTTP-only concurrent-request gate: requests currently admitted and the cap. */
-    public void registerInFlightRequests(Transport transport, IntSupplier inFlightRequests, int limitRequests) {
+    @Override
+    public void registerInFlightRequests(OtlpTransport transport, IntSupplier inFlightRequests, int limitRequests) {
         Gauge.builder(ADMISSION_INFLIGHT_REQUESTS, inFlightRequests::getAsInt)
                 .description("Requests currently past the concurrency gate")
                 .tag(TAG_TRANSPORT, transport.tagValue())
@@ -230,25 +188,25 @@ public class OtlpTraceIngestMetrics {
                 .register(meterRegistry);
     }
 
-    public void spanReceived(Transport transport, int count) {
+    public void spanReceived(OtlpTransport transport, int count) {
         if (count > 0) {
             received.get(transport).increment(count);
         }
     }
 
-    public void spanStored(Transport transport, int count) {
+    public void spanStored(OtlpTransport transport, int count) {
         if (count > 0) {
             storedSpan.get(transport).increment(count);
         }
     }
 
-    public void spanChunkStored(Transport transport, int count) {
+    public void spanChunkStored(OtlpTransport transport, int count) {
         if (count > 0) {
             storedSpanChunk.get(transport).increment(count);
         }
     }
 
-    public void spanRejected(Transport transport, OtlpTraceRejectReason reason, long count) {
+    public void spanRejected(OtlpTransport transport, OtlpTraceRejectReason reason, long count) {
         if (count > 0) {
             spanRejected.get(transport).get(reason).increment(count);
         }
@@ -258,7 +216,8 @@ public class OtlpTraceIngestMetrics {
      * Counts one refused request. The (transport, reason) pair must be one that transport can emit;
      * an unknown pair is a programming error and fails fast.
      */
-    public void requestRejected(Transport transport, RequestRejectReason reason) {
+    @Override
+    public void requestRejected(OtlpTransport transport, OtlpRequestRejectReason reason) {
         final Counter counter = requestRejected.get(transport).get(reason);
         if (counter == null) {
             throw new IllegalArgumentException("reason " + reason + " is not emitted by transport " + transport);

--- a/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTransport.java
+++ b/otlptrace/otlptrace-collector/src/main/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTransport.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.otlp.trace.collector.service;
+
+/**
+ * The wire transport an OTLP export request arrived on. Signal-neutral: every OTLP signal
+ * (traces, logs, metrics) is served over the same gRPC and HTTP endpoints, so the transport tag
+ * value is shared by all of them.
+ */
+public enum OtlpTransport {
+    GRPC("grpc"),
+    HTTP("http");
+
+    private final String tagValue;
+
+    OtlpTransport(String tagValue) {
+        this.tagValue = tagValue;
+    }
+
+    public String tagValue() {
+        return tagValue;
+    }
+}

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModuleTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/OtlpTraceCollectorModuleTest.java
@@ -16,14 +16,36 @@
 
 package com.navercorp.pinpoint.otlp.trace.collector;
 
+import com.navercorp.pinpoint.collector.grpc.config.ServerServiceDefinitions;
 import com.navercorp.pinpoint.exceptiontrace.collector.ExceptionTraceCollectorConfig;
 import com.navercorp.pinpoint.uristat.collector.UriStatCollectorConfig;
+import io.grpc.BindableService;
+import io.grpc.ServerServiceDefinition;
+import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class OtlpTraceCollectorModuleTest {
+
+    @Test
+    void serviceList_registersEveryServiceDefinitionBean_inOrder() {
+        // A second OTLP signal (LogsService) joins the same gRPC servers by declaring its own
+        // ServerServiceDefinition bean; the list must not be pinned to the trace service.
+        ServerServiceDefinition trace = ((BindableService) new TraceServiceGrpc.TraceServiceImplBase() {
+        }).bindService();
+        ServerServiceDefinition logs = ((BindableService) new LogsServiceGrpc.LogsServiceImplBase() {
+        }).bindService();
+
+        ServerServiceDefinitions definitions = new OtlpTraceCollectorModule().serviceList(List.of(trace, logs));
+
+        assertThat(definitions.getDefinitions()).containsExactly(trace, logs);
+    }
+
 
     /**
      * The OTLPTRACE app is its own Spring context, so every storage module its export path writes

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceControllerTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/controller/OtlpTraceControllerTest.java
@@ -26,6 +26,7 @@ import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceRejectReason;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportResult;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceExportService;
 import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics;
+import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTransport;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
@@ -141,7 +142,7 @@ class OtlpTraceControllerTest {
         // The hex IDs must arrive at the export service as the same raw bytes the protobuf path yields.
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<ResourceSpans>> captor = ArgumentCaptor.forClass((Class) List.class);
-        verify(exportService).export(captor.capture(), eq(OtlpTraceIngestMetrics.Transport.HTTP));
+        verify(exportService).export(captor.capture(), eq(OtlpTransport.HTTP));
         Span span = captor.getValue().get(0).getScopeSpans(0).getSpans(0);
         assertThat(span.getTraceId()).isEqualTo(ByteString.copyFrom(HexFormat.of().parseHex(TRACE_ID_HEX)));
         assertThat(span.getSpanId()).isEqualTo(ByteString.copyFrom(HexFormat.of().parseHex(SPAN_ID_HEX)));
@@ -301,7 +302,7 @@ class OtlpTraceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string("{}"));
 
-        verify(exportService).export(eq(List.of()), eq(OtlpTraceIngestMetrics.Transport.HTTP));
+        verify(exportService).export(eq(List.of()), eq(OtlpTransport.HTTP));
     }
 
     @Test

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceServiceTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/GrpcOtlpTraceServiceTest.java
@@ -17,7 +17,6 @@
 package com.navercorp.pinpoint.otlp.trace.collector.service;
 
 import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceCollectorRejectedSpan;
-import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics.Transport;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.DistributionSummary;
@@ -94,7 +93,7 @@ class GrpcOtlpTraceServiceTest {
         // An executor that never runs the task keeps the request "in flight" (permit held).
         List<Runnable> parked = new ArrayList<>();
         Executor parking = parked::add;
-        when(exportService.export(anyList(), eq(Transport.GRPC)))
+        when(exportService.export(anyList(), eq(OtlpTransport.GRPC)))
                 .thenReturn(new OtlpTraceExportResult(new OtlpTraceCollectorRejectedSpan(), 0, ""));
         ExportTraceServiceRequest req = request(5);
         GrpcOtlpTraceService service = new GrpcOtlpTraceService(exportService, parking, 1 << 20, metrics);
@@ -141,7 +140,7 @@ class GrpcOtlpTraceServiceTest {
         assertThat(observer.completed).isFalse();
         assertThat(requestRejected("inflight_bytes")).isEqualTo(1.0);
         assertThat(requestRejected("executor_rejected")).isZero();
-        verify(exportService, never()).export(anyList(), eq(Transport.GRPC));
+        verify(exportService, never()).export(anyList(), eq(OtlpTransport.GRPC));
     }
 
     @Test
@@ -160,12 +159,12 @@ class GrpcOtlpTraceServiceTest {
         assertThat(Status.fromThrowable(second.error).getCode()).isEqualTo(Status.Code.UNAVAILABLE);
         assertThat(requestRejected("executor_rejected")).isEqualTo(2.0);
         assertThat(requestRejected("inflight_bytes")).isZero();
-        verify(exportService, never()).export(anyList(), eq(Transport.GRPC));
+        verify(exportService, never()).export(anyList(), eq(OtlpTransport.GRPC));
     }
 
     @Test
     void accepted_exportsWithGrpcTransport_andCountsNoRequestRejection() {
-        when(exportService.export(anyList(), eq(Transport.GRPC)))
+        when(exportService.export(anyList(), eq(OtlpTransport.GRPC)))
                 .thenReturn(new OtlpTraceExportResult(new OtlpTraceCollectorRejectedSpan(), 0, ""));
         GrpcOtlpTraceService service = new GrpcOtlpTraceService(exportService, DIRECT, 1 << 20, metrics);
         RecordingObserver observer = new RecordingObserver();
@@ -175,7 +174,7 @@ class GrpcOtlpTraceServiceTest {
         assertThat(observer.error).isNull();
         assertThat(observer.completed).isTrue();
         assertThat(observer.responses).hasSize(1);
-        verify(exportService).export(anyList(), eq(Transport.GRPC));
+        verify(exportService).export(anyList(), eq(OtlpTransport.GRPC));
         assertThat(requestRejected("inflight_bytes")).isZero();
         assertThat(requestRejected("executor_rejected")).isZero();
     }
@@ -188,7 +187,7 @@ class GrpcOtlpTraceServiceTest {
     @Test
     void serverErrorResult_unavailable_isNotARequestRejection_andReleasesPermit() {
         // Storage-side failures are reported by the insert error counters, not request.rejected.
-        when(exportService.export(anyList(), eq(Transport.GRPC)))
+        when(exportService.export(anyList(), eq(OtlpTransport.GRPC)))
                 .thenReturn(new OtlpTraceExportResult(new OtlpTraceCollectorRejectedSpan(), 3, "insert error (3)"));
         GrpcOtlpTraceService service = new GrpcOtlpTraceService(exportService, DIRECT, 1 << 20, metrics);
         RecordingObserver observer = new RecordingObserver();
@@ -204,7 +203,7 @@ class GrpcOtlpTraceServiceTest {
     @Test
     void exportThrows_internal_isNotARequestRejection_andReleasesPermit() {
         ExportTraceServiceRequest req = request(3);
-        when(exportService.export(anyList(), eq(Transport.GRPC)))
+        when(exportService.export(anyList(), eq(OtlpTransport.GRPC)))
                 .thenThrow(new IllegalStateException("mapper fault"))
                 .thenReturn(new OtlpTraceExportResult(new OtlpTraceCollectorRejectedSpan(), 0, ""));
         // Budget of exactly one request: a permit leaked by the failing call would turn the second

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportServiceTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceExportServiceTest.java
@@ -94,7 +94,7 @@ class OtlpTraceExportServiceTest {
         OtlpTraceExportService service = newService(mapperData, null);
 
         // 3 + 4 raw spans over two ResourceSpans, sent over HTTP
-        service.export(List.of(resourceSpansWithSpans(3), resourceSpansWithSpans(4)), OtlpTraceIngestMetrics.Transport.HTTP);
+        service.export(List.of(resourceSpansWithSpans(3), resourceSpansWithSpans(4)), OtlpTransport.HTTP);
 
         assertThat(count(OtlpTraceIngestMetrics.SPAN_RECEIVED, "transport", "http")).isEqualTo(7.0);
         assertThat(count(OtlpTraceIngestMetrics.SPAN_STORED, "transport", "http", "type", "span")).isEqualTo(2.0);
@@ -111,7 +111,7 @@ class OtlpTraceExportServiceTest {
         mapperData.getRejectedSpan().addCount(OtlpTraceRejectReason.MAPPING_ERROR, 1);
         OtlpTraceExportService service = newService(mapperData, null);
 
-        OtlpTraceExportResult result = service.export(List.of(resourceSpansWithSpans(8)), OtlpTraceIngestMetrics.Transport.GRPC);
+        OtlpTraceExportResult result = service.export(List.of(resourceSpansWithSpans(8)), OtlpTransport.GRPC);
 
         assertThat(count(OtlpTraceIngestMetrics.SPAN_REJECTED, "transport", "grpc", "reason", "invalid_id")).isEqualTo(2.0);
         assertThat(count(OtlpTraceIngestMetrics.SPAN_REJECTED, "transport", "grpc", "reason", "orphan")).isEqualTo(5.0);
@@ -132,7 +132,7 @@ class OtlpTraceExportServiceTest {
         OtlpTraceExportService service = newService(dataWithUriStatSpan(),
                 new OtlpUriStatService(captureDao, () -> "tenant1"));
 
-        OtlpTraceExportResult result = service.export(List.of(), OtlpTraceIngestMetrics.Transport.GRPC);
+        OtlpTraceExportResult result = service.export(List.of(), OtlpTransport.GRPC);
 
         assertThat(result.serverErrorCount()).isZero();
         assertThat(inserted).hasSize(1);
@@ -148,7 +148,7 @@ class OtlpTraceExportServiceTest {
         OtlpTraceExportService service = newService(dataWithUriStatSpan(),
                 new OtlpUriStatService(throwingDao, () -> "tenant1"));
 
-        OtlpTraceExportResult result = service.export(List.of(), OtlpTraceIngestMetrics.Transport.GRPC);
+        OtlpTraceExportResult result = service.export(List.of(), OtlpTransport.GRPC);
 
         // spans are already stored at this point: the export succeeds and the failure is
         // NOT counted toward serverErrorCount — only the uriStat error counter moves.
@@ -161,7 +161,7 @@ class OtlpTraceExportServiceTest {
     void uriStatDisabled_absentBean_exportsWithoutTouchingUriStat() {
         OtlpTraceExportService service = newService(dataWithUriStatSpan(), null);
 
-        OtlpTraceExportResult result = service.export(List.of(), OtlpTraceIngestMetrics.Transport.GRPC);
+        OtlpTraceExportResult result = service.export(List.of(), OtlpTransport.GRPC);
 
         assertThat(result.serverErrorCount()).isZero();
         assertThat(uriStatErrorCount(meterRegistry)).isZero();

--- a/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceIngestMetricsTest.java
+++ b/otlptrace/otlptrace-collector/src/test/java/com/navercorp/pinpoint/otlp/trace/collector/service/OtlpTraceIngestMetricsTest.java
@@ -17,8 +17,6 @@
 package com.navercorp.pinpoint.otlp.trace.collector.service;
 
 import com.navercorp.pinpoint.otlp.trace.collector.OtlpTraceRejectReason;
-import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics.RequestRejectReason;
-import com.navercorp.pinpoint.otlp.trace.collector.service.OtlpTraceIngestMetrics.Transport;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -43,7 +41,7 @@ class OtlpTraceIngestMetricsTest {
         // Dashboards repeating on the reason tag rely on every combination existing before the
         // first event, so a reason that never fired still renders as a flat zero line.
         List<Counter> spanRejected = registry.get(OtlpTraceIngestMetrics.SPAN_REJECTED).counters().stream().toList();
-        assertThat(spanRejected).hasSize(Transport.values().length * OtlpTraceRejectReason.values().length);
+        assertThat(spanRejected).hasSize(OtlpTransport.values().length * OtlpTraceRejectReason.values().length);
         assertThat(spanRejected).allSatisfy(c -> assertThat(c.count()).isZero());
 
         assertThat(registry.get(OtlpTraceIngestMetrics.SPAN_RECEIVED).counters()).hasSize(2);
@@ -55,11 +53,11 @@ class OtlpTraceIngestMetricsTest {
 
     @Test
     void spanCounters_incrementByCount_perTransport() {
-        metrics.spanReceived(Transport.GRPC, 120);
-        metrics.spanReceived(Transport.HTTP, 5);
-        metrics.spanStored(Transport.GRPC, 30);
-        metrics.spanChunkStored(Transport.GRPC, 2);
-        metrics.spanRejected(Transport.GRPC, OtlpTraceRejectReason.ORPHAN, 4);
+        metrics.spanReceived(OtlpTransport.GRPC, 120);
+        metrics.spanReceived(OtlpTransport.HTTP, 5);
+        metrics.spanStored(OtlpTransport.GRPC, 30);
+        metrics.spanChunkStored(OtlpTransport.GRPC, 2);
+        metrics.spanRejected(OtlpTransport.GRPC, OtlpTraceRejectReason.ORPHAN, 4);
 
         assertThat(counter(OtlpTraceIngestMetrics.SPAN_RECEIVED, "transport", "grpc")).isEqualTo(120.0);
         assertThat(counter(OtlpTraceIngestMetrics.SPAN_RECEIVED, "transport", "http")).isEqualTo(5.0);
@@ -71,8 +69,8 @@ class OtlpTraceIngestMetricsTest {
 
     @Test
     void zeroCounts_leaveCountersUntouched() {
-        metrics.spanReceived(Transport.GRPC, 0);
-        metrics.spanRejected(Transport.HTTP, OtlpTraceRejectReason.INVALID_ID, 0);
+        metrics.spanReceived(OtlpTransport.GRPC, 0);
+        metrics.spanRejected(OtlpTransport.HTTP, OtlpTraceRejectReason.INVALID_ID, 0);
 
         assertThat(counter(OtlpTraceIngestMetrics.SPAN_RECEIVED, "transport", "grpc")).isZero();
         assertThat(counter(OtlpTraceIngestMetrics.SPAN_REJECTED, "transport", "http", "reason", "invalid_id")).isZero();
@@ -80,9 +78,9 @@ class OtlpTraceIngestMetricsTest {
 
     @Test
     void requestRejected_countsOnePerCall_withTransportSpecificReasons() {
-        metrics.requestRejected(Transport.GRPC, RequestRejectReason.INFLIGHT_BYTES);
-        metrics.requestRejected(Transport.GRPC, RequestRejectReason.INFLIGHT_BYTES);
-        metrics.requestRejected(Transport.HTTP, RequestRejectReason.PAYLOAD_TOO_LARGE);
+        metrics.requestRejected(OtlpTransport.GRPC, OtlpRequestRejectReason.INFLIGHT_BYTES);
+        metrics.requestRejected(OtlpTransport.GRPC, OtlpRequestRejectReason.INFLIGHT_BYTES);
+        metrics.requestRejected(OtlpTransport.HTTP, OtlpRequestRejectReason.PAYLOAD_TOO_LARGE);
 
         assertThat(counter(OtlpTraceIngestMetrics.REQUEST_REJECTED, "transport", "grpc", "reason", "inflight_bytes")).isEqualTo(2.0);
         assertThat(counter(OtlpTraceIngestMetrics.REQUEST_REJECTED, "transport", "http", "reason", "payload_too_large")).isEqualTo(1.0);
@@ -92,17 +90,17 @@ class OtlpTraceIngestMetricsTest {
     @Test
     void requestRejected_reasonNotEmittedByTransport_failsFast() {
         // gRPC has no payload-size or encoding gate of its own; wiring such a pair is a bug.
-        assertThatThrownBy(() -> metrics.requestRejected(Transport.GRPC, RequestRejectReason.PAYLOAD_TOO_LARGE))
+        assertThatThrownBy(() -> metrics.requestRejected(OtlpTransport.GRPC, OtlpRequestRejectReason.PAYLOAD_TOO_LARGE))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> metrics.requestRejected(Transport.HTTP, RequestRejectReason.EXECUTOR_REJECTED))
+        assertThatThrownBy(() -> metrics.requestRejected(OtlpTransport.HTTP, OtlpRequestRejectReason.EXECUTOR_REJECTED))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void requestBytes_recordsDistributionPerTransport() {
-        metrics.requestBytes(Transport.GRPC, 1_000);
-        metrics.requestBytes(Transport.GRPC, 3_000);
-        metrics.requestBytes(Transport.HTTP, 0); // ignored
+        metrics.requestBytes(OtlpTransport.GRPC, 1_000);
+        metrics.requestBytes(OtlpTransport.GRPC, 3_000);
+        metrics.requestBytes(OtlpTransport.HTTP, 0); // ignored
 
         DistributionSummary grpc = registry.get(OtlpTraceIngestMetrics.REQUEST_BYTES).tag("transport", "grpc").summary();
         assertThat(grpc.count()).isEqualTo(2);
@@ -115,8 +113,8 @@ class OtlpTraceIngestMetricsTest {
     void inFlightGauges_trackSupplierAndLimit() {
         long[] reserved = {0};
         int[] requests = {0};
-        metrics.registerInFlightBytes(Transport.HTTP, () -> reserved[0], 256L << 20);
-        metrics.registerInFlightRequests(Transport.HTTP, () -> requests[0], 64);
+        metrics.registerInFlightBytes(OtlpTransport.HTTP, () -> reserved[0], 256L << 20);
+        metrics.registerInFlightRequests(OtlpTransport.HTTP, () -> requests[0], 64);
 
         reserved[0] = 12_345;
         requests[0] = 7;
@@ -129,13 +127,13 @@ class OtlpTraceIngestMetricsTest {
 
     @Test
     void tagValues_areStableSnakeCase() {
-        assertThat(Transport.GRPC.tagValue()).isEqualTo("grpc");
-        assertThat(Transport.HTTP.tagValue()).isEqualTo("http");
-        assertThat(RequestRejectReason.INFLIGHT_BYTES.tagValue()).isEqualTo("inflight_bytes");
-        assertThat(RequestRejectReason.EXECUTOR_REJECTED.tagValue()).isEqualTo("executor_rejected");
-        assertThat(RequestRejectReason.CONCURRENCY.tagValue()).isEqualTo("concurrency");
-        assertThat(RequestRejectReason.PAYLOAD_TOO_LARGE.tagValue()).isEqualTo("payload_too_large");
-        assertThat(RequestRejectReason.UNSUPPORTED_ENCODING.tagValue()).isEqualTo("unsupported_encoding");
-        assertThat(RequestRejectReason.PARSE_ERROR.tagValue()).isEqualTo("parse_error");
+        assertThat(OtlpTransport.GRPC.tagValue()).isEqualTo("grpc");
+        assertThat(OtlpTransport.HTTP.tagValue()).isEqualTo("http");
+        assertThat(OtlpRequestRejectReason.INFLIGHT_BYTES.tagValue()).isEqualTo("inflight_bytes");
+        assertThat(OtlpRequestRejectReason.EXECUTOR_REJECTED.tagValue()).isEqualTo("executor_rejected");
+        assertThat(OtlpRequestRejectReason.CONCURRENCY.tagValue()).isEqualTo("concurrency");
+        assertThat(OtlpRequestRejectReason.PAYLOAD_TOO_LARGE.tagValue()).isEqualTo("payload_too_large");
+        assertThat(OtlpRequestRejectReason.UNSUPPORTED_ENCODING.tagValue()).isEqualTo("unsupported_encoding");
+        assertThat(OtlpRequestRejectReason.PARSE_ERROR.tagValue()).isEqualTo("parse_error");
     }
 }


### PR DESCRIPTION
…receiver needs

Three behaviour-preserving changes so a LogsService / POST /v1/logs receiver can live in the OTLPTRACE process without touching the trace path again:

- serviceList collects every ServerServiceDefinition bean instead of the one trace definition, so another OTLP signal registers on the same gRPC servers (plaintext and SSL) by declaring its definition bean. OTLP exporters send all signals to one endpoint and gRPC routes by service name.
- The HTTP admission and decompression filters depend on a new OtlpIngestAdmissionMetrics interface (request rejections, admitted bytes, admission gauges) rather than on OtlpTraceIngestMetrics, so the same filter classes can front another endpoint with its own metrics and budgets. OtlpTraceIngestMetrics implements it; call sites are unchanged.
- OtlpExceptionMapper.parseStackTrace is public so the log receiver reuses the multi-language stacktrace parsing (and its depth cap / raw fallback) instead of duplicating it.

No runtime behaviour changes: the trace service is still the only definition in this context, the filters receive the same metrics bean, and parsing is unchanged. A module test pins the list-based service registration.