### PR TITLE
[#14278]Backport: Fix NoSuchMethodError in the WebFlux and RestTempl…

### DIFF
--- a/agent-module/agent-testweb/spring-boot3-webflux-plugin-testweb/src/main/java/com/pinpoint/test/plugin/SpringBoot3WebfluxPluginController.java
+++ b/agent-module/agent-testweb/spring-boot3-webflux-plugin-testweb/src/main/java/com/pinpoint/test/plugin/SpringBoot3WebfluxPluginController.java
@@ -89,6 +89,32 @@ public class SpringBoot3WebfluxPluginController {
         return Mono.just("Welcome Home");
     }
 
+    /**
+     * Echoes the request headers, one {@code name: value} per line. Call it through {@code /client/headers}
+     * to see whether the WebClient instrumentation put its Pinpoint-* propagation headers on the wire.
+     */
+    @GetMapping("/server/headers")
+    public Mono<String> serverHeaders(ServerWebExchange exchange) {
+        StringBuilder sb = new StringBuilder();
+        exchange.getRequest().getHeaders().forEach((name, values) -> sb.append(name).append(": ").append(values).append('\n'));
+        return Mono.just(sb.toString());
+    }
+
+    /**
+     * WebClient call to {@code /server/headers} on this server; the body lists the headers the server received,
+     * so Pinpoint-TraceID / Pinpoint-SpanID / Pinpoint-pAppName should appear when the client plugin is working.
+     * The response headers are read back by the plugin as well (X-Test-Echo below).
+     */
+    @GetMapping("/client/headers")
+    public Mono<String> clientHeaders() {
+        WebClient client = WebClient.create("http://localhost:18080");
+        return client.get()
+                .uri("/server/headers")
+                .header("X-Test-Echo", "echo")
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
     @PostMapping("/server/post")
     public Mono<String> welcome(@RequestBody String body) {
         return Mono.just("Post=" + body);

--- a/agent-module/plugins-it/spring-it/spring-6-it/pom.xml
+++ b/agent-module/plugins-it/spring-it/spring-6-it/pom.xml
@@ -31,6 +31,7 @@
     <properties>
         <jdk.version>1.8</jdk.version>
         <jdk.home>${env.JAVA_8_HOME}</jdk.home>
+        <reactor-netty.version>1.2.18</reactor-netty.version>
         <spring.version>${spring5.version}</spring.version>
         <jakarta.servlet.version>${jakarta.servlet5.version}</jakarta.servlet.version>
     </properties>
@@ -55,6 +56,21 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
+            <version>${reactor-netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.navercorp.pinpoint</groupId>
+            <artifactId>pinpoint-spring-webflux-plugin</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.navercorp.pinpoint</groupId>

--- a/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebClient_6_x_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebClient_6_x_IT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.HeaderRecordingWebServer;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.it.plugin.utils.WebServer;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
+
+/**
+ * WebClient on Spring Framework 6 with the spring-webflux client instrumentation enabled — the
+ * regression guard for the header adaptor change made for Spring 7 (see the 7.x IT).
+ *
+ * <p>Spring 7.0 dropped the {@code MultiValueMap} implementation from {@code HttpHeaders}. The plugin's
+ * header adaptor used to call the {@code Map} methods it was compiled against on Spring 5.3
+ * ({@code containsKey}, {@code put}, {@code keySet}, {@code get(Object)}), which no longer exist on 7.x:
+ * {@code BodyInserterRequestBuilderWriteToInterceptor.checkBeforeTraceBlockBegin} threw
+ * {@code NoSuchMethodError} on every request, the SPRING_WEBFLUX_CLIENT span event was never recorded
+ * and its header injection was skipped (the reactor-netty plugin underneath kept the trace alive).
+ *
+ * <p>This IT pins both halves: the propagation headers reach the wire, and the WebFlux client event
+ * exists. Without the adaptor fix the second assertion fails on 7.x.
+ */
+@PluginForkedTest
+@PinpointAgent(AgentPath.PATH)
+@JvmVersion(17)
+@Dependency({"org.springframework:spring-webflux:[6.0.0,6.max]",
+        // same version as spring-webflux: ReactorClientHttpConnector implements SmartLifecycle (spring-context, optional for webflux)
+        "org.springframework:spring-context",
+        "io.projectreactor.netty:reactor-netty-http:1.2.18",
+        WebServer.VERSION, PluginITConstants.VERSION})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-webflux-plugin",
+        "com.navercorp.pinpoint:pinpoint-reactor-netty-plugin",
+        "com.navercorp.pinpoint:pinpoint-netty-plugin",
+        "com.navercorp.pinpoint:pinpoint-reactor-plugin"})
+@PinpointConfig("pinpoint-webflux-client.config")
+public class SpringWebClient_6_x_IT {
+
+    // The span event the adaptor fix restores on Spring 7 (absent without it: checkBeforeTraceBlockBegin
+    // threw before the event began).
+    private static final String WRITE_TO = "org.springframework.web.reactive.function.client.DefaultClientRequestBuilder$BodyInserterRequest"
+            + ".writeTo(org.springframework.http.client.reactive.ClientHttpRequest, org.springframework.web.reactive.function.client.ExchangeStrategies)";
+
+    private static HeaderRecordingWebServer webServer;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        webServer = HeaderRecordingWebServer.newTestWebServer();
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        WebServer.cleanup(webServer);
+    }
+
+    @Test
+    public void propagationHeadersReachTheServer_andTheWebFluxClientEventIsRecorded() throws Exception {
+        webServer.clear();
+        WebClient client = WebClient.create(webServer.getCallHttpUrl());
+
+        String body = client.get().uri("/").retrieve().bodyToMono(String.class).block(Duration.ofSeconds(10));
+
+        Assertions.assertNotNull(body);
+        Map<String, String> received = webServer.getLastRequestHeaders();
+        Assertions.assertTrue(received.containsKey("Pinpoint-TraceID"), "Pinpoint-TraceID not propagated: " + received.keySet());
+        Assertions.assertTrue(received.containsKey("Pinpoint-SpanID"), "Pinpoint-SpanID not propagated: " + received.keySet());
+        Assertions.assertTrue(received.containsKey("Pinpoint-pAppName"), "Pinpoint-pAppName not propagated: " + received.keySet());
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.printCache();
+        // Recorded in the reactor-netty async chunk: nextSpanId + destination + http.url come from the request trace writer.
+        verifier.verifyDiscreteTrace(event("SPRING_WEBFLUX_CLIENT", WRITE_TO, null, null, webServer.getHostAndPort(),
+                annotation("http.url", webServer.getCallHttpUrl() + "/")));
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-6-it/src/test/resources/pinpoint-webflux-client.config
+++ b/agent-module/plugins-it/spring-it/spring-6-it/src/test/resources/pinpoint-webflux-client.config
@@ -1,0 +1,7 @@
+# spring-webflux WebClient IT: the client instrumentation is off by default in the shipped config.
+profiler.spring.webflux.enable=true
+profiler.spring.webflux.client.enable=true
+profiler.reactor-netty.enable=true
+profiler.reactor-netty.client.enable=true
+# Record two named response headers so the response header adaptor (getHeaders) runs on every request.
+profiler.http.record.response.headers=X-Test-Echo,X-Test-Multi

--- a/agent-module/plugins-test-module/plugins-it-utils/src/main/java/com/navercorp/pinpoint/it/plugin/utils/HeaderRecordingWebServer.java
+++ b/agent-module/plugins-test-module/plugins-it-utils/src/main/java/com/navercorp/pinpoint/it/plugin/utils/HeaderRecordingWebServer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.utils;
+
+import com.navercorp.pinpoint.testcase.util.SocketUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * A {@link WebServer} that keeps the request headers of every call it served, so an HTTP client IT can
+ * assert that the agent's propagation headers ({@code Pinpoint-TraceID}, {@code Pinpoint-SpanID}, ...)
+ * actually reached the wire — not only that a client span event was recorded. Header names are kept
+ * case-insensitively (NanoHTTPD lower-cases them; HTTP header names are case-insensitive anyway).
+ * The response echoes the received header names so a test can also verify from the client side.
+ */
+public class HeaderRecordingWebServer extends WebServer {
+
+    private final List<Map<String, String>> requests = new CopyOnWriteArrayList<>();
+
+    public HeaderRecordingWebServer(String hostname, int port) {
+        super(hostname, port);
+    }
+
+    public static HeaderRecordingWebServer newTestWebServer() throws IOException {
+        final int port = SocketUtils.findAvailableTcpPort(21000);
+        final HeaderRecordingWebServer webServer = new HeaderRecordingWebServer(LOCAL_HOST, port);
+        webServer.start();
+        return webServer;
+    }
+
+    @Override
+    public Response serve(IHTTPSession session) {
+        final Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        if (session.getHeaders() != null) {
+            headers.putAll(session.getHeaders());
+        }
+        requests.add(Collections.unmodifiableMap(headers));
+        final Response response = newFixedLengthResponse("headers=" + headers.keySet());
+        response.addHeader("X-Test-Echo", "echo");
+        response.addHeader("X-Test-Multi", "a");
+        return response;
+    }
+
+    /** Headers of every request served so far, oldest first. */
+    public List<Map<String, String>> getRequestHeaders() {
+        return new ArrayList<>(requests);
+    }
+
+    /** Headers of the most recent request, or an empty map when nothing was served. */
+    public Map<String, String> getLastRequestHeaders() {
+        if (requests.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return requests.get(requests.size() - 1);
+    }
+
+    public void clear() {
+        requests.clear();
+    }
+}

--- a/agent-module/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/RestTemplateResponseHeaderAdaptor.java
+++ b/agent-module/plugins/resttemplate/src/main/java/com/navercorp/pinpoint/plugin/resttemplate/RestTemplateResponseHeaderAdaptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,21 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.navercorp.pinpoint.plugin.resttemplate;
 
 import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.ClientHttpResponse;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
- * @author yjqg6666
+ * Only {@link HttpHeaders} methods whose signature is identical in Spring 5, 6 and 7 are used
+ * ({@code getFirst}, {@code set}, {@code add}, {@code forEach}). Spring Framework 7.0 dropped the
+ * {@code MultiValueMap} implementation from {@code HttpHeaders}: {@code containsKey(Object)} and
+ * {@code keySet()} are gone and {@code get(Object)} became {@code get(String)}, so the {@code Map}
+ * calls this class was compiled against on 5.3 fail with {@code NoSuchMethodError} at runtime.
+ * {@code forEach(BiConsumer)} is declared on {@code HttpHeaders} in 6.x/7.x and inherited from
+ * {@code Map} as a default method in 5.x, so it resolves on every version.
  */
 public class RestTemplateResponseHeaderAdaptor implements ResponseAdaptor<ClientHttpResponse> {
 
     @Override
     public boolean containsHeader(ClientHttpResponse response, String name) {
-        return response.getHeaders().containsKey(name);
+        return response.getHeaders().getFirst(name) != null;
     }
 
     @Override
@@ -47,11 +57,20 @@ public class RestTemplateResponseHeaderAdaptor implements ResponseAdaptor<Client
 
     @Override
     public Collection<String> getHeaders(ClientHttpResponse response, String name) {
-        return response.getHeaders().get(name);
+        final List<String> values = new ArrayList<>();
+        // HTTP header names are case-insensitive, as is HttpHeaders' own lookup.
+        response.getHeaders().forEach((key, list) -> {
+            if (name.equalsIgnoreCase(key) && list != null) {
+                values.addAll(list);
+            }
+        });
+        return values;
     }
 
     @Override
     public Collection<String> getHeaderNames(ClientHttpResponse response) {
-        return response.getHeaders().keySet();
+        final List<String> names = new ArrayList<>();
+        response.getHeaders().forEach((key, list) -> names.add(key));
+        return names;
     }
 }

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringWebFluxResponseHeaderAdaptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/SpringWebFluxResponseHeaderAdaptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,21 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.navercorp.pinpoint.plugin.spring.webflux;
 
 import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ClientHttpResponse;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
- * @author yjqg6666
+ * Only {@link HttpHeaders} methods whose signature is identical in Spring 5, 6 and 7 are used
+ * ({@code getFirst}, {@code set}, {@code add}, {@code forEach}). Spring Framework 7.0 dropped the
+ * {@code MultiValueMap} implementation from {@code HttpHeaders}: {@code containsKey(Object)} and
+ * {@code keySet()} are gone and {@code get(Object)} became {@code get(String)}, so the {@code Map}
+ * calls this class was compiled against on 5.3 fail with {@code NoSuchMethodError} at runtime.
+ * {@code forEach(BiConsumer)} is declared on {@code HttpHeaders} in 6.x/7.x and inherited from
+ * {@code Map} as a default method in 5.x, so it resolves on every version.
  */
 public class SpringWebFluxResponseHeaderAdaptor implements ResponseAdaptor<ClientHttpResponse> {
 
     @Override
     public boolean containsHeader(ClientHttpResponse response, String name) {
-        return response.getHeaders().containsKey(name);
+        return response.getHeaders().getFirst(name) != null;
     }
 
     @Override
@@ -47,11 +57,20 @@ public class SpringWebFluxResponseHeaderAdaptor implements ResponseAdaptor<Clien
 
     @Override
     public Collection<String> getHeaders(ClientHttpResponse response, String name) {
-        return response.getHeaders().get(name);
+        final List<String> values = new ArrayList<>();
+        // HTTP header names are case-insensitive, as is HttpHeaders' own lookup.
+        response.getHeaders().forEach((key, list) -> {
+            if (name.equalsIgnoreCase(key) && list != null) {
+                values.addAll(list);
+            }
+        });
+        return values;
     }
 
     @Override
     public Collection<String> getHeaderNames(ClientHttpResponse response) {
-        return response.getHeaders().keySet();
+        final List<String> names = new ArrayList<>();
+        response.getHeaders().forEach((key, list) -> names.add(key));
+        return names;
     }
 }

--- a/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/ClientHttpRequestClientHeaderAdaptor.java
+++ b/agent-module/plugins/spring-webflux/src/main/java/com/navercorp/pinpoint/plugin/spring/webflux/interceptor/ClientHttpRequestClientHeaderAdaptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,12 +22,15 @@ import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ClientHttpRequest;
 
-import java.util.Arrays;
-
 /**
- * @author jaehong.kim
+ * Only {@link HttpHeaders} methods whose signature is identical in Spring 5, 6 and 7 are used here
+ * ({@code getFirst(String)}, {@code set(String, String)}). Spring Framework 7.0 dropped the
+ * {@code MultiValueMap} implementation from {@code HttpHeaders}, so the {@code Map} methods this class
+ * was compiled against on 5.3 ({@code containsKey(Object)}, {@code keySet()}, {@code get(Object)})
+ * no longer exist at runtime and fail with {@code NoSuchMethodError}.
  */
 public class ClientHttpRequestClientHeaderAdaptor implements ClientHeaderAdaptor<ClientHttpRequest> {
+
     private final PluginLogger logger = PluginLogManager.getLogger(this.getClass());
     private final boolean isDebug = logger.isDebugEnabled();
 
@@ -37,8 +40,7 @@ public class ClientHttpRequestClientHeaderAdaptor implements ClientHeaderAdaptor
             if (request != null) {
                 final HttpHeaders headers = request.getHeaders();
                 if (headers != null) {
-                    final HttpHeaders httpHeaders = headers;
-                    httpHeaders.put(name, Arrays.asList(value));
+                    headers.set(name, value);
                     if (isDebug) {
                         logger.debug("Set header {}={}", name, value);
                     }
@@ -62,7 +64,6 @@ public class ClientHttpRequestClientHeaderAdaptor implements ClientHeaderAdaptor
             }
         } catch (Exception ignored) {
         }
-        
         return "";
     }
 
@@ -72,7 +73,7 @@ public class ClientHttpRequestClientHeaderAdaptor implements ClientHeaderAdaptor
             if (header != null) {
                 final HttpHeaders headers = header.getHeaders();
                 if (headers != null) {
-                    return headers.containsKey(name);
+                    return headers.getFirst(name) != null;
                 }
             }
         } catch (Exception ignored) {


### PR DESCRIPTION
…ate header adaptors on Spring Framework 7

Backport of 81cfa7b211 (master, PR #14277) without the spring-7-it and Spring Boot 4 testweb parts, which have no module on 3.1.x.

Spring Framework 7.0 (7.0.0-M1, spring-framework#33913) dropped the MultiValueMap implementation from HttpHeaders. The plugins are compiled against Spring 5.3, where HttpHeaders is a Map, so the header adaptors carried the Map descriptors into their bytecode: containsKey(Object) and keySet() no longer exist on 7.x and get(Object) became get(String). On a Spring 7 application agent 3.1.0 logs on every WebClient request

  NoSuchMethodError: 'boolean org.springframework.http.HttpHeaders.containsKey(java.lang.Object)'
    at ClientHttpRequestClientHeaderAdaptor.contains
    at DefaultRequestTraceWriter.isNested
    at BodyInserterRequestBuilderWriteToInterceptor.checkBeforeTraceBlockBegin

when profiler.spring.webflux.client.enable=true. The block interceptor swallows the Error, so the SPRING_WEBFLUX client span event is lost and its header injection is skipped; distributed tracing still continues because the reactor-netty plugin injects the headers underneath. The response adaptors (containsKey / get(Object) / keySet) fail the same way when response header recording is enabled.

Use only HttpHeaders methods whose descriptor is identical on 5.x, 6.x and 7.x: getFirst(String), set(String, String), add(String, String) and forEach(BiConsumer) - declared on HttpHeaders in 6.x/7.x and inherited from Map as a default method on 5.x.

- contains / containsHeader: containsKey(name) -> getFirst(name) != null
- setHeader: put(name, singletonList) -> set(name, value)
- getHeaders(name): get(name) -> forEach collecting the case-insensitively matching entry
- getHeaderNames: keySet() -> forEach collecting the keys

Tests
- SpringWebClient_6_x_IT (spring-6-it, spring-webflux [6.0.0,6.max], reactor-netty 1.2.18) enables the client instrumentation, calls a local server through WebClient and asserts that the Pinpoint propagation headers reached the wire and that the SPRING_WEBFLUX_CLIENT writeTo event was recorded with its destination and http.url.
- HeaderRecordingWebServer (plugins-it-utils) keeps the request headers of every call and answers with X-Test-Echo / X-Test-Multi response headers.
- The Boot 3 WebFlux testweb gets /server/headers and /client/headers echo endpoints for a manual check with the agent attached.