### PR TITLE
[#noissue] Remove ServiceRegistryController tests for the deleted GET endpoint

### DIFF
--- a/service-module/src/test/java/com/navercorp/pinpoint/service/web/controller/ServiceRegistryControllerMvcTest.java
+++ b/service-module/src/test/java/com/navercorp/pinpoint/service/web/controller/ServiceRegistryControllerMvcTest.java
@@ -74,28 +74,6 @@ class ServiceRegistryControllerMvcTest {
     }
 
     @Test
-    void getService_found_200() throws Exception {
-        Service service = new Service("my-svc", 100);
-        when(serviceRegistryService.getService("my-svc")).thenReturn(service);
-
-        MvcResult result = mockMvc.perform(get("/api/v2/services/service").param("serviceName", "my-svc"))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        String body = result.getResponse().getContentAsString();
-        assertThat(body).contains("\"uid\":100");
-        assertThat(body).contains("\"name\":\"my-svc\"");
-    }
-
-    @Test
-    void getService_notFound_204() throws Exception {
-        when(serviceRegistryService.getService("missing")).thenReturn(null);
-
-        mockMvc.perform(get("/api/v2/services/service").param("serviceName", "missing"))
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
     void insertService_reservedName_throws400() throws Exception {
         when(reservedServiceRegistry.contains("DEFAULT")).thenReturn(true);
 

--- a/service-module/src/test/java/com/navercorp/pinpoint/service/web/controller/ServiceRegistryControllerTest.java
+++ b/service-module/src/test/java/com/navercorp/pinpoint/service/web/controller/ServiceRegistryControllerTest.java
@@ -6,14 +6,12 @@ import com.navercorp.pinpoint.service.component.ReservedServiceRegistry;
 import com.navercorp.pinpoint.service.service.ServiceRegistryService;
 import com.navercorp.pinpoint.common.server.uid.Service;
 import com.navercorp.pinpoint.service.web.controller.vo.ServiceNameRequest;
-import com.navercorp.pinpoint.service.web.controller.vo.ServiceView;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Collections;
@@ -84,29 +82,6 @@ class ServiceRegistryControllerTest {
         List<String> result = controller.getServiceNames();
 
         assertThat(result).isEmpty();
-    }
-
-    @Test
-    void getService_found_returns200() {
-        Service service = new Service("my-svc", 100);
-        when(serviceRegistryService.getService("my-svc")).thenReturn(service);
-
-        ResponseEntity<ServiceView> response = controller.getService("my-svc");
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getName()).isEqualTo("my-svc");
-        assertThat(response.getBody().getUid()).isEqualTo(100);
-    }
-
-    @Test
-    void getService_notFound_returns204() {
-        when(serviceRegistryService.getService("missing")).thenReturn(null);
-
-        ResponseEntity<ServiceView> response = controller.getService("missing");
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-        assertThat(response.getBody()).isNull();
     }
 
     @Test


### PR DESCRIPTION
#14272 removed the single-service `GET` endpoint from `ServiceRegistryController` but left the tests that call it: `ServiceRegistryControllerTest` no longer compiles (`cannot find symbol: method getService(String)`) and `ServiceRegistryControllerMvcTest` gets 405 instead of 200/204. This removes those four tests and the imports only they used.

## Test plan

- [x] `./mvnw -pl service-module test` → 64 tests pass
- [x] `./mvnw clean install -DskipTests` succeeds
