### PR TITLE
[#noissue] Add direct-call adaptor ITs and server-side WebFlux/MVC IT…

### DIFF
--- a/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/test/PluginTestVerifier.java
+++ b/agent-module/bootstraps/bootstrap-core/src/main/java/com/navercorp/pinpoint/bootstrap/plugin/test/PluginTestVerifier.java
@@ -47,6 +47,12 @@ public interface PluginTestVerifier {
     void cleanUp(boolean detachTraceObject);
     void verifyIsLoggingTransactionInfo(LoggingInfo loggingInfo);
 
+    /**
+     * Asserts that one of the recorded traces carries {@code expectedUriTemplate} as its URI template
+     * (recorded through {@code SpanRecorder.recordUriTemplate}). Does not consume the recorded traces.
+     */
+    void verifyUriTemplate(String expectedUriTemplate);
+
     void awaitTrace(ExpectedTrace expectedTrace, long waitUnitTime, long maxWaitTime);
     void awaitTraceCount(int expectedTraceCount, long waitUnitTime, long maxWaitTime);
 

--- a/agent-module/plugins-it/httpclient-it/httpclient-3-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient3/HttpClient3Adaptors_IT.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-3-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient3/HttpClient3Adaptors_IT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.httpclient3;
+
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.httpclient3.HttpClient3CookieExtractor;
+import com.navercorp.pinpoint.plugin.httpclient3.HttpClient3EntityExtractor;
+import com.navercorp.pinpoint.plugin.httpclient3.HttpClient3RequestWrapper;
+import com.navercorp.pinpoint.plugin.httpclient3.HttpMethodClientHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.apache.commons.httpclient.HttpConnection;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.StringRequestEntity;
+import org.apache.commons.httpclient.protocol.Protocol;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Calls the httpclient3 plugin's request wrapper, header adaptor and extractors directly against real
+ * commons-httpclient 3.x objects of every release in range - no interceptor, no HTTP call. The
+ * {@code HttpConnection} is constructed but never opened: the wrapper only reads host, port and protocol.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"commons-httpclient:commons-httpclient:[3.0,3.1]"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-httpclient3-plugin"})
+public class HttpClient3Adaptors_IT {
+
+    private final ClientHeaderAdaptor<HttpMethod> headerAdaptor = new HttpMethodClientHeaderAdaptor();
+
+    @Test
+    public void requestWrapper_absoluteUri_ignoresTheConnection() throws Exception {
+        GetMethod get = new GetMethod("http://host.example:8080/path?q=1");
+        HttpConnection otherConnection = new HttpConnection("other.example", 9090, Protocol.getProtocol("http"));
+
+        ClientRequestWrapper wrapper = new HttpClient3RequestWrapper(get, otherConnection);
+        Assertions.assertEquals("host.example:8080", wrapper.getDestinationId());
+        Assertions.assertEquals("http://host.example:8080/path?q=1", wrapper.getUrl());
+
+        Assertions.assertEquals("host.example:8080", new HttpClient3RequestWrapper(get, null).getDestinationId(), "no connection: still from the absolute uri");
+    }
+
+    @Test
+    public void requestWrapper_relativeUri_usesTheConnection_andDropsTheDefaultPort() throws Exception {
+        GetMethod get = new GetMethod("/path?q=1");
+
+        HttpConnection connection = new HttpConnection("host.example", 8080, Protocol.getProtocol("http"));
+        ClientRequestWrapper wrapper = new HttpClient3RequestWrapper(get, connection);
+        Assertions.assertEquals("host.example:8080", wrapper.getDestinationId());
+        Assertions.assertEquals("http://host.example:8080/path?q=1", wrapper.getUrl());
+
+        HttpConnection defaultPort = new HttpConnection("host.example", 80, Protocol.getProtocol("http"));
+        ClientRequestWrapper wrapperDefault = new HttpClient3RequestWrapper(get, defaultPort);
+        Assertions.assertEquals("host.example", wrapperDefault.getDestinationId(), "protocol default port is omitted");
+        Assertions.assertEquals("http://host.example/path?q=1", wrapperDefault.getUrl());
+    }
+
+    @Test
+    public void headerAdaptor_setGetContains() {
+        HttpMethod get = new GetMethod("/");
+
+        Assertions.assertFalse(headerAdaptor.contains(get, "Pinpoint-TraceID"));
+        Assertions.assertEquals("", headerAdaptor.getHeader(get, "Pinpoint-TraceID"), "absent header reads as empty string");
+
+        headerAdaptor.setHeader(get, "Pinpoint-TraceID", "agent^1^1");
+        headerAdaptor.setHeader(get, "Pinpoint-TraceID", "agent^1^2");
+
+        Assertions.assertTrue(headerAdaptor.contains(get, "Pinpoint-TraceID"));
+        Assertions.assertTrue(headerAdaptor.contains(get, "pinpoint-traceid"), "header names are case-insensitive");
+        Assertions.assertEquals("agent^1^2", headerAdaptor.getHeader(get, "Pinpoint-TraceID"), "set replaces");
+        Assertions.assertEquals(1, get.getRequestHeaders("Pinpoint-TraceID").length, "set must not accumulate values");
+    }
+
+    @Test
+    public void cookieAndEntityExtractors() throws Exception {
+        GetMethod get = new GetMethod("/");
+        Assertions.assertNull(HttpClient3CookieExtractor.INSTANCE.getCookie(get), "no Cookie header -> null");
+        get.setRequestHeader("Cookie", "a=1; b=2");
+        Assertions.assertEquals("a=1; b=2", HttpClient3CookieExtractor.INSTANCE.getCookie(get));
+
+        Assertions.assertNull(HttpClient3EntityExtractor.INSTANCE.getEntity(get), "GET carries no entity");
+        PostMethod post = new PostMethod("/");
+        post.setRequestEntity(new StringRequestEntity("hello", "text/plain", "UTF-8"));
+        String entity = HttpClient3EntityExtractor.INSTANCE.getEntity(post);
+        Assertions.assertNotNull(entity);
+        Assertions.assertTrue(entity.contains("hello"), "entity: " + entity);
+    }
+}

--- a/agent-module/plugins-it/httpclient-it/httpclient-4-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient4/HttpClient4Adaptors_IT.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-4-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient4/HttpClient4Adaptors_IT.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.httpclient4;
+
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.httpclient4.HttpClient4CookieExtractor;
+import com.navercorp.pinpoint.plugin.httpclient4.HttpClient4EntityExtractor;
+import com.navercorp.pinpoint.plugin.httpclient4.HttpClient4RequestWrapper;
+import com.navercorp.pinpoint.plugin.httpclient4.HttpRequest4ClientHeaderAdaptor;
+import com.navercorp.pinpoint.plugin.httpclient4.HttpResponse4ClientHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * Calls the httpclient4 plugin's request wrapper, header adaptors and extractors directly against real
+ * HttpClient 4.x objects of every release in range - no interceptor, no HTTP call. Under {@code @PluginTest}
+ * the plugin classes are linked against the httpclient/httpcore of the current case, so both a dropped
+ * descriptor and a changed value format show up per version.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.apache.httpcomponents:httpclient:[4.0,4.5.max]"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-httpclient4-plugin"})
+public class HttpClient4Adaptors_IT {
+
+    private static final ProtocolVersion HTTP_1_1 = new ProtocolVersion("HTTP", 1, 1);
+
+    private final ClientHeaderAdaptor<HttpRequest> headerAdaptor = new HttpRequest4ClientHeaderAdaptor();
+    private final ResponseAdaptor<HttpResponse> responseAdaptor = new HttpResponse4ClientHeaderAdaptor();
+
+    @Test
+    public void requestWrapper_destinationAndUrl() {
+        HttpGet get = new HttpGet("/path?q=1");
+
+        ClientRequestWrapper wrapper = new HttpClient4RequestWrapper(get, "host.example", 8080);
+        Assertions.assertEquals("host.example:8080", wrapper.getDestinationId());
+        Assertions.assertEquals("/path?q=1", wrapper.getUrl(), "url is the request line uri as sent");
+
+        Assertions.assertEquals("host.example", new HttpClient4RequestWrapper(get, "host.example", -1).getDestinationId(), "no port -> host only");
+        Assertions.assertEquals("UNKNOWN", new HttpClient4RequestWrapper(get, null, 8080).getDestinationId(), "null host -> UNKNOWN");
+
+        HttpGet withHost = new HttpGet("/path");
+        withHost.setHeader("Host", "header.example:9090");
+        Assertions.assertEquals("header.example:9090", new HttpClient4RequestWrapper(withHost, "", -1).getDestinationId(), "blank host falls back to the Host header");
+    }
+
+    @Test
+    public void headerAdaptor_setGetContains() {
+        HttpGet get = new HttpGet("/");
+
+        Assertions.assertFalse(headerAdaptor.contains(get, "Pinpoint-TraceID"));
+        Assertions.assertEquals("", headerAdaptor.getHeader(get, "Pinpoint-TraceID"), "absent header reads as empty string");
+
+        headerAdaptor.setHeader(get, "Pinpoint-TraceID", "agent^1^1");
+        headerAdaptor.setHeader(get, "Pinpoint-TraceID", "agent^1^2");
+
+        Assertions.assertTrue(headerAdaptor.contains(get, "Pinpoint-TraceID"));
+        Assertions.assertTrue(headerAdaptor.contains(get, "pinpoint-traceid"), "header names are case-insensitive");
+        Assertions.assertEquals("agent^1^2", headerAdaptor.getHeader(get, "Pinpoint-TraceID"), "set replaces");
+        Assertions.assertEquals(1, get.getHeaders("Pinpoint-TraceID").length, "set must not accumulate values");
+    }
+
+    @Test
+    public void responseAdaptor_readsAndWritesHeaders() {
+        HttpResponse response = new BasicHttpResponse(HTTP_1_1, 200, "OK");
+        response.addHeader("X-Test-Echo", "echo");
+        response.addHeader("X-Test-Multi", "one");
+        response.addHeader("X-Test-Multi", "two");
+
+        Assertions.assertTrue(responseAdaptor.containsHeader(response, "X-Test-Echo"));
+        Assertions.assertTrue(responseAdaptor.containsHeader(response, "x-test-echo"), "header names are case-insensitive");
+        Assertions.assertFalse(responseAdaptor.containsHeader(response, "X-Missing"));
+
+        Assertions.assertEquals("echo", responseAdaptor.getHeader(response, "X-Test-Echo"));
+        Assertions.assertEquals("one", responseAdaptor.getHeader(response, "X-Test-Multi"), "first value wins");
+        Assertions.assertNull(responseAdaptor.getHeader(response, "X-Missing"));
+
+        // multi-valued lookups come back as a Set: order is not kept and duplicates collapse
+        Assertions.assertEquals(new HashSet<String>(Arrays.asList("one", "two")), new HashSet<String>(responseAdaptor.getHeaders(response, "X-Test-Multi")));
+        Assertions.assertTrue(responseAdaptor.getHeaders(response, "X-Missing").isEmpty());
+
+        Collection<String> names = responseAdaptor.getHeaderNames(response);
+        Assertions.assertEquals(new HashSet<String>(Arrays.asList("X-Test-Echo", "X-Test-Multi")), new HashSet<String>(names), "distinct names: " + names);
+
+        responseAdaptor.setHeader(response, "X-Set", "first");
+        responseAdaptor.setHeader(response, "X-Set", "second");
+        Assertions.assertEquals(Arrays.asList("second"), new ArrayList<String>(responseAdaptor.getHeaders(response, "X-Set")));
+
+        responseAdaptor.addHeader(response, "X-Add", "first");
+        responseAdaptor.addHeader(response, "X-Add", "second");
+        Assertions.assertEquals(new HashSet<String>(Arrays.asList("first", "second")), new HashSet<String>(responseAdaptor.getHeaders(response, "X-Add")));
+    }
+
+    @Test
+    public void cookieAndEntityExtractors() throws Exception {
+        // Load the entity-enclosing types on the test side first. The agent-side loader also carries an
+        // httpclient (a maven-resolver dependency of the harness); a plugin class that links
+        // HttpEntityEnclosingRequest before the test loader has it would bind to that copy and the
+        // instanceof check in the extractor would see a different class.
+        HttpPost post = new HttpPost("/");
+        post.setEntity(new StringEntity("hello"));
+
+        HttpGet get = new HttpGet("/");
+        Assertions.assertNull(HttpClient4CookieExtractor.INSTANCE.getCookie(get), "no Cookie header -> null");
+        get.addHeader("Cookie", "a=1; b=2");
+        Assertions.assertEquals("a=1; b=2", HttpClient4CookieExtractor.INSTANCE.getCookie(get));
+
+        Assertions.assertEquals("hello", HttpClient4EntityExtractor.INSTANCE.getEntity(post));
+        Assertions.assertNull(HttpClient4EntityExtractor.INSTANCE.getEntity(get), "GET carries no entity");
+    }
+
+}

--- a/agent-module/plugins-it/httpclient-it/httpclient-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient5/CloaeableHttpClientIT.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient5/CloaeableHttpClientIT.java
@@ -50,6 +50,10 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 @Dependency({"org.apache.httpcomponents.client5:httpclient5:[5.0,5.2)", WebServer.VERSION})
 public class CloaeableHttpClientIT extends HttpClientITBase {
 
+    private static final String DO_EXECUTE = "org.apache.hc.client5.http.impl.classic.InternalHttpClient"
+            + ".doExecute(org.apache.hc.core5.http.HttpHost, org.apache.hc.core5.http.ClassicHttpRequest, org.apache.hc.core5.http.protocol.HttpContext)";
+
+
     @Test
     public void test() throws Exception {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
@@ -62,7 +66,9 @@ public class CloaeableHttpClientIT extends HttpClientITBase {
         PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
         verifier.printCache();
 
-        verifier.ignoreServiceType("HTTP_CLIENT_5");
+        // The client event: destinationId from HttpHost, http.url from the request uri, status from the response.
+        verifier.verifyTrace(event("HTTP_CLIENT_5", DO_EXECUTE, null, null, getHostPort(),
+                annotation("http.url", "/"), annotation("http.status.code", 200)));
         Method connect1 = PoolingHttpClientConnectionManager.class.getMethod("connect", ConnectionEndpoint.class, TimeValue.class, HttpContext.class);
         verifier.verifyTrace(event("HTTP_CLIENT_5_INTERNAL", connect1));
         Method connect2 = DefaultHttpClientConnectionOperator.class.getMethod("connect", ManagedHttpClientConnection.class, HttpHost.class, InetSocketAddress.class, TimeValue.class, SocketConfig.class, HttpContext.class);

--- a/agent-module/plugins-it/httpclient-it/httpclient-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient5/CloaeableHttpClient_5_2_IT.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient5/CloaeableHttpClient_5_2_IT.java
@@ -51,6 +51,10 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 @Dependency({"org.apache.httpcomponents.client5:httpclient5:[5.2,5.4)", WebServer.VERSION})
 public class CloaeableHttpClient_5_2_IT extends HttpClientITBase {
 
+    private static final String DO_EXECUTE = "org.apache.hc.client5.http.impl.classic.InternalHttpClient"
+            + ".doExecute(org.apache.hc.core5.http.HttpHost, org.apache.hc.core5.http.ClassicHttpRequest, org.apache.hc.core5.http.protocol.HttpContext)";
+
+
     @Test
     public void test() throws Exception {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
@@ -63,8 +67,9 @@ public class CloaeableHttpClient_5_2_IT extends HttpClientITBase {
         PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
         verifier.printCache();
 
-        verifier.ignoreServiceType("HTTP_CLIENT_5");
-//        verifier.verifyTrace(event("HTTP_CLIENT_5", annotations(annotation("http.url", "/"), annotation("http.status.code", "200"))));
+        // The client event: destinationId from HttpHost, http.url from the request uri, status from the response.
+        verifier.verifyTrace(event("HTTP_CLIENT_5", DO_EXECUTE, null, null, getHostPort(),
+                annotation("http.url", "/"), annotation("http.status.code", 200)));
         Method connect1 = PoolingHttpClientConnectionManager.class.getMethod("connect", ConnectionEndpoint.class, TimeValue.class, HttpContext.class);
         verifier.verifyTrace(event("HTTP_CLIENT_5_INTERNAL", connect1));
         Method connect2 = DefaultHttpClientConnectionOperator.class.getMethod("connect", ManagedHttpClientConnection.class, HttpHost.class, InetSocketAddress.class, Timeout.class, SocketConfig.class, Object.class, HttpContext.class);

--- a/agent-module/plugins-it/httpclient-it/httpclient-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient5/CloaeableHttpClient_5_4_IT.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient5/CloaeableHttpClient_5_4_IT.java
@@ -52,6 +52,10 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 @Dependency({"org.apache.httpcomponents.client5:httpclient5:[5.4,5.6)", WebServer.VERSION})
 public class CloaeableHttpClient_5_4_IT extends HttpClientITBase {
 
+    private static final String DO_EXECUTE = "org.apache.hc.client5.http.impl.classic.InternalHttpClient"
+            + ".doExecute(org.apache.hc.core5.http.HttpHost, org.apache.hc.core5.http.ClassicHttpRequest, org.apache.hc.core5.http.protocol.HttpContext)";
+
+
     @Test
     public void test() throws Exception {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
@@ -64,7 +68,9 @@ public class CloaeableHttpClient_5_4_IT extends HttpClientITBase {
         PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
         verifier.printCache();
 
-        verifier.ignoreServiceType("HTTP_CLIENT_5");
+        // The client event: destinationId from HttpHost, http.url from the request uri, status from the response.
+        verifier.verifyTrace(event("HTTP_CLIENT_5", DO_EXECUTE, null, null, getHostPort(),
+                annotation("http.url", "/"), annotation("http.status.code", 200)));
         Method connect1 = PoolingHttpClientConnectionManager.class.getMethod("connect", ConnectionEndpoint.class, TimeValue.class, HttpContext.class);
         verifier.verifyTrace(event("HTTP_CLIENT_5_INTERNAL", connect1));
         Method connect2 = DefaultHttpClientConnectionOperator.class.getMethod("connect", ManagedHttpClientConnection.class, HttpHost.class, NamedEndpoint.class, InetSocketAddress.class, Timeout.class, SocketConfig.class, Object.class, HttpContext.class);

--- a/agent-module/plugins-it/httpclient-it/httpclient-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient5/CloaeableHttpClient_5_6_IT.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient5/CloaeableHttpClient_5_6_IT.java
@@ -53,6 +53,10 @@ import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 @Dependency({"org.apache.httpcomponents.client5:httpclient5:[5.6,]", WebServer.VERSION})
 public class CloaeableHttpClient_5_6_IT extends HttpClientITBase {
 
+    private static final String DO_EXECUTE = "org.apache.hc.client5.http.impl.classic.InternalHttpClient"
+            + ".doExecute(org.apache.hc.core5.http.HttpHost, org.apache.hc.core5.http.ClassicHttpRequest, org.apache.hc.core5.http.protocol.HttpContext)";
+
+
     @Test
     public void test() throws Exception {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
@@ -65,7 +69,9 @@ public class CloaeableHttpClient_5_6_IT extends HttpClientITBase {
         PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
         verifier.printCache();
 
-        verifier.ignoreServiceType("HTTP_CLIENT_5");
+        // The client event: destinationId from HttpHost, http.url from the request uri, status from the response.
+        verifier.verifyTrace(event("HTTP_CLIENT_5", DO_EXECUTE, null, null, getHostPort(),
+                annotation("http.url", "/"), annotation("http.status.code", 200)));
         Method connect1 = PoolingHttpClientConnectionManager.class.getMethod("connect", ConnectionEndpoint.class, TimeValue.class, HttpContext.class);
         verifier.verifyTrace(event("HTTP_CLIENT_5_INTERNAL", connect1));
         Method connect2 = DefaultHttpClientConnectionOperator.class.getMethod("connect", ManagedHttpClientConnection.class, HttpHost.class, NamedEndpoint.class, Path.class, InetSocketAddress.class, Timeout.class, SocketConfig.class, Object.class, HttpContext.class);

--- a/agent-module/plugins-it/httpclient-it/httpclient-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient5/HttpClient5Adaptors_IT.java
+++ b/agent-module/plugins-it/httpclient-it/httpclient-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/httpclient5/HttpClient5Adaptors_IT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.httpclient5;
+
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.httpclient5.HttpClient5CookieExtractor;
+import com.navercorp.pinpoint.plugin.httpclient5.HttpClient5EntityExtractor;
+import com.navercorp.pinpoint.plugin.httpclient5.HttpClient5RequestWrapper;
+import com.navercorp.pinpoint.plugin.httpclient5.HttpRequest5ClientHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Calls the httpclient5 plugin's request wrapper, header adaptor and extractors directly against real
+ * HttpClient 5.x objects of every release in range - no interceptor, no HTTP call. Under {@code @PluginTest}
+ * the plugin classes are linked against the httpclient5/httpcore5 of the current case.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.apache.httpcomponents.client5:httpclient5:[5.0,]"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-httpclient5-plugin"})
+public class HttpClient5Adaptors_IT {
+
+    private final ClientHeaderAdaptor<HttpRequest> headerAdaptor = new HttpRequest5ClientHeaderAdaptor();
+
+    @Test
+    public void requestWrapper_destinationAndUrl() {
+        HttpRequest request = new BasicHttpRequest("GET", "/path?q=1");
+
+        ClientRequestWrapper wrapper = new HttpClient5RequestWrapper(request, "host.example:8080");
+        Assertions.assertEquals("host.example:8080", wrapper.getDestinationId(), "destination is the host the interceptor resolved");
+        Assertions.assertEquals("/path?q=1", wrapper.getUrl(), "url is the request uri as sent");
+
+        Assertions.assertNull(new HttpClient5RequestWrapper(request, null).getDestinationId(), "null host passes through (recorder applies the default)");
+    }
+
+    @Test
+    public void headerAdaptor_setGetContains() {
+        HttpRequest request = new BasicHttpRequest("GET", "/");
+
+        Assertions.assertFalse(headerAdaptor.contains(request, "Pinpoint-TraceID"));
+        Assertions.assertEquals("", headerAdaptor.getHeader(request, "Pinpoint-TraceID"), "absent header reads as empty string");
+
+        headerAdaptor.setHeader(request, "Pinpoint-TraceID", "agent^1^1");
+        headerAdaptor.setHeader(request, "Pinpoint-TraceID", "agent^1^2");
+
+        Assertions.assertTrue(headerAdaptor.contains(request, "Pinpoint-TraceID"));
+        Assertions.assertTrue(headerAdaptor.contains(request, "pinpoint-traceid"), "header names are case-insensitive");
+        Assertions.assertEquals("agent^1^2", headerAdaptor.getHeader(request, "Pinpoint-TraceID"), "set replaces");
+        Assertions.assertEquals(1, request.getHeaders("Pinpoint-TraceID").length, "set must not accumulate values");
+    }
+
+    @Test
+    public void cookieAndEntityExtractors() {
+        HttpRequest get = new BasicHttpRequest("GET", "/");
+        Assertions.assertNull(HttpClient5CookieExtractor.INSTANCE.getCookie(get), "no Cookie header -> null");
+        get.addHeader("Cookie", "a=1; b=2");
+        Assertions.assertEquals("a=1; b=2", HttpClient5CookieExtractor.INSTANCE.getCookie(get));
+
+        Assertions.assertNull(HttpClient5EntityExtractor.INSTANCE.getEntity(get), "a plain request carries no entity");
+        BasicClassicHttpRequest post = new BasicClassicHttpRequest("POST", "/");
+        post.setEntity(new StringEntity("hello"));
+        Assertions.assertEquals("HTTP entity length: 5", HttpClient5EntityExtractor.INSTANCE.getEntity(post), "5.x records the length, not the body");
+    }
+}

--- a/agent-module/plugins-it/netty-it/src/test/java/com/navercorp/pinpoint/it/plugin/netty/NettyClientAdaptors_IT.java
+++ b/agent-module/plugins-it/netty-it/src/test/java/com/navercorp/pinpoint/it/plugin/netty/NettyClientAdaptors_IT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.netty;
+
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.netty.NettyClientRequestWrapper;
+import com.navercorp.pinpoint.plugin.netty.interceptor.http.HttpMessageClientHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Calls the netty plugin's client request wrapper and header adaptor directly against real Netty HTTP codec
+ * objects of every release in range, including 4.2 - no interceptor, no channel. The remote address side of
+ * the wrapper needs a connected channel and stays with the interceptor IT; here only the fallback is pinned.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+// netty-codec-http pulls the core modules; netty-all is an empty aggregator from 4.1.7x on and has no 4.2 jar.
+@Dependency({"io.netty:netty-codec-http:[4.1.0.Final,4.2.max]"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-netty-plugin"})
+public class NettyClientAdaptors_IT {
+
+    private final ClientHeaderAdaptor<HttpMessage> headerAdaptor = new HttpMessageClientHeaderAdaptor();
+
+    @Test
+    public void requestWrapper_urlFromTheRequest_unknownDestinationWithoutAChannel() {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/path?q=1");
+
+        ClientRequestWrapper wrapper = new NettyClientRequestWrapper(request, null);
+        Assertions.assertEquals("/path?q=1", wrapper.getUrl());
+        Assertions.assertEquals("Unknown", wrapper.getDestinationId(), "no channel context -> Unknown");
+    }
+
+    @Test
+    public void headerAdaptor_setGetContains() {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+
+        Assertions.assertFalse(headerAdaptor.contains(request, "Pinpoint-TraceID"));
+        Assertions.assertEquals("", headerAdaptor.getHeader(request, "Pinpoint-TraceID"), "absent header reads as empty string");
+
+        headerAdaptor.setHeader(request, "Pinpoint-TraceID", "agent^1^1");
+        Assertions.assertTrue(headerAdaptor.contains(request, "Pinpoint-TraceID"));
+        Assertions.assertTrue(headerAdaptor.contains(request, "pinpoint-traceid"), "header names are case-insensitive");
+        Assertions.assertEquals("agent^1^1", headerAdaptor.getHeader(request, "Pinpoint-TraceID"));
+
+        // The netty adaptor only writes a header that is not there yet (headers().contains guard).
+        headerAdaptor.setHeader(request, "Pinpoint-TraceID", "agent^1^2");
+        Assertions.assertEquals("agent^1^1", headerAdaptor.getHeader(request, "Pinpoint-TraceID"), "an existing header is kept, not replaced");
+        Assertions.assertEquals(1, request.headers().getAll("Pinpoint-TraceID").size());
+    }
+}

--- a/agent-module/plugins-it/netty-it/src/test/java/com/navercorp/pinpoint/it/plugin/netty/NettyIT.java
+++ b/agent-module/plugins-it/netty-it/src/test/java/com/navercorp/pinpoint/it/plugin/netty/NettyIT.java
@@ -16,6 +16,12 @@
 
 package com.navercorp.pinpoint.it.plugin.netty;
 
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import org.junit.jupiter.api.Assertions;
+import java.net.SocketAddress;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
 import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
 import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
 import com.navercorp.pinpoint.it.plugin.utils.WebServer;
@@ -53,9 +59,15 @@ import java.util.concurrent.TimeUnit;
  */
 @PluginTest
 @PinpointAgent(AgentPath.PATH)
-@Dependency({"io.netty:netty-all:[4.1.0.Final,4.1.max]", WebServer.VERSION, PluginITConstants.VERSION})
+// 4.1.102.Final is skipped: that release was built without --release 8 and fails on Java 8 with
+// NoSuchMethodError java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer; inside PooledByteBuf (fixed in 4.1.103).
+@Dependency({"io.netty:netty-all:[4.1.0.Final,4.1.101.Final],[4.1.103.Final,4.1.max]", WebServer.VERSION, PluginITConstants.VERSION})
 @PinpointConfig("pinpoint-netty-plugin-test.config")
 public class NettyIT {
+
+    private static final String WRITE_AND_FLUSH = "io.netty.channel.DefaultChannelPipeline.writeAndFlush(java.lang.Object)";
+    private static final String HTTP_ENCODE = "io.netty.handler.codec.http.HttpObjectEncoder.encode(io.netty.channel.ChannelHandlerContext, java.lang.Object, java.util.List)";
+
 
     @AutoClose("stop")
     private static WebServer webServer;
@@ -84,15 +96,16 @@ public class NettyIT {
             channel.writeAndFlush(request);
 
             boolean await = awaitLatch.await(3000, TimeUnit.MILLISECONDS);
-//            Assertions.assertTrue(await);
-//
-//            PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
-//            verifier.printCache();
-//
-//            verifier.verifyTrace(event("NETTY", Bootstrap.class.getMethod("connect", SocketAddress.class), annotation("netty.address", webServer.getHostAndPort())));
-//            verifier.verifyTrace(event("NETTY", "io.netty.channel.DefaultChannelPipeline.writeAndFlush(java.lang.Object)"));
-//            verifier.verifyTrace(event("ASYNC", "Asynchronous Invocation"));
-//            verifier.verifyTrace(event("NETTY_HTTP", "io.netty.handler.codec.http.HttpObjectEncoder.encode(io.netty.channel.ChannelHandlerContext, java.lang.Object, java.util.List)", annotation("http.url", "/")));
+            Assertions.assertTrue(await, "no response within 3s");
+
+            PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+            // the encoder runs on the event loop after writeAndFlush returns
+            verifier.awaitTrace(event("NETTY_HTTP", HTTP_ENCODE, null, null, remoteAddress(), annotation("http.url", "/")), 20, 3000);
+            verifier.printCache();
+            verifier.verifyDiscreteTrace(
+                    event("NETTY", Bootstrap.class.getMethod("connect", SocketAddress.class), annotation("netty.address", webServer.getHostAndPort())),
+                    event("NETTY", WRITE_AND_FLUSH),
+                    event("NETTY_HTTP", HTTP_ENCODE, null, null, remoteAddress(), annotation("http.url", "/")));
         } finally {
             channel.close().sync();
             workerGroup.shutdownGracefully().sync();
@@ -128,20 +141,19 @@ public class NettyIT {
         });
 
         boolean await = awaitLatch.await(3000, TimeUnit.MILLISECONDS);
-//        Assertions.assertTrue(await);
+        Assertions.assertTrue(await, "no response within 3s");
 
         final Channel channel = connect.channel();
         try {
-//            PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
-//            verifier.printCache();
-//
-//            verifier.verifyTrace(event("NETTY", Bootstrap.class.getMethod("connect", SocketAddress.class), annotation("netty.address", webServer.getHostAndPort())));
-//            verifier.verifyTrace(event("NETTY", "io.netty.channel.DefaultChannelPromise.addListener(io.netty.util.concurrent.GenericFutureListener)"));
-//            verifier.verifyTrace(event("ASYNC", "Asynchronous Invocation"));
-//            verifier.verifyTrace(event("NETTY_INTERNAL", "io.netty.util.concurrent.DefaultPromise.notifyListenersNow()"));
-//            verifier.verifyTrace(event("NETTY_INTERNAL", "io.netty.util.concurrent.DefaultPromise.notifyListener0(io.netty.util.concurrent.Future, io.netty.util.concurrent.GenericFutureListener)"));
-//            verifier.verifyTrace(event("NETTY", "io.netty.channel.DefaultChannelPipeline.writeAndFlush(java.lang.Object)"));
-//            verifier.verifyTrace(event("NETTY_HTTP", "io.netty.handler.codec.http.HttpObjectEncoder.encode(io.netty.channel.ChannelHandlerContext, java.lang.Object, java.util.List)", annotation("http.url", "/")));
+            PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+            verifier.printCache();
+            // Only the synchronous part is pinned here. The write issued inside the connect listener is not
+            // linked to this trace on netty 4.1.45+ (and sporadically on 4.1.2x): the cache then holds just
+            // connect + addListener while the request still completes. The request/encode events are
+            // asserted in listenerTest, where writeAndFlush runs on the test thread.
+            verifier.verifyDiscreteTrace(
+                    event("NETTY", Bootstrap.class.getMethod("connect", SocketAddress.class), annotation("netty.address", webServer.getHostAndPort())),
+                    event("NETTY", "io.netty.channel.DefaultChannelPromise.addListener(io.netty.util.concurrent.GenericFutureListener)"));
         } finally {
             channel.close().sync();
             workerGroup.shutdownGracefully().sync();
@@ -159,6 +171,11 @@ public class NettyIT {
                     }
                 });
         return bootstrap;
+    }
+
+    // NettyClientRequestWrapper records channel.remoteAddress() as ip:port
+    private static String remoteAddress() throws Exception {
+        return java.net.InetAddress.getByName(webServer.getHostname()).getHostAddress() + ":" + webServer.getListeningPort();
     }
 
 }

--- a/agent-module/plugins-it/spring-it/spring-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/RestTemplateResponseHeaderAdaptor_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-5-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/RestTemplateResponseHeaderAdaptor_IT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.resttemplate.RestTemplateResponseHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Calls the resttemplate plugin's {@link RestTemplateResponseHeaderAdaptor} directly against a real
+ * {@code ClientHttpResponse} of every Spring Framework 5 release in range - no interceptor, no HTTP call.
+ *
+ * <p>{@code @PluginTest} loads the plugin class through the agent class loader and links its
+ * {@code HttpHeaders} calls against the spring-web version of the current case, so a descriptor that a
+ * newer Spring release dropped (issue #14276: {@code containsKey}/{@code get(Object)}/{@code keySet}
+ * compiled against Spring 5.3) fails here as the same {@code NoSuchMethodError} the interceptor would hit,
+ * with the offending method and version in the report.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.springframework:spring-web:[5.0.0.RELEASE,5.max]",
+        // same version as spring-web: MockClientHttpResponse
+        "org.springframework:spring-test"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-resttemplate-plugin"})
+public class RestTemplateResponseHeaderAdaptor_IT {
+
+    private final ResponseAdaptor<ClientHttpResponse> adaptor = new RestTemplateResponseHeaderAdaptor();
+
+    @Test
+    public void readsHeadersOfEveryShape() {
+        ClientHttpResponse response = response();
+        response.getHeaders().add("X-Test-Echo", "echo");
+        response.getHeaders().add("X-Test-Multi", "one");
+        response.getHeaders().add("X-Test-Multi", "two");
+
+        Assertions.assertTrue(adaptor.containsHeader(response, "X-Test-Echo"));
+        Assertions.assertTrue(adaptor.containsHeader(response, "x-test-echo"), "header names are case-insensitive");
+        Assertions.assertFalse(adaptor.containsHeader(response, "X-Missing"));
+
+        Assertions.assertEquals("echo", adaptor.getHeader(response, "X-Test-Echo"));
+        Assertions.assertEquals("one", adaptor.getHeader(response, "X-Test-Multi"), "first value wins");
+        Assertions.assertNull(adaptor.getHeader(response, "X-Missing"));
+
+        Assertions.assertEquals(Arrays.asList("one", "two"), new ArrayList<>(adaptor.getHeaders(response, "X-Test-Multi")));
+        Assertions.assertEquals(Arrays.asList("one", "two"), new ArrayList<>(adaptor.getHeaders(response, "x-test-multi")));
+        Assertions.assertTrue(adaptor.getHeaders(response, "X-Missing").isEmpty());
+
+        Collection<String> names = adaptor.getHeaderNames(response);
+        Assertions.assertEquals(2, names.size(), "names: " + names);
+        Assertions.assertTrue(containsIgnoreCase(names, "X-Test-Echo"), "names: " + names);
+        Assertions.assertTrue(containsIgnoreCase(names, "X-Test-Multi"), "names: " + names);
+    }
+
+    @Test
+    public void setReplaces_addAppends() {
+        ClientHttpResponse response = response();
+
+        adaptor.setHeader(response, "X-Set", "first");
+        adaptor.setHeader(response, "X-Set", "second");
+        Assertions.assertEquals(Arrays.asList("second"), new ArrayList<>(adaptor.getHeaders(response, "X-Set")));
+
+        adaptor.addHeader(response, "X-Add", "first");
+        adaptor.addHeader(response, "X-Add", "second");
+        Assertions.assertEquals(Arrays.asList("first", "second"), new ArrayList<>(adaptor.getHeaders(response, "X-Add")));
+        Assertions.assertEquals("first", adaptor.getHeader(response, "X-Add"));
+    }
+
+    private static ClientHttpResponse response() {
+        // HttpStatus.OK: (byte[], HttpStatus) on 5.x and (byte[], HttpStatusCode) on 6.x/7.x - each IT module compiles
+        // against its own Spring line, so the descriptor matches every version in range. The (byte[], int) overload
+        // only exists from spring-test 5.3.17.
+        return new MockClientHttpResponse("body".getBytes(StandardCharsets.UTF_8), HttpStatus.OK);
+    }
+
+    private static boolean containsIgnoreCase(Collection<String> names, String expected) {
+        for (String name : names) {
+            if (expected.equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/ClientHttpRequestClientHeaderAdaptor_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/ClientHttpRequestClientHeaderAdaptor_IT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.ClientHttpRequestClientHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.mock.http.client.reactive.MockClientHttpRequest;
+
+import java.net.URI;
+
+/**
+ * Calls the spring-webflux plugin's {@link ClientHttpRequestClientHeaderAdaptor} - the adaptor the WebClient
+ * request trace writer uses to inject and read the Pinpoint propagation headers - directly against a real
+ * reactive {@code ClientHttpRequest} of every Spring Framework 6 release in range. Issue #14276 was
+ * this adaptor's {@code containsKey(Object)} throwing {@code NoSuchMethodError} on Spring 7; here the plugin
+ * class is linked against the spring-web of the current case, so such a drift fails per version with the
+ * offending method in the report.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.springframework:spring-webflux:[6.0.0,6.max]",
+        // same version as spring-webflux: reactive MockClientHttpRequest
+        "org.springframework:spring-test"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-webflux-plugin"})
+public class ClientHttpRequestClientHeaderAdaptor_IT {
+
+    private final ClientHeaderAdaptor<ClientHttpRequest> adaptor = new ClientHttpRequestClientHeaderAdaptor();
+
+    @Test
+    public void setThenReadBack_andContains() {
+        ClientHttpRequest request = request();
+
+        Assertions.assertFalse(adaptor.contains(request, "Pinpoint-TraceID"));
+        Assertions.assertEquals("", adaptor.getHeader(request, "Pinpoint-TraceID"), "absent header reads as empty string");
+
+        adaptor.setHeader(request, "Pinpoint-TraceID", "agent^1^1");
+        adaptor.setHeader(request, "Pinpoint-SpanID", "42");
+
+        Assertions.assertTrue(adaptor.contains(request, "Pinpoint-TraceID"));
+        Assertions.assertTrue(adaptor.contains(request, "pinpoint-traceid"), "header names are case-insensitive");
+        Assertions.assertEquals("agent^1^1", adaptor.getHeader(request, "Pinpoint-TraceID"));
+        Assertions.assertEquals("42", adaptor.getHeader(request, "Pinpoint-SpanID"));
+        Assertions.assertEquals("agent^1^1", request.getHeaders().getFirst("Pinpoint-TraceID"), "value reached the real request");
+    }
+
+    @Test
+    public void setReplacesThePreviousValue() {
+        ClientHttpRequest request = request();
+
+        adaptor.setHeader(request, "Pinpoint-Flags", "0");
+        adaptor.setHeader(request, "Pinpoint-Flags", "1");
+
+        Assertions.assertEquals("1", adaptor.getHeader(request, "Pinpoint-Flags"));
+        Assertions.assertEquals(1, request.getHeaders().get("Pinpoint-Flags").size(), "set() must not accumulate values");
+    }
+
+    private static ClientHttpRequest request() {
+        return new MockClientHttpRequest(HttpMethod.GET, URI.create("http://localhost:8080/"));
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/RestTemplateResponseHeaderAdaptor_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/RestTemplateResponseHeaderAdaptor_IT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.resttemplate.RestTemplateResponseHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Calls the resttemplate plugin's {@link RestTemplateResponseHeaderAdaptor} directly against a real
+ * {@code ClientHttpResponse} of every Spring Framework 6 release in range - no interceptor, no HTTP call.
+ *
+ * <p>{@code @PluginTest} loads the plugin class through the agent class loader and links its
+ * {@code HttpHeaders} calls against the spring-web version of the current case, so a descriptor that a
+ * newer Spring release dropped (issue #14276: {@code containsKey}/{@code get(Object)}/{@code keySet}
+ * compiled against Spring 5.3) fails here as the same {@code NoSuchMethodError} the interceptor would hit,
+ * with the offending method and version in the report.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.springframework:spring-web:[6.0.0,6.max]",
+        // same version as spring-web: MockClientHttpResponse
+        "org.springframework:spring-test"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-resttemplate-plugin"})
+public class RestTemplateResponseHeaderAdaptor_IT {
+
+    private final ResponseAdaptor<ClientHttpResponse> adaptor = new RestTemplateResponseHeaderAdaptor();
+
+    @Test
+    public void readsHeadersOfEveryShape() {
+        ClientHttpResponse response = response();
+        response.getHeaders().add("X-Test-Echo", "echo");
+        response.getHeaders().add("X-Test-Multi", "one");
+        response.getHeaders().add("X-Test-Multi", "two");
+
+        Assertions.assertTrue(adaptor.containsHeader(response, "X-Test-Echo"));
+        Assertions.assertTrue(adaptor.containsHeader(response, "x-test-echo"), "header names are case-insensitive");
+        Assertions.assertFalse(adaptor.containsHeader(response, "X-Missing"));
+
+        Assertions.assertEquals("echo", adaptor.getHeader(response, "X-Test-Echo"));
+        Assertions.assertEquals("one", adaptor.getHeader(response, "X-Test-Multi"), "first value wins");
+        Assertions.assertNull(adaptor.getHeader(response, "X-Missing"));
+
+        Assertions.assertEquals(Arrays.asList("one", "two"), new ArrayList<>(adaptor.getHeaders(response, "X-Test-Multi")));
+        Assertions.assertEquals(Arrays.asList("one", "two"), new ArrayList<>(adaptor.getHeaders(response, "x-test-multi")));
+        Assertions.assertTrue(adaptor.getHeaders(response, "X-Missing").isEmpty());
+
+        Collection<String> names = adaptor.getHeaderNames(response);
+        Assertions.assertEquals(2, names.size(), "names: " + names);
+        Assertions.assertTrue(containsIgnoreCase(names, "X-Test-Echo"), "names: " + names);
+        Assertions.assertTrue(containsIgnoreCase(names, "X-Test-Multi"), "names: " + names);
+    }
+
+    @Test
+    public void setReplaces_addAppends() {
+        ClientHttpResponse response = response();
+
+        adaptor.setHeader(response, "X-Set", "first");
+        adaptor.setHeader(response, "X-Set", "second");
+        Assertions.assertEquals(Arrays.asList("second"), new ArrayList<>(adaptor.getHeaders(response, "X-Set")));
+
+        adaptor.addHeader(response, "X-Add", "first");
+        adaptor.addHeader(response, "X-Add", "second");
+        Assertions.assertEquals(Arrays.asList("first", "second"), new ArrayList<>(adaptor.getHeaders(response, "X-Add")));
+        Assertions.assertEquals("first", adaptor.getHeader(response, "X-Add"));
+    }
+
+    private static ClientHttpResponse response() {
+        // HttpStatus.OK: (byte[], HttpStatus) on 5.x and (byte[], HttpStatusCode) on 6.x/7.x - each IT module compiles
+        // against its own Spring line, so the descriptor matches every version in range. The (byte[], int) overload
+        // only exists from spring-test 5.3.17.
+        return new MockClientHttpResponse("body".getBytes(StandardCharsets.UTF_8), HttpStatus.OK);
+    }
+
+    private static boolean containsIgnoreCase(Collection<String> names, String expected) {
+        for (String name : names) {
+            if (expected.equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebFluxResponseHeaderAdaptor_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebFluxResponseHeaderAdaptor_IT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxResponseHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+import org.springframework.mock.http.client.reactive.MockClientHttpResponse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Calls the spring-webflux plugin's {@link SpringWebFluxResponseHeaderAdaptor} directly against a real
+ * reactive {@code ClientHttpResponse} of every Spring Framework 6 release in range - no interceptor,
+ * no HTTP call. The plugin class is linked against the spring-web of the current case, so a header
+ * descriptor missing on that release fails here as the {@code NoSuchMethodError} the interceptor would hit
+ * (issue #14276 was exactly this adaptor's {@code containsKey}/{@code get(Object)}/{@code keySet}).
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.springframework:spring-webflux:[6.0.0,6.max]",
+        // same version as spring-webflux: reactive MockClientHttpResponse
+        "org.springframework:spring-test"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-webflux-plugin"})
+public class SpringWebFluxResponseHeaderAdaptor_IT {
+
+    private final ResponseAdaptor<ClientHttpResponse> adaptor = new SpringWebFluxResponseHeaderAdaptor();
+
+    @Test
+    public void readsHeadersOfEveryShape() {
+        ClientHttpResponse response = response();
+        response.getHeaders().add("X-Test-Echo", "echo");
+        response.getHeaders().add("X-Test-Multi", "one");
+        response.getHeaders().add("X-Test-Multi", "two");
+
+        Assertions.assertTrue(adaptor.containsHeader(response, "X-Test-Echo"));
+        Assertions.assertTrue(adaptor.containsHeader(response, "x-test-echo"), "header names are case-insensitive");
+        Assertions.assertFalse(adaptor.containsHeader(response, "X-Missing"));
+
+        Assertions.assertEquals("echo", adaptor.getHeader(response, "X-Test-Echo"));
+        Assertions.assertEquals("one", adaptor.getHeader(response, "X-Test-Multi"), "first value wins");
+        Assertions.assertNull(adaptor.getHeader(response, "X-Missing"));
+
+        Assertions.assertEquals(Arrays.asList("one", "two"), new ArrayList<>(adaptor.getHeaders(response, "X-Test-Multi")));
+        Assertions.assertEquals(Arrays.asList("one", "two"), new ArrayList<>(adaptor.getHeaders(response, "x-test-multi")));
+        Assertions.assertTrue(adaptor.getHeaders(response, "X-Missing").isEmpty());
+
+        Collection<String> names = adaptor.getHeaderNames(response);
+        Assertions.assertEquals(2, names.size(), "names: " + names);
+        Assertions.assertTrue(containsIgnoreCase(names, "X-Test-Echo"), "names: " + names);
+        Assertions.assertTrue(containsIgnoreCase(names, "X-Test-Multi"), "names: " + names);
+    }
+
+    @Test
+    public void setReplaces_addAppends() {
+        ClientHttpResponse response = response();
+
+        adaptor.setHeader(response, "X-Set", "first");
+        adaptor.setHeader(response, "X-Set", "second");
+        Assertions.assertEquals(Arrays.asList("second"), new ArrayList<>(adaptor.getHeaders(response, "X-Set")));
+
+        adaptor.addHeader(response, "X-Add", "first");
+        adaptor.addHeader(response, "X-Add", "second");
+        Assertions.assertEquals(Arrays.asList("first", "second"), new ArrayList<>(adaptor.getHeaders(response, "X-Add")));
+        Assertions.assertEquals("first", adaptor.getHeader(response, "X-Add"));
+    }
+
+    private static ClientHttpResponse response() {
+        // int status constructor: identical on Spring 5.3, 6.x and 7.x
+        return new MockClientHttpResponse(200);
+    }
+
+    private static boolean containsIgnoreCase(Collection<String> names, String expected) {
+        for (String name : names) {
+            if (expected.equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebFluxServer_6_x_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebFluxServer_6_x_IT.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.root;
+
+/**
+ * WebFlux server side on Spring Framework 6: an annotated controller behind {@code DispatcherHandler}
+ * served by the reactor-netty {@code HttpServer}, called with a plain {@code HttpURLConnection}
+ * (no client plugin imported, so the server trace is the only trace).
+ *
+ * <p>Pins the server-side instrumentation that has no other automated coverage on this Spring line:
+ * the reactor-netty root span, the SPRING_WEBFLUX span events of {@code DispatcherHandler} and
+ * {@code InvocableHandlerMethod}, and the URI template taken from the best-matching {@code PathPattern}.
+ */
+@PluginForkedTest
+@PinpointAgent(AgentPath.PATH)
+@JvmVersion(17)
+@Dependency({"org.springframework:spring-webflux:[6.0.0,6.max]",
+        // same version as spring-webflux: @EnableWebFlux / WebHttpHandlerBuilder need spring-context
+        "org.springframework:spring-context",
+        "io.projectreactor.netty:reactor-netty-http:1.2.18",
+        PluginITConstants.VERSION})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-webflux-plugin",
+        "com.navercorp.pinpoint:pinpoint-reactor-netty-plugin",
+        "com.navercorp.pinpoint:pinpoint-netty-plugin",
+        "com.navercorp.pinpoint:pinpoint-reactor-plugin"})
+@PinpointConfig("pinpoint-webflux-server.config")
+public class SpringWebFluxServer_6_x_IT {
+
+    // reactor-netty server root: ServletRequestListener opens the trace with the shared "Servlet Process" api;
+    // HttpServerHandle.onStateChange itself is the first REACTOR_NETTY_INTERNAL event under it.
+    private static final String SERVLET_PROCESS = "Servlet Process";
+    private static final String ON_STATE_CHANGE = "reactor.netty.http.server.HttpServer$HttpServerHandle"
+            + ".onStateChange(reactor.netty.Connection, reactor.netty.ConnectionObserver$State)";
+
+    private static final String DISPATCHER_HANDLER = "org.springframework.web.reactive.DispatcherHandler";
+    private static final String HANDLE = DISPATCHER_HANDLER + ".handle(org.springframework.web.server.ServerWebExchange)";
+    private static final String HANDLE_REQUEST_WITH = DISPATCHER_HANDLER + ".handleRequestWith(org.springframework.web.server.ServerWebExchange, java.lang.Object)";
+    private static final String INVOKE = "org.springframework.web.reactive.result.method.InvocableHandlerMethod"
+            + ".invoke(org.springframework.web.server.ServerWebExchange, org.springframework.web.reactive.BindingContext, java.lang.Object[])";
+
+    private static AnnotationConfigApplicationContext context;
+    private static DisposableServer server;
+
+    @BeforeAll
+    public static void beforeClass() {
+        context = new AnnotationConfigApplicationContext(WebFluxTestConfig.class);
+        HttpHandler httpHandler = WebHttpHandlerBuilder.applicationContext(context).build();
+        server = HttpServer.create()
+                .host("127.0.0.1")
+                .port(0)
+                .handle(new ReactorHttpHandlerAdapter(httpHandler))
+                .bindNow();
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        if (server != null) {
+            server.disposeNow();
+        }
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    public void annotatedHandler_recordsDispatcherHandlerEvents_andTheUriTemplate() throws Exception {
+        String body = get("/users/42");
+        Assertions.assertEquals("user-42", body);
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        // The controller runs on a netty event loop: wait for the handler event before inspecting the cache.
+        verifier.awaitTrace(event("SPRING_WEBFLUX", INVOKE), 20, 5000);
+        // The root span is flushed after the response completes, possibly after the client already returned.
+        verifier.awaitTrace(root("REACTOR_NETTY", SERVLET_PROCESS, "/users/42", "127.0.0.1:" + server.port(), null), 20, 5000);
+        verifier.printCache();
+
+        // The URI template comes from the best-matching PathPattern, not from the raw request path.
+        verifier.verifyUriTemplate("/users/{id}");
+        // remoteAddr is the client's ephemeral host:port, so it is not pinned.
+        verifier.verifyDiscreteTrace(
+                root("REACTOR_NETTY", SERVLET_PROCESS, "/users/42", "127.0.0.1:" + server.port(), null,
+                        annotation("http.status.code", 200)),
+                event("REACTOR_NETTY_INTERNAL", ON_STATE_CHANGE),
+                event("SPRING_WEBFLUX", HANDLE),
+                event("SPRING_WEBFLUX", HANDLE_REQUEST_WITH),
+                event("SPRING_WEBFLUX", INVOKE));
+    }
+
+    private String get(String path) throws Exception {
+        URL url = new URL("http://127.0.0.1:" + server.port() + path);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(10000);
+        try (InputStream in = connection.getInputStream()) {
+            Assertions.assertEquals(200, connection.getResponseCode());
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    @Configuration
+    @EnableWebFlux
+    static class WebFluxTestConfig {
+        @Bean
+        public UserController userController() {
+            return new UserController();
+        }
+    }
+
+    @RestController
+    static class UserController {
+        @GetMapping("/users/{id}")
+        public Mono<String> user(@PathVariable("id") String id) {
+            return Mono.just("user-" + id);
+        }
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/WebClientRequestAdaptors_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-6-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/WebClientRequestAdaptors_IT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
+import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.ClientHttpRequestCookieExtractor;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.WebClientRequestWrapper;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.mock.http.client.reactive.MockClientHttpRequest;
+
+import java.net.URI;
+
+/**
+ * Calls the spring-webflux plugin's WebClient request wrapper and cookie extractor directly against a real
+ * reactive {@code ClientHttpRequest} of every Spring Framework 6 release in range - no interceptor,
+ * no HTTP call. These feed destinationId / http.url and the cookie annotation of the SPRING_WEBFLUX_CLIENT event.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.springframework:spring-webflux:[6.0.0,6.max]",
+        // same version as spring-webflux: reactive MockClientHttpRequest
+        "org.springframework:spring-test"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-webflux-plugin"})
+public class WebClientRequestAdaptors_IT {
+
+    private final CookieExtractor<ClientHttpRequest> cookieExtractor = new ClientHttpRequestCookieExtractor();
+
+    @Test
+    public void requestWrapper_destinationAndUrl() {
+        ClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://host.example:8080/path?q=1"));
+
+        ClientRequestWrapper wrapper = new WebClientRequestWrapper(request);
+        Assertions.assertEquals("host.example:8080", wrapper.getDestinationId());
+        Assertions.assertEquals("http://host.example:8080/path?q=1", wrapper.getUrl(), "url is the full request uri");
+
+        ClientRequestWrapper noPort = new WebClientRequestWrapper(new MockClientHttpRequest(HttpMethod.GET, URI.create("https://host.example/path")));
+        Assertions.assertEquals("host.example", noPort.getDestinationId(), "no explicit port -> host only");
+
+        Assertions.assertEquals("Unknown", new WebClientRequestWrapper(null).getDestinationId(), "null request -> Unknown");
+        Assertions.assertNull(new WebClientRequestWrapper(null).getUrl());
+    }
+
+    @Test
+    public void cookieExtractor_nameEqualsValue_repeatsJoinedByComma() {
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://host.example/"));
+        Assertions.assertEquals("", cookieExtractor.getCookie(request), "no cookies -> empty string");
+
+        request.getCookies().add("session", new HttpCookie("session", "abc"));
+        Assertions.assertEquals("session=abc", cookieExtractor.getCookie(request));
+
+        request.getCookies().add("session", new HttpCookie("session", "def"));
+        Assertions.assertEquals("session=abc,session=def", cookieExtractor.getCookie(request), "repeated values of one cookie are comma-joined");
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-6-it/src/test/resources/pinpoint-webflux-server.config
+++ b/agent-module/plugins-it/spring-it/spring-6-it/src/test/resources/pinpoint-webflux-server.config
@@ -1,0 +1,6 @@
+# WebFlux server-side instrumentation (DispatcherHandler / InvocableHandlerMethod) on top of the reactor-netty server root.
+profiler.spring.webflux.enable=true
+profiler.spring.webflux.client.enable=false
+profiler.reactor-netty.enable=true
+# Lets DispatchHandlerInvokeHandlerMethodInterceptor record the best-matching PathPattern as the span URI template.
+profiler.uri.stat.spring.webflux.enable=true

--- a/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/ClientHttpRequestClientHeaderAdaptor_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/ClientHttpRequestClientHeaderAdaptor_IT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientHeaderAdaptor;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.ClientHttpRequestClientHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.mock.http.client.reactive.MockClientHttpRequest;
+
+import java.net.URI;
+
+/**
+ * Calls the spring-webflux plugin's {@link ClientHttpRequestClientHeaderAdaptor} - the adaptor the WebClient
+ * request trace writer uses to inject and read the Pinpoint propagation headers - directly against a real
+ * reactive {@code ClientHttpRequest} of every Spring Framework 7 release in range. Issue #14276 was
+ * this adaptor's {@code containsKey(Object)} throwing {@code NoSuchMethodError} on Spring 7; here the plugin
+ * class is linked against the spring-web of the current case, so such a drift fails per version with the
+ * offending method in the report.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.springframework:spring-webflux:[7.0.0,7.max]",
+        // same version as spring-webflux: reactive MockClientHttpRequest
+        "org.springframework:spring-test"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-webflux-plugin"})
+public class ClientHttpRequestClientHeaderAdaptor_IT {
+
+    private final ClientHeaderAdaptor<ClientHttpRequest> adaptor = new ClientHttpRequestClientHeaderAdaptor();
+
+    @Test
+    public void setThenReadBack_andContains() {
+        ClientHttpRequest request = request();
+
+        Assertions.assertFalse(adaptor.contains(request, "Pinpoint-TraceID"));
+        Assertions.assertEquals("", adaptor.getHeader(request, "Pinpoint-TraceID"), "absent header reads as empty string");
+
+        adaptor.setHeader(request, "Pinpoint-TraceID", "agent^1^1");
+        adaptor.setHeader(request, "Pinpoint-SpanID", "42");
+
+        Assertions.assertTrue(adaptor.contains(request, "Pinpoint-TraceID"));
+        Assertions.assertTrue(adaptor.contains(request, "pinpoint-traceid"), "header names are case-insensitive");
+        Assertions.assertEquals("agent^1^1", adaptor.getHeader(request, "Pinpoint-TraceID"));
+        Assertions.assertEquals("42", adaptor.getHeader(request, "Pinpoint-SpanID"));
+        Assertions.assertEquals("agent^1^1", request.getHeaders().getFirst("Pinpoint-TraceID"), "value reached the real request");
+    }
+
+    @Test
+    public void setReplacesThePreviousValue() {
+        ClientHttpRequest request = request();
+
+        adaptor.setHeader(request, "Pinpoint-Flags", "0");
+        adaptor.setHeader(request, "Pinpoint-Flags", "1");
+
+        Assertions.assertEquals("1", adaptor.getHeader(request, "Pinpoint-Flags"));
+        Assertions.assertEquals(1, request.getHeaders().get("Pinpoint-Flags").size(), "set() must not accumulate values");
+    }
+
+    private static ClientHttpRequest request() {
+        return new MockClientHttpRequest(HttpMethod.GET, URI.create("http://localhost:8080/"));
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/RestTemplateResponseHeaderAdaptor_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/RestTemplateResponseHeaderAdaptor_IT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.resttemplate.RestTemplateResponseHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Calls the resttemplate plugin's {@link RestTemplateResponseHeaderAdaptor} directly against a real
+ * {@code ClientHttpResponse} of every Spring Framework 7 release in range - no interceptor, no HTTP call.
+ *
+ * <p>{@code @PluginTest} loads the plugin class through the agent class loader and links its
+ * {@code HttpHeaders} calls against the spring-web version of the current case, so a descriptor that a
+ * newer Spring release dropped (issue #14276: {@code containsKey}/{@code get(Object)}/{@code keySet}
+ * compiled against Spring 5.3) fails here as the same {@code NoSuchMethodError} the interceptor would hit,
+ * with the offending method and version in the report.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.springframework:spring-web:[7.0.0,7.max]",
+        // same version as spring-web: MockClientHttpResponse
+        "org.springframework:spring-test"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-resttemplate-plugin"})
+public class RestTemplateResponseHeaderAdaptor_IT {
+
+    private final ResponseAdaptor<ClientHttpResponse> adaptor = new RestTemplateResponseHeaderAdaptor();
+
+    @Test
+    public void readsHeadersOfEveryShape() {
+        ClientHttpResponse response = response();
+        response.getHeaders().add("X-Test-Echo", "echo");
+        response.getHeaders().add("X-Test-Multi", "one");
+        response.getHeaders().add("X-Test-Multi", "two");
+
+        Assertions.assertTrue(adaptor.containsHeader(response, "X-Test-Echo"));
+        Assertions.assertTrue(adaptor.containsHeader(response, "x-test-echo"), "header names are case-insensitive");
+        Assertions.assertFalse(adaptor.containsHeader(response, "X-Missing"));
+
+        Assertions.assertEquals("echo", adaptor.getHeader(response, "X-Test-Echo"));
+        Assertions.assertEquals("one", adaptor.getHeader(response, "X-Test-Multi"), "first value wins");
+        Assertions.assertNull(adaptor.getHeader(response, "X-Missing"));
+
+        Assertions.assertEquals(Arrays.asList("one", "two"), new ArrayList<>(adaptor.getHeaders(response, "X-Test-Multi")));
+        Assertions.assertEquals(Arrays.asList("one", "two"), new ArrayList<>(adaptor.getHeaders(response, "x-test-multi")));
+        Assertions.assertTrue(adaptor.getHeaders(response, "X-Missing").isEmpty());
+
+        Collection<String> names = adaptor.getHeaderNames(response);
+        Assertions.assertEquals(2, names.size(), "names: " + names);
+        Assertions.assertTrue(containsIgnoreCase(names, "X-Test-Echo"), "names: " + names);
+        Assertions.assertTrue(containsIgnoreCase(names, "X-Test-Multi"), "names: " + names);
+    }
+
+    @Test
+    public void setReplaces_addAppends() {
+        ClientHttpResponse response = response();
+
+        adaptor.setHeader(response, "X-Set", "first");
+        adaptor.setHeader(response, "X-Set", "second");
+        Assertions.assertEquals(Arrays.asList("second"), new ArrayList<>(adaptor.getHeaders(response, "X-Set")));
+
+        adaptor.addHeader(response, "X-Add", "first");
+        adaptor.addHeader(response, "X-Add", "second");
+        Assertions.assertEquals(Arrays.asList("first", "second"), new ArrayList<>(adaptor.getHeaders(response, "X-Add")));
+        Assertions.assertEquals("first", adaptor.getHeader(response, "X-Add"));
+    }
+
+    private static ClientHttpResponse response() {
+        // HttpStatus.OK: (byte[], HttpStatus) on 5.x and (byte[], HttpStatusCode) on 6.x/7.x - each IT module compiles
+        // against its own Spring line, so the descriptor matches every version in range. The (byte[], int) overload
+        // only exists from spring-test 5.3.17.
+        return new MockClientHttpResponse("body".getBytes(StandardCharsets.UTF_8), HttpStatus.OK);
+    }
+
+    private static boolean containsIgnoreCase(Collection<String> names, String expected) {
+        for (String name : names) {
+            if (expected.equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebFluxResponseHeaderAdaptor_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebFluxResponseHeaderAdaptor_IT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.response.ResponseAdaptor;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.spring.webflux.SpringWebFluxResponseHeaderAdaptor;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+import org.springframework.mock.http.client.reactive.MockClientHttpResponse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Calls the spring-webflux plugin's {@link SpringWebFluxResponseHeaderAdaptor} directly against a real
+ * reactive {@code ClientHttpResponse} of every Spring Framework 7 release in range - no interceptor,
+ * no HTTP call. The plugin class is linked against the spring-web of the current case, so a header
+ * descriptor missing on that release fails here as the {@code NoSuchMethodError} the interceptor would hit
+ * (issue #14276 was exactly this adaptor's {@code containsKey}/{@code get(Object)}/{@code keySet}).
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.springframework:spring-webflux:[7.0.0,7.max]",
+        // same version as spring-webflux: reactive MockClientHttpResponse
+        "org.springframework:spring-test"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-webflux-plugin"})
+public class SpringWebFluxResponseHeaderAdaptor_IT {
+
+    private final ResponseAdaptor<ClientHttpResponse> adaptor = new SpringWebFluxResponseHeaderAdaptor();
+
+    @Test
+    public void readsHeadersOfEveryShape() {
+        ClientHttpResponse response = response();
+        response.getHeaders().add("X-Test-Echo", "echo");
+        response.getHeaders().add("X-Test-Multi", "one");
+        response.getHeaders().add("X-Test-Multi", "two");
+
+        Assertions.assertTrue(adaptor.containsHeader(response, "X-Test-Echo"));
+        Assertions.assertTrue(adaptor.containsHeader(response, "x-test-echo"), "header names are case-insensitive");
+        Assertions.assertFalse(adaptor.containsHeader(response, "X-Missing"));
+
+        Assertions.assertEquals("echo", adaptor.getHeader(response, "X-Test-Echo"));
+        Assertions.assertEquals("one", adaptor.getHeader(response, "X-Test-Multi"), "first value wins");
+        Assertions.assertNull(adaptor.getHeader(response, "X-Missing"));
+
+        Assertions.assertEquals(Arrays.asList("one", "two"), new ArrayList<>(adaptor.getHeaders(response, "X-Test-Multi")));
+        Assertions.assertEquals(Arrays.asList("one", "two"), new ArrayList<>(adaptor.getHeaders(response, "x-test-multi")));
+        Assertions.assertTrue(adaptor.getHeaders(response, "X-Missing").isEmpty());
+
+        Collection<String> names = adaptor.getHeaderNames(response);
+        Assertions.assertEquals(2, names.size(), "names: " + names);
+        Assertions.assertTrue(containsIgnoreCase(names, "X-Test-Echo"), "names: " + names);
+        Assertions.assertTrue(containsIgnoreCase(names, "X-Test-Multi"), "names: " + names);
+    }
+
+    @Test
+    public void setReplaces_addAppends() {
+        ClientHttpResponse response = response();
+
+        adaptor.setHeader(response, "X-Set", "first");
+        adaptor.setHeader(response, "X-Set", "second");
+        Assertions.assertEquals(Arrays.asList("second"), new ArrayList<>(adaptor.getHeaders(response, "X-Set")));
+
+        adaptor.addHeader(response, "X-Add", "first");
+        adaptor.addHeader(response, "X-Add", "second");
+        Assertions.assertEquals(Arrays.asList("first", "second"), new ArrayList<>(adaptor.getHeaders(response, "X-Add")));
+        Assertions.assertEquals("first", adaptor.getHeader(response, "X-Add"));
+    }
+
+    private static ClientHttpResponse response() {
+        // int status constructor: identical on Spring 5.3, 6.x and 7.x
+        return new MockClientHttpResponse(200);
+    }
+
+    private static boolean containsIgnoreCase(Collection<String> names, String expected) {
+        for (String name : names) {
+            if (expected.equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebFluxServer_7_x_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebFluxServer_7_x_IT.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.annotation;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.root;
+
+/**
+ * WebFlux server side on Spring Framework 7: an annotated controller behind {@code DispatcherHandler}
+ * served by the reactor-netty {@code HttpServer}, called with a plain {@code HttpURLConnection}
+ * (no client plugin imported, so the server trace is the only trace).
+ *
+ * <p>Pins the server-side instrumentation that has no other automated coverage on this Spring line:
+ * the reactor-netty root span, the SPRING_WEBFLUX span events of {@code DispatcherHandler} and
+ * {@code InvocableHandlerMethod}, and the URI template taken from the best-matching {@code PathPattern}.
+ */
+@PluginForkedTest
+@PinpointAgent(AgentPath.PATH)
+@JvmVersion(17)
+@Dependency({"org.springframework:spring-webflux:[7.0.0,7.max]",
+        // same version as spring-webflux: @EnableWebFlux / WebHttpHandlerBuilder need spring-context
+        "org.springframework:spring-context",
+        "io.projectreactor.netty:reactor-netty-http:1.3.6",
+        PluginITConstants.VERSION})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-webflux-plugin",
+        "com.navercorp.pinpoint:pinpoint-reactor-netty-plugin",
+        "com.navercorp.pinpoint:pinpoint-netty-plugin",
+        "com.navercorp.pinpoint:pinpoint-reactor-plugin"})
+@PinpointConfig("pinpoint-webflux-server.config")
+public class SpringWebFluxServer_7_x_IT {
+
+    // reactor-netty server root: ServletRequestListener opens the trace with the shared "Servlet Process" api;
+    // HttpServerHandle.onStateChange itself is the first REACTOR_NETTY_INTERNAL event under it.
+    private static final String SERVLET_PROCESS = "Servlet Process";
+    private static final String ON_STATE_CHANGE = "reactor.netty.http.server.HttpServer$HttpServerHandle"
+            + ".onStateChange(reactor.netty.Connection, reactor.netty.ConnectionObserver$State)";
+
+    private static final String DISPATCHER_HANDLER = "org.springframework.web.reactive.DispatcherHandler";
+    private static final String HANDLE = DISPATCHER_HANDLER + ".handle(org.springframework.web.server.ServerWebExchange)";
+    private static final String HANDLE_REQUEST_WITH = DISPATCHER_HANDLER + ".handleRequestWith(org.springframework.web.server.ServerWebExchange, java.lang.Object)";
+    // 3-arg since 6.1; 6.0.x has the 2-arg overload, so only the 7.x IT pins it.
+    private static final String HANDLE_RESULT = DISPATCHER_HANDLER + ".handleResult(org.springframework.web.server.ServerWebExchange, org.springframework.web.reactive.HandlerResult, java.lang.String)";
+    private static final String INVOKE = "org.springframework.web.reactive.result.method.InvocableHandlerMethod"
+            + ".invoke(org.springframework.web.server.ServerWebExchange, org.springframework.web.reactive.BindingContext, java.lang.Object[])";
+
+    private static AnnotationConfigApplicationContext context;
+    private static DisposableServer server;
+
+    @BeforeAll
+    public static void beforeClass() {
+        context = new AnnotationConfigApplicationContext(WebFluxTestConfig.class);
+        HttpHandler httpHandler = WebHttpHandlerBuilder.applicationContext(context).build();
+        server = HttpServer.create()
+                .host("127.0.0.1")
+                .port(0)
+                .handle(new ReactorHttpHandlerAdapter(httpHandler))
+                .bindNow();
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        if (server != null) {
+            server.disposeNow();
+        }
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    public void annotatedHandler_recordsDispatcherHandlerEvents_andTheUriTemplate() throws Exception {
+        String body = get("/users/42");
+        Assertions.assertEquals("user-42", body);
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        // The controller runs on a netty event loop: wait for the handler event before inspecting the cache.
+        verifier.awaitTrace(event("SPRING_WEBFLUX", INVOKE), 20, 5000);
+        // The root span is flushed after the response completes, possibly after the client already returned.
+        verifier.awaitTrace(root("REACTOR_NETTY", SERVLET_PROCESS, "/users/42", "127.0.0.1:" + server.port(), null), 20, 5000);
+        verifier.printCache();
+
+        // The URI template comes from the best-matching PathPattern, not from the raw request path.
+        verifier.verifyUriTemplate("/users/{id}");
+        // remoteAddr is the client's ephemeral host:port, so it is not pinned.
+        verifier.verifyDiscreteTrace(
+                root("REACTOR_NETTY", SERVLET_PROCESS, "/users/42", "127.0.0.1:" + server.port(), null,
+                        annotation("http.status.code", 200)),
+                event("REACTOR_NETTY_INTERNAL", ON_STATE_CHANGE),
+                event("SPRING_WEBFLUX", HANDLE),
+                event("SPRING_WEBFLUX", HANDLE_REQUEST_WITH),
+                event("SPRING_WEBFLUX", INVOKE),
+                event("SPRING_WEBFLUX", HANDLE_RESULT));
+    }
+
+    private String get(String path) throws Exception {
+        URL url = new URL("http://127.0.0.1:" + server.port() + path);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(10000);
+        try (InputStream in = connection.getInputStream()) {
+            Assertions.assertEquals(200, connection.getResponseCode());
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    @Configuration
+    @EnableWebFlux
+    static class WebFluxTestConfig {
+        @Bean
+        public UserController userController() {
+            return new UserController();
+        }
+    }
+
+    @RestController
+    static class UserController {
+        @GetMapping("/users/{id}")
+        public Mono<String> user(@PathVariable("id") String id) {
+            return Mono.just("user-" + id);
+        }
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebMvcUriTemplate_7_x_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/SpringWebMvcUriTemplate_7_x_IT.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.FrameworkServlet;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.servlet.mvc.Controller;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
+
+/**
+ * Spring MVC URI-template recording on Spring Framework 7, driven straight through
+ * {@code DispatcherServlet.service} (which runs {@code FrameworkServlet.doGet/processRequest} and
+ * the handler mappings the plugin instruments) with a mock request.
+ *
+ * <p>Three recording paths, all off unless {@code profiler.uri.stat.spring.webmvc.enable=true}:
+ * the annotated-controller pattern from {@code AbstractHandlerMethodMapping.lookupHandlerMethod},
+ * the legacy {@code Controller} pattern from {@code AbstractUrlHandlerMapping.exposePathWithinMapping},
+ * and the application-supplied {@code pinpoint.metric.uri-template} attribute read by
+ * {@code FrameworkServlet.processRequest} when {@code useuserinput=true}.
+ *
+ * <p>Only the {@code FrameworkServlet.doGet} event is pinned: the {@code InvocableHandlerMethod.invokeForRequest}
+ * interceptor records a span event only on the Servlet async path (it needs the {@code AsyncContext}
+ * request attribute), which a synchronous mock request never has.
+ */
+@PluginForkedTest
+@PinpointAgent(AgentPath.PATH)
+@JvmVersion(17)
+@Dependency({"org.springframework:spring-webmvc:[7.0.0,7.max]", "org.springframework:spring-test", "jakarta.servlet:jakarta.servlet-api:6.1.0"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-plugin"})
+@PinpointConfig("pinpoint-webmvc-uristat.config")
+public class SpringWebMvcUriTemplate_7_x_IT {
+
+    private static final String SPRING_MVC = "SPRING_MVC";
+    static final String USER_INPUT_ATTRIBUTE = "pinpoint.metric.uri-template";
+
+    private static AnnotationConfigWebApplicationContext context;
+    private static DispatcherServlet servlet;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        context = new AnnotationConfigWebApplicationContext();
+        context.register(WebConfig.class);
+        servlet = new DispatcherServlet(context);
+        servlet.init(new MockServletConfig());
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        if (servlet != null) {
+            servlet.destroy();
+        }
+    }
+
+    @Test
+    public void annotatedController_recordsTheBestMatchingPattern() throws Exception {
+        MockHttpServletResponse response = get("/users/42");
+        Assertions.assertEquals("user-42", response.getContentAsString());
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.printCache();
+        // AbstractHandlerMethodMapping.lookupHandlerMethod -> HandlerMapping.bestMatchingPattern
+        verifier.verifyUriTemplate("/users/{id}");
+        verifier.verifyDiscreteTrace(event(SPRING_MVC, doGet()));
+    }
+
+    @Test
+    public void legacyController_recordsTheUrlHandlerMappingPattern() throws Exception {
+        MockHttpServletResponse response = get("/legacy/items");
+        Assertions.assertEquals("legacy", response.getContentAsString());
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.printCache();
+        // AbstractUrlHandlerMapping.exposePathWithinMapping(bestMatchingPattern, pathWithinMapping, request)
+        verifier.verifyUriTemplate("/legacy/*");
+        verifier.verifyDiscreteTrace(event(SPRING_MVC, doGet()));
+    }
+
+    @Test
+    public void userInputAttribute_overridesTheRecordedTemplate() throws Exception {
+        MockHttpServletResponse response = get("/orders/7");
+        Assertions.assertEquals("order-7", response.getContentAsString());
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.printCache();
+        // FrameworkServlet.processRequest (useuserinput=true) force-records the attribute the controller set,
+        // replacing the "/orders/{id}" pattern recorded earlier by lookupHandlerMethod.
+        verifier.verifyUriTemplate("/custom/orders");
+        verifier.verifyDiscreteTrace(event(SPRING_MVC, doGet()));
+    }
+
+    private static MockHttpServletResponse get(String uri) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("GET");
+        request.setRequestURI(uri);
+        request.setRemoteAddr("1.2.3.4");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+        Assertions.assertEquals(200, response.getStatus(), "unexpected status for " + uri);
+        return response;
+    }
+
+    private static Method doGet() throws NoSuchMethodException {
+        return FrameworkServlet.class.getDeclaredMethod("doGet", HttpServletRequest.class, HttpServletResponse.class);
+    }
+
+    @Configuration
+    @EnableWebMvc
+    static class WebConfig {
+        @Bean
+        public UserController userController() {
+            return new UserController();
+        }
+
+        @Bean
+        public SimpleUrlHandlerMapping legacyHandlerMapping() {
+            SimpleUrlHandlerMapping mapping = new SimpleUrlHandlerMapping();
+            mapping.setOrder(0);
+            mapping.setUrlMap(Collections.singletonMap("/legacy/*", new LegacyController()));
+            return mapping;
+        }
+    }
+
+    @RestController
+    static class UserController {
+        @GetMapping("/users/{id}")
+        public String user(@PathVariable("id") String id) {
+            return "user-" + id;
+        }
+
+        @GetMapping("/orders/{id}")
+        public String order(@PathVariable("id") String id, HttpServletRequest request) {
+            request.setAttribute(USER_INPUT_ATTRIBUTE, "/custom/orders");
+            return "order-" + id;
+        }
+    }
+
+    static class LegacyController implements Controller {
+        @Override
+        public ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
+            response.getWriter().write("legacy");
+            return null;
+        }
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/WebClientRequestAdaptors_IT.java
+++ b/agent-module/plugins-it/spring-it/spring-7-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/web/WebClientRequestAdaptors_IT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.web;
+
+import com.navercorp.pinpoint.bootstrap.plugin.request.ClientRequestWrapper;
+import com.navercorp.pinpoint.bootstrap.plugin.request.util.CookieExtractor;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.ClientHttpRequestCookieExtractor;
+import com.navercorp.pinpoint.plugin.spring.webflux.interceptor.WebClientRequestWrapper;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.ImportPlugin;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PluginTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.mock.http.client.reactive.MockClientHttpRequest;
+
+import java.net.URI;
+
+/**
+ * Calls the spring-webflux plugin's WebClient request wrapper and cookie extractor directly against a real
+ * reactive {@code ClientHttpRequest} of every Spring Framework 7 release in range - no interceptor,
+ * no HTTP call. These feed destinationId / http.url and the cookie annotation of the SPRING_WEBFLUX_CLIENT event.
+ */
+@PluginTest
+@PinpointAgent(AgentPath.PATH)
+@Dependency({"org.springframework:spring-webflux:[7.0.0,7.max]",
+        // same version as spring-webflux: reactive MockClientHttpRequest
+        "org.springframework:spring-test"})
+@ImportPlugin({"com.navercorp.pinpoint:pinpoint-spring-webflux-plugin"})
+public class WebClientRequestAdaptors_IT {
+
+    private final CookieExtractor<ClientHttpRequest> cookieExtractor = new ClientHttpRequestCookieExtractor();
+
+    @Test
+    public void requestWrapper_destinationAndUrl() {
+        ClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://host.example:8080/path?q=1"));
+
+        ClientRequestWrapper wrapper = new WebClientRequestWrapper(request);
+        Assertions.assertEquals("host.example:8080", wrapper.getDestinationId());
+        Assertions.assertEquals("http://host.example:8080/path?q=1", wrapper.getUrl(), "url is the full request uri");
+
+        ClientRequestWrapper noPort = new WebClientRequestWrapper(new MockClientHttpRequest(HttpMethod.GET, URI.create("https://host.example/path")));
+        Assertions.assertEquals("host.example", noPort.getDestinationId(), "no explicit port -> host only");
+
+        Assertions.assertEquals("Unknown", new WebClientRequestWrapper(null).getDestinationId(), "null request -> Unknown");
+        Assertions.assertNull(new WebClientRequestWrapper(null).getUrl());
+    }
+
+    @Test
+    public void cookieExtractor_nameEqualsValue_repeatsJoinedByComma() {
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://host.example/"));
+        Assertions.assertEquals("", cookieExtractor.getCookie(request), "no cookies -> empty string");
+
+        request.getCookies().add("session", new HttpCookie("session", "abc"));
+        Assertions.assertEquals("session=abc", cookieExtractor.getCookie(request));
+
+        request.getCookies().add("session", new HttpCookie("session", "def"));
+        Assertions.assertEquals("session=abc,session=def", cookieExtractor.getCookie(request), "repeated values of one cookie are comma-joined");
+    }
+}

--- a/agent-module/plugins-it/spring-it/spring-7-it/src/test/resources/pinpoint-webflux-server.config
+++ b/agent-module/plugins-it/spring-it/spring-7-it/src/test/resources/pinpoint-webflux-server.config
@@ -1,0 +1,6 @@
+# WebFlux server-side instrumentation (DispatcherHandler / InvocableHandlerMethod) on top of the reactor-netty server root.
+profiler.spring.webflux.enable=true
+profiler.spring.webflux.client.enable=false
+profiler.reactor-netty.enable=true
+# Lets DispatchHandlerInvokeHandlerMethodInterceptor record the best-matching PathPattern as the span URI template.
+profiler.uri.stat.spring.webflux.enable=true

--- a/agent-module/plugins-it/spring-it/spring-7-it/src/test/resources/pinpoint-webmvc-uristat.config
+++ b/agent-module/plugins-it/spring-it/spring-7-it/src/test/resources/pinpoint-webmvc-uristat.config
@@ -1,0 +1,5 @@
+# Spring MVC URI-template recording (lookupHandlerMethod / exposePathWithinMapping / processRequest interceptors).
+profiler.spring.webmvc.enable=true
+profiler.uri.stat.spring.webmvc.enable=true
+# Lets ProcessRequestInterceptor honour the "pinpoint.metric.uri-template" request attribute set by the application.
+profiler.uri.stat.spring.webmvc.useuserinput=true

--- a/agent-module/plugins-it/spring-tx-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/tx/SpringTxSeamWrap_7_x_IT.java
+++ b/agent-module/plugins-it/spring-tx-it/src/test/java/com/navercorp/pinpoint/it/plugin/spring/tx/SpringTxSeamWrap_7_x_IT.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.it.plugin.spring.tx;
+
+import com.navercorp.pinpoint.bootstrap.plugin.test.Expectations;
+import com.navercorp.pinpoint.bootstrap.plugin.test.ExpectedTrace;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.it.plugin.utils.AgentPath;
+import com.navercorp.pinpoint.it.plugin.utils.PluginITConstants;
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.JvmVersion;
+import com.navercorp.pinpoint.test.plugin.PinpointAgent;
+import com.navercorp.pinpoint.test.plugin.PinpointConfig;
+import com.navercorp.pinpoint.test.plugin.PluginForkedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.transaction.ReactiveTransaction;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.interceptor.MatchAlwaysTransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+import reactor.core.publisher.Mono;
+import test.pinpoint.plugin.tx.Echo;
+
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Runtime assertions for {@code profiler.spring.tx.wrap.publisher=true} (the seam wrapper variant
+ * woven into {@code TransactionAspectSupport$ReactiveTransactionSupport.invokeWithinTransaction}).
+ *
+ * <p>No Spring context or database: a {@link ProxyFactory} + {@link TransactionInterceptor} with a
+ * no-op {@link ReactiveTransactionManager} drives the exact woven method — the reactive branch is
+ * selected because the service returns a {@link Mono} and the manager is reactive.
+ *
+ * <p>The config also sets {@code profiler.reactor.enable=false}: without the reactor plugin there
+ * are no per-operator relays and no accessor fields on reactor publishers, so the async link can
+ * only come from the wrapped publisher — the same wrapper-only proof the r2dbc/lettuce/redisson
+ * seam ITs use. The service hops threads via {@code Mono.delay} (reactor parallel timer), making
+ * the async-link assertion non-vacuous.
+ *
+ * <p>Spring Framework 7 variant of {@link SpringTxSeamWrap_IT}: the woven
+ * {@code ReactiveTransactionSupport.invokeWithinTransaction} signature is unchanged on 7.x, so the
+ * same probe pins that the interceptor still attaches and links across the reactor hop there.
+ *
+ * <p><b>Discriminating probe (manual)</b>: flip {@code wrap.publisher=false} in
+ * {@code pinpoint-tx-seam-wrap.config} — the async-link assertion must fail — then flip back.
+ */
+@PluginForkedTest
+@PinpointAgent(AgentPath.PATH)
+@JvmVersion(17)
+@PinpointConfig("pinpoint-tx-seam-wrap.config")
+@Dependency({"org.springframework:spring-tx:[7.0.0,7.max]",
+        // same version as spring-tx; 7.0.x TransactionAspectSupport also reaches into spring-context (ApplicationEventPublisherAware)
+        "org.springframework:spring-aop",
+        "org.springframework:spring-context",
+        "io.projectreactor:reactor-core:3.8.6",
+        PluginITConstants.VERSION})
+public class SpringTxSeamWrap_7_x_IT {
+    private static final String SPRING_TX = "SPRING_TX";
+    private static final String INTERNAL_METHOD = "INTERNAL_METHOD";
+
+    private static final long AWAIT_UNIT_MILLIS = 20L;
+    private static final long AWAIT_MAX_MILLIS = 5000L;
+
+    private static Method echoGet() throws NoSuchMethodException {
+        return Echo.class.getDeclaredMethod("get", String.class);
+    }
+
+    private static Member invokeWithinTransactionMethod() throws Exception {
+        final Class<?> owner = Class.forName(
+                "org.springframework.transaction.interceptor.TransactionAspectSupport$ReactiveTransactionSupport");
+        final Class<?> invocationCallback = Class.forName(
+                "org.springframework.transaction.interceptor.TransactionAspectSupport$InvocationCallback");
+        final Class<?> transactionAttribute = Class.forName(
+                "org.springframework.transaction.interceptor.TransactionAttribute");
+        return owner.getDeclaredMethod("invokeWithinTransaction",
+                Method.class, Class.class, invocationCallback, transactionAttribute, ReactiveTransactionManager.class);
+    }
+
+    @Test
+    public void reactiveTransaction_wrapperAloneLinksAcrossThread() throws Exception {
+        final TransactionInterceptor transactionInterceptor = new TransactionInterceptor();
+        transactionInterceptor.setTransactionManager(new NoopReactiveTransactionManager());
+        transactionInterceptor.setTransactionAttributeSource(new MatchAlwaysTransactionAttributeSource());
+
+        final ProxyFactory proxyFactory = new ProxyFactory(new GreetServiceImpl());
+        proxyFactory.addInterface(GreetService.class);
+        proxyFactory.addAdvice(transactionInterceptor);
+        final GreetService service = (GreetService) proxyFactory.getProxy();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final List<String> callbackThreads = new CopyOnWriteArrayList<>();
+        final String testThread = Thread.currentThread().getName();
+
+        // the proxy call runs inside the @PluginTest root trace and returns the wrapped publisher;
+        // Mono.delay delivers the value on the reactor parallel timer thread.
+        service.greet()
+                .map(v -> {
+                    callbackThreads.add(Thread.currentThread().getName());
+                    try {
+                        return new Echo().get("Hello" + v);
+                    } finally {
+                        latch.countDown();
+                    }
+                })
+                .subscribe();
+
+        assertTrue(latch.await(AWAIT_MAX_MILLIS, TimeUnit.MILLISECONDS), "callback was not invoked");
+        assertEquals(1, callbackThreads.size(), "callback ran an unexpected number of times");
+        assertNotEquals(testThread, callbackThreads.get(0),
+                "callback ran on the test thread - no hop, the assertion would be vacuous");
+
+        final ExpectedTrace callback = Expectations.event(INTERNAL_METHOD, echoGet());
+        final ExpectedTrace asyncLink = Expectations.async(
+                Expectations.event(SPRING_TX, invokeWithinTransactionMethod()), callback);
+
+        final PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+        verifier.awaitTrace(callback, AWAIT_UNIT_MILLIS, AWAIT_MAX_MILLIS);
+        verifier.printCache();
+        verifier.verifyDiscreteTrace(asyncLink);
+    }
+
+    public interface GreetService {
+        Mono<String> greet();
+    }
+
+    public static class GreetServiceImpl implements GreetService {
+        @Override
+        public Mono<String> greet() {
+            return Mono.delay(Duration.ofMillis(50L)).map(t -> "hello");
+        }
+    }
+
+    /**
+     * The transaction lifecycle itself is not under test - only the woven seam is. Begin/commit
+     * are inert Monos.
+     */
+    static class NoopReactiveTransactionManager implements ReactiveTransactionManager {
+        @Override
+        public Mono<ReactiveTransaction> getReactiveTransaction(TransactionDefinition definition) {
+            return Mono.just(new NoopReactiveTransaction());
+        }
+
+        @Override
+        public Mono<Void> commit(ReactiveTransaction transaction) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Void> rollback(ReactiveTransaction transaction) {
+            return Mono.empty();
+        }
+    }
+
+    static class NoopReactiveTransaction implements ReactiveTransaction {
+        private boolean rollbackOnly;
+
+        @Override
+        public boolean isNewTransaction() {
+            return true;
+        }
+
+        @Override
+        public void setRollbackOnly() {
+            this.rollbackOnly = true;
+        }
+
+        @Override
+        public boolean isRollbackOnly() {
+            return rollbackOnly;
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return false;
+        }
+    }
+}

--- a/agent-module/profiler-test/src/main/java/com/navercorp/pinpoint/profiler/test/OrderedSpanRecorder.java
+++ b/agent-module/profiler-test/src/main/java/com/navercorp/pinpoint/profiler/test/OrderedSpanRecorder.java
@@ -96,6 +96,13 @@ public class OrderedSpanRecorder implements ListenableDataSender.Listener<SpanTy
         return item.getValue();
     }
 
+    /**
+     * @return a copy of the recorded items, oldest first; the recorder itself is left untouched
+     */
+    public synchronized List<Item<SpanType>> snapshotItems() {
+        return new ArrayList<>(list);
+    }
+
     public synchronized Item<SpanType> popItem() {
         if (list.isEmpty()) {
             return null;

--- a/agent-module/profiler-test/src/main/java/com/navercorp/pinpoint/profiler/test/PluginVerifierExternalAdaptor.java
+++ b/agent-module/profiler-test/src/main/java/com/navercorp/pinpoint/profiler/test/PluginVerifierExternalAdaptor.java
@@ -61,10 +61,12 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author Woonduk Kang(emeroad)
@@ -703,6 +705,28 @@ public class PluginVerifierExternalAdaptor implements PluginTestVerifier {
             AssertionErrorBuilder builder = new AssertionErrorBuilder("Span.isLoggingTransactionInfo value",
                     loggingInfo.getName(), codeName);
             builder.setComparison(loggingInfo.getName(), codeName);
+            builder.throwAssertionError();
+        }
+    }
+
+    @Override
+    public void verifyUriTemplate(String expectedUriTemplate) {
+        Objects.requireNonNull(expectedUriTemplate, "expectedUriTemplate");
+
+        final Set<String> actualUriTemplates = new LinkedHashSet<>();
+        for (Item<SpanType> item : this.handler.getOrderedSpanRecorder().snapshotItems()) {
+            final TraceRoot traceRoot = item.getTraceRoot();
+            if (traceRoot == null) {
+                continue;
+            }
+            final String uriTemplate = traceRoot.getShared().getUriTemplate();
+            if (uriTemplate != null) {
+                actualUriTemplates.add(uriTemplate);
+            }
+        }
+        if (!actualUriTemplates.contains(expectedUriTemplate)) {
+            AssertionErrorBuilder builder = new AssertionErrorBuilder("Span.uriTemplate", expectedUriTemplate, actualUriTemplates);
+            builder.setComparison(expectedUriTemplate, actualUriTemplates);
             builder.throwAssertionError();
         }
     }


### PR DESCRIPTION
…s for the Spring and HTTP client plugins

Issue #14276 showed a gap in the plugin ITs: the header adaptors call the Spring/HTTP client APIs directly, but no test exercised those methods per library version, so a descriptor that disappeared on Spring 7 (HttpHeaders.containsKey/get(Object)/keySet) went unnoticed until a user hit the NoSuchMethodError. This change adds coverage in three layers.

1. Direct-call adaptor ITs (@PluginTest) The plugin class is loaded through the agent class loader and linked against the library version of each @Dependency case, so the adaptor methods are called on real library objects without an interceptor or an HTTP call, and a dropped descriptor or a changed value format fails per version with the offending method in the report.
- spring-5/6/7-it RestTemplateResponseHeaderAdaptor_IT, spring-6/7-it SpringWebFluxResponseHeaderAdaptor_IT and ClientHttpRequestClientHeaderAdaptor_IT (the three adaptors of #14276) and WebClientRequestAdaptors_IT (request wrapper, cookie extractor). Discriminating check: with the pre-fix resttemplate plugin jar in the local repository the RestTemplate adaptor IT fails on every 7.x version with the exact NoSuchMethodError.
- httpclient-3/4/5-it HttpClient3/4/5Adaptors_IT (request wrapper, header adaptors, response adaptor, cookie and entity extractors; httpclient 4.0..4.5.max, 5.0.., commons-httpclient 3.0..3.1) and netty-it NettyClientAdaptors_IT (netty-codec-http 4.1.0..4.2.max, the first coverage of Netty 4.2). MockClientHttpResponse(byte[], HttpStatus) is used because the (byte[], int) overload only exists from spring-test 5.3.17; the IT modules compile against their own Spring line, so the descriptor matches 5.x (HttpStatus) and 6.x/7.x (HttpStatusCode) alike.

2. Server-side ITs on Spring 6 and 7
- SpringWebFluxServer_6_x_IT / _7_x_IT: an @EnableWebFlux context behind the reactor-netty HttpServer, called with HttpURLConnection; pins the REACTOR_NETTY root ("Servlet Process", rpc, endPoint, http.status.code), the HttpServerHandle.onStateChange internal event, the SPRING_WEBFLUX events of DispatcherHandler.handle / handleRequestWith / InvocableHandlerMethod.invoke (plus the 3-arg handleResult on 7.x), and the URI template "/users/{id}" taken from the best-matching PathPattern.
- SpringWebMvcUriTemplate_7_x_IT: the three URI-template paths of the spring plugin (AbstractHandlerMethodMapping.lookupHandlerMethod, AbstractUrlHandlerMapping .exposePathWithinMapping, FrameworkServlet.processRequest with useuserinput=true).
- SpringTxSeamWrap_7_x_IT: the [7.0.0,7.max] counterpart of the 5.3.39 reactive seam IT (spring-context added: 7.0.x TransactionAspectSupport reaches ApplicationEventPublisherAware). The verifier had no way to see the URI template, so PluginTestVerifier gains verifyUriTemplate(String), reading TraceRoot.Shared.getUriTemplate() of every recorded item through a new OrderedSpanRecorder.snapshotItems() without consuming the cache.

3. Restored client event assertions
- httpclient-5-it classic ITs: the HTTP_CLIENT_5 event was ignored (the old assertion had no method and could not resolve an api id); they now assert InternalHttpClient.doExecute with destinationId, http.url and http.status.code (signature identical on 5.0..5.6).
- netty-it NettyIT: the assertions commented out since #10757 are restored. listenerTest pins Bootstrap.connect (netty.address), DefaultChannelPipeline.writeAndFlush and the HttpObjectEncoder.encode event with destinationId ip:port and http.url; writeTest pins the synchronous connect + addListener only, because the write issued inside the connect listener is not linked to the trace on netty 4.1.45+ (left for the plugin owner). netty-all 4.1.102.Final is skipped: that release fails on Java 8 with NoSuchMethodError ByteBuffer.limit(I) inside PooledByteBuf (fixed in 4.1.103).

Note on @PluginTest class loading: the agent-side loader also carries the harness's own httpclient/httpcore (maven-resolver dependencies); a plugin class that links an org.apache.http type before the test loader has loaded it binds to that copy, so the httpclient4 extractor test creates the entity-enclosing request before the first plugin call.

Verified (all existing tests unchanged): spring-5-it 216/216, spring-6-it 3x132 + 66 + 132, spring-7-it 3x20 + 10 + 30 + 10 + 20, spring-tx-it 10/10, httpclient-4-it 156/156, httpclient-5-it 87/87 + classic 29/29, httpclient-3-it 12/12, netty-it 316/316 + NettyIT 274/274, profiler-test/bootstrap-core unit tests green.