### PR TITLE
Carry the service name in the scatter/heatmap full screen URL

### DIFF
--- a/web-frontend/src/main/v3/.claude/rules/service-map.md
+++ b/web-frontend/src/main/v3/.claude/rules/service-map.md
@@ -146,9 +146,17 @@ service 전체를 대상으로 필터를 걸 수 있게 할지 정해지면 경�
   돌려주므로 파라미터와 service가 항상 같은 렌더에서 함께 바뀐다.
   → `useSyncRenderedRouterPath` (조회 화면들보다 위에서 한 번 호출: `InitialFetchOutlet`).
   호출을 빠뜨리면 `window.location` 폴백으로 동작한다(고쳐지지 않을 뿐 깨지지는 않는다).
+- **새 탭으로 열리는 화면은 특히 경로에 실어야 한다.** transaction 화면들(map의 drag&drop →
+  transactionList)과 스캐터/히트맵의 확대 화면(fullScreenMode)이 그렇다. 새 탭을 열어 둔 뒤
+  원래 탭에서 service를 바꾸면 전역 선택값이 따라 바뀌므로, 그것에 기대면 보고 있는 화면과
+  조회가 어긋난다. fullScreenMode의 돌아갈 링크도 경로의 serviceName으로 정한다
+  (`Servicemap / Scatter` ↔ `Servermap / Scatter`) — filteredMap과 같은 규칙이다.
 - 싣는 화면 목록: `SERVICE_NAME_SEGMENT_PAGES` (`utils/helper/application.ts`).
   **앞으로는 serviceName을 싣는 것이 기본**이고, 아직 안 옮긴 화면은 줄어드는 예외다.
   그 경로에서는 serviceName을 읽을 수 없어 전역 선택값으로 폴백한다.
+  로더가 리다이렉트 목적지를 만들 때 쓰는 페이지 접두사도 같은 목록에서 뽑는다
+  (`getServiceNameSegmentPage`) — 판정이 갈리면 serviceName은 읽었는데 리다이렉트 목적지에서만
+  빠진다.
 - serviceName은 백엔드가 형식을 검증하지 않으므로(`ServiceNameRequest`에 제약이 없다) `/`나 `@`가
   들어올 수 있다. 반드시 `encodeURIComponent`로 싣는다.
 - **읽을 때는 인코딩된 raw pathname을 넘긴다.** react-router의 `params`는 디코딩된 값이라
@@ -468,7 +476,7 @@ servermap/filteredMap 응답에는 이 필드가 없어 그 화면들의 동작�
 | DEFAULT 여부 판단 | `hooks/utility/useIsDefaultService.ts` |
 | 경로에 실린 serviceName 읽기 | `utils/helper/application.ts` (`getServiceNameFromPath`) |
 | 경로 분해 (로더용) | `utils/helper/application.ts` (`parseServiceScopedPath`) |
-| 경로 만들기 | `utils/helper/route.ts` (`getServiceMapPath`, `getServiceMapRealtimePath`, `getFilteredMapPath`, `getTransactionListPath`) |
+| 경로 만들기 | `utils/helper/route.ts` (`getServiceMapPath`, `getServiceMapRealtimePath`, `getFilteredMapPath`, `getTransactionListPath`, `getScatterFullScreenPath`, `getHeatmapFullScreenPath`) |
 | 조회 대상의 service | `hooks/serverMap/useServerMapTargetServiceName.ts` |
 | 지금 경로에서 고른 선택 | `hooks/serverMap/useServerMapCurrentTarget.ts` |
 | 선택에 경로 도장 찍기 | `atoms/serverMap.ts` (`serverMapCurrentTargetAtom`) |

--- a/web-frontend/src/main/v3/apps/web/src/routes/index.tsx
+++ b/web-frontend/src/main/v3/apps/web/src/routes/index.tsx
@@ -126,22 +126,25 @@ const router = createBrowserRouter(
                   loader: filteredMapRouteLoader,
                 },
                 {
-                  path: `${APP_PATH.SCATTER_FULL_SCREEN}/:application?`,
+                  // serviceName을 별도 세그먼트로 싣는다(servicemap·transaction과 같은 표기).
+                  // 세그먼트가 생기기 전 형태(`/scatterFullScreenMode/{application}`)의 링크도
+                  // 그대로 받으므로 두 세그먼트 모두 optional이다.
+                  path: `${APP_PATH.SCATTER_FULL_SCREEN}/:serviceName?/:application?`,
                   element: <ScatterOrHeatmapFullScreen />,
                   loader: scatterOrHeatmapFullScreenLoader,
                 },
                 {
-                  path: `${APP_PATH.SCATTER_FULL_SCREEN_REALTIME}/:application?`,
+                  path: `${APP_PATH.SCATTER_FULL_SCREEN_REALTIME}/:serviceName?/:application?`,
                   element: <ScatterOrHeatmapFullScreen />,
                   loader: scatterOrHeatmapFullScreenRealtimeLoader,
                 },
                 {
-                  path: `${APP_PATH.HEATMAP_FULL_SCREEN}/:application?`,
+                  path: `${APP_PATH.HEATMAP_FULL_SCREEN}/:serviceName?/:application?`,
                   element: <ScatterOrHeatmapFullScreen />,
                   loader: scatterOrHeatmapFullScreenLoader,
                 },
                 {
-                  path: `${APP_PATH.HEATMAP_FULL_SCREEN_REALTIME}/:application?`,
+                  path: `${APP_PATH.HEATMAP_FULL_SCREEN_REALTIME}/:serviceName?/:application?`,
                   element: <ScatterOrHeatmapFullScreen />,
                   loader: scatterOrHeatmapFullScreenRealtimeLoader,
                 },

--- a/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/core/HeatmapChartCore.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/Heatmap/core/HeatmapChartCore.tsx
@@ -67,7 +67,11 @@ const HeatmapChartCore = ({
   const handleExpand = () => {
     if (isRealtime) {
       window.open(
-        `${BASE_PATH}${getHeatmapFullScreenRealtimePath(nodeData)}?${convertParamsToQueryString({
+        `${BASE_PATH}${getHeatmapFullScreenRealtimePath(
+          nodeData,
+          undefined,
+          requestServiceName,
+        )}?${convertParamsToQueryString({
           agentId,
         })}`,
         '_blank',
@@ -75,7 +79,11 @@ const HeatmapChartCore = ({
       return;
     }
     window.open(
-      `${BASE_PATH}${getHeatmapFullScreenPath(nodeData)}?${convertParamsToQueryString({
+      `${BASE_PATH}${getHeatmapFullScreenPath(
+        nodeData,
+        undefined,
+        requestServiceName,
+      )}?${convertParamsToQueryString({
         from: searchParameters.from,
         to: searchParameters.to,
       })}`,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartFetcher.tsx
@@ -103,7 +103,11 @@ export const ScatterChartFetcher = ({
         expand: {
           onClick: () => {
             window.open(
-              `${BASE_PATH}${getScatterFullScreenPath(node)}?${convertParamsToQueryString({
+              `${BASE_PATH}${getScatterFullScreenPath(
+                node,
+                undefined,
+                requestServiceName,
+              )}?${convertParamsToQueryString({
                 from: searchParameters.from,
                 to: searchParameters.to,
               })}`,

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartRealtimeFetcher.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartRealtimeFetcher.tsx
@@ -158,7 +158,11 @@ export const ScatterChartRealtimeFetcher = ({
         expand: {
           onClick: () => {
             window.open(
-              `${BASE_PATH}${getScatterFullScreenRealtimePath(node)}${
+              `${BASE_PATH}${getScatterFullScreenRealtimePath(
+                node,
+                undefined,
+                requestServiceName,
+              )}${
                 agentId === SCATTER_DATA_TOTAL_KEY
                   ? ''
                   : '?' + convertParamsToQueryString({ agentId })

--- a/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartStatic.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/components/ScatterChart/ScatterChartStatic.tsx
@@ -107,7 +107,11 @@ export const ScatterChartStatic = ({
         expand: {
           onClick: () => {
             window.open(
-              `${BASE_PATH}${getScatterFullScreenPath(application)}?${convertParamsToQueryString({
+              `${BASE_PATH}${getScatterFullScreenPath(
+                application,
+                undefined,
+                requestServiceName,
+              )}?${convertParamsToQueryString({
                 from: formatInTimeZone(range[0], timezone, SEARCH_PARAMETER_DATE_FORMAT),
                 to: formatInTimeZone(range[1], timezone, SEARCH_PARAMETER_DATE_FORMAT),
                 agentId: selectedAgentId === SCATTER_DATA_TOTAL_KEY ? undefined : selectedAgentId,

--- a/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.test.ts
@@ -15,9 +15,11 @@ jest.mock('@pinpoint-fe/ui/src/hooks', () => ({
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 
 const APP = 'TestApp@SPRING_BOOT';
-// The loader derives the base path from the first URL path segment.
+// The loader derives the base path from the page prefix carried in the URL.
 const PATHNAME = 'heatmapFullScreenMode';
 const BASE = `/${PATHNAME}/${APP}`;
+const SERVICE_SCOPED_BASE = `/${PATHNAME}/blogService/${APP}`;
+const REALTIME_BASE = `/${PATHNAME}/realtime/blogService/${APP}`;
 const VALID = 'from=2023-11-10-14-30-00&to=2023-11-10-15-00-00';
 
 describe('scatterOrHeatmapFullScreenLoader', () => {
@@ -55,6 +57,40 @@ describe('scatterOrHeatmapFullScreenLoader', () => {
     expect(result.__isRedirect).toBe(true);
   });
 
+  // 확대 버튼은 새 탭을 여는데, 그 화면도 같은 service로 조회해야 한다. 날짜를 고치는
+  // 리다이렉트가 serviceName 세그먼트를 떨어뜨리면 그 순간 전역 선택값으로 폴백한다.
+  test('keeps the service name segment in the redirect destination', async () => {
+    const result = (await scatterOrHeatmapFullScreenLoader(
+      makeArgs(`http://localhost${SERVICE_SCOPED_BASE}`, {
+        serviceName: 'blogService',
+        application: APP,
+      }),
+    )) as unknown as { __isRedirect: boolean; url: string };
+    expect(result.__isRedirect).toBe(true);
+    expect(result.url.startsWith(`${SERVICE_SCOPED_BASE}?`)).toBe(true);
+  });
+
+  // react-router의 params는 디코딩된 값이라 '%2F'가 '/'로 풀려 세그먼트 경계가 어긋난다.
+  test('keeps the encoded service name segment as-is in the redirect destination', async () => {
+    const result = (await scatterOrHeatmapFullScreenLoader(
+      makeArgs(`http://localhost/${PATHNAME}/team%2Fa/${APP}`, {
+        serviceName: 'team/a',
+        application: APP,
+      }),
+    )) as unknown as { __isRedirect: boolean; url: string };
+    expect(result.url.startsWith(`/${PATHNAME}/team%2Fa/${APP}?`)).toBe(true);
+  });
+
+  test('returns the application on a service scoped path with valid dates', async () => {
+    const result = await scatterOrHeatmapFullScreenLoader(
+      makeArgs(`http://localhost${SERVICE_SCOPED_BASE}?${VALID}`, {
+        serviceName: 'blogService',
+        application: APP,
+      }),
+    );
+    expect(result).toEqual({ applicationName: 'TestApp', serviceType: 'SPRING_BOOT' });
+  });
+
   test('redirects to root when the application param is invalid', async () => {
     const result = await scatterOrHeatmapFullScreenLoader(
       makeArgs(`http://localhost/${PATHNAME}/InvalidApp`, { application: 'InvalidApp' }),
@@ -82,6 +118,21 @@ describe('scatterOrHeatmapFullScreenRealtimeLoader', () => {
     expect(result).toEqual({
       __isRedirect: true,
       url: `${BASE}?agentId=agent-1`,
+    });
+  });
+
+  // 예전에는 리다이렉트가 첫 세그먼트만으로 경로를 다시 만들어 '/realtime'을 떨어뜨렸다.
+  // 실시간 화면에서 기간 파라미터가 섞여 들어오면 비실시간 화면으로 튕겨 나갔다.
+  test('keeps the realtime segment and the service name in the redirect destination', () => {
+    const result = scatterOrHeatmapFullScreenRealtimeLoader(
+      makeArgs(`http://localhost${REALTIME_BASE}?agentId=agent-1&from=x`, {
+        serviceName: 'blogService',
+        application: APP,
+      }),
+    );
+    expect(result).toEqual({
+      __isRedirect: true,
+      url: `${REALTIME_BASE}?agentId=agent-1`,
     });
   });
 

--- a/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/loader/scatterOrHeatmapFullScreen.ts
@@ -1,17 +1,53 @@
 import { SEARCH_PARAMETER_DATE_FORMAT, Configuration } from '@pinpoint-fe/ui/src/constants';
 import { getConfiguration } from '@pinpoint-fe/ui/src/hooks';
 import {
-  getApplicationTypeAndName,
   getParsedDateRange,
+  getServiceNameSegmentPage,
   isValidDateRange,
   getTimezone,
+  parseServiceScopedPath,
 } from '@pinpoint-fe/ui/src/utils';
 import { parse } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import { LoaderFunctionArgs, redirect } from 'react-router';
 
-export const scatterOrHeatmapFullScreenLoader = async ({ params, request }: LoaderFunctionArgs) => {
-  const application = getApplicationTypeAndName(params.application);
+/**
+ * `/{page}/{serviceName}?/{applicationName}@{serviceType}` 형태의 fullScreenMode 경로를 분해한다.
+ *
+ * 이 로더들은 scatter/heatmap, 실시간/비실시간 네 라우트가 공유하므로 페이지 접두사를 경로에서
+ * 되찾는다. 판정은 serviceName을 읽는 규칙과 같은 함수(`getServiceNameSegmentPage`)에 맡긴다 —
+ * 앞 세그먼트만 잘라 쓰면 실시간 경로에서 `/realtime`이 떨어져 리다이렉트가 비실시간 화면으로
+ * 나간다.
+ *
+ * **react-router의 `params`가 아니라 인코딩된 원본 경로에서 읽는다.** `params`는 디코딩된 값이라
+ * serviceName 안의 '%2F'가 '/'로 풀려 세그먼트 경계가 어긋나고, 리다이렉트 목적지에도 원본 '/'가
+ * 실려 라우트 매칭이 깨진다.
+ */
+const parseFullScreenPath = (pathname: string) => {
+  const pagePath = getServiceNameSegmentPage(pathname);
+
+  if (!pagePath) {
+    return null;
+  }
+
+  const { encodedServiceName, applicationSegment, application } = parseServiceScopedPath(
+    pagePath,
+    pathname,
+  );
+
+  return {
+    application,
+    /** 리다이렉트 목적지로 쓸, 지금 경로와 같은 형태의 기준 경로. */
+    basePath: `${pagePath}${
+      encodedServiceName ? `/${encodedServiceName}` : ''
+    }/${applicationSegment}`,
+  };
+};
+
+export const scatterOrHeatmapFullScreenLoader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const parsed = parseFullScreenPath(url.pathname);
+  const application = parsed?.application;
 
   let configuration: Configuration | undefined;
   try {
@@ -21,11 +57,9 @@ export const scatterOrHeatmapFullScreenLoader = async ({ params, request }: Load
   }
 
   const timezone = getTimezone();
-  const url = new URL(request.url);
-  const pathname = url?.pathname?.split('/')?.[1] || '';
 
-  if (pathname && application?.applicationName && application.serviceType) {
-    const basePath = `/${pathname}/${params.application}`;
+  if (parsed && application?.applicationName && application.serviceType) {
+    const basePath = parsed.basePath;
     const queryParam = Object.fromEntries(url?.searchParams);
     const conditions = Object.keys(queryParam);
 
@@ -64,19 +98,16 @@ export const scatterOrHeatmapFullScreenLoader = async ({ params, request }: Load
   return application;
 };
 
-export const scatterOrHeatmapFullScreenRealtimeLoader = ({
-  params,
-  request,
-}: LoaderFunctionArgs) => {
+export const scatterOrHeatmapFullScreenRealtimeLoader = ({ request }: LoaderFunctionArgs) => {
   try {
-    const application = getApplicationTypeAndName(params.application!);
     const url = new URL(request.url);
-    const pathname = url?.pathname?.split('/')?.[1] || '';
+    const parsed = parseFullScreenPath(url.pathname);
+    const application = parsed?.application;
     const queryParam = Object.fromEntries(url?.searchParams);
     const queryParamKeys = Object.keys(queryParam);
 
-    if (queryParamKeys.filter((key) => key !== 'agentId').length > 0) {
-      return redirect(`/${pathname}/${params.application}?agentId=${queryParam.agentId}`);
+    if (parsed && queryParamKeys.filter((key) => key !== 'agentId').length > 0) {
+      return redirect(`${parsed.basePath}?agentId=${queryParam.agentId}`);
     }
 
     return application;

--- a/web-frontend/src/main/v3/packages/ui/src/pages/ScatterOrHeatmapFullScreen.tsx
+++ b/web-frontend/src/main/v3/packages/ui/src/pages/ScatterOrHeatmapFullScreen.tsx
@@ -7,6 +7,8 @@ import {
   getScatterFullScreenPath,
   getScatterFullScreenRealtimePath,
   getServerMapPath,
+  getServiceMapPath,
+  getServiceNameFromPath,
 } from '@pinpoint-fe/ui/src/utils';
 import { useConfiguration, useServerMapSearchParameters } from '@pinpoint-fe/ui/src/hooks';
 import { APP_PATH } from '@pinpoint-fe/ui/src/constants';
@@ -36,21 +38,33 @@ export const ScatterOrHeatmapFullScreenPage = () => {
   const { dateRange, application, searchParameters } = useServerMapSearchParameters();
   const isRealtime = dateRange.isRealtime;
   const agentId = searchParameters.agentId;
+  // 이 화면의 service는 경로에 실려 온 값 하나로 정해진다. 전역 선택값으로 폴백하지 않는다 —
+  // 확대 버튼은 새 탭을 열기 때문에, 원래 탭에서 service를 바꾸면 이 화면이 조회하던 대상과
+  // 어긋난다. (filteredMap이 "어느 map에서 왔는가"를 정하는 것과 같은 이유다.)
+  //
+  // react-router의 `params`는 디코딩된 값이라 serviceName 안의 '%2F'가 '/'로 풀려 세그먼트
+  // 경계가 어긋나므로, 인코딩된 원본 경로에서 읽는다.
+  const serviceName = getServiceNameFromPath(location.pathname);
+  // 경로에 serviceName이 실려 있으면 servicemap에서 넘어온 화면이다. 돌아갈 map도 그쪽이어야
+  // 한다. (servermap에서 넘어온 화면은 예전과 같이 servermap으로 돌아간다.)
+  const parentMap = serviceName
+    ? { title: 'Servicemap', path: getServiceMapPath(serviceName, application) }
+    : { title: 'Servermap', path: getServerMapPath(application) };
 
   const handleChangeDateRagePicker = React.useCallback(
     (({ formattedDates, isRealtime }) => {
       if (isRealtime) {
         navigate(
           type === 'scatter'
-            ? getScatterFullScreenRealtimePath(application!)
-            : getHeatmapFullScreenRealtimePath(application!),
+            ? getScatterFullScreenRealtimePath(application!, undefined, serviceName)
+            : getHeatmapFullScreenRealtimePath(application!, undefined, serviceName),
         );
       } else {
         navigate(
           `${
             type === 'scatter'
-              ? getScatterFullScreenPath(application!)
-              : getHeatmapFullScreenPath(application!)
+              ? getScatterFullScreenPath(application!, undefined, serviceName)
+              : getHeatmapFullScreenPath(application!, undefined, serviceName)
           }?${convertParamsToQueryString({
             ...formattedDates,
           })}`,
@@ -66,7 +80,7 @@ export const ScatterOrHeatmapFullScreenPage = () => {
       //   );
       // }
     }) as DatetimePickerChangeHandler,
-    [application?.applicationName, agentId],
+    [application?.applicationName, agentId, serviceName],
   );
 
   return (
@@ -76,8 +90,8 @@ export const ScatterOrHeatmapFullScreenPage = () => {
           <div className="flex items-center gap-2">
             <PiTreeStructureDuotone />
             <span>
-              <Link className="hover:underline" to={getServerMapPath(application)}>
-                Servermap
+              <Link className="hover:underline" to={parentMap.path}>
+                {parentMap.title}
               </Link>{' '}
               / {capitalize(type)}
             </span>

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.test.ts
@@ -2,6 +2,7 @@ import {
   getApplicationTypeAndName,
   getApplicationKey,
   getServiceNameFromPath,
+  getServiceNameSegmentPage,
   hasServiceNameInPath,
   parseServiceScopedPath,
 } from './application';
@@ -125,6 +126,28 @@ describe('Test application helper utils', () => {
       expect(getServiceNameFromPath('/serviceMap/realtime/appName@TOMCAT')).toBeUndefined();
     });
 
+    // 스캐터/히트맵의 확대 버튼은 새 탭을 여는데, 그 화면도 같은 service로 조회해야 한다.
+    // `/{page}/realtime`은 `/{page}`의 하위 경로이므로 'realtime'을 service 이름으로 읽으면 안 된다.
+    test('Read the service name on a fullScreenMode path', () => {
+      expect(getServiceNameFromPath('/scatterFullScreenMode/blogService/appName@TOMCAT')).toBe(
+        'blogService',
+      );
+      expect(getServiceNameFromPath('/heatmapFullScreenMode/blogService/appName@TOMCAT')).toBe(
+        'blogService',
+      );
+      expect(
+        getServiceNameFromPath('/scatterFullScreenMode/realtime/blogService/appName@TOMCAT'),
+      ).toBe('blogService');
+      expect(
+        getServiceNameFromPath('/heatmapFullScreenMode/realtime/team%2Fa%40b/appName@TOMCAT'),
+      ).toBe('team/a@b');
+      // 세그먼트가 생기기 전 형태의 링크·북마크.
+      expect(getServiceNameFromPath('/scatterFullScreenMode/appName@TOMCAT')).toBeUndefined();
+      expect(
+        getServiceNameFromPath('/heatmapFullScreenMode/realtime/appName@TOMCAT'),
+      ).toBeUndefined();
+    });
+
     test('Return undefined on a path that does not carry a service name', () => {
       expect(getServiceNameFromPath('/serverMap/svc@appName@TOMCAT')).toBeUndefined();
     });
@@ -202,6 +225,28 @@ describe('Test application helper utils', () => {
 
       expect(result.serviceName).toBeUndefined();
       expect(result.application).toBeNull();
+    });
+  });
+
+  describe('Test "getServiceNameSegmentPage"', () => {
+    // 로더가 리다이렉트 목적지를 만들 때 쓴다. 더 긴 경로가 먼저 매칭되어야
+    // 실시간 화면의 리다이렉트가 비실시간 화면으로 새지 않는다.
+    test('Return the longest matching page prefix', () => {
+      expect(getServiceNameSegmentPage('/serviceMap/realtime/svc/appName@TOMCAT')).toBe(
+        '/serviceMap/realtime',
+      );
+      expect(getServiceNameSegmentPage('/serviceMap/svc/appName@TOMCAT')).toBe('/serviceMap');
+      expect(getServiceNameSegmentPage('/heatmapFullScreenMode/realtime/svc/appName@TOMCAT')).toBe(
+        '/heatmapFullScreenMode/realtime',
+      );
+      expect(getServiceNameSegmentPage('/scatterFullScreenMode/appName@TOMCAT')).toBe(
+        '/scatterFullScreenMode',
+      );
+    });
+
+    test('Return undefined on a page that does not carry a service name segment', () => {
+      expect(getServiceNameSegmentPage('/serverMap/appName@TOMCAT')).toBeUndefined();
+      expect(getServiceNameSegmentPage('/inspector/appName@TOMCAT')).toBeUndefined();
     });
   });
 

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/application.ts
@@ -57,7 +57,22 @@ const SERVICE_NAME_SEGMENT_PAGES: string[] = [
   APP_PATH.FILTERED_MAP,
   APP_PATH.TRANSACTION_LIST,
   APP_PATH.TRANSACTION_DETAIL,
+  APP_PATH.SCATTER_FULL_SCREEN_REALTIME,
+  APP_PATH.SCATTER_FULL_SCREEN,
+  APP_PATH.HEATMAP_FULL_SCREEN_REALTIME,
+  APP_PATH.HEATMAP_FULL_SCREEN,
 ];
+
+/**
+ * pathname이 속한, serviceName 세그먼트를 싣는 페이지의 경로 접두사.
+ *
+ * 라우트 로더가 리다이렉트 목적지를 만들 때 쓴다. 로더는 여러 라우트가 공유하므로
+ * (`scatterOrHeatmapFullScreenLoader`는 scatter/heatmap 두 경로에 걸려 있다) 접두사를
+ * 경로에서 되찾아야 하는데, 그 판정이 serviceName을 읽는 규칙과 갈리면
+ * "serviceName은 읽었는데 리다이렉트 목적지에는 빠지는" 어긋남이 생긴다.
+ */
+export const getServiceNameSegmentPage = (pathname = '') =>
+  SERVICE_NAME_SEGMENT_PAGES.find((pagePath) => isUnderPage(pathname, pagePath));
 
 /**
  * 경로에 실려 있는 serviceName. 아직 serviceName을 싣지 않는 화면에서는 undefined이므로,
@@ -72,7 +87,7 @@ const SERVICE_NAME_SEGMENT_PAGES: string[] = [
  * 디코딩된 값을 넘기면 serviceName 안의 '%2F'가 '/'로 풀려 세그먼트 경계가 어긋난다.
  */
 export const getServiceNameFromPath = (pathname = '') => {
-  const page = SERVICE_NAME_SEGMENT_PAGES.find((pagePath) => isUnderPage(pathname, pagePath));
+  const page = getServiceNameSegmentPage(pathname);
 
   if (!page) {
     return undefined;

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.test.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.test.ts
@@ -9,6 +9,10 @@ import {
   getTransactionListPath,
   getTransactionDetailPath,
   getServiceMapPath,
+  getScatterFullScreenPath,
+  getScatterFullScreenRealtimePath,
+  getHeatmapFullScreenPath,
+  getHeatmapFullScreenRealtimePath,
 } from './route';
 
 describe('Test route helper utils', () => {
@@ -476,6 +480,56 @@ describe('Test route helper utils', () => {
       );
       expect(getTransactionListPath(application, undefined, 'a b')).toEqual(
         '/transactionList/a%20b/appName@TOMCAT',
+      );
+    });
+  });
+
+  describe('Test the fullScreenMode path builders', () => {
+    const application = { applicationName: 'appName', serviceType: 'TOMCAT' };
+
+    test('Omit the service segment when service name is not given', () => {
+      expect(getScatterFullScreenPath(application)).toEqual(
+        '/scatterFullScreenMode/appName@TOMCAT',
+      );
+      expect(getScatterFullScreenRealtimePath(application)).toEqual(
+        '/scatterFullScreenMode/realtime/appName@TOMCAT',
+      );
+      expect(getHeatmapFullScreenPath(application)).toEqual(
+        '/heatmapFullScreenMode/appName@TOMCAT',
+      );
+      expect(getHeatmapFullScreenRealtimePath(application)).toEqual(
+        '/heatmapFullScreenMode/realtime/appName@TOMCAT',
+      );
+    });
+
+    test('Carry the service name as its own segment, like servicemap', () => {
+      expect(getScatterFullScreenPath(application, undefined, 'svc')).toEqual(
+        '/scatterFullScreenMode/svc/appName@TOMCAT',
+      );
+      expect(getScatterFullScreenRealtimePath(application, undefined, 'svc')).toEqual(
+        '/scatterFullScreenMode/realtime/svc/appName@TOMCAT',
+      );
+      expect(getHeatmapFullScreenPath(application, undefined, 'svc')).toEqual(
+        '/heatmapFullScreenMode/svc/appName@TOMCAT',
+      );
+      expect(getHeatmapFullScreenRealtimePath(application, undefined, 'svc')).toEqual(
+        '/heatmapFullScreenMode/realtime/svc/appName@TOMCAT',
+      );
+    });
+
+    test('Encode the service name so it cannot break the path segment', () => {
+      expect(getHeatmapFullScreenPath(application, undefined, 'a/b')).toEqual(
+        '/heatmapFullScreenMode/a%2Fb/appName@TOMCAT',
+      );
+      expect(getHeatmapFullScreenPath(application, undefined, 'a@b')).toEqual(
+        '/heatmapFullScreenMode/a%40b/appName@TOMCAT',
+      );
+    });
+
+    test('Return the page path only when application is not given', () => {
+      expect(getScatterFullScreenPath(null, undefined, 'svc')).toEqual('/scatterFullScreenMode');
+      expect(getHeatmapFullScreenRealtimePath(null, undefined, 'svc')).toEqual(
+        '/heatmapFullScreenMode/realtime',
       );
     });
   });

--- a/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.ts
+++ b/web-frontend/src/main/v3/packages/ui/src/utils/helper/route.ts
@@ -160,18 +160,6 @@ export const getRealtimePath = getApplicationPath(APP_PATH.SERVER_MAP_REALTIME);
  * (라우트 로더가 실려 들어온 query string을 지운다).
  */
 export const getServiceMapRealtimePath = getServiceScopedMapPath(APP_PATH.SERVICE_MAP_REALTIME);
-/** /scatterFullScreenMode */
-export const getScatterFullScreenPath = getApplicationPath(APP_PATH.SCATTER_FULL_SCREEN);
-/** /scatterFullScreenMode/realtime */
-export const getScatterFullScreenRealtimePath = getApplicationPath(
-  APP_PATH.SCATTER_FULL_SCREEN_REALTIME,
-);
-/** /heatmapFullScreenMode */
-export const getHeatmapFullScreenPath = getApplicationPath(APP_PATH.HEATMAP_FULL_SCREEN);
-/** /heatmapFullScreenMode/realtime */
-export const getHeatmapFullScreenRealtimePath = getApplicationPath(
-  APP_PATH.HEATMAP_FULL_SCREEN_REALTIME,
-);
 /**
  * 필터 대상에서 filteredMap의 기준 application을 고른다. 고를 수 없으면 null이다.
  *
@@ -275,9 +263,10 @@ export const getSystemMetricPath = getHostGroupPath(APP_PATH.SYSTEM_METRIC);
  * serviceName이 주어지면 `/{page}/{serviceName}/{applicationName}@{serviceType}`를 만드는 경로
  * 빌더. servicemap과 같은 세그먼트 표기다.
  *
- * transaction 화면들은 새 탭으로 열리므로(map의 drag&drop → transactionList, transactionList의
- * 외부 링크 → transactionDetail), 어떤 service를 보던 중이었는지 URL에 남겨야 그 화면의 모든
- * API에 pServiceName 헤더를 실을 수 있다. 전역 선택값은 탭 간 공유 저장소라 믿을 수 없다.
+ * 이 경로들은 모두 새 탭으로 열린다(map의 drag&drop → transactionList, transactionList의 외부
+ * 링크 → transactionDetail, 스캐터/히트맵의 확대 버튼 → fullScreenMode). 어떤 service를 보던
+ * 중이었는지 URL에 남겨야 그 화면의 모든 API에 pServiceName 헤더를 실을 수 있다. 전역 선택값은
+ * 탭 간 공유 저장소라 믿을 수 없다.
  *
  * enableServiceMap이 꺼져 있으면 service 개념이 없어 serviceName이 undefined로 들어온다.
  * 그때는 세그먼트를 붙이지 않아 예전과 같은 경로가 된다.
@@ -309,10 +298,26 @@ const getServiceScopedApplicationPath =
     return `${pagePath}${serviceSegment}/${application.applicationName}@${application.serviceType}${queryString}`;
   };
 
-/** /transactionList */
+/** /transactionList/{serviceName}?/{applicationName}@{serviceType} */
 export const getTransactionListPath = getServiceScopedApplicationPath(APP_PATH.TRANSACTION_LIST);
-/** /transactionDetail */
+/** /transactionDetail/{serviceName}?/{applicationName}@{serviceType} */
 export const getTransactionDetailPath = getServiceScopedApplicationPath(
   APP_PATH.TRANSACTION_DETAIL,
+);
+/** /scatterFullScreenMode/{serviceName}?/{applicationName}@{serviceType} */
+export const getScatterFullScreenPath = getServiceScopedApplicationPath(
+  APP_PATH.SCATTER_FULL_SCREEN,
+);
+/** /scatterFullScreenMode/realtime/{serviceName}?/{applicationName}@{serviceType} */
+export const getScatterFullScreenRealtimePath = getServiceScopedApplicationPath(
+  APP_PATH.SCATTER_FULL_SCREEN_REALTIME,
+);
+/** /heatmapFullScreenMode/{serviceName}?/{applicationName}@{serviceType} */
+export const getHeatmapFullScreenPath = getServiceScopedApplicationPath(
+  APP_PATH.HEATMAP_FULL_SCREEN,
+);
+/** /heatmapFullScreenMode/realtime/{serviceName}?/{applicationName}@{serviceType} */
+export const getHeatmapFullScreenRealtimePath = getServiceScopedApplicationPath(
+  APP_PATH.HEATMAP_FULL_SCREEN_REALTIME,
 );
 export const getThreadDumpPath = getApplicationPath(APP_PATH.THREAD_DUMP);


### PR DESCRIPTION
## Summary
- Carry `serviceName` as its own path segment on the scatter/heatmap full screen routes (`/{page}/{serviceName}?/{application}@{serviceType}`), the same notation the transaction screens opened by the map drag & drop already use. The expand button opens a new tab, so the globally selected service cannot be trusted — changing it back in the original tab would silently move the full screen view to another service.
- Registering the four full screen pages in `SERVICE_NAME_SEGMENT_PAGES` is what makes the `pServiceName` header (`resolveRequestService`), the service scoped cache key (`serviceScopedQueryKeyHashFn`) and the links the screen builds (`useServiceNameForLink`) all read the same value. The page also picks its back link from the path (`Servicemap / Scatter` vs `Servermap / Scatter`), like filteredMap does.
- Drive-by: the realtime loader used to rebuild the redirect destination from the first path segment only, dropping `/realtime` and bouncing the realtime view to the static one whenever a date parameter came along. Rebuilding that destination properly fixes it.

Paths without a service name are unchanged, so existing links and bookmarks (`/scatterFullScreenMode/App@TOMCAT`) keep working, and nothing changes when `enableServiceMap` is off.

Related issue (internal): pinpoint/pinpoint-naver#10625

## Test plan
- [x] `yarn build`
- [x] `yarn test` (1130 passed; new cases cover the four path builders, `getServiceNameSegmentPage`, service name parsing on full screen paths, and the loader redirect destinations)
- [x] `yarn lint`
- [ ] Non-DEFAULT servicemap: pick a node, expand the scatter/heatmap — the new tab's URL carries that node's service, and the charts query it
- [ ] Change the period and toggle realtime inside the full screen view — the service segment survives
- [ ] Drag & drop inside the full screen view — the transaction list opens on the same service
- [ ] Servermap (and `enableServiceMap` off): the expand button opens the same URL as before